### PR TITLE
feat(grouping): Add Salesforce record ID parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -161,6 +161,16 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
     ),
     ParameterizationRegex(name="duration", raw_pattern=r"""\b(\d+ms) | (\d+(\.\d+)?s)\b"""),
     ParameterizationRegex(
+        name="salesforce_id",
+        raw_pattern=r"""
+            # Salesforce record IDs: 15 or 18 character alphanumeric strings
+            # containing both letters and digits
+            # https://developer.salesforce.com/docs/atlas.en-us.object_reference.meta/object_reference/field_types.htm
+            (\b(?!0[xX])(?=[a-zA-Z0-9]*[a-zA-Z])(?=[a-zA-Z0-9]*[0-9])[a-zA-Z0-9]{18}\b) |
+            (\b(?!0[xX])(?=[a-zA-Z0-9]*[a-zA-Z])(?=[a-zA-Z0-9]*[0-9])[a-zA-Z0-9]{15}\b)
+        """,
+    ),
+    ParameterizationRegex(
         name="hex",
         raw_pattern=r"""
             # Hex value with `0x/0X` prefix (any length, with any mix of numbers and/or letters -

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -74,6 +74,16 @@ standard_cases = [
     ("duration - 1.234s", "1.234s", "<duration>"),
     ("duration - 10s", "10s", "<duration>"),
     ("duration - 100.0000s", "100.0000s", "<duration>"),
+    # Salesforce record IDs
+    ("salesforce_id - 18 char", "b05R000009Xnq4EEAB", "<salesforce_id>"),
+    ("salesforce_id - 15 char", "006M000002Tks8Z", "<salesforce_id>"),
+    (
+        "salesforce_id - in message",
+        "Failed to update 006M000002Tks8Z record",
+        "Failed to update <salesforce_id> record",
+    ),
+    ("salesforce_id - not pure alpha", "troubleshooters", "troubleshooters"),
+    ("salesforce_id - not pure digits 15", "123456789012345", "<int>"),
     ("hex with prefix - lowercase, 4 digits", "0x9af8", "<hex>"),
     ("hex with prefix - uppercase, 4 digits", "0x9AF8", "<hex>"),
     ("hex with prefix - lowercase, 8 digits", "0x9af8c3be", "<hex>"),


### PR DESCRIPTION
## Summary
- Adds a new `salesforce_id` parameterization regex that matches 15 and 18 character Salesforce record IDs containing both letters and digits
- Placed before the `hex` pattern to avoid partial matches on 18-char IDs
- Uses negative lookahead `(?!0[xX])` to avoid matching hex-prefixed values

## Test plan
- [x] Added test cases for 15-char and 18-char Salesforce IDs
- [x] Added test for Salesforce ID embedded in a message
- [x] Added negative test for pure alphabetic 15-char words
- [x] Added negative test for pure numeric 15-digit strings
- [x] Verified existing hex tests still pass
- [x] `pytest -svv --reuse-db tests/sentry/grouping/test_parameterization.py` — 204 passed