### PR TITLE
fix(uptime): Remove invalid select_related on ManyToManyField

### DIFF
--- a/src/sentry/uptime/subscriptions/subscriptions.py
+++ b/src/sentry/uptime/subscriptions/subscriptions.py
@@ -595,9 +595,7 @@ def is_url_auto_monitored_for_project(project: Project, url: str) -> bool:
                 UptimeMonitorMode.AUTO_DETECTED_ONBOARDING.value,
                 UptimeMonitorMode.AUTO_DETECTED_ACTIVE.value,
             ),
-        )
-        .select_related("data_sources")
-        .values_list("data_sources__source_id", flat=True)
+        ).values_list("data_sources__source_id", flat=True)
     )
 
     return UptimeSubscription.objects.filter(


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Removes invalid `select_related("data_sources")` on a `Detector` queryset in `is_url_auto_monitored_for_project()`.

- `Detector.data_sources` is a **ManyToManyField** → `DataSource` (through `DataSourceDetector`)
- `select_related()` only works on ForeignKey / OneToOneField relationships
- `values_list("data_sources__source_id", flat=True)` already performs the necessary JOIN across the M2M table, so the `select_related` was both invalid and unnecessary

