### PR TITLE
fix(grouping): Remove mechanism type check for RxJava exception detection

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -974,7 +974,6 @@ def java_rxjava_framework_exceptions(exceptions: list[SingleException]) -> int |
             exception.module == "io.reactivex.rxjava3.exceptions"
             and exception.type in JAVA_RXJAVA_FRAMEWORK_EXCEPTION_TYPES
             and exception.mechanism
-            and exception.mechanism.type == "UncaughtExceptionHandler"
         ):
             rxjava_exception_id = exception.mechanism.exception_id
             break

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -275,7 +275,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
                                 "value": "The exception was not handled due to missing onError handler in the subscribe() method call.",
                                 "module": "io.reactivex.rxjava3.exceptions",
                                 "mechanism": {
-                                    "type": "UncaughtExceptionHandler",
+                                    "type": "chained",
                                     "handled": False,
                                     "exception_id": 0,
                                 },


### PR DESCRIPTION
## Summary
- Remove the `mechanism.type == "UncaughtExceptionHandler"` check when detecting RxJava framework exceptions
- RxJava wrapper exceptions (like `OnErrorNotImplementedException`) can have different mechanism types (e.g., `chained`) depending on how they're thrown
- This ensures these wrapper exceptions are properly skipped during grouping regardless of mechanism type

## Test plan
- Updated existing test to use `chained` mechanism type to verify the fix works

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>f31cb5f</u></sup><!-- /BUGBOT_STATUS -->