### PR TITLE
fix(typing): Add typed helpers for relay request attributes

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -251,6 +251,22 @@ class RelayAuthentication(BasicAuthentication):
         return (AnonymousUser(), None)
 
 
+def get_relay_from_request(request: Request) -> Relay:
+    """Get the Relay instance from a relay-authenticated request."""
+    relay: Relay | None = getattr(request, "relay", None)
+    if relay is None:
+        raise AuthenticationFailed("Request not authenticated with relay")
+    return relay
+
+
+def get_relay_request_data(request: Request) -> dict[str, Any]:
+    """Get the unpacked relay request data from a relay-authenticated request."""
+    data: dict[str, Any] | None = getattr(request, "relay_request_data", None)
+    if data is None:
+        raise AuthenticationFailed("Request not authenticated with relay")
+    return data
+
+
 @AuthenticationSiloLimit(SiloMode.CONTROL, SiloMode.REGION)
 class ApiKeyAuthentication(QuietBasicAuthentication):
     token_name = b"basic"

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -8,7 +8,11 @@ from sentry_sdk import set_tag, start_span
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import RelayAuthentication
+from sentry.api.authentication import (
+    RelayAuthentication,
+    get_relay_from_request,
+    get_relay_request_data,
+)
 from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.options.organization_option import OrganizationOption
@@ -39,8 +43,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
     enforce_rate_limit = False
 
     def post(self, request: Request):
-        relay = request.relay  # type: ignore[attr-defined]
-        assert relay is not None  # should be provided during Authentication
+        relay = get_relay_from_request(request)
         response: dict[str, Any] = {}
 
         if not relay.is_internal:
@@ -49,7 +52,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         version = request.GET.get("version") or "1"
         set_tag("relay_protocol_version", version)
 
-        if version == "3" and request.relay_request_data.get("global"):  # type: ignore[attr-defined]
+        if version == "3" and get_relay_request_data(request).get("global"):
             response["global"] = get_global_config()
             response["global_status"] = "ready"
 
@@ -110,7 +113,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return post_or_schedule
 
     def _post_or_schedule_by_key(self, request: Request):
-        public_keys = set(request.relay_request_data.get("publicKeys") or ())  # type: ignore[attr-defined]
+        public_keys = set(get_relay_request_data(request).get("publicKeys") or ())
 
         proj_configs = {}
         pending = []
@@ -144,7 +147,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return None
 
     def _post_by_key(self, request: Request) -> MutableMapping[str, ProjectConfig]:
-        public_keys = request.relay_request_data.get("publicKeys")  # type: ignore[attr-defined]
+        public_keys = get_relay_request_data(request).get("publicKeys")
         public_keys = set(public_keys or ())
 
         project_keys: MutableMapping[str, ProjectKey] = {}
@@ -176,7 +179,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         with start_span(op="relay_fetch_orgs"):
             with metrics.timer("relay_project_configs.fetching_orgs.duration"):
                 for org in Organization.objects.get_many_from_cache(organization_ids):
-                    if request.relay.has_org_access(org):  # type: ignore[attr-defined]
+                    if get_relay_from_request(request).has_org_access(org):
                         orgs[org.id] = org
 
         with start_span(op="relay_fetch_org_options"):
@@ -221,7 +224,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
         return configs
 
     def _post_by_project(self, request: Request) -> MutableMapping[str, ProjectConfig]:
-        project_ids = set(request.relay_request_data.get("projects") or ())  # type: ignore[attr-defined]
+        relay_data = get_relay_request_data(request)
+        project_ids = set(relay_data.get("projects") or ())
 
         with start_span(op="relay_fetch_projects"):
             if project_ids:
@@ -237,7 +241,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
             if org_ids:
                 with metrics.timer("relay_project_configs.fetching_orgs.duration"):
                     orgs_seq = Organization.objects.get_many_from_cache(org_ids)
-                    orgs = {o.id: o for o in orgs_seq if request.relay.has_org_access(o)}  # type: ignore[attr-defined]
+                    relay = get_relay_from_request(request)
+                    orgs = {o.id: o for o in orgs_seq if relay.has_org_access(o)}
             else:
                 orgs = {}
 

--- a/src/sentry/api/endpoints/relay/public_keys.py
+++ b/src/sentry/api/endpoints/relay/public_keys.py
@@ -3,7 +3,11 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import RelayAuthentication
+from sentry.api.authentication import (
+    RelayAuthentication,
+    get_relay_from_request,
+    get_relay_request_data,
+)
 from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models.relay import Relay
@@ -20,8 +24,8 @@ class RelayPublicKeysEndpoint(Endpoint):
     owner = ApiOwner.OWNERS_INGEST
 
     def post(self, request: Request) -> Response:
-        calling_relay = request.relay  # type: ignore[attr-defined]
-        relay_ids = request.relay_request_data.get("relay_ids") or ()  # type: ignore[attr-defined]
+        calling_relay = get_relay_from_request(request)
+        relay_ids = get_relay_request_data(request).get("relay_ids") or ()
 
         legacy_public_keys = dict.fromkeys(relay_ids)
         public_keys = dict.fromkeys(relay_ids)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -18,6 +18,8 @@ from sentry.api.authentication import (
     RpcSignatureAuthentication,
     UserAuthTokenAuthentication,
     compare_service_signature,
+    get_relay_from_request,
+    get_relay_request_data,
 )
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken, is_system_auth
@@ -450,11 +452,11 @@ def test_registered_relay(internal) -> None:
         authenticator.authenticate(request)
 
     # now the request should contain a relay
-    relay = request.relay  # type: ignore[attr-defined]
+    relay = get_relay_from_request(request)
     assert relay.is_internal == internal
     assert relay.public_key == str(pk)
     # data should be deserialized in request.relay_request_data
-    assert request.relay_request_data == data  # type: ignore[attr-defined]
+    assert get_relay_request_data(request) == data
 
 
 @django_db_all
@@ -479,11 +481,11 @@ def test_statically_configured_relay(settings, internal) -> None:
     authenticator.authenticate(request)
 
     # now the request should contain a relay
-    relay = request.relay  # type: ignore[attr-defined]
+    relay = get_relay_from_request(request)
     assert relay.is_internal == internal
     assert relay.public_key == str(pk)
     # data should be deserialized in request.relay_request_data
-    assert request.relay_request_data == data  # type: ignore[attr-defined]
+    assert get_relay_request_data(request) == data
 
 
 @control_silo_test


### PR DESCRIPTION
## Summary

Stacked on #107710. Creates `get_relay_from_request()` and `get_relay_request_data()` typed helper functions in `authentication.py`, replacing `# type: ignore[attr-defined]` on `request.relay` / `request.relay_request_data` across relay endpoints.

**Files:** `authentication.py`, `relay/public_keys.py`, `relay/project_configs.py`, `test_authentication.py`

## Test plan
- [x] mypy passes on all changed files
- [x] Pre-commit hooks pass