### PR TITLE
fix(seer): Use provider.name for consistency

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/configureRootCauseAnalysisStep.tsx
@@ -123,7 +123,7 @@ export function ConfigureRootCauseAnalysisStep() {
           integration_id: repo.integrationId,
           organization_id: parseInt(organization.id, 10),
           owner,
-          provider: repo.provider?.id,
+          provider: repo.provider?.name?.toLowerCase(),
           name,
         });
       }


### PR DESCRIPTION
I missed that this was broken recently due to a backend change: https://github.com/getsentry/sentry/pull/107235 -- specifically [here](https://github.com/getsentry/sentry/pull/107235/changes#diff-069c881c439f4ff7260f1e9bad598201a9b4798611320656c675571d640a5a2fR258)

id === `integrations:${provider.name.toLowerCase}`, so changing what we send as `provider` may break other things, so change it back to use provider.name
