### PR TITLE
perf(agents): Prefetch and load drawer independently of trace's table

### DIFF
--- a/static/app/views/insights/pages/agents/components/drawer.tsx
+++ b/static/app/views/insights/pages/agents/components/drawer.tsx
@@ -133,8 +133,24 @@ export function useTraceViewDrawer({onClose}: UseTraceViewDrawerProps = {}) {
     [openDrawer, onClose, closeDrawer, organization]
   );
 
+  return {
+    openTraceViewDrawer,
+    isTraceViewDrawerOpen: isDrawerOpen,
+    drawerUrlState,
+  };
+}
+
+/**
+ * Hook to handle opening the trace view drawer from URL parameters.
+ * This should only be used ONCE at the top level of the agents page
+ * to avoid duplicate analytics events.
+ */
+export function useOpenTraceViewDrawerFromUrl() {
+  const {openTraceViewDrawer, drawerUrlState, isTraceViewDrawerOpen} =
+    useTraceViewDrawer();
+
   useEffect(() => {
-    if (drawerUrlState.traceId && !isDrawerOpen) {
+    if (drawerUrlState.traceId && !isTraceViewDrawerOpen) {
       openTraceViewDrawer(
         drawerUrlState.traceId,
         drawerUrlState.spanId ?? undefined,
@@ -143,11 +159,6 @@ export function useTraceViewDrawer({onClose}: UseTraceViewDrawerProps = {}) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount
   }, []);
-
-  return {
-    openTraceViewDrawer,
-    isTraceViewDrawerOpen: isDrawerOpen,
-  };
 }
 
 function AITraceView({

--- a/static/app/views/insights/pages/agents/components/drawer.tsx
+++ b/static/app/views/insights/pages/agents/components/drawer.tsx
@@ -133,24 +133,8 @@ export function useTraceViewDrawer({onClose}: UseTraceViewDrawerProps = {}) {
     [openDrawer, onClose, closeDrawer, organization]
   );
 
-  return {
-    openTraceViewDrawer,
-    isTraceViewDrawerOpen: isDrawerOpen,
-    drawerUrlState,
-  };
-}
-
-/**
- * Hook to handle opening the trace view drawer from URL parameters.
- * This should only be used ONCE at the top level of the agents page
- * to avoid duplicate analytics events.
- */
-export function useOpenTraceViewDrawerFromUrl() {
-  const {openTraceViewDrawer, drawerUrlState, isTraceViewDrawerOpen} =
-    useTraceViewDrawer();
-
   useEffect(() => {
-    if (drawerUrlState.traceId && !isTraceViewDrawerOpen) {
+    if (drawerUrlState.traceId && !isDrawerOpen) {
       openTraceViewDrawer(
         drawerUrlState.traceId,
         drawerUrlState.spanId ?? undefined,
@@ -159,6 +143,11 @@ export function useOpenTraceViewDrawerFromUrl() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount
   }, []);
+
+  return {
+    openTraceViewDrawer,
+    isTraceViewDrawerOpen: isDrawerOpen,
+  };
 }
 
 function AITraceView({

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -29,7 +29,7 @@ import {useTraces} from 'sentry/views/explore/hooks/useTraces';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
-import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
+import type {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {LLMCosts} from 'sentry/views/insights/pages/agents/components/llmCosts';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
@@ -85,8 +85,11 @@ const rightAlignColumns = new Set([
   'timestamp',
 ]);
 
-export function TracesTable() {
-  const {openTraceViewDrawer} = useTraceViewDrawer();
+interface TracesTableProps {
+  openTraceViewDrawer: ReturnType<typeof useTraceViewDrawer>['openTraceViewDrawer'];
+}
+
+export function TracesTable({openTraceViewDrawer}: TracesTableProps) {
   const {columns: columnOrder, handleResizeColumn} = useStateBasedColumnResize({
     columns: defaultColumnOrder,
   });

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -33,7 +33,7 @@ import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/comp
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
-import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
+import {useOpenTraceViewDrawerFromUrl} from 'sentry/views/insights/pages/agents/components/drawer';
 import {IssuesWidget} from 'sentry/views/insights/pages/agents/components/issuesWidget';
 import LLMGenerationsWidget from 'sentry/views/insights/pages/agents/components/llmCallsWidget';
 import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
@@ -77,10 +77,8 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
   useDefaultToAllProjects();
 
   const [urlState] = useTraceDrawerQueryState();
-  // Start fetching data and open drawer without
-  // waiting for table to finish loading
+  // Start fetching data without waiting for table to finish loading
   useAITrace(urlState.traceId ?? '', urlState.timestamp ?? undefined);
-  useTraceViewDrawer();
 
   const agentSpanSearchProps = useAgentSpanSearchProps();
   const isSentryEmployee = useIsSentryEmployee();
@@ -92,6 +90,7 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
 
   useOverviewPageTrackPageload();
   useAgentMonitoringTrackPageView();
+  useOpenTraceViewDrawerFromUrl();
 
   // Fire a request to check if there are any agent runs
   // If there are, we show the count/duration of agent runs

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -33,7 +33,7 @@ import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/comp
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
-import {useOpenTraceViewDrawerFromUrl} from 'sentry/views/insights/pages/agents/components/drawer';
+import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {IssuesWidget} from 'sentry/views/insights/pages/agents/components/issuesWidget';
 import LLMGenerationsWidget from 'sentry/views/insights/pages/agents/components/llmCallsWidget';
 import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
@@ -77,8 +77,10 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
   useDefaultToAllProjects();
 
   const [urlState] = useTraceDrawerQueryState();
-  // Start fetching data without waiting for table to finish loading
+  // Start fetching data and open drawer without
+  // waiting for table to finish loading
   useAITrace(urlState.traceId ?? '', urlState.timestamp ?? undefined);
+  const {openTraceViewDrawer} = useTraceViewDrawer();
 
   const agentSpanSearchProps = useAgentSpanSearchProps();
   const isSentryEmployee = useIsSentryEmployee();
@@ -90,7 +92,6 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
 
   useOverviewPageTrackPageload();
   useAgentMonitoringTrackPageView();
-  useOpenTraceViewDrawerFromUrl();
 
   // Fire a request to check if there are any agent runs
   // If there are, we show the count/duration of agent runs
@@ -193,7 +194,7 @@ function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
                       <ToolUsageWidget />
                     </WidgetGrid.Position3>
                   </WidgetGrid>
-                  <TracesTable />
+                  <TracesTable openTraceViewDrawer={openTraceViewDrawer} />
                 </Stack>
               )}
             </ModuleLayout.Full>

--- a/static/app/views/insights/pages/agents/overview.tsx
+++ b/static/app/views/insights/pages/agents/overview.tsx
@@ -33,6 +33,7 @@ import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/comp
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
+import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {IssuesWidget} from 'sentry/views/insights/pages/agents/components/issuesWidget';
 import LLMGenerationsWidget from 'sentry/views/insights/pages/agents/components/llmCallsWidget';
 import {WidgetGrid} from 'sentry/views/insights/pages/agents/components/styles';
@@ -41,11 +42,15 @@ import ToolUsageWidget from 'sentry/views/insights/pages/agents/components/toolC
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
 import {useAgentMonitoringTrackPageView} from 'sentry/views/insights/pages/agents/hooks/useAgentMonitoringTrackPageView';
 import {useAgentSpanSearchProps} from 'sentry/views/insights/pages/agents/hooks/useAgentSpanSearchProps';
+import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
 import {useShowAgentOnboarding} from 'sentry/views/insights/pages/agents/hooks/useShowAgentOnboarding';
 import {Onboarding} from 'sentry/views/insights/pages/agents/onboarding';
 import {getAgentRunsFilter} from 'sentry/views/insights/pages/agents/utils/query';
 import {Referrer} from 'sentry/views/insights/pages/agents/utils/referrers';
-import {TableUrlParams} from 'sentry/views/insights/pages/agents/utils/urlParams';
+import {
+  TableUrlParams,
+  useTraceDrawerQueryState,
+} from 'sentry/views/insights/pages/agents/utils/urlParams';
 import {DomainOverviewPageProviders} from 'sentry/views/insights/pages/domainOverviewPageProviders';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
 
@@ -55,8 +60,27 @@ interface AgentsOverviewPageProps {
 
 function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
   const organization = useOrganization();
+
+  return (
+    <Feature
+      features="performance-view"
+      organization={organization}
+      renderDisabled={NoAccess}
+    >
+      <AgentsContent datePageFilterProps={datePageFilterProps} />
+    </Feature>
+  );
+}
+
+function AgentsContent({datePageFilterProps}: AgentsOverviewPageProps) {
   const showOnboarding = useShowAgentOnboarding();
   useDefaultToAllProjects();
+
+  const [urlState] = useTraceDrawerQueryState();
+  // Start fetching data and open drawer without
+  // waiting for table to finish loading
+  useAITrace(urlState.traceId ?? '', urlState.timestamp ?? undefined);
+  useTraceViewDrawer();
 
   const agentSpanSearchProps = useAgentSpanSearchProps();
   const isSentryEmployee = useIsSentryEmployee();
@@ -87,106 +111,96 @@ function AgentsOverviewPage({datePageFilterProps}: AgentsOverviewPageProps) {
 
   return (
     <SearchQueryBuilderProvider {...agentSpanSearchProps.provider}>
-      <Feature
-        features="performance-view"
-        organization={organization}
-        renderDisabled={NoAccess}
-      >
-        <Layout.Body>
-          <Layout.Main width="full">
-            <ModuleLayout.Layout>
-              <ModuleLayout.Full>
-                <ToolRibbon>
-                  <PageFilterBar condensed>
-                    <InsightsProjectSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <InsightsEnvironmentSelector
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                    <DatePageFilter
-                      {...datePageFilterProps}
-                      resetParamsOnChange={[TableUrlParams.CURSOR]}
-                    />
-                  </PageFilterBar>
-                  <AgentSelector
-                    storageKeyPrefix="agents:agent-filter"
-                    referrer={Referrer.AGENT_SELECTOR}
+      <Layout.Body>
+        <Layout.Main width="full">
+          <ModuleLayout.Layout>
+            <ModuleLayout.Full>
+              <ToolRibbon>
+                <PageFilterBar condensed>
+                  <InsightsProjectSelector
+                    resetParamsOnChange={[TableUrlParams.CURSOR]}
                   />
-                  {!showOnboarding && (
-                    <Flex flex={2}>
-                      <TraceItemSearchQueryBuilder
-                        {...agentSpanSearchProps.queryBuilder}
-                      />
-                    </Flex>
-                  )}
-                </ToolRibbon>
-              </ModuleLayout.Full>
-
-              {showSeerDataBanner && (
-                <ModuleLayout.Full>
-                  <Alert
-                    variant="warning"
-                    trailingItems={
-                      <Button
-                        aria-label="Dismiss"
-                        icon={<IconClose />}
-                        size="xs"
-                        onClick={dismiss}
-                      />
-                    }
-                  >
-                    SENTRY EMPLOYEES: Transaction size limits make seer instrumentation
-                    incomplete. Data shown here does not reflect actual state.
-                  </Alert>
-                </ModuleLayout.Full>
-              )}
-
-              <ModuleLayout.Full>
-                {showOnboarding ? (
-                  <Onboarding />
-                ) : (
-                  <Stack gap="xl">
-                    <WidgetGrid rowHeight={210} paddingBottom={0}>
-                      <WidgetGrid.Position1>
-                        {hasAgentRuns === undefined ? (
-                          <LoadingPanel />
-                        ) : (
-                          <OverviewAgentsRunsChartWidget hasAgentRuns={hasAgentRuns} />
-                        )}
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        {hasAgentRuns === undefined ? (
-                          <LoadingPanel />
-                        ) : (
-                          <OverviewAgentsDurationChartWidget
-                            hasAgentRuns={hasAgentRuns}
-                          />
-                        )}
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <IssuesWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <WidgetGrid rowHeight={260} paddingBottom={0}>
-                      <WidgetGrid.Position1>
-                        <LLMGenerationsWidget />
-                      </WidgetGrid.Position1>
-                      <WidgetGrid.Position2>
-                        <TokenUsageWidget />
-                      </WidgetGrid.Position2>
-                      <WidgetGrid.Position3>
-                        <ToolUsageWidget />
-                      </WidgetGrid.Position3>
-                    </WidgetGrid>
-                    <TracesTable />
-                  </Stack>
+                  <InsightsEnvironmentSelector
+                    resetParamsOnChange={[TableUrlParams.CURSOR]}
+                  />
+                  <DatePageFilter
+                    {...datePageFilterProps}
+                    resetParamsOnChange={[TableUrlParams.CURSOR]}
+                  />
+                </PageFilterBar>
+                <AgentSelector
+                  storageKeyPrefix="agents:agent-filter"
+                  referrer={Referrer.AGENT_SELECTOR}
+                />
+                {!showOnboarding && (
+                  <Flex flex={2}>
+                    <TraceItemSearchQueryBuilder {...agentSpanSearchProps.queryBuilder} />
+                  </Flex>
                 )}
+              </ToolRibbon>
+            </ModuleLayout.Full>
+
+            {showSeerDataBanner && (
+              <ModuleLayout.Full>
+                <Alert
+                  variant="warning"
+                  trailingItems={
+                    <Button
+                      aria-label="Dismiss"
+                      icon={<IconClose />}
+                      size="xs"
+                      onClick={dismiss}
+                    />
+                  }
+                >
+                  SENTRY EMPLOYEES: Transaction size limits make seer instrumentation
+                  incomplete. Data shown here does not reflect actual state.
+                </Alert>
               </ModuleLayout.Full>
-            </ModuleLayout.Layout>
-          </Layout.Main>
-        </Layout.Body>
-      </Feature>
+            )}
+
+            <ModuleLayout.Full>
+              {showOnboarding ? (
+                <Onboarding />
+              ) : (
+                <Stack gap="xl">
+                  <WidgetGrid rowHeight={210} paddingBottom={0}>
+                    <WidgetGrid.Position1>
+                      {hasAgentRuns === undefined ? (
+                        <LoadingPanel />
+                      ) : (
+                        <OverviewAgentsRunsChartWidget hasAgentRuns={hasAgentRuns} />
+                      )}
+                    </WidgetGrid.Position1>
+                    <WidgetGrid.Position2>
+                      {hasAgentRuns === undefined ? (
+                        <LoadingPanel />
+                      ) : (
+                        <OverviewAgentsDurationChartWidget hasAgentRuns={hasAgentRuns} />
+                      )}
+                    </WidgetGrid.Position2>
+                    <WidgetGrid.Position3>
+                      <IssuesWidget />
+                    </WidgetGrid.Position3>
+                  </WidgetGrid>
+                  <WidgetGrid rowHeight={260} paddingBottom={0}>
+                    <WidgetGrid.Position1>
+                      <LLMGenerationsWidget />
+                    </WidgetGrid.Position1>
+                    <WidgetGrid.Position2>
+                      <TokenUsageWidget />
+                    </WidgetGrid.Position2>
+                    <WidgetGrid.Position3>
+                      <ToolUsageWidget />
+                    </WidgetGrid.Position3>
+                  </WidgetGrid>
+                  <TracesTable />
+                </Stack>
+              )}
+            </ModuleLayout.Full>
+          </ModuleLayout.Layout>
+        </Layout.Main>
+      </Layout.Body>
     </SearchQueryBuilderProvider>
   );
 }


### PR DESCRIPTION
We’re happy with the result, so I am replicating the same solution used in https://github.com/getsentry/sentry/pull/107655.

closes https://linear.app/getsentry/issue/TET-1880/do-not-wait-for-table-to-finish-loading-before-loading-conversation