### PR TITLE
debug(autopilot): Log exception for seer permission error

### DIFF
--- a/src/sentry/autopilot/tasks/missing_sdk_integration.py
+++ b/src/sentry/autopilot/tasks/missing_sdk_integration.py
@@ -140,7 +140,7 @@ def run_missing_sdk_integration_detector_for_project_task(
             intelligence_level="medium",
         )
     except SeerPermissionError:
-        logger.warning(
+        logger.exception(
             "missing_sdk_integration_detector.no_seer_access",
             extra={"organization_id": organization.id, "project_id": project.id},
         )


### PR DESCRIPTION
We are logging quite generic message, when there could be many reasons for this failure, so loggin exception should help with debugging.
