### PR TITLE
Flaky test other exception

### DIFF
--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -41,6 +41,11 @@ def make_event(**kwargs: Any) -> dict[str, Any]:
 
 
 class TestGetEventSeverity(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # Clear cache to ensure test isolation
+        cache.delete(SEER_ERROR_COUNT_KEY)
+
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",
         return_value=HTTPResponse(body=orjson.dumps({"severity": 0.1231})),
@@ -332,6 +337,11 @@ class TestGetEventSeverity(TestCase):
 @with_feature("projects:first-event-severity-calculation")
 @with_feature("organizations:seer-based-priority")
 class TestEventManagerSeverity(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        # Clear cache to ensure test isolation
+        cache.delete(SEER_ERROR_COUNT_KEY)
+
     @patch("sentry.event_manager._get_severity_score", return_value=(0.1121, "ml"))
     def test_flag_on(self, mock_get_severity_score: MagicMock) -> None:
         manager = EventManager(


### PR DESCRIPTION
Fixes flakiness in `test_other_exception` and related tests (ID-1347) by ensuring proper test isolation. The `SEER_ERROR_COUNT_KEY` cache is now cleared in `setUp` methods for `TestGetEventSeverity` and `TestEventManagerSeverity` to prevent state leakage between test runs.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1347](https://linear.app/getsentry/issue/ID-1347/flaky-test-test-other-exception)

<p><a href="https://cursor.com/background-agent?bcId=bc-abe2849a-7991-478c-88c3-46c12bd72e45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-abe2849a-7991-478c-88c3-46c12bd72e45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

