### PR TITLE
bug(infra): Add migrations exclusion to selected test computation

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -5,6 +5,7 @@ on:
       - '.pre-commit-config.yaml'
       - 'Makefile'
       - '.github/workflows/development-environment.yml'
+      - '.github/workflows/scripts/**'
       - 'requirements-*.txt'
       - 'pyproject.toml'
       - 'uv.lock'

--- a/.github/workflows/scripts/compute-selected-tests.py
+++ b/.github/workflows/scripts/compute-selected-tests.py
@@ -3,23 +3,33 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sqlite3
 import sys
 from pathlib import Path
 
-# Files that, if changed, should trigger the full test suite (can't determine affected tests)
-FULL_SUITE_TRIGGER_FILES = [
+# Files/patterns that, if matched by any changed file, should trigger the full test suite.
+# Strings are matched as suffixes, re.Pattern entries are matched with .search().
+FULL_SUITE_TRIGGERS: list[str | re.Pattern[str]] = [
     "sentry/testutils/pytest/sentry.py",
     "pyproject.toml",
     "Makefile",
     "sentry/conf/server.py",
     "sentry/web/urls.py",
+    # Django migrations can affect schema and invalidate selective test coverage
+    re.compile(r"/migrations/\d{4}_[^/]+\.py$"),
 ]
+
+
+def _matches_trigger(file_path: str, trigger: str | re.Pattern[str]) -> bool:
+    if isinstance(trigger, re.Pattern):
+        return trigger.search(file_path) is not None
+    return file_path.endswith(trigger)
 
 
 def should_run_full_suite(changed_files: list[str]) -> bool:
     for file_path in changed_files:
-        if any(file_path.endswith(trigger) for trigger in FULL_SUITE_TRIGGER_FILES):
+        if any(_matches_trigger(file_path, t) for t in FULL_SUITE_TRIGGERS):
             return True
     return False
 
@@ -100,7 +110,7 @@ def main() -> int:
         affected_test_files: set[str] = set()
     elif should_run_full_suite(changed_files):
         triggered_by = [
-            f for f in changed_files if any(f.endswith(t) for t in FULL_SUITE_TRIGGER_FILES)
+            f for f in changed_files if any(_matches_trigger(f, t) for t in FULL_SUITE_TRIGGERS)
         ]
         print(f"Full test suite triggered by: {', '.join(triggered_by)}")
         affected_test_files = set()

--- a/.github/workflows/scripts/compute-selected-tests.py
+++ b/.github/workflows/scripts/compute-selected-tests.py
@@ -34,12 +34,18 @@ def should_run_full_suite(changed_files: list[str]) -> bool:
     return False
 
 
+# Test directories excluded from backend test runs (must match calculate-backend-test-shards.py)
+EXCLUDED_TEST_PATTERNS: list[str | re.Pattern[str]] = [
+    re.compile(r"^tests/(acceptance|apidocs|js|tools)/"),
+]
+
+
 def get_changed_test_files(changed_files: list[str]) -> set[str]:
     test_files: set[str] = set()
     for file_path in changed_files:
-        # Match test files in the tests/ directory
         if file_path.startswith("tests/") and file_path.endswith(".py"):
-            test_files.add(file_path)
+            if not any(_matches_trigger(file_path, p) for p in EXCLUDED_TEST_PATTERNS):
+                test_files.add(file_path)
     return test_files
 
 

--- a/tests/tools/test_compute_selected_tests.py
+++ b/tests/tools/test_compute_selected_tests.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import runpy
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_mod = runpy.run_path(
+    str(Path(__file__).resolve().parents[2] / ".github/workflows/scripts/compute-selected-tests.py")
+)
+should_run_full_suite = _mod["should_run_full_suite"]
+get_changed_test_files = _mod["get_changed_test_files"]
+get_affected_test_files = _mod["get_affected_test_files"]
+
+
+def test_full_suite_triggered():
+    trigger_files = [
+        "sentry/testutils/pytest/sentry.py",
+        "src/sentry/testutils/pytest/sentry.py",
+        "pyproject.toml",
+        "Makefile",
+        "sentry/conf/server.py",
+        "src/sentry/conf/server.py",
+        "sentry/web/urls.py",
+        "src/sentry/migrations/0001_initial.py",
+        "src/sentry/replays/migrations/0042_add_index.py",
+        "src/sentry/issues/migrations/9999_something.py",
+    ]
+    for path in trigger_files:
+        assert should_run_full_suite([path]) is True, path
+
+
+def test_full_suite_not_triggered():
+    safe_files = [
+        "src/sentry/migrations/initial.py",
+        "src/sentry/utils/migrations_helper.py",
+        "src/sentry/migrations/0001_initial.txt",
+        "src/sentry/models/group.py",
+        "src/sentry/api/endpoints/project.py",
+    ]
+    for path in safe_files:
+        assert should_run_full_suite([path]) is False, path
+    assert should_run_full_suite([]) is False
+    assert (
+        should_run_full_suite(["src/sentry/api/foo.py", "src/sentry/migrations/0500_bar.py"])
+        is True
+    )
+
+
+def test_get_changed_test_files():
+    changed = [
+        "tests/sentry/api/test_base.py",
+        "src/sentry/api/base.py",
+        "tests/sentry/models/test_group.py",
+        "README.md",
+    ]
+    assert get_changed_test_files(changed) == {
+        "tests/sentry/api/test_base.py",
+        "tests/sentry/models/test_group.py",
+    }
+
+
+def test_get_changed_test_files_empty():
+    assert get_changed_test_files([]) == set()
+
+
+def test_get_affected_test_files(tmp_path):
+    db_path = tmp_path / ".coverage.combined"
+    _create_coverage_db(
+        db_path,
+        {
+            "src/sentry/models/group.py": [
+                "tests/sentry/models/test_group.py::TestGroup::test_get|run",
+                "tests/sentry/api/test_issues.py::TestIssues::test_list|run",
+            ],
+            "src/sentry/models/project.py": [
+                "tests/sentry/models/test_project.py::TestProject::test_create|run",
+            ],
+        },
+    )
+
+    assert get_affected_test_files(str(db_path), ["src/sentry/models/group.py"]) == {
+        "tests/sentry/models/test_group.py",
+        "tests/sentry/api/test_issues.py",
+    }
+
+
+def test_get_affected_test_files_no_match(tmp_path):
+    db_path = tmp_path / ".coverage.combined"
+    _create_coverage_db(
+        db_path,
+        {
+            "src/sentry/models/group.py": [
+                "tests/sentry/models/test_group.py::TestGroup::test_get|run"
+            ]
+        },
+    )
+
+    assert get_affected_test_files(str(db_path), ["src/sentry/unrelated.py"]) == set()
+
+
+def test_get_affected_test_files_missing_tables(tmp_path):
+    db_path = tmp_path / ".coverage.combined"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE file (id INTEGER PRIMARY KEY, path TEXT)")
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(ValueError, match="missing line_bits/context tables"):
+        get_affected_test_files(str(db_path), ["src/sentry/models/group.py"])
+
+
+def _create_coverage_db(db_path, file_contexts):
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE file (id INTEGER PRIMARY KEY, path TEXT)")
+    cur.execute("CREATE TABLE context (id INTEGER PRIMARY KEY, context TEXT)")
+    cur.execute("CREATE TABLE line_bits (file_id INTEGER, context_id INTEGER, numbits BLOB)")
+
+    file_id = 0
+    ctx_id = 0
+    seen_contexts: dict[str, int] = {}
+
+    for file_path, contexts in file_contexts.items():
+        file_id += 1
+        cur.execute("INSERT INTO file VALUES (?, ?)", (file_id, file_path))
+        for ctx in contexts:
+            if ctx not in seen_contexts:
+                ctx_id += 1
+                seen_contexts[ctx] = ctx_id
+                cur.execute("INSERT INTO context VALUES (?, ?)", (ctx_id, ctx))
+            cur.execute(
+                "INSERT INTO line_bits VALUES (?, ?, ?)", (file_id, seen_contexts[ctx], b"\x01")
+            )
+
+    cur.execute("INSERT INTO context VALUES (?, ?)", (ctx_id + 1, ""))
+    conn.commit()
+    conn.close()

--- a/tests/tools/test_compute_selected_tests.py
+++ b/tests/tools/test_compute_selected_tests.py
@@ -53,6 +53,8 @@ def test_get_changed_test_files():
         "tests/sentry/api/test_base.py",
         "src/sentry/api/base.py",
         "tests/sentry/models/test_group.py",
+        "tests/tools/test_compute_selected_tests.py",
+        "tests/acceptance/test_foo.py",
         "README.md",
     ]
     assert get_changed_test_files(changed) == {


### PR DESCRIPTION
Following some investigations in https://www.notion.so/Selective-testing-rollout-results-2fe8b10e4b5d80caa9bcf61e49798d50?source=copy_link, I discovered 2 concerning selective test failures. One was caused by a migration, which due to indirect dependency changes, caused a test to fail in the full suite that did not fail in the selective suite. This PR fixes that by opting in any migrations-related changes to the full test suite.

This updates the `compute-selective-tests.py` script to parse strings/regex combos for exclusion and will now run the full suite for any migrations.

Also adds a basic test for the selective tests script that should run as part of `make test-tools` to ensure our selective test logic is valid.