### PR TITLE
ref(explorer): prevent superuser hook when typing backtick in chat

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -280,6 +280,11 @@ function ExplorerPanel() {
       return;
     }
 
+    // While input is focused, prevent backtick from triggering superuser ViewAsHookMiddleware
+    if (e.key === '`') {
+      e.stopPropagation();
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       if (inputValue.trim() && !isPolling) {


### PR DESCRIPTION
relates to slack thread https://sentry.slack.com/archives/C8V02RHC7/p1770316690313009