### PR TITLE
chore(seer): Wrap all Seer settings pages with analyticsArea

### DIFF
--- a/static/app/views/settings/components/settingsWrapper.tsx
+++ b/static/app/views/settings/components/settingsWrapper.tsx
@@ -2,6 +2,7 @@ import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import {useLocation} from 'sentry/utils/useLocation';
 import useScrollToTop from 'sentry/utils/useScrollToTop';
 import {BreadcrumbProvider} from 'sentry/views/settings/components/settingsBreadcrumb/context';
@@ -15,11 +16,13 @@ export default function SettingsWrapper() {
   useScrollToTop({location, disable: scrollDisable});
 
   return (
-    <StyledSettingsWrapper>
-      <BreadcrumbProvider>
-        <Outlet />
-      </BreadcrumbProvider>
-    </StyledSettingsWrapper>
+    <AnalyticsArea name="settings">
+      <StyledSettingsWrapper>
+        <BreadcrumbProvider>
+          <Outlet />
+        </BreadcrumbProvider>
+      </StyledSettingsWrapper>
+    </AnalyticsArea>
   );
 }
 

--- a/static/app/views/settings/organization/organizationSettingsLayout.tsx
+++ b/static/app/views/settings/organization/organizationSettingsLayout.tsx
@@ -1,11 +1,14 @@
 import {Outlet} from 'react-router-dom';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
 export default function OrganizationSettingsLayout() {
   return (
-    <SettingsLayout>
-      <Outlet />
-    </SettingsLayout>
+    <AnalyticsArea name="organization-settings">
+      <SettingsLayout>
+        <Outlet />
+      </SettingsLayout>
+    </AnalyticsArea>
   );
 }

--- a/static/app/views/settings/organization/organizationSettingsLayout.tsx
+++ b/static/app/views/settings/organization/organizationSettingsLayout.tsx
@@ -5,7 +5,7 @@ import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
 export default function OrganizationSettingsLayout() {
   return (
-    <AnalyticsArea name="organization-settings">
+    <AnalyticsArea name="organization">
       <SettingsLayout>
         <Outlet />
       </SettingsLayout>

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -5,6 +5,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import {navigateTo} from 'sentry/actionCreators/navigation';
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {IconProject} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -59,28 +60,32 @@ export default function ProjectSettingsLayout() {
 
   if (params.projectId === ':projectId') {
     return (
-      <Flex justify="center" align="center" flex="1">
-        <EmptyMessage
-          icon={<IconProject size="xl" />}
-          title={t('Choose a Project')}
-          action={
-            <Button
-              priority="primary"
-              onClick={() => navigateTo(location.pathname, router)}
-            >
-              {t('Choose Project')}
-            </Button>
-          }
-        >
-          {t('Select a project to continue.')}
-        </EmptyMessage>
-      </Flex>
+      <AnalyticsArea name="project-settings">
+        <Flex justify="center" align="center" flex="1">
+          <EmptyMessage
+            icon={<IconProject size="xl" />}
+            title={t('Choose a Project')}
+            action={
+              <Button
+                priority="primary"
+                onClick={() => navigateTo(location.pathname, router)}
+              >
+                {t('Choose Project')}
+              </Button>
+            }
+          >
+            {t('Select a project to continue.')}
+          </EmptyMessage>
+        </Flex>
+      </AnalyticsArea>
     );
   }
 
   return (
-    <ProjectContext projectSlug={params.projectId}>
-      {({project}) => <InnerProjectSettingsLayout project={project} />}
-    </ProjectContext>
+    <AnalyticsArea name="project-settings">
+      <ProjectContext projectSlug={params.projectId}>
+        {({project}) => <InnerProjectSettingsLayout project={project} />}
+      </ProjectContext>
+    </AnalyticsArea>
   );
 }

--- a/static/app/views/settings/project/projectSettingsLayout.tsx
+++ b/static/app/views/settings/project/projectSettingsLayout.tsx
@@ -60,7 +60,7 @@ export default function ProjectSettingsLayout() {
 
   if (params.projectId === ':projectId') {
     return (
-      <AnalyticsArea name="project-settings">
+      <AnalyticsArea name="project">
         <Flex justify="center" align="center" flex="1">
           <EmptyMessage
             icon={<IconProject size="xl" />}
@@ -82,7 +82,7 @@ export default function ProjectSettingsLayout() {
   }
 
   return (
-    <AnalyticsArea name="project-settings">
+    <AnalyticsArea name="project">
       <ProjectContext projectSlug={params.projectId}>
         {({project}) => <InnerProjectSettingsLayout project={project} />}
       </ProjectContext>

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -3,6 +3,7 @@ import {Outlet} from 'react-router-dom';
 
 import {Stack} from '@sentry/scraps/layout';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import {NoAccess} from 'sentry/components/noAccess';
 import Placeholder from 'sentry/components/placeholder';
@@ -17,18 +18,24 @@ export default function SeerAutomationRoot() {
   const {isLoading, billing, setupAcknowledgement} = useOrganizationSeerSetup();
 
   if (organization.hideAiFeatures) {
-    return <NoAccess />;
+    return (
+      <AnalyticsArea name="seer">
+        <NoAccess />
+      </AnalyticsArea>
+    );
   }
 
   // Show loading placeholders while checking setup
   if (isLoading) {
     return (
-      <Stack gap="lg">
-        <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
-        <Placeholder height="60px" />
-        <Placeholder height="200px" />
-        <Placeholder height="200px" />
-      </Stack>
+      <AnalyticsArea name="seer">
+        <Stack gap="lg">
+          <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
+          <Placeholder height="60px" />
+          <Placeholder height="200px" />
+          <Placeholder height="200px" />
+        </Stack>
+      </AnalyticsArea>
     );
   }
 
@@ -42,12 +49,18 @@ export default function SeerAutomationRoot() {
   // Show setup screen if needed
   if (needsSetup) {
     return (
-      <Fragment>
-        <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
-        <AiSetupDataConsent />
-      </Fragment>
+      <AnalyticsArea name="seer">
+        <Fragment>
+          <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
+          <AiSetupDataConsent />
+        </Fragment>
+      </AnalyticsArea>
     );
   }
 
-  return <Outlet />;
+  return (
+    <AnalyticsArea name="seer">
+      <Outlet />
+    </AnalyticsArea>
+  );
 }

--- a/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboarding.tsx
@@ -1,3 +1,4 @@
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -11,8 +12,16 @@ export default function SeerOnboarding() {
   const organization = useOrganization();
 
   if (showNewSeer(organization)) {
-    return <SeerOnboardingSeatBased />;
+    return (
+      <AnalyticsArea name="onboarding">
+        <SeerOnboardingSeatBased />
+      </AnalyticsArea>
+    );
   }
 
-  return <SeerOnboardingLegacy />;
+  return (
+    <AnalyticsArea name="onboarding">
+      <SeerOnboardingLegacy />
+    </AnalyticsArea>
+  );
 }

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -7,6 +5,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import FeatureDisabled from 'sentry/components/acl/featureDisabled';
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
@@ -42,17 +41,19 @@ function SeerProjectDetails() {
 
   if (!organization.features.includes('autofix-seer-preferences')) {
     return (
-      <FeatureDisabled
-        featureName={t('Autofix')}
-        features={['autofix-seer-preferences']}
-        hideHelpToggle
-        message={t('Autofix is not enabled for this organization.')}
-      />
+      <AnalyticsArea name="project-details">
+        <FeatureDisabled
+          featureName={t('Autofix')}
+          features={['autofix-seer-preferences']}
+          hideHelpToggle
+          message={t('Autofix is not enabled for this organization.')}
+        />
+      </AnalyticsArea>
     );
   }
 
   return (
-    <Fragment>
+    <AnalyticsArea name="project-details">
       <SentryDocumentTitle
         title={t('Project Seer Settings')}
         projectSlug={project.slug}
@@ -115,6 +116,6 @@ function SeerProjectDetails() {
           />
         </Stack>
       )}
-    </Fragment>
+    </AnalyticsArea>
   );
 }

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -1,10 +1,14 @@
+import AnalyticsArea from 'sentry/components/analyticsArea';
+
 import SeerProjectTable from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTable';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationProjects() {
   return (
-    <SeerSettingsPageWrapper>
-      <SeerProjectTable />
-    </SeerSettingsPageWrapper>
+    <AnalyticsArea name="projects">
+      <SeerSettingsPageWrapper>
+        <SeerProjectTable />
+      </SeerSettingsPageWrapper>
+    </AnalyticsArea>
   );
 }

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -1,8 +1,7 @@
-import {Fragment} from 'react';
-
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import NotFound from 'sentry/components/errors/notFound';
 import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -38,19 +37,31 @@ export default function SeerRepoDetails() {
   });
 
   if (!hasSeer) {
-    return <NotFound />;
+    return (
+      <AnalyticsArea name="repo-details">
+        <NotFound />
+      </AnalyticsArea>
+    );
   }
 
   if (isPending) {
-    return <LoadingIndicator />;
+    return (
+      <AnalyticsArea name="repo-details">
+        <LoadingIndicator />
+      </AnalyticsArea>
+    );
   }
 
   if (error) {
-    return <LoadingError onRetry={refetch} />;
+    return (
+      <AnalyticsArea name="repo-details">
+        <LoadingError onRetry={refetch} />
+      </AnalyticsArea>
+    );
   }
 
   return (
-    <Fragment>
+    <AnalyticsArea name="repo-details">
       <SentryDocumentTitle
         title={t('Repository Seer Settings')}
         projectSlug={repoWithSettings?.name}
@@ -83,6 +94,6 @@ export default function SeerRepoDetails() {
       ) : (
         <Alert variant="warning">{t('Seer is not supported for this repository.')}</Alert>
       )}
-    </Fragment>
+    </AnalyticsArea>
   );
 }

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -1,10 +1,14 @@
+import AnalyticsArea from 'sentry/components/analyticsArea';
+
 import SeerRepoTable from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationRepos() {
   return (
-    <SeerSettingsPageWrapper>
-      <SeerRepoTable />
-    </SeerSettingsPageWrapper>
+    <AnalyticsArea name="repos">
+      <SeerSettingsPageWrapper>
+        <SeerRepoTable />
+      </SeerSettingsPageWrapper>
+    </AnalyticsArea>
   );
 }

--- a/static/gsApp/views/seerAutomation/trial.tsx
+++ b/static/gsApp/views/seerAutomation/trial.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 import seerConfigBug1 from 'getsentry-images/spot/seer-config-bug-1.svg';
 import seerConfigCheck from 'getsentry-images/spot/seer-config-check.svg';
@@ -13,6 +13,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import AnalyticsArea from 'sentry/components/analyticsArea';
 import {IconUpgrade} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import showNewSeer from 'sentry/utils/seer/showNewSeer';
@@ -73,7 +74,7 @@ export default function SeerAutomationTrial() {
   }, [navigate, organization.features, organization.slug, organization]);
 
   return (
-    <Fragment>
+    <AnalyticsArea name="trial">
       <Flex justify="center">
         <img
           src={seerConfigMain}
@@ -166,6 +167,6 @@ export default function SeerAutomationTrial() {
           </Flex>
         </Stack>
       </Container>
-    </Fragment>
+    </AnalyticsArea>
   );
 }


### PR DESCRIPTION
This wraps all the seer related settings pages in `<AnalyticsArea>` which will be helpful to contextualize any repeated components rendered inside.