### PR TITLE
feat(dashboards): register Frontend Overview prebuilt dashboard on backend

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -75,6 +75,7 @@ class PrebuiltDashboardId(IntEnum):
     MOBILE_VITALS_SCREEN_RENDERING = 11
     BACKEND_OVERVIEW = 12
     MOBILE_SESSION_HEALTH = 13
+    FRONTEND_OVERVIEW = 14
 
 
 class PrebuiltDashboard(TypedDict):
@@ -143,6 +144,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.MOBILE_SESSION_HEALTH,
         "title": "Mobile Session Health",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_OVERVIEW,
+        "title": "Frontend Overview",
     },
 ]
 


### PR DESCRIPTION
## Summary
- Add `FRONTEND_OVERVIEW = 14` to the `PrebuiltDashboardId` enum on the backend
- Register the "Frontend Overview" prebuilt dashboard in the `PREBUILT_DASHBOARDS` list

This syncs the backend with the frontend configuration added in #87629.

## Test plan
- [ ] Verify the prebuilt dashboard appears in the dashboard list when the feature flag is enabled