### PR TITLE
Issues pagination consistency

### DIFF
--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -393,7 +393,11 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
 
         # Adjust X-Hits to account for post-filtering
         # If post-filtering removed items, we need to adjust the hit count proportionally
-        if cursor_result.hits is not None and pre_filter_count > 0 and post_filter_count < pre_filter_count:
+        if (
+            cursor_result.hits is not None
+            and pre_filter_count > 0
+            and post_filter_count < pre_filter_count
+        ):
             # Calculate the filter ratio and apply it to the total hits
             filter_ratio = post_filter_count / pre_filter_count
             adjusted_hits = int(cursor_result.hits * filter_ratio)

--- a/src/sentry/issues/endpoints/organization_group_index.py
+++ b/src/sentry/issues/endpoints/organization_group_index.py
@@ -414,8 +414,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEndpoint):
                     # Cap hits to actual count (all results fit on one page)
                     if cursor_result.hits > post_filter_count:
                         cursor_result.hits = post_filter_count
-                # Or if we got fewer results than requested even though we asked for count_hits
-                # This indicates the search backend didn't have enough results to fill the page
+                # Or if we got fewer results than requested even though we asked for
+                # count_hits. This indicates the search backend didn't have enough
+                # results to fill the page
                 elif post_filter_count < query_kwargs.get("limit", 100):
                     # We likely have all results, so cap to actual count
                     cursor_result.hits = post_filter_count

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -221,8 +221,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
                     # Cap hits to actual count (all results fit on one page)
                     if cursor_result.hits > post_filter_count:
                         cursor_result.hits = post_filter_count
-                # Or if we got fewer results than requested even though we asked for count_hits
-                # This indicates the search backend didn't have enough results to fill the page
+                # Or if we got fewer results than requested even though we asked for
+                # count_hits. This indicates the search backend didn't have enough
+                # results to fill the page
                 elif post_filter_count < query_kwargs.get("limit", 100):
                     # We likely have all results, so cap to actual count
                     cursor_result.hits = post_filter_count

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -200,7 +200,11 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
 
         # Adjust X-Hits to account for post-filtering
         # If post-filtering removed items, we need to adjust the hit count proportionally
-        if cursor_result.hits is not None and pre_filter_count > 0 and post_filter_count < pre_filter_count:
+        if (
+            cursor_result.hits is not None
+            and pre_filter_count > 0
+            and post_filter_count < pre_filter_count
+        ):
             # Calculate the filter ratio and apply it to the total hits
             filter_ratio = post_filter_count / pre_filter_count
             adjusted_hits = int(cursor_result.hits * filter_ratio)

--- a/src/sentry/issues/endpoints/project_group_index.py
+++ b/src/sentry/issues/endpoints/project_group_index.py
@@ -192,9 +192,36 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint):
             for search_filter in query_kwargs.get("search_filters", [])
             if search_filter.key.name == "status" and search_filter.operator in EQUALITY_OPERATORS
         ]
+        pre_filter_count = len(context)
         if status and (GroupStatus.UNRESOLVED in status[0].value.raw_value):
             status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
             context = [r for r in context if "status" not in r or r["status"] in status_labels]
+        post_filter_count = len(context)
+
+        # Adjust X-Hits to account for post-filtering
+        # If post-filtering removed items, we need to adjust the hit count proportionally
+        if cursor_result.hits is not None and pre_filter_count > 0 and post_filter_count < pre_filter_count:
+            # Calculate the filter ratio and apply it to the total hits
+            filter_ratio = post_filter_count / pre_filter_count
+            adjusted_hits = int(cursor_result.hits * filter_ratio)
+            # Don't increase hits, only decrease if filtering occurred
+            cursor_result.hits = min(cursor_result.hits, adjusted_hits)
+
+        # Sanity check: Cap X-Hits to actual results count when appropriate
+        # This handles cases where sampling overestimated or post-filtering reduced results
+        if cursor_result.hits is not None:
+            # If we're on the first page with no cursor
+            if not request.GET.get("cursor"):
+                # And there are no more results after this page
+                if cursor_result.next.has_results is False:
+                    # Cap hits to actual count (all results fit on one page)
+                    if cursor_result.hits > post_filter_count:
+                        cursor_result.hits = post_filter_count
+                # Or if we got fewer results than requested even though we asked for count_hits
+                # This indicates the search backend didn't have enough results to fill the page
+                elif post_filter_count < query_kwargs.get("limit", 100):
+                    # We likely have all results, so cap to actual count
+                    cursor_result.hits = post_filter_count
 
         response = Response(context)
 

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -1038,10 +1038,12 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         # Should return 10 groups
         assert len(response.data) == 10
 
-        # X-Hits should be adjusted if post-filtering occurred
-        # Since all groups are unresolved, no filtering should occur
-        # So X-Hits should remain at the mocked value of 100
-        assert response["X-Hits"] == "100"
+        # X-Hits should be capped to 10 because:
+        # 1. We're on the first page (no cursor)
+        # 2. There are no more results (next.has_results = False)
+        # 3. The mocked estimate (100) is greater than actual results (10)
+        # This is correct behavior - we cap overestimates when we have all results
+        assert response["X-Hits"] == "10"
 
     def test_hits_capped_on_short_first_page(self) -> None:
         """


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes pagination inconsistencies in the Issues list by ensuring accurate `X-Hits` and consistent page item counts.

**Why these changes?**
The Issues list pagination experienced:
1.  **Inconsistent `X-Hits`**: The total count (`X-Hits` header) would fluctuate between pages due to sampling-based estimations and post-filtering.
2.  **Short Pages**: Post-filtering (e.g., by status) removed items *after* pagination, leading to pages with fewer items than requested, even when more results existed.

This resulted in incorrect "X–Y of Z" displays and a poor user experience.

**What was changed?**
-   **Adjusted `X-Hits` for post-filtering**: `X-Hits` is now proportionally adjusted downwards if post-filters remove items from the result set.
-   **Capped `X-Hits` on short first pages**: If the first page returns fewer items than requested (and no more results exist or the backend couldn't fill the page), `X-Hits` is capped to the actual number of items returned.
-   Applied these fixes consistently to both organization and project group index endpoints.
-   Added new tests to verify `X-Hits` adjustment and capping behavior.

These changes ensure `X-Hits` remains consistent and accurately reflects the total number of items after all filtering, resolving the pagination display issues.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1343](https://linear.app/getsentry/issue/ID-1343/issues-list-pagination-returns-inconsistent-total-counts-and-fewer)

<p><a href="https://cursor.com/background-agent?bcId=bc-3321ec26-161f-4e48-ba0f-ef4ffcad8297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3321ec26-161f-4e48-ba0f-ef4ffcad8297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

