### PR TITLE
ref(grouping): Parameterize messages in custom fingerprints

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from sentry.grouping.fingerprinting.types import FingerprintInfo
+from sentry.grouping.utils import normalize_message_for_grouping
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -229,7 +230,12 @@ def resolve_fingerprint_variable(
             or get_path(event.data, "logentry", "message")
             or get_path(event.data, "exception", "values", -1, "value")
         )
-        return message or "<no-message>"
+        normalized_message = (
+            normalize_message_for_grouping(message, event, source="fingerprint", trim_message=False)
+            if message
+            else None
+        )
+        return normalized_message or "<no-message>"
 
     elif variable_key in ("type", "error.type"):
         exception_type = get_path(event.data, "exception", "values", -1, "type")

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: fingerprint
 hashing_metadata: {
   "client_fingerprint": "['{{ message }}', 'dogs are great']",
-  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring 2 balls back!\", 'dogs are great']",
+  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring <int> balls back!\", 'dogs are great']",
   "fingerprint_source": "client",
   "is_hybrid_fingerprint": false
 }
@@ -21,6 +21,6 @@ metrics with tags: {
 ---
 contributing variants:
   custom_client_fingerprint*
-    hash: "69d81763f9ec386fc0c0607ef62cabfa"
+    hash: "b31e899e08ed071ee0534f28745910d0"
     fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
-    values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]
+    values: ["FailedToFetchError: Charlie didn't bring <int> balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouphash_metadata/test_metadata_from_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -4,7 +4,7 @@ source: tests/sentry/grouping/test_grouphash_metadata.py::test_metadata_from_var
 hash_basis: fingerprint
 hashing_metadata: {
   "client_fingerprint": "['{{ message }}', 'dogs are great']",
-  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring 2 balls back!\", 'dogs are great']",
+  "fingerprint": "[\"FailedToFetchError: Charlie didn't bring <int> balls back!\", 'dogs are great']",
   "fingerprint_source": "client",
   "is_hybrid_fingerprint": false
 }
@@ -21,6 +21,6 @@ metrics with tags: {
 ---
 contributing variants:
   custom_client_fingerprint*
-    hash: "69d81763f9ec386fc0c0607ef62cabfa"
+    hash: "b31e899e08ed071ee0534f28745910d0"
     fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
-    values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]
+    values: ["FailedToFetchError: Charlie didn't bring <int> balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -60,12 +60,12 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       ],
       "contributes": true,
       "description": "custom client fingerprint",
-      "hash": "69d81763f9ec386fc0c0607ef62cabfa",
+      "hash": "b31e899e08ed071ee0534f28745910d0",
       "hint": null,
       "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
-        "FailedToFetchError: Charlie didn't bring 2 balls back!",
+        "FailedToFetchError: Charlie didn't bring <int> balls back!",
         "dogs are great"
       ]
     }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -60,12 +60,12 @@ source: tests/sentry/grouping/test_grouping_info.py::test_grouping_info
       ],
       "contributes": true,
       "description": "custom client fingerprint",
-      "hash": "69d81763f9ec386fc0c0607ef62cabfa",
+      "hash": "b31e899e08ed071ee0534f28745910d0",
       "hint": null,
       "key": "custom_client_fingerprint",
       "type": "custom_fingerprint",
       "values": [
-        "FailedToFetchError: Charlie didn't bring 2 balls back!",
+        "FailedToFetchError: Charlie didn't bring <int> balls back!",
         "dogs are great"
       ]
     }

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2023_01_11/custom_fingerprint_message_parameterization.pysnap
@@ -14,6 +14,6 @@ app:
           "FailedToFetchError: Charlie didn't bring <int> balls back!"
 --------------------------------------------------------------------------
 custom_client_fingerprint:
-  hash: "69d81763f9ec386fc0c0607ef62cabfa"
+  hash: "b31e899e08ed071ee0534f28745910d0"
   fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
-  values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]
+  values: ["FailedToFetchError: Charlie didn't bring <int> balls back!","dogs are great"]

--- a/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/variants/test_variants/newstyle@2026_01_20/custom_fingerprint_message_parameterization.pysnap
@@ -14,6 +14,6 @@ app:
           "FailedToFetchError: Charlie didn't bring <int> balls back!"
 --------------------------------------------------------------------------
 custom_client_fingerprint:
-  hash: "69d81763f9ec386fc0c0607ef62cabfa"
+  hash: "b31e899e08ed071ee0534f28745910d0"
   fingerprint_info: {"client_fingerprint":["{{ message }}","dogs are great"]}
-  values: ["FailedToFetchError: Charlie didn't bring 2 balls back!","dogs are great"]
+  values: ["FailedToFetchError: Charlie didn't bring <int> balls back!","dogs are great"]


### PR DESCRIPTION
When we group events based on either a log message (from `captureMessage`) or an error message, we first do our best to parameterize them, so that `Error with user 1` and `Error with user 2` don't create separate groups. The same is not true, however, if that message appears as part of a custom fingerprint. This PR fixes that, by using the same `normalize_message_for_grouping` helper that we use in the first two cases in the latter case.

Note: Since prior to this change messages in fingerprints haven't been getting trimmed, this change preserves that behavior by setting `trim_message` to `False`. This is different from what we do when we're grouping log or error message directly, but means that message-containing fingerprints unaffected by parameterization won't change as a result of this PR.