### PR TITLE
fix(ACI): Update customer facing automation text to alert

### DIFF
--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -54,15 +54,15 @@ export function AutomationsTableActions({
   const getEnableConfirmMessage = useCallback(() => {
     if (allInQuerySelected) {
       return tct(
-        'Are you sure you want to enable all [queryCount] automations that match the search?',
+        'Are you sure you want to enable all [queryCount] alerts that match the search?',
         {
           queryCount,
         }
       );
     }
     return tn(
-      `Are you sure you want to enable this %s automation?`,
-      `Are you sure you want to enable these %s automations?`,
+      `Are you sure you want to enable this %s alert?`,
+      `Are you sure you want to enable these %s alerts?`,
       selected.size
     );
   }, [allInQuerySelected, queryCount, selected.size]);
@@ -70,15 +70,15 @@ export function AutomationsTableActions({
   const getDisableConfirmMessage = useCallback(() => {
     if (allInQuerySelected) {
       return tct(
-        'Are you sure you want to disable all [queryCount] automations that match the search?',
+        'Are you sure you want to disable all [queryCount] alerts that match the search?',
         {
           queryCount,
         }
       );
     }
     return tn(
-      `Are you sure you want to disable this %s automation?`,
-      `Are you sure you want to disable these %s automations?`,
+      `Are you sure you want to disable this %s alert?`,
+      `Are you sure you want to disable these %s alerts?`,
       selected.size
     );
   }, [allInQuerySelected, queryCount, selected.size]);


### PR DESCRIPTION
I noticed this modal that uses the old terminology so I updated it to say alerts. 

<img width="610" height="158" alt="Screenshot 2026-02-04 at 1 34 54 PM" src="https://github.com/user-attachments/assets/a3605dda-6600-4aef-92ea-aa89f9e2065f" />

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>9ae528d</u></sup><!-- /BUGBOT_STATUS -->