### PR TITLE
fix(code mappings): For platforms lacking supported extensions, fall back to default frame info

### DIFF
--- a/src/sentry/issues/auto_source_code_config/constants.py
+++ b/src/sentry/issues/auto_source_code_config/constants.py
@@ -10,7 +10,6 @@ DERIVED_ENHANCEMENTS_OPTION_KEY = "sentry:derived_grouping_enhancements"
 SUPPORTED_INTEGRATIONS = [IntegrationProviderSlug.GITHUB.value]
 STACK_ROOT_MAX_LEVEL = 4
 
-# Any new languages should also require updating the stacktraceLink.tsx
 # The extensions do not need to be exhaustive but only include the ones that show up in stacktraces
 PLATFORMS_CONFIG: dict[str, Mapping[str, Any]] = {
     # C#, F#, VB, PowerShell, C# Script, F# Script

--- a/src/sentry/issues/auto_source_code_config/frame_info.py
+++ b/src/sentry/issues/auto_source_code_config/frame_info.py
@@ -14,7 +14,7 @@ from .errors import (
     NeedsExtension,
     UnsupportedFrameInfo,
 )
-from .utils.platform import PlatformConfig
+from .utils.platform import PlatformConfig, supported_platform
 
 NOT_FOUND = -1
 
@@ -24,7 +24,7 @@ UNSUPPORTED_FRAME_PATH_PATTERN = re.compile(r"^[\[<]|https?://", re.IGNORECASE)
 
 def create_frame_info(frame: Mapping[str, Any], platform: str | None = None) -> FrameInfo:
     """Factory function to create the appropriate FrameInfo instance."""
-    if platform:
+    if platform and supported_platform(platform):
         platform_config = PlatformConfig(platform)
         if platform_config.extracts_filename_from_module():
             return ModuleBasedFrameInfo(frame)

--- a/tests/sentry/issues/auto_source_code_config/test_frame_info.py
+++ b/tests/sentry/issues/auto_source_code_config/test_frame_info.py
@@ -162,3 +162,8 @@ class TestFrameInfo:
         frame_info = create_frame_info({"filename": frame_filename})
         assert frame_info.normalized_path == normalized_path
         assert frame_info.stack_root == stack_root
+
+    def test_unsupported_platform_returns_path_based_frame_info(self) -> None:
+        frame_info = create_frame_info({"filename": "Sources/App/AppDelegate.swift"}, "cocoa")
+        assert frame_info.normalized_path == "Sources/App/AppDelegate.swift"
+        assert frame_info.stack_root == "Sources"


### PR DESCRIPTION
Same changes as https://github.com/getsentry/sentry/pull/107752, just separating backend & frontend changes.

Precursor to https://github.com/getsentry/sentry/pull/107894.

Part of [ID-1333](https://linear.app/getsentry/issue/ID-1333/enable-the-set-up-code-mapping-modal-from-issue-details-for-all).

The "Set Up Code Mapping" modal is different from the code mapping config in the integration settings. The former takes the source code URL for the file and attempts to derive what the source/stack root should be; the latter just asks for that input directly.

To account for this, I modified `src/sentry/issues/auto_source_code_config/frame_info.py` to not fail for any "unsupported" platforms. The only effect of this will be that there's no auto-suggested URL in the modal for native platforms, but creating a code mapping will still work from there. No regression/change in behavior for platforms that are already included in `PLATFORMS_CONFIG`.