### PR TITLE
chore(launchpad): Update launchpad services and add objectstore

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -165,7 +165,7 @@ x-sentry-service-config:
     migrations: [postgres, redis]
     acceptance-ci: [postgres, snuba, chartcuterie]
     chartcuterie: [postgres, snuba, chartcuterie, spotlight]
-    launchpad: [snuba, postgres, relay, spotlight, launchpad, taskbroker, taskworker]
+    launchpad: [snuba, postgres, launchpad, taskbroker, taskworker, objectstore]
     objectstore: [snuba, postgres, relay, spotlight, objectstore]
     taskbroker: [snuba, postgres, relay, spotlight, taskbroker]
     taskworker:


### PR DESCRIPTION
Removes relay and spotlight as launchpad shouldn't need these. Adds objectstore as it's now leveraged with launchpad.

This should allow easy running of `devservices up --mode=launchpad`