### PR TITLE
fix(codeowners): move AI conversation rules after endpoints catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -504,9 +504,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/api/endpoints/test_organization_onboarding*                        @getsentry/telemetry-experience
 /src/sentry/api/endpoints/organization_sampling_project_span_counts.py           @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py    @getsentry/telemetry-experience
-/src/sentry/api/endpoints/organization_ai_conversation*.py                       @getsentry/telemetry-experience
-/src/sentry/api/serializers/rest_framework/ai_conversations.py                   @getsentry/telemetry-experience
-/tests/sentry/api/endpoints/test_organization_ai_conversation*.py                @getsentry/telemetry-experience
 /src/sentry/dynamic_sampling/                                                    @getsentry/telemetry-experience
 /tests/sentry/dynamic_sampling/                                                  @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                @getsentry/telemetry-experience
@@ -634,6 +631,13 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/test_llm_issue_detection.py             @getsentry/issue-detection-backend
 /tests/snuba/search/                                        @getsentry/issue-workflow
 ## End of Issues
+
+## AI Conversations (Telemetry Experience)
+# These must come after /src/sentry/api/endpoints/ catch-all above
+/src/sentry/api/endpoints/organization_ai_conversation*.py                       @getsentry/telemetry-experience
+/src/sentry/api/serializers/rest_framework/ai_conversations.py                   @getsentry/telemetry-experience
+/tests/sentry/api/endpoints/test_organization_ai_conversation*.py                @getsentry/telemetry-experience
+## End of AI Conversations
 
 ## Billing
 /src/sentry/api/endpoints/check_am2_compatibility.py    @getsentry/revenue


### PR DESCRIPTION
## Summary
- Fix CODEOWNERS precedence for AI conversation endpoints
- Move rules to a dedicated section after the `/src/sentry/api/endpoints/` catch-all
- PRs touching `organization_ai_conversation*.py` will now correctly tag `@getsentry/telemetry-experience`

## Problem
GitHub CODEOWNERS uses **last matching pattern wins** precedence. The AI conversation endpoint rules were at line 507-509, but the catch-all `/src/sentry/api/endpoints/` rule at line 554 was overriding them, incorrectly assigning `@getsentry/issue-workflow`.
