### PR TITLE
feat(preprod): use Arcade embed in onboarding panel

### DIFF
--- a/static/app/components/preprod/preprodOnboardingPanel.tsx
+++ b/static/app/components/preprod/preprodOnboardingPanel.tsx
@@ -1,9 +1,6 @@
 import {useTheme} from '@emotion/react';
 
-import sizeAnalysisPreview from 'sentry-images/spot/releases-tour-commits.svg';
-
 import {LinkButton} from '@sentry/scraps/button';
-import {Image} from '@sentry/scraps/image';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -17,6 +14,8 @@ import type {PlatformKey} from 'sentry/types/project';
 type SupportedPlatform = 'ios' | 'android' | 'flutter' | 'react-native';
 
 const PRODUCT_DOC_URL = 'https://docs.sentry.io/product/size-analysis/';
+const PREPROD_ONBOARDING_ARCADE_URL =
+  'https://demo.arcade.software/llDAtVroCp4jCvnPj5qu?embed';
 
 const PLATFORM_DOCS: Array<{
   buttonLabel: string;
@@ -63,8 +62,8 @@ export function PreprodOnboardingPanel({platform, onDocsClick}: Props) {
   return (
     <Panel>
       <PanelBody>
-        <Flex justify="between" align="start" width="100%" padding="3xl" gap="xl">
-          <Container flex={1}>
+        <Flex align="start" width="100%" padding="3xl" gap="xl">
+          <Container flex={1} minWidth={0}>
             <Heading as="h1" size="2xl">
               {t('Upload Mobile Builds to Sentry')}
             </Heading>
@@ -102,11 +101,24 @@ export function PreprodOnboardingPanel({platform, onDocsClick}: Props) {
               ) : null}
             </Flex>
           </Container>
-          <Container display={{xs: 'none', md: 'block'}}>
-            <Image
-              src={sizeAnalysisPreview}
-              alt={t('Size analysis illustration')}
-              height="120px"
+          <Container
+            display={{xs: 'none', md: 'block'}}
+            flex={1}
+            minWidth={0}
+            borderLeft="muted"
+            paddingLeft="xl"
+          >
+            <iframe
+              title={t('Pre-release build walkthrough')}
+              src={PREPROD_ONBOARDING_ARCADE_URL}
+              loading="lazy"
+              allowFullScreen
+              style={{
+                width: '100%',
+                height: '360px',
+                border: 0,
+                colorScheme: 'auto',
+              }}
             />
           </Container>
         </Flex>


### PR DESCRIPTION
add arcade
<img width="2598" height="1336" alt="CleanShot 2026-02-05 at 14 43 18@2x" src="https://github.com/user-attachments/assets/a0ed783d-06a7-416a-a96d-8fb120ec8d45" />
