### PR TITLE
chore(ui): Lint against arrow functions in renderHook tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -445,6 +445,7 @@ export default typescript.config([
     name: 'plugin/@sentry/sentry',
     plugins: {'@sentry': sentryPlugin},
     rules: {
+      '@sentry/no-inline-render-hook-callback': 'error',
       '@sentry/no-static-translations': 'error',
     },
   },

--- a/static/eslint/eslintPluginSentry/index.mjs
+++ b/static/eslint/eslintPluginSentry/index.mjs
@@ -1,5 +1,7 @@
+import noInlineRenderHookCallback from './no-inline-render-hook-callback.mjs';
 import noStaticTranslations from './no-static-translations.mjs';
 
 export const rules = {
+  'no-inline-render-hook-callback': noInlineRenderHookCallback,
   'no-static-translations': noStaticTranslations,
 };

--- a/static/eslint/eslintPluginSentry/no-inline-render-hook-callback.mjs
+++ b/static/eslint/eslintPluginSentry/no-inline-render-hook-callback.mjs
@@ -1,0 +1,64 @@
+const HOOK_RENDERERS = new Set(['renderHook', 'renderHookWithProviders']);
+
+/**
+ * @param {import('estree').Expression | import('estree').Super | null | undefined} callee
+ * @returns {callee is import('estree').Identifier}
+ */
+function isHookRenderer(callee) {
+  return Boolean(
+    callee && callee.type === 'Identifier' && HOOK_RENDERERS.has(callee.name)
+  );
+}
+
+/**
+ * @param {import('estree').CallExpression['arguments'][number] | undefined} node
+ * @returns {node is import('estree').ArrowFunctionExpression | import('estree').FunctionExpression}
+ */
+function isInlineFunction(node) {
+  return Boolean(
+    node &&
+    (node.type === 'ArrowFunctionExpression' || node.type === 'FunctionExpression')
+  );
+}
+
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const noInlineRenderHookCallback = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow inline callbacks for renderHook and renderHookWithProviders. Pass the hook directly and use initialProps.',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      forbidden:
+        'Do not pass an inline function to {{renderer}}. Pass the hook directly and provide values via `initialProps`.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isHookRenderer(node.callee)) {
+          return;
+        }
+
+        const callbackArg = node.arguments[0];
+        if (!isInlineFunction(callbackArg)) {
+          return;
+        }
+
+        context.report({
+          node: callbackArg,
+          messageId: 'forbidden',
+          data: {renderer: node.callee.name},
+        });
+      },
+    };
+  },
+};
+
+export default noInlineRenderHookCallback;

--- a/static/eslint/eslintPluginSentry/no-inline-render-hook-callback.spec.mjs
+++ b/static/eslint/eslintPluginSentry/no-inline-render-hook-callback.spec.mjs
@@ -1,0 +1,41 @@
+import {RuleTester} from 'eslint';
+
+import noInlineRenderHookCallback from './no-inline-render-hook-callback.mjs';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-inline-render-hook-callback', noInlineRenderHookCallback, {
+  valid: [
+    {
+      code: 'renderHook(useBootstrapOrganizationQuery, {wrapper, initialProps: orgSlug});',
+    },
+    {
+      code: 'renderHookWithProviders(useBootstrapOrganizationQuery, {initialProps: orgSlug});',
+    },
+    {
+      code: 'renderHook(callback, {wrapper});',
+    },
+    {
+      code: 'someOtherRenderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});',
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'renderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});',
+      errors: [{messageId: 'forbidden'}],
+    },
+    {
+      code: 'renderHook(props => useBootstrapOrganizationQuery(props), {wrapper});',
+      errors: [{messageId: 'forbidden'}],
+    },
+    {
+      code: 'renderHookWithProviders(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});',
+      errors: [{messageId: 'forbidden'}],
+    },
+    {
+      code: 'renderHookWithProviders(function () { return useBootstrapOrganizationQuery(orgSlug); }, {wrapper});',
+      errors: [{messageId: 'forbidden'}],
+    },
+  ],
+});


### PR DESCRIPTION
instead point them towards initialProps
