### PR TITLE
Issues first release search

### DIFF
--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -57,7 +57,7 @@ for substatus_key, substatus_value in SUBSTATUS_UPDATE_CHOICES.items():
 
 issue_search_config = SearchConfig.create_from(
     default_config,
-    allow_boolean=False,
+    allow_boolean=True,
     is_filter_translation=is_filter_translation,
     numeric_keys=default_config.numeric_keys | {"times_seen"},
     date_keys=default_config.date_keys | {"date", "first_seen", "last_seen", "issue.seer_last_run"},

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -143,6 +143,7 @@ def _wildcard_to_regex(pattern: str) -> str:
     """Convert a wildcard pattern to a regex pattern for database queries."""
     # Escape special regex characters except *
     import re
+
     escaped = re.escape(pattern)
     # Replace escaped \* with .* for regex matching
     regex_pattern = escaped.replace(r"\*", ".*")
@@ -155,9 +156,9 @@ def first_release_all_environments_filter(
     # Separate exact matches from wildcard patterns
     exact_versions = [v for v in versions if not _has_wildcard(v)]
     wildcard_patterns = [v for v in versions if _has_wildcard(v)]
-    
+
     query = Q()
-    
+
     # Handle exact version matches
     if exact_versions:
         releases: dict[str | None, int] = {
@@ -179,19 +180,18 @@ def first_release_all_environments_filter(
         # first_release of any environment that the group has been
         # seen in.
         query |= Q(first_release_id__in=list(releases.values()))
-    
+
     # Handle wildcard patterns
     if wildcard_patterns:
         wildcard_query = Q()
         for pattern in wildcard_patterns:
             regex_pattern = _wildcard_to_regex(pattern)
             matching_releases = Release.objects.filter(
-                organization=projects[0].organization_id,
-                version__iregex=regex_pattern
+                organization=projects[0].organization_id, version__iregex=regex_pattern
             ).values_list("id", flat=True)
             wildcard_query |= Q(first_release_id__in=list(matching_releases))
         query |= wildcard_query
-    
+
     return query
 
 
@@ -651,14 +651,14 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
 
         if environments is not None:
             environment_ids = [environment.id for environment in environments]
-            
+
             def first_release_with_env_filter(versions: Sequence[str]) -> Q:
                 # Separate exact matches from wildcard patterns
                 exact_versions = [v for v in versions if not _has_wildcard(v)]
                 wildcard_patterns = [v for v in versions if _has_wildcard(v)]
-                
+
                 query = Q()
-                
+
                 # Handle exact version matches
                 if exact_versions:
                     query |= Q(
@@ -668,7 +668,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
                             environment_id__in=environment_ids,
                         ).values_list("group_id")
                     )
-                
+
                 # Handle wildcard patterns
                 if wildcard_patterns:
                     for pattern in wildcard_patterns:
@@ -680,9 +680,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
                                 environment_id__in=environment_ids,
                             ).values_list("group_id")
                         )
-                
+
                 return query
-            
+
             queryset_conditions.update(
                 {
                     "first_release": QCallbackCondition(first_release_with_env_filter),

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import re
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -141,9 +142,6 @@ def _has_wildcard(version: str) -> bool:
 
 def _wildcard_to_regex(pattern: str) -> str:
     """Convert a wildcard pattern to a regex pattern for database queries."""
-    # Escape special regex characters except *
-    import re
-
     escaped = re.escape(pattern)
     # Replace escaped \* with .* for regex matching
     regex_pattern = escaped.replace(r"\*", ".*")

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -134,28 +134,65 @@ def linked_filter(linked: bool, projects: Sequence[Project]) -> Q:
     return query
 
 
+def _has_wildcard(version: str) -> bool:
+    """Check if a version string contains wildcard characters."""
+    return "*" in version
+
+
+def _wildcard_to_regex(pattern: str) -> str:
+    """Convert a wildcard pattern to a regex pattern for database queries."""
+    # Escape special regex characters except *
+    import re
+    escaped = re.escape(pattern)
+    # Replace escaped \* with .* for regex matching
+    regex_pattern = escaped.replace(r"\*", ".*")
+    return f"^{regex_pattern}$"
+
+
 def first_release_all_environments_filter(
     versions: Sequence[str], projects: Sequence[Project]
 ) -> Q:
-    releases: dict[str | None, int] = {
-        id_: version
-        for id_, version in Release.objects.filter(
-            organization=projects[0].organization_id, version__in=versions
-        ).values_list("version", "id")
-    }
-    for version in versions:
-        if version not in releases:
-            # TODO: This is mostly around for legacy reasons - we should probably just
-            # raise a validation here an inform the user that they passed an invalid
-            # release
-            releases[None] = -1
-            # We only need to find the first non-existent release here
-            break
+    # Separate exact matches from wildcard patterns
+    exact_versions = [v for v in versions if not _has_wildcard(v)]
+    wildcard_patterns = [v for v in versions if _has_wildcard(v)]
+    
+    query = Q()
+    
+    # Handle exact version matches
+    if exact_versions:
+        releases: dict[str | None, int] = {
+            id_: version
+            for id_, version in Release.objects.filter(
+                organization=projects[0].organization_id, version__in=exact_versions
+            ).values_list("version", "id")
+        }
+        for version in exact_versions:
+            if version not in releases:
+                # TODO: This is mostly around for legacy reasons - we should probably just
+                # raise a validation here an inform the user that they passed an invalid
+                # release
+                releases[None] = -1
+                # We only need to find the first non-existent release here
+                break
 
         # If no specific environments are supplied, we look at the
         # first_release of any environment that the group has been
         # seen in.
-    return Q(first_release_id__in=list(releases.values()))
+        query |= Q(first_release_id__in=list(releases.values()))
+    
+    # Handle wildcard patterns
+    if wildcard_patterns:
+        wildcard_query = Q()
+        for pattern in wildcard_patterns:
+            regex_pattern = _wildcard_to_regex(pattern)
+            matching_releases = Release.objects.filter(
+                organization=projects[0].organization_id,
+                version__iregex=regex_pattern
+            ).values_list("id", flat=True)
+            wildcard_query |= Q(first_release_id__in=list(matching_releases))
+        query |= wildcard_query
+    
+    return query
 
 
 def inbox_filter(inbox: bool, projects: Sequence[Project]) -> Q:
@@ -614,19 +651,41 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
 
         if environments is not None:
             environment_ids = [environment.id for environment in environments]
-            queryset_conditions.update(
-                {
-                    "first_release": QCallbackCondition(
-                        lambda versions: Q(
-                            # if environment(s) are selected, we just filter on the group
-                            # environment's first_release attribute.
+            
+            def first_release_with_env_filter(versions: Sequence[str]) -> Q:
+                # Separate exact matches from wildcard patterns
+                exact_versions = [v for v in versions if not _has_wildcard(v)]
+                wildcard_patterns = [v for v in versions if _has_wildcard(v)]
+                
+                query = Q()
+                
+                # Handle exact version matches
+                if exact_versions:
+                    query |= Q(
+                        id__in=GroupEnvironment.objects.filter(
+                            first_release__organization_id=projects[0].organization_id,
+                            first_release__version__in=exact_versions,
+                            environment_id__in=environment_ids,
+                        ).values_list("group_id")
+                    )
+                
+                # Handle wildcard patterns
+                if wildcard_patterns:
+                    for pattern in wildcard_patterns:
+                        regex_pattern = _wildcard_to_regex(pattern)
+                        query |= Q(
                             id__in=GroupEnvironment.objects.filter(
                                 first_release__organization_id=projects[0].organization_id,
-                                first_release__version__in=versions,
+                                first_release__version__iregex=regex_pattern,
                                 environment_id__in=environment_ids,
-                            ).values_list("group_id"),
+                            ).values_list("group_id")
                         )
-                    ),
+                
+                return query
+            
+            queryset_conditions.update(
+                {
+                    "first_release": QCallbackCondition(first_release_with_env_filter),
                     "first_seen": ScalarCondition(
                         "groupenvironment__first_seen",
                         {"groupenvironment__environment_id__in": environment_ids},

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -139,15 +139,15 @@ class ParseSearchQueryTest(unittest.TestCase):
         # Test that boolean operators are now supported
         result = parse_search_query("user.email:foo@example.com OR user.email:bar@example.com")
         assert len(result) == 3  # Two filters + one OR operator
-        
+
         result = parse_search_query("user.email:foo@example.com AND user.email:bar@example.com")
         assert len(result) == 3  # Two filters + one AND operator
-    
+
     def test_first_release_with_or_operator(self) -> None:
         # Test that OR operator works with firstRelease
         result = parse_search_query("firstRelease:1.0.0 OR firstRelease:1.0.1")
         assert len(result) == 3  # Two filters + one OR operator
-        
+
         result = parse_search_query("first-release:1.0.0 OR first-release:1.0.1")
         assert len(result) == 3  # Two filters + one OR operator
 

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -135,19 +135,21 @@ class ParseSearchQueryTest(unittest.TestCase):
             with pytest.raises(InvalidSearchQuery, match="Invalid number"):
                 parse_search_query(invalid_query)
 
-    def test_boolean_operators_not_allowed(self) -> None:
-        invalid_queries = [
-            "user.email:foo@example.com OR user.email:bar@example.com",
-            "user.email:foo@example.com AND user.email:bar@example.com",
-            "user.email:foo@example.com OR user.email:bar@example.com OR user.email:foobar@example.com",
-            "user.email:foo@example.com AND user.email:bar@example.com AND user.email:foobar@example.com",
-        ]
-        for invalid_query in invalid_queries:
-            with pytest.raises(
-                InvalidSearchQuery,
-                match='Boolean statements containing "OR" or "AND" are not supported in this search',
-            ):
-                parse_search_query(invalid_query)
+    def test_boolean_operators_allowed(self) -> None:
+        # Test that boolean operators are now supported
+        result = parse_search_query("user.email:foo@example.com OR user.email:bar@example.com")
+        assert len(result) == 3  # Two filters + one OR operator
+        
+        result = parse_search_query("user.email:foo@example.com AND user.email:bar@example.com")
+        assert len(result) == 3  # Two filters + one AND operator
+    
+    def test_first_release_with_or_operator(self) -> None:
+        # Test that OR operator works with firstRelease
+        result = parse_search_query("firstRelease:1.0.0 OR firstRelease:1.0.1")
+        assert len(result) == 3  # Two filters + one OR operator
+        
+        result = parse_search_query("first-release:1.0.0 OR first-release:1.0.1")
+        assert len(result) == 3  # Two filters + one OR operator
 
     def test_parens_in_query(self) -> None:
         assert parse_search_query(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2187,7 +2187,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         release_1 = self.create_release(self.project, version="com.example@1.2.0")
         release_2 = self.create_release(self.project, version="com.example@1.2.1")
         release_3 = self.create_release(self.project, version="com.example@1.3.0")
-        
+
         # Create groups for different releases
         group_1 = self.store_event(
             data={
@@ -2200,7 +2200,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         group_2 = self.store_event(
             data={
                 "fingerprint": ["wildcard-group-2"],
@@ -2212,7 +2212,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         group_3 = self.store_event(
             data={
                 "fingerprint": ["wildcard-group-3"],
@@ -2224,15 +2224,15 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         # Test wildcard matching com.example@1.2.*
         results = self.make_query(search_filter_query="first_release:com.example@1.2.*")
         assert set(results) == {group_1, group_2}
-        
+
         # Test wildcard matching all com.example@*
         results = self.make_query(search_filter_query="first_release:com.example@*")
         assert set(results) == {group_1, group_2, group_3}
-        
+
         # Test wildcard matching com.example@1.*.0
         results = self.make_query(search_filter_query="first_release:com.example@1.*.0")
         assert set(results) == {group_1, group_3}
@@ -2242,7 +2242,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         release_1 = self.create_release(self.project, version="app@2.0.0")
         release_2 = self.create_release(self.project, version="app@2.0.1")
         release_3 = self.create_release(self.project, version="app@3.0.0")
-        
+
         # Create groups for different releases in production environment
         group_1 = self.store_event(
             data={
@@ -2255,7 +2255,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         group_2 = self.store_event(
             data={
                 "fingerprint": ["wildcard-env-group-2"],
@@ -2267,7 +2267,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         group_3 = self.store_event(
             data={
                 "fingerprint": ["wildcard-env-group-3"],
@@ -2279,18 +2279,18 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
             },
             project_id=self.project.id,
         ).group
-        
+
         # Test wildcard matching app@2.0.* in production environment
         results = self.make_query(
             environments=[self.environments["production"]],
-            search_filter_query="first_release:app@2.0.*"
+            search_filter_query="first_release:app@2.0.*",
         )
         assert set(results) == {group_1, group_2}
-        
+
         # Test wildcard matching all app@* in production environment
         results = self.make_query(
             environments=[self.environments["production"]],
-            search_filter_query="first_release:app@*"
+            search_filter_query="first_release:app@*",
         )
         assert set(results) == {group_1, group_2, group_3}
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR addresses Linear issue ID-1326 by enabling boolean operators and wildcard support for the `firstRelease` filter in Issues search.

**Why these changes?**
Previously, users could only perform exact matches on `firstRelease`, making it difficult to find new issues introduced across multiple related releases (e.g., "show me all new issues introduced in releases 1.2.0 OR 1.2.1"). This enhancement allows developers to efficiently query for issues impacting a range of releases.

**Changes include:**
*   Enabling `AND`/`OR` operators for all issue search fields.
*   Implementing wildcard (`*`) support for the `firstRelease` filter, converting patterns to regex for database matching.
*   Ensuring wildcard functionality works correctly with environment-specific `firstRelease` queries.

**Examples of new query support:**
*   `firstRelease:1.0.0 OR firstRelease:1.0.1`
*   `firstRelease:com.example@1.2.*`
*   `firstRelease:app@1.* OR firstRelease:app@2.*`

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1326](https://linear.app/getsentry/issue/ID-1326/issues-search-support-andor-operators-and-wildcards-for-firstrelease)

<p><a href="https://cursor.com/background-agent?bcId=bc-c5ad887b-c357-4c77-9ecb-e32868cb3d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c5ad887b-c357-4c77-9ecb-e32868cb3d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

