### PR TITLE
Convert and mark some more superuser -> staff tests 

### DIFF
--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps_stats.py
@@ -45,6 +45,7 @@ class SentryAppsStatsTest(APITestCase):
             "avatars": [serialize(self.app_one_avatar)],
         } in orjson.loads(response.content)
 
+    @override_options({"staff.ga-rollout": False})
     def test_superuser_has_access(self) -> None:
         self.login_as(user=self.superuser, superuser=True)
         response = self.get_success_response(status_code=200)
@@ -57,12 +58,15 @@ class SentryAppsStatsTest(APITestCase):
         response = self.get_success_response(status_code=200)
         self._check_response(response)
 
+    @override_options({"staff.ga-rollout": True})
     def test_nonsuperusers_have_no_access(self) -> None:
         self.login_as(user=self.user)
         self.get_error_response(status_code=403)
 
+    @override_options({"staff.ga-rollout": True})
     def test_per_page(self) -> None:
-        self.login_as(user=self.superuser, superuser=True)
+        staff_user = self.create_user(is_staff=True)
+        self.login_as(user=staff_user, staff=True)
 
         self.create_sentry_app_installation(
             slug=self.app_one.slug, organization=self.create_organization()


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/107368, where I'm trying to convert and mark tests that depends on superusers who should be migrated to staff. This ensures all tests work with staff.ga-rollout=True while maintaining test coverage during the transition. Superuser tests in duplicate pairs can be easily identified and removed later. This is part of the effort to remove the staff.ga-rollout flag and migrate to staff-only mode.

Changes:
- Converted 5 superuser-only tests to staff in test_sentry_app_details.py:
  - test_staff_can_set_publish_request_inprogress_status
  - test_staff_delete_unpublished_app
  - test_staff_delete_unpublished_app_with_installs
  - test_staff_cannot_delete_published_app
  - test_staff_cannot_delete_partner_apps
- Converted 1 superuser-only test to staff in test_sentry_apps_stats.py:
  - test_per_page
- Updated DeleteSentryAppDetailsTest setUp to use staff user by default:
  - Creates staff user as org member in setUp
  - Logs in as staff instead of superuser
  - Simplifies individual test methods (no repeated membership creation)
- Added decorators to ALL tests (47 total):
  - False decorator on superuser tests in duplicate pairs
  - True decorator on all other tests (staff and general tests)

