### PR TITLE
feat(scraps): expand font-size for headings

### DIFF
--- a/static/app/components/core/principles/tokens/tokens.mdx
+++ b/static/app/components/core/principles/tokens/tokens.mdx
@@ -15,7 +15,7 @@ import {useTheme} from '@emotion/react';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
-import {Text} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import * as Storybook from 'sentry/stories';
 // eslint-disable-next-line @sentry/scraps/no-token-import -- temporary until theme.borderWidth is exposed
@@ -237,11 +237,20 @@ export function FontSize() {
     <Storybook.TokenReference
       scale="font.size"
       tokens={theme.font.size}
-      renderToken={({token}) => (
-        <Text size={token} variant="accent">
-          Aa
-        </Text>
-      )}
+      renderToken={({token}) => {
+        if (['3xl', '4xl'].includes(token)) {
+          return (
+            <Heading size={token} variant="accent">
+              Aa
+            </Heading>
+          );
+        }
+        return (
+          <Text size={token} variant="accent">
+            Aa
+          </Text>
+        );
+      }}
     />
   );
 }

--- a/static/app/components/core/text/heading.mdx
+++ b/static/app/components/core/text/heading.mdx
@@ -59,10 +59,12 @@ Use the required `as` prop to specify the semantic heading level. Each level has
 
 Override the default size with the `size` prop to decouple visual appearance from semantic meaning.
 
+Heading supports up to `4xl` as opposed to [Text](/stories/core/text/) which only allows `2xl`.
+
 <Storybook.Demo>
   <Storybook.SideBySide vertical>
-    <Heading as="h3" size="2xl">
-      H3 with 2xl size
+    <Heading as="h2" size="4xl">
+      H2 with 4xl size
     </Heading>
     <Heading as="h1" size="md">
       H1 with medium size
@@ -70,20 +72,26 @@ Override the default size with the `size` prop to decouple visual appearance fro
     <Heading as="h5" size="xl">
       H5 with extra large size
     </Heading>
+    <Heading as="h3" size="3xl">
+      H3 with 3xl size
+    </Heading>
     <Heading as="h6" size={{md: 'xs', lg: 'xl'}}>
       H6 with responsive size
     </Heading>
   </Storybook.SideBySide>
 </Storybook.Demo>
 ```jsx
-<Heading as="h3" size="2xl">
-  H3 with 2xl size
+<Heading as="h2" size="4xl">
+  H2 with 4xl size
 </Heading>
 <Heading as="h1" size="md">
   H1 with medium size
 </Heading>
 <Heading as="h5" size="xl">
   H5 with extra large size
+</Heading>
+<Heading as="h3" size="3xl">
+  H3 with 3xl size
 </Heading>
 <Heading as="h6" size={{md: 'xs', lg: 'xl'}}>
   H6 with responsive size
@@ -273,3 +281,8 @@ Headings support responsive sizes using breakpoint objects. Breakpoints are: `xs
   Responsive heading
 </Heading>
 ```
+
+## See Also
+
+- [Text](/stories/core/text/) - Related component for body text
+- [Prose](/stories/core/prose/) - Related component for long-form content

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -87,7 +87,7 @@ export const Heading = styled(
   padding: 0;
 `;
 
-function getDefaultHeadingFontSize(as: HeadingProps['as']): FontSize {
+function getDefaultHeadingFontSize(as: HeadingProps['as']): HeadingSize {
   switch (as) {
     case 'h1':
       return '2xl';

--- a/static/app/components/core/text/heading.tsx
+++ b/static/app/components/core/text/heading.tsx
@@ -1,9 +1,9 @@
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
-import {rc} from '@sentry/scraps/layout';
+import {rc, type Responsive} from '@sentry/scraps/layout';
 
-import type {FontSize} from 'sentry/utils/theme';
+import type {HeadingSize} from 'sentry/utils/theme';
 
 import {getFontSize, getLineHeight, getTextDecoration} from './styles';
 import {type BaseTextProps, type ExclusiveTextEllipsisProps} from './text';
@@ -17,6 +17,11 @@ export type HeadingProps = BaseHeadingProps & {
    */
   as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   ref?: React.Ref<HTMLHeadingElement | null> | undefined;
+  /**
+   * The size of the text.
+   * @default md
+   */
+  size?: Responsive<HeadingSize>;
   /**
    * Deprecated in favor of the Text component API.
    * If you have an is an unsupported use-case, please contact design engineering for support.

--- a/static/app/components/core/text/styles.tsx
+++ b/static/app/components/core/text/styles.tsx
@@ -1,6 +1,6 @@
 import type {Theme} from '@emotion/react';
 
-import type {FontSize} from 'sentry/utils/theme';
+import type {HeadingSize, TextSize} from 'sentry/utils/theme';
 
 import type {HeadingProps} from './heading';
 import type {TextProps} from './text';
@@ -39,7 +39,7 @@ export function getLineHeight(
 }
 
 export function getFontSize(
-  size: FontSize | undefined,
+  size: TextSize | HeadingSize | undefined,
   theme: Theme
 ): string | undefined {
   if (size === undefined) {

--- a/static/app/components/core/text/text.mdx
+++ b/static/app/components/core/text/text.mdx
@@ -349,3 +349,8 @@ Text components support responsive sizes using breakpoint objects. Breakpoints a
 ## Accessibility
 
 Text components automatically meet WCAG 2.2 AA compliance for color contrast and text spacing. When using semantic headings, ensure proper heading hierarchy for screen readers.
+
+## See Also
+
+- [Heading](/stories/core/heading/) - Related component for semantic headings
+- [Prose](/stories/core/prose/) - Related component for long-form content

--- a/static/app/components/core/text/text.tsx
+++ b/static/app/components/core/text/text.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {rc, type Responsive} from '@sentry/scraps/layout';
 
-import type {ContentVariant, FontSize} from 'sentry/utils/theme';
+import type {ContentVariant, TextSize} from 'sentry/utils/theme';
 
 import {getFontSize, getLineHeight, getTextDecoration} from './styles';
 
@@ -43,12 +43,6 @@ export interface BaseTextProps {
    * If true, the text will be displayed in a monospace font.
    */
   monospace?: boolean;
-
-  /**
-   * The size of the text.
-   * @default md
-   */
-  size?: Responsive<FontSize>;
 
   /**
    * Strikethrough the text.
@@ -133,6 +127,11 @@ interface TextAttributes<T extends 'span' | 'p' | 'label' | 'div' = 'span'>
    *
    */
   htmlFor?: T extends 'label' ? string : never;
+  /**
+   * The size of the text.
+   * @default md
+   */
+  size?: Responsive<TextSize>;
 
   /**
    * Deprecated in favor of the Text component API.

--- a/static/app/utils/theme/scraps/tokens/typography.tsx
+++ b/static/app/utils/theme/scraps/tokens/typography.tsx
@@ -28,6 +28,14 @@ export const typography = {
        * A named fontSize value evaluating to “24px”
        */
       '2xl': '24px',
+      /**
+       * A named fontSize value evaluating to “32px”
+       */
+      '3xl': '32px',
+      /**
+       * A named fontSize value evaluating to “40px”
+       */
+      '4xl': '40px',
     },
     weight: {
       sans: {
@@ -53,11 +61,11 @@ export const typography = {
     },
     family: {
       /**
-       * A named fontFamily value evaluating to “rubik”
+       * Sans-serif font family for headings and body copy
        */
-      sans: "'Rubik', 'Avenir Next', sans-serif",
+      sans: "Rubik, 'Avenir Next', sans-serif",
       /**
-       * A named fontFamily value evaluating to “roboto mono”
+       * Monospace font family for code samples
        */
       mono: "'Roboto Mono', Monaco, Consolas, 'Courier New', monospace",
     },
@@ -65,15 +73,15 @@ export const typography = {
       /**
        * A named lineHeight value evaluating to “1”
        */
-      compressed: 1,
+      compressed: '1',
       /**
        * A named lineHeight value evaluating to “1.2”
        */
-      default: 1.2,
+      default: '1.2',
       /**
        * A named lineHeight value evaluating to “1.4”
        */
-      comfortable: 1.4,
+      comfortable: '1.4',
       /**
        * A named lineHeight value evaluating to “1rem”
        */

--- a/static/app/utils/theme/scraps/tokens/typography.tsx
+++ b/static/app/utils/theme/scraps/tokens/typography.tsx
@@ -73,15 +73,15 @@ export const typography = {
       /**
        * A named lineHeight value evaluating to “1”
        */
-      compressed: '1',
+      compressed: 1,
       /**
        * A named lineHeight value evaluating to “1.2”
        */
-      default: '1.2',
+      default: 1.2,
       /**
        * A named lineHeight value evaluating to “1.4”
        */
-      comfortable: '1.4',
+      comfortable: 1.4,
       /**
        * A named lineHeight value evaluating to “1rem”
        */

--- a/static/app/utils/theme/types.tsx
+++ b/static/app/utils/theme/types.tsx
@@ -1,7 +1,12 @@
 /**
- * Font size constraint for typography.
+ * Font size constraint for body typography.
  */
-export type FontSize = SizeRange<'xs', '2xl'>;
+export type TextSize = SizeRange<'xs', '2xl'>;
+
+/**
+ * Font size constraint for heading typography.
+ */
+export type HeadingSize = SizeRange<'xs', '4xl'>;
 
 /**
  * Responsive breakpoint size constraint.
@@ -104,7 +109,7 @@ export type AlertVariant = 'muted' | 'info' | 'warning' | 'success' | 'danger';
 // Internal types
 // -----------------------------------------------------------------------------
 
-type SizeKeys = readonly ['0', '2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl'];
+type SizeKeys = readonly ['0', '2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
 type Size = SizeKeys[number];
 
 // Extracts a contiguous range of keys from the size scale


### PR DESCRIPTION
- Updates `fontSize` tokens to support up to 4xl
- Splits `FontSize` types into `TextSize` (up to 2xl) and `HeadingSize` (up to 4xl)
- Updates Storybook (token reference, text, and heading)
- Closes DE-793