### PR TITLE
fix(github-copilot): GET task status returns unwrapped task

### DIFF
--- a/src/sentry/integrations/github_copilot/client.py
+++ b/src/sentry/integrations/github_copilot/client.py
@@ -138,7 +138,7 @@ class GithubCopilotAgentClient(CodingAgentClient):
             },
         )
 
-        return GithubCopilotTaskResponse.validate(api_response.json).task
+        return GithubCopilotTask.validate(api_response.json)
 
     def get_pr_from_graphql(self, global_id: str) -> GithubPRFromGraphQL | None:
         query = """

--- a/tests/sentry/integrations/github_copilot/test_client.py
+++ b/tests/sentry/integrations/github_copilot/test_client.py
@@ -46,19 +46,17 @@ class GithubCopilotAgentClientTest(TestCase):
         """Test that get_task_status correctly fetches and parses task status"""
         mock_response = Mock()
         mock_response.json = {
-            "task": {
-                "id": "task-123",
-                "status": "completed",
-                "created_at": "2024-01-01T00:00:00Z",
-                "last_updated_at": "2024-01-01T01:00:00Z",
-                "artifacts": [
-                    {
-                        "provider": "github",
-                        "type": "pull_request",
-                        "data": {"id": 456, "type": "pull", "global_id": "PR_abc123"},
-                    }
-                ],
-            }
+            "id": "task-123",
+            "status": "completed",
+            "created_at": "2024-01-01T00:00:00Z",
+            "last_updated_at": "2024-01-01T01:00:00Z",
+            "artifacts": [
+                {
+                    "provider": "github",
+                    "type": "pull_request",
+                    "data": {"id": 456, "type": "pull", "global_id": "PR_abc123"},
+                }
+            ],
         }
         mock_response.status_code = 200
         mock_get.return_value = mock_response
@@ -87,10 +85,8 @@ class GithubCopilotAgentClientTest(TestCase):
         """Test that get_task_status handles responses without artifacts"""
         mock_response = Mock()
         mock_response.json = {
-            "task": {
-                "id": "task-123",
-                "status": "running",
-            }
+            "id": "task-123",
+            "status": "running",
         }
         mock_response.status_code = 200
         mock_get.return_value = mock_response


### PR DESCRIPTION
## Summary
- The GET `/repos/{owner}/{repo}/tasks/{id}` endpoint returns the task object directly at the top level, while POST wraps it in `{"task": {...}}`
- The previous commit applied the `{"task": ...}` wrapper to both endpoints, causing a `ValidationError` on every poll: `task: field required (type=value_error.missing)`
- This fix uses `GithubCopilotTask.validate()` directly for the GET endpoint, keeping `GithubCopilotTaskResponse` (with wrapper) only for POST

Fixes SENTRY-5J55 (137 occurrences, escalating)

## Test plan
- [x] `pytest tests/sentry/integrations/github_copilot/test_client.py` — 10 passed
- [x] `pytest tests/sentry/seer/autofix/test_coding_agent.py -k copilot` — 9 passed
- [ ] Verify in staging that poll no longer throws ValidationError