### PR TITLE
fix(onboarding): platform Xamarin does not support logs

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -105,7 +105,7 @@ export const platformProductAvailability = {
   'dotnet-maui': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   'dotnet-winforms': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   'dotnet-wpf': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
-  'dotnet-xamarin': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
+  'dotnet-xamarin': [ProductSolution.PERFORMANCE_MONITORING],
   dart: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   kotlin: [ProductSolution.PERFORMANCE_MONITORING],
   go: [

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -394,7 +394,10 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
-export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir', 'dotnet-xamarin']);
+export const withoutLoggingSupport: Set<PlatformKey> = new Set([
+  'elixir',
+  'dotnet-xamarin',
+]);
 
 // List of platforms that have metrics onboarding checklist content
 export const withMetricsOnboarding: Set<PlatformKey> = new Set([

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -315,7 +315,6 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
   'dotnet-maui',
   'dotnet-winforms',
   'dotnet-wpf',
-  'dotnet-xamarin',
   'flutter',
   'go',
   'go-echo',
@@ -395,7 +394,7 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
-export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir']);
+export const withoutLoggingSupport: Set<PlatformKey> = new Set(['elixir', 'dotnet-xamarin']);
 
 // List of platforms that have metrics onboarding checklist content
 export const withMetricsOnboarding: Set<PlatformKey> = new Set([

--- a/static/app/gettingStartedDocs/dotnet-xamarin/index.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/index.tsx
@@ -1,6 +1,5 @@
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {feedback} from 'sentry/gettingStartedDocs/dotnet/feedback';
-import {logs} from 'sentry/gettingStartedDocs/dotnet/logs';
 
 import {crashReport} from './crashReport';
 import {onboarding} from './onboarding';
@@ -9,7 +8,6 @@ const docs: Docs = {
   onboarding,
   feedbackOnboardingCrashApi: feedback,
   crashReportOnboarding: crashReport,
-  logsOnboarding: logs,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.spec.tsx
@@ -14,7 +14,7 @@ describe('xamarin onboarding docs', () => {
           version: '1.99.9',
         },
       },
-      selectedProducts: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
+      selectedProducts: [ProductSolution.PERFORMANCE_MONITORING],
     });
 
     // Renders main headings
@@ -24,7 +24,6 @@ describe('xamarin onboarding docs', () => {
     expect(screen.getByRole('heading', {name: 'Tracing'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Documentation'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Limitations'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Verify Logs'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Samples'})).toBeInTheDocument();
 
     // Renders SDK version from registry

--- a/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.tsx
@@ -194,7 +194,7 @@ export const onboarding: OnboardingConfig = {
       ],
     },
   ],
-  verify: params => [
+  verify: () => [
     {
       type: StepType.VERIFY,
       content: [

--- a/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.tsx
+++ b/static/app/gettingStartedDocs/dotnet-xamarin/onboarding.tsx
@@ -5,7 +5,6 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {logsVerify} from 'sentry/gettingStartedDocs/dotnet/logs';
 import {t, tct} from 'sentry/locale';
 import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
@@ -40,12 +39,6 @@ public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompa
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;`
                 : ''
-            }${
-              params.isLogsSelected
-                ? `
-            // Enable logs to be sent to Sentry
-            options.EnableLogs = true;`
-                : ''
             }
             // If you installed Sentry.Xamarin.Forms:
             options.AddXamarinFormsIntegration();
@@ -67,12 +60,6 @@ public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsAppli
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;`
                 : ''
-            }${
-              params.isLogsSelected
-                ? `
-            // Enable logs to be sent to Sentry
-            options.EnableLogs = true;`
-                : ''
             }
             options.AddXamarinFormsIntegration();
         });`;
@@ -92,12 +79,6 @@ sealed partial class App : Application
             // Set TracesSampleRate to 1.0 to capture 100% of transactions for tracing.
             // We recommend adjusting this value in production.
             options.TracesSampleRate = 1.0;`
-                : ''
-            }${
-              params.isLogsSelected
-                ? `
-            // Enable logs to be sent to Sentry
-            options.EnableLogs = true;`
                 : ''
             }
             options.AddXamarinFormsIntegration();
@@ -261,14 +242,6 @@ export const onboarding: OnboardingConfig = {
         },
       ],
     },
-    ...(params.isLogsSelected
-      ? [
-          {
-            title: t('Verify Logs'),
-            content: [logsVerify(params)],
-          },
-        ]
-      : []),
     {
       title: t('Documentation'),
       content: [


### PR DESCRIPTION
### Summary
Remove Xamarin (`dotnet-xamarin`) from platforms that support Structured Logs.

### Remarks
Follow-up to #104234.

An oversight on my end.
Platform `dotnet-xamarin` does not support logs.

Neither does `dotnet-xamarin` support Metrics.
Related: getsentry/sentry#106551
