### PR TITLE
Open team membership validation

### DIFF
--- a/src/sentry/issues/endpoints/project_ownership.py
+++ b/src/sentry/issues/endpoints/project_ownership.py
@@ -69,10 +69,10 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
         """
         Validate that the user has permission to assign ownership to the teams
         referenced in the rules.
-        
+
         Validation is skipped if:
         - Open Team Membership is enabled for the organization (users can join any team)
-        
+
         Otherwise, users must either have team:admin scope or be
         a member of each team they're assigning ownership to.
         """

--- a/src/sentry/issues/endpoints/project_ownership.py
+++ b/src/sentry/issues/endpoints/project_ownership.py
@@ -68,7 +68,12 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
     def _validate_team_ownership(self, rules):
         """
         Validate that the user has permission to assign ownership to the teams
-        referenced in the rules. Users must either have team:admin scope or be
+        referenced in the rules.
+        
+        Validation is skipped if:
+        - Open Team Membership is enabled for the organization (users can join any team)
+        
+        Otherwise, users must either have team:admin scope or be
         a member of each team they're assigning ownership to.
         """
         team_slugs = {
@@ -78,6 +83,14 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
             if owner.get("type") == "team"
         }
         if not team_slugs:
+            return
+
+        project = self.context["ownership"].project
+        organization = project.organization
+
+        # If Open Team Membership is enabled, users can assign any team
+        # since they could join any team anyway
+        if organization.flags.allow_joinleave:
             return
 
         request = self.context.get("request")
@@ -90,10 +103,9 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
         user = getattr(request, "user", None) if request else None
         if not user or not user.is_authenticated:
             raise serializers.ValidationError(
-                {"raw": "You do not have permission to assign ownership to one or more teams."}
+                {"raw": "You can only assign teams you are a member of."}
             )
 
-        project = self.context["ownership"].project
         user_team_count = OrganizationMemberTeam.objects.filter(
             team__slug__in=team_slugs,
             team__projectteam__project=project,
@@ -103,7 +115,7 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
 
         if user_team_count < len(team_slugs):
             raise serializers.ValidationError(
-                {"raw": "You do not have permission to assign ownership to one or more teams."}
+                {"raw": "You can only assign teams you are a member of."}
             )
 
     def get_max_length(self):

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -407,7 +407,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
         resp = self.client.put(self.path, {"raw": "*.js #other-team"})
         assert resp.status_code == 400
-        assert "do not have permission" in str(resp.data["raw"][0])
+        assert "can only assign teams you are a member of" in str(resp.data["raw"][0]).lower()
 
         ownership = ProjectOwnership.objects.filter(project=self.project).first()
         assert ownership is None or ownership.raw is None
@@ -447,4 +447,68 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
 
         resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
         assert resp.status_code == 400
-        assert "do not have permission" in str(resp.data["raw"][0])
+        assert "can only assign teams you are a member of" in str(resp.data["raw"][0]).lower()
+
+    def test_open_membership_allows_any_team(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can add ownership rules
+        for teams they are not members of.
+        """
+        # Enable Open Team Membership
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
+        self.project.add_team(other_team)
+
+        self.login_as(user=self.member_user)
+
+        # Member should be able to assign ownership to team they're not a member of
+        resp = self.client.put(self.path, {"raw": "*.js #other-team"})
+        assert resp.status_code == 200
+        assert resp.data["raw"] == "*.js #other-team"
+
+    def test_open_membership_allows_mixed_teams(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can save ownership rules
+        that reference multiple teams, even if they're not members of all of them.
+        This is the main regression test for the reported issue.
+        """
+        # Enable Open Team Membership
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
+        third_team = self.create_team(organization=self.organization, slug="third-team", members=[])
+        self.project.add_team(other_team)
+        self.project.add_team(third_team)
+
+        self.login_as(user=self.member_user)
+
+        # Member should be able to save rules with multiple teams
+        resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team #third-team"})
+        assert resp.status_code == 200
+        assert resp.data["raw"] == "*.js #tiger-team #other-team #third-team"
+
+    def test_open_membership_allows_no_changes_save(self) -> None:
+        """
+        Test that when Open Team Membership is enabled, members can re-save existing
+        ownership rules without making changes, even if the rules reference teams they're
+        not members of. This is the specific scenario from the bug report.
+        """
+        # Setup: Admin creates rules with multiple teams
+        other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
+        self.project.add_team(other_team)
+
+        self.login_as(user=self.user)
+        self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
+
+        # Enable Open Team Membership
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        # Member (only in tiger-team) should be able to save without changes
+        self.login_as(user=self.member_user)
+        resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
+        assert resp.status_code == 200
+        assert resp.data["raw"] == "*.js #tiger-team #other-team"


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue (ID-1337) where users in organizations with "Open Team Membership" enabled were blocked from saving project ownership rules if those rules referenced teams they were not explicit members of.

Previously, the `_validate_team_ownership` method did not respect the `organization.flags.allow_joinleave` flag, causing a 400 error even when re-saving existing rules. This contradicted Sentry's membership documentation and the behavior established for alerts, monitors, and detectors in #107333.

This PR updates `_validate_team_ownership` to bypass the team membership check when `organization.flags.allow_joinleave` is enabled, allowing project members to save ownership rules referencing any team. Error messages have also been updated for consistency. New tests cover the corrected behavior, including the specific scenario of re-saving existing rules without changes.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1337](https://linear.app/getsentry/issue/ID-1337/open-team-membership-not-respected-when-saving-ownership-rules)

<p><a href="https://cursor.com/background-agent?bcId=bc-1b898868-d946-4aea-a27a-7a5376fa7cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b898868-d946-4aea-a27a-7a5376fa7cd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

