### PR TITLE
feat(preprod): Add FlaggedInsight model for treemap insight savings

### DIFF
--- a/src/sentry/preprod/size_analysis/models.py
+++ b/src/sentry/preprod/size_analysis/models.py
@@ -69,6 +69,15 @@ class TreemapElementMisc(BaseModel):
     scale: int | None = None
 
 
+class FlaggedInsight(BaseModel):
+    """An insight flagged on a treemap node with its per-file savings."""
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    savings: int = 0
+
+
 class TreemapElement(BaseModel):
 
     model_config = ConfigDict(frozen=True)
@@ -81,7 +90,7 @@ class TreemapElement(BaseModel):
     """ Some files (like zip files) are not directories but have children. """
     children: list[TreemapElement]
     misc: TreemapElementMisc | None = None
-    flagged_insights: list[str] = []
+    flagged_insights: list[str | FlaggedInsight] = []
 
 
 class TreemapResults(BaseModel):

--- a/tests/sentry/preprod/size_analysis/test_compare.py
+++ b/tests/sentry/preprod/size_analysis/test_compare.py
@@ -23,6 +23,7 @@ from sentry.preprod.size_analysis.models import (
     DiffType,
     FileAnalysis,
     FileInfo,
+    FlaggedInsight,
     SizeAnalysisResults,
     SizeMetricDiffItem,
     TreemapElement,
@@ -44,7 +45,7 @@ class CompareSizeAnalysisTest(TestCase):
         path=None,
         children=None,
         element_type="files",
-        flagged_insights: list[str] | None = None,
+        flagged_insights: list[str | FlaggedInsight] | None = None,
     ):
         return TreemapElement(
             name=name,


### PR DESCRIPTION
Add `FlaggedInsight` Pydantic model with `key` and `savings` fields to represent per-file insight savings on treemap nodes. Update `TreemapElement.flagged_insights` from `list[str]` to `list[str | FlaggedInsight]` so the field accepts both plain string keys and the new structured format.

This is backward compatible — existing data with plain string keys continues to deserialize correctly. The launchpad analysis pipeline (getsentry/launchpad#563) will start sending `FlaggedInsight` objects once deployed, and the frontend PR (#107786) renders the savings in treemap tooltips.

Refs LINEAR-EME-802