### PR TITLE
fix(notifications): use <wbr> instead of soft-hyphens in HTML emails

### DIFF
--- a/src/sentry/templates/sentry/emails/_group.html
+++ b/src/sentry/templates/sentry/emails/_group.html
@@ -15,7 +15,7 @@
           {% endif %}
           <br />
           {% if metadata.value %}
-            <small>{{ metadata.value|truncatechars:100|soft_break:40 }}</small>
+            <small>{{ metadata.value|truncatechars:100|soft_break_html:40 }}</small>
           {% endif %}
           {% else %}
           {%if rule %}
@@ -57,7 +57,7 @@
         {% endif %}
         <br />
         {% if metadata.value %}
-          <small>{{ metadata.value|truncatechars:100|soft_break:40 }}</small>
+          <small>{{ metadata.value|truncatechars:100|soft_break_html:40 }}</small>
         {% endif %}
      </h3>
     </div>

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -110,7 +110,7 @@
                         {% endif %}
                         <br />
                         {% if metadata.value %}
-                          <small>{{ metadata.value|truncatechars:100|soft_break:40 }}</small>
+                          <small>{{ metadata.value|truncatechars:100|soft_break_html:40 }}</small>
                         {% endif %}
                       {% else %}
                         <a href="{% absolute_uri link %}">{{ metadata.value|truncatechars:40 }}</a><br />
@@ -151,7 +151,7 @@
                       {% endif %}
                       <br />
                       {% if subtitle and not is_new_design %}
-                        <small>{{ subtitle|truncatechars:40|soft_break:40 }}</small>
+                        <small>{{ subtitle|truncatechars:40|soft_break_html:40 }}</small>
                       {% endif %}
                     </h3>
                   </div>

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -19,9 +19,7 @@ from sentry.utils import json
 from sentry.utils.strings import soft_break as _soft_break
 from sentry.utils.strings import soft_hyphenate, truncatechars
 
-SentryVersion = namedtuple(
-    "SentryVersion", ["current", "latest", "update_available", "build"]
-)
+SentryVersion = namedtuple("SentryVersion", ["current", "latest", "update_available", "build"])
 
 register = template.Library()
 
@@ -317,9 +315,7 @@ def soft_break_html(value, length):
         _soft_break(
             escaped,
             length,
-            functools.partial(
-                soft_hyphenate, length=max(length // 10, 10), hyphen="<wbr>"
-            ),
+            functools.partial(soft_hyphenate, length=max(length // 10, 10), hyphen="<wbr>"),
             delimiter_break="<wbr>",
         )
     )

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -108,9 +108,7 @@ def soft_break(
             for HTML contexts so that copied text contains no invisible
             characters.
     """
-    delimiters = re.compile(
-        r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}")))
-    )
+    delimiters = re.compile(r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}"))))
 
     def soft_break_delimiter(match: re.Match[str]) -> str:
         results = []
@@ -128,9 +126,7 @@ def soft_break(
     return re.sub(rf"\S{{{length},}}", soft_break_delimiter, value)
 
 
-valid_dot_atom_characters = frozenset(
-    string.ascii_letters + string.digits + ".!#$%&'*+-/=?^_`{|}~"
-)
+valid_dot_atom_characters = frozenset(string.ascii_letters + string.digits + ".!#$%&'*+-/=?^_`{|}~")
 
 
 def is_valid_dot_atom(value: str) -> bool:


### PR DESCRIPTION
## Description

Notification emails insert Unicode soft-hyphens (`U+00AD`) into long identifiers (error messages, file paths, class names) to help with line wrapping. When users copy these strings from the email, the invisible soft-hyphen characters are included in the clipboard text, silently corrupting the identifier and causing searches in editors and tools to fail.

## Related Issue

Fixes #103714

## Changes Made

| File | Change |
|------|--------|
| `src/sentry/utils/strings.py` | Added `delimiter_break` parameter to `soft_break()` so the break character is configurable (`<wbr>` for HTML, `\u200b` for plain text) |
| `src/sentry/templatetags/sentry_helpers.py` | Added `soft_break_html` template filter that uses `<wbr>` tags instead of `\u00ad` / `\u200b`, with XSS-safe HTML escaping |
| `src/sentry/templates/sentry/emails/issue_alert_base.html` | Switched from `soft_break` to `soft_break_html` for HTML email rendering |
| `src/sentry/templates/sentry/emails/_group.html` | Switched from `soft_break` to `soft_break_html` for HTML email rendering |

## How It Works

- **Before**: `soft_break` inserts `\u00ad` (soft-hyphen) every N characters → copied text contains invisible characters
- **After**: `soft_break_html` inserts `<wbr>` (word break opportunity) tags → identical line-break behavior in email clients, but copied text is clean

The original `soft_break` filter is preserved for non-HTML contexts (plain-text emails, etc.).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Ruff check and format pass
- [x] Existing `soft_break` / `soft_hyphenate` behavior unchanged (backward compatible)
- [x] New `soft_break_html` filter escapes HTML input before inserting `<wbr>` tags (XSS safe)