### PR TITLE
fix(aci): add errors support for dataSources

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -128,6 +128,12 @@ const mapMetricDetectorFormErrors = (error: unknown) => {
       ...error.dataSource,
     };
   }
+  if ('dataSources' in error && typeof error.dataSources === 'object') {
+    return {
+      ...error,
+      ...error.dataSources,
+    };
+  }
   return error;
 };
 

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -128,11 +128,19 @@ const mapMetricDetectorFormErrors = (error: unknown) => {
       ...error.dataSource,
     };
   }
-  if ('dataSources' in error && typeof error.dataSources === 'object') {
-    return {
-      ...error,
-      ...error.dataSources,
-    };
+  if ('dataSources' in error) {
+    if (Array.isArray(error.dataSources)) {
+      return {
+        ...error,
+        ...error.dataSources[0],
+      };
+    }
+    if (typeof error.dataSources === 'object') {
+      return {
+        ...error,
+        ...error.dataSources,
+      };
+    }
   }
   return error;
 };


### PR DESCRIPTION
With the transactions -> spans alerts migration we're throwing errors in the `dataSources` object but this check only checks the `dataSource` object. I assume this was probably changed recently but these errors were not being shown properly in the Monitors UI.