### PR TITLE
chore(trace-waterfall): Update link from Replays

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
@@ -1,9 +1,12 @@
 import {LinkButton} from '@sentry/scraps/button';
 
+import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {t} from 'sentry/locale';
 import type EventView from 'sentry/utils/discover/eventView';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {getExploreUrl} from 'sentry/views/explore/utils';
 import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnalytics';
 import {
   getSearchInExploreTarget,
@@ -11,11 +14,18 @@ import {
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 type Props = {
+  source: string;
   traceEventView: EventView;
   trace_id: string;
+  replayId?: string;
 };
 
-export function TraceOpenInExploreButton({trace_id, traceEventView}: Props) {
+export function TraceOpenInExploreButton({
+  trace_id,
+  traceEventView,
+  source,
+  replayId,
+}: Props) {
   const organization = useOrganization();
   const hasExploreEnabled = organization.features.includes('visibility-explore-view');
   const location = useLocation();
@@ -25,6 +35,47 @@ export function TraceOpenInExploreButton({trace_id, traceEventView}: Props) {
   }
 
   const {start, end, statsPeriod} = traceEventView;
+
+  // When viewing from replay page, link to explore with replayId query and trace groupBy
+  if (source === 'replay' && replayId) {
+    const search = new MutableSearch('');
+    search.addFilterValue('replayId', replayId);
+    const target = getExploreUrl({
+      organization,
+      selection: {
+        datetime: {
+          start: start ?? null,
+          end: end ?? null,
+          period: start && end ? null : (statsPeriod ?? null),
+          utc: null,
+        },
+        projects: [],
+        environments: [],
+      },
+      query: search.formatString(),
+      groupBy: ['trace'],
+      mode: Mode.AGGREGATE,
+    });
+
+    return (
+      <LinkButton
+        size="xs"
+        to={target}
+        onClick={() => {
+          traceAnalytics.trackExploreSearch(
+            organization,
+            'replayId',
+            replayId,
+            TraceDrawerActionKind.INCLUDE,
+            'toolbar_menu'
+          );
+        }}
+      >
+        {t('Open in Explore')}
+      </LinkButton>
+    );
+  }
+
   const target = getSearchInExploreTarget(
     organization,
     {

--- a/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
+++ b/static/app/views/performance/newTraceDetails/traceOpenInExploreButton.tsx
@@ -12,9 +12,10 @@ import {
   getSearchInExploreTarget,
   TraceDrawerActionKind,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import type {TraceWaterfallSource} from 'sentry/views/performance/newTraceDetails/traceWaterfall';
 
 type Props = {
-  source: string;
+  source: TraceWaterfallSource;
   traceEventView: EventView;
   trace_id: string;
   replayId?: string;

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -672,6 +672,8 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
         <TraceOpenInExploreButton
           trace_id={props.traceSlug}
           traceEventView={props.traceEventView}
+          source={props.source}
+          replayId={props.replay?.id}
         />
         <TraceResetZoomButton
           viewManager={viewManager}

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -72,12 +72,14 @@ import {useTraceQueryParamStateSync} from './useTraceQueryParamStateSync';
 import {useTraceScrollToPath} from './useTraceScrollToPath';
 import {useTraceTimelineChangeSync} from './useTraceTimelineChangeSync';
 
+export type TraceWaterfallSource = 'issues' | 'performance' | 'replay' | 'trace_view';
+
 export interface TraceWaterfallProps {
   meta: TraceMetaQueryResults;
   organization: Organization;
   replay: ReplayRecord | null;
   rootEventResults: TraceRootEventQueryResults;
-  source: string;
+  source: TraceWaterfallSource;
   trace: UseApiQueryResult<TraceTree.Trace, RequestError>;
   traceEventView: EventView;
   traceSlug: string;


### PR DESCRIPTION
This PR modifies the "Open in Explore" link from the replay trace tab to look for spans that have the `replayId`, and aggregate them by trace, as replay's can have more than one trace attached to them which wasn't being shown with the previous query params.

Ticket: EXP-751