### PR TITLE
ref(nextjs): update auto vercel cron config references

### DIFF
--- a/static/app/views/insights/crons/components/upsertPlatformGuides.tsx
+++ b/static/app/views/insights/crons/components/upsertPlatformGuides.tsx
@@ -614,8 +614,10 @@ module.exports = withSentryConfig(
     // Your Next.js config
   },
   {
-    automaticVercelMonitors: true, // Enable Vercel Cron Jobs monitoring
     // ... other Sentry options
+    webpack: {
+      automaticVercelMonitors: true, // Enable Vercel Cron Jobs monitoring
+    },
   }
 );`;
 
@@ -633,16 +635,16 @@ module.exports = withSentryConfig(
     <Fragment>
       <div>
         {tct(
-          'Use the [additionalDocs:Next.js SDK] with [automaticVercelMonitors:automaticVercelMonitors] to automatically create monitors for your Vercel Cron Jobs.',
+          'Use the [additionalDocs:Next.js SDK] with [automaticVercelMonitors:webpack.automaticVercelMonitors] to automatically create monitors for your Vercel Cron Jobs.',
           {
             additionalDocs: (
-              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/build/" />
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/build/#webpack.automaticVercelMonitors" />
             ),
             automaticVercelMonitors: <code />,
           }
         )}
       </div>
-      <div>{t('Enable automaticVercelMonitors in your next.config.js:')}</div>
+      <div>{t('Enable webpack.automaticVercelMonitors in your next.config.js:')}</div>
       <CodeBlock language="javascript">{configCode}</CodeBlock>
       <div>{t('Configure your Vercel Cron Jobs in vercel.json:')}</div>
       <CodeBlock language="json">{cronCode}</CodeBlock>

--- a/static/app/views/insights/crons/components/upsertPlatformGuides.tsx
+++ b/static/app/views/insights/crons/components/upsertPlatformGuides.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {Alert} from '@sentry/scraps/alert';
 import {CodeBlock} from '@sentry/scraps/code';
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -653,6 +654,11 @@ module.exports = withSentryConfig(
           'Monitors will be automatically created for each cron job in your vercel.json configuration.'
         )}
       </div>
+      <Alert variant="info">
+        {t(
+          'This option only works when using Webpack. If you are using Turbopack, this option will have no effect.'
+        )}
+      </Alert>
     </Fragment>
   );
 }


### PR DESCRIPTION
We recently [changed](https://github.com/getsentry/sentry-docs/pull/15691) the `automaticVercelMonitors` to `webpack.automaticVercelMonitors` since it only affected webpack configurations and didn't have an effect for Turbopack users.

This PR updates the references to use the new configuration path and code snippets. 