### PR TITLE
fix(github-copilot): Poll Copilot agents in Explorer autofix path

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import secrets
 import string
+from typing import Any
 
 import orjson
 from django.conf import settings
@@ -465,15 +466,17 @@ def launch_coding_agents_for_run(
 
 
 def poll_github_copilot_agents(
-    autofix_state: AutofixState,
-    user_id: int,
+    autofix_state: AutofixState | None = None,
+    user_id: int = 0,
+    coding_agents: dict[str, Any] | None = None,
 ) -> None:
-    if not autofix_state.coding_agents:
+    agents = coding_agents or (autofix_state.coding_agents if autofix_state else None)
+    if not agents:
         return
 
     user_access_token: str | None = None
 
-    for agent_id, agent_state in autofix_state.coding_agents.items():
+    for agent_id, agent_state in agents.items():
         if agent_state.provider != CodingAgentProviderType.GITHUB_COPILOT_AGENT:
             continue
 

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -300,6 +300,9 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
         if state is None:
             return Response({"autofix": None})
 
+        if state.coding_agents and request.user.id:
+            poll_github_copilot_agents(coding_agents=state.coding_agents, user_id=request.user.id)
+
         # Return the Explorer state directly - frontend will handle the format
         return Response(
             {


### PR DESCRIPTION
## Summary
- The Explorer autofix GET endpoint (`_get_explorer`) was not calling `poll_github_copilot_agents()`, so coding agent status and PR URLs were never fetched from GitHub
- Regular autofix (`_get_legacy`) already had this polling, which is why it worked
- Widened `poll_github_copilot_agents()` to accept a `coding_agents` dict directly (in addition to the existing `AutofixState` parameter) so it works with both `AutofixState.coding_agents` and `SeerRunState.coding_agents`
- Also fixed a pre-existing mypy error on the same file (`request.organization.id` → `group.organization.id`)

## Test plan
- [x] All existing copilot tests pass (19/19)
- [x] Verify in staging that Explorer autofix correctly shows Copilot PR status