### PR TITLE
fix(issues): Use background color on project icons

### DIFF
--- a/static/app/components/projectList.tsx
+++ b/static/app/components/projectList.tsx
@@ -1,5 +1,5 @@
 import type {ReactNode} from 'react';
-import {css} from '@emotion/react';
+import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -88,8 +88,9 @@ const ProjectListWrapper = styled('div')`
   padding-right: 8px;
 `;
 
-const AvatarStyle = (p: any) => css`
-  border: 2px solid ${p.theme.tokens.border.primary};
+const AvatarStyle = (p: {theme: Theme}) => css`
+  /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
+  border: 2px solid ${p.theme.tokens.background.primary};
   margin-right: -8px;
   cursor: default;
 


### PR DESCRIPTION
reverts a change from #107451 on [issue views](https://sentry.sentry.io/issues/views/)

before

<img width="171" height="199" alt="image" src="https://github.com/user-attachments/assets/6bb65a06-0d1e-4974-88c3-67417ca6052f" />



after

<img width="101" height="73" alt="image" src="https://github.com/user-attachments/assets/38276fa2-1323-419b-a8f4-c909a8b3f4ea" />
