### PR TITLE
feat(uptime-assertion-failure-tree) Merging logical ops

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
@@ -56,17 +56,15 @@ describe('AssertionFailureTree', () => {
     render(<AssertionFailureTree assertion={assertion} />);
 
     const rows = screen.getAllByTestId('assertion-failure-tree-row');
-    expect(rows).toHaveLength(4);
+    expect(rows).toHaveLength(3);
 
-    expect(rows[0]!).toHaveTextContent(/Assert All/);
-    expect(rows[1]!).toHaveTextContent(/Assert Any/);
+    expect(rows[0]!).toHaveTextContent(/Assert Any/);
 
-    expect(rows[2]!).toHaveTextContent(
+    expect(rows[1]!).toHaveTextContent(
       /\[Failed\]\s*JSON Path \| Rule:\s*\$\.status\s*=\s*""\s*ok/
     );
 
-    const headerText = rows[3]!.textContent ?? '';
-    expect(headerText).toMatch(
+    expect(rows[2]!).toHaveTextContent(
       /\[Failed\]\s*Header Check \| Rule:\s*key\s*=\s*""\s*content-type,\s*value\s*=\s*""\s*application\/json/
     );
   });

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Assertion Failure Tree model Builds the expected tree 1`] = `
+"
+AND - op-1
+  STATUS CODE - op-2
+  OR - op-3
+    JSON PATH - op-4
+  (negated) AND - op-6
+    HEADER CHECK - op-7
+"
+`;
+
+exports[`Assertion Failure Tree model Merges logical ops - non-root 1`] = `
+"
+(negated) AND - op-3
+  STATUS CODE - op-4
+  JSON PATH - op-5
+"
+`;
+
+exports[`Assertion Failure Tree model Merges logical ops - root 1`] = `
+"
+(negated) OR - op-3
+  STATUS CODE - op-4
+"
+`;

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
@@ -7,6 +7,6 @@ import {TreeNode} from './treeNode';
 
 export class AndOpTreeNode extends TreeNode<AndOp> {
   renderRow(): ReactNode {
-    return <AndOpRow />;
+    return <AndOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {AndOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class AndOpTreeNode extends TreeNode<AndOp> {
+  printNode(): string {
+    return `AND - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <AndOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {HeaderCheckOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class HeaderCheckOpTreeNode extends TreeNode<HeaderCheckOp> {
+  printNode(): string {
+    return `HEADER CHECK - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <HeaderCheckOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {JsonPathOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class JsonPathOpTreeNode extends TreeNode<JsonPathOp> {
+  printNode(): string {
+    return `JSON PATH - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <JsonPathOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
@@ -10,6 +10,10 @@ export class NotOpTreeNode extends TreeNode<NotOp> {
     return [this.value.operand];
   }
 
+  printNode(): string {
+    return `NOT - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <NotOpRow />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {OrOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class OrOpTreeNode extends TreeNode<OrOp> {
+  printNode(): string {
+    return `OR - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <OrOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
@@ -7,6 +7,6 @@ import {TreeNode} from './treeNode';
 
 export class OrOpTreeNode extends TreeNode<OrOp> {
   renderRow(): ReactNode {
-    return <OrOpRow />;
+    return <OrOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {StatusCodeOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class StatusCodeOpTreeNode extends TreeNode<StatusCodeOp> {
+  printNode(): string {
+    return `STATUS CODE - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <StatusCodeOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
@@ -8,78 +8,75 @@ import {
 } from 'sentry/views/alerts/rules/uptime/assertions/testUtils';
 import type {Assertion} from 'sentry/views/alerts/rules/uptime/types';
 
-import {AndOpTreeNode} from './andOpTreeNode';
-import {HeaderCheckOpTreeNode} from './headerCheckOpTreeNode';
-import {JsonPathOpTreeNode} from './jsonPathOpTreeNode';
-import {NotOpTreeNode} from './notOpTreeNode';
-import {OrOpTreeNode} from './orOpTreeNode';
-import {StatusCodeOpTreeNode} from './statusCodeOpTreeNode';
 import {Tree} from './tree';
 
 describe('Assertion Failure Tree model', () => {
-  it('FromAssertion builds the expected tree', () => {
-    const leafStatus = makeStatusCodeOp({id: 'op-2', value: 200});
-    const leafJson = makeJsonPathOp({id: 'op-4'});
-    const leafHeader = makeHeaderCheckOp({id: 'op-7'});
-
-    const orGroup = makeOrOp({id: 'op-3', children: [leafJson]});
-
-    const innerAnd = makeAndOp({id: 'op-6', children: [leafHeader]});
-    const notGroup = makeNotOp({id: 'op-5', operand: innerAnd});
-
-    const rootAndOp = makeAndOp({id: 'op-1', children: [leafStatus, orGroup, notGroup]});
-    const assertion: Assertion = {root: rootAndOp};
+  it('Builds the expected tree', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeStatusCodeOp({id: 'op-2', value: 200}),
+          makeOrOp({
+            id: 'op-3',
+            children: [makeJsonPathOp({id: 'op-4'})],
+          }),
+          makeNotOp({
+            id: 'op-5',
+            operand: makeAndOp({
+              id: 'op-6',
+              children: [makeHeaderCheckOp({id: 'op-7'})],
+            }),
+          }),
+        ],
+      }),
+    };
 
     const tree = Tree.FromAssertion(assertion);
 
-    expect(tree.root).not.toBeNull();
-    expect(tree.root).toBeInstanceOf(AndOpTreeNode);
+    expect(tree.serialize()).toMatchSnapshot();
+  });
 
-    expect(tree.nodes.map(n => n.value.id)).toEqual([
-      'op-1',
-      'op-2',
-      'op-3',
-      'op-4',
-      'op-5',
-      'op-6',
-      'op-7',
-    ]);
+  it('Merges logical ops - root', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeNotOp({
+            id: 'op-2',
+            operand: makeOrOp({
+              id: 'op-3',
+              children: [makeStatusCodeOp({id: 'op-4', value: 200})],
+            }),
+          }),
+        ],
+      }),
+    };
 
-    expect(tree.nodes[0]).toBeInstanceOf(AndOpTreeNode);
-    expect(tree.nodes[1]).toBeInstanceOf(StatusCodeOpTreeNode);
-    expect(tree.nodes[2]).toBeInstanceOf(OrOpTreeNode);
-    expect(tree.nodes[3]).toBeInstanceOf(JsonPathOpTreeNode);
-    expect(tree.nodes[4]).toBeInstanceOf(NotOpTreeNode);
-    expect(tree.nodes[5]).toBeInstanceOf(AndOpTreeNode);
-    expect(tree.nodes[6]).toBeInstanceOf(HeaderCheckOpTreeNode);
+    const tree = Tree.FromAssertion(assertion);
+    expect(tree.serialize()).toMatchSnapshot();
+  });
 
-    // Testing hierarchy
-    const root = tree.root;
-    expect(root!.parent).toBeNull();
-    expect(root!.children.map(n => n.value.id)).toEqual(['op-2', 'op-3', 'op-5']);
+  it('Merges logical ops - non-root', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeNotOp({
+            id: 'op-2',
+            operand: makeAndOp({
+              id: 'op-3',
+              children: [
+                makeStatusCodeOp({id: 'op-4', value: 200}),
+                makeJsonPathOp({id: 'op-5'}),
+              ],
+            }),
+          }),
+        ],
+      }),
+    };
 
-    const statusNode = tree.nodes[1];
-    expect(statusNode!.parent).toBe(root);
-    expect(statusNode!.children).toHaveLength(0);
-
-    const orNode = tree.nodes[2];
-    expect(orNode!.parent).toBe(root);
-    expect(orNode!.children.map(n => n.value.id)).toEqual(['op-4']);
-
-    const jsonNode = tree.nodes[3];
-    expect(jsonNode!.parent).toBe(orNode);
-    expect(jsonNode!.children).toHaveLength(0);
-
-    const notNode = tree.nodes[4];
-    expect(notNode!.parent).toBe(root);
-    expect(notNode!.children.map(n => n.value.id)).toEqual(['op-6']);
-
-    const innerAndNode = tree.nodes[5];
-    expect(innerAndNode!.parent).toBe(notNode);
-    expect(innerAndNode!.children.map(n => n.value.id)).toEqual(['op-7']);
-
-    const headerNode = tree.nodes[6];
-    expect(headerNode!.parent).toBe(innerAndNode);
-    expect(headerNode!.children).toHaveLength(0);
+    const tree = Tree.FromAssertion(assertion);
+    expect(tree.serialize()).toMatchSnapshot();
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
@@ -1,5 +1,6 @@
 import {
   isAndOp,
+  isGroupOp,
   isHeaderCheckOp,
   isJsonPathOp,
   isNotOp,
@@ -28,7 +29,8 @@ export class Tree {
     const root = Tree.buildNode(assertion.root, null);
 
     const tree = new Tree(root);
-    tree.nodes = Tree.flatten(root);
+    tree.mergeLogicalOps();
+    tree.nodes = tree.flatten();
     return tree;
   }
 
@@ -53,7 +55,6 @@ export class Tree {
       return new HeaderCheckOpTreeNode(op, parent);
     }
 
-    // Should be unreachable if `Op` stays in sync.
     throw new Error('Unknown uptime assertion op');
   }
 
@@ -67,15 +68,99 @@ export class Tree {
     return node;
   }
 
-  private static flatten(root: TreeNode): TreeNode[] {
-    const out: TreeNode[] = [];
+  private flatten(): TreeNode[] {
+    const nodes: TreeNode[] = [];
 
-    const walk = (node: TreeNode) => {
-      out.push(node);
-      node.children.forEach(walk);
+    const visit = (node: TreeNode) => {
+      nodes.push(node);
+      node.children.forEach(visit);
     };
 
-    walk(root);
-    return out;
+    if (this.root) {
+      visit(this.root);
+    }
+
+    return nodes;
+  }
+
+  private removeNode(node: TreeNode): void {
+    const nodeIsRoot = node === this.root;
+    if (nodeIsRoot) {
+      // If the root has multiple children, removing it would require introducing
+      // a new synthetic root; we don't do that here.
+      if (node.children.length > 1) {
+        return;
+      }
+
+      // Replace the root with its only child
+      const newRoot = node.children[0] ?? null;
+      if (newRoot) {
+        newRoot.parent = null;
+      }
+      this.root = newRoot;
+
+      // Fully detach the removed node.
+      node.parent = null;
+      node.children = [];
+      return;
+    }
+
+    const parent = node.parent;
+    if (!parent) {
+      return;
+    }
+
+    const index = parent.children.indexOf(node);
+    if (index === -1) {
+      return;
+    }
+
+    const children = node.children;
+
+    // For non-root nodes, we just replace the node with its children.
+    parent.children.splice(index, 1, ...children);
+
+    for (const child of children) {
+      child.parent = parent;
+    }
+
+    // Fully detach the removed node.
+    node.parent = null;
+    node.children = [];
+  }
+
+  private mergeLogicalOps(): void {
+    const visit = (node: TreeNode) => {
+      const parent = node.parent;
+
+      // If the node is a GROUP op and its parent is a NOT op
+      // we negate the node. This is done to simplify the tree.
+      // Example: 'Assert NOT then Assert All' to 'Assert None'
+      if (
+        isGroupOp(node.value) &&
+        parent &&
+        isNotOp(parent.value) &&
+        parent.children.length === 1
+      ) {
+        node.isNegated = true;
+        this.removeNode(parent);
+      }
+      node.children.forEach(visit);
+    };
+
+    if (this.root) {
+      visit(this.root);
+
+      // The root is always forced to be an AND op.
+      // After the logical ops have been merged, if the root has only one GROUP op child,
+      // we can remove the root to simplify the tree.
+      // Example: 'Assert All then Assert Any' to just 'Assert Any'
+      if (this.root && this.root.children.length === 1) {
+        const child = this.root.children[0];
+        if (child && isGroupOp(child.value)) {
+          this.removeNode(this.root);
+        }
+      }
+    }
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
@@ -135,14 +135,18 @@ export class Tree {
 
       // If the node is a GROUP op and its parent is a NOT op
       // we negate the node. This is done to simplify the tree.
-      // Example: 'Assert NOT then Assert All' to 'Assert None'
+      // Example: 'Assert NOT then Assert All' to 'Assert NOT All'
       if (
         isGroupOp(node.value) &&
         parent &&
+        // Note: Chained NOT operations are not merged.
+        // The assertions UI enforces that a NOT op may only parent a GROUP op.
         isNotOp(parent.value) &&
         parent.children.length === 1
       ) {
         node.isNegated = true;
+
+        // Safe: removes parent, not current node, so child iteration continues correctly
         this.removeNode(parent);
       }
       node.children.forEach(visit);

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
@@ -167,4 +167,19 @@ export class Tree {
       }
     }
   }
+
+  // Used for debugging and snapshot testing
+  serialize(): string {
+    return (
+      '\n' +
+      this.nodes
+        .map(node => {
+          const padding = '  '.repeat(node.depth);
+          return padding + (node.isNegated ? '(negated) ' : '') + node.printNode();
+        })
+        .filter(Boolean)
+        .join('\n') +
+      '\n'
+    );
+  }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
@@ -17,6 +17,10 @@ class MockTreeNode<T extends Op = Op> extends TreeNode<T> {
       </span>
     );
   }
+
+  printNode(): string {
+    return `${this.value.op} - ${this.value.id}`;
+  }
 }
 
 describe('Assertion Failure TreeNode model', () => {

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
@@ -13,6 +13,7 @@ export abstract class TreeNode<T extends Op = Op> {
   value: T;
   parent: TreeNode | null;
   children: TreeNode[];
+  isNegated = false;
 
   constructor(value: T, parent: TreeNode | null = null) {
     this.value = value;

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
@@ -25,6 +25,10 @@ export abstract class TreeNode<T extends Op = Op> {
     }
   }
 
+  get id(): string {
+    return this.value.id;
+  }
+
   get nextOps(): Op[] {
     return 'children' in this.value ? this.value.children : [];
   }
@@ -70,6 +74,8 @@ export abstract class TreeNode<T extends Op = Op> {
 
     return connectors;
   }
+
+  abstract printNode(): string;
 
   abstract renderRow(): ReactNode;
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
@@ -2,9 +2,10 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
+import type {AndOpTreeNode} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode';
 
-export function AndOpRow() {
-  const label = t('Assert All');
+export function AndOpRow({node}: {node: AndOpTreeNode}) {
+  const label = node.isNegated ? t('Assert None') : t('Assert All');
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow.tsx
@@ -1,11 +1,11 @@
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {t} from 'sentry/locale';
 import type {AndOpTreeNode} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode';
+import {getGroupOpLabel} from 'sentry/views/alerts/rules/uptime/assertions/utils';
 
 export function AndOpRow({node}: {node: AndOpTreeNode}) {
-  const label = node.isNegated ? t('Assert None') : t('Assert All');
+  const label = getGroupOpLabel(node.value, node.isNegated);
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
@@ -2,9 +2,10 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
+import type {OrOpTreeNode} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode';
 
-export function OrOpRow() {
-  const label = t('Assert Any');
+export function OrOpRow({node}: {node: OrOpTreeNode}) {
+  const label = node.isNegated ? t('Assert Not Any') : t('Assert Any');
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow.tsx
@@ -1,11 +1,11 @@
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {t} from 'sentry/locale';
 import type {OrOpTreeNode} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode';
+import {getGroupOpLabel} from 'sentry/views/alerts/rules/uptime/assertions/utils';
 
 export function OrOpRow({node}: {node: OrOpTreeNode}) {
-  const label = node.isNegated ? t('Assert Not Any') : t('Assert Any');
+  const label = getGroupOpLabel(node.value, node.isNegated);
 
   return (
     <Tooltip title={label} showOnlyOnOverflow>

--- a/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/index.stories.tsx
@@ -333,7 +333,7 @@ export default Storybook.story('Uptime Assertions', story => {
     );
   });
 
-  story('Group Op - Assert None (Not And)', () => {
+  story('Group Op - Assert Not All (Not And)', () => {
     const [groupOp, setGroupOp] = useState<LogicalOp>({
       id: 'story-not-1',
       op: 'not',
@@ -360,8 +360,8 @@ export default Storybook.story('Uptime Assertions', story => {
     return (
       <Fragment>
         <p>
-          "Assert None" fails if all child assertions pass (negated AND). This is useful
-          for asserting that none of a set of conditions are met.
+          "Assert Not All" fails if all child assertions pass (negated AND). This is
+          useful for asserting that none of a set of conditions are met.
         </p>
         <AssertionOpGroup value={groupOp} onChange={setGroupOp} />
         <CodeBlock language="javascript">{JSON.stringify(groupOp, null, 2)}</CodeBlock>
@@ -369,7 +369,7 @@ export default Storybook.story('Uptime Assertions', story => {
     );
   });
 
-  story('Group Op - Assert Not Any (Not Or)', () => {
+  story('Group Op - Assert None (Not Or)', () => {
     const [groupOp, setGroupOp] = useState<LogicalOp>({
       id: 'story-not-2',
       op: 'not',
@@ -396,8 +396,8 @@ export default Storybook.story('Uptime Assertions', story => {
     return (
       <Fragment>
         <p>
-          "Assert Not Any" fails if any child assertion passes (negated OR). This is
-          useful for ensuring that none of several error conditions occur.
+          "Assert None" fails if any child assertion passes (negated OR). This is useful
+          for ensuring that none of several error conditions occur.
         </p>
         <AssertionOpGroup value={groupOp} onChange={setGroupOp} />
         <CodeBlock language="javascript">{JSON.stringify(groupOp, null, 2)}</CodeBlock>

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.spec.tsx
@@ -151,7 +151,7 @@ describe('AssertionOpGroup', () => {
       await userEvent.click(document.body);
 
       // Click to remove negation (same "Negate result" option toggles it off)
-      await userEvent.click(screen.getByRole('button', {name: 'Assert Not Any'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Assert None'}));
       await userEvent.click(await screen.findByRole('option', {name: 'Negate result'}));
       await userEvent.click(document.body);
 
@@ -164,9 +164,9 @@ describe('AssertionOpGroup', () => {
       await userEvent.click(await screen.findByRole('option', {name: 'Negate result'}));
       await userEvent.click(document.body);
 
-      // Verify label is "Assert None"
+      // Verify label is "Assert Not All"
       expect(
-        await screen.findByRole('button', {name: 'Assert None'})
+        await screen.findByRole('button', {name: 'Assert Not All'})
       ).toBeInTheDocument();
     });
 

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -20,6 +20,7 @@ import {AnimatedOp} from './opCommon';
 import {AssertionOpHeader} from './opHeader';
 import {AssertionOpJsonPath} from './opJsonPath';
 import {AssertionOpStatusCode} from './opStatusCode';
+import {getGroupOpLabel} from './utils';
 
 interface AssertionOpGroupProps {
   onChange: (op: LogicalOp) => void;
@@ -92,14 +93,7 @@ export function AssertionOpGroup({
     onChange(negated ? {id: newNotId, op: 'not', operand: groupOp} : groupOp);
   };
 
-  // Generate label based on negation and group type
-  const triggerLabel = isNegated
-    ? groupOp.op === 'and'
-      ? t('Assert None')
-      : t('Assert Not Any')
-    : groupOp.op === 'and'
-      ? t('Assert All')
-      : t('Assert Any');
+  const triggerLabel = getGroupOpLabel(groupOp, isNegated);
 
   const {attributes, setNodeRef, setActivatorNodeRef, listeners, isDragging} =
     useDraggable({

--- a/static/app/views/alerts/rules/uptime/assertions/typeGuards.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/typeGuards.tsx
@@ -1,5 +1,6 @@
 import type {
   AndOp,
+  GroupOp,
   HeaderCheckOp,
   JsonPathOp,
   NotOp,
@@ -14,6 +15,10 @@ export function isAndOp(value: Op): value is AndOp {
 
 export function isOrOp(value: Op): value is OrOp {
   return value.op === 'or';
+}
+
+export function isGroupOp(value: Op): value is GroupOp {
+  return isAndOp(value) || isOrOp(value);
 }
 
 export function isNotOp(value: Op): value is NotOp {

--- a/static/app/views/alerts/rules/uptime/assertions/utils.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.tsx
@@ -350,3 +350,15 @@ export function getJsonPathCombinedLabelAndTooltip(op: JsonPathOp): {
 
   return {combinedLabel, combinedTooltip};
 }
+
+export function getGroupOpLabel(op: GroupOp, isNegated: boolean): string {
+  if (op.op === 'and') {
+    // By De Morgan's Laws, NOT (A AND B) is equivalent to (NOT A OR NOT B),
+    // i.e. passing when at least one child fails.
+    return isNegated ? t('Assert Not All') : t('Assert All');
+  }
+
+  // By De Morgan's Laws, NOT (A OR B) is equivalent to (NOT A AND NOT B),
+  // i.e. passing when all children fail.
+  return isNegated ? t('Assert None') : t('Assert Any');
+}


### PR DESCRIPTION
Negates group ops: 
From `NOT then ASSERT ALL then NOT then ASSERT ANY` to `ASSERT NONE then ASSERT NOT ANY`

Adding testing in stacked PR: https://github.com/getsentry/sentry/pull/107783

Relies on it to pass CI ^

Added plenty comments, kept code readable 