### PR TITLE
Release commit author limit

### DIFF
--- a/INVESTIGATION_FINDINGS.md
+++ b/INVESTIGATION_FINDINGS.md
@@ -3,6 +3,7 @@
 ## Background
 
 From Slack #discuss-integrations (2/9/2026):
+
 > Canva (enterprise customer) wrote in asking about github integration and commits associated with releases. They're finding that some authors are missing in the author list of those releases. It doesn't seem to be tied to single user or commit. Username and email between github and sentry is consistent. What could be the issue here? Can only 250 commits be associated to a release and if that's the case any commit authors after the 250 cut off will be left out?
 
 ## Investigation Summary

--- a/INVESTIGATION_FINDINGS.md
+++ b/INVESTIGATION_FINDINGS.md
@@ -1,0 +1,118 @@
+# Investigation: Is there a 250 commit limit per release in Sentry?
+
+## Background
+
+From Slack #discuss-integrations (2/9/2026):
+> Canva (enterprise customer) wrote in asking about github integration and commits associated with releases. They're finding that some authors are missing in the author list of those releases. It doesn't seem to be tied to single user or commit. Username and email between github and sentry is consistent. What could be the issue here? Can only 250 commits be associated to a release and if that's the case any commit authors after the 250 cut off will be left out?
+
+## Investigation Summary
+
+**Conclusion: There is NO 250 commit limit per release in Sentry.**
+
+## Detailed Findings
+
+### 1. API Serializer (No Limit)
+
+**File:** `src/sentry/api/serializers/rest_framework/release.py`
+
+```python
+commits = serializers.ListField(
+    child=CommitSerializer(),
+    required=False,
+    allow_null=False,
+    help_text="An optional list of commit data to be associated.",
+)
+```
+
+- No `max_length` parameter on the `ListField`
+- Unlimited commits can be sent via API
+
+### 2. Database Model (No Limit)
+
+**File:** `src/sentry/models/release.py`
+
+```python
+authors = ArrayField(models.TextField(), default=list, null=True)
+```
+
+- PostgreSQL `ArrayField` with no size constraint
+- Arrays in PostgreSQL can theoretically hold up to 2GB per element
+
+### 3. Commit Processing (No Limit)
+
+**File:** `src/sentry/models/releases/set_commits.py`
+
+Lines 97-108 show how authors are populated:
+
+```python
+release.update(
+    commit_count=len(commit_list),
+    authors=[
+        str(a_id)
+        for a_id in ReleaseCommit.objects.filter(
+            release=release, commit__author_id__isnull=False
+        )
+        .values_list("commit__author_id", flat=True)
+        .distinct()
+    ],
+    last_commit_id=latest_commit.id if latest_commit else None,
+)
+```
+
+- **No `[:250]` slice** or any limit on the `.distinct()` query
+- All unique commit authors are captured
+
+### 4. Historical Context
+
+Recent commits show improvements but no limits:
+
+- **d082f857506** (Jan 15, 2026): "perf(releases): Batch CommitAuthor queries" - Optimized to handle any number of authors efficiently, reducing queries from 2N+ to at most 4 queries
+- **b40ad28a1fb** (2024): "ref: improve release serializer where Release.authors is None" - Bug fix for null authors
+- **668079e47cd**: "feat(releases): Increase max commit author email length" - Increased email length, not commit count limits
+
+### 5. Constants
+
+The only "250" constant found is:
+
+```python
+DB_VERSION_LENGTH = 250  # Maximum length for version STRING, not commit count
+```
+
+This is for the release version string length (e.g., "1.0.0"), NOT for commit counts.
+
+## Possible Causes of Missing Authors
+
+If Canva is experiencing missing authors, it's likely NOT due to a 250 limit. Possible causes:
+
+1. **Commits without authors**: Some commits may have `author_id__isnull=True` and are filtered out
+2. **Email mismatches**: Author matching is case-insensitive but requires exact email matches
+3. **Race conditions**: If multiple releases are created rapidly, the locking mechanism might cause some commits to fail
+4. **Query timeouts**: For extremely large commit sets (1000s), database queries might timeout
+5. **Pagination in UI**: The frontend paginates commits at 40 per page, which might make it seem like commits are missing
+6. **API client issues**: The Sentry CLI or other client might be truncating the commit list before sending
+
+## Test Coverage
+
+Created comprehensive test in `tests/sentry/models/test_release_commit_author_limit.py`:
+
+- `test_release_with_more_than_250_commit_authors()`: Tests 300 commits with 300 distinct authors
+- `test_release_with_exactly_250_commit_authors()`: Tests exactly 250 commits as a baseline
+- `test_release_authors_query_efficiency()`: Tests 350 commits and verifies query correctness
+
+## Recommendation
+
+To help Canva debug their issue:
+
+1. **Check the actual commit count**: Have them query their release to see `release.commit_count` and `len(release.authors)`
+2. **Verify author emails**: Ensure all commits have valid author emails
+3. **Check for duplicate authors**: Multiple commits by the same author only appear once in the authors list
+4. **Review API logs**: Check if the full commit list is being sent to Sentry
+5. **Database query**: Run a direct query on their release to verify all authors are stored:
+   ```sql
+   SELECT count(*) FROM sentry_releasecommit WHERE release_id = <their_release_id>;
+   ```
+
+## Files Modified
+
+- `tests/sentry/models/test_release_commit_author_limit.py` (new)
+- `INVESTIGATION_FINDINGS.md` (this file)

--- a/tests/sentry/models/test_release_commit_author_limit.py
+++ b/tests/sentry/models/test_release_commit_author_limit.py
@@ -5,7 +5,6 @@ This test file addresses customer concerns about a potential 250 commit/author l
 reported in the #discuss-integrations Slack channel.
 """
 
-from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit

--- a/tests/sentry/models/test_release_commit_author_limit.py
+++ b/tests/sentry/models/test_release_commit_author_limit.py
@@ -1,0 +1,166 @@
+"""
+Test that releases can handle more than 250 commits with distinct authors.
+
+This test file addresses customer concerns about a potential 250 commit/author limit
+reported in the #discuss-integrations Slack channel.
+"""
+
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.release import Release
+from sentry.models.releasecommit import ReleaseCommit
+from sentry.models.repository import Repository
+from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
+
+
+class ReleaseCommitAuthorLimitTest(TestCase):
+    """Test that releases can handle more than 250 commits with distinct authors."""
+
+    def test_release_with_more_than_250_commit_authors(self) -> None:
+        """
+        Verify that a release can have more than 250 commits with distinct authors.
+        This test addresses customer concerns about a potential 250 commit/author limit.
+
+        Background: Canva (enterprise customer) reported that some authors are missing
+        from their release author lists, and they suspected a 250 commit limit might exist.
+        """
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="test-project")
+        repo = Repository.objects.create(organization_id=org.id, name="test/repo")
+
+        release = Release.objects.create(version="1.0.0-large-commit-test", organization=org)
+        release.add_project(project)
+
+        # Create 300 commits with 300 distinct authors to verify no 250 limit exists
+        num_commits = 300
+        commits = []
+        for i in range(num_commits):
+            commits.append(
+                {
+                    "id": f"{'a' * 39}{i:01x}",  # Unique 40-char commit SHA
+                    "repository": repo.name,
+                    "author_email": f"author{i}@example.com",
+                    "author_name": f"Author {i}",
+                    "message": f"commit {i}",
+                }
+            )
+
+        # Set all commits on the release
+        release.set_commits(commits)
+
+        # Verify all commits were created
+        release_commits = ReleaseCommit.objects.filter(release=release)
+        assert release_commits.count() == num_commits
+
+        # Verify the release has the correct commit count
+        release.refresh_from_db()
+        assert release.commit_count == num_commits
+
+        # Verify all distinct authors were captured
+        assert len(release.authors) == num_commits, (
+            f"Expected {num_commits} authors in release.authors, "
+            f"but got {len(release.authors)}. This may indicate a hidden limit."
+        )
+
+        # Verify all commit authors were created
+        commit_authors = CommitAuthor.objects.filter(
+            organization_id=org.id, email__startswith="author"
+        )
+        assert commit_authors.count() == num_commits
+
+        # Verify authors at key positions are correctly associated
+        # Particularly checking around the suspected 250 limit
+        for i in [0, 100, 200, 249, 250, 251, 299]:
+            author = CommitAuthor.objects.get(organization_id=org.id, email=f"author{i}@example.com")
+            assert str(author.id) in release.authors, (
+                f"Author {i} (email: author{i}@example.com, id: {author.id}) "
+                f"not found in release.authors. This suggests authors after position {i} may be missing."
+            )
+
+    def test_release_with_exactly_250_commit_authors(self) -> None:
+        """
+        Test with exactly 250 commits to establish a baseline.
+        """
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="test-project")
+        repo = Repository.objects.create(organization_id=org.id, name="test/repo")
+
+        release = Release.objects.create(version="1.0.0-exactly-250", organization=org)
+        release.add_project(project)
+
+        # Create exactly 250 commits
+        num_commits = 250
+        commits = []
+        for i in range(num_commits):
+            commits.append(
+                {
+                    "id": f"{'b' * 39}{i:01x}",
+                    "repository": repo.name,
+                    "author_email": f"author{i}@example.com",
+                    "author_name": f"Author {i}",
+                    "message": f"commit {i}",
+                }
+            )
+
+        release.set_commits(commits)
+
+        # Verify all commits and authors were created
+        release.refresh_from_db()
+        assert release.commit_count == num_commits
+        assert len(release.authors) == num_commits
+
+        # Verify the last author (index 249) is included
+        last_author = CommitAuthor.objects.get(
+            organization_id=org.id, email="author249@example.com"
+        )
+        assert str(last_author.id) in release.authors
+
+    def test_release_authors_query_efficiency(self) -> None:
+        """
+        Verify that the query to populate release.authors doesn't have implicit limits.
+        
+        This test checks that the .distinct() query in set_commits.py properly
+        retrieves all unique author IDs without truncation.
+        """
+        org = self.create_organization(owner=Factories.create_user())
+        project = self.create_project(organization=org, name="test-project")
+        repo = Repository.objects.create(organization_id=org.id, name="test/repo")
+
+        release = Release.objects.create(version="1.0.0-query-test", organization=org)
+        release.add_project(project)
+
+        # Create 350 commits to test well beyond any suspected limit
+        num_commits = 350
+        commits = []
+        for i in range(num_commits):
+            commits.append(
+                {
+                    "id": f"{'c' * 39}{i:03x}",
+                    "repository": repo.name,
+                    "author_email": f"test{i}@example.com",
+                    "author_name": f"Test Author {i}",
+                    "message": f"Test commit {i}",
+                }
+            )
+
+        release.set_commits(commits)
+        release.refresh_from_db()
+
+        # Verify all authors are present
+        assert len(release.authors) == num_commits
+
+        # Verify the query that populates authors doesn't skip any
+        release_commit_author_ids = set(
+            ReleaseCommit.objects.filter(release=release, commit__author_id__isnull=False)
+            .values_list("commit__author_id", flat=True)
+            .distinct()
+        )
+
+        # Compare with release.authors (stored as strings)
+        stored_author_ids = {int(author_id) for author_id in release.authors}
+
+        assert release_commit_author_ids == stored_author_ids, (
+            f"Mismatch between ReleaseCommit authors and stored release.authors. "
+            f"Expected {len(release_commit_author_ids)} but got {len(stored_author_ids)}"
+        )

--- a/tests/sentry/models/test_release_commit_author_limit.py
+++ b/tests/sentry/models/test_release_commit_author_limit.py
@@ -72,7 +72,9 @@ class ReleaseCommitAuthorLimitTest(TestCase):
         # Verify authors at key positions are correctly associated
         # Particularly checking around the suspected 250 limit
         for i in [0, 100, 200, 249, 250, 251, 299]:
-            author = CommitAuthor.objects.get(organization_id=org.id, email=f"author{i}@example.com")
+            author = CommitAuthor.objects.get(
+                organization_id=org.id, email=f"author{i}@example.com"
+            )
             assert str(author.id) in release.authors, (
                 f"Author {i} (email: author{i}@example.com, id: {author.id}) "
                 f"not found in release.authors. This suggests authors after position {i} may be missing."
@@ -119,7 +121,7 @@ class ReleaseCommitAuthorLimitTest(TestCase):
     def test_release_authors_query_efficiency(self) -> None:
         """
         Verify that the query to populate release.authors doesn't have implicit limits.
-        
+
         This test checks that the .distinct() query in set_commits.py properly
         retrieves all unique author IDs without truncation.
         """

--- a/tests/sentry/models/test_release_commit_author_limit.py
+++ b/tests/sentry/models/test_release_commit_author_limit.py
@@ -57,6 +57,7 @@ class ReleaseCommitAuthorLimitTest(TestCase):
         assert release.commit_count == num_commits
 
         # Verify all distinct authors were captured
+        assert release.authors is not None
         assert len(release.authors) == num_commits, (
             f"Expected {num_commits} authors in release.authors, "
             f"but got {len(release.authors)}. This may indicate a hidden limit."
@@ -70,6 +71,7 @@ class ReleaseCommitAuthorLimitTest(TestCase):
 
         # Verify authors at key positions are correctly associated
         # Particularly checking around the suspected 250 limit
+        assert release.authors is not None
         for i in [0, 100, 200, 249, 250, 251, 299]:
             author = CommitAuthor.objects.get(
                 organization_id=org.id, email=f"author{i}@example.com"
@@ -109,6 +111,7 @@ class ReleaseCommitAuthorLimitTest(TestCase):
         # Verify all commits and authors were created
         release.refresh_from_db()
         assert release.commit_count == num_commits
+        assert release.authors is not None
         assert len(release.authors) == num_commits
 
         # Verify the last author (index 249) is included
@@ -149,6 +152,7 @@ class ReleaseCommitAuthorLimitTest(TestCase):
         release.refresh_from_db()
 
         # Verify all authors are present
+        assert release.authors is not None
         assert len(release.authors) == num_commits
 
         # Verify the query that populates authors doesn't skip any


### PR DESCRIPTION
This PR addresses a customer inquiry regarding a suspected 250-commit limit per release that might cause missing authors.

**Key Findings:**
A thorough investigation confirmed that **no 250-commit limit exists** in Sentry's API, database, or commit processing logic for releases.

**Changes:**
- Adds `tests/sentry/models/test_release_commit_author_limit.py` to explicitly verify releases can handle well over 250 unique commit authors.
- Includes `INVESTIGATION_FINDINGS.md` to document the detailed analysis and potential alternative causes for missing authors.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/CD4NYFD34/p1770609769533959?thread_ts=1770609769.533959&cid=CD4NYFD34)

<p><a href="https://cursor.com/background-agent?bcId=bc-dc78968d-61fb-5b3e-9c04-4fa338fd4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc78968d-61fb-5b3e-9c04-4fa338fd4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

