### PR TITLE
feat(preprod): Snapshots upload API

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -19,6 +19,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodArtifactApiAssembleEvent
+from sentry.preprod.api.schemas import SHA_PATTERN, VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.exceptions import NoPreprodQuota
 from sentry.preprod.tasks import assemble_preprod_artifact, create_preprod_artifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
@@ -70,10 +71,10 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict[str, Any
     schema = {
         "type": "object",
         "properties": {
-            "checksum": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+            "checksum": {"type": "string", "pattern": SHA_PATTERN},
             "chunks": {
                 "type": "array",
-                "items": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+                "items": {"type": "string", "pattern": SHA_PATTERN},
             },
             # Optional metadata
             "build_configuration": {"type": "string"},
@@ -83,15 +84,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict[str, Any
                 "items": {"type": "string", "maxLength": 255},
                 "minItems": 1,
             },
-            # VCS parameters - allow empty strings to support clearing auto-filled values
-            "head_sha": {"type": "string", "pattern": "^(|[0-9a-f]{40})$"},
-            "base_sha": {"type": "string", "pattern": "^(|[0-9a-f]{40})$"},
-            "provider": {"type": "string", "maxLength": 255},
-            "head_repo_name": {"type": "string", "maxLength": 255},
-            "base_repo_name": {"type": "string", "maxLength": 255},
-            "head_ref": {"type": "string", "maxLength": 255},
-            "base_ref": {"type": "string", "maxLength": 255},
-            "pr_number": {"type": "integer", "minimum": 1},
+            **VCS_SCHEMA_PROPERTIES,
         },
         "required": ["checksum", "chunks"],
         "additionalProperties": False,
@@ -103,14 +96,7 @@ def validate_preprod_artifact_schema(request_body: bytes) -> tuple[dict[str, Any
         "build_configuration": "The build_configuration field must be a string.",
         "release_notes": "The release_notes field must be a string.",
         "install_groups": "The install_groups field must be an array of strings, each with maximum length of 255 characters.",
-        "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
-        "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
-        "provider": "The provider field must be a string with maximum length of 255 characters containing the domain of the VCS provider (ex. github.com)",
-        "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
-        "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
-        "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",
-        "base_ref": "The base_ref field must be a string with maximum length of 255 characters.",
-        "pr_number": "The pr_number field must be a positive integer.",
+        **VCS_ERROR_MESSAGES,
     }
 
     try:

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -142,7 +142,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         pr_number = data.get("pr_number")
 
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
-            # Create CommitComparison if VCS info is provided
             commit_comparison = None
             if head_sha and provider and head_repo_name and head_ref:
                 commit_comparison, _ = CommitComparison.objects.get_or_create(
@@ -159,7 +158,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     },
                 )
 
-            # Create new PreprodArtifact for snapshots
             artifact = PreprodArtifact.objects.create(
                 project=project,
                 state=PreprodArtifact.ArtifactState.UPLOADED,
@@ -182,16 +180,13 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 },
             )
 
-            # Serialize manifest using the Pydantic model for consistent format
-            manifest = SnapshotManifest(images=images)
-
             session = get_preprod_session(project.organization_id, project.id)
             manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
 
+            manifest = SnapshotManifest(images=images)
             manifest_json = manifest.json(by_alias=True, exclude_none=True)
             session.put(manifest_json.encode(), key=manifest_key)
 
-            # Store manifest file reference in extras
             extras = snapshot_metrics.extras or {}
             extras["manifest_key"] = manifest_key
             snapshot_metrics.extras = extras

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -21,23 +21,12 @@ from sentry.models.project import Project
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.manifest import (
-    AndroidImageMetadata,
-    BYOImageMetadata,
-    SnapshotManifest,
-)
+from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
-
-SNAPSHOT_IMAGE_SCHEMA: dict[str, Any] = {
-    "anyOf": [
-        BYOImageMetadata.schema(),
-        AndroidImageMetadata.schema(),
-    ]
-}
 
 SNAPSHOT_REQUEST_SCHEMA: dict[str, Any] = {
     "type": "object",
@@ -45,7 +34,7 @@ SNAPSHOT_REQUEST_SCHEMA: dict[str, Any] = {
         "app_id": {"type": "string", "maxLength": 255},
         "images": {
             "type": "object",
-            "additionalProperties": SNAPSHOT_IMAGE_SCHEMA,
+            "additionalProperties": ImageMetadata.schema(),
             "maxProperties": 1000,
         },
         **VCS_SCHEMA_PROPERTIES,
@@ -184,7 +173,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
 
             manifest = SnapshotManifest(images=images)
-            manifest_json = manifest.json(by_alias=True, exclude_none=True)
+            manifest_json = manifest.json(exclude_none=True)
             session.put(manifest_json.encode(), key=manifest_key)
 
             extras = snapshot_metrics.extras or {}

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -128,6 +128,8 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         provider = data.get("provider")
         head_repo_name = data.get("head_repo_name")
         head_ref = data.get("head_ref")
+        base_repo_name = data.get("base_repo_name")
+        base_ref = data.get("base_ref")
         pr_number = data.get("pr_number")
 
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
@@ -140,9 +142,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     head_repo_name=head_repo_name,
                     defaults={
                         "provider": provider,
-                        "base_repo_name": head_repo_name,
+                        "base_repo_name": base_repo_name or head_repo_name,
                         "head_ref": head_ref,
-                        "base_ref": None,
+                        "base_ref": base_ref,
                         "pr_number": pr_number,
                     },
                 )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -20,65 +20,58 @@ from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.files.file import File
 from sentry.models.project import Project
-from sentry.preprod.api.schemas import VCS_SCHEMA_PROPERTIES
+from sentry.preprod.api.schemas import (
+    VCS_ERROR_MESSAGES,
+    VCS_SCHEMA_PROPERTIES,
+    VCS_SCHEMA_REQUIRED,
+)
 from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.manifest import (
+    AndroidImageMetadata,
+    BYOImageMetadata,
+    SnapshotManifest,
+)
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils.json import dumps_htmlsafe
 
 logger = logging.getLogger(__name__)
 
-# Shared base properties for all image manifest types
-BASE_IMAGE_PROPERTIES: dict[str, Any] = {
-    "fileName": {"type": "string"},
-    "groupName": {"type": ["string", "null"]},
-    "displayName": {"type": ["string", "null"]},
-    "precision": {"type": ["integer", "null"], "minimum": 0},
-    "width": {"type": "integer", "minimum": 0},
-    "height": {"type": "integer", "minimum": 0},
-    "imageId": {"type": ["string", "null"]},
-}
-
-BASE_IMAGE_REQUIRED = ["width", "height"]
-
-BYO_IMAGE_SCHEMA: dict[str, Any] = {
-    "type": "object",
-    "properties": {
-        **BASE_IMAGE_PROPERTIES,
-        "darkMode": {"type": "boolean"},
-        "orientation": {"type": "string", "enum": ["landscape", "portrait"]},
-        "device": {"type": "string"},
-    },
-    "required": [*BASE_IMAGE_REQUIRED, "orientation", "device"],
-    "additionalProperties": False,
-}
-
 SNAPSHOT_IMAGE_SCHEMA: dict[str, Any] = {
     "anyOf": [
-        BYO_IMAGE_SCHEMA,
-        # Add other image schemas here as needed (e.g. iOS/Android/etc)
+        BYOImageMetadata.schema(),
+        AndroidImageMetadata.schema(),
     ]
+}
+
+SNAPSHOT_REQUEST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "app_id": {"type": "string", "maxLength": 255},
+        "images": {"type": "object", "additionalProperties": SNAPSHOT_IMAGE_SCHEMA},
+        **VCS_SCHEMA_PROPERTIES,
+    },
+    "required": ["app_id", "images", *VCS_SCHEMA_REQUIRED],
+    "additionalProperties": True,
+}
+
+SNAPSHOT_REQUEST_ERROR_MESSAGES: dict[str, str] = {
+    "app_id": "The app_id field is required and must be a string with maximum length of 255 characters.",
+    "images": "The images field is required and must be an object mapping image names to image metadata.",
+    **VCS_ERROR_MESSAGES,
 }
 
 
 def validate_preprod_snapshot_schema(request_body: bytes) -> tuple[dict[str, Any], str | None]:
-    schema = {
-        "type": "object",
-        "properties": {
-            **VCS_SCHEMA_PROPERTIES,
-            "images": {"type": "object", "additionalProperties": SNAPSHOT_IMAGE_SCHEMA},
-        },
-        "required": ["images"],
-        "additionalProperties": True,
-    }
-
     try:
         data = orjson.loads(request_body)
-        jsonschema.validate(data, schema)
+        jsonschema.validate(data, SNAPSHOT_REQUEST_SCHEMA)
         return data, None
     except jsonschema.ValidationError as e:
         error_message = e.message
+        if e.path:
+            if field := e.path[0]:
+                error_message = SNAPSHOT_REQUEST_ERROR_MESSAGES.get(str(field), error_message)
         return {}, error_message
     except (orjson.JSONDecodeError, TypeError):
         return {}, "Invalid json body"
@@ -138,7 +131,8 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         if error_message:
             return Response({"detail": error_message}, status=400)
 
-        images = data.get("images", [])
+        app_id = data.get("app_id")
+        images = data.get("images", {})
 
         # VCS info
         head_sha = data.get("head_sha")
@@ -168,6 +162,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             artifact = PreprodArtifact.objects.create(
                 project=project,
                 state=PreprodArtifact.ArtifactState.UPLOADED,
+                app_id=app_id,
                 commit_comparison=commit_comparison,
             )
 
@@ -197,17 +192,17 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 snapshot_metrics.extras = extras
                 snapshot_metrics.save(update_fields=["image_count", "extras"])
 
-            # Store manifest data in object store
-            manifest_data = {
-                "images": images,
-            }
+            # Serialize manifest using the Pydantic model for consistent format
+            manifest = SnapshotManifest(images=images)
 
+            # TODO: need to store in object store
             manifest_file = File.objects.create(
                 name="snapshot.json",
                 type="preprod.snapshot_manifest",
                 headers={"Content-Type": "application/json"},
             )
-            manifest_file.putfile(BytesIO(dumps_htmlsafe(manifest_data).encode()))
+            manifest_json = manifest.json(by_alias=True)
+            manifest_file.putfile(BytesIO(manifest_json.encode()))
 
             # Store manifest file reference in extras
             extras = snapshot_metrics.extras or {}

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from io import BytesIO
 from typing import Any
 
 import jsonschema
@@ -18,13 +17,9 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.models.commitcomparison import CommitComparison
-from sentry.models.files.file import File
 from sentry.models.project import Project
-from sentry.preprod.api.schemas import (
-    VCS_ERROR_MESSAGES,
-    VCS_SCHEMA_PROPERTIES,
-    VCS_SCHEMA_REQUIRED,
-)
+from sentry.objectstore import get_preprod_session
+from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.manifest import (
     AndroidImageMetadata,
@@ -48,10 +43,14 @@ SNAPSHOT_REQUEST_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
         "app_id": {"type": "string", "maxLength": 255},
-        "images": {"type": "object", "additionalProperties": SNAPSHOT_IMAGE_SCHEMA},
+        "images": {
+            "type": "object",
+            "additionalProperties": SNAPSHOT_IMAGE_SCHEMA,
+            "maxProperties": 1000,
+        },
         **VCS_SCHEMA_PROPERTIES,
     },
-    "required": ["app_id", "images", *VCS_SCHEMA_REQUIRED],
+    "required": ["app_id", "images"],
     "additionalProperties": True,
 }
 
@@ -96,23 +95,23 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project: Project, snapshot_id: str) -> Response:
         """
-        Retrieves snapshot data with all shards and paginated images
+        Retrieves snapshot data
         """
 
         if not settings.IS_DEV and not features.has(
             "organizations:preprod-frontend-routes", project.organization, actor=request.user
         ):
-            return Response({"error": "Feature not enabled"}, status=403)
+            return Response({"detail": "Feature not enabled"}, status=403)
 
         try:
             offset = int(request.GET.get("offset", "0"))
             limit = int(request.GET.get("limit", "20"))
         except ValueError:
-            return Response({"error": "Invalid offset or limit parameter"}, status=400)
+            return Response({"detail": "Invalid offset or limit parameter"}, status=400)
 
         if offset < 0 or limit <= 0 or limit > 100:
             return Response(
-                {"error": "offset must be >= 0, limit must be > 0 and <= 100"}, status=400
+                {"detail": "offset must be >= 0, limit must be > 0 and <= 100"}, status=400
             )
 
         with sentry_sdk.start_span(op="preprod_artifact.get_snapshot_data"):
@@ -150,12 +149,14 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                     organization_id=project.organization_id,
                     head_sha=head_sha.lower(),
                     base_sha=base_sha.lower() if base_sha else None,
-                    provider=provider,
                     head_repo_name=head_repo_name,
-                    base_repo_name=head_repo_name,
-                    head_ref=head_ref,
-                    base_ref=None,
-                    pr_number=pr_number,
+                    defaults={
+                        "provider": provider,
+                        "base_repo_name": head_repo_name,
+                        "head_ref": head_ref,
+                        "base_ref": None,
+                        "pr_number": pr_number,
+                    },
                 )
 
             # Create new PreprodArtifact for snapshots
@@ -166,12 +167,9 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 commit_comparison=commit_comparison,
             )
 
-            # Get or create PreprodSnapshotMetrics
-            snapshot_metrics, created = PreprodSnapshotMetrics.objects.get_or_create(
+            snapshot_metrics = PreprodSnapshotMetrics.objects.create(
                 preprod_artifact=artifact,
-                defaults={
-                    "image_count": len(images),
-                },
+                image_count=len(images),
             )
 
             logger.info(
@@ -184,32 +182,18 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 },
             )
 
-            if not created:
-                # Update existing metrics with this shard's data
-                extras = snapshot_metrics.extras or {}
-
-                snapshot_metrics.image_count += len(images)
-                snapshot_metrics.extras = extras
-                snapshot_metrics.save(update_fields=["image_count", "extras"])
-
             # Serialize manifest using the Pydantic model for consistent format
             manifest = SnapshotManifest(images=images)
 
-            # TODO: need to store in object store
-            manifest_file = File.objects.create(
-                name="snapshot.json",
-                type="preprod.snapshot_manifest",
-                headers={"Content-Type": "application/json"},
-            )
-            manifest_json = manifest.json(by_alias=True)
-            manifest_file.putfile(BytesIO(manifest_json.encode()))
+            session = get_preprod_session(project.organization_id, project.id)
+            manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
+
+            manifest_json = manifest.json(by_alias=True, exclude_none=True)
+            session.put(manifest_json.encode(), key=manifest_key)
 
             # Store manifest file reference in extras
             extras = snapshot_metrics.extras or {}
-            manifest_files = extras.get("manifest_file_ids", {})
-            shard_index = str(len(manifest_files))
-            manifest_files[shard_index] = manifest_file.id
-            extras["manifest_file_ids"] = manifest_files
+            extras["manifest_key"] = manifest_key
             snapshot_metrics.extras = extras
             snapshot_metrics.save(update_fields=["extras"])
 
@@ -218,17 +202,16 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 extra={
                     "preprod_artifact_id": artifact.id,
                     "snapshot_metrics_id": snapshot_metrics.id,
-                    "manifest_file_id": manifest_file.id,
+                    "manifest_key": manifest_key,
                     "image_count": len(images),
                 },
             )
 
-            # Check if all shards have been received
             return Response(
                 {
                     "artifactId": str(artifact.id),
                     "snapshotMetricsId": str(snapshot_metrics.id),
                     "imageCount": snapshot_metrics.image_count,
                 },
-                status=201,
+                status=200,
             )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import jsonschema
 import orjson
-import sentry_sdk
 from django.conf import settings
 from django.db import router, transaction
 from rest_framework.request import Request
@@ -103,11 +102,10 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 {"detail": "offset must be >= 0, limit must be > 0 and <= 100"}, status=400
             )
 
-        with sentry_sdk.start_span(op="preprod_artifact.get_snapshot_data"):
-            return Response(
-                {},
-                status=200,
-            )
+        return Response(
+            {},
+            status=200,
+        )
 
     def post(self, request: Request, project: Project) -> Response:
         if not settings.IS_DEV and not features.has(
@@ -137,12 +135,12 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             if head_sha and provider and head_repo_name and head_ref:
                 commit_comparison, _ = CommitComparison.objects.get_or_create(
                     organization_id=project.organization_id,
-                    head_sha=head_sha.lower(),
-                    base_sha=base_sha.lower() if base_sha else None,
                     head_repo_name=head_repo_name,
+                    head_sha=head_sha,
+                    base_sha=base_sha,
                     defaults={
                         "provider": provider,
-                        "base_repo_name": base_repo_name or head_repo_name,
+                        "base_repo_name": base_repo_name,
                         "head_ref": head_ref,
                         "base_ref": base_ref,
                         "pr_number": pr_number,

--- a/src/sentry/preprod/api/schemas.py
+++ b/src/sentry/preprod/api/schemas.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+# Regex patterns
+SHA_PATTERN = "^[0-9a-f]{40}$"
+SHA_PATTERN_OPTIONAL_EMPTY = "^(|[0-9a-f]{40})$"
+
+# Shared VCS schema properties
+VCS_SCHEMA_PROPERTIES: dict[str, Any] = {
+    "head_sha": {"type": "string", "pattern": SHA_PATTERN_OPTIONAL_EMPTY},
+    "base_sha": {"type": "string", "pattern": SHA_PATTERN_OPTIONAL_EMPTY},
+    "provider": {"type": "string", "maxLength": 255},
+    "head_repo_name": {"type": "string", "maxLength": 255},
+    "base_repo_name": {"type": "string", "maxLength": 255},
+    "head_ref": {"type": "string", "maxLength": 255},
+    "base_ref": {"type": "string", "maxLength": 255},
+    "pr_number": {"type": "integer", "minimum": 1},
+}
+
+VCS_ERROR_MESSAGES: dict[str, str] = {
+    "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
+    "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
+    "provider": "The provider field must be a string with maximum length of 255 characters containing the domain of the VCS provider (ex. github.com)",
+    "head_repo_name": "The head_repo_name field must be a string with maximum length of 255 characters.",
+    "base_repo_name": "The base_repo_name field must be a string with maximum length of 255 characters.",
+    "head_ref": "The head_ref field must be a string with maximum length of 255 characters.",
+    "base_ref": "The base_ref field must be a string with maximum length of 255 characters.",
+    "pr_number": "The pr_number field must be a positive integer.",
+}

--- a/src/sentry/preprod/api/schemas.py
+++ b/src/sentry/preprod/api/schemas.py
@@ -18,17 +18,6 @@ VCS_SCHEMA_PROPERTIES: dict[str, Any] = {
     "pr_number": {"type": "integer", "minimum": 1},
 }
 
-VCS_SCHEMA_REQUIRED: list[str] = [
-    "head_sha",
-    "base_sha",
-    "provider",
-    "head_repo_name",
-    "base_repo_name",
-    "head_ref",
-    "base_ref",
-    "pr_number",
-]
-
 VCS_ERROR_MESSAGES: dict[str, str] = {
     "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
     "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",

--- a/src/sentry/preprod/api/schemas.py
+++ b/src/sentry/preprod/api/schemas.py
@@ -18,6 +18,17 @@ VCS_SCHEMA_PROPERTIES: dict[str, Any] = {
     "pr_number": {"type": "integer", "minimum": 1},
 }
 
+VCS_SCHEMA_REQUIRED: list[str] = [
+    "head_sha",
+    "base_sha",
+    "provider",
+    "head_repo_name",
+    "base_repo_name",
+    "head_ref",
+    "base_ref",
+    "pr_number",
+]
+
 VCS_ERROR_MESSAGES: dict[str, str] = {
     "head_sha": "The head_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",
     "base_sha": "The base_sha field must be a 40-character hexadecimal SHA1 string (no uppercase letters).",

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -3,20 +3,14 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 
-class BaseImageMetadata(BaseModel):
-    file_name: str | None = Field(None, alias="fileName")
+class ImageMetadata(BaseModel):
+    file_name: str | None = None
     width: int = Field(ge=0)
     height: int = Field(ge=0)
 
-
-class BYOImageMetadata(BaseImageMetadata):
-    dark_mode: bool | None = Field(None, alias="darkMode")
-
-
-class AndroidImageMetadata(BaseImageMetadata):
-    device: str | None = None
+    class Config:
+        extra = "allow"
 
 
 class SnapshotManifest(BaseModel):
-
-    images: dict[str, BYOImageMetadata | AndroidImageMetadata]
+    images: dict[str, ImageMetadata]

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class BaseImageMetadata(BaseModel):
+    file_name: str | None = Field(None, alias="fileName")
+    width: int = Field(ge=0)
+    height: int = Field(ge=0)
+
+
+class BYOImageMetadata(BaseImageMetadata):
+    dark_mode: bool | None = Field(None, alias="darkMode")
+
+
+class AndroidImageMetadata(BaseImageMetadata):
+    device: str | None = None
+
+
+class SnapshotManifest(BaseModel):
+
+    images: dict[str, BYOImageMetadata | AndroidImageMetadata]

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1,5 +1,8 @@
 from django.urls import reverse
 
+from sentry.models.files.file import File
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
 
 
@@ -11,7 +14,6 @@ class ProjectPreprodSnapshotTest(APITestCase):
         self.project = self.create_project(organization=self.org)
 
     def _get_create_url(self):
-        """URL for POST (creating snapshots)"""
         return reverse(
             "sentry-api-0-project-preprod-snapshots-create",
             args=[self.org.slug, self.project.slug],
@@ -27,135 +29,166 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_successful_snapshot_upload(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 2,
-            "images": [
-                {
+            "images": {
+                "abc123def456": {
+                    "fileName": "test.png",
                     "width": 375,
                     "height": 812,
-                    "colorScheme": "dark",
+                    "darkMode": True,
                     "orientation": "landscape",
                     "device": "iPhone 11",
                 },
-                {
-                    "width": 375,
-                    "height": 812,
-                    "colorScheme": "dark",
-                    "orientation": "landscape",
-                    "device": "iPhone 11",
-                },
-            ],
-            "errors": [],
+            },
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 200
+        assert response.status_code == 201
+        assert "artifactId" in response.data
+        assert "snapshotMetricsId" in response.data
+        assert response.data["imageCount"] == 1
+
+        # Verify database models were created
+        artifact = PreprodArtifact.objects.get(id=response.data["artifactId"])
+        assert artifact.project == self.project
+        assert artifact.state == PreprodArtifact.ArtifactState.UPLOADED
+
+        snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
+        assert snapshot_metrics.preprod_artifact == artifact
+        assert snapshot_metrics.image_count == 1
+
+    def test_snapshot_upload_creates_commit_comparison(self):
+        url = self._get_create_url()
+        data = {
+            "head_sha": "a" * 40,
+            "base_sha": "b" * 40,
+            "provider": "github",
+            "head_repo_name": "owner/repo",
+            "head_ref": "feature-branch",
+            "pr_number": 123,
+            "images": {
+                "img1": {
+                    "width": 100,
+                    "height": 200,
+                    "orientation": "portrait",
+                    "device": "iPhone 14",
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 201
+
+        artifact = PreprodArtifact.objects.get(id=response.data["artifactId"])
+        assert artifact.commit_comparison is not None
+
+        commit_comparison = artifact.commit_comparison
+        assert commit_comparison.head_sha == "a" * 40
+        assert commit_comparison.base_sha == "b" * 40
+        assert commit_comparison.provider == "github"
+        assert commit_comparison.head_repo_name == "owner/repo"
+        assert commit_comparison.pr_number == 123
+
+    def test_snapshot_upload_stores_manifest_file(self):
+        url = self._get_create_url()
+        data = {
+            "images": {
+                "hash1": {
+                    "fileName": "screen1.png",
+                    "width": 100,
+                    "height": 200,
+                    "orientation": "portrait",
+                    "device": "iPhone",
+                },
+            },
+        }
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 201
+
+        snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
+        assert "manifest_file_ids" in snapshot_metrics.extras
+        assert "0" in snapshot_metrics.extras["manifest_file_ids"]
+
+        manifest_file_id = snapshot_metrics.extras["manifest_file_ids"]["0"]
+        manifest_file = File.objects.get(id=manifest_file_id)
+        assert manifest_file.type == "preprod.snapshot_manifest"
 
     def test_snapshot_with_empty_images(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 1,
-            "numShards": 3,
-            "images": [],
-            "errors": [],
+            "images": {},
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 200
+        assert response.status_code == 201
+        assert response.data["imageCount"] == 0
 
     def test_snapshot_missing_required_field(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "images": [
-                {
-                    "width": 375,
-                    "height": 812,
-                    "colorScheme": "dark",
-                    "orientation": "portrait",
-                    "device": "iPhone 11",
-                },
-            ],
-            # Missing errors field
+            # Missing images field
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "error" in response.data
+        assert "detail" in response.data
 
     def test_snapshot_invalid_image_schema(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 1,
-            "images": [
-                {
+            "images": {
+                "hash1": {
                     "width": 375,
-                    # Missing height
-                    "colorScheme": "dark",
-                    "orientation": "portrait",
-                    "device": "iPhone 11",
+                    # Missing height, orientation, device
                 },
-            ],
-            "errors": [],
+            },
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "error" in response.data
+        assert "detail" in response.data
 
     def test_snapshot_negative_dimensions(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 1,
-            "images": [
-                {
+            "images": {
+                "hash1": {
                     "width": -100,
                     "height": 812,
-                    "colorScheme": "dark",
                     "orientation": "portrait",
                     "device": "iPhone 11",
                 },
-            ],
-            "errors": [],
+            },
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
-        assert "error" in response.data
+        assert "detail" in response.data
 
     def test_snapshot_without_feature_flag(self):
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 1,
-            "images": [
-                {
-                    "width": 375,
-                    "height": 812,
-                    "colorScheme": "dark",
-                    "orientation": "portrait",
-                    "device": "iPhone 11",
-                },
-            ],
-            "errors": [],
+            "images": {},
         }
 
         response = self.client.post(url, data, format="json")
 
         assert response.status_code == 403
-        assert response.data["error"] == "Feature not enabled"
+        assert response.data["detail"] == "Feature not enabled"
 
     def test_snapshot_invalid_json(self):
         url = self._get_create_url()
@@ -164,19 +197,15 @@ class ProjectPreprodSnapshotTest(APITestCase):
             response = self.client.post(url, "invalid json", content_type="application/json")
 
         assert response.status_code == 400
-        assert "error" in response.data
+        assert "detail" in response.data
 
     def test_snapshot_requires_authentication(self):
-        # Create a new unauthenticated client instead of logging out
         from rest_framework.test import APIClient
 
         unauthenticated_client = APIClient()
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 1,
-            "images": [],
-            "errors": [],
+            "images": {},
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
@@ -190,13 +219,22 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
         url = self._get_create_url()
         data = {
-            "shardIndex": 0,
-            "numShards": 1,
-            "images": [],
-            "errors": [],
+            "images": {},
         }
 
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 403
+
+    def test_snapshot_invalid_sha_format(self):
+        url = self._get_create_url()
+        data = {
+            "head_sha": "not-a-valid-sha",
+            "images": {},
+        }
+
+        with self.feature("organizations:preprod-frontend-routes"):
+            response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 400

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 
-from sentry.models.files.file import File
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.testutils.cases import APITestCase
@@ -44,7 +43,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 201
+        assert response.status_code == 200
         assert "artifactId" in response.data
         assert "snapshotMetricsId" in response.data
         assert response.data["imageCount"] == 1
@@ -80,7 +79,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 201
+        assert response.status_code == 200
 
         artifact = PreprodArtifact.objects.get(id=response.data["artifactId"])
         assert artifact.commit_comparison is not None
@@ -92,7 +91,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert commit_comparison.head_repo_name == "owner/repo"
         assert commit_comparison.pr_number == 123
 
-    def test_snapshot_upload_stores_manifest_file(self):
+    def test_snapshot_upload_stores_manifest_key(self):
         url = self._get_create_url()
         data = {
             "images": {
@@ -100,8 +99,6 @@ class ProjectPreprodSnapshotTest(APITestCase):
                     "fileName": "screen1.png",
                     "width": 100,
                     "height": 200,
-                    "orientation": "portrait",
-                    "device": "iPhone",
                 },
             },
         }
@@ -109,15 +106,16 @@ class ProjectPreprodSnapshotTest(APITestCase):
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 201
+        assert response.status_code == 200
 
         snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
-        assert "manifest_file_ids" in snapshot_metrics.extras
-        assert "0" in snapshot_metrics.extras["manifest_file_ids"]
+        assert "manifest_key" in snapshot_metrics.extras
 
-        manifest_file_id = snapshot_metrics.extras["manifest_file_ids"]["0"]
-        manifest_file = File.objects.get(id=manifest_file_id)
-        assert manifest_file.type == "preprod.snapshot_manifest"
+        artifact_id = response.data["artifactId"]
+        expected_key = (
+            f"{self.project.organization_id}/{self.project.id}/{artifact_id}/manifest.json"
+        )
+        assert snapshot_metrics.extras["manifest_key"] == expected_key
 
     def test_snapshot_with_empty_images(self):
         url = self._get_create_url()
@@ -128,7 +126,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         with self.feature("organizations:preprod-frontend-routes"):
             response = self.client.post(url, data, format="json")
 
-        assert response.status_code == 201
+        assert response.status_code == 200
         assert response.data["imageCount"] == 0
 
     def test_snapshot_missing_required_field(self):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -31,10 +31,10 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "app_id": "com.example.app",
             "images": {
                 "abc123def456": {
-                    "fileName": "test.png",
+                    "file_name": "test.png",
                     "width": 375,
                     "height": 812,
-                    "darkMode": True,
+                    "dark_mode": True,
                 },
             },
         }
@@ -96,7 +96,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "app_id": "com.example.app",
             "images": {
                 "hash1": {
-                    "fileName": "screen1.png",
+                    "file_name": "screen1.png",
                     "width": 100,
                     "height": 200,
                 },

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -109,6 +109,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         assert response.status_code == 200
 
         snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
+        assert snapshot_metrics.extras is not None
         assert "manifest_key" in snapshot_metrics.extras
 
         artifact_id = response.data["artifactId"]
@@ -132,7 +133,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
     def test_snapshot_missing_required_field(self):
         url = self._get_create_url()
-        data = {
+        data: dict[str, str] = {
             # Missing images field
         }
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -28,14 +28,13 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_successful_snapshot_upload(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {
                 "abc123def456": {
                     "fileName": "test.png",
                     "width": 375,
                     "height": 812,
                     "darkMode": True,
-                    "orientation": "landscape",
-                    "device": "iPhone 11",
                 },
             },
         }
@@ -60,6 +59,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_upload_creates_commit_comparison(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "head_sha": "a" * 40,
             "base_sha": "b" * 40,
             "provider": "github",
@@ -70,7 +70,6 @@ class ProjectPreprodSnapshotTest(APITestCase):
                 "img1": {
                     "width": 100,
                     "height": 200,
-                    "orientation": "portrait",
                     "device": "iPhone 14",
                 },
             },
@@ -94,6 +93,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_upload_stores_manifest_key(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {
                 "hash1": {
                     "fileName": "screen1.png",
@@ -120,6 +120,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_with_empty_images(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {},
         }
 
@@ -144,10 +145,11 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_invalid_image_schema(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {
                 "hash1": {
                     "width": 375,
-                    # Missing height, orientation, device
+                    # Missing height (required)
                 },
             },
         }
@@ -161,12 +163,11 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_negative_dimensions(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {
                 "hash1": {
                     "width": -100,
                     "height": 812,
-                    "orientation": "portrait",
-                    "device": "iPhone 11",
                 },
             },
         }
@@ -180,6 +181,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_without_feature_flag(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {},
         }
 
@@ -203,6 +205,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
         unauthenticated_client = APIClient()
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {},
         }
 
@@ -217,6 +220,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
 
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "images": {},
         }
 
@@ -228,6 +232,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_invalid_sha_format(self):
         url = self._get_create_url()
         data = {
+            "app_id": "com.example.app",
             "head_sha": "not-a-valid-sha",
             "images": {},
         }


### PR DESCRIPTION
Adds the initial snapshots POST API. This api does a few things and is intended to be invoked by the CLI:
- Creates `PreprodArtifact`, `PreprodSnapshotMetrics` and `CommitComparison` DB models
- Creates image metadata based on what's uploaded from CLI
- Stores metadata in objectstore

Notably images are uploaded directly to objectstore from CLI

Tested E2E locally with objectstore and WIP CLI branch (https://github.com/getsentry/sentry-cli/pull/3110)

Resolves EME-773