### PR TITLE
feat(llm-detection): Pass span count to Seer with trace metadata

### DIFF
--- a/src/sentry/autopilot/tasks/trace_instrumentation.py
+++ b/src/sentry/autopilot/tasks/trace_instrumentation.py
@@ -12,8 +12,8 @@ from sentry.models.project import Project
 from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.tools import get_trace_waterfall
 from sentry.seer.models import SeerPermissionError
-from sentry.seer.sentry_data_models import TraceMetadata
 from sentry.tasks.base import instrumented_task
+from sentry.tasks.llm_issue_detection.detection import TraceMetadataWithSpanCount
 from sentry.tasks.llm_issue_detection.trace_data import (
     get_project_top_transaction_traces_for_llm_detection,
 )
@@ -151,7 +151,9 @@ def _build_instrumentation_prompt(trace_json: str, project_slug: str) -> str:
     )
 
 
-def sample_trace_for_instrumentation_analysis(project: Project) -> TraceMetadata | None:
+def sample_trace_for_instrumentation_analysis(
+    project: Project,
+) -> TraceMetadataWithSpanCount | None:
     """
     Sample ONE trace for instrumentation analysis.
     Uses top transaction sampling with random time offset.

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -19,9 +19,6 @@ from sentry.net.http import connection_from_url
 from sentry.seer.sentry_data_models import TraceMetadata
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.llm_issue_detection.trace_data import (
-    get_project_top_transaction_traces_for_llm_detection,
-)
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils import json
 from sentry.utils.redis import redis_clusters
@@ -92,8 +89,12 @@ class DetectedIssue(BaseModel):
     transaction_name: str
 
 
+class TraceMetadataWithSpanCount(TraceMetadata):
+    span_count: int
+
+
 class IssueDetectionRequest(BaseModel):
-    traces: list[TraceMetadata]
+    traces: list[TraceMetadataWithSpanCount]
     organization_id: int
     project_id: int
     org_slug: str
@@ -242,6 +243,10 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     For each deduped transaction, gets first trace_id from the start of time window, which has small random variation.
     Sends these trace_ids to seer, which uses get_trace_waterfall to construct an EAPTrace to analyze.
     """
+    from sentry.tasks.llm_issue_detection.trace_data import (  # circular imports
+        get_project_top_transaction_traces_for_llm_detection,
+    )
+
     project = Project.objects.get_from_cache(id=project_id)
     organization = project.organization
     organization_id = organization.id
@@ -270,7 +275,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         sentry_sdk.metrics.count("llm_issue_detection.trace.skipped", skipped)
 
     # Take up to NUM_TRANSACTIONS_TO_PROCESS
-    traces_to_send: list[TraceMetadata] = [
+    traces_to_send: list[TraceMetadataWithSpanCount] = [
         t for t in evidence_traces if t.trace_id in unprocessed_ids
     ][:NUM_TRANSACTIONS_TO_PROCESS]
 


### PR DESCRIPTION
- Add `span_count` field to trace metadata sent to Seer for LLM issue detection. Will add this to metrics so we can compare span count with token usage
- Refactor `get_valid_trace_ids_by_span_count` to return `dict[str, int]` instead of `set[str]`
- Introduce `TraceMetadataWithSpanCount` model extending `TraceMetadata`