### PR TITLE
feat(dashboards): support linked dashboards in legend breakdown

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -3,8 +3,6 @@ import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import partial from 'lodash/partial';
-import pick from 'lodash/pick';
-import * as qs from 'query-string';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
@@ -23,7 +21,6 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import {RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
-import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import UserMisery from 'sentry/components/userMisery';
 import Version from 'sentry/components/version';
 import {IconDownload} from 'sentry/icons';
@@ -51,7 +48,6 @@ import {
 } from 'sentry/utils/discover/fields';
 import ViewReplayLink from 'sentry/utils/discover/viewReplayLink';
 import {getShortEventId} from 'sentry/utils/events';
-import {FieldKind} from 'sentry/utils/fields';
 import {formatRate} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {formatApdex} from 'sentry/utils/number/formatApdex';
@@ -61,12 +57,11 @@ import toPercent from 'sentry/utils/number/toPercent';
 import Projects from 'sentry/utils/projects';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {isUrl} from 'sentry/utils/string/isUrl';
+import {type DashboardFilters, type Widget} from 'sentry/views/dashboards/types';
 import {
-  DashboardFilterKeys,
-  type DashboardFilters,
-  type GlobalFilter,
-  type Widget,
-} from 'sentry/views/dashboards/types';
+  findLinkedDashboardForField,
+  getLinkedDashboardUrl,
+} from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
 import {QuickContextHoverWrapper} from 'sentry/views/discover/table/quickContext/quickContextWrapper';
 import {ContextType} from 'sentry/views/discover/table/quickContext/utils';
 import type {TraceItemDetailsMeta} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -1423,68 +1418,32 @@ function getDashboardUrl(
   dashboardFilters: DashboardFilters | undefined = undefined
 ) {
   const {organization, location, projects} = baggage;
-  if (widget?.widgetType && dashboardFilters) {
-    // Table widget only has one query
-    const dashboardLink = widget.queries[0]?.linkedDashboards?.find(
-      linkedDashboard => linkedDashboard.field === field
-    );
-    if (dashboardLink && dashboardLink.dashboardId !== '-1') {
-      const datasetsToApplyFiltersTo = [
-        widget.widgetType,
-        ...(dashboardLink.additionalGlobalFilterDatasetTargets ?? []),
-      ];
+  if (!widget?.widgetType || !dashboardFilters) {
+    return undefined;
+  }
 
-      const newTemporaryFilters: GlobalFilter[] = [
-        ...(dashboardFilters[DashboardFilterKeys.GLOBAL_FILTER] ?? []),
-      ].filter(
-        filter =>
-          Boolean(filter.value) &&
-          !(filter.tag.key === field && datasetsToApplyFiltersTo.includes(filter.dataset))
-      );
+  const linkedDashboard = findLinkedDashboardForField(widget.queries[0], field);
+  if (!linkedDashboard) {
+    return undefined;
+  }
 
-      // Format the value as a proper filter condition string
-      const mutableSearch = new MutableSearch('');
-      const formattedValue = mutableSearch
-        .addFilterValueList(field, [data[field]])
-        .toString();
-
-      datasetsToApplyFiltersTo.forEach(dataset => {
-        newTemporaryFilters.push({
-          dataset,
-          tag: {key: field, name: field, kind: FieldKind.TAG},
-          value: formattedValue,
-          isTemporary: true,
-        });
-      });
-
-      // Preserve project, environment, and time range query params
-      const filterParams = pick(location.query, [
-        'release',
-        'environment',
-        'project',
-        'statsPeriod',
-        'start',
-        'end',
-      ]);
-
-      if ('project' in data) {
-        const projectId = projects?.find(project => project.slug === data.project)?.id;
-        if (projectId) {
-          filterParams.project = projectId;
-        }
-      }
-
-      const url = `/organizations/${organization.slug}/dashboard/${dashboardLink.dashboardId}/?${qs.stringify(
-        {
-          [DashboardFilterKeys.GLOBAL_FILTER]: newTemporaryFilters.map(filter =>
-            JSON.stringify(filter)
-          ),
-          ...filterParams,
-        }
-      )}`;
-
-      return url;
+  // Get project ID override from data if available
+  let projectIdOverride: string | number | undefined;
+  if ('project' in data) {
+    const projectId = projects?.find(project => project.slug === data.project)?.id;
+    if (projectId) {
+      projectIdOverride = projectId;
     }
   }
-  return undefined;
+
+  return getLinkedDashboardUrl({
+    linkedDashboard,
+    organizationSlug: organization.slug,
+    field,
+    value: data[field],
+    widgetType: widget.widgetType,
+    dashboardFilters,
+    locationQuery: location.query,
+    projectIdOverride,
+  });
 }

--- a/static/app/views/dashboards/utils/getLinkedDashboardUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getLinkedDashboardUrl.spec.tsx
@@ -48,7 +48,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -80,7 +80,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedNewFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -95,7 +95,7 @@ describe('getLinkedDashboardUrl', () => {
         {
           dataset: WidgetType.SPANS,
           tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-          value: 'browser.name:Firefox',
+          value: 'browser.name:[Firefox]',
           isTemporary: true,
         },
       ],
@@ -112,7 +112,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -139,7 +139,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -163,7 +163,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -190,14 +190,14 @@ describe('getLinkedDashboardUrl', () => {
     const expectedSpansFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
     const expectedErrorsFilter: GlobalFilter = {
       dataset: WidgetType.ERRORS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -224,21 +224,21 @@ describe('getLinkedDashboardUrl', () => {
     const expectedSpansFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
     const expectedErrorsFilter: GlobalFilter = {
       dataset: WidgetType.ERRORS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
     const expectedTransactionsFilter: GlobalFilter = {
       dataset: WidgetType.TRANSACTIONS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:Chrome',
+      value: 'browser.name:[Chrome]',
       isTemporary: true,
     };
 
@@ -258,7 +258,7 @@ describe('getLinkedDashboardUrl', () => {
     const expectedFilter: GlobalFilter = {
       dataset: WidgetType.SPANS,
       tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
-      value: 'browser.name:"Chrome \\"Browser\\""',
+      value: 'browser.name:["Chrome \\"Browser\\""]',
       isTemporary: true,
     };
 

--- a/static/app/views/dashboards/utils/getLinkedDashboardUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getLinkedDashboardUrl.spec.tsx
@@ -1,0 +1,269 @@
+import {FieldKind} from 'sentry/utils/fields';
+import type {
+  DashboardFilters,
+  GlobalFilter,
+  LinkedDashboard,
+} from 'sentry/views/dashboards/types';
+import {DashboardFilterKeys, WidgetType} from 'sentry/views/dashboards/types';
+import {getLinkedDashboardUrl} from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
+
+describe('getLinkedDashboardUrl', () => {
+  const organizationSlug = 'test-org';
+
+  const linkedDashboard: LinkedDashboard = {
+    dashboardId: '123',
+    field: 'browser.name',
+  };
+
+  it('returns undefined for invalid dashboard ID', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard: {dashboardId: '', field: 'browser.name'},
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for placeholder dashboard ID', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard: {dashboardId: '-1', field: 'browser.name'},
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns a URL with temporary global filter for the field value', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+    });
+
+    const expectedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedFilter))}`
+    );
+  });
+
+  it('preserves existing global filters', () => {
+    const existingFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'environment', name: 'environment', kind: FieldKind.TAG},
+      value: 'environment:production',
+      isTemporary: false,
+    };
+
+    const dashboardFilters: DashboardFilters = {
+      [DashboardFilterKeys.GLOBAL_FILTER]: [existingFilter],
+    };
+
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      dashboardFilters,
+    });
+
+    const expectedNewFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(existingFilter))}&${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedNewFilter))}`
+    );
+  });
+
+  it('removes duplicate filters for the same field and dataset', () => {
+    const dashboardFilters: DashboardFilters = {
+      [DashboardFilterKeys.GLOBAL_FILTER]: [
+        {
+          dataset: WidgetType.SPANS,
+          tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+          value: 'browser.name:Firefox',
+          isTemporary: true,
+        },
+      ],
+    };
+
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      dashboardFilters,
+    });
+
+    const expectedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedFilter))}`
+    );
+  });
+
+  it('preserves page filter params from location query', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      locationQuery: {
+        project: '1',
+        environment: 'production',
+        statsPeriod: '7d',
+        release: '1.0.0',
+        unrelatedParam: 'should-be-ignored',
+      },
+    });
+
+    const expectedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?environment=production&${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedFilter))}&project=1&release=1.0.0&statsPeriod=7d`
+    );
+  });
+
+  it('overrides project with projectIdOverride', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      locationQuery: {
+        project: '1',
+      },
+      projectIdOverride: '999',
+    });
+
+    const expectedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedFilter))}&project=999`
+    );
+  });
+
+  it('applies filters to additional dataset targets', () => {
+    const linkedDashboardWithTargets: LinkedDashboard = {
+      dashboardId: '123',
+      field: 'browser.name',
+      additionalGlobalFilterDatasetTargets: [WidgetType.ERRORS],
+    };
+
+    const result = getLinkedDashboardUrl({
+      linkedDashboard: linkedDashboardWithTargets,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      widgetType: WidgetType.SPANS,
+    });
+
+    const expectedSpansFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    const expectedErrorsFilter: GlobalFilter = {
+      dataset: WidgetType.ERRORS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedSpansFilter))}&${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedErrorsFilter))}`
+    );
+  });
+
+  it('applies filters to multiple additional dataset targets', () => {
+    const linkedDashboardWithTargets: LinkedDashboard = {
+      dashboardId: '123',
+      field: 'browser.name',
+      additionalGlobalFilterDatasetTargets: [WidgetType.ERRORS, WidgetType.TRANSACTIONS],
+    };
+
+    const result = getLinkedDashboardUrl({
+      linkedDashboard: linkedDashboardWithTargets,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome',
+      widgetType: WidgetType.SPANS,
+    });
+
+    const expectedSpansFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    const expectedErrorsFilter: GlobalFilter = {
+      dataset: WidgetType.ERRORS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    const expectedTransactionsFilter: GlobalFilter = {
+      dataset: WidgetType.TRANSACTIONS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:Chrome',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedSpansFilter))}&${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedErrorsFilter))}&${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedTransactionsFilter))}`
+    );
+  });
+
+  it('properly escapes special characters in values', () => {
+    const result = getLinkedDashboardUrl({
+      linkedDashboard,
+      organizationSlug,
+      field: 'browser.name',
+      value: 'Chrome "Browser"',
+    });
+
+    const expectedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'browser.name', kind: FieldKind.TAG},
+      value: 'browser.name:"Chrome \\"Browser\\""',
+      isTemporary: true,
+    };
+
+    expect(result).toBe(
+      `/organizations/test-org/dashboard/123/?${DashboardFilterKeys.GLOBAL_FILTER}=${encodeURIComponent(JSON.stringify(expectedFilter))}`
+    );
+  });
+});

--- a/static/app/views/dashboards/utils/getLinkedDashboardUrl.tsx
+++ b/static/app/views/dashboards/utils/getLinkedDashboardUrl.tsx
@@ -1,0 +1,113 @@
+import type {LocationDescriptor} from 'history';
+import pick from 'lodash/pick';
+import qs from 'query-string';
+
+import {FieldKind} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import type {
+  DashboardFilters,
+  GlobalFilter,
+  LinkedDashboard,
+  WidgetQuery,
+} from 'sentry/views/dashboards/types';
+import {DashboardFilterKeys, WidgetType} from 'sentry/views/dashboards/types';
+
+interface GetLinkedDashboardUrlOptions {
+  field: string;
+  linkedDashboard: LinkedDashboard;
+  organizationSlug: string;
+  value: string;
+  dashboardFilters?: DashboardFilters;
+  locationQuery?: Record<string, any>;
+  projectIdOverride?: string | number;
+  widgetType?: WidgetType;
+}
+
+/**
+ * Given a linked dashboard and a table field and the associated value,
+ * builds a URL to a linked dashboard, applying a temporary global filter for the clicked field value.
+ * Preserves existing global filters and page filter params (project, environment, time range).
+ */
+export function getLinkedDashboardUrl({
+  linkedDashboard,
+  organizationSlug,
+  field,
+  value,
+  widgetType = WidgetType.SPANS,
+  dashboardFilters,
+  locationQuery,
+  projectIdOverride,
+}: GetLinkedDashboardUrlOptions): LocationDescriptor | undefined {
+  // Skip if no valid dashboard ID (dashboardId '-1' is used for prebuilt dashboard placeholders)
+  if (!linkedDashboard.dashboardId || linkedDashboard.dashboardId === '-1') {
+    return undefined;
+  }
+
+  const datasetsToApplyFiltersTo = [
+    widgetType,
+    ...(linkedDashboard.additionalGlobalFilterDatasetTargets ?? []),
+  ];
+
+  // Preserve existing global filters, excluding any for the field being clicked
+  // to avoid duplicates
+  const existingFilters = dashboardFilters?.[DashboardFilterKeys.GLOBAL_FILTER] ?? [];
+  const newTemporaryFilters: GlobalFilter[] = existingFilters.filter(
+    filter =>
+      Boolean(filter.value) &&
+      !(filter.tag.key === field && datasetsToApplyFiltersTo.includes(filter.dataset))
+  );
+
+  // Format the value as a proper filter condition string
+  const mutableSearch = new MutableSearch('');
+  mutableSearch.addFilterValues(field, [value]);
+  const formattedValue = mutableSearch.formatString();
+
+  // Add temporary filters for each dataset
+  datasetsToApplyFiltersTo.forEach(dataset => {
+    newTemporaryFilters.push({
+      dataset,
+      tag: {key: field, name: field, kind: FieldKind.TAG},
+      value: formattedValue,
+      isTemporary: true,
+    });
+  });
+
+  // Preserve project, environment, and time range query params
+  const filterParams: Record<string, any> = locationQuery
+    ? pick(locationQuery, [
+        'release',
+        'environment',
+        'project',
+        'statsPeriod',
+        'start',
+        'end',
+      ])
+    : {};
+
+  // Override project if provided (e.g., from table row data)
+  if (projectIdOverride) {
+    filterParams.project = projectIdOverride;
+  }
+
+  const url = `/organizations/${organizationSlug}/dashboard/${linkedDashboard.dashboardId}/?${qs.stringify(
+    {
+      [DashboardFilterKeys.GLOBAL_FILTER]: newTemporaryFilters.map(filter =>
+        JSON.stringify(filter)
+      ),
+      ...filterParams,
+    }
+  )}`;
+
+  return url;
+}
+
+export function findLinkedDashboardForField(
+  query: WidgetQuery | undefined,
+  field: string | undefined
+): LinkedDashboard | undefined {
+  if (!query || !field) {
+    return undefined;
+  }
+
+  return query.linkedDashboards?.find(ld => ld.field === field);
+}

--- a/static/app/views/dashboards/utils/getLinkedDashboardUrl.tsx
+++ b/static/app/views/dashboards/utils/getLinkedDashboardUrl.tsx
@@ -2,8 +2,8 @@ import type {LocationDescriptor} from 'history';
 import pick from 'lodash/pick';
 import qs from 'query-string';
 
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {FieldKind} from 'sentry/utils/fields';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {
   DashboardFilters,
   GlobalFilter,
@@ -57,10 +57,10 @@ export function getLinkedDashboardUrl({
       !(filter.tag.key === field && datasetsToApplyFiltersTo.includes(filter.dataset))
   );
 
-  // Format the value as a proper filter condition string
-  const mutableSearch = new MutableSearch('');
-  mutableSearch.addFilterValues(field, [value]);
-  const formattedValue = mutableSearch.formatString();
+  // Format the value as a proper filter condition string (bracket syntax e.g. field:[value])
+  const formattedValue = new MutableSearch('')
+    .addFilterValueList(field, [value])
+    .toString();
 
   // Add temporary filters for each dataset
   datasetsToApplyFiltersTo.forEach(dataset => {

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -210,7 +210,7 @@ function VisualizationWidgetContent({
         const dataUnit = plottable?.dataUnit ?? undefined;
         const label = plottable?.label ?? series.seriesName;
         const linkedUrl =
-          linkedDashboard && firstColumn
+          linkedDashboard && firstColumn && widget.widgetType
             ? getLinkedDashboardUrl({
                 linkedDashboard,
                 organizationSlug: organization.slug,

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 
 import {Container, Flex, type ContainerProps} from '@sentry/scraps/layout';
@@ -10,9 +11,15 @@ import type {Series} from 'sentry/types/echarts';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
 import {transformLegacySeriesToPlottables} from 'sentry/utils/timeSeries/transformLegacySeriesToPlottables';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {
+  findLinkedDashboardForField,
+  getLinkedDashboardUrl,
+} from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
 import {FALLBACK_TYPE} from 'sentry/views/dashboards/widgets/timeSeriesWidget/settings';
@@ -94,6 +101,7 @@ export function VisualizationWidget({
             releases={releases}
             showReleaseAs={showReleaseAs}
             renderErrorMessage={renderErrorMessage}
+            dashboardFilters={dashboardFilters}
           />
         );
       }}
@@ -107,6 +115,7 @@ interface VisualizationWidgetContentProps {
   showReleaseAs: LoadableChartWidgetProps['showReleaseAs'];
   timeseriesResults: Series[];
   widget: Widget;
+  dashboardFilters?: DashboardFilters;
   errorMessage?: string;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   tableResults?: TableDataWithTitle[];
@@ -125,8 +134,11 @@ function VisualizationWidgetContent({
   releases,
   showReleaseAs,
   renderErrorMessage,
+  dashboardFilters,
 }: VisualizationWidgetContentProps) {
   const theme = useTheme();
+  const organization = useOrganization();
+  const location = useLocation();
 
   const plottables = transformLegacySeriesToPlottables(
     timeseriesResults,
@@ -150,8 +162,13 @@ function VisualizationWidgetContent({
     tableResults.length > 0;
 
   const tableDataRows = tableResults?.[0]?.data;
-  const aggregates = widget.queries[0]?.aggregates ?? [];
-  const columns = widget.queries[0]?.columns ?? [];
+  const widgetQuery = widget.queries[0];
+  const aggregates = widgetQuery?.aggregates ?? [];
+  const columns = widgetQuery?.columns ?? [];
+
+  // Find linked dashboard for the groupBy field (first column)
+  const groupByField = columns[0];
+  const linkedDashboard = findLinkedDashboardForField(widgetQuery, groupByField);
 
   // Filter out "Other" series for the legend breakdown
   const filteredSeriesWithIndex = showBreakdownData
@@ -192,6 +209,25 @@ function VisualizationWidgetContent({
         const dataType = plottable?.dataType ?? FALLBACK_TYPE;
         const dataUnit = plottable?.dataUnit ?? undefined;
         const label = plottable?.label ?? series.seriesName;
+        const linkedUrl =
+          linkedDashboard && groupByField
+            ? getLinkedDashboardUrl({
+                linkedDashboard,
+                organizationSlug: organization.slug,
+                field: groupByField,
+                value: series.seriesName,
+                widgetType: widget.widgetType,
+                dashboardFilters,
+                locationQuery: location.query,
+              })
+            : undefined;
+
+        const labelContent = linkedUrl ? (
+          <Link to={linkedUrl}>{label}</Link>
+        ) : (
+          <Text>{label}</Text>
+        );
+
         return (
           <Fragment key={series.seriesName}>
             <Container>
@@ -202,7 +238,7 @@ function VisualizationWidgetContent({
               />
             </Container>
             <Tooltip title={label} showOnlyOnOverflow>
-              <Text>{label}</Text>
+              {labelContent}
             </Tooltip>
             <TextAlignRight>
               {value === null ? '—' : formatYAxisValue(value, dataType, dataUnit)}

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -166,9 +166,9 @@ function VisualizationWidgetContent({
   const aggregates = widgetQuery?.aggregates ?? [];
   const columns = widgetQuery?.columns ?? [];
 
-  // Find linked dashboard for the groupBy field (first column)
-  const groupByField = columns[0];
-  const linkedDashboard = findLinkedDashboardForField(widgetQuery, groupByField);
+  // We only support one column for legend breakdown right now
+  const firstColumn = columns[0];
+  const linkedDashboard = findLinkedDashboardForField(widgetQuery, firstColumn);
 
   // Filter out "Other" series for the legend breakdown
   const filteredSeriesWithIndex = showBreakdownData
@@ -210,11 +210,11 @@ function VisualizationWidgetContent({
         const dataUnit = plottable?.dataUnit ?? undefined;
         const label = plottable?.label ?? series.seriesName;
         const linkedUrl =
-          linkedDashboard && groupByField
+          linkedDashboard && firstColumn
             ? getLinkedDashboardUrl({
                 linkedDashboard,
                 organizationSlug: organization.slug,
-                field: groupByField,
+                field: firstColumn,
                 value: series.seriesName,
                 widgetType: widget.widgetType,
                 dashboardFilters,


### PR DESCRIPTION
This pr adds support for linked dashboards to the legend breakdown. The link is generated from a new getLinkedDashboard url function that is extracted from the logic in the field renderers.
<img width="732" height="435" alt="image" src="https://github.com/user-attachments/assets/81849503-d6f5-4b57-a856-dcc7c6a62600" />

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 2 potential issues for commit <u>be0d574</u></sup><!-- /BUGBOT_STATUS -->