### PR TITLE
feat(autopilot): Prepare missing integration detection for experiment

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1095,7 +1095,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     },
     "autopilot-run-missing-sdk-integration-detector": {
         "task": "autopilot:sentry.autopilot.tasks.run_missing_sdk_integration_detector",
-        "schedule": task_crontab("*/20", "*", "*", "*", "*"),
+        "schedule": task_crontab("0", "*/4", "*", "*", "*"),
     },
     "autopilot-run-trace-instrumentation-detector": {
         "task": "autopilot:sentry.autopilot.tasks.run_trace_instrumentation_detector",
@@ -1287,6 +1287,7 @@ LOGGING: LoggingConfig = {
         },
         "sentry.rules": {"handlers": ["console"], "propagate": False},
         "sentry.profiles": {"level": "INFO"},
+        "sentry.autopilot.tasks.missing_sdk_integration": {"level": "INFO"},
         "multiprocessing": {
             "handlers": ["console"],
             # https://github.com/celery/celery/commit/597a6b1f3359065ff6dbabce7237f86b866313df

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3964,6 +3964,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Project ID allowlist to enable missing SDK integration detector for specific projects.
+register(
+    "autopilot.missing-sdk-integration.projects-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Global flag to enable API token async flush
 register(
     "api-token-async-flush",


### PR DESCRIPTION
Prepares missing sdk integration detector for a shadow run experiement. We are planning to run this on 200 projects to get the feeling how often this could detect a problem in a real world traces and repositories. This will not create real issues as they will not get ingested, but we will use the metrics and logs to learn more about the performance of the detector.

Closes [TET-1899: Implement shadow run for 200 pre-selected projects](https://linear.app/getsentry/issue/TET-1899/implement-shadow-run-for-200-pre-selected-projects)