### PR TITLE
Release filter quick add

### DIFF
--- a/src/sentry/api/endpoints/project_filter_add_release.py
+++ b/src/sentry/api/endpoints/project_filter_add_release.py
@@ -10,7 +10,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_SUCCESS
 from sentry.apidocs.parameters import GlobalParams
-from sentry.models.options.project_option import ProjectOption
 
 
 class AddReleaseFilterSerializer(serializers.Serializer):
@@ -23,7 +22,7 @@ class AddReleaseFilterSerializer(serializers.Serializer):
 @region_silo_endpoint
 @extend_schema(tags=["Projects"])
 class ProjectFilterAddReleaseEndpoint(ProjectEndpoint):
-    owner = ApiOwner.UNOWNED
+    owner = ApiOwner.OWNERS_INGEST
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }

--- a/src/sentry/api/endpoints/project_filter_add_release.py
+++ b/src/sentry/api/endpoints/project_filter_add_release.py
@@ -1,0 +1,91 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import audit_log
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_SUCCESS
+from sentry.apidocs.parameters import GlobalParams
+from sentry.models.options.project_option import ProjectOption
+
+
+class AddReleaseFilterSerializer(serializers.Serializer):
+    release = serializers.CharField(
+        required=True,
+        help_text="The release version to add to the inbound filters.",
+    )
+
+
+@region_silo_endpoint
+@extend_schema(tags=["Projects"])
+class ProjectFilterAddReleaseEndpoint(ProjectEndpoint):
+    owner = ApiOwner.UNOWNED
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+
+    @extend_schema(
+        operation_id="Add Release to Inbound Filters",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=AddReleaseFilterSerializer,
+        responses={
+            200: RESPONSE_SUCCESS,
+            400: RESPONSE_BAD_REQUEST,
+            403: RESPONSE_FORBIDDEN,
+        },
+    )
+    def post(self, request: Request, project) -> Response:
+        """
+        Add a release version to the project's inbound data filters.
+
+        This will add the release to the filters:releases option, which causes
+        future events from this release to be discarded during ingestion.
+        """
+        serializer = AddReleaseFilterSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        release_version = serializer.validated_data["release"]
+
+        # Get current release filters
+        current_filters = project.get_option("filters:releases", default="")
+
+        # Parse existing filters (newline-separated)
+        if current_filters:
+            filter_list = [f.strip() for f in current_filters.split("\n") if f.strip()]
+        else:
+            filter_list = []
+
+        # Add the new release if not already present
+        if release_version not in filter_list:
+            filter_list.append(release_version)
+
+            # Update the option
+            new_filters = "\n".join(filter_list)
+            project.update_option("filters:releases", new_filters)
+
+            # Create audit log entry
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=project.id,
+                event=audit_log.get_event_id("PROJECT_EDIT"),
+                data={
+                    "slug": project.slug,
+                    "filters:releases": new_filters,
+                    "added_release": release_version,
+                },
+            )
+
+        return Response(
+            {"detail": "Release filter added successfully", "release": release_version},
+            status=200,
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -793,6 +793,7 @@ from .endpoints.project_artifact_bundle_files import ProjectArtifactBundleFilesE
 from .endpoints.project_commits import ProjectCommitsEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
 from .endpoints.project_create_sample_transaction import ProjectCreateSampleTransactionEndpoint
+from .endpoints.project_filter_add_release import ProjectFilterAddReleaseEndpoint
 from .endpoints.project_filter_details import ProjectFilterDetailsEndpoint
 from .endpoints.project_filters import ProjectFiltersEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
@@ -2847,6 +2848,11 @@ PROJECT_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/filters/$",
         ProjectFiltersEndpoint.as_view(),
         name="sentry-api-0-project-filters",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/filters/add-release/$",
+        ProjectFilterAddReleaseEndpoint.as_view(),
+        name="sentry-api-0-project-filters-add-release",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/filters/(?P<filter_id>[^/]+)/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -633,6 +633,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/source-maps/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/filters/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/filters/$filterId/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/filters/add-release/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/grouping-configs/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/groups/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/groups/stats/'

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -381,6 +381,49 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
     ));
   };
 
+  const onDiscardRelease = () => {
+    const releaseVersion = event?.release?.version;
+    if (!releaseVersion) {
+      return;
+    }
+
+    openConfirmModal({
+      message: t(
+        'Are you sure you want to discard all future events from release "%s"? This will add the release to your project\'s inbound data filters.',
+        releaseVersion
+      ),
+      priority: 'danger',
+      confirmText: t('Discard Events'),
+      onConfirm: () => {
+        addLoadingMessage(t('Adding release to filters\u2026'));
+
+        api.request(
+          `/projects/${organization.slug}/${project.slug}/filters/add-release/`,
+          {
+            method: 'POST',
+            data: {release: releaseVersion},
+            success: () => {
+              clearIndicators();
+              addSuccessMessage(
+                t('Successfully added release %s to inbound filters', releaseVersion)
+              );
+              trackAnalytics('issue_details.discard_release_clicked', {
+                organization,
+                release: releaseVersion,
+                ...getAnalyticsDataForGroup(group),
+                ...getAnalyicsDataForProject(project),
+              });
+            },
+            error: () => {
+              clearIndicators();
+              addSuccessMessage(t('Failed to add release to filters'));
+            },
+          }
+        );
+      },
+    });
+  };
+
   const handleClick = (onClick: (event?: MouseEvent) => void) => {
     return function (innerEvent: MouseEvent) {
       if (disabled) {
@@ -571,6 +614,14 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
             label: t('Reprocess events'),
             hidden: !displayReprocessEventAction(event),
             onAction: onReprocessEvent,
+          },
+          {
+            key: 'discard-release',
+            priority: 'danger',
+            label: t('Discard events from this release'),
+            hidden: !event?.release?.version,
+            disabled: !event?.release?.version,
+            onAction: onDiscardRelease,
           },
           {
             key: 'delete-issue',

--- a/tests/sentry/api/endpoints/test_project_filter_add_release.py
+++ b/tests/sentry/api/endpoints/test_project_filter_add_release.py
@@ -116,7 +116,6 @@ class ProjectFilterAddReleaseTest(APITestCase):
         assert "release" in response.data
 
     def test_requires_authentication(self):
-        self.logout()
         project = self.create_project()
 
         self.get_error_response(

--- a/tests/sentry/api/endpoints/test_project_filter_add_release.py
+++ b/tests/sentry/api/endpoints/test_project_filter_add_release.py
@@ -5,6 +5,7 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test
 class ProjectFilterAddReleaseTest(APITestCase):
     endpoint = "sentry-api-0-project-filters-add-release"
+    method = "POST"
 
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_project_filter_add_release.py
+++ b/tests/sentry/api/endpoints/test_project_filter_add_release.py
@@ -116,16 +116,6 @@ class ProjectFilterAddReleaseTest(APITestCase):
 
         assert "release" in response.data
 
-    def test_requires_authentication(self):
-        project = self.create_project()
-
-        self.get_error_response(
-            project.organization.slug,
-            project.slug,
-            release="1.2.3",
-            status_code=401,
-        )
-
     def test_requires_project_access(self):
         other_user = self.create_user()
         self.login_as(user=other_user)
@@ -136,4 +126,20 @@ class ProjectFilterAddReleaseTest(APITestCase):
             project.slug,
             release="1.2.3",
             status_code=403,
+        )
+
+
+@region_silo_test
+class ProjectFilterAddReleaseTestUnauthenticated(APITestCase):
+    endpoint = "sentry-api-0-project-filters-add-release"
+    method = "POST"
+
+    def test_requires_authentication(self):
+        project = self.create_project()
+
+        self.get_error_response(
+            project.organization.slug,
+            project.slug,
+            release="1.2.3",
+            status_code=401,
         )

--- a/tests/sentry/api/endpoints/test_project_filter_add_release.py
+++ b/tests/sentry/api/endpoints/test_project_filter_add_release.py
@@ -1,0 +1,139 @@
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class ProjectFilterAddReleaseTest(APITestCase):
+    endpoint = "sentry-api-0-project-filters-add-release"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_add_release_filter(self):
+        project = self.create_project()
+        release_version = "1.2.3"
+
+        response = self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release=release_version,
+        )
+
+        assert response.data["release"] == release_version
+        assert response.data["detail"] == "Release filter added successfully"
+
+        # Verify the filter was added to project options
+        filters = project.get_option("filters:releases", default="")
+        assert release_version in filters
+
+    def test_add_multiple_releases(self):
+        project = self.create_project()
+
+        # Add first release
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release="1.0.0",
+        )
+
+        # Add second release
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release="2.0.0",
+        )
+
+        # Verify both releases are in the filter
+        filters = project.get_option("filters:releases", default="")
+        assert "1.0.0" in filters
+        assert "2.0.0" in filters
+
+    def test_add_duplicate_release(self):
+        project = self.create_project()
+        release_version = "1.2.3"
+
+        # Add release first time
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release=release_version,
+        )
+
+        # Add same release again
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release=release_version,
+        )
+
+        # Verify release appears only once
+        filters = project.get_option("filters:releases", default="")
+        filter_list = [f.strip() for f in filters.split("\n") if f.strip()]
+        assert filter_list.count(release_version) == 1
+
+    def test_add_release_to_existing_filters(self):
+        project = self.create_project()
+
+        # Set existing filters
+        project.update_option("filters:releases", "0.9.*\nold-release")
+
+        # Add new release
+        new_release = "1.2.3"
+        self.get_success_response(
+            project.organization.slug,
+            project.slug,
+            release=new_release,
+        )
+
+        # Verify all filters are present
+        filters = project.get_option("filters:releases", default="")
+        assert "0.9.*" in filters
+        assert "old-release" in filters
+        assert new_release in filters
+
+    def test_missing_release_parameter(self):
+        project = self.create_project()
+
+        response = self.get_error_response(
+            project.organization.slug,
+            project.slug,
+            status_code=400,
+        )
+
+        assert "release" in response.data
+
+    def test_empty_release_parameter(self):
+        project = self.create_project()
+
+        response = self.get_error_response(
+            project.organization.slug,
+            project.slug,
+            release="",
+            status_code=400,
+        )
+
+        assert "release" in response.data
+
+    def test_requires_authentication(self):
+        self.logout()
+        project = self.create_project()
+
+        self.get_error_response(
+            project.organization.slug,
+            project.slug,
+            release="1.2.3",
+            status_code=401,
+        )
+
+    def test_requires_project_access(self):
+        other_user = self.create_user()
+        self.login_as(user=other_user)
+        project = self.create_project()
+
+        self.get_error_response(
+            project.organization.slug,
+            project.slug,
+            release="1.2.3",
+            status_code=403,
+        )


### PR DESCRIPTION
<!-- Describe your PR here. -->
Adds a "Discard events from this release" action to the issue details page. This allows users to quickly add a problematic release to their project's inbound data filters, simplifying the process of preventing events from unmaintained releases from being ingested.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1336](https://linear.app/getsentry/issue/ID-1336/easily-add-a-release-to-data-filters-from-the-issue-page)

<p><a href="https://cursor.com/background-agent?bcId=bc-b5525e17-51c8-4d0a-be00-af622257b928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b5525e17-51c8-4d0a-be00-af622257b928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

