### PR TITLE
fix(users): Use project_id for HybridCloudForeignKey filter

### DIFF
--- a/src/sentry/users/models/user_option.py
+++ b/src/sentry/users/models/user_option.py
@@ -59,7 +59,7 @@ class UserOptionManager(OptionManager["UserOption"]):
         """
         This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
         """
-        self.filter(user=user, project=project, key=key).delete()
+        self.filter(user=user, project_id=project.id, key=key).delete()
 
         if not hasattr(self, "_metadata"):
             return

--- a/tests/sentry/users/models/test_user_option.py
+++ b/tests/sentry/users/models/test_user_option.py
@@ -1,0 +1,16 @@
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.users.models.user_option import UserOption
+
+
+@control_silo_test
+class UserOptionManagerTest(TestCase):
+    def test_unset_value(self) -> None:
+        project = self.create_project()
+        UserOption.objects.set_value(self.user, "foo", "bar", project=project)
+        assert UserOption.objects.filter(user=self.user, project_id=project.id, key="foo").exists()
+
+        UserOption.objects.unset_value(self.user, project, "foo")
+        assert not UserOption.objects.filter(
+            user=self.user, project_id=project.id, key="foo"
+        ).exists()


### PR DESCRIPTION
## Summary

Found during mypy / django-stubs upgrade in https://github.com/getsentry/sentry/pull/107710.

Changes `.filter(project=project)` to `.filter(project_id=project.id)` in `UserOptionManager.unset_value()`. The `project` field is a `HybridCloudForeignKey`, which doesn't support passing a model instance directly — use the `_id` suffix instead.'


I believe that this code never ran in prod? As the test written breaks with code in master, passes on this branch.