### PR TITLE
ref(slack): Replace Seer button with context block for running automation

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -62,6 +62,7 @@ from sentry.notifications.utils.participants import (
     get_suspect_commit_users,
 )
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.seer.autofix.issue_summary import is_group_triggering_automation
 from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -508,6 +509,18 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self._is_compact = features.has(
             "organizations:slack-compact-alerts", self.group.organization
         )
+        self._has_seer_slack_access = SeerOperator.has_access(
+            organization=self.group.project.organization, entrypoint_key=SeerEntrypointKey.SLACK
+        )
+        self._is_triggering_automation = False
+        if self._has_seer_slack_access:
+            try:
+                self._is_triggering_automation = is_group_triggering_automation(self.group)
+            except Exception:
+                # The helper raises value errors in some cases for permission issues. We don't
+                # want to stop building the notification if that happens, just assume it is not
+                # triggering an automation.
+                pass
 
     def get_title_block(
         self,
@@ -689,6 +702,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self._is_compact and summary_text:
             blocks.append(self.get_context_block(summary_text))
 
+        if self._has_seer_slack_access and self._is_triggering_automation:
+            status_text = SeerSlackRenderer.render_status_text(group=self.group)
+            blocks.append(self.get_context_block(status_text))
+
         if not self._is_compact and len(suggested_assignees) > 0:
             blocks.append(self.get_suggested_assignees_block(suggested_assignees))
 
@@ -834,10 +851,8 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     )
                 )
 
-        if SeerOperator.has_access(
-            organization=self.group.project.organization, entrypoint_key=SeerEntrypointKey.SLACK
-        ):
-            autofix_button = SeerSlackRenderer.render_alert_autofix_element(group=self.group)
+        if self._has_seer_slack_access and not self._is_triggering_automation:
+            autofix_button = SeerSlackRenderer.render_autofix_button(group=self.group)
             # We have to coerce this since we're not using the proper SlackSDK client to emit this
             # notification yet, it just takes JSON.
             actions.append(autofix_button.to_dict())

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -223,27 +223,10 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         ]
 
     @classmethod
-    def render_alert_autofix_element(cls, group: Group) -> InteractiveElement:
+    def render_autofix_button(cls, group: Group) -> InteractiveElement:
         """
-        Returns either an autofix button or a link to the autofix panel in Sentry.
-        When automation will run, shows a link (updates will be threaded later).
-        When automation won't run, shows an autofix button for manual RCA trigger.
+        Returns an autofix button for manual RCA trigger.
         """
-        from sentry.seer.autofix.issue_summary import is_group_triggering_automation
-        from sentry.seer.entrypoints.integrations.slack import SlackEntrypoint
-
-        try:
-            is_triggering = is_group_triggering_automation(group)
-        except Exception:
-            is_triggering = False
-
-        if is_triggering:
-            return cls._render_link_button(
-                organization_id=group.project.organization_id,
-                project_id=group.project_id,
-                group_link=SlackEntrypoint.get_group_link(group),
-                text="Watch Seer Work :sparkles:",
-            )
 
         return cls._render_autofix_button(
             data=SeerAutofixTrigger(
@@ -253,3 +236,14 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
             )
         )
+
+    @classmethod
+    def render_status_text(cls, group: Group) -> str:
+        """
+        Returns mrkdwn text for the Seer running context block.
+        The entire text is a link to the issue page.
+        """
+        from sentry.seer.entrypoints.integrations.slack import SlackEntrypoint
+
+        group_link = SlackEntrypoint.get_group_link(group)
+        return f"_<{group_link}|:hourglass: Seer is running a root cause analysis...>_"

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -246,4 +246,4 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         from sentry.seer.entrypoints.integrations.slack import SlackEntrypoint
 
         group_link = SlackEntrypoint.get_group_link(group)
-        return f"_<{group_link}|:hourglass: Seer is running a root cause analysis...>_"
+        return f"<{group_link}|:hourglass: Seer is running a root cause analysis...>"

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -93,24 +93,19 @@ class SeerSlackRendererTest(TestCase):
         blocks = SeerSlackRenderer.render_footer_blocks(data=data, stage_completed=True)
         assert len(blocks) == 0
 
-    @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=False)
-    def test_render_alert_autofix_element_without_automation(
-        self, _mock_is_triggering: Mock
-    ) -> None:
-        element = SeerSlackRenderer.render_alert_autofix_element(group=self.group)
+    def test_render_autofix_button(self) -> None:
+        element = SeerSlackRenderer.render_autofix_button(group=self.group)
         assert isinstance(element, ButtonElement)
         assert element.text is not None
         assert element.text.text == "Fix with Seer"
         assert element.value == AutofixStoppingPoint.ROOT_CAUSE.value
 
-    @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
-    def test_render_alert_autofix_element_with_automation(self, _mock_is_triggering: Mock) -> None:
-        element = SeerSlackRenderer.render_alert_autofix_element(group=self.group)
-        assert isinstance(element, LinkButtonElement)
-        assert element.text is not None
-        assert element.text.text == "Watch Seer Work :sparkles:"
-        assert element.url is not None
-        assert "seerDrawer=true" in element.url
+    def test_render_status_text(self) -> None:
+        text = SeerSlackRenderer.render_status_text(group=self.group)
+        assert ":hourglass: Seer is running a root cause analysis..." in text
+        assert "seerDrawer=true" in text
+        assert text.startswith("_<")
+        assert text.endswith(">_")
 
     @patch(
         "sentry.notifications.platform.templates.seer.organization_service.get_option",

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -104,8 +104,8 @@ class SeerSlackRendererTest(TestCase):
         text = SeerSlackRenderer.render_status_text(group=self.group)
         assert ":hourglass: Seer is running a root cause analysis..." in text
         assert "seerDrawer=true" in text
-        assert text.startswith("_<")
-        assert text.endswith(">_")
+        assert text.startswith("<")
+        assert text.endswith(">")
 
     @patch(
         "sentry.notifications.platform.templates.seer.organization_service.get_option",


### PR DESCRIPTION
replaces the "watch seer work" button with a context block showing ":hourglass: seer is running a root cause analysis..." as a clickable link when automation is triggered.

the context block appears after the initial guess section in slack alerts instead of as a button in the actions row.

<img width="684" height="272" alt="image" src="https://github.com/user-attachments/assets/83e42a19-2e9f-494b-90b4-8882c881116f" />
