### PR TITLE
chore(autofix): Use low intelligence level for autofix by default

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -135,7 +135,7 @@ def trigger_autofix_explorer(
     step: AutofixStep,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "high",
+    intelligence_level: Literal["low", "medium", "high"] = "low",
 ) -> int:
     """
     Start or continue an Explorer-based autofix run.

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -101,7 +101,7 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
     intelligence_level = serializers.ChoiceField(
         required=False,
         choices=["low", "medium", "high"],
-        default="high",
+        default="low",
         help_text="The intelligence level to use.",
     )
 


### PR DESCRIPTION
Low intelligence level gives a better balance of results vs cost.