### PR TITLE
ref: Replace SENTRY_DEFAULT_ORGANIZATION_ID with SUPERUSER_ORG_ID

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1438,8 +1438,8 @@ SENTRY_PROJECT_KEY: int | None = None
 # Used as a default when in SINGLE_ORGANIZATION mode.
 SENTRY_ORGANIZATION: int | None = None
 
-# Default organization ID for granting superuser privileges (typically organization 1 in SaaS mode)
-SENTRY_DEFAULT_ORGANIZATION_ID = 1
+# Organization ID for granting superuser/staff privileges.
+SUPERUSER_ORG_ID: int | None = None
 
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT: int | None = None

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -216,7 +216,7 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         # in addition to removing the membership.
         if (
             settings.SENTRY_MODE == SentryMode.SAAS
-            and organization.id == settings.SENTRY_DEFAULT_ORGANIZATION_ID
+            and organization.id == settings.SUPERUSER_ORG_ID
             and user_id is not None
         ):
             user = user_service.get_user(user_id=user_id)

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -46,9 +46,12 @@ TIMEZONE_CHOICES = get_timezone_choices()
 
 
 def user_can_elevate(target_user: User) -> bool:
+    if settings.SUPERUSER_ORG_ID is None:
+        return False
+
     try:
         org_member_exists = OrganizationMemberMapping.objects.filter(
-            organization_id=settings.SENTRY_DEFAULT_ORGANIZATION_ID,
+            organization_id=settings.SUPERUSER_ORG_ID,
             user=target_user,
         ).exists()
     except Exception:


### PR DESCRIPTION
@markstory informed me that there is already a way to specify the org used for superuser/staff. So I'm going to remove the custom setting that I added and use that other setting instead.

Consolidate two duplicate constants that reference the same organization ID. SENTRY_DEFAULT_ORGANIZATION_ID was hardcoded to 1 in server.py, while SUPERUSER_ORG_ID already exists in superuser.py for the same purpose.

This change:
- Removes SENTRY_DEFAULT_ORGANIZATION_ID from conf/server.py
- Updates SCIM member deletion to use settings.SUPERUSER_ORG_ID
- Updates user elevation check to use settings.SUPERUSER_ORG_ID
- Updates test fixtures to override SUPERUSER_ORG_ID setting

No behavior change - both constants referenced organization 1 for privilege management in SaaS mode.