### PR TITLE
feat(dashboards): Add dashboard link to Network Requests by Time Spent widget

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -194,6 +194,9 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
           aggregates: ['p75(span.duration)'],
           columns: [SpanFields.SPAN_DOMAIN],
           orderby: `-sum(span.duration)`,
+          linkedDashboards: [
+            {dashboardId: '-1', field: SpanFields.SPAN_DOMAIN, staticDashboardId: 5},
+          ],
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Adds a `linkedDashboards` configuration to the "Network Requests by Time Spent" widget in the Frontend Overview prebuilt dashboard
- Links the `span.domain` column to the frontend overview static dashboard (ID 5), enabling users to drill down from the widget into the full dashboard view

## Test plan
- [ ] Verify the Network Requests by Time Spent widget renders correctly
- [ ] Verify clicking on a span domain value navigates to the linked dashboard