### PR TITLE
fix(debug-files): Extract query param to avoid passing None to ORM filter

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -346,10 +346,11 @@ class DebugFilesEndpoint(ProjectEndpoint):
         :qparam string id: The id of the DIF to delete.
         :auth: required
         """
-        if request.GET.get("id") and _has_delete_permission(request.access, project):
+        debug_file_id = request.GET.get("id")
+        if debug_file_id and _has_delete_permission(request.access, project):
             with atomic_transaction(using=router.db_for_write(File)):
                 debug_file = (
-                    ProjectDebugFile.objects.filter(id=request.GET.get("id"), project_id=project.id)
+                    ProjectDebugFile.objects.filter(id=debug_file_id, project_id=project.id)
                     .select_related("file")
                     .first()
                 )

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -220,6 +220,14 @@ class DebugFilesTest(DebugFilesTestCases):
         assert response.status_code == 204, response.content
         assert ProjectDebugFile.objects.count() == 0
 
+    def test_delete_without_id_returns_404(self) -> None:
+        response = self._upload_proguard(self.url, PROGUARD_UUID)
+        assert response.status_code == 201
+
+        response = self.client.delete(self.url)
+        assert response.status_code == 404, response.content
+        assert ProjectDebugFile.objects.count() == 1
+
     def test_dsyms_as_team_admin(self) -> None:
         response = self._upload_proguard(self.url, PROGUARD_UUID)
         assert response.status_code == 201


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Extracts `request.GET.get("id")` into a local variable so the narrowed type is used in the `.filter(id=...)` call, avoiding passing a potentially `None` value to the ORM lookup.

## Test plan
- [x] Pre-commit hooks pass