### PR TITLE
feat(uptime-assertion-failure-tree) Adding snapshot tests for tree class

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/assertionFailureTree.spec.tsx
@@ -56,17 +56,15 @@ describe('AssertionFailureTree', () => {
     render(<AssertionFailureTree assertion={assertion} />);
 
     const rows = screen.getAllByTestId('assertion-failure-tree-row');
-    expect(rows).toHaveLength(4);
+    expect(rows).toHaveLength(3);
 
-    expect(rows[0]!).toHaveTextContent(/Assert All/);
-    expect(rows[1]!).toHaveTextContent(/Assert Any/);
+    expect(rows[0]!).toHaveTextContent(/Assert Any/);
 
-    expect(rows[2]!).toHaveTextContent(
+    expect(rows[1]!).toHaveTextContent(
       /\[Failed\]\s*JSON Path \| Rule:\s*\$\.status\s*=\s*""\s*ok/
     );
 
-    const headerText = rows[3]!.textContent ?? '';
-    expect(headerText).toMatch(
+    expect(rows[2]!).toHaveTextContent(
       /\[Failed\]\s*Header Check \| Rule:\s*key\s*=\s*""\s*content-type,\s*value\s*=\s*""\s*application\/json/
     );
   });

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
@@ -13,15 +13,15 @@ AND - op-1
 
 exports[`Assertion Failure Tree model Merges logical ops - non-root 1`] = `
 "
-(negated) AND - bd67e86b-6eea-a536-32df-35196ff83a42
-  STATUS CODE - op-3
-  JSON PATH - op-4
+(negated) AND - op-3
+  STATUS CODE - op-4
+  JSON PATH - op-5
 "
 `;
 
 exports[`Assertion Failure Tree model Merges logical ops - root 1`] = `
 "
-(negated) OR - f82d9236-6a49-16be-a18d-3fc914aa5f30
-  STATUS CODE - op-3
+(negated) OR - op-3
+  STATUS CODE - op-4
 "
 `;

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/__snapshots__/tree.spec.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Assertion Failure Tree model Builds the expected tree 1`] = `
+"
+AND - op-1
+  STATUS CODE - op-2
+  OR - op-3
+    JSON PATH - op-4
+  (negated) AND - op-6
+    HEADER CHECK - op-7
+"
+`;
+
+exports[`Assertion Failure Tree model Merges logical ops - non-root 1`] = `
+"
+(negated) AND - bd67e86b-6eea-a536-32df-35196ff83a42
+  STATUS CODE - op-3
+  JSON PATH - op-4
+"
+`;
+
+exports[`Assertion Failure Tree model Merges logical ops - root 1`] = `
+"
+(negated) OR - f82d9236-6a49-16be-a18d-3fc914aa5f30
+  STATUS CODE - op-3
+"
+`;

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {AndOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class AndOpTreeNode extends TreeNode<AndOp> {
+  printNode(): string {
+    return `AND - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <AndOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {HeaderCheckOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class HeaderCheckOpTreeNode extends TreeNode<HeaderCheckOp> {
+  printNode(): string {
+    return `HEADER CHECK - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <HeaderCheckOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {JsonPathOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class JsonPathOpTreeNode extends TreeNode<JsonPathOp> {
+  printNode(): string {
+    return `JSON PATH - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <JsonPathOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
@@ -10,6 +10,10 @@ export class NotOpTreeNode extends TreeNode<NotOp> {
     return [this.value.operand];
   }
 
+  printNode(): string {
+    return `NOT - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <NotOpRow />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {OrOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class OrOpTreeNode extends TreeNode<OrOp> {
+  printNode(): string {
+    return `OR - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <OrOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
@@ -6,6 +6,10 @@ import type {StatusCodeOp} from 'sentry/views/alerts/rules/uptime/types';
 import {TreeNode} from './treeNode';
 
 export class StatusCodeOpTreeNode extends TreeNode<StatusCodeOp> {
+  printNode(): string {
+    return `STATUS CODE - ${this.id}`;
+  }
+
   renderRow(): ReactNode {
     return <StatusCodeOpRow node={this} />;
   }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
@@ -8,78 +8,71 @@ import {
 } from 'sentry/views/alerts/rules/uptime/assertions/testUtils';
 import type {Assertion} from 'sentry/views/alerts/rules/uptime/types';
 
-import {AndOpTreeNode} from './andOpTreeNode';
-import {HeaderCheckOpTreeNode} from './headerCheckOpTreeNode';
-import {JsonPathOpTreeNode} from './jsonPathOpTreeNode';
-import {NotOpTreeNode} from './notOpTreeNode';
-import {OrOpTreeNode} from './orOpTreeNode';
-import {StatusCodeOpTreeNode} from './statusCodeOpTreeNode';
 import {Tree} from './tree';
 
 describe('Assertion Failure Tree model', () => {
-  it('FromAssertion builds the expected tree', () => {
-    const leafStatus = makeStatusCodeOp({id: 'op-2', value: 200});
-    const leafJson = makeJsonPathOp({id: 'op-4'});
-    const leafHeader = makeHeaderCheckOp({id: 'op-7'});
-
-    const orGroup = makeOrOp({id: 'op-3', children: [leafJson]});
-
-    const innerAnd = makeAndOp({id: 'op-6', children: [leafHeader]});
-    const notGroup = makeNotOp({id: 'op-5', operand: innerAnd});
-
-    const rootAndOp = makeAndOp({id: 'op-1', children: [leafStatus, orGroup, notGroup]});
-    const assertion: Assertion = {root: rootAndOp};
+  it('Builds the expected tree', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeStatusCodeOp({id: 'op-2', value: 200}),
+          makeOrOp({
+            id: 'op-3',
+            children: [makeJsonPathOp({id: 'op-4'})],
+          }),
+          makeNotOp({
+            id: 'op-5',
+            operand: makeAndOp({
+              id: 'op-6',
+              children: [makeHeaderCheckOp({id: 'op-7'})],
+            }),
+          }),
+        ],
+      }),
+    };
 
     const tree = Tree.FromAssertion(assertion);
 
-    expect(tree.root).not.toBeNull();
-    expect(tree.root).toBeInstanceOf(AndOpTreeNode);
+    expect(tree.serialize()).toMatchSnapshot();
+  });
 
-    expect(tree.nodes.map(n => n.value.id)).toEqual([
-      'op-1',
-      'op-2',
-      'op-3',
-      'op-4',
-      'op-5',
-      'op-6',
-      'op-7',
-    ]);
+  it('Merges logical ops - root', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeNotOp({
+            id: 'op-2',
+            operand: makeOrOp({children: [makeStatusCodeOp({id: 'op-3', value: 200})]}),
+          }),
+        ],
+      }),
+    };
 
-    expect(tree.nodes[0]).toBeInstanceOf(AndOpTreeNode);
-    expect(tree.nodes[1]).toBeInstanceOf(StatusCodeOpTreeNode);
-    expect(tree.nodes[2]).toBeInstanceOf(OrOpTreeNode);
-    expect(tree.nodes[3]).toBeInstanceOf(JsonPathOpTreeNode);
-    expect(tree.nodes[4]).toBeInstanceOf(NotOpTreeNode);
-    expect(tree.nodes[5]).toBeInstanceOf(AndOpTreeNode);
-    expect(tree.nodes[6]).toBeInstanceOf(HeaderCheckOpTreeNode);
+    const tree = Tree.FromAssertion(assertion);
+    expect(tree.serialize()).toMatchSnapshot();
+  });
 
-    // Testing hierarchy
-    const root = tree.root;
-    expect(root!.parent).toBeNull();
-    expect(root!.children.map(n => n.value.id)).toEqual(['op-2', 'op-3', 'op-5']);
+  it('Merges logical ops - non-root', () => {
+    const assertion: Assertion = {
+      root: makeAndOp({
+        id: 'op-1',
+        children: [
+          makeNotOp({
+            id: 'op-2',
+            operand: makeAndOp({
+              children: [
+                makeStatusCodeOp({id: 'op-3', value: 200}),
+                makeJsonPathOp({id: 'op-4'}),
+              ],
+            }),
+          }),
+        ],
+      }),
+    };
 
-    const statusNode = tree.nodes[1];
-    expect(statusNode!.parent).toBe(root);
-    expect(statusNode!.children).toHaveLength(0);
-
-    const orNode = tree.nodes[2];
-    expect(orNode!.parent).toBe(root);
-    expect(orNode!.children.map(n => n.value.id)).toEqual(['op-4']);
-
-    const jsonNode = tree.nodes[3];
-    expect(jsonNode!.parent).toBe(orNode);
-    expect(jsonNode!.children).toHaveLength(0);
-
-    const notNode = tree.nodes[4];
-    expect(notNode!.parent).toBe(root);
-    expect(notNode!.children.map(n => n.value.id)).toEqual(['op-6']);
-
-    const innerAndNode = tree.nodes[5];
-    expect(innerAndNode!.parent).toBe(notNode);
-    expect(innerAndNode!.children.map(n => n.value.id)).toEqual(['op-7']);
-
-    const headerNode = tree.nodes[6];
-    expect(headerNode!.parent).toBe(innerAndNode);
-    expect(headerNode!.children).toHaveLength(0);
+    const tree = Tree.FromAssertion(assertion);
+    expect(tree.serialize()).toMatchSnapshot();
   });
 });

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.spec.tsx
@@ -44,7 +44,10 @@ describe('Assertion Failure Tree model', () => {
         children: [
           makeNotOp({
             id: 'op-2',
-            operand: makeOrOp({children: [makeStatusCodeOp({id: 'op-3', value: 200})]}),
+            operand: makeOrOp({
+              id: 'op-3',
+              children: [makeStatusCodeOp({id: 'op-4', value: 200})],
+            }),
           }),
         ],
       }),
@@ -62,9 +65,10 @@ describe('Assertion Failure Tree model', () => {
           makeNotOp({
             id: 'op-2',
             operand: makeAndOp({
+              id: 'op-3',
               children: [
-                makeStatusCodeOp({id: 'op-3', value: 200}),
-                makeJsonPathOp({id: 'op-4'}),
+                makeStatusCodeOp({id: 'op-4', value: 200}),
+                makeJsonPathOp({id: 'op-5'}),
               ],
             }),
           }),

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
@@ -163,4 +163,19 @@ export class Tree {
       }
     }
   }
+
+  // Used for debugging and snapshot testing
+  serialize(): string {
+    return (
+      '\n' +
+      this.nodes
+        .map(node => {
+          const padding = '  '.repeat(node.depth);
+          return padding + (node.isNegated ? '(negated) ' : '') + node.printNode();
+        })
+        .filter(Boolean)
+        .join('\n') +
+      '\n'
+    );
+  }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.spec.tsx
@@ -17,6 +17,10 @@ class MockTreeNode<T extends Op = Op> extends TreeNode<T> {
       </span>
     );
   }
+
+  printNode(): string {
+    return `${this.value.op} - ${this.value.id}`;
+  }
 }
 
 describe('Assertion Failure TreeNode model', () => {

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
@@ -25,6 +25,10 @@ export abstract class TreeNode<T extends Op = Op> {
     }
   }
 
+  get id(): string {
+    return this.value.id;
+  }
+
   get nextOps(): Op[] {
     return 'children' in this.value ? this.value.children : [];
   }
@@ -70,6 +74,8 @@ export abstract class TreeNode<T extends Op = Op> {
 
     return connectors;
   }
+
+  abstract printNode(): string;
 
   abstract renderRow(): ReactNode;
 }


### PR DESCRIPTION
Makes testing the model much simpler:
<img width="1255" height="607" alt="Screenshot 2026-02-06 at 1 02 30 PM" src="https://github.com/user-attachments/assets/9ca0f06a-e814-467a-a715-7b06d50e021e" />

Also the snapshots let you visualize what you are expecting in the tests:
<img width="505" height="195" alt="Screenshot 2026-02-06 at 1 03 41 PM" src="https://github.com/user-attachments/assets/158ad469-014a-4be3-945a-83bd7d906ec1" />