### PR TITLE
fix(settings): Add tooltip to explain Unknown Provider on repos page

### DIFF
--- a/static/app/components/repositoryRow.spec.tsx
+++ b/static/app/components/repositoryRow.spec.tsx
@@ -20,6 +20,9 @@ describe('RepositoryRow', () => {
   const pendingRepo = RepositoryFixture({
     status: RepositoryStatus.PENDING_DELETION,
   });
+  const unknownProviderRepo = RepositoryFixture({
+    provider: {id: 'unknown', name: 'Unknown Provider'},
+  });
 
   describe('rendering with access', () => {
     const organization = OrganizationFixture({
@@ -38,6 +41,34 @@ describe('RepositoryRow', () => {
 
       // No cancel button
       expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
+    });
+
+    it('displays "Unknown Provider" with a help tooltip for repos without a provider', () => {
+      render(
+        <RepositoryRow
+          repository={unknownProviderRepo}
+          orgSlug={organization.slug}
+          showProvider
+        />,
+        {organization}
+      );
+
+      expect(screen.getByText('Unknown Provider')).toBeInTheDocument();
+      expect(screen.getByTestId('more-information')).toBeInTheDocument();
+    });
+
+    it('displays provider name when provider is known', () => {
+      render(
+        <RepositoryRow
+          repository={repository}
+          orgSlug={organization.slug}
+          showProvider
+        />,
+        {organization}
+      );
+
+      expect(screen.getByText('github')).toBeInTheDocument();
+      expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
     });
 
     it('displays cancel pending button', () => {

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -2,17 +2,18 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Stack} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {cancelDeleteRepository, hideRepository} from 'sentry/actionCreators/integrations';
 import Access from 'sentry/components/acl/access';
 import Confirm from 'sentry/components/confirm';
 import PanelItem from 'sentry/components/panels/panelItem';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import getRepoStatusLabel from 'sentry/components/repositories/getRepoStatusLabel';
 import {IconDelete} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Repository} from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
@@ -96,7 +97,23 @@ export default function RepositoryRow({
               )}
             </RepositoryTitle>
             <div>
-              {showProvider && <small>{repository.provider.name}</small>}
+              {showProvider && (
+                <Flex as="span" align="center" gap="xs" display="inline-flex">
+                  <small>{repository.provider.name}</small>
+                  {repository.provider.id === 'unknown' && (
+                    <QuestionTooltip
+                      isHoverable
+                      size="xs"
+                      title={tct(
+                        'This repository is not linked to a source code management integration. It was detected from your release or stack trace data. [link:Set up an integration].',
+                        {
+                          link: <Link to={`/settings/${orgSlug}/integrations/`} />,
+                        }
+                      )}
+                    />
+                  )}
+                </Flex>
+              )}
               {showProvider && repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
               {repository.url && (
                 <small>


### PR DESCRIPTION
## Summary
- Repositories created via release commits or auto source code config have no provider set, showing a confusing "Unknown Provider" label on `/settings/repos/`
- Adds a `QuestionTooltip` beside the label explaining the repo was detected from release or stack trace data, with a link to set up an integration

Before:
<img width="700" alt="CleanShot 2026-02-06 at 15 41 46@2x" src="https://github.com/user-attachments/assets/bb89e532-b7ea-474c-9d22-ae982f4afce2" />

After:
<img width="700" alt="CleanShot 2026-02-06 at 15 42 53@2x" src="https://github.com/user-attachments/assets/f94966d7-0a9c-44f8-9ef7-5af8b09da014" />


## Test plan
- [x] Existing tests pass
- [x] Added test: tooltip appears for unknown-provider repos
- [x] Added test: tooltip does not appear for known-provider repos
- [x] ESLint, Prettier, Stylelint all pass