### PR TITLE
Test_same_group flakiness

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3485,7 +3485,7 @@ class ReleaseIssueTest(TestCase):
         release = Release.objects.get(
             organization=event.project.organization.id, version=event.get_tag("sentry:release")
         )
-        
+
         # Process the buffer to flush new_issues_count to the database
         # This is necessary because new_issues_count is incremented via buffer_incr
         # in event_manager.py and may not be flushed to the database yet
@@ -3498,7 +3498,7 @@ class ReleaseIssueTest(TestCase):
                 "environment_id": event.get_environment().id,
             },
         )
-        
+
         release_project_envs = ReleaseProjectEnvironment.objects.filter(
             release=release, project=event.project, environment=event.get_environment()
         )

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3480,9 +3480,25 @@ class ReleaseIssueTest(TestCase):
     def assert_release_project_environment(
         self, event: Event, new_issues_count: int, first_seen: float, last_seen: float
     ) -> None:
+        from sentry import buffer
+
         release = Release.objects.get(
             organization=event.project.organization.id, version=event.get_tag("sentry:release")
         )
+        
+        # Process the buffer to flush new_issues_count to the database
+        # This is necessary because new_issues_count is incremented via buffer_incr
+        # in event_manager.py and may not be flushed to the database yet
+        buffer.backend.process(
+            ReleaseProjectEnvironment,
+            columns={"new_issues_count": 0},
+            filters={
+                "project_id": event.project.id,
+                "release_id": release.id,
+                "environment_id": event.get_environment().id,
+            },
+        )
+        
         release_project_envs = ReleaseProjectEnvironment.objects.filter(
             release=release, project=event.project, environment=event.get_environment()
         )


### PR DESCRIPTION
Fixes flakiness in `tests/sentry/event_manager/test_event_manager.py::ReleaseIssueTest::test_same_group`.

The test was flaky because `new_issues_count` is incremented via a buffer, but the test asserted the value directly from the database before the buffer was flushed. This PR adds a call to `buffer.backend.process()` in `assert_release_project_environment` to ensure the buffered value is flushed before the assertion.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1342](https://linear.app/getsentry/issue/ID-1342/flaky-test-test-same-group)

<p><a href="https://cursor.com/background-agent?bcId=bc-58c14619-ee6a-4ae3-ac81-f80519413ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58c14619-ee6a-4ae3-ac81-f80519413ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

