### PR TITLE
chore: Remove defunct Processing label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -198,8 +198,6 @@
   color: '8D5494'
 - name: 'Product Area: Performance'
   color: '8D5494'
-- name: 'Product Area: Processing'
-  color: '8D5494'
 - name: 'Product Area: Profiling'
   color: '8D5494'
 - name: 'Product Area: Projects - Project Creation'


### PR DESCRIPTION
The Processing team was absorbed into the Ingest team. 
Since then, the Processing label has been used as a catch-all for miscategorized issues. 
Remove it to keep label assignments intentional.

