### PR TITLE
fix(onboarding): Correct "capture first error" onboarding link

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -58,14 +58,20 @@ function getOnboardingInstructionsUrl({projects, organization}: Options) {
   // but if the user falls into this case for some reason,
   // he needs to select the platform again since it is not available as a parameter here
   if (!projects?.length) {
-    return `/organizations/${organization.slug}/insights/projects/:projectId/getting-started/`;
+    return makeProjectsPathname({
+      path: `/:projectId/getting-started/`,
+      organization,
+    });
   }
 
   const allProjectsWithoutErrors = projects.every(project => !project.firstEvent);
   // If all created projects don't have any errors,
   // we ask the user to pick a project before navigating to the instructions
   if (allProjectsWithoutErrors) {
-    return `/organizations/${organization.slug}/insights/projects/:projectId/getting-started/`;
+    return makeProjectsPathname({
+      path: `/:projectId/getting-started/`,
+      organization,
+    });
   }
 
   // Pick the first project without an error
@@ -74,13 +80,10 @@ function getOnboardingInstructionsUrl({projects, organization}: Options) {
   // but if the user falls into this case for some reason, we pick the first project
   const project = firstProjectWithoutError ?? projects[0]!;
 
-  let url = `/organizations/${organization.slug}/insights/projects/${project.slug}/getting-started/`;
-
-  if (project.platform) {
-    url = url + `${project.platform}/`;
-  }
-
-  return url;
+  return makeProjectsPathname({
+    path: `/${project.slug}/getting-started/`,
+    organization,
+  });
 }
 
 export function getOnboardingTasks({


### PR DESCRIPTION
Fixes an onboarding link that was linking to `https://sentry.sentry.io/insights/projects/apple-macos/getting-started/apple-macos/?referrer=onboarding_task` didn't find any other instances of this link so i'm not adding  a redirect

fixes JAVASCRIPT-36X2
