### PR TITLE
feat(seer): Let api endpoint `/seer/onboarding-check/` return `needsConfigReminder`

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -670,6 +670,13 @@ register(
     default=15,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Organizations that should always see the Seer config reminder
+register(
+    "seer.organizations.force-config-reminder",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Coding Workflows
 register(


### PR DESCRIPTION
This field is a hint that the UI should encourage users configure seer a little more completely

Depends on https://github.com/getsentry/sentry-options-automator/pull/6367

Will be cleaned up with: https://linear.app/getsentry/issue/CW-771/cleanup-seerorganizationsforce-config-reminder