### PR TITLE
fix(integrations): filter installed repos by organization in repo listing

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -55,9 +55,9 @@ class OrganizationIntegrationReposEndpoint(RegionOrganizationIntegrationBaseEndp
         if integration.status == ObjectStatus.DISABLED:
             return self.respond({"repos": []})
 
-        installed_repos = Repository.objects.filter(integration_id=integration.id).exclude(
-            status=ObjectStatus.HIDDEN
-        )
+        installed_repos = Repository.objects.filter(
+            integration_id=integration.id, organization_id=organization.id
+        ).exclude(status=ObjectStatus.HIDDEN)
         installed_repo_names = {installed_repo.name for installed_repo in installed_repos}
 
         install = integration.get_installation(organization_id=organization.id)

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -9,6 +9,7 @@ class OrganizationIntegrationReposTest(APITestCase):
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")
+        self.project = self.create_project(organization=self.org)
         self.integration = self.create_integration(
             organization=self.org, provider="github", name="Example", external_id="github:1"
         )
@@ -145,6 +146,41 @@ class OrganizationIntegrationReposTest(APITestCase):
                     "name": "rad-repo",
                     "identifier": "Example2/rad-repo",
                     "defaultBranch": "dev",
+                    "isInstalled": False,
+                },
+            ],
+            "searchable": True,
+        }
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_repo_installed_by_other_org_not_excluded(self, get_repositories: MagicMock) -> None:
+        """
+        When two organizations share the same integration, a repo installed by
+        one organization should not affect the available repos for the other.
+        """
+        get_repositories.return_value = [
+            {"name": "shared-repo", "identifier": "Example/shared-repo", "default_branch": "main"},
+        ]
+
+        other_org = self.create_organization(owner=self.user, name="other-org")
+        other_project = self.create_project(organization=other_org)
+        self.create_repo(
+            project=other_project,
+            integration_id=self.integration.id,
+            name="Example/shared-repo",
+        )
+
+        response = self.client.get(self.path, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "repos": [
+                {
+                    "name": "shared-repo",
+                    "identifier": "Example/shared-repo",
+                    "defaultBranch": "main",
                     "isInstalled": False,
                 },
             ],


### PR DESCRIPTION
fixes a bug since orgs can now share github integrations.

- we have to filter the 'available repos' by the organization, otherwise orgs won't be able to share repos even if they share a github integration.


Resolves this issue, where another org already added the repo
<img width="777" height="345" alt="image" src="https://github.com/user-attachments/assets/8063add8-d39b-4830-b018-7ff5e47b3568" />
