### PR TITLE
fix(uptime-ongoing-issues): Issue list errors when check-in timeline is zoomed

### DIFF
--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -26,7 +26,7 @@ export function DetectorDetailsOngoingIssues({
       ? getUtcDateString(selection.datetime.start)
       : undefined,
     end: selection.datetime.end ? getUtcDateString(selection.datetime.end) : undefined,
-    statsPeriod: selection.datetime.period,
+    statsPeriod: selection.datetime.period ?? undefined,
   };
 
   return (


### PR DESCRIPTION
`statsPeriod:null` 400s the endpoint