### PR TITLE
fix(issue owners): Allow updates when team membership is open

### DIFF
--- a/src/sentry/issues/endpoints/project_ownership.py
+++ b/src/sentry/issues/endpoints/project_ownership.py
@@ -94,6 +94,13 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
             )
 
         project = self.context["ownership"].project
+        organization = project.organization
+
+        # If open team membership is enabled, users can assign any team as owner since they could
+        # join any team anyway
+        if organization and organization.flags.allow_joinleave:
+            return
+
         user_team_count = OrganizationMemberTeam.objects.filter(
             team__slug__in=team_slugs,
             team__projectteam__project=project,

--- a/src/sentry/issues/endpoints/project_ownership.py
+++ b/src/sentry/issues/endpoints/project_ownership.py
@@ -67,9 +67,10 @@ class ProjectOwnershipRequestSerializer(serializers.Serializer):
 
     def _validate_team_ownership(self, rules):
         """
-        Validate that the user has permission to assign ownership to the teams
-        referenced in the rules. Users must either have team:admin scope or be
-        a member of each team they're assigning ownership to.
+        Validate that the user has permission to assign ownership to the teams referenced in the
+        rules. If the organization has open team membership enabled, any user can assign ownership.
+        Otherwise, users must either have `team:admin` scope or be a member of each team to which
+        they're assigning ownership.
         """
         team_slugs = {
             owner.get("identifier")

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -444,6 +444,22 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 200
         assert resp.data["raw"] == "*.js #other-team"
 
+    def test_open_membership_org_member_can_assign_any_team(self) -> None:
+        """
+        Test that a user in an org with open membership CAN add ownership rules for any team.
+        """
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
+        self.project.add_team(other_team)
+
+        self.login_as(user=self.member_user)
+
+        resp = self.client.put(self.path, {"raw": "*.js #other-team"})
+        assert resp.status_code == 200
+        assert resp.data["raw"] == "*.js #other-team"
+
     def test_closed_membership_org_member_mixed_teams_denied(self) -> None:
         """
         Test that in an org with closed team membership, if a member tries to add rules with
@@ -460,3 +476,20 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
         assert resp.status_code == 400
         assert "do not have permission" in str(resp.data["raw"][0])
+
+    def test_open_membership_org_member_mixed_teams_allowed(self) -> None:
+        """
+        Test that in an org with open team membership, if a member tries to add rules with multiple
+        teams, and they're not a member of one of them, the request still goes through.
+        """
+        self.organization.flags.allow_joinleave = True
+        self.organization.save()
+
+        other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
+        self.project.add_team(other_team)
+
+        self.login_as(user=self.member_user)
+
+        resp = self.client.put(self.path, {"raw": "*.js #tiger-team #other-team"})
+        assert resp.status_code == 200
+        assert resp.data["raw"] == "*.js #tiger-team #other-team"

--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -400,12 +400,15 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.put(self.path, {"fallthrough": False})
         assert resp.status_code == 403
 
-    def test_member_cannot_assign_team_not_member_of(self) -> None:
+    def test_closed_membership_org_member_cannot_assign_team_not_member_of(self) -> None:
         """
-        Test that a member cannot add an ownership rule assigning issues to a team
-        they are not a member of. This is a regression test for an authorization
-        bypass vulnerability.
+        Test that a member cannot add an ownership rule assigning issues to a team they are not a
+        member of if the org has open team membership off. This is a regression test for an
+        authorization bypass vulnerability.
         """
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
         self.project.add_team(other_team)
 
@@ -441,11 +444,14 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 200
         assert resp.data["raw"] == "*.js #other-team"
 
-    def test_member_mixed_teams_denied(self) -> None:
+    def test_closed_membership_org_member_mixed_teams_denied(self) -> None:
         """
-        Test that if a member tries to add rules with multiple teams,
-        and they're not a member of one of them, the request is denied.
+        Test that in an org with closed team membership, if a member tries to add rules with
+        multiple teams, and they're not a member of one of them, the request is denied.
         """
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
         other_team = self.create_team(organization=self.organization, slug="other-team", members=[])
         self.project.add_team(other_team)
 


### PR DESCRIPTION
Currently, for users with member permissions, updating issue owners rules is restricted to projects to which the user belongs. However, in orgs with open team membership, member users can choose to belong to any project, so they should be able to update the rules for any project. This is similar to the fix made in https://github.com/getsentry/sentry/pull/107333 which did the same for alerts, monitors, and detectors. 

Fixes https://github.com/getsentry/sentry/issues/107815.