### PR TITLE
feat(dashboards): add retry logic to spans and issues dataset queries

### DIFF
--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -36,6 +36,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type ErrorsAndTransactionsSeriesResponse =
   | EventsStats
@@ -228,6 +229,7 @@ export function useErrorsAndTransactionsSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -456,6 +458,7 @@ export function useErrorsAndTransactionsTableQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
     })),
   });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -28,6 +28,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type ErrorsSeriesResponse =
   | EventsStats
@@ -137,6 +138,7 @@ export function useErrorsSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -309,6 +311,7 @@ export function useErrorsTableQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
     })),
   });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -28,6 +28,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type LogsSeriesResponse =
   | EventsStats
@@ -142,6 +143,7 @@ export function useLogsSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -300,6 +302,7 @@ export function useLogsTableQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
     })),
   });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -17,6 +17,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type MobileAppSizeSeriesResponse = EventsStats | MultiSeriesEventsStats;
 
@@ -137,6 +138,7 @@ export function useMobileAppSizeSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
@@ -17,6 +17,7 @@ import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueu
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {applyDashboardFiltersToWidget} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {requiresCustomReleaseSorting} from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 import {getReleasesRequestData} from './utils/releases';
 
@@ -140,6 +141,7 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -332,6 +334,7 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -22,6 +22,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type TraceMetricsSeriesResponse = EventsTimeSeriesResponse;
 type TraceMetricsTableResponse = EventsTableData;
@@ -157,6 +158,7 @@ export function useTraceMetricsSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -333,6 +335,7 @@ export function useTraceMetricsTableQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
     })),
   });
 

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -32,6 +32,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type TransactionsSeriesResponse =
   | EventsStats
@@ -211,6 +212,7 @@ export function useTransactionsSeriesQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
       placeholderData: (previousData: unknown) => previousData,
     })),
   });
@@ -422,6 +424,7 @@ export function useTransactionsTableQuery(
             }
             return false;
           },
+      retryDelay: getRetryDelay,
     })),
   });
 


### PR DESCRIPTION
## Summary
- Adds retry logic for 429 rate limit errors to spans and issues widget queries , was lost in the promise -> hook conversion. This is only when there is no queue because the queue does it's own retry.
- Matches the behavior of other datasets like errors and transactions
- Retries up to 10 times on 429 errors when the `visibility-dashboards-async-queue` feature is not enabled
- Add retry delay where missing

## Test plan
- Existing tests pass
- Manual testing on dashboards with spans and issues widgets under rate limiting conditions