### PR TITLE
ref(buttonbar) fix dropdownmenu support

### DIFF
--- a/static/app/components/actions/archive.tsx
+++ b/static/app/components/actions/archive.tsx
@@ -299,7 +299,7 @@ function ArchiveActions({
 
   return (
     <ButtonBar merged gap="0">
-      <ArchiveButton
+      <Button
         size={size}
         className={className}
         tooltipProps={{delay: 1000, disabled, isHoverable: true}}
@@ -315,13 +315,13 @@ function ArchiveActions({
         disabled={disabled}
       >
         {t('Archive')}
-      </ArchiveButton>
+      </Button>
       <DropdownMenu
         size="sm"
         className={className}
         minMenuWidth={270}
         trigger={(triggerProps, isOpen) => (
-          <DropdownTrigger
+          <Button
             {...triggerProps}
             aria-label={t('Archive options')}
             size={size}
@@ -347,17 +347,6 @@ function ArchiveActions({
 }
 
 export default ArchiveActions;
-
-const ArchiveButton = styled(Button)`
-  box-shadow: none;
-  border-radius: ${p => p.theme.radius.md} 0 0 ${p => p.theme.radius.md};
-`;
-
-const DropdownTrigger = styled(Button)`
-  box-shadow: none;
-  border-radius: 0 ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0;
-  border-left: none;
-`;
 
 const StyledExternalLink = styled(ExternalLink)`
   font-weight: ${p => p.theme.font.weight.sans.regular};

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -289,7 +289,7 @@ function ResolveActions({
         itemsHidden={shouldDisplayCta}
         items={items}
         trigger={(triggerProps, isOpen) => (
-          <DropdownTrigger
+          <Button
             {...triggerProps}
             size={size}
             priority={priority}
@@ -350,7 +350,7 @@ function ResolveActions({
   return (
     <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
       <ButtonBar merged gap="0">
-        <ResolveButton
+        <Button
           priority={priority}
           size={size}
           title={t("We'll nag you with a notification if another event is seen.")}
@@ -371,7 +371,7 @@ function ResolveActions({
           disabled={disabled}
         >
           {t('Resolve')}
-        </ResolveButton>
+        </Button>
         {!disableResolveInRelease && renderDropdownMenu()}
       </ButtonBar>
     </Tooltip>
@@ -379,16 +379,6 @@ function ResolveActions({
 }
 
 export default ResolveActions;
-
-const ResolveButton = styled(Button)`
-  box-shadow: none;
-`;
-
-const DropdownTrigger = styled(Button)`
-  box-shadow: none;
-  border-radius: 0 ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0;
-  border-left: none;
-`;
 
 /**
  * Used to hide the list items when prompting to set up releases

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -1,8 +1,6 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {StyledButton} from '@sentry/scraps/button';
-
 import type {SpaceSize} from 'sentry/utils/theme';
 
 interface ButtonBarProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className'> {
@@ -39,6 +37,7 @@ const MergedButtonBarStyles = () => css`
     z-index: 2;
   }
 
+  & > [role='presentation'],
   & > .dropdown,
   & > button,
   & > input,
@@ -50,38 +49,29 @@ const MergedButtonBarStyles = () => css`
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
 
-      & > .dropdown-actor > ${StyledButton} {
+      & > .dropdown-actor > button {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
       }
     }
 
     /* Middle buttons are square */
-    &:not(:last-child):not(:first-child) {
+    &:not(:last-child):not(:first-child),
+    &[role='presentation']:not(:last-child):not(:first-child) > button {
       border-radius: 0;
 
-      & > .dropdown-actor > ${StyledButton} {
+      & > .dropdown-actor > button {
         border-radius: 0;
       }
     }
 
     /* Middle buttons only need one border so we don't get a double line */
     &:first-child {
+      & + [role='presentation'] > button,
       & + .dropdown:not(:last-child),
       & + a:not(:last-child),
       & + input:not(:last-child),
       & + button:not(:last-child) {
-        margin-left: -1px;
-      }
-    }
-
-    /* Middle buttons only need one border so we don't get a double line */
-    /* stylelint-disable-next-line no-duplicate-selectors */
-    &:not(:last-child):not(:first-child) {
-      & + .dropdown,
-      & + button,
-      & + input,
-      & + a {
         margin-left: -1px;
       }
     }
@@ -92,7 +82,8 @@ const MergedButtonBarStyles = () => css`
       border-bottom-left-radius: 0;
       margin-left: -1px;
 
-      & > .dropdown-actor > ${StyledButton} {
+      & > .dropdown-actor > button,
+      &[role='presentation'] > button {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         margin-left: -1px;

--- a/static/app/components/core/button/buttonBar.tsx
+++ b/static/app/components/core/button/buttonBar.tsx
@@ -57,7 +57,8 @@ const MergedButtonBarStyles = () => css`
 
     /* Middle buttons are square */
     &:not(:last-child):not(:first-child),
-    &[role='presentation']:not(:last-child):not(:first-child) > button {
+    &:not(:last-child):not(:first-child)[role='presentation'] > button,
+    &:not(:last-child):not(:first-child)[role='presentation'] > a {
       border-radius: 0;
 
       & > .dropdown-actor > button {
@@ -66,14 +67,13 @@ const MergedButtonBarStyles = () => css`
     }
 
     /* Middle buttons only need one border so we don't get a double line */
-    &:first-child {
-      & + [role='presentation'] > button,
-      & + .dropdown:not(:last-child),
-      & + a:not(:last-child),
-      & + input:not(:last-child),
-      & + button:not(:last-child) {
-        margin-left: -1px;
-      }
+    & + [role='presentation'] > button,
+    & + [role='presentation'] > a,
+    & + .dropdown:not(:last-child),
+    & + a:not(:last-child),
+    & + input:not(:last-child),
+    & + button:not(:last-child) {
+      margin-left: -1px;
     }
 
     /* Last button is square on the left side */
@@ -82,8 +82,9 @@ const MergedButtonBarStyles = () => css`
       border-bottom-left-radius: 0;
       margin-left: -1px;
 
-      & > .dropdown-actor > button,
-      &[role='presentation'] > button {
+      &[role='presentation'] > button,
+      &[role='presentation'] > a,
+      & > .dropdown-actor > button {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
         margin-left: -1px;


### PR DESCRIPTION
Fix ButtoBar styling so that it supports DropdownMenu children. The reason this didn't work was because dropdownmenu creates a wrapper with display:contents which breaks the > child CSS rules that ButtonBar relies on

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>5b4a28f</u></sup><!-- /BUGBOT_STATUS -->