### PR TITLE
fix(alerts): Open in Metrics for trace metrics alerts 

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -8,12 +8,12 @@ import {Select} from '@sentry/scraps/select';
 
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import {parseFunction} from 'sentry/utils/discover/fields';
 import usePrevious from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
+import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,
   type TraceMetricTypeValue,
@@ -38,29 +38,6 @@ interface MetricSelectOption {
 
 function makeMetricSelectValue(metric: TraceMetric): string {
   return `${metric.name}||${metric.type}`;
-}
-
-function parseMetricAggregate(aggregate: string): {
-  aggregation: string;
-  traceMetric: TraceMetric;
-} {
-  const parsed = parseFunction(aggregate);
-  if (!parsed) {
-    return {
-      aggregation: 'count',
-      traceMetric: {name: '', type: ''},
-    };
-  }
-
-  // Format is: aggregate(value,metric_name,metric_type,unit)
-  const args = parsed.arguments ?? [];
-  const metricName = args[1] ?? '';
-  const metricType = args[2] ?? '';
-
-  return {
-    aggregation: parsed.name,
-    traceMetric: {name: metricName, type: metricType},
-  };
 }
 
 export default function EAPMetricsField({

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -10,6 +10,7 @@ import {Dataset, type MetricRule} from 'sentry/views/alerts/rules/metric/types';
 import {
   getAlertRuleExploreUrl,
   getAlertRuleLogsUrl,
+  getAlertRuleMetricsUrl,
 } from 'sentry/views/alerts/rules/utils';
 import {getMetricRuleDiscoverUrl} from 'sentry/views/alerts/utils/getMetricRuleDiscoverUrl';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -60,6 +61,17 @@ export function makeDefaultCta({
       return {
         buttonText: t('Open in Logs'),
         to: getAlertRuleLogsUrl({
+          rule,
+          organization,
+          timePeriod,
+          projectId: projects[0]!.id,
+        }),
+      };
+    }
+    if (traceItemType === TraceItemDataset.TRACEMETRICS) {
+      return {
+        buttonText: t('Open in Metrics'),
+        to: getAlertRuleMetricsUrl({
           rule,
           organization,
           timePeriod,

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -18,7 +18,7 @@ import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams'
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
-import {getMetricsUrl} from 'sentry/views/explore/metrics/utils';
+import {getMetricsUrl, makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -213,7 +213,9 @@ export function getAlertRuleMetricsUrl({
   metricQuery.queryParams = metricQuery.queryParams.replace({
     mode: Mode.AGGREGATE,
     query: rule.query,
-    aggregateFields: [new VisualizeFunction(`${aggregation}(value)`)],
+    aggregateFields: [
+      new VisualizeFunction(makeMetricsAggregate({aggregate: aggregation, traceMetric})),
+    ],
   });
 
   return getMetricsUrl({

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -18,7 +18,7 @@ import {LOGS_QUERY_KEY} from 'sentry/views/explore/contexts/logs/logsPageParams'
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
-import {getMetricsUrl, makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+import {getMetricsUrl} from 'sentry/views/explore/metrics/utils';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -206,16 +206,14 @@ export function getAlertRuleMetricsUrl({
   const interval =
     TIME_WINDOW_TO_INTERVAL[rule.timeWindow as keyof typeof TIME_WINDOW_TO_INTERVAL];
 
-  const {aggregation, traceMetric} = parseMetricAggregate(rule.aggregate);
+  const {traceMetric} = parseMetricAggregate(rule.aggregate);
 
   const metricQuery = defaultMetricQuery();
   metricQuery.metric = traceMetric;
   metricQuery.queryParams = metricQuery.queryParams.replace({
     mode: Mode.AGGREGATE,
     query: rule.query,
-    aggregateFields: [
-      new VisualizeFunction(makeMetricsAggregate({aggregate: aggregation, traceMetric})),
-    ],
+    aggregateFields: [new VisualizeFunction(rule.aggregate)],
   });
 
   return getMetricsUrl({

--- a/static/app/views/explore/metrics/parseMetricsAggregate.tsx
+++ b/static/app/views/explore/metrics/parseMetricsAggregate.tsx
@@ -1,0 +1,25 @@
+import {parseFunction} from 'sentry/utils/discover/fields';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+
+export function parseMetricAggregate(aggregate: string): {
+  aggregation: string;
+  traceMetric: TraceMetric;
+} {
+  const parsed = parseFunction(aggregate);
+  if (!parsed) {
+    return {
+      aggregation: 'count',
+      traceMetric: {name: '', type: ''},
+    };
+  }
+
+  // Format is: aggregate(value,metric_name,metric_type,unit)
+  const args = parsed.arguments ?? [];
+  const metricName = args[1] ?? '';
+  const metricType = args[2] ?? '';
+
+  return {
+    aggregation: parsed.name,
+    traceMetric: {name: metricName, type: metricType},
+  };
+}


### PR DESCRIPTION
Should be open in metrics (similar to open in logs) for the alert details page.