### PR TITLE
feat(dashboards): filter frontend overview by frontend data

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -19,8 +19,12 @@ import {
 import {SpanFields} from 'sentry/views/insights/types';
 
 const BASE_QUERY = new MutableSearch('');
-BASE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
+BASE_QUERY.addOp('(');
 BASE_QUERY.addFilterValue('span.op', `[${FRONTEND_OVERVIEW_PAGE_OPS.join(',')}]`);
+BASE_QUERY.addOp('OR');
+BASE_QUERY.addFilterValue('sdk.name', `[${FRONTEND_SDK_NAMES.join(',')}]`);
+BASE_QUERY.addOp(')');
+BASE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
 BASE_QUERY.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
 const TABLE_QUERY = new MutableSearch('');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -198,6 +198,20 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
   {h: 3, minH: 3}
 );
 
+const TABLE_FIELDS = [
+  SpanFields.IS_STARRED_TRANSACTION,
+  SpanFields.TRANSACTION,
+  SpanFields.PROJECT,
+  'tpm()',
+  `p50_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
+  `p75_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
+  `p95_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
+  `failure_rate_if(${SpanFields.IS_TRANSACTION},equals,true)`,
+  `count_unique(${SpanFields.USER})`,
+  `sum_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
+  `performance_score(measurements.score.total)`,
+];
+
 const TRANSACTIONS_TABLE: Widget = {
   id: 'frontend-overview-table',
   title: t('Transactions'),
@@ -205,6 +219,7 @@ const TRANSACTIONS_TABLE: Widget = {
   widgetType: WidgetType.SPANS,
   interval: '5m',
   limit: 50,
+  tableWidths: TABLE_FIELDS.map(() => -1),
   queries: [
     {
       name: '',
@@ -219,19 +234,7 @@ const TRANSACTIONS_TABLE: Widget = {
         `sum_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
         `performance_score(measurements.score.total)`,
       ],
-      fields: [
-        SpanFields.IS_STARRED_TRANSACTION,
-        SpanFields.TRANSACTION,
-        SpanFields.PROJECT,
-        'tpm()',
-        `p50_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
-        `p75_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
-        `p95_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
-        `failure_rate_if(${SpanFields.IS_TRANSACTION},equals,true)`,
-        `count_unique(${SpanFields.USER})`,
-        `sum_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
-        `performance_score(measurements.score.total)`,
-      ],
+      fields: TABLE_FIELDS,
       fieldAliases: [
         t('Starred'),
         t('Transaction'),

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -3,7 +3,10 @@ import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendOverview/settings';
+import {
+  DASHBOARD_TITLE,
+  FRONTEND_SDK_NAMES,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendOverview/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {getResourcesEventViewQuery} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
 import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
@@ -16,16 +19,24 @@ import {
 import {SpanFields} from 'sentry/views/insights/types';
 
 const BASE_QUERY = new MutableSearch('');
+BASE_QUERY.addOp('(');
 BASE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
 BASE_QUERY.addFilterValue('span.op', `[${FRONTEND_OVERVIEW_PAGE_OPS.join(',')}]`);
+BASE_QUERY.addOp('OR');
+BASE_QUERY.addFilterValue('sdk.name', `[${FRONTEND_SDK_NAMES.join(',')}]`);
+BASE_QUERY.addOp(')');
 BASE_QUERY.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
 const TABLE_QUERY = new MutableSearch('');
+TABLE_QUERY.addOp('(');
 TABLE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
 TABLE_QUERY.addFilterValue(
   'span.op',
   `[${[...FRONTEND_OVERVIEW_PAGE_OPS, ...WEB_VITALS_OPS].join(',')}]`
 );
+TABLE_QUERY.addOp('OR');
+TABLE_QUERY.addFilterValue('sdk.name', `[${FRONTEND_SDK_NAMES.join(',')}]`);
+TABLE_QUERY.addOp(')');
 TABLE_QUERY.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
 const ASSETS_BY_TIME_SPENT_QUERY = getResourcesEventViewQuery(

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -24,8 +24,8 @@ BASE_QUERY.addFilterValue('span.op', `[${FRONTEND_OVERVIEW_PAGE_OPS.join(',')}]`
 BASE_QUERY.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
 const TABLE_QUERY = new MutableSearch('');
-TABLE_QUERY.addOp('(');
 TABLE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
+TABLE_QUERY.addOp('(');
 TABLE_QUERY.addFilterValue(
   'span.op',
   `[${[...FRONTEND_OVERVIEW_PAGE_OPS, ...WEB_VITALS_OPS].join(',')}]`

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -51,7 +51,7 @@ const FIRST_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
   [
     {
       id: 'throughput-widget',
-      title: t('Throughput'),
+      title: t('Transaction Throughput'),
       displayType: DisplayType.LINE,
       interval: '5m',
       queries: [
@@ -69,7 +69,7 @@ const FIRST_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
     },
     {
       id: 'duration-widget',
-      title: t('Duration'),
+      title: t('Transaction Duration'),
       displayType: DisplayType.LINE,
       interval: '5m',
       queries: [

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -19,12 +19,8 @@ import {
 import {SpanFields} from 'sentry/views/insights/types';
 
 const BASE_QUERY = new MutableSearch('');
-BASE_QUERY.addOp('(');
 BASE_QUERY.addFilterValues('!span.op', BACKEND_OVERVIEW_PAGE_ALLOWED_OPS);
 BASE_QUERY.addFilterValue('span.op', `[${FRONTEND_OVERVIEW_PAGE_OPS.join(',')}]`);
-BASE_QUERY.addOp('OR');
-BASE_QUERY.addFilterValue('sdk.name', `[${FRONTEND_SDK_NAMES.join(',')}]`);
-BASE_QUERY.addOp(')');
 BASE_QUERY.addFilterValue(SpanFields.IS_TRANSACTION, 'true');
 
 const TABLE_QUERY = new MutableSearch('');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/settings.ts
@@ -1,3 +1,33 @@
 import {t} from 'sentry/locale';
 
 export const DASHBOARD_TITLE = t('Frontend Overview');
+
+export const FRONTEND_SDK_NAMES = [
+  'dart',
+  'dart-sentry-client',
+  'sentry.dart',
+  'sentry.dart.browser',
+  'sentry.dart.flutter',
+  'sentry.dart.logging',
+  'raven-js',
+  'sentry-browser',
+  'sentry.javascript.angular',
+  'sentry.javascript.angular-ivy',
+  'sentry.javascript.astro',
+  'sentry.javascript.browser',
+  'sentry.javascript.electron',
+  'sentry.javascript.ember',
+  'sentry.javascript.enrio',
+  'sentry.javascript.gatsby',
+  'sentry.javascript.miniapp',
+  'sentry.javascript.nextjs',
+  'sentry.javascript.nuxt',
+  'sentry.javascript.react',
+  'sentry.javascript.remix',
+  'sentry.javascript.solid',
+  'sentry.javascript.solidstart',
+  'sentry.javascript.svelte',
+  'sentry.javascript.sveltekit',
+  'sentry.javascript.uniapp',
+  'sentry.javascript.vue',
+];


### PR DESCRIPTION
Following the pattern from the insights page, this PR makes the frontend overview table explicitly filter for frontend data by applying an `sdk.name = [...frontendSdks]` filter. 

This is a little different because the insights filtered for selected frontend projects, and applied a `projects = [selectedFrontendProjects]` filter, this kept the overall filter string much smaller, but because we're migrating this to dashboards, this is the equivalent way to get it working in dashboards without adding logic into it.

Also threw in a minor change to apply `TableWidths = -1` so that the table does not horizontally scroll