### PR TITLE
feat(deletion): Add partition support to BulkDeleteQuery and cleanup command

### DIFF
--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from django.db import connections, router
-from django.db.models import QuerySet
+from django.db.models import F, Func, QuerySet, Value
+from django.db.models.fields import IntegerField
 from django.utils import timezone
 
 from sentry.utils.query import RangeQuerySetWrapper
@@ -24,6 +25,7 @@ class BulkDeleteQuery:
         dtfield: str | None = None,
         days: int | None = None,
         order_by: str | None = None,
+        partition: tuple[int, int, str] | None = None,
     ):
         self.model = model
         self.project_id = int(project_id) if project_id else None
@@ -31,6 +33,7 @@ class BulkDeleteQuery:
         self.dtfield = dtfield
         self.days = int(days) if days is not None else None
         self.order_by = order_by
+        self.partition = partition
         self.using = router.db_for_write(model)
 
     def execute(self, chunk_size: int = 10000) -> None:
@@ -48,6 +51,9 @@ class BulkDeleteQuery:
             where.append(f"project_id = {self.project_id}")
         if self.organization_id:
             where.append(f"organization_id = {self.organization_id}")
+        if self.partition:
+            bucket, total, key = self.partition
+            where.append(f"{quote_name(key)} % {total} = {bucket}")
 
         if where:
             where_clause = "where {}".format(" and ".join(where))
@@ -103,6 +109,13 @@ class BulkDeleteQuery:
             queryset = queryset.filter(project_id=self.project_id)  # type: ignore[misc]
         if self.organization_id:
             queryset = queryset.filter(organization_id=self.organization_id)  # type: ignore[misc]
+        if self.partition:
+            bucket, total, key = self.partition
+            queryset = queryset.annotate(
+                _partition_bucket=Func(
+                    F(key), Value(total), function="MOD", output_field=IntegerField()
+                )
+            ).filter(_partition_bucket=bucket)
 
         order_field = "id"
         descending = False

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -41,6 +41,79 @@ class BulkDeleteQueryTest(TestCase):
         assert not Group.objects.filter(id=group1_2.id).exists()
         assert Group.objects.filter(id=group1_3.id).exists()
 
+    def test_partition_restriction(self) -> None:
+        project = self.create_project()
+        groups = [self.create_group(project, create_open_period=False) for _ in range(8)]
+
+        # Delete only groups where id % 2 == 0
+        BulkDeleteQuery(model=Group, project_id=project.id, partition=(0, 2, "id")).execute()
+
+        remaining = Group.objects.filter(project_id=project.id)
+        remaining_ids = set(remaining.values_list("id", flat=True))
+
+        # All remaining groups should have id % 2 == 1
+        for gid in remaining_ids:
+            assert gid % 2 == 1
+
+        # All deleted groups should have had id % 2 == 0
+        deleted_ids = {g.id for g in groups} - remaining_ids
+        for gid in deleted_ids:
+            assert gid % 2 == 0
+
+        assert len(deleted_ids) > 0
+        assert len(remaining_ids) > 0
+
+    def test_partition_with_datetime_restriction(self) -> None:
+        now = timezone.now()
+        project = self.create_project()
+
+        old_groups = [
+            self.create_group(project, create_open_period=False, last_seen=now - timedelta(days=2))
+            for _ in range(8)
+        ]
+        recent_groups = [
+            self.create_group(project, create_open_period=False, last_seen=now) for _ in range(4)
+        ]
+
+        # Delete old groups in partition bucket 0 only
+        BulkDeleteQuery(
+            model=Group,
+            project_id=project.id,
+            dtfield="last_seen",
+            days=1,
+            partition=(0, 2, "id"),
+        ).execute()
+
+        remaining_ids = set(
+            Group.objects.filter(project_id=project.id).values_list("id", flat=True)
+        )
+
+        # All recent groups should still exist
+        for g in recent_groups:
+            assert g.id in remaining_ids
+
+        # Old groups in bucket 0 (id % 2 == 0) should be deleted
+        for g in old_groups:
+            if g.id % 2 == 0:
+                assert g.id not in remaining_ids
+            else:
+                assert g.id in remaining_ids
+
+    def test_partition_all_buckets_cover_all_rows(self) -> None:
+        project = self.create_project()
+        groups = [self.create_group(project, create_open_period=False) for _ in range(8)]
+        all_ids = {g.id for g in groups}
+
+        # Delete bucket 0
+        BulkDeleteQuery(model=Group, project_id=project.id, partition=(0, 2, "id")).execute()
+
+        # Delete bucket 1
+        BulkDeleteQuery(model=Group, project_id=project.id, partition=(1, 2, "id")).execute()
+
+        # All groups should now be deleted
+        remaining = Group.objects.filter(id__in=all_ids)
+        assert remaining.count() == 0
+
 
 class BulkDeleteQueryIteratorTestCase(TestCase):
     def test_iteration(self) -> None:
@@ -112,3 +185,32 @@ class BulkDeleteQueryIteratorTestCase(TestCase):
 
         # All groups should be returned, even with identical timestamps
         assert results == expected_group_ids
+
+    def test_iteration_with_partition(self) -> None:
+        target_project = self.project
+        groups = [self.create_group() for _ in range(8)]
+
+        iterator = BulkDeleteQuery(
+            model=Group,
+            project_id=target_project.id,
+            dtfield="last_seen",
+            order_by="last_seen",
+            days=0,
+            partition=(0, 2, "id"),
+        ).iterator(chunk_size=100)
+
+        results: set[int] = set()
+        for chunk in iterator:
+            results.update(chunk)
+
+        # Only IDs where id % 2 == 0 should be returned
+        for gid in results:
+            assert gid % 2 == 0
+
+        # Verify we got some results (not empty)
+        assert len(results) > 0
+
+        # Verify IDs with id % 2 == 1 are NOT in results
+        all_ids = {g.id for g in groups}
+        for gid in all_ids - results:
+            assert gid % 2 == 1


### PR DESCRIPTION
## Summary

- Add `partition` parameter to `BulkDeleteQuery` to split deletion work across multiple runs using modulo-based row bucketing
- Add `--partition-bucket`, `--partition-total`, and `--partition-key` flags to the `sentry cleanup` CLI command
- Fully backward compatible: behavior is unchanged when partition flags are not provided

## Problem

The daily `sentry cleanup` CronJob for `SpikeProjections` and `Spike` models runs a tight DELETE loop via `BulkDeleteQuery._continuous_query()`, creating a burst of dead tuples on `db-usage-1`. This triggers a massive autovacuum that causes WAL replication delay, forcing `db-usage-repl` to fall back to GSCP recovery.

Since `valid_date` values are always at midnight UTC, simply running the CronJob more frequently doesn't help — all eligible rows become deletable at the same instant. We need a way to **partition the rows** across multiple runs.

## Solution

Add `id % N` partitioning to `BulkDeleteQuery`:

```
sentry cleanup --model=SpikeProjections --days=90 --partition-bucket=0 --partition-total=4
sentry cleanup --model=SpikeProjections --days=90 --partition-bucket=1 --partition-total=4
sentry cleanup --model=SpikeProjections --days=90 --partition-bucket=2 --partition-total=4
sentry cleanup --model=SpikeProjections --days=90 --partition-bucket=3 --partition-total=4
```

Each run adds `WHERE id % 4 = {bucket}` to the DELETE query, handling ~25% of eligible rows. The `--partition-key` flag allows using a different column (defaults to `id`).

Using `id` (auto-increment) ensures uniform distribution, following the same principle as [PR #18736](https://github.com/getsentry/getsentry/pull/18736) which switched spike projection batching from `organization_id` (snowflake, uneven) to `subscription.id` (auto-increment, uniform).

## Changes

### `src/sentry/db/deletion.py`
- Added `partition: tuple[int, int, str] | None` parameter to `BulkDeleteQuery.__init__()`
- Added partition filter to the WHERE clause in `execute()`
- Added partition filter to `iterator()` via `Func(F(key), Value(total), function="MOD")`

### `src/sentry/runner/commands/cleanup.py`
- Added `--partition-bucket` CLI flag (integer, 0-based bucket index)
- Added `--partition-total` CLI flag (integer, total number of buckets)
- Added `--partition-key` CLI flag (default: `id`)
- Validation: both bucket and total must be used together, bucket must be non-negative and less than total, total must be positive
- Threaded through `cleanup()` → `_cleanup()` → `run_bulk_query_deletes()` → `BulkDeleteQuery()`

## Test plan

- [x] `test_partition_restriction` — verifies only rows in the matching bucket are deleted
- [x] `test_partition_with_datetime_restriction` — combines partition + date filter
- [x] `test_partition_all_buckets_cover_all_rows` — verifies complete coverage across all buckets
- [x] `test_iteration_with_partition` — verifies `iterator()` respects partition filter
- [x] `test_partition_bucket_exceeds_total` — validation error for bucket >= total
- [x] `test_partition_negative_bucket` — validation error for negative bucket
- [x] `test_partition_zero_total` — validation error for zero total
- [x] `test_partition_bucket_without_total` — validation error when only bucket is set
- [x] `test_partition_total_without_bucket` — validation error when only total is set

## Related

- Ops PR (K8s config): https://github.com/getsentry/ops/pull/19081
- Analysis: daily mass deletion on `accounts_spike_projections` causes replication delay on `db-usage-1`