### PR TITLE
fix(typing): Use subscript access for required event_id in delayed_processing

### DIFF
--- a/src/sentry/rules/processing/delayed_processing.py
+++ b/src/sentry/rules/processing/delayed_processing.py
@@ -296,16 +296,9 @@ def build_group_to_groupevent(
     group_to_groupevent: dict[Group, tuple[GroupEvent, datetime | None]] = {}
 
     for rule_group, instance_data in parsed_rulegroup_to_event_data.items():
-        event_id = instance_data.get("event_id")
+        event_id = instance_data["event_id"]
         occurrence_id = instance_data.get("occurrence_id")
         start_timestamp = instance_data.get("start_timestamp")
-
-        if event_id is None:
-            logger.info(
-                "delayed_processing.missing_event_id",
-                extra={"rule": rule_group[0], "project_id": project_id},
-            )
-            continue
 
         event = bulk_event_id_to_events.get(event_id)
         group = group_id_to_group.get(int(rule_group[1]))


### PR DESCRIPTION
## Summary
- Use `instance_data["event_id"]` subscript access instead of `.get()` since `event_id` is a required key in the `EventData` TypedDict
- Remove the dead `if event_id is None` branch that could never be reached
- Pre-work for mypy 1.19 upgrade

Ref: https://github.com/getsentry/sentry/pull/107710