### PR TITLE
feat(seer): Show the autofix Seer config step if the org needs a config reminder

### DIFF
--- a/static/app/components/events/autofix/v2/autofixConfigureSeer.tsx
+++ b/static/app/components/events/autofix/v2/autofixConfigureSeer.tsx
@@ -30,14 +30,14 @@ interface AutofixConfigureSeerProps {
 
 export function AutofixConfigureSeer({event, group, project}: AutofixConfigureSeerProps) {
   const organization = useOrganization();
-  const seerOnboardingCheck = useSeerOnboardingCheck();
+  const {data: setupCheck} = useSeerOnboardingCheck();
   const {data, isPending, isError} = useGroupSummary(group, event, project);
 
   const orgNeedsToConfigureSeer =
     // needs to enable autofix
-    !seerOnboardingCheck.data?.isAutofixEnabled ||
+    !setupCheck?.isAutofixEnabled ||
     // catch all, ensure seer is configured
-    !seerOnboardingCheck.data?.isSeerConfigured;
+    !setupCheck?.isSeerConfigured;
 
   return (
     <Fragment>

--- a/static/app/utils/useSeerOnboardingCheck.tsx
+++ b/static/app/utils/useSeerOnboardingCheck.tsx
@@ -7,6 +7,7 @@ interface SeerOnboardingCheckResponse {
   isAutofixEnabled: boolean;
   isCodeReviewEnabled: boolean;
   isSeerConfigured: boolean;
+  needsConfigReminder: boolean;
 }
 
 export function useSeerOnboardingCheck({

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -92,15 +92,12 @@ function WelcomeScreen({
 export function SeerDrawer({group, project, event}: SeerDrawerProps) {
   const organization = useOrganization();
   const aiConfig = useAiConfig(group, project);
-  const seerOnboardingCheck = useSeerOnboardingCheck();
+  const {isPending, data} = useSeerOnboardingCheck();
 
   const seatBasedSeer = organization.features.includes('seat-based-seer-enabled');
 
   // Handle loading state at the top level
-  if (
-    aiConfig.isAutofixSetupLoading ||
-    (seatBasedSeer && seerOnboardingCheck.isPending)
-  ) {
+  if (aiConfig.isAutofixSetupLoading || (seatBasedSeer && isPending)) {
     return (
       <SeerDrawerContainer className="seer-drawer-container">
         <SeerDrawerHeader>
@@ -153,9 +150,9 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
       // needs to have autofix enabled for this group's project
       !aiConfig.autofixEnabled ||
       // needs to enable autofix
-      !seerOnboardingCheck.data?.isAutofixEnabled ||
+      !data?.isAutofixEnabled ||
       // catch all, ensure seer is configured
-      !seerOnboardingCheck.data?.isSeerConfigured
+      !data?.isSeerConfigured
     ) {
       return (
         <SeerDrawerContainer className="seer-drawer-container">

--- a/static/gsApp/views/seerAutomation/components/seerWizardSetupBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerWizardSetupBanner.tsx
@@ -23,7 +23,10 @@ export default function SeerWizardSetupBanner() {
     return null;
   }
 
-  if (data?.isSeerConfigured && !data?.needsConfigReminder) {
+  if (
+    data?.isSeerConfigured ||
+    (data?.needsConfigReminder && !data?.isCodeReviewEnabled)
+  ) {
     return null;
   }
 

--- a/static/gsApp/views/seerAutomation/components/seerWizardSetupBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerWizardSetupBanner.tsx
@@ -23,7 +23,7 @@ export default function SeerWizardSetupBanner() {
     return null;
   }
 
-  if (data?.isSeerConfigured) {
+  if (data?.isSeerConfigured && !data?.needsConfigReminder) {
     return null;
   }
 

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
@@ -16,15 +16,18 @@ export function useSeerOnboardingStep() {
       needsConfigReminder,
     } = data;
 
-    if (isSeerConfigured) {
-      initialStep = Steps.WRAP_UP; // Next steps
-    } else if (!hasSupportedScmIntegration) {
+    // Once the org has setup code-review then we'll stop bugging them.
+    const shouldShowConfigReminder = needsConfigReminder && !isCodeReviewEnabled;
+
+    if (!hasSupportedScmIntegration) {
       initialStep = Steps.CONNECT_GITHUB; // Connect GitHub
     } else if (!isCodeReviewEnabled) {
       initialStep = Steps.SETUP_CODE_REVIEW; // Setup Code Review
-    } else if (!isAutofixEnabled || needsConfigReminder) {
+    } else if (!isAutofixEnabled || shouldShowConfigReminder) {
       // This shouldn't happen because `isSeerConfigured` = `isCodeReviewEnabled` OR `isAutofixEnabled`
       initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
+    } else if (isSeerConfigured) {
+      initialStep = Steps.WRAP_UP; // Next steps
     }
   }
 

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
@@ -3,17 +3,18 @@ import {useSeerOnboardingCheck} from 'sentry/utils/useSeerOnboardingCheck';
 import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
 export function useSeerOnboardingStep() {
-  const statusQuery = useSeerOnboardingCheck({staleTime: 60_000});
+  const {isPending, data} = useSeerOnboardingCheck({staleTime: 60_000});
 
   let initialStep = Steps.CONNECT_GITHUB;
 
-  if (!statusQuery.isPending && statusQuery.data) {
+  if (!isPending && data) {
     const {
       hasSupportedScmIntegration,
       isCodeReviewEnabled,
       isAutofixEnabled,
       isSeerConfigured,
-    } = statusQuery.data;
+      needsConfigReminder,
+    } = data;
 
     if (isSeerConfigured) {
       initialStep = Steps.WRAP_UP; // Next steps
@@ -21,14 +22,14 @@ export function useSeerOnboardingStep() {
       initialStep = Steps.CONNECT_GITHUB; // Connect GitHub
     } else if (!isCodeReviewEnabled) {
       initialStep = Steps.SETUP_CODE_REVIEW; // Setup Code Review
-    } else if (!isAutofixEnabled) {
+    } else if (!isAutofixEnabled || needsConfigReminder) {
       // This shouldn't happen because `isSeerConfigured` = `isCodeReviewEnabled` OR `isAutofixEnabled`
       initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
     }
   }
 
   return {
-    isPending: statusQuery.isPending,
+    isPending,
     initialStep,
   };
 }

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
@@ -12,22 +12,22 @@ export function useSeerOnboardingStep() {
       hasSupportedScmIntegration,
       isCodeReviewEnabled,
       isAutofixEnabled,
-      isSeerConfigured,
       needsConfigReminder,
     } = data;
 
     // Once the org has setup code-review then we'll stop bugging them.
     const shouldShowConfigReminder = needsConfigReminder && !isCodeReviewEnabled;
 
-    if (!hasSupportedScmIntegration) {
+    if (hasSupportedScmIntegration) {
+      if (isAutofixEnabled && isCodeReviewEnabled) {
+        initialStep = Steps.WRAP_UP; // Next steps
+      } else if (!isAutofixEnabled || shouldShowConfigReminder) {
+        initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
+      } else if (!isCodeReviewEnabled) {
+        initialStep = Steps.SETUP_CODE_REVIEW; // Setup Code Review
+      }
+    } else {
       initialStep = Steps.CONNECT_GITHUB; // Connect GitHub
-    } else if (!isCodeReviewEnabled) {
-      initialStep = Steps.SETUP_CODE_REVIEW; // Setup Code Review
-    } else if (!isAutofixEnabled || shouldShowConfigReminder) {
-      // This shouldn't happen because `isSeerConfigured` = `isCodeReviewEnabled` OR `isAutofixEnabled`
-      initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
-    } else if (isSeerConfigured) {
-      initialStep = Steps.WRAP_UP; // Next steps
     }
   }
 

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/panel.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/panel.tsx
@@ -151,7 +151,8 @@ function ProductBreakdownPanel({
   const setupRequired =
     shouldCheckSetup &&
     !setupCheckLoading &&
-    (!setupCheck?.isSeerConfigured || setupCheck?.needsConfigReminder);
+    (!setupCheck?.isSeerConfigured ||
+      (setupCheck?.needsConfigReminder && !setupCheck?.isCodeReviewEnabled));
 
   if (!billedCategory) {
     return null;

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/panel.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/panel.tsx
@@ -149,7 +149,9 @@ function ProductBreakdownPanel({
     staleTime: 60_000,
   });
   const setupRequired =
-    shouldCheckSetup && !setupCheckLoading && !setupCheck?.isSeerConfigured;
+    shouldCheckSetup &&
+    !setupCheckLoading &&
+    (!setupCheck?.isSeerConfigured || setupCheck?.needsConfigReminder);
 
   if (!billedCategory) {
     return null;


### PR DESCRIPTION
I touched all the places that call `useSeerOnboardingCheck()` mostly to validate the logic, and add `needsConfigReminder` if needed.

The main place that's changed is `useSeerOnboardingStep()` (different hook!) which will return `SETUP_ROOT_CAUSE_ANALYSIS` if the org needs a reminder.
This step will also get returned into `<PrimaryNavSeerConfigReminder>` and cause it to pop up for the user. So they should see that popup on any page, then get taken into the Wizard. 


Depends on https://github.com/getsentry/sentry/pull/107702

Will be cleaned up with: https://linear.app/getsentry/issue/CW-771/cleanup-seerorganizationsforce-config-reminder