### PR TITLE
 feat(search-bar): Support async tag fetching

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -12,6 +12,7 @@ import * as Sentry from '@sentry/react';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import type {
+  GetTagKeys,
   GetTagValues,
   SearchQueryBuilderProps,
 } from 'sentry/components/searchQueryBuilder';
@@ -71,6 +72,7 @@ interface SearchQueryBuilderContextData {
   wrapperRef: React.RefObject<HTMLDivElement | null>;
   caseInsensitive?: CaseInsensitive;
   filterKeyAliases?: TagCollection;
+  getTagKeys?: GetTagKeys;
   matchKeySuggestions?: Array<{key: string; valuePattern: RegExp}>;
   namespace?: string;
   onCaseInsensitiveClick?: (value: CaseInsensitive) => void;
@@ -112,6 +114,7 @@ export function SearchQueryBuilderProvider({
   filterKeyMenuWidth = 460,
   filterKeySections,
   getSuggestedFilterKey,
+  getTagKeys,
   getTagValues,
   onSearch,
   placeholder,
@@ -253,6 +256,7 @@ export function SearchQueryBuilderProvider({
       filterKeys: stableFilterKeys,
       getSuggestedFilterKey: stableGetSuggestedFilterKey,
       getTagValues,
+      getTagKeys,
       getFieldDefinition: stableFieldDefinitionGetter,
       dispatch,
       wrapperRef,
@@ -295,6 +299,7 @@ export function SearchQueryBuilderProvider({
     filterKeyAliases,
     filterKeyMenuWidth,
     filterKeySections,
+    getTagKeys,
     getTagValues,
     handleSearch,
     matchKeySuggestions,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -5635,4 +5635,95 @@ describe('SearchQueryBuilder', () => {
       });
     });
   });
+
+  describe('async filter keys (getTagKeys)', () => {
+    const asyncTags = [
+      {key: 'async_tag_one', name: 'Async Tag One', kind: FieldKind.TAG},
+      {key: 'async_tag_two', name: 'Async Tag Two', kind: FieldKind.TAG},
+    ];
+
+    it('displays async keys in the filter key dropdown', async () => {
+      const mockGetTagKeys = jest.fn().mockResolvedValue(asyncTags);
+      render(<SearchQueryBuilder {...defaultProps} getTagKeys={mockGetTagKeys} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('async');
+
+      expect(
+        await screen.findByRole('option', {name: 'async_tag_one'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'async_tag_two'})).toBeInTheDocument();
+    });
+
+    it('deduplicates async keys that overlap with static keys', async () => {
+      const mockGetTagKeys = jest.fn().mockResolvedValue([
+        {key: FieldKey.BROWSER_NAME, name: 'Browser Name', kind: FieldKind.FIELD},
+        {key: 'novel_async_key', name: 'Novel Async Key', kind: FieldKind.TAG},
+      ]);
+      render(<SearchQueryBuilder {...defaultProps} getTagKeys={mockGetTagKeys} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('brow');
+
+      // browser.name should appear only once despite being in both static and async keys
+      await waitFor(() => {
+        expect(screen.getAllByRole('option', {name: 'browser.name'})).toHaveLength(1);
+      });
+    });
+
+    it('can select an async-only key to create a filter token', async () => {
+      const mockGetTagKeys = jest.fn().mockResolvedValue(asyncTags);
+      const mockOnChange = jest.fn();
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          getTagKeys={mockGetTagKeys}
+          onChange={mockOnChange}
+        />
+      );
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('async');
+
+      await userEvent.click(await screen.findByRole('option', {name: 'async_tag_one'}));
+
+      expect(await screen.findByRole('row', {name: /async_tag_one/})).toBeInTheDocument();
+    });
+
+    it('shows async keys when editing an existing filter key', async () => {
+      const mockGetTagKeys = jest.fn().mockResolvedValue(asyncTags);
+      render(
+        <SearchQueryBuilder
+          {...defaultProps}
+          getTagKeys={mockGetTagKeys}
+          initialQuery="browser.name:Firefox"
+        />
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Edit key for filter: browser.name'})
+      );
+
+      const input = screen.getByRole('combobox', {name: 'Edit filter key'});
+      await userEvent.clear(input);
+      await userEvent.type(input, 'async');
+
+      expect(
+        await screen.findByRole('option', {name: 'async_tag_one'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'async_tag_two'})).toBeInTheDocument();
+    });
+
+    it('calls getTagKeys with the current search input', async () => {
+      const mockGetTagKeys = jest.fn().mockResolvedValue([]);
+      render(<SearchQueryBuilder {...defaultProps} getTagKeys={mockGetTagKeys} />);
+
+      await userEvent.click(getLastInput());
+      await userEvent.keyboard('some_query');
+
+      await waitFor(() => {
+        expect(mockGetTagKeys).toHaveBeenCalledWith('some_query');
+      });
+    });
+  });
 });

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -17,7 +17,7 @@ import type {
 } from 'sentry/components/searchQueryBuilder/types';
 import {InvalidReason} from 'sentry/components/searchSyntax/parser';
 import * as Storybook from 'sentry/stories';
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {
   FieldKey,
   FieldKind,
@@ -932,6 +932,50 @@ function SearchQueryBuilderExample(queryBuilderProps: SearchQueryBuilderProps) {
         </CodeBlock>
         <p>The following is the above code in action:</p>
         <SearchQueryBuilderExample />
+      </Fragment>
+    );
+  });
+
+  story('Async filter keys', () => {
+    const asyncGetTagKeys = (searchQuery: string): Promise<Tag[]> => {
+      const allKeys: Tag[] = [
+        {key: 'dynamic_key_1', name: 'dynamic_key_1', kind: FieldKind.TAG},
+        {key: 'dynamic_key_2', name: 'dynamic_key_2', kind: FieldKind.TAG},
+        {key: 'dynamic_key_3', name: 'dynamic_key_3', kind: FieldKind.TAG},
+      ];
+
+      return new Promise(resolve => {
+        setTimeout(() => {
+          resolve(
+            searchQuery
+              ? allKeys.filter(k => k.key.includes(searchQuery.toLowerCase()))
+              : allKeys
+          );
+        }, 300);
+      });
+    };
+
+    return (
+      <Fragment>
+        <p>
+          When filter keys are not fully known upfront, use <code>getTagKeys</code> to
+          fetch them asynchronously. This is useful when the set of available keys depends
+          on user input or needs to be loaded from an API.
+        </p>
+        <p>
+          The function receives the current search input and should return an array of{' '}
+          <code>Tag</code> objects. The returned keys are automatically merged with any
+          static <code>filterKeys</code> and deduplicated. Requests are debounced
+          internally.
+        </p>
+        <SearchQueryBuilder
+          initialQuery=""
+          filterKeys={FILTER_KEYS}
+          filterKeySections={FILTER_KEY_SECTIONS}
+          getTagValues={getTagValues}
+          getTagKeys={asyncGetTagKeys}
+          searchSource="storybook"
+        />
       </Fragment>
     );
   });

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -36,6 +36,8 @@ export type GetTagValues = (
   searchQuery: string
 ) => Promise<string[]>;
 
+export type GetTagKeys = (searchQuery: string) => Promise<Tag[]>;
+
 export interface SearchQueryBuilderProps {
   /**
    * A complete mapping of all possible filter keys.
@@ -118,6 +120,12 @@ export interface SearchQueryBuilderProps {
    * known column.
    */
   getSuggestedFilterKey?: (key: string) => string | null;
+  /**
+   * When provided, enables async fetching of filter keys.
+   * The combobox will call this function with the current search query
+   * and display the returned keys alongside any static filterKeys.
+   */
+  getTagKeys?: GetTagKeys;
 
   /**
    * Allows for customization of the invalid token messages.

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -25,6 +25,7 @@ import type {SelectKey, SelectOptionOrSectionWithKey} from '@sentry/scraps/compa
 import {Input, useAutosizeInput} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
 
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay} from 'sentry/components/overlay';
 import {AskSeer} from 'sentry/components/searchQueryBuilder/askSeer/askSeer';
 import {ASK_SEER_CONSENT_ITEM_KEY} from 'sentry/components/searchQueryBuilder/askSeer/askSeerConsentOption';
@@ -75,6 +76,11 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
    */
   description?: ReactNode;
   filterValue?: string;
+  /**
+   * Whether the combobox is loading async items.
+   * When true, a loading indicator will be displayed in the dropdown.
+   */
+  isLoading?: boolean;
   /**
    * When passing `isOpen`, the open state is controlled by the parent.
    */
@@ -148,16 +154,23 @@ function menuIsOpen({
   totalOptions,
   hasCustomMenu,
   isOpen,
+  isLoading,
 }: {
   hiddenOptions: Set<SelectKey>;
   state: ComboBoxState<any>;
   totalOptions: number;
   hasCustomMenu?: boolean;
+  isLoading?: boolean;
   isOpen?: boolean;
 }) {
   const openState = isOpen ?? state.isOpen;
 
   if (hasCustomMenu) {
+    return openState;
+  }
+
+  // Keep the menu open when loading so the loading indicator is visible
+  if (isLoading) {
     return openState;
   }
 
@@ -261,12 +274,14 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   filterValue,
   hiddenOptions,
   isOpen,
+  isLoading,
   listBoxProps,
   listBoxRef,
   popoverRef,
   state,
   overlayProps,
   portalTarget,
+  totalOptions,
 }: {
   filterValue: string;
   hiddenOptions: Set<SelectKey>;
@@ -276,10 +291,13 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   overlayProps: OverlayProps;
   popoverRef: React.RefObject<HTMLDivElement | null>;
   state: ComboBoxState<any>;
+  totalOptions: number;
   customMenu?: CustomComboboxMenu<T>;
+  isLoading?: boolean;
   portalTarget?: HTMLElement | null;
 }) {
   const {enableAISearch} = useSearchQueryBuilder();
+  const anyItemsShowing = totalOptions > hiddenOptions.size;
 
   if (customMenu) {
     return customMenu({
@@ -298,15 +316,26 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
   return (
     <StyledPositionWrapper {...overlayProps} visible={isOpen}>
       <ListBoxOverlay ref={popoverRef}>
-        <ListBox
-          {...listBoxProps}
-          ref={listBoxRef}
-          listState={state}
-          hasSearch={!!filterValue}
-          hiddenOptions={hiddenOptions}
-          overlayIsOpen={isOpen}
-          size="sm"
-        />
+        {isLoading && !anyItemsShowing ? (
+          <Flex justify="center" align="center" height="140px" width="200px">
+            <LoadingIndicator size={24} style={{margin: 0}} />
+          </Flex>
+        ) : (
+          <ListBox
+            {...listBoxProps}
+            ref={listBoxRef}
+            listState={state}
+            hasSearch={!!filterValue}
+            hiddenOptions={hiddenOptions}
+            overlayIsOpen={isOpen}
+            size="sm"
+          />
+        )}
+        {isLoading && anyItemsShowing ? (
+          <Flex justify="center" align="center" height="32px" width="100%">
+            <LoadingIndicator size={24} style={{margin: 0}} />
+          </Flex>
+        ) : null}
         {enableAISearch ? <AskSeer state={state} /> : null}
       </ListBoxOverlay>
     </StyledPositionWrapper>
@@ -345,6 +374,7 @@ export function SearchQueryBuilderCombobox<
   onPaste,
   onClick,
   customMenu,
+  isLoading: incomingIsLoading,
   isOpen: incomingIsOpen,
   ['data-test-id']: dataTestId,
   ref,
@@ -473,6 +503,7 @@ export function SearchQueryBuilderCombobox<
     hiddenOptions,
     totalOptions,
     hasCustomMenu,
+    isLoading: incomingIsLoading,
     isOpen: incomingIsOpen,
   });
 
@@ -600,12 +631,14 @@ export function SearchQueryBuilderCombobox<
         filterValue={filterValue}
         hiddenOptions={hiddenOptions}
         isOpen={isOpen}
+        isLoading={incomingIsLoading}
         listBoxProps={listBoxProps}
         listBoxRef={listBoxRef}
         popoverRef={popoverRef}
         state={state}
         overlayProps={overlayProps}
         portalTarget={portalTarget}
+        totalOptions={totalOptions}
       />
     </Flex>
   );

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterKeyCombobox.tsx
@@ -36,7 +36,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
 
   const organization = useOrganization();
   const {mutate: seerAcknowledgeMutate} = useSeerAcknowledgeMutation();
-  const sortedFilterKeys = useSortedFilterKeyItems({
+  const {items: sortedFilterKeys, isLoading} = useSortedFilterKeyItems({
     filterValue: inputValue,
     inputValue,
     includeSuggestions: false,
@@ -167,6 +167,7 @@ export function FilterKeyCombobox({token, onCommit, item}: KeyComboboxProps) {
       <SearchQueryBuilderCombobox
         ref={inputRef}
         items={sortedFilterKeys}
+        isLoading={isLoading}
         onOptionSelected={onOptionSelected}
         onCustomValueCommitted={onValueCommitted}
         onCustomValueBlurred={onCustomValueBlurred}

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -301,11 +301,12 @@ function SearchQueryBuilderInputInternal({
     useFilterKeyListBox({
       filterValue,
     });
-  const sortedFilteredItems = useSortedFilterKeyItems({
-    filterValue,
-    inputValue,
-    includeSuggestions: true,
-  });
+  const {items: sortedFilteredItems, isLoading: isLoadingFilterKeys} =
+    useSortedFilterKeyItems({
+      filterValue,
+      inputValue,
+      includeSuggestions: true,
+    });
 
   const items = customMenu ? sectionItems : sortedFilteredItems;
 
@@ -438,6 +439,7 @@ function SearchQueryBuilderInputInternal({
         customMenu={customMenu}
         ref={inputRef}
         items={items}
+        isLoading={isLoadingFilterKeys}
         placeholder={query === '' ? placeholder : undefined}
         onOptionSelected={option => {
           if (handleOptionSelected) {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -223,11 +223,6 @@ export function useSortedFilterKeyItems({
     return merged;
   }, [filterKeys, asyncKeys]);
 
-  // When async fetching is active, debounce the filter value used for fuzzy search
-  // so it only runs once (after the API response lands) instead of on every keystroke.
-  const debouncedFilterValue = useDebouncedValue(filterValue);
-  const effectiveFilterValue = shouldFetchAsync ? debouncedFilterValue : filterValue;
-
   const searchableItems = useMemo<FilterKeySearchItem[]>(() => {
     const searchKeyItems: FilterKeySearchItem[] = flatKeys.map(key => {
       const fieldDef = getFieldDefinition(key.key);
@@ -255,7 +250,7 @@ export function useSortedFilterKeyItems({
   const search = useFuzzySearch(searchableItems, FUZZY_SEARCH_OPTIONS);
 
   return useMemo(() => {
-    if (!effectiveFilterValue || !search) {
+    if (!filterValue || !search) {
       if (!filterKeySections.length) {
         return flatKeys
           .map(key => createItem(key, getFieldDefinition(key.key)))
@@ -272,7 +267,7 @@ export function useSortedFilterKeyItems({
         .map(key => createItem(key, getFieldDefinition(key.key)));
     }
 
-    const searched = search.search(effectiveFilterValue);
+    const searched = search.search(filterValue);
 
     const keyItems = searched
       .map(({item: filterSearchKeyItem}) => filterSearchKeyItem)
@@ -397,9 +392,9 @@ export function useSortedFilterKeyItems({
   }, [
     allKeysLookup,
     disallowFreeText,
-    effectiveFilterValue,
     enableAISearch,
     filterKeySections,
+    filterValue,
     flatKeys,
     getFieldDefinition,
     includeSuggestions,

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -21,7 +21,7 @@ import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
-import {keepPreviousData, useQuery} from 'sentry/utils/queryClient';
+import {useQuery} from 'sentry/utils/queryClient';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -183,11 +183,10 @@ export function useSortedFilterKeyItems({
   // Async key fetching with debounce when getTagKeys is provided
   const shouldFetchAsync = !!getTagKeys;
   const debouncedFilterValue = useDebouncedValue(filterValue);
-  const {data: asyncKeys, isFetching: isQueryLoading} = useQuery({
+  const {data: asyncKeys, isLoading: isQueryLoading} = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['search-query-builder-tag-keys', debouncedFilterValue],
     queryFn: ctx => getTagKeys!(ctx.queryKey[1] ?? ''),
-    placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });
 

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -192,13 +192,18 @@ export function useSortedFilterKeyItems({
 
   const isLoading = shouldFetchAsync && isQueryLoading;
 
+  // Set of Tag.key values from static filterKeys, used consistently for deduplication.
+  const staticKeyValues = useMemo(
+    () => new Set(Object.values(filterKeys).map(k => k.key)),
+    [filterKeys]
+  );
+
   const flatKeys = useMemo(() => {
     const keys = Object.values(filterKeys);
     if (!asyncKeys?.length) return keys;
 
-    const existing = new Set(keys.map(k => k.key));
-    return [...keys, ...asyncKeys.filter(k => !existing.has(k.key))];
-  }, [filterKeys, asyncKeys]);
+    return [...keys, ...asyncKeys.filter(k => !staticKeyValues.has(k.key))];
+  }, [filterKeys, asyncKeys, staticKeyValues]);
 
   // Keys that exist only in asyncKeys and not in the static filterKeys.
   // Used to partition results so async-only keys always render below static keys.
@@ -206,8 +211,8 @@ export function useSortedFilterKeyItems({
     if (!asyncKeys?.length) {
       return new Set<string>();
     }
-    return new Set(asyncKeys.filter(k => !(k.key in filterKeys)).map(k => k.key));
-  }, [asyncKeys, filterKeys]);
+    return new Set(asyncKeys.filter(k => !staticKeyValues.has(k.key)).map(k => k.key));
+  }, [asyncKeys, staticKeyValues]);
 
   // Merged lookup of static + async keys, used for validating search results.
   // Without this, async-only keys would be filtered out by the `filterKeys` check.
@@ -216,12 +221,12 @@ export function useSortedFilterKeyItems({
 
     const merged = {...filterKeys};
     for (const tag of asyncKeys) {
-      if (!(tag.key in merged)) {
+      if (!staticKeyValues.has(tag.key)) {
         merged[tag.key] = tag;
       }
     }
     return merged;
-  }, [filterKeys, asyncKeys]);
+  }, [filterKeys, asyncKeys, staticKeyValues]);
 
   const searchableItems = useMemo<FilterKeySearchItem[]>(() => {
     const searchKeyItems: FilterKeySearchItem[] = flatKeys.map(key => {

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -183,31 +183,38 @@ export function useSortedFilterKeyItems({
   // Async key fetching with debounce when getTagKeys is provided
   const shouldFetchAsync = !!getTagKeys;
   const debouncedFilterValue = useDebouncedValue(filterValue);
-  const isDebouncing = filterValue !== debouncedFilterValue;
-  const {data: asyncKeys, isFetching} = useQuery({
+  const {data: asyncKeys, isFetching: isQueryLoading} = useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['search-query-builder-tag-keys', debouncedFilterValue],
-    queryFn: ctx => getTagKeys?.(ctx.queryKey[1] ?? '') ?? [],
+    queryFn: ctx => getTagKeys!(ctx.queryKey[1] ?? ''),
     placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });
 
-  const isLoading = shouldFetchAsync && (isFetching || isDebouncing);
+  const isLoading = shouldFetchAsync && isQueryLoading;
 
   const flatKeys = useMemo(() => {
     const keys = Object.values(filterKeys);
-    if (!asyncKeys?.length) {
-      return keys;
-    }
+    if (!asyncKeys?.length) return keys;
+
     const existing = new Set(keys.map(k => k.key));
     return [...keys, ...asyncKeys.filter(k => !existing.has(k.key))];
   }, [filterKeys, asyncKeys]);
 
+  // Keys that exist only in asyncKeys and not in the static filterKeys.
+  // Used to partition results so async-only keys always render below static keys.
+  const asyncOnlyKeys = useMemo(() => {
+    if (!asyncKeys?.length) {
+      return new Set<string>();
+    }
+    return new Set(asyncKeys.filter(k => !(k.key in filterKeys)).map(k => k.key));
+  }, [asyncKeys, filterKeys]);
+
   // Merged lookup of static + async keys, used for validating search results.
   // Without this, async-only keys would be filtered out by the `filterKeys` check.
   const allKeysLookup = useMemo(() => {
-    if (!asyncKeys?.length) {
-      return filterKeys;
-    }
+    if (!asyncKeys?.length) return filterKeys;
+
     const merged = {...filterKeys};
     for (const tag of asyncKeys) {
       if (!(tag.key in merged)) {
@@ -246,9 +253,16 @@ export function useSortedFilterKeyItems({
   const items = useMemo(() => {
     if (!filterValue || !search) {
       if (!filterKeySections.length) {
-        return flatKeys
-          .map(key => createItem(key, getFieldDefinition(key.key)))
+        const allItems = flatKeys.map(key =>
+          createItem(key, getFieldDefinition(key.key))
+        );
+        const staticItems = allItems
+          .filter(item => !asyncOnlyKeys.has(item.value))
           .sort((a, b) => a.textValue.localeCompare(b.textValue));
+        const asyncItems = allItems
+          .filter(item => asyncOnlyKeys.has(item.value))
+          .sort((a, b) => a.textValue.localeCompare(b.textValue));
+        return [...staticItems, ...asyncItems];
       }
 
       const filterSectionKeys = [
@@ -263,7 +277,7 @@ export function useSortedFilterKeyItems({
 
     const searched = search.search(filterValue);
 
-    const keyItems = searched
+    const allKeyItems = searched
       .map(({item: filterSearchKeyItem}) => filterSearchKeyItem)
       .filter(
         filterSearchKeyItem =>
@@ -285,6 +299,12 @@ export function useSortedFilterKeyItems({
         const {key} = filterSearchKeyItem.item;
         return createItem(allKeysLookup[key]!, getFieldDefinition(key));
       });
+
+    // Partition so async-only keys always appear below static keys,
+    // preserving fuzzy score order within each group.
+    const staticKeyItems = allKeyItems.filter(item => !asyncOnlyKeys.has(item.value));
+    const asyncKeyItems = allKeyItems.filter(item => asyncOnlyKeys.has(item.value));
+    const keyItems = [...staticKeyItems, ...asyncKeyItems];
 
     const askSeerItem = [];
     if (enableAISearch) {
@@ -385,6 +405,7 @@ export function useSortedFilterKeyItems({
     return [...keyItems, ...askSeerItem];
   }, [
     allKeysLookup,
+    asyncOnlyKeys,
     disallowFreeText,
     enableAISearch,
     filterKeySections,

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -182,18 +182,11 @@ export function useSortedFilterKeyItems({
 
   // Async key fetching with debounce when getTagKeys is provided
   const shouldFetchAsync = !!getTagKeys;
-  const queryParams = useMemo(() => [filterValue] as const, [filterValue]);
-  const baseQueryKey = useMemo(
-    () => ['search-query-builder-tag-keys', queryParams] as const,
-    [queryParams]
-  );
-  const debouncedQueryKey = useDebouncedValue(baseQueryKey);
-
-  const isDebouncing = baseQueryKey !== debouncedQueryKey;
-
+  const debouncedFilterValue = useDebouncedValue(filterValue);
+  const isDebouncing = filterValue !== debouncedFilterValue;
   const {data: asyncKeys, isFetching} = useQuery({
-    queryKey: debouncedQueryKey,
-    queryFn: ctx => getTagKeys?.(...ctx.queryKey[1]) ?? [],
+    queryKey: ['search-query-builder-tag-keys', debouncedFilterValue],
+    queryFn: ctx => getTagKeys?.(ctx.queryKey[1] ?? '') ?? [],
     placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -21,6 +21,8 @@ import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {FieldKey, FieldKind} from 'sentry/utils/fields';
 import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
+import {keepPreviousData, useQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type FilterKeySearchItem = {
@@ -170,6 +172,7 @@ export function useSortedFilterKeyItems({
     replaceRawSearchKeys,
     matchKeySuggestions,
     enableAISearch,
+    getTagKeys,
   } = useSearchQueryBuilder();
 
   const organization = useOrganization();
@@ -177,7 +180,53 @@ export function useSortedFilterKeyItems({
     'search-query-builder-conditionals-combobox-menus'
   );
 
-  const flatKeys = useMemo(() => Object.values(filterKeys), [filterKeys]);
+  // Async key fetching with debounce when getTagKeys is provided
+  const shouldFetchAsync = !!getTagKeys;
+  const queryParams = useMemo(
+    () => [getTagKeys, filterValue] as const,
+    [getTagKeys, filterValue]
+  );
+  const baseQueryKey = useMemo(
+    () => ['search-query-builder-tag-keys', queryParams] as const,
+    [queryParams]
+  );
+  const debouncedQueryKey = useDebouncedValue(baseQueryKey);
+
+  const {data: asyncKeys} = useQuery({
+    queryKey: debouncedQueryKey,
+    queryFn: ctx => ctx.queryKey[1][0]!(ctx.queryKey[1][1]),
+    placeholderData: keepPreviousData,
+    enabled: shouldFetchAsync,
+  });
+
+  const flatKeys = useMemo(() => {
+    const keys = Object.values(filterKeys);
+    if (!asyncKeys?.length) {
+      return keys;
+    }
+    const existing = new Set(keys.map(k => k.key));
+    return [...keys, ...asyncKeys.filter(k => !existing.has(k.key))];
+  }, [filterKeys, asyncKeys]);
+
+  // Merged lookup of static + async keys, used for validating search results.
+  // Without this, async-only keys would be filtered out by the `filterKeys` check.
+  const allKeysLookup = useMemo(() => {
+    if (!asyncKeys?.length) {
+      return filterKeys;
+    }
+    const merged = {...filterKeys};
+    for (const tag of asyncKeys) {
+      if (!(tag.key in merged)) {
+        merged[tag.key] = tag;
+      }
+    }
+    return merged;
+  }, [filterKeys, asyncKeys]);
+
+  // When async fetching is active, debounce the filter value used for fuzzy search
+  // so it only runs once (after the API response lands) instead of on every keystroke.
+  const debouncedFilterValue = useDebouncedValue(filterValue);
+  const effectiveFilterValue = shouldFetchAsync ? debouncedFilterValue : filterValue;
 
   const searchableItems = useMemo<FilterKeySearchItem[]>(() => {
     const searchKeyItems: FilterKeySearchItem[] = flatKeys.map(key => {
@@ -206,7 +255,7 @@ export function useSortedFilterKeyItems({
   const search = useFuzzySearch(searchableItems, FUZZY_SEARCH_OPTIONS);
 
   return useMemo(() => {
-    if (!filterValue || !search) {
+    if (!effectiveFilterValue || !search) {
       if (!filterKeySections.length) {
         return flatKeys
           .map(key => createItem(key, getFieldDefinition(key.key)))
@@ -218,19 +267,19 @@ export function useSortedFilterKeyItems({
       ].slice(0, 50);
 
       return filterSectionKeys
-        .map(key => filterKeys[key])
+        .map(key => allKeysLookup[key])
         .filter(defined)
         .map(key => createItem(key, getFieldDefinition(key.key)));
     }
 
-    const searched = search.search(filterValue);
+    const searched = search.search(effectiveFilterValue);
 
     const keyItems = searched
       .map(({item: filterSearchKeyItem}) => filterSearchKeyItem)
       .filter(
         filterSearchKeyItem =>
           (filterSearchKeyItem.type === 'key' &&
-            filterKeys[filterSearchKeyItem.item.key]) ||
+            allKeysLookup[filterSearchKeyItem.item.key]) ||
           filterSearchKeyItem.type === 'logic'
       )
       .map(filterSearchKeyItem => {
@@ -245,7 +294,7 @@ export function useSortedFilterKeyItems({
         }
 
         const {key} = filterSearchKeyItem.item;
-        return createItem(filterKeys[key]!, getFieldDefinition(key));
+        return createItem(allKeysLookup[key]!, getFieldDefinition(key));
       });
 
     const askSeerItem = [];
@@ -346,11 +395,11 @@ export function useSortedFilterKeyItems({
 
     return [...keyItems, ...askSeerItem];
   }, [
+    allKeysLookup,
     disallowFreeText,
+    effectiveFilterValue,
     enableAISearch,
     filterKeySections,
-    filterKeys,
-    filterValue,
     flatKeys,
     getFieldDefinition,
     includeSuggestions,

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -182,10 +182,7 @@ export function useSortedFilterKeyItems({
 
   // Async key fetching with debounce when getTagKeys is provided
   const shouldFetchAsync = !!getTagKeys;
-  const queryParams = useMemo(
-    () => [getTagKeys, filterValue] as const,
-    [getTagKeys, filterValue]
-  );
+  const queryParams = useMemo(() => [filterValue] as const, [filterValue]);
   const baseQueryKey = useMemo(
     () => ['search-query-builder-tag-keys', queryParams] as const,
     [queryParams]
@@ -196,7 +193,7 @@ export function useSortedFilterKeyItems({
 
   const {data: asyncKeys, isFetching} = useQuery({
     queryKey: debouncedQueryKey,
-    queryFn: ctx => ctx.queryKey[1][0]!(ctx.queryKey[1][1]),
+    queryFn: ctx => getTagKeys?.(...ctx.queryKey[1]) ?? [],
     placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -163,7 +163,7 @@ export function useSortedFilterKeyItems({
   filterValue: string;
   includeSuggestions: boolean;
   inputValue: string;
-}): SearchKeyItem[] {
+}): {isLoading: boolean; items: SearchKeyItem[]} {
   const {
     filterKeys,
     getFieldDefinition,
@@ -192,12 +192,16 @@ export function useSortedFilterKeyItems({
   );
   const debouncedQueryKey = useDebouncedValue(baseQueryKey);
 
-  const {data: asyncKeys} = useQuery({
+  const isDebouncing = baseQueryKey !== debouncedQueryKey;
+
+  const {data: asyncKeys, isFetching} = useQuery({
     queryKey: debouncedQueryKey,
     queryFn: ctx => ctx.queryKey[1][0]!(ctx.queryKey[1][1]),
     placeholderData: keepPreviousData,
     enabled: shouldFetchAsync,
   });
+
+  const isLoading = shouldFetchAsync && (isFetching || isDebouncing);
 
   const flatKeys = useMemo(() => {
     const keys = Object.values(filterKeys);
@@ -249,7 +253,7 @@ export function useSortedFilterKeyItems({
 
   const search = useFuzzySearch(searchableItems, FUZZY_SEARCH_OPTIONS);
 
-  return useMemo(() => {
+  const items = useMemo(() => {
     if (!filterValue || !search) {
       if (!filterKeySections.length) {
         return flatKeys
@@ -403,4 +407,6 @@ export function useSortedFilterKeyItems({
     replaceRawSearchKeys,
     search,
   ]);
+
+  return {items, isLoading};
 }

--- a/static/app/utils/useDebouncedValue.tsx
+++ b/static/app/utils/useDebouncedValue.tsx
@@ -30,7 +30,9 @@ export function useDebouncedValue<T>(
 
   useEffect(() => {
     return () => {
-      debounceFn.cancel();
+      // debounceFn may be undefined during unmount in React 19 strict mode
+      // when the ref is reset between effect invocations
+      debounceFn?.cancel();
     };
   }, [debounceFn]);
 


### PR DESCRIPTION
This PR adds in the ability to pass a function that will fetch tags from the API. This solves an issue that users may run into where they have more than 3000 attributes (limit of the attributes endpoint) and they're not able to access all of them. 

Ran into a test failure that was caused in `useDebouncedValue` which has been patched with an optional chain, and comment.

Ticket: EXP-638