### PR TITLE
fix(spans-migration): add validation to not update alerts to transactions or generic_metrics

### DIFF
--- a/src/sentry/explore/translation/alerts_translation.py
+++ b/src/sentry/explore/translation/alerts_translation.py
@@ -118,7 +118,10 @@ def translate_detector_and_update_subscription_in_snuba(snuba_query: SnubaQuery)
         logger.info("No snapshot created for snuba query %s", snuba_query.id)
         return
 
-    if snapshot.get("user_updated"):
+    if (
+        snapshot.get("user_updated")
+        and snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value
+    ):
         logger.info(
             "Skipping roll forward for user-updated query", extra={"snuba_query_id": snuba_query.id}
         )

--- a/src/sentry/incidents/metric_issue_detector.py
+++ b/src/sentry/incidents/metric_issue_detector.py
@@ -268,12 +268,22 @@ class MetricIssueDetectorValidator(BaseDetectorTypeValidator):
     def is_editing_transaction_dataset(
         self, snuba_query: SnubaQuery, data_source: SnubaQueryDataSourceType
     ) -> bool:
-        if data_source.get("dataset") in [Dataset.PerformanceMetrics, Dataset.Transactions] and (
-            data_source.get("dataset", Dataset(snuba_query.dataset)) != Dataset(snuba_query.dataset)
-            or data_source.get("query", snuba_query.query) != snuba_query.query
-            or data_source.get("aggregate", snuba_query.aggregate) != snuba_query.aggregate
-            or data_source.get("time_window", snuba_query.time_window) != snuba_query.time_window
-            or data_source.get("event_types", snuba_query.event_types) != snuba_query.event_types
+        organization = self.context.get("organization")
+        current_dataset = Dataset(snuba_query.dataset)
+        new_dataset = data_source.get("dataset", current_dataset)
+
+        if (
+            features.has("organizations:discover-saved-queries-deprecation", organization)
+            and new_dataset in [Dataset.PerformanceMetrics, Dataset.Transactions]
+            and (
+                new_dataset != current_dataset
+                or data_source.get("query", snuba_query.query) != snuba_query.query
+                or data_source.get("aggregate", snuba_query.aggregate) != snuba_query.aggregate
+                or data_source.get("time_window", snuba_query.time_window)
+                != snuba_query.time_window
+                or data_source.get("event_types", snuba_query.event_types)
+                != snuba_query.event_types
+            )
         ):
             return True
         return False

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -9,6 +9,7 @@ from parsimonious.exceptions import ParseError
 from rest_framework import serializers
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
+from sentry import features
 from sentry.api.exceptions import BadRequest, RequestTimeout
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
@@ -151,6 +152,17 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             aggregate = data.get("aggregate")
             validate_trace_metrics_aggregate(aggregate)
 
+    def validate_deprecated_transactions_datasets(self, data):
+        new_dataset = data.get("dataset")
+        organization = self.context.get("organization")
+        if organization and features.has(
+            "organizations:discover-saved-queries-deprecation", organization
+        ):
+            if new_dataset in [Dataset.Transactions, Dataset.PerformanceMetrics]:
+                raise serializers.ValidationError(
+                    "Updating transaction-based alerts is disabled as we migrate to the spans dataset. Update the dataset to events_analytics_platform with the is_transaction:true filter instead."
+                )
+
     def validate(self, data):
         """
         Performs validation on an alert rule's data.
@@ -162,6 +174,8 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
         data = super().validate(data)
         if data.get("dataset") == Dataset.EventsAnalyticsPlatform:
             self.validate_eap_rule(data)
+
+        self.validate_deprecated_transactions_datasets(data)
 
         triggers = data.get("triggers", [])
         if not triggers:

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -1443,6 +1443,52 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         ):
             update_validator.save()
 
+    @with_feature("organizations:mep-rollout-flag")
+    def test_transaction_dataset_deprecation_update_to_transactions(self) -> None:
+        data = {
+            **self.valid_data,
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                    "dataset": Dataset.EventsAnalyticsPlatform.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()],
+                },
+            ],
+        }
+        validator = MetricIssueDetectorValidator(data=data, context=self.context)
+        assert validator.is_valid(), validator.errors
+        detector = validator.save()
+
+        update_data = {
+            "dataSources": [
+                {
+                    "queryType": SnubaQuery.Type.PERFORMANCE.value,
+                    "dataset": Dataset.Transactions.value,
+                    "query": "test query",
+                    "aggregate": "count()",
+                    "timeWindow": 3600,
+                    "environment": self.environment.name,
+                    "eventTypes": [SnubaQueryEventType.EventType.TRANSACTION.name.lower()],
+                }
+            ],
+        }
+        update_validator = MetricIssueDetectorValidator(
+            instance=detector, data=update_data, context=self.context, partial=True
+        )
+        assert update_validator.is_valid(), update_validator.errors
+        with (
+            self.assertRaisesMessage(
+                ValidationError,
+                expected_message="Updates to transaction-based alerts is disabled, as we migrate to the span dataset. Create span-based alerts (dataset: events_analytics_platform) with the is_transaction:true filter instead.",
+            ),
+            with_feature("organizations:discover-saved-queries-deprecation"),
+        ):
+            update_validator.save()
+
     def test_invalid_extrapolation_mode_create(self) -> None:
         data = {
             **self.valid_data,


### PR DESCRIPTION
had a few cases where orgs were making updates to their migrated transaction alerts via some automated update call which ended up migrating them back to the transactions dataset. We're making sure that updates to alerts like this raise an error.

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 2 potential issues for commit <u>20bb86a</u></sup><!-- /BUGBOT_STATUS -->