### PR TITLE
fix(llm-detector): Add `org_slug` to Seer request

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -96,6 +96,7 @@ class IssueDetectionRequest(BaseModel):
     traces: list[TraceMetadata]
     organization_id: int
     project_id: int
+    org_slug: str
 
 
 def get_base_platform(platform: str | None) -> str | None:
@@ -244,6 +245,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     project = Project.objects.get_from_cache(id=project_id)
     organization = project.organization
     organization_id = organization.id
+    organization_slug = organization.slug
 
     has_access = features.has("organizations:gen-ai-features", organization) and not bool(
         organization.get_option("sentry:hide_ai_features")
@@ -285,6 +287,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         traces=traces_to_send,
         organization_id=organization_id,
         project_id=project_id,
+        org_slug=organization_slug,
     )
 
     response = make_signed_seer_api_request(


### PR DESCRIPTION
need the org_slug for the verification stage

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>100b5e8</u></sup><!-- /BUGBOT_STATUS -->