### PR TITLE
ci(warden): Add Django access review automation

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,21 +1,27 @@
 name: Warden
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# contents: write required for resolving review threads via GraphQL
-# See: https://github.com/orgs/community/discussions/44650
-permissions:
-  contents: write
-  pull-requests: write
-  checks: write
-
 jobs:
   review:
     runs-on: ubuntu-latest
+    env:
+      WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+      WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.WARDEN_APP_ID }}
+          private-key: ${{ secrets.WARDEN_PRIVATE_KEY }}
+
       - uses: getsentry/warden@v0
         with:
-          anthropic-api-key: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -1,0 +1,21 @@
+name: Warden
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# contents: write required for resolving review threads via GraphQL
+# See: https://github.com/orgs/community/discussions/44650
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: getsentry/warden@v0
+        with:
+          anthropic-api-key: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,40 @@
+# Warden Configuration
+# https://github.com/getsentry/warden
+#
+# Warden reviews code using AI-powered skills triggered by GitHub events.
+# Skills live in .warden/skills/, .agents/skills/, or .claude/skills/
+#
+# Add skills with: warden add <skill-name>
+
+version = 1
+
+# Default settings inherited by all triggers
+[defaults.output]
+# Severity levels: critical, high, medium, low, info
+# failOn: minimum severity that fails the check
+failOn = "high"
+# commentOn: minimum severity that creates PR annotations
+commentOn = "medium"
+
+# Triggers map GitHub events to skills
+# Add triggers with: warden add <skill-name>
+#
+# Example trigger with path filters:
+#
+# [[triggers]]
+# name = "security-review"
+# event = "pull_request"
+# actions = ["opened", "synchronize", "reopened"]
+# skill = "security-review"
+#
+# # Path filters prevent running on irrelevant files
+# [triggers.filters]
+# paths = ["src/**/*.ts", "src/**/*.tsx"]
+# ignorePaths = ["**/*.test.ts", "**/__fixtures__/**"]
+
+[[triggers]]
+name = "django-access-review"
+event = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+skill = "django-access-review"
+remote = "getsentry/skills"

--- a/warden.toml
+++ b/warden.toml
@@ -38,3 +38,7 @@ event = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
 skill = "django-access-review"
 remote = "getsentry/skills"
+
+[triggers.filters]
+paths = ["src/sentry/**/*.py"]
+ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]

--- a/warden.toml
+++ b/warden.toml
@@ -2,43 +2,26 @@
 # https://github.com/getsentry/warden
 #
 # Warden reviews code using AI-powered skills triggered by GitHub events.
-# Skills live in .warden/skills/, .agents/skills/, or .claude/skills/
+# Skills live in .agents/skills/ or .claude/skills/
 #
 # Add skills with: warden add <skill-name>
 
 version = 1
 
-# Default settings inherited by all triggers
-[defaults.output]
-# Severity levels: critical, high, medium, low, info
+# Default settings inherited by all skills
+[defaults]
+# Severity levels: critical, high, medium, low, info, off
 # failOn: minimum severity that fails the check
 failOn = "high"
-# commentOn: minimum severity that creates PR annotations
-commentOn = "medium"
+# reportOn: minimum severity that creates PR annotations
+reportOn = "medium"
 
-# Triggers map GitHub events to skills
-# Add triggers with: warden add <skill-name>
-#
-# Example trigger with path filters:
-#
-# [[triggers]]
-# name = "security-review"
-# event = "pull_request"
-# actions = ["opened", "synchronize", "reopened"]
-# skill = "security-review"
-#
-# # Path filters prevent running on irrelevant files
-# [triggers.filters]
-# paths = ["src/**/*.ts", "src/**/*.tsx"]
-# ignorePaths = ["**/*.test.ts", "**/__fixtures__/**"]
-
-[[triggers]]
+[[skills]]
 name = "django-access-review"
-event = "pull_request"
-actions = ["opened", "synchronize", "reopened"]
-skill = "django-access-review"
 remote = "getsentry/skills"
-
-[triggers.filters]
 paths = ["src/sentry/**/*.py"]
 ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Add Warden CI integration to automatically review Django access patterns on pull requests.

Warden is an AI-powered code review tool that runs skills triggered by GitHub events. This configures the `django-access-review` skill from `getsentry/skills` to flag potential access control issues in Django code.

Configuration:
- Workflow runs on PR open, sync, and reopen events
- Fails checks on high severity findings
- Comments on medium severity findings