### PR TITLE
feat(grouping): Add ULID parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -161,6 +161,17 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
     ),
     ParameterizationRegex(name="duration", raw_pattern=r"""\b(\d+ms) | (\d+(\.\d+)?s)\b"""),
     ParameterizationRegex(
+        name="ulid",
+        raw_pattern=r"""
+            # ULIDs: 26 character Crockford's Base32 strings (case-insensitive)
+            # Excludes I, L, O, U to avoid ambiguity
+            # https://github.com/ulid/spec
+            # Lookaheads require both a letter and a digit to avoid matching
+            # pure-alpha words or pure-numeric strings
+            (\b(?!0[xX])(?=[0-9A-HJ-KM-NP-TV-Za-hj-km-np-tv-z]*[A-HJ-KM-NP-TV-Za-hj-km-np-tv-z])(?=[0-9A-HJ-KM-NP-TV-Za-hj-km-np-tv-z]*[0-9])[0-9A-HJ-KM-NP-TV-Za-hj-km-np-tv-z]{26}\b)
+        """,
+    ),
+    ParameterizationRegex(
         name="hex",
         raw_pattern=r"""
             # Hex value with `0x/0X` prefix (any length, with any mix of numbers and/or letters -

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -74,6 +74,16 @@ standard_cases = [
     ("duration - 1.234s", "1.234s", "<duration>"),
     ("duration - 10s", "10s", "<duration>"),
     ("duration - 100.0000s", "100.0000s", "<duration>"),
+    # ULIDs
+    ("ulid - uppercase", "01ARZ3NDEKTSV4RRFFQ69G5FAV", "<ulid>"),
+    ("ulid - lowercase", "01arz3ndektsv4rrffq69g5fav", "<ulid>"),
+    (
+        "ulid - in message",
+        "Failed to process 01H5V5KBSMQ8E6MTMHKQ8KT3SY",
+        "Failed to process <ulid>",
+    ),
+    ("ulid - not pure alpha 26 chars", "ABCDEFGHJKMNPQRSTVWXYZABCD", "ABCDEFGHJKMNPQRSTVWXYZABCD"),
+    ("ulid - contains excluded char I", "01ARZ3NDEKISV4RRFFQ69G5FAV", "01ARZ3NDEKISV4RRFFQ69G5FAV"),
     ("hex with prefix - lowercase, 4 digits", "0x9af8", "<hex>"),
     ("hex with prefix - uppercase, 4 digits", "0x9AF8", "<hex>"),
     ("hex with prefix - lowercase, 8 digits", "0x9af8c3be", "<hex>"),


### PR DESCRIPTION
## Summary
- Adds a new `ulid` parameterization regex that matches 26-character ULID identifiers
- ULIDs use Crockford's Base32 encoding (`0-9, A-H, J-K, M-N, P-T, V-Z`), deliberately excluding I, L, O, U to avoid ambiguity
- Pattern is case-insensitive (accepts both upper and lowercase)
- Lookaheads require both a letter and a digit to avoid matching pure-alpha words or pure-numeric strings
- `(?!0[xX])` negative lookahead prevents matching 0x-prefixed hex values
- Placed before the `hex` pattern to match before general hex matching

## ULID Format
From the [ULID spec](https://github.com/ulid/spec):
```
 01ARZ3NDEK TSVO4RRFFQ69G5FAV
|----------|  |----------------|
 Timestamp       Randomness
 (10 chars)      (16 chars)
```

## Test plan
- [x] Added test for uppercase ULID
- [x] Added test for lowercase ULID
- [x] Added test for ULID embedded in a message
- [x] Added negative test for pure-alpha 26-char Crockford Base32 string
- [x] Added negative test for string containing excluded char `I`
- [x] Verified existing hex tests still pass (including 24-digit 0x-prefixed hex)
- [x] `pytest -svv --reuse-db tests/sentry/grouping/test_parameterization.py` -- 204 passed