### PR TITLE
fix(aci): Use correct value for anomaly detection issue occurrence

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -170,10 +170,14 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
         data_packet: DataPacket[MetricUpdate],
         priority: DetectorPriorityLevel,
     ) -> dict[str, Any]:
+        evidence: dict[str, Any] = {}
+
+        if isinstance(data_packet.packet, AnomalyDetectionUpdate):
+            evidence["value"] = data_packet.packet.values.get("value")
 
         try:
             alert_rule_detector = AlertRuleDetector.objects.get(detector=self.detector)
-            return {"alert_id": alert_rule_detector.alert_rule_id}
+            evidence["alert_id"] = alert_rule_detector.alert_rule_id
         except AlertRuleDetector.DoesNotExist:
             logger.warning(
                 "No alert rule detector found for detector id %s",
@@ -182,7 +186,9 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
                     "detector_id": self.detector.id,
                 },
             )
-            return {"alert_id": None}
+            evidence["alert_id"] = None
+
+        return evidence
 
     def create_occurrence(
         self,

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -619,11 +619,18 @@ class StatefulDetectorHandler(
         """
         Decorate the issue occurrence with the data from the detector's evaluation result.
         """
-        evidence_data = self._build_workflow_engine_evidence_data(
-            evaluation_result,
-            data_packet,
-            data_value,
-        )
+        evidence_data = {
+            **self._build_workflow_engine_evidence_data(
+                evaluation_result,
+                data_packet,
+                data_value,
+            ),
+            **self.build_detector_evidence_data(
+                evaluation_result,
+                data_packet,
+                new_priority,
+            ),
+        }
 
         fingerprint = [
             *self.build_issue_fingerprint(group_key),

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -1,14 +1,28 @@
+from unittest import mock
+
+import orjson
+from urllib3.response import HTTPResponse
+
 from sentry.incidents.grouptype import (
+    MetricIssue,
     MetricIssueDetectorHandler,
     SessionsAggregate,
     get_alert_type_from_aggregate_dataset,
 )
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.seer.anomaly_detection.types import (
+    AnomalyDetectionSeasonality,
+    AnomalyDetectionSensitivity,
+    AnomalyDetectionThresholdType,
+    AnomalyType,
+    DetectAnomaliesResponse,
+)
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import DataCondition
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.utils.test_metric_issue_base import BaseMetricIssueTest
 
 
@@ -141,6 +155,64 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         assert isinstance(occurrence, IssueOccurrence)
 
         self.verify_issue_occurrence(occurrence, evidence_data, self.critical_detector_trigger)
+
+    @mock.patch(
+        "sentry.seer.anomaly_detection.get_anomaly_data.SEER_ANOMALY_DETECTION_CONNECTION_POOL.urlopen"
+    )
+    def test_anomaly_detection_evidence_extracts_value(
+        self, mock_seer_request: mock.MagicMock
+    ) -> None:
+        """
+        When the data packet is an AnomalyDetectionUpdate, the evidence data
+        should contain the numeric value extracted from the anomaly dict,
+        not the entire dict.
+        """
+        self.detector = self.create_detector(
+            project=self.project,
+            workflow_condition_group=self.create_data_condition_group(),
+            type=MetricIssue.slug,
+            created_by_id=self.user.id,
+            owner_user_id=self.user.id,
+            config={"threshold_period": 1, "detection_type": "dynamic"},
+        )
+        anomaly_condition = self.create_data_condition(
+            type=Condition.ANOMALY_DETECTION,
+            comparison={
+                "sensitivity": AnomalyDetectionSensitivity.MEDIUM.value,
+                "seasonality": AnomalyDetectionSeasonality.AUTO.value,
+                "threshold_type": AnomalyDetectionThresholdType.ABOVE_AND_BELOW.value,
+            },
+            condition_result=DetectorPriorityLevel.HIGH,
+            condition_group=self.detector.workflow_condition_group,
+        )
+        self.create_data_source_detector(self.data_source, self.detector)
+        self.alert_rule = self.create_alert_rule()
+        self.create_alert_rule_detector(alert_rule_id=self.alert_rule.id, detector=self.detector)
+        self.handler = MetricIssueDetectorHandler(self.detector)
+
+        value = 8938
+        data_packet = self.create_anomaly_detection_packet(value)
+
+        seer_response: DetectAnomaliesResponse = {
+            "success": True,
+            "timeseries": [
+                {
+                    "anomaly": {
+                        "anomaly_score": 0.9,
+                        "anomaly_type": AnomalyType.HIGH_CONFIDENCE,
+                    },
+                    "timestamp": 1,
+                    "value": value,
+                }
+            ],
+        }
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_response), status=200)
+
+        evidence_data = self.generate_evidence_data(value, anomaly_condition)
+        occurrence = self.process_packet_and_return_result(data_packet)
+        assert isinstance(occurrence, IssueOccurrence)
+
+        self.verify_issue_occurrence(occurrence, evidence_data, anomaly_condition)
 
 
 class TestConstructTitle(TestEvaluateMetricDetector):

--- a/tests/sentry/incidents/utils/test_metric_issue_base.py
+++ b/tests/sentry/incidents/utils/test_metric_issue_base.py
@@ -4,6 +4,7 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import (
     DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION,
+    AnomalyDetectionUpdate,
     ProcessedSubscriptionUpdate,
 )
 from sentry.issues.issue_occurrence import IssueOccurrence
@@ -86,6 +87,25 @@ class BaseMetricIssueTest(TestCase):
             timestamp=datetime.now(UTC) + timedelta(minutes=time_jump),
         )
         return DataPacket[ProcessedSubscriptionUpdate](
+            source_id=str(self.query_subscription.id), packet=packet
+        )
+
+    def create_anomaly_detection_packet(
+        self, value: int, time_jump: int = 0
+    ) -> DataPacket[AnomalyDetectionUpdate]:
+        timestamp = datetime.now(UTC) + timedelta(minutes=time_jump)
+        packet = AnomalyDetectionUpdate(
+            entity="entity",
+            subscription_id=str(self.query_subscription.id),
+            values={
+                "value": value,
+                "source_id": str(self.query_subscription.id),
+                "subscription_id": str(self.query_subscription.id),
+                "timestamp": timestamp,
+            },
+            timestamp=timestamp,
+        )
+        return DataPacket[AnomalyDetectionUpdate](
             source_id=str(self.query_subscription.id), packet=packet
         )
 


### PR DESCRIPTION
Fixes ISWF-1990

For metric issues, the evidence data has a `value` property for the evaluated value. This works for threshold and percent changes which simply use a number value for the data packet. However, anomaly detectors send an object with subscription ID and other properties which aren't really useful to have on the occurrence data. This is rendered poorly on the frontend because it does account for this (see screenshot).

I could have modified the frontend to look at `value.value`, but I think it's probably better if we fix this on the event data side so the evidence data schema stays consistent. To do that, there are two change:

1. Override the evidence `value` in `build_detector_evidence_data` for anomaly packets
2. Fix the `_create_decorated_issue_occurrence` function to include the overrides in `build_detector_evidence_data()`

<img width="793" height="277" alt="CleanShot 2026-02-09 at 15 04 44" src="https://github.com/user-attachments/assets/7911b123-8c51-483d-a047-b603c4401bf1" />
