### PR TITLE
fix(tokens): add missing `as` prop

### DIFF
--- a/static/app/components/core/principles/tokens/tokens.mdx
+++ b/static/app/components/core/principles/tokens/tokens.mdx
@@ -13,7 +13,7 @@ resources:
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -240,7 +240,7 @@ export function FontSize() {
       renderToken={({token}) => {
         if (['3xl', '4xl'].includes(token)) {
           return (
-            <Heading size={token} variant="accent">
+            <Heading as="h4" size={token} variant="accent">
               Aa
             </Heading>
           );
@@ -525,9 +525,8 @@ export function BorderColors() {
           radius="sm"
         />
       )}
-     />
-
-);
+    />
+  );
 }
 
 export function GraphicsColors() {


### PR DESCRIPTION
Poorly named branch, but this fixes the `tokens` page error :(

Still investigating MDX typechecking in CI (which would have prevented this) but we are still blocked by the lack of CLI https://github.com/mdx-js/mdx-analyzer/issues/292.