### PR TITLE
fix(tests): prevent tests from producing real Kafka messages to taskbroker

### DIFF
--- a/tests/sentry/taskworker/test_registry.py
+++ b/tests/sentry/taskworker/test_registry.py
@@ -19,6 +19,15 @@ from sentry.taskworker.router import DefaultRouter
 from sentry.taskworker.task import Task
 
 
+@pytest.fixture
+def real_send_task():
+    """Restore real send_task for tests that directly test send_task behavior."""
+    original = TaskNamespace._original_send_task  # type: ignore[attr-defined]
+    TaskNamespace.send_task = original  # type: ignore[method-assign]
+    yield
+    TaskNamespace.send_task = lambda self, *args, **kwargs: None  # type: ignore[method-assign]
+
+
 def test_namespace_register_task() -> None:
     namespace = TaskNamespace(
         name="tests",
@@ -112,7 +121,7 @@ def test_namespace_get_unknown() -> None:
 
 
 @pytest.mark.django_db
-def test_namespace_send_task_no_retry() -> None:
+def test_namespace_send_task_no_retry(real_send_task: None) -> None:
     namespace = TaskNamespace(
         name="tests",
         application="sentry",
@@ -200,7 +209,7 @@ def test_namespace_send_task_with_auto_compression() -> None:
 
 
 @pytest.mark.django_db
-def test_namespace_send_task_with_retry() -> None:
+def test_namespace_send_task_with_retry(real_send_task: None) -> None:
     namespace = TaskNamespace(
         name="tests",
         application="sentry",
@@ -231,7 +240,7 @@ def test_namespace_send_task_with_retry() -> None:
 
 
 @pytest.mark.django_db
-def test_namespace_with_retry_send_task() -> None:
+def test_namespace_with_retry_send_task(real_send_task: None) -> None:
     namespace = TaskNamespace(
         name="tests",
         application="sentry",
@@ -262,7 +271,7 @@ def test_namespace_with_retry_send_task() -> None:
 
 
 @pytest.mark.django_db
-def test_namespace_with_wait_for_delivery_send_task() -> None:
+def test_namespace_with_wait_for_delivery_send_task(real_send_task: None) -> None:
     namespace = TaskNamespace(
         name="tests",
         application="sentry",


### PR DESCRIPTION
## Summary

Tests produce real Kafka messages via the taskworker pipeline, causing stale tasks to accumulate in the taskbroker's SQLite queue. Running 20 tests produced **266 tasks** (relay config invalidations, Slack notifications, code owners updates, spike projections). Over multiple test sessions, these accumulate into thousands.

### Root Cause

Three factors combine to produce real Kafka messages during tests:

1. **`simulate_on_commit`** (autouse fixture) fires `on_commit` callbacks during tests
2. **Django signal handlers** queue tasks via `task.delay()` on model `post_save`
3. **`TASKWORKER_ALWAYS_EAGER=False`** sends those tasks to real Kafka at `127.0.0.1:9092`

### Fix

Patch `TaskNamespace.send_task` as a no-op at session start via `pytest_sessionstart`. This is surgical — it blocks only the Kafka production step while preserving:

- `_signal_send` hooks (`BurstTaskRunner`, `stale_database_reads`)
- Serialization validation (`create_activation()` still runs)
- `TaskRunner` (uses `ALWAYS_EAGER`, bypasses `send_task` entirely)
- `BurstTaskRunner` (captures at `_signal_send`, before `send_task`)

The 4 tests in `test_registry.py` that directly test `send_task` behavior use a `real_send_task` fixture to restore the original method.

### Verification

Ran `tests/getsentry/tasks/test_quota_exceeded_notification.py` (20 tests) before and after, with taskbroker running but no taskworker draining the queue:

| Metric | Before Fix | After Fix |
|---|---|---|
| Tests passing | 20/20 | 20/20 |
| Baseline tasks (devserver scheduler) | 7 | 8 |
| Tasks after test run | **273** (7 + 266 from tests) | **8** (0 from tests) |
| Test-originated tasks | **266** | **0** |

Before-fix breakdown (266 test-originated tasks from 20 tests):
- 151 `invalidate_project_config`
- 45 `update_code_owners_schema`
- 45 `new_organization_notify` (Slack)
- 25 `run_spike_projection`

Additional regression tests all pass:
- `tests/sentry/taskworker/test_registry.py` — 15/15 (including 4 with `real_send_task` fixture)
- `tests/sentry/taskworker/` (full suite) — 177/177
- `tests/getsentry/consumers/test_outcomes_consumer.py` — 80/80 (`BurstTaskRunner` works correctly)

## Test plan

- [x] Verified 266 tasks accumulate in taskbroker from 20 tests (before fix)
- [x] Verified 0 test-originated tasks after fix
- [x] All 177 taskworker tests pass
- [x] BurstTaskRunner tests pass (80/80)
- [x] Pre-commit hooks pass