### PR TITLE
test(autofix): Move autofix state check test to run_automation, and refactor rate limtis

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -388,12 +388,12 @@ def run_automation(
         }
     )
 
-    if not is_group_triggering_automation(group):
-        return
-
     autofix_state = get_autofix_state(group_id=group.id, organization_id=group.organization.id)
     if autofix_state:
         return  # already have an autofix on this issue
+
+    if not is_group_triggering_automation(group):
+        return
 
     # Increment the rate limit counter only when we are actually about to trigger.
     if is_seer_autotriggered_autofix_rate_limited_and_increment(group.project, group.organization):

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -28,6 +28,7 @@ from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
+    is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
@@ -393,6 +394,10 @@ def run_automation(
     autofix_state = get_autofix_state(group_id=group.id, organization_id=group.organization.id)
     if autofix_state:
         return  # already have an autofix on this issue
+
+    # Increment the rate limit counter only when we are actually about to trigger.
+    if is_seer_autotriggered_autofix_rate_limited_and_increment(group.project, group.organization):
+        return
 
     stopping_point = None
     if is_seer_seat_based_tier_enabled(group.organization):

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -549,12 +549,51 @@ AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS = {
 }
 
 
+class AutoTriggerRateLimitConfig(TypedDict):
+    limit: int
+    key: str
+    window: int
+
+
+def _get_autofix_rate_limit_config(project: Project) -> AutoTriggerRateLimitConfig:
+    """Returns the computed rate limit for autotriggered autofix runs for a project."""
+    limit = options.get("seer.max_num_autofix_autotriggered_per_hour", 20)
+
+    # The more selective automation is, the higher the limit we allow.
+    # This is to protect projects with extreme settings from starting too many runs
+    # while allowing big projects with reasonable settings to run more often.
+    option = project.get_option("sentry:autofix_automation_tuning")
+    multiplier = AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS.get(option, 1)
+    limit *= multiplier
+    return AutoTriggerRateLimitConfig(limit=limit, key="autofix.auto_triggered", window=60 * 60)
+
+
 def is_seer_autotriggered_autofix_rate_limited(
+    project: Project, organization: Organization
+) -> bool:
+    """
+    Read-only check of whether the autofix rate limit has been reached.
+    Does NOT increment the counter. Safe to call from non-triggering code paths.
+    """
+    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
+        return False
+
+    config = _get_autofix_rate_limit_config(project)
+    current = ratelimits.backend.current_value(
+        key=config["key"],
+        project=project,
+        window=config["window"],
+    )
+    return current >= config["limit"]
+
+
+def is_seer_autotriggered_autofix_rate_limited_and_increment(
     project: Project, organization: Organization
 ) -> bool:
     """
     Check if Seer Autofix automation is rate limited for a given project and organization.
     Calling this method increments the counter used to enforce the rate limit, and tracks rate limited outcomes.
+    Only call this when you are actually about to trigger an automation run.
 
     Args:
         project: The project to check.
@@ -566,27 +605,20 @@ def is_seer_autotriggered_autofix_rate_limited(
     if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
         return False
 
-    limit = options.get("seer.max_num_autofix_autotriggered_per_hour", 20)
-
-    # The more selective automation is, the higher the limit we allow.
-    # This is to protect projects with extreme settings from starting too many runs
-    # while allowing big projects with reasonable settings to run more often.
-    option = project.get_option("sentry:autofix_automation_tuning")
-    multiplier = AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS.get(option, 1)
-    limit *= multiplier
+    config = _get_autofix_rate_limit_config(project)
 
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
-        key="autofix.auto_triggered",
-        limit=limit,
-        window=60 * 60,  # 1 hour
+        key=config["key"],
+        limit=config["limit"],
+        window=config["window"],
     )
     if is_rate_limited:
         logger.info(
             "Autofix auto-trigger rate limit hit",
             extra={
                 "auto_run_count": current,
-                "auto_run_limit": limit,
+                "auto_run_limit": config["limit"],
                 "org_slug": organization.slug,
                 "project_slug": project.slug,
             },

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -860,6 +860,17 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[1]["stopping_point"] is None
 
+    @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
+    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
+    def test_skips_when_autofix_in_progress(self, mock_state, mock_triggering, mock_trigger):
+        """run_automation skips triggering autofix when one is already in progress"""
+        mock_state.return_value = {"status": "in_progress"}
+
+        run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
+
+        mock_trigger.assert_not_called()
+
 
 class TestFetchUserPreference:
     @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
@@ -1266,15 +1277,11 @@ class TestIsGroupTriggeringAutomation(APITestCase, SnubaTestCase):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
 
     @patch("sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.quotas.backend.check_seer_quota")
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_returns_true_when_all_checks_pass(
-        self, mock_fixability, mock_quota, mock_state, mock_rate_limit
-    ):
+    def test_returns_true_when_all_checks_pass(self, mock_fixability, mock_quota, mock_rate_limit):
         mock_fixability.return_value = 0.80
         mock_quota.return_value = True
-        mock_state.return_value = None
         mock_rate_limit.return_value = False
         self.group.times_seen = 10
         self.group.times_seen_pending = 0
@@ -1301,28 +1308,12 @@ class TestIsGroupTriggeringAutomation(APITestCase, SnubaTestCase):
 
         assert is_group_triggering_automation(self.group) is False
 
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    @patch("sentry.quotas.backend.check_seer_quota")
-    @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_returns_false_when_autofix_in_progress(self, mock_fixability, mock_quota, mock_state):
-        mock_fixability.return_value = 0.80
-        mock_quota.return_value = True
-        mock_state.return_value = {"status": "in_progress"}
-        self.group.times_seen = 10
-        self.group.times_seen_pending = 0
-
-        assert is_group_triggering_automation(self.group) is False
-
     @patch("sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited")
-    @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.quotas.backend.check_seer_quota")
     @patch("sentry.seer.autofix.issue_summary.get_and_update_group_fixability_score")
-    def test_returns_false_when_rate_limited(
-        self, mock_fixability, mock_quota, mock_state, mock_rate_limit
-    ):
+    def test_returns_false_when_rate_limited(self, mock_fixability, mock_quota, mock_rate_limit):
         mock_fixability.return_value = 0.80
         mock_quota.return_value = True
-        mock_state.return_value = None
         mock_rate_limit.return_value = True
         self.group.times_seen = 10
         self.group.times_seen_pending = 0

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -783,7 +783,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -809,7 +809,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -835,7 +835,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -998,7 +998,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary._fetch_user_preference")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -1030,7 +1030,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary._fetch_user_preference")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -1062,7 +1062,7 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary._fetch_user_preference")
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
@@ -1129,7 +1129,7 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
         mock_trigger.delay.assert_not_called()
 
     @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited",
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
         return_value=False,
     )
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")


### PR DESCRIPTION
I extracted this helper earlier but didn't notice it checked for existing runs, which meant it wasn't idempotent, so two threads calling it would yield different results :( fixes that for my purposes. all notifications for automations will render the same

update: bots caught that the `is_x_rate_limited` check actually increments the counter, meaning its not safe to call outside of the `run_automation` call :( 

I refactored it so that the `is_x_rate_limited` check doesnt increment, but `is_x_rate_limited_and_increment` does, then updated call sites, tests and added a test. Also put together a small util to ensure the rate limit config for both functions stays consistent.

ISWF-2015