### PR TITLE
fix(bug-prediction): Accept unprefixed provider

### DIFF
--- a/tests/sentry/seer/fetch_issues/test_utils.py
+++ b/tests/sentry/seer/fetch_issues/test_utils.py
@@ -78,6 +78,24 @@ class TestGetRepoAndProjects(TestCase):
                 external_id="123",
             )
 
+    def test_get_repo_and_projects_unprefixed_provider(self):
+        repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+        )
+        self.create_code_mapping(project=self.project, repo=repo)
+
+        result = get_repo_and_projects(
+            organization_id=self.organization.id,
+            provider="github",
+            external_id="123",
+        )
+
+        assert result.repo == repo
+        assert len(result.projects) == 1
+
     def test_get_repo_and_projects_repo_not_found(self):
         from sentry.models.repository import Repository
 


### PR DESCRIPTION
next will make repo filtering in seer use the same function so these failures don't happen again