### PR TITLE
fix(typing): Add None guards for ORM lookups with nullable values

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -346,10 +346,11 @@ class DebugFilesEndpoint(ProjectEndpoint):
         :qparam string id: The id of the DIF to delete.
         :auth: required
         """
-        if request.GET.get("id") and _has_delete_permission(request.access, project):
+        debug_file_id = request.GET.get("id")
+        if debug_file_id and _has_delete_permission(request.access, project):
             with atomic_transaction(using=router.db_for_write(File)):
                 debug_file = (
-                    ProjectDebugFile.objects.filter(id=request.GET.get("id"), project_id=project.id)  # type: ignore[misc]
+                    ProjectDebugFile.objects.filter(id=debug_file_id, project_id=project.id)
                     .select_related("file")
                     .first()
                 )

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -635,9 +635,10 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         ]
 
     def semver_package_autocomplete_function(self):
+        assert self.snuba_params.organization_id is not None
         packages = (
             Release.objects.filter(
-                organization_id=self.snuba_params.organization_id,  # type: ignore[misc]
+                organization_id=self.snuba_params.organization_id,
                 package__startswith=self.query,
             )
             .values_list("package")
@@ -645,7 +646,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         )
 
         versions = Release.objects.filter(
-            organization_id=self.snuba_params.organization_id,  # type: ignore[misc]
+            organization_id=self.snuba_params.organization_id,
             package__in=packages,
             id__in=ReleaseProject.objects.filter(
                 project_id__in=self.snuba_params.project_ids

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -480,7 +480,10 @@ class VercelIntegrationProvider(IntegrationProvider):
             )
             return
 
-        user = User.objects.get(id=extra.get("user_id"))  # type: ignore[misc]
+        user_id = extra.get("user_id")
+        if user_id is None:
+            raise ValueError("user_id is required in post_install_data")
+        user = User.objects.get(id=user_id)
         # create the internal integration and link it to the join table
         sentry_app = SentryAppCreator(
             name="Vercel Internal Integration",

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -167,7 +167,9 @@ class VstsApiClient(IntegrationProxyClient, RepositoryClient):
     def identity(self):
         if self._identity:
             return self._identity
-        self._identity = Identity.objects.get(id=self.identity_id)  # type: ignore[misc]
+        if self.identity_id is None:
+            raise ValueError("identity_id is not set")
+        self._identity = Identity.objects.get(id=self.identity_id)
         return self._identity
 
     def request(self, method: str, *args: Any, **kwargs: Any) -> Any:

--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -30,8 +30,9 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         Retrieve a list of starred views for the current organization member.
         """
 
+        assert request.user.id is not None
         starred_views = GroupSearchViewStarred.objects.filter(
-            organization=organization, user_id=request.user.id  # type: ignore[misc]
+            organization=organization, user_id=request.user.id
         ).select_related("group_search_view")
 
         return self.paginate(

--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -202,7 +202,8 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
         # Using `request.user` here because superuser/staff should not be able to set a user's 2fa
         if user.id != request.user.id:
-            user = User.objects.get(id=request.user.id)  # type: ignore[misc]
+            assert request.user.id is not None
+            user = User.objects.get(id=request.user.id)
 
         # start activation
         serializer_cls = serializer_map.get(interface_id, None)

--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -59,7 +59,7 @@ class UserOptionManager(OptionManager["UserOption"]):
         """
         This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
         """
-        self.filter(user=user, project=project, key=key).delete()  # type: ignore[misc]
+        self.filter(user=user, project_id=project.id, key=key).delete()
 
         if not hasattr(self, "_metadata"):
             return


### PR DESCRIPTION
## Summary

Stacked on #107710. Adds explicit None checks and assertions before ORM `.get(id=...)` and `.filter()` calls where the ID could be `None`, replacing `# type: ignore[misc]`.

### Changes
- `vsts/client.py` — guard `identity_id is None` before `.get()`
- `vercel/integration.py` — extract and check `user_id` before `.get()`
- `user_authenticator_enroll.py` — assert `request.user.id is not None`
- `organization_trace_item_attributes.py` — assert `organization_id is not None`
- `organization_group_search_views_starred.py` — assert `request.user.id is not None`
- `debug_files.py` — extract `request.GET.get("id")` into variable
- `user_option.py` — use `project_id=project.id` for HybridCloudForeignKey

## Test plan
- [x] mypy passes on all changed files
- [x] Pre-commit hooks pass