### PR TITLE
fix(code-review): add "Copilot" user login special case to bot check

### DIFF
--- a/src/sentry/models/organizationcontributors.py
+++ b/src/sentry/models/organizationcontributors.py
@@ -47,4 +47,4 @@ class OrganizationContributors(DefaultFieldsModel):
 
     @property
     def is_bot(self) -> bool:
-        return self.alias is not None and (self.alias.endswith("[bot]") or self.alias == "copilot")
+        return self.alias is not None and (self.alias.endswith("[bot]") or self.alias == "Copilot")

--- a/src/sentry/models/organizationcontributors.py
+++ b/src/sentry/models/organizationcontributors.py
@@ -47,4 +47,4 @@ class OrganizationContributors(DefaultFieldsModel):
 
     @property
     def is_bot(self) -> bool:
-        return self.alias is not None and self.alias.endswith("[bot]")
+        return self.alias is not None and (self.alias.endswith("[bot]") or self.alias == "copilot")

--- a/src/sentry/models/organizationcontributors.py
+++ b/src/sentry/models/organizationcontributors.py
@@ -47,4 +47,7 @@ class OrganizationContributors(DefaultFieldsModel):
 
     @property
     def is_bot(self) -> bool:
+        """
+        Check if the contributor is a bot (has a [bot] suffix) or is Copilot (special case without [bot] suffix)
+        """
         return self.alias is not None and (self.alias.endswith("[bot]") or self.alias == "Copilot")


### PR DESCRIPTION
Fixes CW-791

Per the eligibility check logs ([example](https://console.cloud.google.com/logs/query;cursorTimestamp=2026-02-06T19:12:23.643439098Z;duration=P30D;query=search%2528%22github.webhook.organization_contributor.eligibility_check%22%2529%0AjsonPayload.%22user_login%22:%22copilot%22%0Atimestamp%3D%222026-02-06T19:11:24.594634852Z%22%0AinsertId%3D%22fp7psvdz21bh6z4y%22?project=internal-sentry)) Copilot uses the "Copilot" login without the "[bot]" suffix so let's add it to the bot check.