### PR TITLE
chore(aci): unhook conditions from rules code

### DIFF
--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -2,8 +2,11 @@ from typing import Any
 
 from django.utils import timezone
 
-from sentry.rules.age import AgeComparisonType, age_comparison_map
 from sentry.rules.filters.age_comparison import timeranges
+from sentry.workflow_engine.handlers.condition.utils.age import (
+    AgeComparisonType,
+    age_comparison_map,
+)
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData

--- a/src/sentry/workflow_engine/handlers/condition/issue_open_duration_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_open_duration_handler.py
@@ -3,8 +3,11 @@ from typing import Any
 from django.utils import timezone
 
 from sentry.models.groupopenperiod import get_latest_open_period
-from sentry.rules.age import AgeComparisonType, age_comparison_map
 from sentry.rules.filters.age_comparison import timeranges
+from sentry.workflow_engine.handlers.condition.utils.age import (
+    AgeComparisonType,
+    age_comparison_map,
+)
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 

--- a/src/sentry/workflow_engine/handlers/condition/utils/age.py
+++ b/src/sentry/workflow_engine/handlers/condition/utils/age.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import operator
+from enum import StrEnum
+
+
+class ModelAgeType(StrEnum):
+    OLDEST = "oldest"
+    NEWEST = "newest"
+
+
+model_age_choices = [(ModelAgeType.OLDEST, "oldest"), (ModelAgeType.NEWEST, "newest")]
+
+
+class AgeComparisonType(StrEnum):
+    OLDER = "older"
+    NEWER = "newer"
+
+
+age_comparison_choices = [(AgeComparisonType.OLDER, "older"), (AgeComparisonType.NEWER, "newer")]
+age_comparison_map = {AgeComparisonType.OLDER: operator.lt, AgeComparisonType.NEWER: operator.gt}

--- a/src/sentry/workflow_engine/handlers/condition/utils/age.py
+++ b/src/sentry/workflow_engine/handlers/condition/utils/age.py
@@ -4,14 +4,6 @@ import operator
 from enum import StrEnum
 
 
-class ModelAgeType(StrEnum):
-    OLDEST = "oldest"
-    NEWEST = "newest"
-
-
-model_age_choices = [(ModelAgeType.OLDEST, "oldest"), (ModelAgeType.NEWEST, "newest")]
-
-
 class AgeComparisonType(StrEnum):
     OLDER = "older"
     NEWER = "newer"

--- a/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_age_comparison_handler.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta, timezone
 import pytest
 from jsonschema import ValidationError
 
-from sentry.rules.age import AgeComparisonType
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.workflow_engine.handlers.condition.utils.age import AgeComparisonType
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_open_duration_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_open_duration_handler.py
@@ -6,8 +6,8 @@ from jsonschema import ValidationError
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.groupopenperiod import get_latest_open_period
-from sentry.rules.age import AgeComparisonType
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.workflow_engine.handlers.condition.utils.age import AgeComparisonType
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
 from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionTestCase


### PR DESCRIPTION
For easier deletion later, the conditions should not rely on utils from the rules directory.