### PR TITLE
feat: Send org_id and project_id to Seer severity score endpoint

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2174,6 +2174,8 @@ def _get_severity_score(event: Event) -> tuple[float, str]:
         "message": title,
         "has_stacktrace": int(has_stacktrace(event.data)),
         "handled": is_handled(event.data),
+        "org_id": event.project.organization_id,
+        "project_id": event.project_id,
     }
 
     if options.get("processing.severity-backlog-test.timeout"):

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -92,7 +94,7 @@ class TestGetEventSeverity(TestCase):
                 body=orjson.dumps(payload),
                 headers={
                     "content-type": "application/json;charset=utf-8",
-                    "Authorization": "Rpcsignature rpc0:b14214093c3e7c633e68ac90b01087e710fe2f96c0544b232b9ec9bc6ca971f4",
+                    "Authorization": f"Rpcsignature rpc0:{hmac.new(b'some-secret', orjson.dumps(payload), hashlib.sha256).hexdigest()}",
                 },
                 timeout=options.get("issues.severity.seer-timeout", settings.SEER_SEVERITY_TIMEOUT),
             )

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -66,6 +66,8 @@ class TestGetEventSeverity(TestCase):
             "message": "NopeError: Nopey McNopeface",
             "has_stacktrace": 0,
             "handled": True,
+            "org_id": self.project.organization_id,
+            "project_id": self.project.id,
         }
 
         mock_urlopen.assert_called_with(
@@ -118,6 +120,8 @@ class TestGetEventSeverity(TestCase):
                 "message": "Dogs are great!",
                 "has_stacktrace": 0,
                 "handled": None,
+                "org_id": self.project.organization_id,
+                "project_id": self.project.id,
             }
 
             mock_urlopen.assert_called_with(


### PR DESCRIPTION
## Summary
- Passes `org_id` and `project_id` to the Seer severity score endpoint (`/v0/issues/severity-score`)
- Seer-side PR: https://github.com/getsentry/seer/pull/4765 (adds these as optional fields, so deploy order doesn't matter)

## Test plan
- [x] Updated existing payload assertions in `test_severity.py`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)