### PR TITLE
feat(aci): Include Rule in legacy model tracking

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -6,6 +6,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models.rule import Rule
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 class RuleEndpoint(ProjectEndpoint):
@@ -20,6 +21,9 @@ class RuleEndpoint(ProjectEndpoint):
 
         if not rule_id.isdigit():
             raise ResourceDoesNotExist
+
+        # Mark that we're using legacy Rule models (before query to track failures too)
+        report_used_legacy_models()
 
         try:
             kwargs["rule"] = Rule.objects.get(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -44,6 +44,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         },
         examples=IssueAlertExamples.GET_PROJECT_RULE,
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-details")
     def get(self, request: Request, project, rule) -> Response:
         """
         ## Deprecated
@@ -168,6 +170,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         },
         examples=IssueAlertExamples.UPDATE_PROJECT_RULE,
     )
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-project-rule-details")
     def put(self, request: Request, project, rule) -> Response:
         """
         ## Deprecated
@@ -376,6 +379,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-rule-details")
     def delete(self, request: Request, project, rule) -> Response:
         """
         ## Deprecated

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -44,7 +44,10 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
-from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
+from sentry.workflow_engine.utils.legacy_metric_tracking import (
+    report_used_legacy_models,
+    track_alert_endpoint_execution,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -393,6 +396,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
          - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
          - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
+        report_used_legacy_models()
         with transaction.atomic(router.db_for_write(Rule)):
             rule.update(status=ObjectStatus.PENDING_DELETION)
             RuleActivity.objects.create(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -34,6 +34,10 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
+from sentry.workflow_engine.utils.legacy_metric_tracking import (
+    report_used_legacy_models,
+    track_alert_endpoint_execution,
+)
 
 
 def clean_rule_data(data):
@@ -232,6 +236,9 @@ class DuplicateRuleEvaluator:
             all_rules = Rule.objects.exclude(id=self._rule_id)
 
         existing_rules = all_rules.filter(project__id=self._project_id, status=ObjectStatus.ACTIVE)
+        # Mark that we're using legacy Rule models (even if query returns no results)
+        report_used_legacy_models()
+
         for existing_rule in existing_rules:
             keys_checked = 0
             keys_matched = 0
@@ -693,6 +700,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         },
         examples=IssueAlertExamples.LIST_PROJECT_RULES,
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-rules")
     def get(self, request: Request, project: Project) -> Response:
         """
         ## Deprecated
@@ -710,6 +718,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             project=project,
             status=ObjectStatus.ACTIVE,
         ).select_related("project")
+        # Mark that we're using legacy Rule models
+        report_used_legacy_models()
 
         expand = request.GET.getlist("expand", ["lastTriggered"])
 
@@ -737,6 +747,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         },
         examples=IssueAlertExamples.CREATE_ISSUE_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
     def post(self, request: Request, project) -> Response:
         """
         ## Deprecated

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -792,6 +792,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 break
 
         rules = Rule.objects.filter(project=project, status=ObjectStatus.ACTIVE)
+        report_used_legacy_models()
         slow_rules = 0
         for rule in rules:
             for condition in rule.data["conditions"]:

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -29,6 +29,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 def generate_rule_label(project, rule, data):
@@ -259,6 +260,9 @@ class RuleSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs) -> RuleSerializerResponse:
+        # Mark that we're using legacy Rule models
+        report_used_legacy_models()
+
         environment = attrs["environment"]
         all_conditions = [
             dict(list(o.items()) + [("name", generate_rule_label(obj.project, obj, o))])

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -493,6 +493,8 @@ class CombinedRuleSerializer(Serializer):
             report_used_legacy_models()
             updated_attrs["type"] = "alert_rule"
         elif isinstance(obj, Rule):
+            # Mark that we're using legacy Rule models
+            report_used_legacy_models()
             updated_attrs["type"] = "rule"
         elif isinstance(obj, Detector) and obj.type == GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE:
             updated_attrs["type"] = "uptime"

--- a/src/sentry/projects/project_rules/creator.py
+++ b/src/sentry/projects/project_rules/creator.py
@@ -11,6 +11,7 @@ from sentry.models.rule import Rule, RuleSource
 from sentry.types.actor import Actor
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.processors.detector import ensure_default_detectors
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,8 @@ class ProjectRuleCreator:
     def _create_rule(self) -> Rule:
         kwargs = self._get_kwargs()
         rule = Rule.objects.create(**kwargs)
+        # Mark that we're using legacy Rule models
+        report_used_legacy_models()
 
         return rule
 

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -11,6 +11,7 @@ from sentry.types.actor import Actor
 from sentry.workflow_engine.migration_helpers.issue_alert_dual_write import (
     update_migrated_issue_alert,
 )
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,8 @@ class ProjectRuleUpdater:
             self._update_conditions()
             self._update_frequency()
             self.rule.save()
+            # Mark that we're using legacy Rule models
+            report_used_legacy_models()
 
             # uncaught errors will rollback the transaction
             workflow = update_migrated_issue_alert(self.rule)

--- a/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
+++ b/src/sentry/workflow_engine/utils/legacy_metric_tracking.py
@@ -1,9 +1,9 @@
 """
-Utilities for tracking legacy AlertRule model usage in API endpoints.
+Utilities for tracking legacy AlertRule and Rule model usage in API endpoints.
 
 This module provides a decorator and reporting mechanism to track which endpoints
-are using legacy AlertRule models vs the new workflow engine models. This helps
-with migration progress tracking.
+are using legacy AlertRule and Rule models vs the new workflow engine models. This
+helps with migration progress tracking.
 """
 
 from __future__ import annotations
@@ -25,11 +25,12 @@ T = TypeVar("T", bound=HttpResponseBase)
 
 def report_used_legacy_models() -> None:
     """
-    Mark the current request context as having used legacy AlertRule models.
+    Mark the current request context as having used legacy AlertRule or Rule models.
 
     This should be called from:
-    - Serializers that serialize AlertRule or related models
-    - Endpoint logic that directly uses AlertRule models
+    - Serializers that serialize AlertRule, Rule, or related models
+    - Immediately after ORM queries that fetch AlertRule or Rule objects
+    - When creating or updating AlertRule or Rule instances
 
     The value is tracked in a ContextVar and will be read when the
     track_alert_endpoint_execution decorator exits.


### PR DESCRIPTION
We care about Rule also, and this will allow us to maintain a traffic and endpoint-based burndown tracker.
