### PR TITLE
feat(tracemetrics): Return units from aggregate in response

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -420,12 +420,13 @@ class TraceMetricAggregateDefinition(AggregateDefinition):
         if (
             trace_metric
             and trace_metric.metric_unit
-            and (
+            and self.internal_function not in [Function.FUNCTION_COUNT, Function.FUNCTION_UNIQ]
+        ):
+            if (
                 trace_metric.metric_unit in constants.DURATION_TYPE
                 or trace_metric.metric_unit in constants.SIZE_TYPE
-            )
-        ):
-            resolved_search_type = cast(constants.SearchType, trace_metric.metric_unit)
+            ):
+                resolved_search_type = cast(constants.SearchType, trace_metric.metric_unit)
 
         return ResolvedTraceMetricAggregate(
             public_alias=alias,

--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -414,10 +414,23 @@ class TraceMetricAggregateDefinition(AggregateDefinition):
 
         trace_metric = extract_trace_metric_aggregate_arguments(resolved_arguments)
 
+        # The search type for the first argument is always going to be 'number', but
+        # the real unit for the metric is stored in the metric_unit field of the trace metric
+        resolved_search_type = search_type
+        if (
+            trace_metric
+            and trace_metric.metric_unit
+            and (
+                trace_metric.metric_unit in constants.DURATION_TYPE
+                or trace_metric.metric_unit in constants.SIZE_TYPE
+            )
+        ):
+            resolved_search_type = cast(constants.SearchType, trace_metric.metric_unit)
+
         return ResolvedTraceMetricAggregate(
             public_alias=alias,
             internal_name=self.internal_function,
-            search_type=search_type,
+            search_type=resolved_search_type,
             internal_type=self.internal_type,
             processor=self.processor,
             extrapolation_mode=resolve_extrapolation_mode(

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -11,6 +11,13 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.validator import literal_validator
 
+VALID_METRIC_UNITS = [
+    "",
+    "-",
+    *constants.DURATION_TYPE,
+    *constants.SIZE_TYPE,
+]
+
 TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
     AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
     AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
@@ -44,7 +51,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
         attribute_resolver=count_argument_resolver_optimized(
             TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES
@@ -81,7 +92,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "sum": TraceMetricAggregateDefinition(
@@ -111,7 +126,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "avg": TraceMetricAggregateDefinition(
@@ -142,7 +161,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "p50": TraceMetricAggregateDefinition(
@@ -173,7 +196,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "p75": TraceMetricAggregateDefinition(
@@ -204,7 +231,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "p90": TraceMetricAggregateDefinition(
@@ -235,7 +266,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "p95": TraceMetricAggregateDefinition(
@@ -266,7 +301,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "p99": TraceMetricAggregateDefinition(
@@ -297,7 +336,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "max": TraceMetricAggregateDefinition(
@@ -328,7 +371,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
     "min": TraceMetricAggregateDefinition(
@@ -359,7 +406,11 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
+            ValueArgumentDefinition(
+                argument_types={"string"},
+                validator=literal_validator(VALID_METRIC_UNITS),
+                default_arg="",
+            ),
         ],
     ),
 }

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -13,7 +13,7 @@ from sentry.search.eap.validator import literal_validator
 
 VALID_METRIC_UNITS = [
     "",
-    "-",
+    "-",  # Explicit null unit indicating the unit should be ignored
     *constants.DURATION_TYPE,
     *constants.SIZE_TYPE,
 ]

--- a/src/sentry/search/eap/trace_metrics/aggregates.py
+++ b/src/sentry/search/eap/trace_metrics/aggregates.py
@@ -11,13 +11,6 @@ from sentry.search.eap.columns import (
 )
 from sentry.search.eap.validator import literal_validator
 
-VALID_METRIC_UNITS = [
-    "",
-    "-",  # Explicit null unit indicating the unit should be ignored
-    *constants.DURATION_TYPE,
-    *constants.SIZE_TYPE,
-]
-
 TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES = [
     AttributeKey(name="sentry.metric_name", type=AttributeKey.Type.TYPE_STRING),
     AttributeKey(name="sentry.metric_type", type=AttributeKey.Type.TYPE_STRING),
@@ -51,11 +44,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
         attribute_resolver=count_argument_resolver_optimized(
             TRACE_METRICS_ALWAYS_PRESENT_ATTRIBUTES
@@ -92,11 +81,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "sum": TraceMetricAggregateDefinition(
@@ -126,11 +111,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "avg": TraceMetricAggregateDefinition(
@@ -161,11 +142,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p50": TraceMetricAggregateDefinition(
@@ -196,11 +173,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p75": TraceMetricAggregateDefinition(
@@ -231,11 +204,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p90": TraceMetricAggregateDefinition(
@@ -266,11 +235,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p95": TraceMetricAggregateDefinition(
@@ -301,11 +266,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "p99": TraceMetricAggregateDefinition(
@@ -336,11 +297,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "max": TraceMetricAggregateDefinition(
@@ -371,11 +328,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
     "min": TraceMetricAggregateDefinition(
@@ -406,11 +359,7 @@ TRACE_METRICS_AGGREGATE_DEFINITIONS: dict[str, AggregateDefinition] = {
                 ),
                 default_arg="",
             ),
-            ValueArgumentDefinition(
-                argument_types={"string"},
-                validator=literal_validator(VALID_METRIC_UNITS),
-                default_arg="",
-            ),
+            ValueArgumentDefinition(argument_types={"string"}, default_arg=""),
         ],
     ),
 }

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -576,6 +576,49 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             meta["units"]["avg(value,request_duration,distribution,millisecond)"] == "millisecond"
         )
 
+    def test_count_aggregates_return_number_in_meta(self):
+        trace_metrics = [
+            self.create_trace_metric(
+                "request_duration", 100.0, "distribution", metric_unit="millisecond"
+            ),
+            self.create_trace_metric(
+                "request_duration", 200.0, "distribution", metric_unit="second"
+            ),
+        ]
+        self.store_trace_metrics(trace_metrics)
+
+        response = self.do_request(
+            {
+                "field": [
+                    "count(value,request_duration,distribution,millisecond)",
+                    "count_unique(value,request_duration,distribution,millisecond)",
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        meta = response.data["meta"]
+
+        assert len(data) == 1
+        assert data[0]["count(value,request_duration,distribution,millisecond)"] == 1
+
+        # The field type should be "integer"
+        assert meta["fields"]["count(value,request_duration,distribution,millisecond)"] == "integer"
+        assert (
+            meta["fields"]["count_unique(value,request_duration,distribution,millisecond)"]
+            == "integer"
+        )
+
+        # There should be no unit in meta["units"]
+        assert "units" in meta, "meta should contain 'units' key"
+        assert meta["units"]["count(value,request_duration,distribution,millisecond)"] is None
+        assert (
+            meta["units"]["count_unique(value,request_duration,distribution,millisecond)"] is None
+        )
+
     def test_aggregate_without_unit_returns_null_unit_in_meta(self):
         """Test that when no unit is specified (using '-'), meta["units"] is null for that field."""
         trace_metrics = [


### PR DESCRIPTION
Currently, we define aggregates for metrics in the format `function(value,metric_name,metric_type,metric_unit)`, but `metric_unit` is not being used by the frontend yet. The backend will use this value in its filter but the unit is lost by the time we formulate the response

This PR builds a `unit` dict in the events meta so we can read it and pass it back to the frontend. I also went ahead and restricted the valid unit args to size and duration keys because that's what we're allowing in the SDKs at the moment.