### PR TITLE
fix(alerts): Fix disabled 'create alert' button for org owners

### DIFF
--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -1,14 +1,11 @@
-import {ExternalLink, Link} from '@sentry/scraps/link';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import type {GuidesContent} from 'sentry/components/assistant/types';
 import {t, tct} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import {getDemoModeGuides} from 'sentry/utils/demoMode/guides';
 
-export default function getGuidesContent(
-  organization: Organization | null
-): GuidesContent {
+export default function getGuidesContent(): GuidesContent {
   if (isDemoModeActive()) {
     return getDemoModeGuides();
   }
@@ -90,27 +87,6 @@ export default function getGuidesContent(
               ),
             }
           ),
-        },
-      ],
-    },
-    {
-      guide: 'alerts_write_owner',
-      requiredTargets: ['alerts_write_owner'],
-      steps: [
-        {
-          target: 'alerts_write_owner',
-          description: tct(
-            `Today only admins in your organization can create alert rules but we recommend [link:allowing members to create alerts], too.`,
-            {
-              link: (
-                <Link
-                  to={organization?.slug ? `/settings/${organization.slug}` : `/settings`}
-                />
-              ),
-            }
-          ),
-          nextText: t('Allow'),
-          hasNextGuide: true,
         },
       ],
     },

--- a/static/app/components/createAlertButton.spec.tsx
+++ b/static/app/components/createAlertButton.spec.tsx
@@ -6,7 +6,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import CreateAlertButton, {
   CreateAlertFromViewButton,
 } from 'sentry/components/createAlertButton';
-import GuideStore from 'sentry/stores/guideStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/results/data';
@@ -140,46 +139,6 @@ describe('CreateAlertFromViewButton', () => {
     );
 
     expect(screen.getByRole('button', {name: 'Create Alert'})).toBeEnabled();
-  });
-
-  it('shows a guide for org-member', () => {
-    const noAccessOrg = {
-      ...organization,
-      access: [],
-    };
-
-    render(
-      <CreateAlertButton
-        aria-label="Create Alert"
-        organization={noAccessOrg}
-        showPermissionGuide
-      />,
-      {
-        organization: noAccessOrg,
-      }
-    );
-
-    expect(GuideStore.state.anchors).toEqual(new Set(['alerts_write_member']));
-  });
-
-  it('shows a guide for org-owner/manager', () => {
-    const adminAccessOrg = OrganizationFixture({
-      ...organization,
-      access: ['org:write'],
-    });
-
-    render(
-      <CreateAlertButton
-        aria-label="Create Alert"
-        organization={adminAccessOrg}
-        showPermissionGuide
-      />,
-      {
-        organization: adminAccessOrg,
-      }
-    );
-
-    expect(GuideStore.state.anchors).toEqual(new Set(['alerts_write_owner']));
   });
 
   it('redirects to alert wizard with no project', async () => {

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -4,14 +4,8 @@ import type {LinkButtonProps} from '@sentry/scraps/button';
 import {LinkButton} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
 
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import {hasEveryAccess} from 'sentry/components/acl/access';
-import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import {IconSiren} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t, tct} from 'sentry/locale';
@@ -20,7 +14,6 @@ import type {Project} from 'sentry/types/project';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
 import type EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
-import useApi from 'sentry/utils/useApi';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
@@ -143,7 +136,6 @@ type CreateAlertButtonProps = {
   onEnter?: () => void;
   projectSlug?: string;
   referrer?: string;
-  showPermissionGuide?: boolean;
   to?: string | LocationDescriptor;
 } & Omit<LinkButtonProps, 'to'>;
 
@@ -153,14 +145,12 @@ export default function CreateAlertButton({
   iconProps,
   referrer,
   hideIcon,
-  showPermissionGuide,
   alertOption,
   onEnter,
   to,
   ...buttonProps
 }: CreateAlertButtonProps) {
   const router = useRouter();
-  const api = useApi();
   const {projects} = useProjects();
   const shouldDirectToMonitors =
     organization.features.includes('workflow-engine-ui') &&
@@ -199,31 +189,20 @@ export default function CreateAlertButton({
     navigateTo(createAlertUrl(':projectId'), router);
   }
 
-  async function enableAlertsMemberWrite() {
-    const settingsEndpoint = `/organizations/${organization.slug}/`;
-    addLoadingMessage();
-    try {
-      await api.requestPromise(settingsEndpoint, {
-        method: 'PUT',
-        data: {
-          alertsMemberWrite: true,
-        },
-      });
-      addSuccessMessage(t('Successfully updated organization settings'));
-    } catch (err) {
-      addErrorMessage(t('Unable to update organization settings'));
-    }
-  }
-
   const permissionTooltipText = tct(
     'Ask your organization owner or manager to [settingsLink:enable alerts access] for you.',
     {settingsLink: <Link to={`/settings/${organization.slug}/`} />}
   );
 
-  const renderButton = (hasAccess: boolean) => (
+  const canCreateAlert =
+    isDemoModeActive() ||
+    hasEveryAccess(['alerts:write'], {organization}) ||
+    projects.some(p => hasEveryAccess(['alerts:write'], {project: p}));
+
+  return (
     <LinkButton
-      disabled={!hasAccess}
-      title={hasAccess ? undefined : permissionTooltipText}
+      disabled={!canCreateAlert}
+      title={canCreateAlert ? undefined : permissionTooltipText}
       icon={!hideIcon && <IconSiren {...iconProps} />}
       to={to ?? (projectSlug ? createAlertUrl(projectSlug) : '')}
       tooltipProps={{
@@ -238,23 +217,5 @@ export default function CreateAlertButton({
     >
       {buttonProps.children ?? defaultButtonLabel}
     </LinkButton>
-  );
-
-  const showGuide = !organization.alertsMemberWrite && !!showPermissionGuide;
-  const canCreateAlert =
-    isDemoModeActive() ||
-    hasEveryAccess(['alerts:write'], {organization}) ||
-    projects.some(p => hasEveryAccess(['alerts:write'], {project: p}));
-  const hasOrgWrite = hasEveryAccess(['org:write'], {organization});
-
-  return showGuide ? (
-    <GuideAnchor
-      target={hasOrgWrite ? 'alerts_write_owner' : 'alerts_write_member'}
-      onFinish={hasOrgWrite ? enableAlertsMemberWrite : undefined}
-    >
-      {renderButton(canCreateAlert)}
-    </GuideAnchor>
-  ) : (
-    renderButton(canCreateAlert)
   );
 }

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -162,7 +162,7 @@ const storeConfig: GuideStoreDefinition = {
       return;
     }
 
-    const guidesContent: GuidesContent = getGuidesContent(this.state.organization);
+    const guidesContent: GuidesContent = getGuidesContent();
     // map server guide state (i.e. seen status) with guide content
     const guides = guidesContent.reduce((acc: Guide[], content) => {
       const serverGuide = data.find(guide => guide.guide === content.guide);

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -64,7 +64,6 @@ function AlertHeader({activeTab}: Props) {
             size="sm"
             priority="primary"
             referrer="alert_stream"
-            showPermissionGuide
             projectSlug={
               selection.projects.length === 1
                 ? ProjectsStore.getById(`${selection.projects[0]}`)?.slug


### PR DESCRIPTION
Org owners who have not seen the `alerts_write_owner` guide and whose org does not have `alertsMemberWrite` enabled will have a "Create Alert" button that looks enabled, but is blocked by an invisible guide. 

This was happening because the `alerts_write_owner` guide did not have a `title` and thus the TourGuide component component  did not render a tooltip for it.

I made a couple different changes to fix this:

1. Removed the guide entirely. It was originally added 4 years ago when we added the alertsMemberWrite setting, but since it defaults to true, we don't really need it anymore (org owners who have toggled it off have done so for a reason).
2. Fixed the TourGuide logic so that it only skips rendering the tooltip if both `title` _and_ `description` are missing

![CleanShot 2026-02-05 at 15 33 30](https://github.com/user-attachments/assets/bf1dd283-f7ef-4a51-8a36-b62785a6f767)
