### PR TITLE
Event project serialization

### DIFF
--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -161,11 +161,11 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         data = serialize(
             event, request.user, SqlFormatEventSerializer(), include_full_release_data=False
         )
-        
+
         # Handle serialization failure gracefully
         if data is None:
             return Response({"detail": "Failed to serialize event"}, status=500)
-        
+
         data["projectSlug"] = project.slug
 
         return Response(data)

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -161,6 +161,11 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         data = serialize(
             event, request.user, SqlFormatEventSerializer(), include_full_release_data=False
         )
+        
+        # Handle serialization failure gracefully
+        if data is None:
+            return Response({"detail": "Failed to serialize event"}, status=500)
+        
         data["projectSlug"] = project.slug
 
         return Response(data)

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -43,6 +43,11 @@ def wrap_event_response(
         IssueEventSerializer(),
         include_full_release_data=include_full_release_data,
     )
+    
+    # Handle serialization failure gracefully
+    if event_data is None:
+        return None
+    
     # Used for paginating through events of a single issue in group details
     # Skip next/prev for issueless events
     next_event_id = None
@@ -146,6 +151,10 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             start=start,
             end=end,
         )
+        
+        if data is None:
+            return Response({"detail": "Failed to serialize event"}, status=500)
+        
         return Response(data)
 
 

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -43,11 +43,11 @@ def wrap_event_response(
         IssueEventSerializer(),
         include_full_release_data=include_full_release_data,
     )
-    
+
     # Handle serialization failure gracefully
     if event_data is None:
         return None
-    
+
     # Used for paginating through events of a single issue in group details
     # Skip next/prev for issueless events
     next_event_id = None
@@ -151,10 +151,10 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             start=start,
             end=end,
         )
-        
+
         if data is None:
             return Response({"detail": "Failed to serialize event"}, status=500)
-        
+
         return Response(data)
 
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds graceful handling for event/project serialization failures in API endpoints. Previously, `data["key"]` assignments would fail with a `TypeError` if the `serialize` function returned `None`. This PR introduces checks for `None` after serialization and returns a 500 error response with a detail message, preventing crashes and providing clearer API feedback.

**Affected files:**
*   `src/sentry/issues/endpoints/organization_event_details.py`
*   `src/sentry/issues/endpoints/project_event_details.py`

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1180](https://linear.app/getsentry/issue/ID-1180/api-graceful-handling-of-eventproject-serialization-failures)

<a href="https://cursor.com/background-agent?bcId=bc-41aab4c8-90b1-435c-8e45-8f0a34136b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41aab4c8-90b1-435c-8e45-8f0a34136b27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

