### PR TITLE
fix(api): Accept project slugs in `?project=` query parameter

### DIFF
--- a/src/sentry/api/helpers/projects.py
+++ b/src/sentry/api/helpers/projects.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_id_or_slug_params(values: Iterable[str]) -> tuple[set[int], set[str]]:
+    """
+    Partition identifier strings into numeric IDs and slugs.
+
+    All-digit values are treated as IDs, everything else as slugs.
+    Uses ``.isdecimal()`` consistent with ``IdOrSlugLookup``.
+    A single leading ``-`` is allowed to support the ``-1`` all-access sigil.
+    """
+    ids: set[int] = set()
+    slugs: set[str] = set()
+    for val in values:
+        if not val:
+            continue
+        if val.isdecimal():
+            ids.add(int(val))
+        elif len(val) > 1 and val[0] == "-" and val[1:].isdecimal():
+            ids.add(int(val))
+        else:
+            slugs.add(val)
+    return ids, slugs

--- a/tests/sentry/api/helpers/test_projects.py
+++ b/tests/sentry/api/helpers/test_projects.py
@@ -1,0 +1,53 @@
+from sentry.api.helpers.projects import parse_id_or_slug_params
+
+
+class TestParseIdOrSlugParams:
+    def test_empty_input(self):
+        ids, slugs = parse_id_or_slug_params([])
+        assert ids == set()
+        assert slugs == set()
+
+    def test_numeric_values(self):
+        ids, slugs = parse_id_or_slug_params(["1", "2", "3"])
+        assert ids == {1, 2, 3}
+        assert slugs == set()
+
+    def test_slug_values(self):
+        ids, slugs = parse_id_or_slug_params(["my-project", "another-proj"])
+        assert ids == set()
+        assert slugs == {"my-project", "another-proj"}
+
+    def test_mixed_values(self):
+        ids, slugs = parse_id_or_slug_params(["1", "my-project", "42"])
+        assert ids == {1, 42}
+        assert slugs == {"my-project"}
+
+    def test_empty_strings_are_skipped(self):
+        ids, slugs = parse_id_or_slug_params(["", "1", "", "foo"])
+        assert ids == {1}
+        assert slugs == {"foo"}
+
+    def test_negative_numbers_are_ids(self):
+        ids, slugs = parse_id_or_slug_params(["-1"])
+        assert ids == {-1}
+        assert slugs == set()
+
+    def test_all_access_sigil(self):
+        ids, slugs = parse_id_or_slug_params(["$all"])
+        assert ids == set()
+        assert slugs == {"$all"}
+
+    def test_deduplication(self):
+        ids, slugs = parse_id_or_slug_params(["1", "1", "foo", "foo"])
+        assert ids == {1}
+        assert slugs == {"foo"}
+
+    def test_multiple_dashes_are_slugs(self):
+        ids, slugs = parse_id_or_slug_params(["--1", "---5"])
+        assert ids == set()
+        assert slugs == {"--1", "---5"}
+
+    def test_bare_dash_is_slug(self):
+        ids, slugs = parse_id_or_slug_params(["-"])
+        assert ids == set()
+        assert slugs == {"-"}


### PR DESCRIPTION
Accept project slugs in the `?project=` query parameter, which previously only accepted numeric IDs (returning HTTP 400 for slug values).

Since project slugs are never numeric (enforced by `no_numeric_validator`), there is no ambiguity between IDs and slugs — `.isdecimal()` cleanly distinguishes them. This means `?project=` can accept both `?project=123` and `?project=my-slug` (and mixed: `?project=123&project=my-slug`).

The change is in the shared `get_projects()` code path on `OrganizationEndpoint`, so ~20 endpoints gain slug support at once.

**What changed:**

- New `parse_id_or_slug_params()` utility in `src/sentry/api/helpers/projects.py` partitions query param values into numeric IDs and slug strings
- `get_projects()` uses this to parse `?project=` values, building a `Q(id__in=...) | Q(slug__in=...)` filter when both are present
- `_validate_fetched_projects()` switched from `!=` to `.issubset()` to handle mixed ID+slug requests where both may resolve to the same project
- `get_requested_project_ids_unchecked()` no longer raises `ParseError` on non-numeric values — silently drops slugs and returns only numeric IDs (all 6 callers were audited and are safe)
- `?projectSlug=` now emits a deprecation warning and metric since `?project=` accepts slugs directly

Fixes #107832