### PR TITLE
chore(onboarding): Update tanstack start vite plugin to subpath export

### DIFF
--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -218,7 +218,7 @@ export default createServerEntry(
               language: 'typescript',
               filename: 'vite.config.ts',
               code: `import { defineConfig } from "vite";
-import { sentryTanstackStart } from "@sentry/tanstackstart-react";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 
 export default defineConfig({


### PR DESCRIPTION
Updating the onboarding as we will have to change this to a subpath export: https://github.com/getsentry/sentry-javascript/pull/19182

Should be merged after the `10.40.0` release of the javascript SDKs
