### PR TITLE
fix(issues): Assert user.id is not None before ORM filter

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_search_views_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views_starred.py
@@ -30,6 +30,7 @@ class OrganizationGroupSearchViewsStarredEndpoint(OrganizationEndpoint):
         Retrieve a list of starred views for the current organization member.
         """
 
+        assert request.user.id is not None
         starred_views = GroupSearchViewStarred.objects.filter(
             organization=organization, user_id=request.user.id
         ).select_related("group_search_view")


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Adds `assert request.user.id is not None` before `GroupSearchViewStarred.objects.filter(user_id=request.user.id)` in the starred views endpoint. `user.id` is typed as `int | None`.

## Test plan
- [x] Pre-commit hooks pass