### PR TITLE
feat(onboarding): Add metrics onboarding for React Native

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -404,6 +404,7 @@ export const withMetricsOnboarding: Set<PlatformKey> = new Set([
   'apple',
   'apple-ios',
   'apple-macos',
+  'react-native',
   'go',
   'go-echo',
   'go-fasthttp',

--- a/static/app/gettingStartedDocs/react-native/index.tsx
+++ b/static/app/gettingStartedDocs/react-native/index.tsx
@@ -1,6 +1,7 @@
 import type {Docs} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {crashReport} from './crashReport';
+import {metrics} from './metrics';
 import {onboarding} from './onboarding';
 import {profiling} from './profiling';
 import {sessionReplay} from './sessionReplay';
@@ -12,6 +13,7 @@ const docs: Docs = {
   crashReportOnboarding: crashReport,
   replayOnboarding: sessionReplay,
   profilingOnboarding: profiling,
+  metricsOnboarding: metrics,
 };
 
 export default docs;

--- a/static/app/gettingStartedDocs/react-native/metrics.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.tsx
@@ -3,57 +3,21 @@ import {ExternalLink} from '@sentry/scraps/link';
 import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
-import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+import {installCodeBlock} from './utils';
 
 export const metrics: OnboardingConfig = {
-  install: params => [
+  install: () => [
     {
       type: StepType.INSTALL,
       content: [
         {
           type: 'text',
-          text: tct(
-            'Metrics for React Native are supported in Sentry React Native SDK version [code:7.8.0] and above. If you are using an older version of the SDK, follow our [link:migration guide] to upgrade.',
-            {
-              code: <code />,
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/react-native/migration/" />
-              ),
-            }
+          text: t(
+            'Make sure your Sentry React Native SDK version is at least 7.8.0. If you already have the SDK installed, you can update it to the latest version with:'
           ),
         },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'npm',
-              language: 'bash',
-              code: `npm install --save @sentry/react-native@${getPackageVersion(
-                params,
-                '@sentry/react-native',
-                '7.8.0'
-              )}`,
-            },
-            {
-              label: 'yarn',
-              language: 'bash',
-              code: `yarn add @sentry/react-native@${getPackageVersion(
-                params,
-                '@sentry/react-native',
-                '7.8.0'
-              )}`,
-            },
-            {
-              label: 'pnpm',
-              language: 'bash',
-              code: `pnpm add @sentry/react-native@${getPackageVersion(
-                params,
-                '@sentry/react-native',
-                '7.8.0'
-              )}`,
-            },
-          ],
-        },
+        installCodeBlock,
       ],
     },
   ],
@@ -69,12 +33,17 @@ export const metrics: OnboardingConfig = {
         },
         {
           type: 'code',
-          language: 'javascript',
-          code: `import * as Sentry from '@sentry/react-native';
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
-  dsn: '${params.dsn.public}',
+  dsn: "${params.dsn.public}",
 });`,
+            },
+          ],
         },
       ],
     },
@@ -91,8 +60,11 @@ Sentry.init({
         },
         {
           type: 'code',
-          language: 'javascript',
-          code: `import * as Sentry from '@sentry/react-native';
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `import * as Sentry from "@sentry/react-native";
 
 // Counter metric
 Sentry.metrics.count('button_click', 1);
@@ -113,6 +85,8 @@ Sentry.metrics.count('network_request', 1, {
     method: 'POST',
   },
 });`,
+            },
+          ],
         },
         {
           type: 'text',

--- a/static/app/gettingStartedDocs/react-native/metrics.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.tsx
@@ -1,0 +1,131 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+import {getPackageVersion} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
+
+export const metrics: OnboardingConfig = {
+  install: params => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Metrics for React Native are supported in Sentry React Native SDK version [code:7.8.0] and above. If you are using an older version of the SDK, follow our [link:migration guide] to upgrade.',
+            {
+              code: <code />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/react-native/migration/" />
+              ),
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'npm',
+              language: 'bash',
+              code: `npm install --save @sentry/react-native@${getPackageVersion(
+                params,
+                '@sentry/react-native',
+                '7.8.0'
+              )}`,
+            },
+            {
+              label: 'yarn',
+              language: 'bash',
+              code: `yarn add @sentry/react-native@${getPackageVersion(
+                params,
+                '@sentry/react-native',
+                '7.8.0'
+              )}`,
+            },
+            {
+              label: 'pnpm',
+              language: 'bash',
+              code: `pnpm add @sentry/react-native@${getPackageVersion(
+                params,
+                '@sentry/react-native',
+                '7.8.0'
+              )}`,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Metrics are enabled by default once the SDK is initialized. No additional configuration is required.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
+          code: `import * as Sentry from '@sentry/react-native';
+
+Sentry.init({
+  dsn: '${params.dsn.public}',
+});`,
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Send test metrics from your app to verify metrics are arriving in Sentry.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'javascript',
+          code: `import * as Sentry from '@sentry/react-native';
+
+// Counter metric
+Sentry.metrics.count('button_click', 1);
+
+// Gauge metric
+Sentry.metrics.gauge('queue_depth', 42);
+
+// Distribution metric with unit
+Sentry.metrics.distribution('response_time', 187.5, {
+  unit: 'millisecond',
+});
+
+// Counter with unit and attributes
+Sentry.metrics.count('network_request', 1, {
+  unit: 'request',
+  attributes: {
+    endpoint: '/api/users',
+    method: 'POST',
+  },
+});`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'For more detailed information, see the [link:metrics documentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/react-native/metrics/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/react-native/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/onboarding.spec.tsx
@@ -24,4 +24,11 @@ describe('getting started with react-native', () => {
       screen.getByRole('heading', {name: /manual configuration/i})
     ).toBeInTheDocument();
   });
+
+  it('has metrics onboarding configuration', () => {
+    expect(docs.metricsOnboarding).toBeDefined();
+    expect(docs.metricsOnboarding?.install).toBeDefined();
+    expect(docs.metricsOnboarding?.configure).toBeDefined();
+    expect(docs.metricsOnboarding?.verify).toBeDefined();
+  });
 });

--- a/static/app/gettingStartedDocs/react-native/sessionReplay.tsx
+++ b/static/app/gettingStartedDocs/react-native/sessionReplay.tsx
@@ -6,7 +6,11 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils/replayOnboarding';
 import {t} from 'sentry/locale';
 
-import {getReplayConfigurationSnippet, getReplaySetupSnippet} from './utils';
+import {
+  getReplayConfigurationSnippet,
+  getReplaySetupSnippet,
+  installCodeBlock,
+} from './utils';
 
 export const sessionReplay: OnboardingConfig = {
   install: params => [
@@ -19,26 +23,7 @@ export const sessionReplay: OnboardingConfig = {
             'Make sure your Sentry React Native SDK version is at least 6.5.0. If you already have the SDK installed, you can update it to the latest version with:'
           ),
         },
-        {
-          type: 'code',
-          tabs: [
-            {
-              label: 'npm',
-              language: 'bash',
-              code: `npm install @sentry/react-native@latest`,
-            },
-            {
-              label: 'yarn',
-              language: 'bash',
-              code: `yarn add @sentry/react-native`,
-            },
-            {
-              label: 'pnpm',
-              language: 'bash',
-              code: `pnpm add @sentry/react-native`,
-            },
-          ],
-        },
+        installCodeBlock,
         {
           type: 'text',
           text: t(

--- a/static/app/gettingStartedDocs/react-native/sessionReplay.tsx
+++ b/static/app/gettingStartedDocs/react-native/sessionReplay.tsx
@@ -25,7 +25,7 @@ export const sessionReplay: OnboardingConfig = {
             {
               label: 'npm',
               language: 'bash',
-              code: `npm install @sentry/react-native --save`,
+              code: `npm install @sentry/react-native@latest`,
             },
             {
               label: 'yarn',

--- a/static/app/gettingStartedDocs/react-native/utils.tsx
+++ b/static/app/gettingStartedDocs/react-native/utils.tsx
@@ -10,7 +10,7 @@ export const installCodeBlock: ContentBlock = {
     {
       label: 'npm',
       language: 'bash',
-      code: `npm install @sentry/react-native --save`,
+      code: `npm install @sentry/react-native@latest`,
     },
     {
       label: 'yarn',

--- a/static/app/gettingStartedDocs/react-native/utils.tsx
+++ b/static/app/gettingStartedDocs/react-native/utils.tsx
@@ -15,12 +15,12 @@ export const installCodeBlock: ContentBlock = {
     {
       label: 'yarn',
       language: 'bash',
-      code: `yarn add @sentry/react-native`,
+      code: `yarn add @sentry/react-native@latest`,
     },
     {
       label: 'pnpm',
       language: 'bash',
-      code: `pnpm add @sentry/react-native`,
+      code: `pnpm add @sentry/react-native@latest`,
     },
   ],
 };


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds metrics onboarding documentation for React Native SDK.

See https://docs.sentry.io/platforms/react-native/metrics/

Part of https://github.com/getsentry/sentry-react-native/issues/5610

To test:
- [Get Cookie sync and sync cookies](https://develop.sentry.dev/development-infrastructure/frontend-development-server/)
- VIsit https://sentry-8k4qb9u3f.sentry.dev/explore/metrics/?guidedStep=1

<img width="1512" height="1208" alt="Screenshot 2026-02-05 at 15 51 42" src="https://github.com/user-attachments/assets/17e56b07-02eb-47da-b785-4a1d6bcab87d" />
<img width="1512" height="1208" alt="Screenshot 2026-02-05 at 15 51 53" src="https://github.com/user-attachments/assets/55cb60a3-e173-4e6f-bcf5-54b7d2532aee" />
<img width="1512" height="1208" alt="Screenshot 2026-02-05 at 15 52 09" src="https://github.com/user-attachments/assets/8cfcfbec-5de5-4a66-91c9-c89d27703c86" />



