### PR TITLE
fix(dashboards): Use dataset axis range for app size charts

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -162,6 +162,11 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     pageFilters: PageFilters
   ) => TableData;
   /**
+   * Optional y-axis range for timeseries visualizations.
+   * If omitted, the visualization component default is used.
+   */
+  axisRange?: 'auto' | 'dataMin';
+  /**
    * Default field to add to the widget query when adding a new field for series display type.
    */
   defaultSeriesField?: QueryFieldValue;

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -252,6 +252,7 @@ export const MobileAppSizeConfig: DatasetConfig<
   SearchBar: MobileAppSizeSearchBar,
   useSearchBarDataProvider: useMobileAppSizeSearchBarDataProvider,
   supportedDisplayTypes: [DisplayType.LINE],
+  axisRange: 'dataMin',
   getTableFieldOptions: getPrimaryFieldOptions,
   filterYAxisAggregateParams: () => filterAggregateParams,
   filterYAxisOptions,

--- a/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
+++ b/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
@@ -7,6 +7,7 @@ const SUPPORTED_WIDGET_TYPES = new Set<WidgetType>([
   WidgetType.LOGS,
   WidgetType.ERRORS,
   WidgetType.TRACEMETRICS,
+  WidgetType.PREPROD_APP_SIZE,
 ]);
 
 const SUPPORTED_DISPLAY_TYPES = new Set<DisplayType>([

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -14,6 +14,7 @@ import {transformLegacySeriesToPlottables} from 'sentry/utils/timeSeries/transfo
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {
@@ -160,6 +161,7 @@ function VisualizationWidgetContent({
     usesTimeSeriesData(widget.displayType) &&
     tableResults &&
     tableResults.length > 0;
+  const datasetConfig = getDatasetConfig(widget.widgetType);
 
   const tableDataRows = tableResults?.[0]?.data;
   const widgetQuery = widget.queries[0];
@@ -271,6 +273,7 @@ function VisualizationWidgetContent({
             releases={releases}
             showReleaseAs={showReleaseAs}
             showLegend="never"
+            axisRange={datasetConfig.axisRange}
           />
         </Container>
         <Flex flex={1} direction="column" borderTop="primary">
@@ -288,6 +291,7 @@ function VisualizationWidgetContent({
         plottables={plottables}
         releases={releases}
         showReleaseAs={showReleaseAs}
+        axisRange={datasetConfig.axisRange}
       />
     </Container>
   );


### PR DESCRIPTION

<img width="2792" height="1410" alt="CleanShot 2026-02-06 at 11 19 30@2x" src="https://github.com/user-attachments/assets/5ea4e8f3-1722-4600-897f-2f150f64b957" />

- Add an optional axisRange setting to dashboard dataset config and set mobile app size widgets to use dataMin in timeseries visualizations.

- Also allow PREPROD_APP_SIZE widgets to use the timeseries visualization path so the dataset setting is respected consistently.

Refs EME-837
