### PR TITLE
Default highlights attributes

### DIFF
--- a/src/sentry/issues/highlights.py
+++ b/src/sentry/issues/highlights.py
@@ -39,8 +39,12 @@ DEFAULT_HIGHLIGHT_TAGS = ["handled", "level"]
 DEFAULT_HIGHLIGHT_CTX = {"trace": ["trace_id"]}
 
 MOBILE_HIGHLIGHTS: HighlightPreset = {
-    "tags": DEFAULT_HIGHLIGHT_TAGS + ["mobile", "main_thread"],
-    "context": {**DEFAULT_HIGHLIGHT_CTX, "profile": ["profile_id"], "app": ["name"]},
+    "tags": DEFAULT_HIGHLIGHT_TAGS + ["device.class", "release", "main_thread", "user"],
+    "context": {
+        "device": ["low_memory", "locale"],
+        "app": ["in_foreground"],
+        "user": ["geo.country_code"],
+    },
 }
 FALLBACK_HIGHLIGHTS: HighlightPreset = {
     "tags": DEFAULT_HIGHLIGHT_TAGS + ["url"],

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -193,6 +193,35 @@ class ProjectDetailsTest(APITestCase):
         assert resp.data["highlightContext"] == expected_preset["context"]
         assert resp.data["highlightTags"] == expected_preset["tags"]
 
+    def test_highlight_preset_mobile(self) -> None:
+        # Test mobile platform gets mobile-specific highlights
+        mobile_project = self.create_project(platform="react-native")
+        resp = self.get_success_response(mobile_project.organization.slug, mobile_project.slug)
+        expected_preset = get_highlight_preset_for_project(mobile_project)
+        
+        # Verify mobile-specific tags are included
+        assert "device.class" in expected_preset["tags"]
+        assert "release" in expected_preset["tags"]
+        assert "main_thread" in expected_preset["tags"]
+        assert "user" in expected_preset["tags"]
+        
+        # Verify mobile-specific context keys are included
+        assert "device" in expected_preset["context"]
+        assert "low_memory" in expected_preset["context"]["device"]
+        assert "locale" in expected_preset["context"]["device"]
+        assert "app" in expected_preset["context"]
+        assert "in_foreground" in expected_preset["context"]["app"]
+        assert "user" in expected_preset["context"]
+        assert "geo.country_code" in expected_preset["context"]["user"]
+        
+        # Verify removed items are not present
+        assert "trace" not in expected_preset["context"]
+        assert "profile" not in expected_preset["context"]
+        
+        assert resp.data["highlightPreset"] == expected_preset
+        assert resp.data["highlightContext"] == expected_preset["context"]
+        assert resp.data["highlightTags"] == expected_preset["tags"]
+
     def test_is_dynamically_sampled_pan_rate(self) -> None:
         # test with feature flags disabled
         with self.feature("organizations:dynamic-sampling"):

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -198,13 +198,13 @@ class ProjectDetailsTest(APITestCase):
         mobile_project = self.create_project(platform="react-native")
         resp = self.get_success_response(mobile_project.organization.slug, mobile_project.slug)
         expected_preset = get_highlight_preset_for_project(mobile_project)
-        
+
         # Verify mobile-specific tags are included
         assert "device.class" in expected_preset["tags"]
         assert "release" in expected_preset["tags"]
         assert "main_thread" in expected_preset["tags"]
         assert "user" in expected_preset["tags"]
-        
+
         # Verify mobile-specific context keys are included
         assert "device" in expected_preset["context"]
         assert "low_memory" in expected_preset["context"]["device"]
@@ -213,11 +213,11 @@ class ProjectDetailsTest(APITestCase):
         assert "in_foreground" in expected_preset["context"]["app"]
         assert "user" in expected_preset["context"]
         assert "geo.country_code" in expected_preset["context"]["user"]
-        
+
         # Verify removed items are not present
         assert "trace" not in expected_preset["context"]
         assert "profile" not in expected_preset["context"]
-        
+
         assert resp.data["highlightPreset"] == expected_preset
         assert resp.data["highlightContext"] == expected_preset["context"]
         assert resp.data["highlightTags"] == expected_preset["tags"]


### PR DESCRIPTION
This PR addresses Linear ID-1344 by improving the default highlights section for mobile SDK issues.

Based on feedback from the mobile team, the highlights were previously sparse and lacked actionable debugging information. This change updates the `MOBILE_HIGHLIGHTS` preset to include more relevant tags and context keys, such as `device.class`, `release`, `main_thread`, `user`, `low_memory`, `in_foreground`, `locale`, and `user.geo.country_code`. Less useful items like `trace.trace_id` and `profile.profile_id` have been removed.

A new test has been added to ensure the mobile highlight preset is correctly applied.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1344](https://linear.app/getsentry/issue/ID-1344/improve-default-attributes-for-highlights-section)

<p><a href="https://cursor.com/background-agent?bcId=bc-36fe6989-6650-4ba9-ac6c-5486588c178d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-36fe6989-6650-4ba9-ac6c-5486588c178d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

