### PR TITLE
fix(typing): Replace type: ignore comments with proper type fixes

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -251,6 +251,22 @@ class RelayAuthentication(BasicAuthentication):
         return (AnonymousUser(), None)
 
 
+def get_relay_from_request(request: Request) -> Relay:
+    """Get the Relay instance from a relay-authenticated request."""
+    relay: Relay | None = getattr(request, "relay", None)
+    if relay is None:
+        raise AuthenticationFailed("Request not authenticated with relay")
+    return relay
+
+
+def get_relay_request_data(request: Request) -> dict[str, Any]:
+    """Get the unpacked relay request data from a relay-authenticated request."""
+    data: dict[str, Any] | None = getattr(request, "relay_request_data", None)
+    if data is None:
+        raise AuthenticationFailed("Request not authenticated with relay")
+    return data
+
+
 @AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.REGION)
 class ApiKeyAuthentication(QuietBasicAuthentication):
     token_name = b"basic"

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -346,10 +346,11 @@ class DebugFilesEndpoint(ProjectEndpoint):
         :qparam string id: The id of the DIF to delete.
         :auth: required
         """
-        if request.GET.get("id") and _has_delete_permission(request.access, project):
+        debug_file_id = request.GET.get("id")
+        if debug_file_id and _has_delete_permission(request.access, project):
             with atomic_transaction(using=router.db_for_write(File)):
                 debug_file = (
-                    ProjectDebugFile.objects.filter(id=request.GET.get("id"), project_id=project.id)  # type: ignore[misc]
+                    ProjectDebugFile.objects.filter(id=debug_file_id, project_id=project.id)
                     .select_related("file")
                     .first()
                 )

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1021,7 +1021,8 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
                     current_generation = 0
                     break
 
-            snuba_params = self.get_snuba_params(self.request, self.request.organization)  # type: ignore[attr-defined]
+            organization: Organization = getattr(self.request, "organization")
+            snuba_params = self.get_snuba_params(self.request, organization)
             if current_generation is None:
                 for root in roots:
                     # We might not be necessarily connected to the root if we're on an orphan event
@@ -1173,7 +1174,8 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         parent_events: dict[str, TraceEvent] = {}
         results_map: dict[str | None, list[TraceEvent]] = defaultdict(list)
         to_check: Deque[SnubaTransaction] = deque()
-        snuba_params = self.get_snuba_params(self.request, self.request.organization)  # type: ignore[attr-defined]
+        organization: Organization = getattr(self.request, "organization")
+        snuba_params = self.get_snuba_params(self.request, organization)
         # The root of the orphan tree we're currently navigating through
         orphan_root: SnubaTransaction | None = None
         if roots:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -635,9 +635,10 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         ]
 
     def semver_package_autocomplete_function(self):
+        assert self.snuba_params.organization_id is not None
         packages = (
             Release.objects.filter(
-                organization_id=self.snuba_params.organization_id,  # type: ignore[misc]
+                organization_id=self.snuba_params.organization_id,
                 package__startswith=self.query,
             )
             .values_list("package")
@@ -645,7 +646,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         )
 
         versions = Release.objects.filter(
-            organization_id=self.snuba_params.organization_id,  # type: ignore[misc]
+            organization_id=self.snuba_params.organization_id,
             package__in=packages,
             id__in=ReleaseProject.objects.filter(
                 project_id__in=self.snuba_params.project_ids

--- a/src/sentry/api/endpoints/organization_unsubscribe.py
+++ b/src/sentry/api/endpoints/organization_unsubscribe.py
@@ -23,6 +23,7 @@ from sentry.notifications.types import (
 )
 from sentry.types.actor import Actor, ActorType
 from sentry.utils import auth
+from sentry.utils.auth import is_user_signed_request
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -71,7 +72,7 @@ class OrganizationUnsubscribeBase(Endpoint, Generic[T]):
     def post(
         self, request: Request, organization_id_or_slug: int | str, id: int, **kwargs
     ) -> Response:
-        if not request.user_from_signed_request:  # type: ignore[attr-defined]
+        if not is_user_signed_request(request):
             raise NotFound()
         instance = self.fetch_instance(request, organization_id_or_slug, id)
 

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -8,7 +8,11 @@ from sentry_sdk import set_tag, start_span
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import RelayAuthentication
+from sentry.api.authentication import (
+    RelayAuthentication,
+    get_relay_from_request,
+    get_relay_request_data,
+)
 from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.options.organization_option import OrganizationOption
@@ -39,8 +43,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
     enforce_rate_limit = False
 
     def post(self, request: Request):
-        relay = request.relay  # type: ignore[attr-defined]
-        assert relay is not None  # should be provided during Authentication
+        relay = get_relay_from_request(request)
         response: dict[str, Any] = {}
 
         if not relay.is_internal:
@@ -49,7 +52,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         version = request.GET.get("version") or "1"
         set_tag("relay_protocol_version", version)
 
-        if version == "3" and request.relay_request_data.get("global"):  # type: ignore[attr-defined]
+        if version == "3" and get_relay_request_data(request).get("global"):
             response["global"] = get_global_config()
             response["global_status"] = "ready"
 
@@ -110,7 +113,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return post_or_schedule
 
     def _post_or_schedule_by_key(self, request: Request):
-        public_keys = set(request.relay_request_data.get("publicKeys") or ())  # type: ignore[attr-defined]
+        public_keys = set(get_relay_request_data(request).get("publicKeys") or ())
 
         proj_configs = {}
         pending = []
@@ -144,7 +147,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return None
 
     def _post_by_key(self, request: Request) -> MutableMapping[str, ProjectConfig]:
-        public_keys = request.relay_request_data.get("publicKeys")  # type: ignore[attr-defined]
+        public_keys = get_relay_request_data(request).get("publicKeys")
         public_keys = set(public_keys or ())
 
         project_keys: MutableMapping[str, ProjectKey] = {}
@@ -176,7 +179,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         with start_span(op="relay_fetch_orgs"):
             with metrics.timer("relay_project_configs.fetching_orgs.duration"):
                 for org in Organization.objects.get_many_from_cache(organization_ids):
-                    if request.relay.has_org_access(org):  # type: ignore[attr-defined]
+                    if get_relay_from_request(request).has_org_access(org):
                         orgs[org.id] = org
 
         with start_span(op="relay_fetch_org_options"):
@@ -221,7 +224,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return configs
 
     def _post_by_project(self, request: Request) -> MutableMapping[str, ProjectConfig]:
-        project_ids = set(request.relay_request_data.get("projects") or ())  # type: ignore[attr-defined]
+        relay_data = get_relay_request_data(request)
+        project_ids = set(relay_data.get("projects") or ())
 
         with start_span(op="relay_fetch_projects"):
             if project_ids:
@@ -237,7 +241,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
             if org_ids:
                 with metrics.timer("relay_project_configs.fetching_orgs.duration"):
                     orgs_seq = Organization.objects.get_many_from_cache(org_ids)
-                    orgs = {o.id: o for o in orgs_seq if request.relay.has_org_access(o)}  # type: ignore[attr-defined]
+                    relay = get_relay_from_request(request)
+                    orgs = {o.id: o for o in orgs_seq if relay.has_org_access(o)}
             else:
                 orgs = {}
 

--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -3,7 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import RelayAuthentication
+from sentry.api.authentication import (
+    RelayAuthentication,
+    get_relay_from_request,
+    get_relay_request_data,
+)
 from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.relay import Relay
@@ -20,8 +24,8 @@ class RelayPublicKeysEndpoint(Endpoint):
     owner = ApiOwner.OWNERS_INGEST
 
     def post(self, request: Request) -> Response:
-        calling_relay = request.relay  # type: ignore[attr-defined]
-        relay_ids = request.relay_request_data.get("relay_ids") or ()  # type: ignore[attr-defined]
+        calling_relay = get_relay_from_request(request)
+        relay_ids = get_relay_request_data(request).get("relay_ids") or ()
 
         legacy_public_keys = dict.fromkeys(relay_ids)
         public_keys = dict.fromkeys(relay_ids)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -480,7 +480,10 @@ class VercelIntegrationProvider(IntegrationProvider):
             )
             return
 
-        user = User.objects.get(id=extra.get("user_id"))  # type: ignore[misc]
+        user_id = extra.get("user_id")
+        if user_id is None:
+            raise ValueError("user_id is required in post_install_data")
+        user = User.objects.get(id=user_id)
         # create the internal integration and link it to the join table
         sentry_app = SentryAppCreator(
             name="Vercel Internal Integration",

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -167,7 +167,9 @@ class VstsApiClient(IntegrationProxyClient, RepositoryClient):
     def identity(self):
         if self._identity:
             return self._identity
-        self._identity = Identity.objects.get(id=self.identity_id)  # type: ignore[misc]
+        if self.identity_id is None:
+            raise ValueError("identity_id is not set")
+        self._identity = Identity.objects.get(id=self.identity_id)
         return self._identity
 
     def request(self, method: str, *args: Any, **kwargs: Any) -> Any:

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -30,8 +30,9 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         Retrieve a list of starred views for the current organization member.
         """
 
+        assert request.user.id is not None
         starred_views = GroupSearchViewStarred.objects.filter(
-            organization=organization, user_id=request.user.id  # type: ignore[misc]
+            organization=organization, user_id=request.user.id
         ).select_related("group_search_view")
 
         return self.paginate(

--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -296,16 +296,9 @@ def build_group_to_groupevent(
     group_to_groupevent: dict[Group, tuple[GroupEvent, datetime | None]] = {}
 
     for rule_group, instance_data in parsed_rulegroup_to_event_data.items():
-        event_id = instance_data.get("event_id")
+        event_id = instance_data["event_id"]
         occurrence_id = instance_data.get("occurrence_id")
         start_timestamp = instance_data.get("start_timestamp")
-
-        if event_id is None:
-            logger.info(  # type: ignore[unreachable]
-                "delayed_processing.missing_event_id",
-                extra={"rule": rule_group[0], "project_id": project_id},
-            )
-            continue
 
         event = bulk_event_id_to_events.get(event_id)
         group = group_id_to_group.get(int(rule_group[1]))

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -360,7 +360,10 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             user_ids = autofix_state.actor_ids
             if user_ids:
                 users = user_service.serialize_many(
-                    filter={"user_ids": user_ids, "organization_id": request.organization.id},  # type: ignore[attr-defined]
+                    filter={
+                        "user_ids": user_ids,
+                        "organization_id": getattr(request, "organization").id,
+                    },
                     as_user=request.user,
                 )
 

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -128,7 +128,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         if not request.user.is_authenticated:
             return Response(status=400)
 
-        org: Organization = request.organization  # type: ignore[attr-defined]
+        org: Organization = getattr(request, "organization")
 
         integration_check = None
         # This check is to skip using the GitHub integration for Autofix in s4s.

--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -595,9 +595,7 @@ def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:
                 UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
                 UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
             ),
-        )
-        .select_related("data_sources")  # type: ignore[misc]
-        .values_list("data_sources__source_id", flat=True)
+        ).values_list("data_sources__source_id", flat=True)
     )
 
     return UptimeSubscription.objects.filter(

--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -202,7 +202,8 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
         # Using `request.user` here because superuser/staff should not be able to set a user's 2fa
         if user.id != request.user.id:
-            user = User.objects.get(id=request.user.id)  # type: ignore[misc]
+            assert request.user.id is not None
+            user = User.objects.get(id=request.user.id)
 
         # start activation
         serializer_cls = serializer_map.get(interface_id, None)

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -59,7 +59,7 @@ class UserOptionManager(OptionManager["UserOption"]):
         """
         This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
         """
-        self.filter(user=user, project=project, key=key).delete()  # type: ignore[misc]
+        self.filter(user=user, project_id=project.id, key=key).delete()
 
         if not hasattr(self, "_metadata"):
             return

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -398,10 +398,7 @@ def is_user_signed_request(request: Request) -> bool:
     """
     This function returns True if the request is a signed valid link
     """
-    try:
-        return bool(request.user_from_signed_request)  # type: ignore[attr-defined]
-    except AttributeError:
-        return False
+    return bool(getattr(request, "user_from_signed_request", False))
 
 
 def set_active_org(request: HttpRequest, org_slug: str) -> None:

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -133,7 +133,7 @@ def fetch_workflow_groups_paginated(
         .annotate(count=Count("group"))
         .annotate(event_id=Subquery(group_max_dates.values("event_id")))
         .annotate(last_triggered=Max("date_added"))
-        .annotate(detector_id=Subquery(detector_subquery))  # type: ignore[no-redef]
+        .annotate(detector_id=Subquery(detector_subquery))  # type: ignore[no-redef]  # shadows model field
     )
 
     # Count distinct groups for pagination

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -18,6 +18,8 @@ from sentry.api.authentication import (
     RpcSignatureAuthentication,
     UserAuthTokenAuthentication,
     compare_service_signature,
+    get_relay_from_request,
+    get_relay_request_data,
 )
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken, is_system_auth
@@ -450,11 +452,11 @@ def test_registered_relay(internal) -> None:
         authenticator.authenticate(request)
 
     # now the request should contain a relay
-    relay = request.relay  # type: ignore[attr-defined]
+    relay = get_relay_from_request(request)
     assert relay.is_internal == internal
     assert relay.public_key == str(pk)
     # data should be deserialized in request.relay_request_data
-    assert request.relay_request_data == data  # type: ignore[attr-defined]
+    assert get_relay_request_data(request) == data
 
 
 @django_db_all
@@ -479,11 +481,11 @@ def test_statically_configured_relay(settings, internal) -> None:
     authenticator.authenticate(request)
 
     # now the request should contain a relay
-    relay = request.relay  # type: ignore[attr-defined]
+    relay = get_relay_from_request(request)
     assert relay.is_internal == internal
     assert relay.public_key == str(pk)
     # data should be deserialized in request.relay_request_data
-    assert request.relay_request_data == data  # type: ignore[attr-defined]
+    assert get_relay_request_data(request) == data
 
 
 @control_silo_test

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from operator import itemgetter
-from typing import Any, ContextManager, NotRequired, TypedDict
+from typing import Any, ContextManager, NotRequired, TypedDict, cast
 from unittest.mock import patch
 
 import pytest
@@ -92,7 +92,7 @@ def reset_watermarks() -> None:
 
 @pytest.fixture
 def saved_search_owner_id_field() -> HybridCloudForeignKey[int, int]:
-    return SavedSearch._meta.get_field("owner_id")  # type: ignore[return-value]
+    return cast(HybridCloudForeignKey[int, int], SavedSearch._meta.get_field("owner_id"))
 
 
 @django_db_all


### PR DESCRIPTION
## Summary

Stacked on #107710. Fixes the `# type: ignore` comments that were added during the mypy 1.19.1 upgrade by replacing them with proper type-safe solutions.

### Changes by category

**`attr-defined` fixes (relay, organization, user_from_signed_request):**
- Created `get_relay_from_request()` and `get_relay_request_data()` typed helpers in `authentication.py`
- Updated all relay endpoint files to use the new helpers instead of `request.relay` / `request.relay_request_data`
- Used `getattr()` for `request.organization` access (returns `Any`, satisfies mypy)
- Used existing `is_user_signed_request()` helper for `user_from_signed_request`

**`misc` fixes (ORM lookups with possibly-None values):**
- Added explicit None checks before ORM `.get(id=...)` calls where the ID could be None
- Used `assert ... is not None` for authenticated user IDs and organization IDs
- Extracted `request.GET.get("id")` into a variable to help mypy narrow the type
- Changed `filter(project=project)` to `filter(project_id=project.id)` for HybridCloudForeignKey

**`arg-type` fix (base_query_set.py):**
- Added `isinstance(col, str)` check before dict lookup, properly narrowing `str | Combinable`

**`unreachable` fix (delayed_processing.py):**
- Changed `instance_data.get("event_id")` to `instance_data["event_id"]` since `event_id` is a required key in the `EventData` TypedDict — the None check was correctly flagged as unreachable

**Other fixes:**
- Removed invalid `select_related()` on a ManyToManyField (uptime subscriptions)
- Used `cast()` for Django `_meta.get_field()` return type in test fixture
- Kept `# type: ignore[no-redef]` for annotation shadowing model field (genuine mypy limitation)

### Remaining type: ignore

One `# type: ignore[no-redef]` remains in `workflow_group_history_serializer.py` — this is a known mypy limitation where `.annotate(detector_id=...)` shadows an existing model field name.

## Test plan

- [x] `mypy` passes on all 21 changed files with 0 errors
- [x] All pre-commit hooks pass
- [ ] CI passes