### PR TITLE
feat(ai-conversation): Do not allow for querying more than 30d of data

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -75,12 +75,12 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         now = timezone.now()
         max_retention_cutoff = now - max_retention
 
-        if stats_period:
-            # Always use full 30d range when statsPeriod is passed
+        if stats_period or not has_explicit_range:
+            # Always use full 30d range when statsPeriod is passed or no date params
             snuba_params.start = max_retention_cutoff
             snuba_params.end = now
         else:
-            # Validate start/end aren't older than retention limit
+            # Validate explicit start/end aren't older than retention limit
             if snuba_params.start and snuba_params.start < max_retention_cutoff:
                 return Response(
                     {"detail": f"start time cannot be older than {MAX_RETENTION_DAYS} days"},
@@ -91,10 +91,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
                     {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
                     status=400,
                 )
-            if not has_explicit_range:
-                # No date params passed - use full 30d range
-                snuba_params.start = max_retention_cutoff
-                snuba_params.end = now
 
         selected_columns = AI_CONVERSATION_ATTRIBUTES
 

--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -1,3 +1,6 @@
+from datetime import timedelta
+
+from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -12,6 +15,8 @@ from sentry.models.organization import Organization
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+
+MAX_RETENTION_DAYS = 30
 
 # Base span fields always returned
 AI_CONVERSATION_ATTRIBUTES = [
@@ -56,15 +61,40 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         if not features.has("organizations:gen-ai-conversations", organization, actor=request.user):
             return Response(status=404)
 
-        # Ignore statsPeriod so old links don't fail when opened later
-        mutable_query = request.GET.copy()
-        mutable_query.pop("statsPeriod", None)
-        request.GET = mutable_query  # type: ignore[assignment]
+        # Check what date params were passed before calling get_snuba_params
+        stats_period = request.GET.get("statsPeriod")
+        has_explicit_range = request.GET.get("start") or request.GET.get("end")
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
+
+        # Enforce 30-day retention limit
+        max_retention = timedelta(days=MAX_RETENTION_DAYS)
+        now = timezone.now()
+        max_retention_cutoff = now - max_retention
+
+        if stats_period:
+            # Always use full 30d range when statsPeriod is passed
+            snuba_params.start = max_retention_cutoff
+            snuba_params.end = now
+        else:
+            # Validate start/end aren't older than retention limit
+            if snuba_params.start and snuba_params.start < max_retention_cutoff:
+                return Response(
+                    {"detail": f"start time cannot be older than {MAX_RETENTION_DAYS} days"},
+                    status=400,
+                )
+            if snuba_params.end and snuba_params.end < max_retention_cutoff:
+                return Response(
+                    {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
+                    status=400,
+                )
+            if not has_explicit_range:
+                # No date params passed - use full 30d range
+                snuba_params.start = max_retention_cutoff
+                snuba_params.end = now
 
         selected_columns = AI_CONVERSATION_ATTRIBUTES
 

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -120,7 +120,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_multi_trace_conversation(self) -> None:
         """Test returns all spans for a conversation across multiple traces"""
-        now = before_now(days=30).replace(microsecond=0)
+        now = before_now(days=10).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id_1 = uuid4().hex
         trace_id_2 = uuid4().hex
@@ -175,7 +175,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_returns_conversation_attributes(self) -> None:
         """Test that the endpoint returns all AI conversation attributes"""
-        now = before_now(days=40).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 
@@ -230,7 +230,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_pagination(self) -> None:
         """Test pagination works correctly"""
-        now = before_now(days=50).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -276,7 +276,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_span_ordering(self) -> None:
         """Test spans are ordered by timestamp ascending"""
-        now = before_now(days=60).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -311,7 +311,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_only_returns_matching_conversation(self) -> None:
         """Test that only spans from the requested conversation are returned"""
-        now = before_now(days=70).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         conversation_id_1 = uuid4().hex
         conversation_id_2 = uuid4().hex
         trace_id = uuid4().hex
@@ -361,7 +361,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
 
     def test_returns_tool_attributes(self) -> None:
         """Test that tool spans include gen_ai.tool.name attribute"""
-        now = before_now(days=80).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 
@@ -389,9 +389,9 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert span["gen_ai.operation.type"] == "tool"
         assert span["gen_ai.tool.name"] == "search_database"
 
-    def test_stats_period_is_ignored(self) -> None:
-        """Test that statsPeriod parameter is ignored so old links still work"""
-        timestamp = before_now(days=90).replace(microsecond=0)
+    def test_stats_period_overrides_to_30d(self) -> None:
+        """Test that statsPeriod is overridden to 30d so all recent data is returned"""
+        timestamp = before_now(days=15).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 
@@ -402,13 +402,11 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
             trace_id=trace_id,
         )
 
-        # Use explicit start/end that includes the span, but add statsPeriod=1h
-        # which would normally restrict to last hour and exclude our 90-day-old span
+        # statsPeriod=1h would normally restrict to last hour and exclude our 15-day-old span,
+        # but endpoint overrides to 30d
         query = {
             "project": [self.project.id],
-            "start": (timestamp - timedelta(hours=1)).isoformat(),
-            "end": (timestamp + timedelta(hours=1)).isoformat(),
-            "statsPeriod": "1h",  # This should be ignored
+            "statsPeriod": "1h",
         }
 
         response = self.do_request(conversation_id, query)
@@ -423,7 +421,7 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         filter by gen_ai.operation.type:ai_client when summing tokens/costs
         to avoid double counting from agent spans that may also have token data.
         """
-        now = before_now(days=91).replace(microsecond=0)
+        now = before_now(days=5).replace(microsecond=0)
         trace_id = uuid4().hex
         conversation_id = uuid4().hex
 


### PR DESCRIPTION
We handle this on frontend, but just to be extra safe we should also handle this on the backend as well.

Closes [TET-1898: EAP going to downsampled tier for `statsPeriod` older than 30d](https://linear.app/getsentry/issue/TET-1898/eap-going-to-downsampled-tier-for-statsperiod-older-than-30d)
