### PR TITLE
chore(autofix): Add BQ analytics events for the automation tasks

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -7,6 +7,7 @@ from .alert_sent import *  # noqa: F401,F403
 from .api_token_created import *  # noqa: F401,F403
 from .api_token_deleted import *  # noqa: F401,F403
 from .auth_v2 import *  # noqa: F401,F403
+from .autofix_automation_events import *  # noqa: F401,F403
 from .checkin_processing_error_stored import *  # noqa: F401,F403
 from .codeowners_assignment import *  # noqa: F401,F403
 from .codeowners_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/autofix_automation_events.py
+++ b/src/sentry/analytics/events/autofix_automation_events.py
@@ -1,33 +1,14 @@
 from sentry import analytics
 
 
-@analytics.eventclass("ai.autofix.automation.generate_summary_and_run_automation")
-class AiAutofixGenerateSummaryAndRunAutomationEvent(analytics.Event):
+@analytics.eventclass("ai.autofix.automation")
+class AiAutofixAutomationEvent(analytics.Event):
     organization_id: int
     project_id: int
     group_id: int
+    task_name: str
     issue_event_count: int
     fixability_score: float | None
 
 
-@analytics.eventclass("ai.autofix.automation.generate_issue_summary_only")
-class AiAutofixGenerateIssueSummaryOnlyEvent(analytics.Event):
-    organization_id: int
-    project_id: int
-    group_id: int
-    issue_event_count: int
-    fixability_score: float | None
-
-
-@analytics.eventclass("ai.autofix.automation.run_automation_only")
-class AiAutofixRunAutomationOnlyEvent(analytics.Event):
-    organization_id: int
-    project_id: int
-    group_id: int
-    issue_event_count: int
-    fixability_score: float | None
-
-
-analytics.register(AiAutofixGenerateSummaryAndRunAutomationEvent)
-analytics.register(AiAutofixGenerateIssueSummaryOnlyEvent)
-analytics.register(AiAutofixRunAutomationOnlyEvent)
+analytics.register(AiAutofixAutomationEvent)

--- a/src/sentry/analytics/events/autofix_automation_events.py
+++ b/src/sentry/analytics/events/autofix_automation_events.py
@@ -1,0 +1,33 @@
+from sentry import analytics
+
+
+@analytics.eventclass("ai.autofix.automation.generate_summary_and_run_automation")
+class AiAutofixGenerateSummaryAndRunAutomationEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    group_id: int
+    issue_event_count: int
+    fixability_score: float | None
+
+
+@analytics.eventclass("ai.autofix.automation.generate_issue_summary_only")
+class AiAutofixGenerateIssueSummaryOnlyEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    group_id: int
+    issue_event_count: int
+    fixability_score: float | None
+
+
+@analytics.eventclass("ai.autofix.automation.run_automation_only")
+class AiAutofixRunAutomationOnlyEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    group_id: int
+    issue_event_count: int
+    fixability_score: float | None
+
+
+analytics.register(AiAutofixGenerateSummaryAndRunAutomationEvent)
+analytics.register(AiAutofixGenerateIssueSummaryOnlyEvent)
+analytics.register(AiAutofixRunAutomationOnlyEvent)

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -68,11 +68,6 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
-        metrics.incr(
-            "sentry.tasks.autofix.generate_summary_and_run_automation",
-            tags={"organization": organization.slug, "organization_id": organization.id},
-            sample_rate=1.0,
-        )
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,
@@ -112,11 +107,6 @@ def generate_issue_summary_only(group_id: int) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
-        metrics.incr(
-            "sentry.tasks.autofix.generate_issue_summary_only",
-            tags={"organization": organization.slug, "organization_id": organization.id},
-            sample_rate=1.0,
-        )
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,
@@ -165,11 +155,6 @@ def run_automation_only_task(group_id: int) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
-        metrics.incr(
-            "sentry.tasks.autofix.run_automation_only_task",
-            tags={"organization": organization.slug, "organization_id": organization.id},
-            sample_rate=1.0,
-        )
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -5,11 +5,7 @@ import sentry_sdk
 from django.utils import timezone
 
 from sentry import analytics
-from sentry.analytics.events.autofix_automation_events import (
-    AiAutofixGenerateIssueSummaryOnlyEvent,
-    AiAutofixGenerateSummaryAndRunAutomationEvent,
-    AiAutofixRunAutomationOnlyEvent,
-)
+from sentry.analytics.events.autofix_automation_events import AiAutofixAutomationEvent
 from sentry.constants import ObjectStatus
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -29,6 +25,7 @@ from sentry.seer.autofix.utils import (
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import ingest_errors_tasks, issues_tasks
 from sentry.taskworker.retry import Retry
+from sentry.taskworker.state import current_task
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -68,20 +65,25 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
 
     group = Group.objects.get(id=group_id)
     organization = group.project.organization
-    metrics.incr(
-        "sentry.tasks.autofix.generate_summary_and_run_automation",
-        tags={"organization": organization.slug, "organization_id": organization.id},
-        sample_rate=1.0,
-    )
-    analytics.record(
-        AiAutofixGenerateSummaryAndRunAutomationEvent(
-            organization_id=organization.id,
-            project_id=group.project_id,
-            group_id=group.id,
-            issue_event_count=group.times_seen,
-            fixability_score=group.seer_fixability_score,
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr(
+            "sentry.tasks.autofix.generate_summary_and_run_automation",
+            tags={"organization": organization.slug, "organization_id": organization.id},
+            sample_rate=1.0,
         )
-    )
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="generate_summary_and_run_automation",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
+
     get_issue_summary(group=group, source=SeerAutomationSource.POST_PROCESS)
 
 
@@ -107,20 +109,25 @@ def generate_issue_summary_only(group_id: int) -> None:
 
     group = Group.objects.get(id=group_id)
     organization = group.project.organization
-    metrics.incr(
-        "sentry.tasks.autofix.generate_issue_summary_only",
-        tags={"organization": organization.slug, "organization_id": organization.id},
-        sample_rate=1.0,
-    )
-    analytics.record(
-        AiAutofixGenerateIssueSummaryOnlyEvent(
-            organization_id=organization.id,
-            project_id=group.project_id,
-            group_id=group.id,
-            issue_event_count=group.times_seen,
-            fixability_score=group.seer_fixability_score,
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr(
+            "sentry.tasks.autofix.generate_issue_summary_only",
+            tags={"organization": organization.slug, "organization_id": organization.id},
+            sample_rate=1.0,
         )
-    )
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="generate_issue_summary_only",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
+
     summary_data, status_code = get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
@@ -155,20 +162,24 @@ def run_automation_only_task(group_id: int) -> None:
 
     group = Group.objects.get(id=group_id)
     organization = group.project.organization
-    metrics.incr(
-        "sentry.tasks.autofix.run_automation_only_task",
-        tags={"organization": organization.slug, "organization_id": organization.id},
-        sample_rate=1.0,
-    )
-    analytics.record(
-        AiAutofixRunAutomationOnlyEvent(
-            organization_id=organization.id,
-            project_id=group.project_id,
-            group_id=group.id,
-            issue_event_count=group.times_seen,
-            fixability_score=group.seer_fixability_score,
+
+    task_state = current_task()
+    if task_state is None or task_state.attempt == 0:
+        metrics.incr(
+            "sentry.tasks.autofix.run_automation_only_task",
+            tags={"organization": organization.slug, "organization_id": organization.id},
+            sample_rate=1.0,
         )
-    )
+        analytics.record(
+            AiAutofixAutomationEvent(
+                organization_id=organization.id,
+                project_id=group.project_id,
+                group_id=group.id,
+                task_name="run_automation_only",
+                issue_event_count=group.times_seen,
+                fixability_score=group.seer_fixability_score,
+            )
+        )
 
     event = group.get_latest_event()
 
@@ -178,7 +189,9 @@ def run_automation_only_task(group_id: int) -> None:
 
     # Track issue age when running automation
     issue_age_days = int((timezone.now() - group.first_seen).total_seconds() / (60 * 60 * 24))
-    metrics.distribution("seer.automation.issue_age_since_first_seen", issue_age_days, unit="day")
+    metrics.distribution(
+        "seer.automation.issue_age_since_first_seen", issue_age_days, unit="day", sample_rate=1.0
+    )
 
     run_automation(
         group=group, user=AnonymousUser(), event=event, source=SeerAutomationSource.POST_PROCESS

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -68,6 +68,7 @@ def generate_summary_and_run_automation(group_id: int, **kwargs) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.generate_summary_and_run_automation", sample_rate=1.0)
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,
@@ -107,6 +108,7 @@ def generate_issue_summary_only(group_id: int) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.generate_issue_summary_only", sample_rate=1.0)
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,
@@ -155,6 +157,7 @@ def run_automation_only_task(group_id: int) -> None:
 
     task_state = current_task()
     if task_state is None or task_state.attempt == 0:
+        metrics.incr("sentry.tasks.autofix.run_automation_only_task", sample_rate=1.0)
         analytics.record(
             AiAutofixAutomationEvent(
                 organization_id=organization.id,


### PR DESCRIPTION
## PR Details
+ Added new analytics event ai.autofix.automation to track autofix task executions in BigQuery (super-big-data.analytics.events) with fields: organization_id, project_id, group_id, task_name, issue_event_count, and fixability_score.
+ This is so we can query these analytics past the 90 day TTL in sentry.            
+ Also removed the `metrics.incr` tags since they logged org id. This is a high cardinality field which leads to large costs in Datadog.                                                                                     
+ Instrumented 3 autofix tasks in src/sentry/tasks/autofix.py: generate_summary_and_run_automation, generate_issue_summary_only, and run_automation_only               
+ Added retry detection using current_task() to only log metrics and analytics on the first attempt, preventing duplicate events on task retries