### PR TITLE
fix(settings): Prevent overflow from OpenTelementry yaml

### DIFF
--- a/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
+++ b/static/app/views/settings/project/projectKeys/credentials/otlp.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
 
 import {CodeBlock} from '@sentry/scraps/code';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -137,10 +138,16 @@ export function OtlpTab({
         inline={false}
         flexibleControlStateSize
       >
-        <CodeBlock language="yaml" filename="config.yaml">
+        <UnsetHeightCodeBlock language="yaml" filename="config.yaml" isRounded>
           {buildCollectorConfig}
-        </CodeBlock>
+        </UnsetHeightCodeBlock>
       </FieldGroup>
     </Fragment>
   );
 }
+
+const UnsetHeightCodeBlock = styled(CodeBlock)`
+  pre {
+    height: unset;
+  }
+`;


### PR DESCRIPTION
height: 100% looking at the parent

before

<img width="884" height="350" alt="image" src="https://github.com/user-attachments/assets/a53c5157-3510-4e8c-a3e1-e5908e4460e0" />


after

<img width="890" height="354" alt="Screenshot 2026-02-06 at 12 25 37 PM" src="https://github.com/user-attachments/assets/34ad3904-a496-4076-9215-a0f4005f0042" />