### PR TITLE
fix(users): Assert user.id is not None before ORM get

### DIFF
--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -202,6 +202,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
         # Using `request.user` here because superuser/staff should not be able to set a user's 2fa
         if user.id != request.user.id:
+            assert request.user.id is not None
             user = User.objects.get(id=request.user.id)
 
         # start activation


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Adds `assert request.user.id is not None` before `User.objects.get(id=request.user.id)` in the authenticator enrollment endpoint. `user.id` is typed as `int | None`.

## Test plan
- [x] Pre-commit hooks pass