### PR TITLE
feat(billing): Move locked products to bottom of usage overview table

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
@@ -481,8 +481,8 @@ describe('UsageOverviewTable', () => {
 
     await screen.findByRole('columnheader', {name: 'Feature'});
 
-    const allRows = document.querySelectorAll('[data-test-id^="product-row"]');
-    const rowTestIds = Array.from(allRows).map(row => row.getAttribute('data-test-id')!);
+    const allRows = screen.getAllByTestId(/^product-row/);
+    const rowTestIds = allRows.map(row => row.getAttribute('data-test-id')!);
 
     const enabledRows = rowTestIds.filter(id => !id.startsWith('product-row-disabled-'));
     const disabledRows = rowTestIds.filter(id => id.startsWith('product-row-disabled-'));

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/table.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/table.tsx
@@ -1,10 +1,12 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import partition from 'lodash/partition';
 
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 
+import type {AddOnCategoryInfo, BillingMetricHistory} from 'getsentry/types';
 import {
   checkIsAddOnChildCategory,
   getBilledCategory,
@@ -34,11 +36,9 @@ function UsageOverviewTable({
   const filteredCategories = sortedCategories.filter(
     categoryInfo => !addOnDataCategories.includes(categoryInfo.category)
   );
-  const enabledCategories = filteredCategories.filter(categoryInfo =>
-    productIsEnabled(subscription, categoryInfo.category)
-  );
-  const disabledCategories = filteredCategories.filter(
-    categoryInfo => !productIsEnabled(subscription, categoryInfo.category)
+  const [enabledCategories, disabledCategories] = partition(
+    filteredCategories,
+    categoryInfo => productIsEnabled(subscription, categoryInfo.category)
   );
 
   // Partition add-on categories into enabled and disabled (locked) groups
@@ -47,14 +47,11 @@ function UsageOverviewTable({
     // as long as they're available
     addOnInfo => subscription.addOns?.[addOnInfo.apiName]?.isAvailable ?? false
   );
-  const enabledAddOns = availableAddOns.filter(addOnInfo =>
+  const [enabledAddOns, disabledAddOns] = partition(availableAddOns, addOnInfo =>
     productIsEnabled(subscription, addOnInfo.apiName)
   );
-  const disabledAddOns = availableAddOns.filter(
-    addOnInfo => !productIsEnabled(subscription, addOnInfo.apiName)
-  );
 
-  const renderCategoryRow = (categoryInfo: (typeof sortedCategories)[number]) => {
+  const renderCategoryRow = (categoryInfo: BillingMetricHistory) => {
     const {category} = categoryInfo;
     return (
       <UsageOverviewTableRow
@@ -69,7 +66,7 @@ function UsageOverviewTable({
     );
   };
 
-  const renderAddOnRows = (addOnInfo: (typeof availableAddOns)[number]) => {
+  const renderAddOnRows = (addOnInfo: AddOnCategoryInfo) => {
     const {apiName, dataCategories} = addOnInfo;
     const billedCategory = getBilledCategory(subscription, apiName);
     if (!billedCategory) {


### PR DESCRIPTION
Closes https://linear.app/getsentry/issue/BIL-2114/move-locked-products-to-bottom-of-subscription-overview-table

## Summary
- Reorder the subscription overview usage table so that locked/disabled products are grouped at the bottom, instead of being interspersed with enabled products based on their backend `order` field
- Extract inline rendering logic into reusable helpers (`renderCategoryRow`, `renderAddOnRows`) to support the partitioning without code duplication

Fixes BIL-2114

## How it works
Uses the existing `productIsEnabled()` utility to partition both regular data categories and add-on categories into enabled/disabled groups at the table level. The rendering order becomes:

1. Enabled regular categories (sorted by existing `order`)
2. Enabled add-ons (with sub-category rows)
3. Disabled/locked regular categories (with lock icon)
4. Disabled/locked add-ons (with lock icon)

No changes to individual row rendering, side panel behavior, or trial CTAs.

<img width="1001" height="691" alt="Screenshot 2026-02-05 at 4 33 45 PM" src="https://github.com/user-attachments/assets/a9c18afc-b515-4c82-b10a-e925feb1d3bb" />


## Test plan
- [x] All 44 existing usage overview tests pass (5 test suites)
- [x] New test verifies all disabled rows appear after all enabled rows in DOM order
- [x] Pre-commit hooks pass (eslint, stylelint, prettier)
- [ ] Visual verification on subscription overview page with a plan that has both enabled and disabled products