### PR TITLE
fix(redis): Cast Redis version to string before parsing

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -344,7 +344,7 @@ def check_cluster_versions(
         # NOTE: This assumes there is no routing magic going on here, and
         # all requests to this host are being served by the same database.
         key = f"{host.host}:{host.port}"
-        versions[key] = Version([int(part) for part in info["redis_version"].split(".", 3)])
+        versions[key] = Version([int(part) for part in str(info["redis_version"]).split(".", 3)])
 
     check_versions(
         "Redis" if label is None else f"Redis ({label})", versions, required, recommended


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry/issues/107394.

Fixes version parsing in `check_cluster_versions` to handle cases where `redis_version` is returned as a float instead of a string.

AWS Valkey (a Redis fork) returns `redis_version` as `"7.2"` (2-part version) which some Redis client libraries auto-coerce to a Python float (`7.2`). This caused a `'float' object has no attribute 'split'` error during service startup validation.

The fix wraps the version value with `str()` before calling `.split()`, which handles both string and float inputs correctly.