### PR TITLE
feat: Add seer-apple-apps feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -425,6 +425,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    # Enable Seer Apple Apps feature
+    manager.add("organizations:seer-apple-apps", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable coding agent integrations for AI-powered code fixes
     manager.add("organizations:seer-coding-agent-integrations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Config Reminder in the primary nav


### PR DESCRIPTION
## Summary
- Register `organizations:seer-apple-apps` as a temporary FLAGPOLE feature flag

## Test plan
- [ ] CI passes
- [ ] Merge this PR before the sentry-options-automator PR

🤖 Generated with [Claude Code](https://claude.ai/code)