### PR TITLE
feat(seer): Update copy and link targets for the Seer Config Reminder

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -145,21 +145,27 @@ function useReminderCopywriting() {
       description: t(
         'Seer is enabled, but Github is not connected. Connect your GitHub account to enable Root Cause Analysis and Code Review.'
       ),
-      pathname: `/settings/${organization.slug}/seer/onboarding/`,
+      pathname: hasLegacySeer
+        ? `/settings/${organization.slug}/seer/`
+        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_ROOT_CAUSE_ANALYSIS]: {
       title: t('Start using Seer\u2019s Issue Autofix'),
       description: t(
         'Seer is enabled but Root Cause Analysis is not configured. Configure Seer to automatically look at issues and generate code fixes.'
       ),
-      pathname: `/settings/${organization.slug}/seer/projects/`,
+      pathname: hasLegacySeer
+        ? `/settings/${organization.slug}/seer/`
+        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_CODE_REVIEW]: {
       title: t('Start using Seer\u2019s AI Code Review'),
       description: t(
         'Seer is enabled but Code Review is not configured for any repos. Configure Seer to automatically review PRs and flag potential issues.'
       ),
-      pathname: `/settings/${organization.slug}/seer/repos/`,
+      pathname: hasLegacySeer
+        ? `/settings/${organization.slug}/seer/repos/`
+        : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_DEFAULTS]: null,
     [Steps.WRAP_UP]: null,

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -101,9 +101,9 @@ function useCanSeeReminder(organization: Organization) {
     [hasSeatBasedSeer, hasLegacySeer, hasCodeReviewBeta, initialStep]
   );
 
-  // if (!organization.features.includes('seer-config-reminder')) {
-  //   return {canSeeReminder: false, analyticsParams};
-  // }
+  if (!organization.features.includes('seer-config-reminder')) {
+    return {canSeeReminder: false, analyticsParams};
+  }
 
   if (!hasSeer) {
     return {canSeeReminder: false, analyticsParams};

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -164,7 +164,7 @@ function useReminderCopywriting() {
         'Seer is enabled but Code Review is not configured for any repos. Configure Seer to automatically review PRs and flag potential issues.'
       ),
       pathname: hasLegacySeer
-        ? `/settings/${organization.slug}/seer/repos/`
+        ? `/settings/${organization.slug}/seer/?tab=repos`
         : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_DEFAULTS]: null,

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
@@ -2,7 +2,7 @@ import {useSeerOnboardingCheck} from 'sentry/utils/useSeerOnboardingCheck';
 
 import {Steps} from 'getsentry/views/seerAutomation/onboarding/types';
 
-export function useSeerOnboardingStep() {
+export function useSeerOnboardingStep(): {initialStep: Steps; isPending: boolean} {
   const {isPending, data} = useSeerOnboardingCheck({staleTime: 60_000});
 
   let initialStep = Steps.CONNECT_GITHUB;


### PR DESCRIPTION
In all cases we only show a reminder if the org has Seer somehow (through a business trial, seer-specific product trial, or if seer is added fully to their subscription).

We only show it if something is not yet configured. The criteria are different depending on where people started; but for net-new orgs the goal is for them to have:
1. Github Integration
2. AT LEAST ONE OF: root-cause-analysis OR code-review. 

So if an org doesn't have both those things we'll show a reminder for them to fill in the missing piece.

| Context | Img | 
| --- | --- |
| Needs Github Setup | <img width="481" height="192" alt="SCR-20260210-mxei" src="https://github.com/user-attachments/assets/aab5f489-3834-4f8e-800a-7f7b7d6d004b" />
| Needs either: rca or code-review | <img width="480" height="194" alt="SCR-20260210-mxfq" src="https://github.com/user-attachments/assets/762dc1cc-4baa-444d-8d8d-a08f019460c4" />
| Needs code review only | <img width="472" height="187" alt="SCR-20260210-mxgp" src="https://github.com/user-attachments/assets/f3fec11b-1073-436e-a82c-6da6ad3a9202" />
