### PR TITLE
feat(preprod): Make head_ref optional for size analysis

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -51,7 +51,6 @@ def validate_vcs_parameters(data: dict[str, Any]) -> str | None:
         "head_sha": head_sha,
         "head_repo_name": data.get("head_repo_name"),
         "provider": data.get("provider"),
-        "head_ref": data.get("head_ref"),
     }
 
     if any(vcs_params.values()) and any(not v for v in vcs_params.values()):

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -230,7 +230,7 @@ def create_preprod_artifact(
         with transaction.atomic(router.db_for_write(PreprodArtifact)):
             # Create CommitComparison if git information is provided
             commit_comparison = None
-            if head_sha and head_repo_name and provider and head_ref:
+            if head_sha and head_repo_name and provider:
                 commit_comparison, _ = CommitComparison.objects.get_or_create(
                     organization_id=org_id,
                     head_repo_name=head_repo_name,


### PR DESCRIPTION
## Summary
Make the `head_ref` parameter optional when creating preprod artifacts with VCS features. The API previously required all VCS parameters (head_sha, head_repo_name, provider, head_ref) as an "all or nothing" set, but `head_ref` is not essential for core functionality.

Head ref is not needed for size analysis comparisons and isn't a required field in the database.