### PR TITLE
feat(seer): Rename "Agent Delegation" to "Coding Agent" in settings

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/backgroundAgentFields.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/backgroundAgentFields.tsx
@@ -59,7 +59,9 @@ function CursorIntegrationFields({
   if (!isAutoFixEnabled) {
     disabledReason = t('Turn on Auto-Triggered Fixes to use this feature.');
   } else if (!isBackgroundAgentEnabled) {
-    disabledReason = t('This setting is only available when using background agents.');
+    disabledReason = t(
+      'This setting is only available when using an external coding agent.'
+    );
   }
 
   return (

--- a/static/gsApp/views/seerAutomation/components/projectDetails/backgroundAgentPicker.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/backgroundAgentPicker.tsx
@@ -90,16 +90,16 @@ export default function BackgroundAgentPicker({
                   onSuccess: () =>
                     addSuccessMessage(
                       value
-                        ? tct('Started using [name] background agent', {
+                        ? tct('Started using [name] as coding agent', {
                             name: <strong>{integration.name}</strong>,
                           })
-                        : tct('Stopped using [name] background agent', {
+                        : tct('Stopped using [name] as coding agent', {
                             name: <strong>{integration.name}</strong>,
                           })
                     ),
                   onError: () =>
                     addErrorMessage(
-                      tct('Failed to enable [name] background agent', {
+                      tct('Failed to set [name] as coding agent', {
                         name: <strong>{integration.name}</strong>,
                       })
                     ),
@@ -156,18 +156,18 @@ export default function BackgroundAgentPicker({
             onSuccess: () =>
               addSuccessMessage(
                 integration
-                  ? tct('Started using [name] background agent', {
+                  ? tct('Started using [name] as coding agent', {
                       name: <strong>{integration.name}</strong>,
                     })
-                  : t('Stopped using background agent')
+                  : t('Removed coding agent')
               ),
             onError: () =>
               addErrorMessage(
                 integration
-                  ? tct('Failed to enable [name] background agent', {
+                  ? tct('Failed to set [name] as coding agent', {
                       name: <strong>{integration.name}</strong>,
                     })
-                  : t('Failed to disable background agent')
+                  : t('Failed to update coding agent')
               ),
           }
         );

--- a/static/gsApp/views/seerAutomation/components/projectDetails/seerAgentSection.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/seerAgentSection.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 /**
  * Toggle for allowing PR auto creation within the Seer Agent section.
- * This is disabled when background agents are configured.
+ * This is disabled when an external coding agent is configured.
  */
 export default function SeerAgentSection({canWrite, project, preference}: Props) {
   const organization = useOrganization();
@@ -50,7 +50,9 @@ export default function SeerAgentSection({canWrite, project, preference}: Props)
   } else if (!isAutoFixEnabled) {
     disabledReason = t('Turn on Auto-Triggered Fixes to use this feature.');
   } else if (isBackgroundAgentEnabled) {
-    disabledReason = t('This setting is not available when using background agents.');
+    disabledReason = t(
+      'This setting is not available when using an external coding agent.'
+    );
   }
 
   return (

--- a/static/gsApp/views/seerAutomation/components/projectDetails/seerSettingsContainer.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/seerSettingsContainer.tsx
@@ -76,7 +76,7 @@ export default function SeerSettingsContainer({canWrite, preference, project}: P
       {showBackgroundAgentSection && (
         <Fragment>
           <PanelNoMargin>
-            <PanelHeader>{t('Agent Delegation')}</PanelHeader>
+            <PanelHeader>{t('Coding Agent')}</PanelHeader>
             <PanelBody>
               <BackgroundAgentPicker
                 supportedIntegrations={supportedIntegrations}

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -60,7 +60,7 @@ const COLUMNS = [
         {t('Coding Agent')}
         <QuestionTooltip
           title={t(
-            'Coding agent delegation can only be changed on the individual project settings page.'
+            'Coding agent delegation can only be changed on the individual project settings page. Coding agents have more settings that are not shown here.'
           )}
           size="xs"
         />

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -57,10 +57,10 @@ const COLUMNS = [
   {
     title: (
       <Flex gap="sm" align="center">
-        {t('Background Agent')}
+        {t('Coding Agent')}
         <QuestionTooltip
           title={t(
-            'Background agent delegation can only be changed on the individual project settings page. Background agents have more settings that are not shown here.'
+            'Coding agent delegation can only be changed on the individual project settings page.'
           )}
           size="xs"
         />

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -108,7 +108,9 @@ export default function SeerProjectTableRow({
           <Flex align="center" gap="sm">
             {'n/a'}
             <QuestionTooltip
-              title={t('This setting does not apply to background agents.')}
+              title={t(
+                'This setting does not apply when using an external coding agent.'
+              )}
               size="xs"
             />
           </Flex>

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -113,9 +113,9 @@ export default function SeerAutomationSettings() {
                 {
                   visible: false, // TODO(ryan953): Disabled until the backend is fully ready
                   name: 'allowBackgroundAgentDelegation',
-                  label: t('Allow Delegation to Background Agents'),
+                  label: t('Allow Delegation to External Coding Agents'),
                   help: tct(
-                    'Enable this to allow projects to use Agents other than Seer for automation tasks. [docs:Read the docs] to learn more.',
+                    'Enable this to allow projects to use coding agents other than Seer for automation tasks. [docs:Read the docs] to learn more.',
                     {
                       docs: (
                         <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />


### PR DESCRIPTION
## Summary

Unifies terminology across org-level and project-level Seer settings to consistently use **"Coding Agent"** instead of "Agent Delegation" or "Background Agent".

**Changes:**
- Org-level project table: "Background Agent" column → "Coding Agent"
- Project-level settings: "Agent Delegation" panel → "Coding Agent"
- Org-level settings: "Allow Delegation to Background Agents" → "Allow Delegation to External Coding Agents"
- All tooltips, disabled reasons, and toast messages updated to use "coding agent" terminology

Slack thread here: https://sentry.slack.com/archives/C0AAF0JD0GK/p1770420115850909?thread_ts=1770409158.925689&cid=C0AAF0JD0GK