### PR TITLE
chore(ACI): Remove references to SentryAppIdentifier

### DIFF
--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -23,7 +23,6 @@ export interface ActionConfig {
   targetDisplay: string | null;
   targetIdentifier: string | null;
   targetType: ActionTarget | null;
-  sentryAppIdentifier?: SentryAppIdentifier;
 }
 
 export enum ActionTarget {
@@ -55,11 +54,6 @@ export enum ActionGroup {
   NOTIFICATION = 'notification',
   TICKET_CREATION = 'ticket_creation',
   OTHER = 'other',
-}
-
-export enum SentryAppIdentifier {
-  SENTRY_APP_INSTALLATION_UUID = 'sentry_app_installation_uuid',
-  SENTRY_APP_ID = 'sentry_app_id',
 }
 
 export interface ActionHandler {

--- a/static/app/views/automations/components/actionNodeList.tsx
+++ b/static/app/views/automations/components/actionNodeList.tsx
@@ -8,7 +8,6 @@ import {t} from 'sentry/locale';
 import {
   ActionGroup,
   ActionType,
-  SentryAppIdentifier,
   type Action,
   type ActionHandler,
 } from 'sentry/types/workflowEngine/actions';
@@ -46,16 +45,10 @@ function getActionHandler(
       if (handler.type !== ActionType.SENTRY_APP) {
         return false;
       }
-      const {sentryAppIdentifier, targetIdentifier} = action.config;
+      const {targetIdentifier} = action.config;
       const sentryApp = handler.sentryApp;
 
-      const isMatchingAppId =
-        sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_ID &&
-        targetIdentifier === sentryApp?.id;
-      const isMatchingInstallationUuid =
-        sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID &&
-        targetIdentifier === sentryApp?.installationUuid;
-      return isMatchingAppId || isMatchingInstallationUuid;
+      return targetIdentifier === sentryApp?.id;
     });
   }
   return availableActions.find(handler => handler.type === action.type);

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -507,7 +507,6 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     targetType,
     targetIdentifier,
     targetDisplay,
-    ...(actionHandler.sentryApp?.id && {}),
   };
 }
 

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -6,12 +6,7 @@ import type {
   ActionConfig,
   ActionHandler,
 } from 'sentry/types/workflowEngine/actions';
-import {
-  ActionGroup,
-  ActionTarget,
-  ActionType,
-  SentryAppIdentifier,
-} from 'sentry/types/workflowEngine/actions';
+import {ActionGroup, ActionTarget, ActionType} from 'sentry/types/workflowEngine/actions';
 import {
   DataConditionGroupLogicType,
   DataConditionType,
@@ -512,9 +507,7 @@ function getDefaultConfig(actionHandler: ActionHandler): ActionConfig {
     targetType,
     targetIdentifier,
     targetDisplay,
-    ...(actionHandler.sentryApp?.id && {
-      sentryAppIdentifier: SentryAppIdentifier.SENTRY_APP_ID,
-    }),
+    ...(actionHandler.sentryApp?.id && {}),
   };
 }
 

--- a/static/app/views/automations/components/conditionsPanel.tsx
+++ b/static/app/views/automations/components/conditionsPanel.tsx
@@ -8,7 +8,6 @@ import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {
   ActionType,
-  SentryAppIdentifier,
   type Action,
   type ActionHandler,
 } from 'sentry/types/workflowEngine/actions';
@@ -70,13 +69,8 @@ function findActionHandler(
   availableActions: ActionHandler[]
 ): ActionHandler | undefined {
   if (action.type === ActionType.SENTRY_APP) {
-    if (action.config.sentryAppIdentifier === SentryAppIdentifier.SENTRY_APP_ID) {
-      return availableActions.find(
-        handler => handler.sentryApp?.id === action.config.targetIdentifier
-      );
-    }
     return availableActions.find(
-      handler => handler.sentryApp?.installationUuid === action.config.targetIdentifier
+      handler => handler.sentryApp?.id === action.config.targetIdentifier
     );
   }
   return availableActions.find(handler => handler.type === action.type);

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -434,7 +434,6 @@ describe('AutomationNewSettings', () => {
           targetType: 'sentry_app',
           targetIdentifier: 'sentry-app-1',
           targetDisplay: 'My Sentry App',
-          sentryAppIdentifier: 'sentry_app_id',
         },
       },
       github: {


### PR DESCRIPTION
Now that we've migrated the `Action` data to only ever have a sentry app id (and not an installation uuid) we can remove references to the sentry app identifier as it was only used to differentiate between actions with a sentry app id and actions with a sentry app installation uuid. 

Closes ISWF-2034