### PR TITLE
chore(ACI): Make sentry_app_installation_uuid optional

### DIFF
--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -94,7 +94,7 @@ def process_sentry_app_installation_deletes(
     action_service.update_action_status_for_sentry_app_via_uuid__region(
         region_name=region_name,
         status=ObjectStatus.DISABLED,
-        sentry_app_install_uuid=payload["uuid"],
+        sentry_app_install_uuid=payload.get("uuid"),
         sentry_app_id=payload.get("sentry_app_id"),
         organization_id=payload.get("organization_id"),
     )

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -165,7 +165,6 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
                 payload={
-                    "uuid": self.uuid,
                     "sentry_app_id": self.sentry_app_id,
                     "organization_id": self.organization_id,
                 },

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -165,6 +165,7 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
                 payload={
+                    "uuid": self.uuid,
                     "sentry_app_id": self.sentry_app_id,
                     "organization_id": self.organization_id,
                 },

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -33,10 +33,11 @@ class DatabaseBackedActionService(ActionService):
         *,
         organization_id: int,
         status: int,
-        sentry_app_install_uuid: str,
+        sentry_app_install_uuid: str | None = None,
         sentry_app_id: int | None = None,
     ) -> None:
         sentry_app_id_actions = Action.objects.none()
+        installation_uuid_actions = Action.objects.none()
 
         if sentry_app_id:
             sentry_app_id_actions = Action.objects.filter(
@@ -45,12 +46,13 @@ class DatabaseBackedActionService(ActionService):
                 type=Action.Type.SENTRY_APP,
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
-        installation_uuid_actions = Action.objects.filter(
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
-            config__target_identifier=sentry_app_install_uuid,
-            type=Action.Type.SENTRY_APP,
-            dataconditiongroupaction__condition_group__organization_id=organization_id,
-        )
+        if sentry_app_install_uuid:
+            installation_uuid_actions = Action.objects.filter(
+                config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                config__target_identifier=sentry_app_install_uuid,
+                type=Action.Type.SENTRY_APP,
+                dataconditiongroupaction__condition_group__organization_id=organization_id,
+            )
 
         actions = sentry_app_id_actions | installation_uuid_actions
         if actions:
@@ -61,11 +63,12 @@ class DatabaseBackedActionService(ActionService):
         *,
         region_name: str,
         status: int,
-        sentry_app_install_uuid: str,
+        sentry_app_install_uuid: str | None = None,
         organization_id: int | None = None,
         sentry_app_id: int | None = None,
     ) -> None:
         sentry_app_id_actions = Action.objects.none()
+        installation_uuid_actions = Action.objects.none()
 
         if sentry_app_id and organization_id:
             sentry_app_id_actions = Action.objects.filter(
@@ -74,14 +77,14 @@ class DatabaseBackedActionService(ActionService):
                 type=Action.Type.SENTRY_APP,
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
-        if organization_id:
+        if sentry_app_install_uuid and organization_id:
             installation_uuid_actions = Action.objects.filter(
                 config__target_identifier=sentry_app_install_uuid,
                 type=Action.Type.SENTRY_APP,
                 config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
                 dataconditiongroupaction__condition_group__organization_id=organization_id,
             )
-        else:
+        elif sentry_app_install_uuid:
             installation_uuid_actions = Action.objects.filter(
                 config__target_identifier=sentry_app_install_uuid,
                 type=Action.Type.SENTRY_APP,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -1,6 +1,10 @@
+import logging
+
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.service.action.service import ActionService
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
+
+logger = logging.getLogger(__name__)
 
 
 class DatabaseBackedActionService(ActionService):
@@ -69,6 +73,12 @@ class DatabaseBackedActionService(ActionService):
     ) -> None:
         sentry_app_id_actions = Action.objects.none()
         installation_uuid_actions = Action.objects.none()
+
+        if not sentry_app_id and not organization_id:
+            logger.info(
+                "Expected sentry_app_id and organization_id, but they were not passed",
+                extra={"sentry_app_id": sentry_app_id, "organization_id": organization_id},
+            )
 
         if sentry_app_id and organization_id:
             sentry_app_id_actions = Action.objects.filter(

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -41,7 +41,7 @@ class ActionService(RpcService):
         *,
         organization_id: int,
         status: int,
-        sentry_app_install_uuid: str,
+        sentry_app_install_uuid: str | None = None,
         sentry_app_id: int | None = None,
     ) -> None:
         pass
@@ -53,7 +53,7 @@ class ActionService(RpcService):
         *,
         region_name: str,
         status: int,
-        sentry_app_install_uuid: str,
+        sentry_app_install_uuid: str | None = None,
         organization_id: int | None = None,
         sentry_app_id: int | None = None,
     ) -> None:

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -123,8 +123,8 @@ class TestSentryAppInstallationDeletionTask(TestCase):
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
-                "target_identifier": self.install.uuid,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_identifier": str(self.install.sentry_app_id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -134,7 +134,7 @@ class TestSentryAppInstallationDeletionTask(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": "1234567890",
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -129,8 +129,8 @@ class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
         action = self.create_action(
             type=Action.Type.SENTRY_APP,
             config={
-                "target_identifier": self.installation2.uuid,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
+                "target_identifier": str(self.installation2.sentry_app_id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -311,6 +311,51 @@ class TestActionService(TestCase):
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
             assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
 
+    def test_update_action_status_for_sentry_app__sentry_app_id(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        sentry_app_id_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group()
+        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg)
+
+        # make a new org to ensure we are not disabling actions related to the same sentry app based on a different installation being removed
+        org2 = self.create_organization()
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=org2,
+        )
+        sentry_app_id_action2 = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group(organization=org2)
+        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
+
+        action_service.update_action_status_for_sentry_app_via_uuid(
+            organization_id=self.organization.id,
+            sentry_app_id=sentry_app_installation.sentry_app.id,
+            status=ObjectStatus.DISABLED,
+        )
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            sentry_app_id_action.refresh_from_db()
+            sentry_app_id_action2.refresh_from_db()
+            assert sentry_app_id_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
+
     def test_update_action_status_for_sentry_app__installation_uuid__region(self) -> None:
         sentry_app_installation = self.create_sentry_app_installation(
             slug=self.sentry_app.slug,
@@ -368,6 +413,51 @@ class TestActionService(TestCase):
             sentry_app_id_action.refresh_from_db()
             sentry_app_id_action2.refresh_from_db()
             assert installation_uuid_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
+
+    def test_update_action_status_for_sentry_app__sentry_app_id__region(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        sentry_app_id_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group()
+        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg)
+
+        # make a new org to ensure we are not disabling actions related to the same sentry app
+        org2 = self.create_organization()
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=org2,
+        )
+        sentry_app_id_action2 = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group(organization=org2)
+        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
+
+        action_service.update_action_status_for_sentry_app_via_uuid__region(
+            region_name="us",
+            sentry_app_id=sentry_app_installation.sentry_app.id,
+            organization_id=self.organization.id,
+            status=ObjectStatus.DISABLED,
+        )
+        with assume_test_silo_mode(SiloMode.REGION):
+            sentry_app_id_action.refresh_from_db()
+            sentry_app_id_action2.refresh_from_db()
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
             assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/107460 to make passing the `sentry_app_installation_uuid` optional in preparation for completely removing it. The migration to update all `Action`s with a `sentry_app_identifier` of `sentry_app_installation_uuid` to store the `sentry_app_id` has completed and we no longer have any of these rows in the database.