### PR TITLE
fix(typing): Use getattr for user_from_signed_request access

### DIFF
--- a/src/sentry/api/endpoints/organization_unsubscribe.py
+++ b/src/sentry/api/endpoints/organization_unsubscribe.py
@@ -23,6 +23,7 @@ from sentry.notifications.types import (
 )
 from sentry.types.actor import Actor, ActorType
 from sentry.utils import auth
+from sentry.utils.auth import is_user_signed_request
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -71,7 +72,7 @@ class OrganizationUnsubscribeBase(Endpoint, Generic[T]):
     def post(
         self, request: Request, organization_id_or_slug: int | str, id: int, **kwargs
     ) -> Response:
-        if not request.user_from_signed_request:  # type: ignore[attr-defined]
+        if not is_user_signed_request(request):
             raise NotFound()
         instance = self.fetch_instance(request, organization_id_or_slug, id)
 

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -398,10 +398,7 @@ def is_user_signed_request(request: Request) -> bool:
     """
     This function returns True if the request is a signed valid link
     """
-    try:
-        return bool(request.user_from_signed_request)  # type: ignore[attr-defined]
-    except AttributeError:
-        return False
+    return bool(getattr(request, "user_from_signed_request", False))
 
 
 def set_active_org(request: HttpRequest, org_slug: str) -> None:


### PR DESCRIPTION
## Summary

Stacked on #107710. Replaces `# type: ignore[attr-defined]` on `request.user_from_signed_request` with `getattr()` in `is_user_signed_request()`, and uses the existing helper in `organization_unsubscribe.py`.

**Files:** `utils/auth.py`, `organization_unsubscribe.py`

## Test plan
- [x] mypy passes on all changed files
- [x] Pre-commit hooks pass