### PR TITLE
fix(code mappings): Display the modal from issue details for all platforms

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -103,7 +103,7 @@ describe('StacktraceLink', () => {
     });
   });
 
-  it('should hide stacktrace link error state on unsupported platforms', async () => {
+  it('should show setup button for native platforms', async () => {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       body: {
@@ -112,17 +112,15 @@ describe('StacktraceLink', () => {
         integrations: [integration],
       },
     });
-    const {container} = render(
+    render(
       <StacktraceLink
         frame={frame}
-        event={{...event, platform: 'unreal'}}
+        event={{...event, platform: 'cocoa'}}
         line=""
         disableSetup={false}
       />
     );
-    await waitFor(() => {
-      expect(container).toBeEmptyDOMElement();
-    });
+    expect(await screen.findByText('Set up Code Mapping')).toBeInTheDocument();
   });
 
   it('renders the codecov link', async () => {

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -17,7 +17,6 @@ import type {Event, Frame} from 'sentry/types/event';
 import type {StacktraceLinkResult} from 'sentry/types/integrations';
 import {CodecovStatusCode} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
-import type {PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForEvent} from 'sentry/utils/events';
 import {getIntegrationIcon, getIntegrationSourceUrl} from 'sentry/utils/integrationUtil';
@@ -28,22 +27,6 @@ import useProjects from 'sentry/utils/useProjects';
 
 import StacktraceLinkModal from './stacktraceLinkModal';
 import useStacktraceLink from './useStacktraceLink';
-
-// Keep this list in sync with PLATFORMS_CONFIG in auto_source_code_config/constants.py
-const supportedStacktracePlatforms: PlatformKey[] = [
-  'clojure',
-  'csharp',
-  'elixir', // Elixir is not listed on the main list
-  'go',
-  'groovy',
-  'java',
-  'javascript',
-  'node',
-  'php',
-  'python',
-  'ruby',
-  'scala',
-];
 
 const scmProviders = ['github', 'gitlab', 'bitbucket'];
 
@@ -231,11 +214,8 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
   // Check if the line starts and ends with {snip}
   const isMinifiedJsError =
     event.platform === 'javascript' && /(\{snip\}).*\1/.test(line ?? '');
-  const isUnsupportedPlatform = !supportedStacktracePlatforms.includes(
-    event.platform as PlatformKey
-  );
 
-  const hideErrors = isMinifiedJsError || isUnsupportedPlatform || disableSetup;
+  const hideErrors = isMinifiedJsError || disableSetup;
   // for .NET projects, if there is no match found but there is a GitHub source link, use that
   if (
     frame.sourceLink &&

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -411,7 +411,7 @@ function NativeFrame({
                 : tn('Show %s more frame', 'Show %s more frames', hiddenFrameCount)}
             </ShowHideButton>
           ) : null}
-          <Flex>
+          <Flex align="center" gap="sm">
             {showStacktraceLink && (
               <ErrorBoundary>
                 <StacktraceLink


### PR DESCRIPTION
Same changes as https://github.com/getsentry/sentry/pull/107752, just separating backend & frontend changes.

Follow-up to https://github.com/getsentry/sentry/pull/107893.

Part of [ID-1333](https://linear.app/getsentry/issue/ID-1333/enable-the-set-up-code-mapping-modal-from-issue-details-for-all).

This PR displays the "Set Up Code Mapping" button from in-app stack frames on the issue details page for all platforms.

After changes:
<img width="355" height="342" alt="image" src="https://github.com/user-attachments/assets/919d1572-08de-46d5-8386-cd3669d65dd5" />
<img width="343" height="337" alt="image" src="https://github.com/user-attachments/assets/7dc8d286-af04-40ff-8d5d-a40f5f05aa06" />