### PR TITLE
fix(seer): Respect enable_seer_enhanced_alerts option in Slack entrypoint

### DIFF
--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from slack_sdk.models.blocks.blocks import Block
 
 from sentry import features
-from sentry.constants import ENABLE_SEER_CODING_DEFAULT, ObjectStatus
+from sentry.constants import (
+    ENABLE_SEER_CODING_DEFAULT,
+    ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
+    ObjectStatus,
+)
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.locks import locks
@@ -96,7 +100,10 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
     def has_access(organization: Organization) -> bool:
         has_feature_flag = features.has("organizations:seer-slack-workflows", organization)
         has_enhanced_alerts = bool(
-            organization.get_option("sentry:enable_seer_enhanced_alerts", default=True)
+            organization.get_option(
+                "sentry:enable_seer_enhanced_alerts",
+                default=ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
+            )
         )
         return has_feature_flag and has_enhanced_alerts
 

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -94,7 +94,11 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
-        return features.has("organizations:seer-slack-workflows", organization)
+        has_feature_flag = features.has("organizations:seer-slack-workflows", organization)
+        has_enhanced_alerts = bool(
+            organization.get_option("sentry:enable_seer_enhanced_alerts", default=True)
+        )
+        return has_feature_flag and has_enhanced_alerts
 
     @staticmethod
     def get_group_link(group: Group) -> str:

--- a/tests/sentry/seer/entrypoints/integrations/test_slack.py
+++ b/tests/sentry/seer/entrypoints/integrations/test_slack.py
@@ -68,10 +68,14 @@ class SlackEntrypointTest(TestCase):
         )
 
     def test_has_access(self):
-        with self.feature("organizations:seer-slack-workflows"):
-            assert SlackEntrypoint.has_access(self.organization)
         with self.feature({"organizations:seer-slack-workflows": False}):
             assert not SlackEntrypoint.has_access(self.organization)
+        with self.feature("organizations:seer-slack-workflows"):
+            assert SlackEntrypoint.has_access(self.organization)
+            self.organization.update_option("sentry:enable_seer_enhanced_alerts", False)
+            assert not SlackEntrypoint.has_access(self.organization)
+            self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
+            assert SlackEntrypoint.has_access(self.organization)
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_autofix_error(self, mock_send_threaded_ephemeral_message):


### PR DESCRIPTION
Check the organization's `sentry:enable_seer_enhanced_alerts` option in addition to the feature flag when determining Slack entrypoint access.

Refs ISWF-2007