### PR TITLE
fix(trace-attrs): Assert organization_id is not None before ORM filter

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -635,6 +635,7 @@ class TraceItemAttributeValuesAutocompletionExecutor(BaseSpanFieldValuesAutocomp
         ]
 
     def semver_package_autocomplete_function(self):
+        assert self.snuba_params.organization_id is not None
         packages = (
             Release.objects.filter(
                 organization_id=self.snuba_params.organization_id,


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Adds `assert self.snuba_params.organization_id is not None` before two `Release.objects.filter(organization_id=...)` calls in `semver_package_autocomplete_function()`, where `organization_id` is typed as `int | None`.

## Test plan
- [x] Pre-commit hooks pass