### PR TITLE
feat(scim): Manage privileges via SCIM Groups

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1436,6 +1436,12 @@ SENTRY_ORGANIZATION: int | None = None
 # Organization ID for granting superuser/staff privileges.
 SUPERUSER_ORG_ID: int | None = None
 
+# SCIM team slugs for managing privileged access.
+# When set, adding/removing members from these teams will grant/revoke the corresponding privileges.
+SENTRY_SCIM_STAFF_TEAM_SLUG: str | None = None
+SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG: str | None = None
+SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG: str | None = None
+
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT: int | None = None
 # DSN for the frontend to use explicitly, which takes priority

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -358,7 +358,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         return (
             settings.SENTRY_MODE == SentryMode.SAAS
             and team.organization.id == settings.SUPERUSER_ORG_ID
-            and team.slug in ("snty-staff", "snty-superuser")
+            and team.slug in ("snty-staff", "snty-superuser-read", "snty-superuser-write")
         )
 
     def _grant_privilege(self, member: OrganizationMember, team: Team) -> None:
@@ -366,30 +366,51 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             return
 
         attrs = {}
+        permission_added = False
+
         if team.slug == "snty-staff":
             attrs["is_staff"] = True
-        elif team.slug == "snty-superuser":
+        elif team.slug == "snty-superuser-read":
             attrs["is_superuser"] = True
+        elif team.slug == "snty-superuser-write":
+            attrs["is_superuser"] = True
+            # Add permission first, track if successful
+            permission_added = user_service.add_permission(
+                user_id=member.user_id, permission="superuser.write"
+            )
 
         if attrs:
-            user_service.update_user(user_id=member.user_id, attrs=attrs)
-            metrics.incr(
-                "sentry.scim.team.grant_privilege",
-                tags={
-                    "organization": team.organization.slug,
-                    "team": team.slug,
-                },
-            )
+            try:
+                user_service.update_user(user_id=member.user_id, attrs=attrs)
+                metrics.incr(
+                    "sentry.scim.team.grant_privilege",
+                    tags={
+                        "organization": team.organization.slug,
+                        "team": team.slug,
+                    },
+                )
+            except Exception:
+                # Rollback: remove permission if we added it
+                if permission_added:
+                    user_service.remove_permission(
+                        user_id=member.user_id, permission="superuser.write"
+                    )
+                raise
 
     def _revoke_privileges(self, member: OrganizationMember, team: Team) -> None:
         if not self._should_manage_privileges(team) or not member.user_id:
             return
 
         attrs = {}
+
         if team.slug == "snty-staff":
             attrs["is_staff"] = False
-        elif team.slug == "snty-superuser":
+        elif team.slug == "snty-superuser-read":
             attrs["is_superuser"] = False
+        elif team.slug == "snty-superuser-write":
+            attrs["is_superuser"] = False
+            # Remove permission - if update_user fails later, we keep permission removed
+            user_service.remove_permission(user_id=member.user_id, permission="superuser.write")
 
         if attrs:
             user_service.update_user(user_id=member.user_id, attrs=attrs)

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -3,6 +3,7 @@ import re
 from typing import Any
 
 import sentry_sdk
+from django.conf import settings
 from django.db import IntegrityError, router, transaction
 from django.http.response import HttpResponseBase
 from django.utils.text import slugify
@@ -31,6 +32,7 @@ from sentry.apidocs.constants import (
 from sentry.apidocs.examples.scim_examples import SCIMExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.conf.types.sentry_config import SentryMode
 from sentry.core.endpoints.organization_teams import CONFLICTING_SLUG_ERROR, TeamPostSerializer
 from sentry.core.endpoints.team_details import TeamDetailsEndpoint
 from sentry.core.endpoints.team_details import TeamDetailsSerializer as TeamSerializer
@@ -39,6 +41,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team, TeamStatus
 from sentry.signals import team_created
+from sentry.users.services.user.service import user_service
 from sentry.utils import json, metrics
 from sentry.utils.cursors import SCIMCursor
 from sentry.utils.snowflake import MaxSnowflakeRetryError
@@ -63,6 +66,7 @@ from .utils import (
 )
 
 delete_logger = logging.getLogger("sentry.deletions.api")
+logger = logging.getLogger(__name__)
 
 
 @extend_schema_serializer(many=True)
@@ -350,13 +354,61 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         )
         return Response(context)
 
-    def _add_members_operation(self, request: Request, operation, team):
-        for member in operation["value"]:
+    def _should_manage_privileges(self, team: Team) -> bool:
+        return (
+            settings.SENTRY_MODE == SentryMode.SAAS
+            and team.organization.id == settings.SUPERUSER_ORG_ID
+            and team.slug in ("snty-staff", "snty-superuser")
+        )
+
+    def _grant_privilege(self, member: OrganizationMember, team: Team) -> None:
+        if not self._should_manage_privileges(team) or not member.user_id:
+            return
+
+        attrs = {}
+        if team.slug == "snty-staff":
+            attrs["is_staff"] = True
+        elif team.slug == "snty-superuser":
+            attrs["is_superuser"] = True
+
+        if attrs:
+            user_service.update_user(user_id=member.user_id, attrs=attrs)
+            metrics.incr(
+                "sentry.scim.team.grant_privilege",
+                tags={
+                    "organization": team.organization.slug,
+                    "team": team.slug,
+                },
+            )
+
+    def _revoke_privileges(self, member: OrganizationMember, team: Team) -> None:
+        if not self._should_manage_privileges(team) or not member.user_id:
+            return
+
+        attrs = {}
+        if team.slug == "snty-staff":
+            attrs["is_staff"] = False
+        elif team.slug == "snty-superuser":
+            attrs["is_superuser"] = False
+
+        if attrs:
+            user_service.update_user(user_id=member.user_id, attrs=attrs)
+            metrics.incr(
+                "sentry.scim.team.revoke_privileges",
+                tags={
+                    "organization": team.organization.slug,
+                    "team": team.slug,
+                },
+            )
+
+    def _add_members_operation(self, request: Request, operation, team) -> list[OrganizationMember]:
+        added_members = []
+
+        for member_data in operation["value"]:
             member = OrganizationMember.objects.get(
-                organization=team.organization, id=member["value"]
+                organization=team.organization, id=member_data["value"]
             )
             if OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists():
-                # if a member already belongs to a team, do nothing
                 continue
 
             with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
@@ -370,8 +422,13 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                     data=omt.get_audit_log_data(),
                 )
 
-    def _remove_members_operation(self, request: Request, member_id, team):
+            added_members.append(member)
+
+        return added_members
+
+    def _remove_members_operation(self, request: Request, member_id, team) -> None:
         member = OrganizationMember.objects.get(organization=team.organization, id=member_id)
+
         with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
             try:
                 omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
@@ -431,6 +488,50 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
         if len(operations) > 100:
             return Response(SCIM_400_TOO_MANY_PATCH_OPS_ERROR, status=400)
+
+        members_to_revoke: list[tuple[OrganizationMember, Team]] = []
+
+        for operation in operations:
+            op = operation["op"].lower()
+
+            if op == TeamPatchOps.REMOVE and "members" in operation["path"]:
+                try:
+                    member_id = self._get_member_id_for_remove_op(operation)
+                    member = OrganizationMember.objects.get(
+                        organization=team.organization, id=member_id
+                    )
+                    members_to_revoke.append((member, team))
+                except OrganizationMember.DoesNotExist:
+                    pass
+
+            elif op == TeamPatchOps.REPLACE:
+                path = operation.get("path")
+                if path == "members":
+                    existing = OrganizationMemberTeam.objects.filter(
+                        team_id=team.id
+                    ).select_related("organizationmember")
+                    for omt in existing:
+                        members_to_revoke.append((omt.organizationmember, team))
+
+        for member, team_obj in members_to_revoke:
+            try:
+                self._revoke_privileges(member, team_obj)
+            except Exception:
+                logger.exception(
+                    "scim.privilege_revocation_failed",
+                    extra={
+                        "organization_id": team.organization.id,
+                        "team_id": team.id,
+                        "member_id": member.id,
+                    },
+                )
+                return Response(
+                    {"detail": "Failed to revoke user privileges"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
+
+        members_to_grant_privileges: list[OrganizationMember] = []
+
         try:
             with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
                 team.idp_provisioned = True
@@ -438,12 +539,16 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
                 for operation in operations:
                     op = operation["op"].lower()
+
                     if op == TeamPatchOps.ADD and operation["path"] == "members":
-                        self._add_members_operation(request, operation, team)
+                        added_members = self._add_members_operation(request, operation, team)
+                        members_to_grant_privileges.extend(added_members)
+
                     elif op == TeamPatchOps.REMOVE and "members" in operation["path"]:
                         self._remove_members_operation(
                             request, self._get_member_id_for_remove_op(operation), team
                         )
+
                     elif op == TeamPatchOps.REPLACE:
                         path = operation.get("path")
 
@@ -451,11 +556,16 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                             # delete all the current team members
                             # and replace with the ones in the operation list
                             with transaction.atomic(router.db_for_write(OrganizationMember)):
-                                existing = list(
+                                existing_members = list(
                                     OrganizationMemberTeam.objects.filter(team_id=team.id)
                                 )
-                                OrganizationMemberTeam.objects.bulk_delete(existing)
-                                self._add_members_operation(request, operation, team)
+                                OrganizationMemberTeam.objects.bulk_delete(existing_members)
+
+                                added_members = self._add_members_operation(
+                                    request, operation, team
+                                )
+                                members_to_grant_privileges.extend(added_members)
+
                         # azure and okta handle team name change operation differently
                         elif path is None:
                             # for okta
@@ -473,6 +583,23 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         except IntegrityError as e:
             sentry_sdk.capture_exception(e)
             return Response(SCIM_400_INTEGRITY_ERROR, status=400)
+
+        for member in members_to_grant_privileges:
+            try:
+                self._grant_privilege(member, team)
+            except Exception:
+                logger.exception(
+                    "scim.privilege_grant_failed",
+                    extra={
+                        "organization_id": team.organization.id,
+                        "team_id": team.id,
+                        "member_id": member.id,
+                    },
+                )
+                return Response(
+                    {"detail": "Failed to grant user privileges"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
 
         metrics.incr("sentry.scim.team.update", tags={"organization": organization})
         return self.respond(status=204)

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -358,7 +358,12 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         return (
             settings.SENTRY_MODE == SentryMode.SAAS
             and team.organization.id == settings.SUPERUSER_ORG_ID
-            and team.slug in ("snty-staff", "snty-superuser-read", "snty-superuser-write")
+            and team.slug
+            in (
+                settings.SENTRY_SCIM_STAFF_TEAM_SLUG,
+                settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG,
+                settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG,
+            )
         )
 
     def _grant_privilege(self, member: OrganizationMember, team: Team) -> None:
@@ -368,11 +373,11 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         attrs = {}
         permission_added = False
 
-        if team.slug == "snty-staff":
+        if team.slug == settings.SENTRY_SCIM_STAFF_TEAM_SLUG:
             attrs["is_staff"] = True
-        elif team.slug == "snty-superuser-read":
+        elif team.slug == settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG:
             attrs["is_superuser"] = True
-        elif team.slug == "snty-superuser-write":
+        elif team.slug == settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG:
             attrs["is_superuser"] = True
             # Add permission first, track if successful
             permission_added = user_service.add_permission(
@@ -403,11 +408,11 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
 
         attrs = {}
 
-        if team.slug == "snty-staff":
+        if team.slug == settings.SENTRY_SCIM_STAFF_TEAM_SLUG:
             attrs["is_staff"] = False
-        elif team.slug == "snty-superuser-read":
+        elif team.slug == settings.SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG:
             attrs["is_superuser"] = False
-        elif team.slug == "snty-superuser-write":
+        elif team.slug == settings.SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG:
             attrs["is_superuser"] = False
             # Remove permission - if update_user fails later, we keep permission removed
             user_service.remove_permission(user_id=member.user_id, permission="superuser.write")

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -618,6 +618,28 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         """
         Delete a team with a SCIM Group DELETE Request.
         """
+        # Revoke privileges from all team members before deletion
+        if self._should_manage_privileges(team):
+            members = OrganizationMemberTeam.objects.filter(team=team).select_related(
+                "organizationmember"
+            )
+            for omt in members:
+                try:
+                    self._revoke_privileges(omt.organizationmember, team)
+                except Exception:
+                    logger.exception(
+                        "scim.privilege_revocation_on_team_delete_failed",
+                        extra={
+                            "organization_id": team.organization.id,
+                            "team_id": team.id,
+                            "member_id": omt.organizationmember.id,
+                        },
+                    )
+                    return Response(
+                        {"detail": "Failed to revoke user privileges"},
+                        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    )
+
         metrics.incr("sentry.scim.team.delete")
         return super().delete(request, team)
 

--- a/src/sentry/users/services/user/service.py
+++ b/src/sentry/users/services/user/service.py
@@ -314,6 +314,30 @@ class UserService(RpcService):
         """
         pass
 
+    @rpc_method
+    @abstractmethod
+    def add_permission(self, *, user_id: int, permission: str) -> bool:
+        """
+        Add a permission to a user
+
+        :param user_id: The user to add the permission to.
+        :param permission: The permission name to add (e.g., "superuser.write").
+        :return: True if permission was added, False if it already existed.
+        """
+        pass
+
+    @rpc_method
+    @abstractmethod
+    def remove_permission(self, *, user_id: int, permission: str) -> bool:
+        """
+        Remove a permission from a user
+
+        :param user_id: The user to remove the permission from.
+        :param permission: The permission name to remove (e.g., "superuser.write").
+        :return: True if permission was removed, False if it didn't exist.
+        """
+        pass
+
 
 @back_with_silo_cache("user_service.get_user", SiloMode.REGION, RpcUser)
 def get_user(user_id: int) -> RpcUser | None:

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -692,3 +692,130 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
                 )
 
                 assert response.data["detail"] == "Failed to revoke user privileges"
+
+
+class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
+    endpoint = "sentry-api-0-organization-scim-team-details"
+    method = "delete"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user_one = self.create_user(email="staff_user@example.com")
+        self.member_one = self.create_member(user=self.user_one, organization=self.organization)
+
+        self.user_two = self.create_user(email="superuser_user@example.com")
+        self.member_two = self.create_member(user=self.user_two, organization=self.organization)
+
+    def test_deleting_staff_team_revokes_privileges(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            # Add two members to the team and grant them is_staff
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            user_service.update_user(user_id=self.user_two.id, attrs={"is_staff": True})
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_one
+            )
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_two
+            )
+
+            # Verify users have is_staff
+            user_one = user_service.get_user(user_id=self.user_one.id)
+            assert user_one is not None
+            assert user_one.is_staff
+            user_two = user_service.get_user(user_id=self.user_two.id)
+            assert user_two is not None
+            assert user_two.is_staff
+
+            # Delete the team
+            self.get_success_response(self.organization.slug, staff_team.id, status_code=204)
+
+            # Verify is_staff was revoked from both users, but is_superuser retained
+            user_one = user_service.get_user(user_id=self.user_one.id)
+            assert user_one is not None
+            assert not user_one.is_staff
+            assert user_one.is_superuser  # Should still have superuser
+            user_two = user_service.get_user(user_id=self.user_two.id)
+            assert user_two is not None
+            assert not user_two.is_staff
+
+    def test_deleting_superuser_team_revokes_privileges(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            superuser_team = self.create_team(
+                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+            )
+
+            # Add member to the team and grant is_superuser
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            OrganizationMemberTeam.objects.create(
+                team=superuser_team, organizationmember=self.member_one
+            )
+
+            # Verify user has is_superuser
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_superuser
+
+            # Delete the team
+            self.get_success_response(self.organization.slug, superuser_team.id, status_code=204)
+
+            # Verify is_superuser was revoked but is_staff retained
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff  # Should still have staff
+            assert not user.is_superuser
+
+    def test_deleting_regular_team_does_not_affect_privileges(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            regular_team = self.create_team(
+                organization=self.organization, slug="engineering", idp_provisioned=True
+            )
+
+            # Add member with privileges
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            OrganizationMemberTeam.objects.create(
+                team=regular_team, organizationmember=self.member_one
+            )
+
+            # Delete the team
+            self.get_success_response(self.organization.slug, regular_team.id, status_code=204)
+
+            # Verify privileges were not affected
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+            assert user.is_superuser
+
+    def test_deleting_team_with_privilege_revocation_failure_returns_500(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            # Add member to the team
+            user_service.update_user(user_id=self.user_one.id, attrs={"is_staff": True})
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_one
+            )
+
+            # Mock user_service.update_user to raise an exception
+            with patch("sentry.core.endpoints.scim.teams.user_service.update_user") as mock_update:
+                mock_update.side_effect = Exception("RPC failure")
+
+                response = self.get_error_response(
+                    self.organization.slug,
+                    staff_team.id,
+                    status_code=500,
+                )
+
+                assert response.data["detail"] == "Failed to revoke user privileges"

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -346,7 +346,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
         self.member_two = self.create_member(user=self.user_two, organization=self.organization)
 
     def test_adding_to_staff_group_grants_is_staff(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -378,7 +384,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert user.is_staff
 
     def test_adding_to_superuser_group_grants_is_superuser(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             superuser_team = self.create_team(
                 organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
@@ -410,7 +422,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert user.is_superuser
 
     def test_removing_from_staff_group_revokes_only_is_staff(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -444,7 +462,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert user.is_superuser
 
     def test_removing_from_superuser_group_revokes_only_is_superuser(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             superuser_team = self.create_team(
                 organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
@@ -478,7 +502,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert not user.is_superuser
 
     def test_replace_members_revokes_privileges_for_removed_members(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -518,7 +548,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert user_two.is_staff
 
     def test_regular_team_does_not_affect_privileges(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             regular_team = self.create_team(
                 organization=self.organization, slug="engineering", idp_provisioned=True
             )
@@ -551,7 +587,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert not user.is_superuser
 
     def test_non_default_org_does_not_grant_privileges(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             other_org = self.create_organization(name="Other Org")
             other_member = self.create_member(user=self.user_one, organization=other_org)
 
@@ -598,7 +640,11 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
 
     def test_non_saas_mode_does_not_grant_privileges(self) -> None:
         with override_settings(
-            SENTRY_MODE=SentryMode.SELF_HOSTED, SUPERUSER_ORG_ID=self.organization.id
+            SENTRY_MODE=SentryMode.SELF_HOSTED,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
         ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
@@ -630,7 +676,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             assert not user.is_staff
 
     def test_privilege_grant_failure_returns_500(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -662,7 +714,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
                 assert response.data["detail"] == "Failed to grant user privileges"
 
     def test_privilege_revocation_failure_returns_500(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -695,7 +753,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
 
     def test_superuser_write_grant_failure_rolls_back_permission(self) -> None:
         """Test that if update_user fails, add_permission is rolled back for snty-superuser-write."""
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             from sentry.users.models.userpermission import UserPermission
 
             superuser_write_team = self.create_team(
@@ -741,7 +805,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
                 ).exists()
 
     def test_adding_to_superuser_write_group_grants_is_superuser_and_permission(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             from sentry.users.models.userpermission import UserPermission
 
             superuser_write_team = self.create_team(
@@ -787,7 +857,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
                 ).exists()
 
     def test_removing_from_superuser_write_group_revokes_is_superuser_and_permission(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             from sentry.users.models.userpermission import UserPermission
 
             superuser_write_team = self.create_team(
@@ -840,7 +916,13 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
 
     def test_superuser_write_revoke_failure_keeps_permission_removed(self) -> None:
         """Test that if update_user fails, permission stays removed (fail-secure) for snty-superuser-write."""
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             from sentry.users.models.userpermission import UserPermission
 
             superuser_write_team = self.create_team(
@@ -906,7 +988,13 @@ class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
         self.member_two = self.create_member(user=self.user_two, organization=self.organization)
 
     def test_deleting_staff_team_revokes_privileges(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
@@ -944,7 +1032,13 @@ class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
             assert not user_two.is_staff
 
     def test_deleting_superuser_team_revokes_privileges(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             superuser_team = self.create_team(
                 organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
@@ -972,7 +1066,13 @@ class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
             assert not user.is_superuser
 
     def test_deleting_regular_team_does_not_affect_privileges(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             regular_team = self.create_team(
                 organization=self.organization, slug="engineering", idp_provisioned=True
             )
@@ -995,7 +1095,13 @@ class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
             assert user.is_superuser
 
     def test_deleting_team_with_privilege_revocation_failure_returns_500(self) -> None:
-        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+        with override_settings(
+            SENTRY_MODE=SentryMode.SAAS,
+            SUPERUSER_ORG_ID=self.organization.id,
+            SENTRY_SCIM_STAFF_TEAM_SLUG="snty-staff",
+            SENTRY_SCIM_SUPERUSER_READ_TEAM_SLUG="snty-superuser-read",
+            SENTRY_SCIM_SUPERUSER_WRITE_TEAM_SLUG="snty-superuser-write",
+        ):
             staff_team = self.create_team(
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -1,11 +1,18 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.urls import reverse
 
+from sentry.conf.types.sentry_config import SentryMode
+from sentry.models.apitoken import ApiToken
+from sentry.models.authprovider import AuthProvider as AuthProviderModel
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team, TeamStatus
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import SCIMTestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.users.services.user.service import user_service
 
 
 class SCIMDetailGetTest(SCIMTestCase):
@@ -319,3 +326,369 @@ class SCIMDetailDeleteTest(SCIMTestCase):
 
         assert Team.objects.get(id=team.id).status == TeamStatus.PENDING_DELETION
         mock_metrics.incr.assert_called_with("sentry.scim.team.delete")
+
+
+class SCIMPrivilegeManagementTest(SCIMTestCase):
+    endpoint = "sentry-api-0-organization-scim-team-details"
+    method = "patch"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.base_data: dict[str, Any] = {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+        }
+
+        self.user_one = self.create_user(email="staff_user@example.com")
+        self.member_one = self.create_member(user=self.user_one, organization=self.organization)
+
+        self.user_two = self.create_user(email="superuser_user@example.com")
+        self.member_two = self.create_member(user=self.user_two, organization=self.organization)
+
+    def test_adding_to_staff_group_grants_is_staff(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, staff_team.id, **self.base_data, status_code=204
+            )
+
+            # Verify is_staff was granted
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+
+    def test_adding_to_superuser_group_grants_is_superuser(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            superuser_team = self.create_team(
+                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_two.id)
+            assert user is not None
+            assert not user.is_superuser
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_two.id,
+                            "display": self.member_two.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, superuser_team.id, **self.base_data, status_code=204
+            )
+
+            # Verify is_superuser was granted
+            user = user_service.get_user(user_id=self.user_two.id)
+            assert user is not None
+            assert user.is_superuser
+
+    def test_removing_from_staff_group_revokes_only_is_staff(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_one
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+            assert user.is_superuser
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "remove",
+                    "path": f'members[value eq "{self.member_one.id}"]',
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, staff_team.id, **self.base_data, status_code=204
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+            assert user.is_superuser
+
+    def test_removing_from_superuser_group_revokes_only_is_superuser(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            superuser_team = self.create_team(
+                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+            )
+
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            OrganizationMemberTeam.objects.create(
+                team=superuser_team, organizationmember=self.member_one
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+            assert user.is_superuser
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "remove",
+                    "path": f'members[value eq "{self.member_one.id}"]',
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, superuser_team.id, **self.base_data, status_code=204
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+            assert not user.is_superuser
+
+    def test_replace_members_revokes_privileges_for_removed_members(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            user_service.update_user(user_id=self.user_one.id, attrs={"is_staff": True})
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_one
+            )
+
+            user_one = user_service.get_user(user_id=self.user_one.id)
+            assert user_one is not None
+            assert user_one.is_staff
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "replace",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_two.id,
+                            "display": self.member_two.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, staff_team.id, **self.base_data, status_code=204
+            )
+
+            user_one = user_service.get_user(user_id=self.user_one.id)
+            assert user_one is not None
+            assert not user_one.is_staff
+            assert not user_one.is_superuser
+            user_two = user_service.get_user(user_id=self.user_two.id)
+            assert user_two is not None
+            assert user_two.is_staff
+
+    def test_regular_team_does_not_affect_privileges(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            regular_team = self.create_team(
+                organization=self.organization, slug="engineering", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+            assert not user.is_superuser
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, regular_team.id, **self.base_data, status_code=204
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+            assert not user.is_superuser
+
+    def test_non_default_org_does_not_grant_privileges(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            other_org = self.create_organization(name="Other Org")
+            other_member = self.create_member(user=self.user_one, organization=other_org)
+
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                other_auth_provider = AuthProviderModel(
+                    organization_id=other_org.id, provider="dummy"
+                )
+                other_auth_provider.enable_scim(self.user)
+                other_auth_provider.save()
+                other_scim_user = ApiToken.objects.get(
+                    token=other_auth_provider.get_scim_token()
+                ).user
+
+            self.login_as(user=other_scim_user)
+
+            staff_team = self.create_team(
+                organization=other_org, slug="snty-staff", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": other_member.id,
+                            "display": other_member.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                other_org.slug, staff_team.id, **self.base_data, status_code=204
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+
+    def test_non_saas_mode_does_not_grant_privileges(self) -> None:
+        with override_settings(
+            SENTRY_MODE=SentryMode.SELF_HOSTED, SUPERUSER_ORG_ID=self.organization.id
+        ):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, staff_team.id, **self.base_data, status_code=204
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_staff
+
+    def test_privilege_grant_failure_returns_500(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            # Mock user_service.update_user to raise an exception
+            with patch("sentry.core.endpoints.scim.teams.user_service.update_user") as mock_update:
+                mock_update.side_effect = Exception("RPC failure")
+
+                response = self.get_error_response(
+                    self.organization.slug,
+                    staff_team.id,
+                    **self.base_data,
+                    status_code=500,
+                )
+
+                assert response.data["detail"] == "Failed to grant user privileges"
+
+    def test_privilege_revocation_failure_returns_500(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            staff_team = self.create_team(
+                organization=self.organization, slug="snty-staff", idp_provisioned=True
+            )
+
+            # Set up user with privileges
+            user_service.update_user(user_id=self.user_one.id, attrs={"is_staff": True})
+            OrganizationMemberTeam.objects.create(
+                team=staff_team, organizationmember=self.member_one
+            )
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "remove",
+                    "path": f'members[value eq "{self.member_one.id}"]',
+                }
+            ]
+
+            # Mock user_service.update_user to raise an exception
+            with patch("sentry.core.endpoints.scim.teams.user_service.update_user") as mock_update:
+                mock_update.side_effect = Exception("RPC failure")
+
+                response = self.get_error_response(
+                    self.organization.slug,
+                    staff_team.id,
+                    **self.base_data,
+                    status_code=500,
+                )
+
+                assert response.data["detail"] == "Failed to revoke user privileges"

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -380,7 +380,7 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
     def test_adding_to_superuser_group_grants_is_superuser(self) -> None:
         with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
             superuser_team = self.create_team(
-                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+                organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
 
             user = user_service.get_user(user_id=self.user_two.id)
@@ -446,7 +446,7 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
     def test_removing_from_superuser_group_revokes_only_is_superuser(self) -> None:
         with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
             superuser_team = self.create_team(
-                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+                organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
 
             user_service.update_user(
@@ -693,6 +693,204 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
 
                 assert response.data["detail"] == "Failed to revoke user privileges"
 
+    def test_superuser_write_grant_failure_rolls_back_permission(self) -> None:
+        """Test that if update_user fails, add_permission is rolled back for snty-superuser-write."""
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            from sentry.users.models.userpermission import UserPermission
+
+            superuser_write_team = self.create_team(
+                organization=self.organization, slug="snty-superuser-write", idp_provisioned=True
+            )
+
+            # Verify user doesn't have permission initially
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert not UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            # Mock update_user to fail AFTER add_permission succeeds
+            with patch("sentry.core.endpoints.scim.teams.user_service.update_user") as mock_update:
+                mock_update.side_effect = Exception("RPC failure")
+
+                response = self.get_error_response(
+                    self.organization.slug,
+                    superuser_write_team.id,
+                    **self.base_data,
+                    status_code=500,
+                )
+
+                assert response.data["detail"] == "Failed to grant user privileges"
+
+            # Verify permission was rolled back - should not exist
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert not UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+    def test_adding_to_superuser_write_group_grants_is_superuser_and_permission(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            from sentry.users.models.userpermission import UserPermission
+
+            superuser_write_team = self.create_team(
+                organization=self.organization, slug="snty-superuser-write", idp_provisioned=True
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert not user.is_superuser
+
+            # Verify user doesn't have superuser.write permission
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert not UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "add",
+                    "path": "members",
+                    "value": [
+                        {
+                            "value": self.member_one.id,
+                            "display": self.member_one.email,
+                        }
+                    ],
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, superuser_write_team.id, **self.base_data, status_code=204
+            )
+
+            # Verify is_superuser was granted
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_superuser
+
+            # Verify superuser.write permission was granted
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+    def test_removing_from_superuser_write_group_revokes_is_superuser_and_permission(self) -> None:
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            from sentry.users.models.userpermission import UserPermission
+
+            superuser_write_team = self.create_team(
+                organization=self.organization, slug="snty-superuser-write", idp_provisioned=True
+            )
+
+            # Grant user is_superuser and is_staff and add permission
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                UserPermission.objects.create(
+                    user_id=self.user_one.id, permission="superuser.write"
+                )
+            OrganizationMemberTeam.objects.create(
+                team=superuser_write_team, organizationmember=self.member_one
+            )
+
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff
+            assert user.is_superuser
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "remove",
+                    "path": f'members[value eq "{self.member_one.id}"]',
+                }
+            ]
+
+            self.get_success_response(
+                self.organization.slug, superuser_write_team.id, **self.base_data, status_code=204
+            )
+
+            # Verify is_superuser was revoked but is_staff retained
+            user = user_service.get_user(user_id=self.user_one.id)
+            assert user is not None
+            assert user.is_staff  # Should still have staff
+            assert not user.is_superuser
+
+            # Verify superuser.write permission was revoked
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert not UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+    def test_superuser_write_revoke_failure_keeps_permission_removed(self) -> None:
+        """Test that if update_user fails, permission stays removed (fail-secure) for snty-superuser-write."""
+        with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
+            from sentry.users.models.userpermission import UserPermission
+
+            superuser_write_team = self.create_team(
+                organization=self.organization, slug="snty-superuser-write", idp_provisioned=True
+            )
+
+            # Set up user with privileges and permission
+            user_service.update_user(
+                user_id=self.user_one.id, attrs={"is_staff": True, "is_superuser": True}
+            )
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                UserPermission.objects.create(
+                    user_id=self.user_one.id, permission="superuser.write"
+                )
+            OrganizationMemberTeam.objects.create(
+                team=superuser_write_team, organizationmember=self.member_one
+            )
+
+            # Verify permission exists initially
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
+            self.base_data["Operations"] = [
+                {
+                    "op": "remove",
+                    "path": f'members[value eq "{self.member_one.id}"]',
+                }
+            ]
+
+            # Mock update_user to fail AFTER remove_permission succeeds
+            with patch("sentry.core.endpoints.scim.teams.user_service.update_user") as mock_update:
+                mock_update.side_effect = Exception("RPC failure")
+
+                response = self.get_error_response(
+                    self.organization.slug,
+                    superuser_write_team.id,
+                    **self.base_data,
+                    status_code=500,
+                )
+
+                assert response.data["detail"] == "Failed to revoke user privileges"
+
+            # Verify permission was NOT rolled back - safer to keep it removed
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                assert not UserPermission.objects.filter(
+                    user_id=self.user_one.id, permission="superuser.write"
+                ).exists()
+
 
 class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
     endpoint = "sentry-api-0-organization-scim-team-details"
@@ -748,7 +946,7 @@ class SCIMTeamDeletePrivilegeManagementTest(SCIMTestCase):
     def test_deleting_superuser_team_revokes_privileges(self) -> None:
         with override_settings(SENTRY_MODE=SentryMode.SAAS, SUPERUSER_ORG_ID=self.organization.id):
             superuser_team = self.create_team(
-                organization=self.organization, slug="snty-superuser", idp_provisioned=True
+                organization=self.organization, slug="snty-superuser-read", idp_provisioned=True
             )
 
             # Add member to the team and grant is_superuser

--- a/tests/sentry/users/services/test_user.py
+++ b/tests/sentry/users/services/test_user.py
@@ -1,5 +1,7 @@
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TransactionTestCase
-from sentry.testutils.silo import all_silo_test
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
+from sentry.users.models.userpermission import UserPermission
 from sentry.users.services.user.service import user_service
 
 
@@ -56,3 +58,37 @@ class UserServiceTest(TransactionTestCase):
         result = user_service.get_many_by_id(ids=target_ids)
         result_two = user_service.get_many_by_id(ids=target_ids)
         assert result == result_two
+
+    def test_add_permission(self) -> None:
+        # Test adding a new permission
+        created = user_service.add_permission(user_id=self.user.id, permission="superuser.write")
+        assert created is True
+
+        # Verify permission was created
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert UserPermission.objects.filter(
+                user_id=self.user.id, permission="superuser.write"
+            ).exists()
+
+        # Test adding the same permission again returns False
+        created = user_service.add_permission(user_id=self.user.id, permission="superuser.write")
+        assert created is False
+
+    def test_remove_permission(self) -> None:
+        # Create a permission first
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            UserPermission.objects.create(user_id=self.user.id, permission="superuser.write")
+
+        # Test removing existing permission
+        removed = user_service.remove_permission(user_id=self.user.id, permission="superuser.write")
+        assert removed is True
+
+        # Verify permission was removed
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert not UserPermission.objects.filter(
+                user_id=self.user.id, permission="superuser.write"
+            ).exists()
+
+        # Test removing non-existent permission returns False
+        removed = user_service.remove_permission(user_id=self.user.id, permission="superuser.write")
+        assert removed is False


### PR DESCRIPTION
The main purpose of this PR is to allow our SaaS instance to manage elevated privileges in a secondary IdP system. It is done by specific team names (i.e. `snty-staff` and `snty-superuser`) created on the default org.

When members are added/removed from "staff" or "superuser" teams in the default SaaS organization, automatically grant or revoke the corresponding is_staff/is_superuser flags.

Key changes:
- Grant is_staff when adding to "staff" team, is_superuser to "superuser" team
- Revoke only the matching privilege when removing from privileged teams
- Security-first two-pass architecture: revoke before delete, grant after add
- Handle transaction constraints (RPC calls outside transactions)
- Add error handling and logging for privilege update failures
- Add comprehensive test coverage (8 new tests)
