### PR TITLE
feat(seer): Iterate on copy in the settings pages

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
-  {title: t('Auto Fix'), key: 'fixes'},
+  {title: t('Root Cause Analysis'), key: 'fixes'},
   {title: t('PR Creation'), key: 'pr_creation'},
   {
     title: (

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -27,6 +27,7 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Name'), key: 'name', sortKey: 'name'},
+  {title: t('Code Review'), key: 'code_review'},
   {
     title: (
       <Flex gap="sm" align="center">
@@ -42,7 +43,6 @@ const COLUMNS = [
     ),
     key: 'trigger',
   },
-  {title: t('Code Review'), key: 'code_review'},
 ];
 
 export default function SeerRepoTableHeader({

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -99,19 +99,6 @@ export default function SeerRepoTableRow({
         </Stack>
       </SimpleTable.RowCell>
       <SimpleTable.RowCell justify="end">
-        <Text size="sm">
-          {repository.settings?.codeReviewTriggers
-            .sort()
-            .map(triggerToLabel)
-            .map((label, index, array) => (
-              <div key={label}>
-                {label}
-                {index === array.length - 1 ? '' : ', '}
-              </div>
-            ))}
-        </Text>
-      </SimpleTable.RowCell>
-      <SimpleTable.RowCell justify="end">
         <Switch
           disabled={!canWrite}
           checked={repository.settings?.enabledCodeReview ?? false}
@@ -157,6 +144,19 @@ export default function SeerRepoTableRow({
             );
           }}
         />
+      </SimpleTable.RowCell>
+      <SimpleTable.RowCell justify="end">
+        <Text size="sm">
+          {repository.settings?.codeReviewTriggers
+            .sort()
+            .map(triggerToLabel)
+            .map((label, index, array) => (
+              <div key={label}>
+                {label}
+                {index === array.length - 1 ? '' : ', '}
+              </div>
+            ))}
+        </Text>
       </SimpleTable.RowCell>
     </SimpleTable.Row>
   );

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
@@ -57,9 +57,9 @@ export default function SeerSettingsPageWrapper({children}: Props) {
       <SettingsPageHeader
         title={t('Seer')}
         subtitle={tct(
-          'Choose how Seer automatically triages and diagnoses incoming issues before you even notice them. Seer currently includes [autofix:Autofix], an agent that can root-cause issues and create pull requests, and [code_review:AI Code Review], an agent that will review your pull requests to detect issues before they happen.',
+          'Choose how Seer automatically triages and diagnoses incoming issues before you even notice them. Seer currently includes [rca:Root Cause Analysis], an agent that can root-cause issues and create pull requests, and [code_review:AI Code Review], an agent that will review your pull requests to detect issues before they happen.',
           {
-            autofix: (
+            rca: (
               <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/issue-fix/#root-cause-analysis" />
             ),
             code_review: (

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -81,7 +81,7 @@ export default function SeerAutomationSettings() {
                 },
                 {
                   name: 'autoOpenPrs',
-                  label: t('Enable Autofix PR Creation by Default'),
+                  label: t('Allow Root Cause Analysis to create PRs by Default'),
                   help: t(
                     'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
                   ),


### PR DESCRIPTION
The product is Root Cause Analysis now, not Autofix anymore

| Where | Before | After |
| --- | --- | --- |
| Across all the settings, projects, repos lists "Autofix" link renamed | <img width="628" height="167" alt="SCR-20260206-lkdw" src="https://github.com/user-attachments/assets/3c6e3b91-4208-4129-b440-a151529f73e0" /> | <img width="627" height="174" alt="SCR-20260206-lkeu" src="https://github.com/user-attachments/assets/4917f722-922e-4489-ab72-28b2f8fdd355" />
| Main seer settings, "Enable Autofix PR Creation by Default" renamed | <img width="564" height="256" alt="SCR-20260206-lkpx" src="https://github.com/user-attachments/assets/5081b1d3-ac19-4cfd-9c0e-03abd6963c8d" /> | <img width="556" height="257" alt="SCR-20260206-lkqu" src="https://github.com/user-attachments/assets/265b85f0-fad9-4355-b08d-e04f8c31f2ec" />
| Project List headers | <img width="915" height="192" alt="SCR-20260206-llfs" src="https://github.com/user-attachments/assets/8beceec3-2d77-4d60-9544-bef5982f5b71" /> | <img width="916" height="194" alt="SCR-20260206-lldz" src="https://github.com/user-attachments/assets/5cee355e-1156-4fdf-aff0-72439641eb4f" />
| Repo list header order | <img width="925" height="127" alt="SCR-20260206-llra" src="https://github.com/user-attachments/assets/af221517-b8a3-4aaa-aa7c-7e46e6aa6186" /> | <img width="910" height="120" alt="SCR-20260206-llrz" src="https://github.com/user-attachments/assets/932b986c-ac61-46b1-9463-784722a2821e" />
