### PR TITLE
ref(dashboards): Improve categorical series types and structure

### DIFF
--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatXAxisValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatXAxisValue.spec.tsx
@@ -1,0 +1,42 @@
+import {formatXAxisValue} from './formatXAxisValue';
+
+describe('formatXAxisValue', () => {
+  it('returns "(empty)" for null values', () => {
+    expect(formatXAxisValue(null)).toBe('(empty)');
+  });
+
+  it('returns string values unchanged', () => {
+    expect(formatXAxisValue('Chrome')).toBe('Chrome');
+    expect(formatXAxisValue('/api/users')).toBe('/api/users');
+    expect(formatXAxisValue('')).toBe('');
+  });
+
+  it('formats number values with locale string', () => {
+    expect(formatXAxisValue(42)).toBe('42');
+    expect(formatXAxisValue(1000)).toBe('1,000');
+    // toLocaleString() uses default precision (typically 3 decimal places)
+    expect(formatXAxisValue(3.14159)).toBe('3.142');
+  });
+
+  it('formats boolean values as strings', () => {
+    expect(formatXAxisValue(true)).toBe('true');
+    expect(formatXAxisValue(false)).toBe('false');
+  });
+
+  it('formats string arrays by joining with comma', () => {
+    expect(formatXAxisValue(['Chrome', 'Firefox'])).toBe('Chrome, Firefox');
+    expect(formatXAxisValue(['single'])).toBe('single');
+    expect(formatXAxisValue([])).toBe('');
+  });
+
+  it('handles null values within string arrays', () => {
+    // Test defensive handling of unexpected null values in arrays
+    // (TypeScript types don't allow this, but runtime data might have it)
+    expect(formatXAxisValue(['Chrome', null, 'Safari'] as string[])).toBe(
+      'Chrome, (empty), Safari'
+    );
+    expect(formatXAxisValue([null, null] as unknown as string[])).toBe(
+      '(empty), (empty)'
+    );
+  });
+});

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatXAxisValue.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatXAxisValue.tsx
@@ -1,0 +1,42 @@
+import {t} from 'sentry/locale';
+import type {CategoricalItemCategory} from 'sentry/views/dashboards/widgets/common/types';
+
+/**
+ * Format a category value for display on the X axis of a categorical chart.
+ *
+ * This function converts the raw category value (which can be various types
+ * from a TabularRow) into a string suitable for display. This is analogous
+ * to how formatYAxisValue handles numeric values for the Y axis.
+ *
+ * Note: Truncation should be handled separately by the caller (e.g., using
+ * truncationFormatter) since different contexts may need different truncation.
+ *
+ * @param value The raw category value from a CategoricalItem
+ * @returns A string representation suitable for display
+ */
+export function formatXAxisValue(value: CategoricalItemCategory): string {
+  if (value === null || value === undefined) {
+    return t('(empty)');
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value.toLocaleString();
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  if (Array.isArray(value)) {
+    // For string arrays, join with comma
+    // Filter out null values and format each element
+    return value.map(item => (item === null ? t('(empty)') : String(item))).join(', ');
+  }
+
+  // Fallback for any unexpected types
+  return String(value);
+}

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/bars.tsx
@@ -4,6 +4,7 @@ import type {BarSeriesOption, LineSeriesOption} from 'echarts';
 
 import barSeries from 'sentry/components/charts/series/barSeries';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import {formatXAxisValue} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatXAxisValue';
 import type {
   CategoricalItem,
   CategoricalSeries,
@@ -92,10 +93,12 @@ export class Bars
         itemStyle: {
           opacity: 1.0,
         },
-        data: this.categoricalSeries.values.map(item => ({
-          name: item.category,
-          value: item.value,
-        })),
+        data: this.categoricalSeries.values.map(item =>
+          // This name must match with the `data` setting of the `xAxis` config
+          // in ECharts. ECharts wants both a full list of the categories for
+          // the X axis, and for the series data points to specify the name.
+          [formatXAxisValue(item.category), item.value]
+        ),
       }),
     ];
   }

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/categoricalDataSeries.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/categoricalDataSeries.tsx
@@ -4,11 +4,15 @@ import type {SeriesOption} from 'echarts';
 import type {DataUnit} from 'sentry/utils/discover/fields';
 import {formatCategoricalSeriesLabel} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesLabel';
 import {formatCategoricalSeriesName} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesName';
+import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/categoricalSeriesWidget/settings';
+import {PLOTTABLE_TIME_SERIES_VALUE_TYPES} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   CategoricalItem,
+  CategoricalItemCategory,
   CategoricalSeries,
-  CategoricalValueType,
 } from 'sentry/views/dashboards/widgets/common/types';
+
+import type {PlottableCategoricalValueType} from './plottable';
 
 export type CategoricalDataSeriesConfig = {
   /**
@@ -102,9 +106,18 @@ export abstract class CategoricalDataSeries<
 
   /**
    * The type of values in this series (e.g., "duration", "number").
+   * Constrained to plottable types - defaults to fallback type for unsupported types.
    */
-  get dataType(): CategoricalValueType {
-    return this.categoricalSeries.meta.valueType;
+  get dataType(): PlottableCategoricalValueType {
+    const valueType = this.categoricalSeries.meta.valueType;
+    if (
+      PLOTTABLE_TIME_SERIES_VALUE_TYPES.includes(
+        valueType as PlottableCategoricalValueType
+      )
+    ) {
+      return valueType as PlottableCategoricalValueType;
+    }
+    return FALLBACK_TYPE;
   }
 
   /**
@@ -115,9 +128,9 @@ export abstract class CategoricalDataSeries<
   }
 
   /**
-   * The category labels for all data points in this series.
+   * The raw category values for all data points in this series.
    */
-  get categories(): string[] {
+  get categories(): CategoricalItemCategory[] {
     return this.categoricalSeries.values.map(item => item.category);
   }
 

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/plottable.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/plottables/plottable.tsx
@@ -2,7 +2,16 @@ import type {SeriesOption} from 'echarts';
 
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {DataUnit} from 'sentry/utils/discover/fields';
-import type {CategoricalValueType} from 'sentry/views/dashboards/widgets/common/types';
+import type {PLOTTABLE_TIME_SERIES_VALUE_TYPES} from 'sentry/views/dashboards/widgets/common/settings';
+import type {CategoricalItemCategory} from 'sentry/views/dashboards/widgets/common/types';
+
+/**
+ * The constrained set of value types that can be plotted in a categorical chart.
+ * This mirrors PlottableTimeSeriesValueType - the plottable layer constrains
+ * what types are actually renderable, even though the data layer accepts any type.
+ */
+export type PlottableCategoricalValueType =
+  (typeof PLOTTABLE_TIME_SERIES_VALUE_TYPES)[number];
 
 /**
  * A `CategoricalPlottable` is any object that can be converted to an ECharts
@@ -13,13 +22,15 @@ import type {CategoricalValueType} from 'sentry/views/dashboards/widgets/common/
  */
 export interface CategoricalPlottable {
   /**
-   * The category labels for this plottable's data points.
+   * The raw category values for this plottable's data points.
+   * Use formatXAxisValue() to convert to display strings.
    */
-  categories: string[];
+  categories: CategoricalItemCategory[];
   /**
    * Type of the underlying data (e.g., "duration", "number").
+   * Constrained to plottable types only.
    */
-  dataType: CategoricalValueType;
+  dataType: PlottableCategoricalValueType;
   /**
    * Unit of the underlying data (e.g., "millisecond"), or null if unitless.
    */

--- a/static/app/views/dashboards/widgets/common/types.tsx
+++ b/static/app/views/dashboards/widgets/common/types.tsx
@@ -1,7 +1,6 @@
 import type {Confidence} from 'sentry/types/organization';
 import type {DataUnit} from 'sentry/utils/discover/fields';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds';
-import type {PLOTTABLE_TIME_SERIES_VALUE_TYPES} from 'sentry/views/dashboards/widgets/common/settings';
 
 type AttributeValueType =
   | 'number'
@@ -108,10 +107,11 @@ export type TabularMeta<TFields extends string = string> = {
   fields: Record<TFields, TabularValueType>;
   units: Record<TFields, TabularValueUnit>;
 };
+type TabularRowValue = number | string | string[] | boolean | null;
 
 export type TabularRow<TFields extends string = string> = Record<
   TFields,
-  number | string | string[] | boolean | null
+  TabularRowValue
 >;
 
 export type TabularData<TFields extends string = string> = {
@@ -148,10 +148,18 @@ export type LegendSelection = Record<string, boolean>;
 
 /**
  * The type of values in a categorical series.
- * This is the same set of types supported by time series, but defined locally
- * to avoid coupling to time series widgets.
+ * This is the broadest set of types supported - any value type that can come
+ * from the API. The plottable layer constrains this to plottable types.
  */
-export type CategoricalValueType = (typeof PLOTTABLE_TIME_SERIES_VALUE_TYPES)[number];
+type CategoricalValueType = AttributeValueType;
+
+/**
+ * The type of a category in a categorical series.
+ * Matches the possible values in a TabularRow, since the source data is from
+ * the same endpoint
+ */
+export type CategoricalItemCategory = TabularRowValue;
+type CategoricalItemValue = number | null;
 
 /**
  * A single item in a categorical bar chart series.
@@ -160,11 +168,11 @@ export interface CategoricalItem {
   /**
    * The category value for this data point.
    */
-  category: string;
+  category: CategoricalItemCategory;
   /**
    * The numeric value for this category.
    */
-  value: number | null;
+  value: CategoricalItemValue;
 }
 
 /**


### PR DESCRIPTION
A few improvements to the types and code around categorical bar charts.

The main change is that I'm loosening the types around categorical data itself. Right now, the category can only be a string according to the types, but that's a bit too tight. Tabular data can return any kind of thing, and categorical data is just tabular data re-arranged. In this PR, I make it so that category and value are much looser, and corresponding to the incoming data rather than what can be plotted on the chart.

As a consequence of that, the type for what can actually be plotted is moved out to the categorical plottables, after all they decide what can be plotted! Handling for formatting these new looser category values as strings is moved into a formatting function.

This creates a pleasant symmetry between categorical and time series charts, now they have the same approach for how to handle different data types. It also makes converting between tabular data and categorical data simpler, which will come in handy soon.

The quirk is that ECharts needs all the categories to be strings even before formatting is applied, so we have to run X axis formatting on the data in `Bars` rather than in the X axis configuration. Alas!

Last important change is using the `[category, value]` format instead of `{name: category, value: value}` format in output of `toSeries`. The former is more robust and allows ECharts to correctly assign points to categories regardless of order. This is _very_ important in cases where different plottables have different categories! Otherwise ECharts will silently put points on the wrong categories which is ... catastrophically fucked up

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>acafc7a</u></sup><!-- /BUGBOT_STATUS -->