### PR TITLE
fix(seer): RCA Onboarding step broken due to provider

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -123,7 +123,7 @@ export function ConfigureRootCauseAnalysisStep() {
           integration_id: repo.integrationId,
           organization_id: parseInt(organization.id, 10),
           owner,
-          provider: repo.provider?.name,
+          provider: repo.provider?.id,
           name,
         });
       }


### PR DESCRIPTION
I dont know yet if something changed but provider name was being sent e.g. (GitHub), but its all lowercase in the db

repo.id will be something like `integrations:github` which is what we want vs name which is `GitHub` (backend checks both using the `provider` property (e.g. matches `${provider}` and `integrations:${provider}`
