### PR TITLE
fix(typing): Use getattr for dynamic request.organization access

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1021,7 +1021,8 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
                     current_generation = 0
                     break
 
-            snuba_params = self.get_snuba_params(self.request, self.request.organization)  # type: ignore[attr-defined]
+            organization: Organization = getattr(self.request, "organization")
+            snuba_params = self.get_snuba_params(self.request, organization)
             if current_generation is None:
                 for root in roots:
                     # We might not be necessarily connected to the root if we're on an orphan event
@@ -1173,7 +1174,8 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         parent_events: dict[str, TraceEvent] = {}
         results_map: dict[str | None, list[TraceEvent]] = defaultdict(list)
         to_check: Deque[SnubaTransaction] = deque()
-        snuba_params = self.get_snuba_params(self.request, self.request.organization)  # type: ignore[attr-defined]
+        organization: Organization = getattr(self.request, "organization")
+        snuba_params = self.get_snuba_params(self.request, organization)
         # The root of the orphan tree we're currently navigating through
         orphan_root: SnubaTransaction | None = None
         if roots:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -360,7 +360,10 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
             user_ids = autofix_state.actor_ids
             if user_ids:
                 users = user_service.serialize_many(
-                    filter={"user_ids": user_ids, "organization_id": request.organization.id},  # type: ignore[attr-defined]
+                    filter={
+                        "user_ids": user_ids,
+                        "organization_id": getattr(request, "organization").id,
+                    },
                     as_user=request.user,
                 )
 

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -128,7 +128,7 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         if not request.user.is_authenticated:
             return Response(status=400)
 
-        org: Organization = request.organization  # type: ignore[attr-defined]
+        org: Organization = getattr(request, "organization")
 
         integration_check = None
         # This check is to skip using the GitHub integration for Autofix in s4s.


### PR DESCRIPTION
## Summary

Stacked on #107710. Replaces `# type: ignore[attr-defined]` on `request.organization` with `getattr(request, "organization")` which returns `Any` and satisfies mypy while preserving runtime behavior.

**Files:** `organization_events_trace.py`, `group_autofix_setup_check.py`, `group_ai_autofix.py`

## Test plan
- [x] mypy passes on all changed files
- [x] Pre-commit hooks pass