### PR TITLE
fix(admin): Use Customer details endpoint rather than deprecated subscription details

### DIFF
--- a/static/gsApp/stores/subscriptionStore.spec.tsx
+++ b/static/gsApp/stores/subscriptionStore.spec.tsx
@@ -22,7 +22,7 @@ describe('SubscriptionStore', () => {
 
   it('should load data', async () => {
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       body: subscription,
     });
 
@@ -35,7 +35,7 @@ describe('SubscriptionStore', () => {
 
   it('should mark trial started and clear trial', async () => {
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       body: subscription,
     });
 

--- a/static/gsApp/stores/subscriptionStore.tsx
+++ b/static/gsApp/stores/subscriptionStore.tsx
@@ -107,7 +107,7 @@ const subscriptionStoreConfig: SubscriptionStoreDefintion = {
     }
     this.loadingData[orgSlug] = true;
 
-    const data = await this.api.requestPromise(`/subscriptions/${orgSlug}/`);
+    const data = await this.api.requestPromise(`/customers/${orgSlug}/`);
     if (markStartedTrial) {
       data.isTrialStarted = true;
     }


### PR DESCRIPTION
The subscription-based path has been considered deprecated for 9 years, since 7c83890.
