### PR TITLE
perf(conversations): Prefetch and load drawer independently of trace's table

### DIFF
--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -18,18 +18,6 @@ export interface UseConversationsOptions {
 }
 
 /**
- * Prefetch conversation data when a conversationId is provided.
- * Call this at the page level to start fetching before the drawer opens,
- * so data is ready (or loading) when the drawer content mounts.
- */
-export function usePrefetchConversation(conversationId: string | null) {
-  // This just calls useConversation with the provided ID.
-  // React Query will cache the result, so when ConversationDrawerContent
-  // mounts and calls useConversation with the same ID, data is already available.
-  useConversation({conversationId: conversationId ?? ''});
-}
-
-/**
  * Raw span data returned from the AI conversation details endpoint
  */
 interface ConversationApiSpan {

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -18,6 +18,18 @@ export interface UseConversationsOptions {
 }
 
 /**
+ * Prefetch conversation data when a conversationId is provided.
+ * Call this at the page level to start fetching before the drawer opens,
+ * so data is ready (or loading) when the drawer content mounts.
+ */
+export function usePrefetchConversation(conversationId: string | null) {
+  // This just calls useConversation with the provided ID.
+  // React Query will cache the result, so when ConversationDrawerContent
+  // mounts and calls useConversation with the same ID, data is already available.
+  useConversation({conversationId: conversationId ?? ''});
+}
+
+/**
  * Raw span data returned from the AI conversation details endpoint
  */
 interface ConversationApiSpan {

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -56,7 +56,7 @@ function ConversationsOverviewPage({
   const [urlState] = useConversationDrawerQueryState();
   // Start fetching data and open drawer without
   // waiting for table to finish loading
-  useConversation(urlState.conversationId ?? '');
+  useConversation({conversationId: urlState.conversationId ?? ''});
   useConversationViewDrawer();
 
   const [searchQuery, setSearchQuery] = useQueryState(

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -36,7 +36,7 @@ import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableC
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
 import {useConversationViewDrawer} from 'sentry/views/insights/pages/conversations/components/conversationDrawer';
 import {ConversationsTable} from 'sentry/views/insights/pages/conversations/components/conversationsTable';
-import {usePrefetchConversation} from 'sentry/views/insights/pages/conversations/hooks/useConversation';
+import {useConversation} from 'sentry/views/insights/pages/conversations/hooks/useConversation';
 import {useConversationDrawerQueryState} from 'sentry/views/insights/pages/conversations/utils/urlParams';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 
@@ -56,7 +56,7 @@ function ConversationsOverviewPage({
   const [urlState] = useConversationDrawerQueryState();
   // Start fetching data and open drawer without
   // waiting for table to finish loading
-  usePrefetchConversation(urlState.conversationId);
+  useConversation(urlState.conversationId ?? '');
   useConversationViewDrawer();
 
   const [searchQuery, setSearchQuery] = useQueryState(

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -34,7 +34,10 @@ import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
 import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
+import {useConversationViewDrawer} from 'sentry/views/insights/pages/conversations/components/conversationDrawer';
 import {ConversationsTable} from 'sentry/views/insights/pages/conversations/components/conversationsTable';
+import {usePrefetchConversation} from 'sentry/views/insights/pages/conversations/hooks/useConversation';
+import {useConversationDrawerQueryState} from 'sentry/views/insights/pages/conversations/utils/urlParams';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 
 const DISABLE_AGGREGATES: never[] = [];
@@ -49,6 +52,12 @@ function ConversationsOverviewPage({
 }: ConversationsOverviewPageProps) {
   const organization = useOrganization();
   useDefaultToAllProjects();
+
+  const [urlState] = useConversationDrawerQueryState();
+  // Start fetching data and open drawer without
+  // waiting for table to finish loading
+  usePrefetchConversation(urlState.conversationId);
+  useConversationViewDrawer();
 
   const [searchQuery, setSearchQuery] = useQueryState(
     'query',


### PR DESCRIPTION
**Problem**
When a user lands on the conversations page with a drawer URL (e.g., from a shared link or browser back), the drawer wouldn't open until the trace's table finished loading. This created unnecessary wait time for users who just want to see the conversation details.

**Solution**
Move `useConversationViewDrawer()` to the page level so the drawer opens immediately, independent of table loading state.
Also added `usePrefetchConversation` to start fetching data at the page level, leveraging React Query's caching to have data ready when the drawer mounts.


closes https://linear.app/getsentry/issue/TET-1880/do-not-wait-for-table-to-finish-loading-before-loading-conversation