### PR TITLE
feat(seer): Use flagpole to control rendering the seer config reminder

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -101,6 +101,10 @@ function useCanSeeReminder(organization: Organization) {
     [hasSeatBasedSeer, hasLegacySeer, hasCodeReviewBeta, initialStep]
   );
 
+  if (!organization.features.includes('seer-config-reminder')) {
+    return {canSeeReminder: false, analyticsParams};
+  }
+
   if (!hasSeer) {
     return {canSeeReminder: false, analyticsParams};
   }


### PR DESCRIPTION
See also: 
- https://github.com/getsentry/sentry/pull/107798
- https://github.com/getsentry/sentry-options-automator/pull/6388