### PR TITLE
fix(autofix): Only coerce projects autofix automation on to medium

### DIFF
--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -181,9 +181,11 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
     # If seer is enabled for an org, every project must have project level settings
     for project in projects:
         project.update_option("sentry:seer_scanner_automation", True)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
+        autofix_automation_tuning = project.get_option("sentry:autofix_automation_tuning")
+        if autofix_automation_tuning != AutofixAutomationTuningSettings.OFF:
+            project.update_option(
+                "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+            )
 
     preferences_by_id = bulk_get_project_preferences(organization_id, project_ids)
 

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -214,6 +214,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         mock_bulk_get.assert_called_once()
         mock_bulk_set.assert_called_once()
 
+    @pytest.mark.skip("DO NOT override autofix automation tuning off")
     @patch("sentry.tasks.autofix.bulk_set_project_preferences")
     @patch("sentry.tasks.autofix.bulk_get_project_preferences")
     def test_overrides_autofix_off_to_medium(


### PR DESCRIPTION
It's unexpected that all projects get autofix enabled when starting a trial. This only coerces all the project's existing autofix automation tuning to medium if it's already enabled.