### PR TITLE
fix(sdk): Let the SDK instantiate MultiplexingTransport so that dsn is setup correctly

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -482,7 +482,7 @@ def configure_sdk():
         # set back the sentry4sentry_dsn popped above since we need a default dsn on the client
         # for dynamic sampling context public_key population
         dsn=dsns.sentry4sentry,
-        transport=MultiplexingTransport(),
+        transport=MultiplexingTransport,
         integrations=[
             DjangoAtomicIntegration(),
             DjangoIntegration(


### PR DESCRIPTION
The transport needs to be instantiated with correct options so that [`parsed_dsn`](https://github.com/getsentry/sentry-python/blob/1476ff06541f547fa2db8dd68640bf73ee336785/sentry_sdk/transport.py#L72) is setup and the `public_key` is populated in the DSC. This change lets the SDK instantiate the object correctly instead of instantiating it prematurely here.