### PR TITLE
chore(jira): use paginated projects API instead of deprecated one

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -161,7 +161,9 @@ class JiraIntegration(IssueSyncIntegration):
         try:
             projects: list[JiraProjectMapping] = [
                 JiraProjectMapping(value=p["id"], label=p["name"])
-                for p in client.get_projects_list()
+                for p in client.get_projects_paginated({"maxResults": MAX_PER_PROJECT_QUERIES})[
+                    "values"
+                ]
             ]
             self._set_status_choices_in_organization_config(configuration, projects)
             configuration[0]["addDropdown"]["items"] = projects


### PR DESCRIPTION
Use the not-deprecated projects endpoint

https://github.com/getsentry/sentry/blob/aa709613ffe98848abd10114cef29c261cfac6fa/src/sentry/integrations/jira/client.py#L128-L134

Fixes https://linear.app/getsentry/issue/ISWF-2026/user-has-no-projects-listed-under-jira-sync-settings

The paginated endpoint response looks like this
https://github.com/getsentry/sentry/blob/aa709613ffe98848abd10114cef29c261cfac6fa/fixtures/integrations/jira/stubs/projects_paginated.json#L1-L32

So indexing into `values` to fetch the fields is correct