### PR TITLE
fix(vsts): Guard identity_id is not None before ORM get

### DIFF
--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -167,6 +167,8 @@ class VstsApiClient(IntegrationProxyClient, RepositoryClient):
     def identity(self):
         if self._identity:
             return self._identity
+        if self.identity_id is None:
+            raise ValueError("identity_id is not set")
         self._identity = Identity.objects.get(id=self.identity_id)
         return self._identity
 

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -142,6 +142,20 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert identity.data["refresh_token"] == refresh_token != self.refresh_token
         assert identity.data["expires"] == expires
 
+    def test_identity_property_raises_when_identity_id_is_none(self) -> None:
+        self.assert_installation()
+        integration, installation = self._get_integration_and_install()
+        assert installation.org_integration is not None
+
+        client = VstsApiClient(
+            base_url=self.vsts_base_url,
+            oauth_redirect_url=VstsIntegrationProvider.oauth_redirect_url,
+            org_integration_id=installation.org_integration.id,
+            identity_id=None,
+        )
+        with pytest.raises(ValueError, match="identity_id is not set"):
+            client.identity
+
     def test_project_pagination(self) -> None:
         def request_callback(request):
             query = parse_qs(request.url.split("?")[1])


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Adds a `None` check on `self.identity_id` before `Identity.objects.get(id=self.identity_id)` in `VstsApiClient.identity`. The field is typed as `int | None`, so a missing identity_id now raises a clear `ValueError` instead of a confusing ORM error.

## Test plan
- [x] Pre-commit hooks pass