### PR TITLE
feat(explore): Allow clearing of last group by

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -112,6 +112,14 @@ export function ToolbarGroupByDropdown({
           icon={<IconDelete size="sm" />}
           onClick={() => onColumnDelete()}
         />
+      ) : column.column ? (
+        <Button
+          aria-label={t('Clear Group By')}
+          priority="transparent"
+          size="zero"
+          icon={<IconDelete size="sm" />}
+          onClick={() => onColumnChange('')}
+        />
       ) : null}
     </ToolbarRow>
   );

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -238,6 +238,29 @@ describe('LogsToolbar', () => {
         )
       );
     });
+
+    it('can clear the last selected group by', async () => {
+      const {router} = render(<LogsToolbar />, {
+        organization,
+        additionalWrapper: Wrapper,
+      });
+
+      const section = screen.getByTestId('section-group-by');
+      const editorColumn = screen.getAllByTestId('editor-column')[0]!;
+      await userEvent.click(within(editorColumn).getByRole('button', {name: '—'}));
+      await userEvent.click(screen.getByRole('option', {name: 'message'}));
+
+      expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
+
+      await userEvent.click(within(section).getByLabelText('Clear Group By'));
+      expect(router.location.query.aggregateField).toEqual(
+        [{groupBy: ''}, {yAxes: ['count(message)']}].map(aggregateField =>
+          JSON.stringify(aggregateField)
+        )
+      );
+
+      expect(within(section).queryByLabelText('Clear Group By')).not.toBeInTheDocument();
+    });
   });
 
   it('re-fetches attributes on search', async () => {

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -240,16 +240,20 @@ describe('LogsToolbar', () => {
     });
 
     it('can clear the last selected group by', async () => {
-      const {router} = render(<LogsToolbar />, {
-        organization,
-        additionalWrapper: Wrapper,
-      });
+      let mode: Mode | undefined = undefined;
+
+      function Component() {
+        mode = useQueryParamsMode();
+        return <LogsToolbar />;
+      }
+      const {router} = render(<Component />, {organization, additionalWrapper: Wrapper});
 
       const section = screen.getByTestId('section-group-by');
       const editorColumn = screen.getAllByTestId('editor-column')[0]!;
       await userEvent.click(within(editorColumn).getByRole('button', {name: '—'}));
       await userEvent.click(screen.getByRole('option', {name: 'message'}));
 
+      expect(mode).toEqual(Mode.AGGREGATE);
       expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
 
       await userEvent.click(within(section).getByLabelText('Clear Group By'));
@@ -259,6 +263,7 @@ describe('LogsToolbar', () => {
         )
       );
 
+      expect(mode).toEqual(Mode.SAMPLES);
       expect(within(section).queryByLabelText('Clear Group By')).not.toBeInTheDocument();
     });
   });

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -493,11 +493,19 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
 
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
-      // automatically switch to aggregates mode when a group by is inserted/updated
-      if (op === 'insert' || op === 'update') {
+      const hasValidGroupBy = columns.some(Boolean);
+
+      // insert/update keeps aggregate mode while a valid group by exists
+      if (op === 'insert' || (op === 'update' && hasValidGroupBy)) {
         setGroupBys(columns, Mode.AGGREGATE);
-      } else {
+        return;
+      }
+
+      if (hasValidGroupBy) {
         setGroupBys(columns);
+      } else {
+        // when the last group by is cleared, return to samples table
+        setGroupBys(columns, Mode.SAMPLES);
       }
     },
     [setGroupBys]

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -367,9 +367,11 @@ describe('ExploreToolbar', () => {
 
   it('clears the last selected group by', async () => {
     let groupBys: readonly string[] = [];
+    let mode: Mode | undefined = undefined;
 
     function Component() {
       groupBys = useQueryParamsGroupBys();
+      mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
     render(<Component />, {additionalWrapper: Wrapper});
@@ -382,10 +384,12 @@ describe('ExploreToolbar', () => {
     await userEvent.click(within(editorColumn).getByRole('button', {name: '—'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.op'}));
 
+    expect(mode).toEqual(Mode.AGGREGATE);
     expect(groupBys).toEqual(['span.op']);
     expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
 
     await userEvent.click(within(section).getByLabelText('Clear Group By'));
+    expect(mode).toEqual(Mode.SAMPLES);
     expect(groupBys).toEqual(['']);
     expect(within(section).queryByLabelText('Clear Group By')).not.toBeInTheDocument();
   });

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -365,6 +365,31 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
   });
 
+  it('clears the last selected group by', async () => {
+    let groupBys: readonly string[] = [];
+
+    function Component() {
+      groupBys = useQueryParamsGroupBys();
+      return <ExploreToolbar />;
+    }
+    render(<Component />, {additionalWrapper: Wrapper});
+
+    const section = screen.getByTestId('section-group-by');
+    const editorColumn = screen.getAllByTestId('editor-column')[0]!;
+
+    expect(groupBys).toEqual(['']);
+
+    await userEvent.click(within(editorColumn).getByRole('button', {name: '—'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.op'}));
+
+    expect(groupBys).toEqual(['span.op']);
+    expect(within(section).queryByLabelText('Remove Column')).not.toBeInTheDocument();
+
+    await userEvent.click(within(section).getByLabelText('Clear Group By'));
+    expect(groupBys).toEqual(['']);
+    expect(within(section).queryByLabelText('Clear Group By')).not.toBeInTheDocument();
+  });
+
   it('switches to aggregates mode when modifying group bys', async () => {
     let groupBys: any;
     let mode: any;

--- a/static/app/views/explore/toolbar/toolbarGroupBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarGroupBy.tsx
@@ -28,11 +28,19 @@ interface ToolbarGroupByProps {
 export function ToolbarGroupBy({groupBys, setGroupBys}: ToolbarGroupByProps) {
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
-      // automatically switch to aggregates mode when a group by is inserted/updated
-      if (op === 'insert' || op === 'update') {
+      const hasValidGroupBy = columns.some(Boolean);
+
+      // insert/update keeps aggregate mode while a valid group by exists
+      if (op === 'insert' || (op === 'update' && hasValidGroupBy)) {
         setGroupBys(columns, Mode.AGGREGATE);
-      } else {
+        return;
+      }
+
+      if (hasValidGroupBy) {
         setGroupBys(columns);
+      } else {
+        // when the last group by is cleared, return to samples table
+        setGroupBys(columns, Mode.SAMPLES);
       }
     },
     [setGroupBys]


### PR DESCRIPTION
This PR modifies the "Group By" selector so that users can easily clear out their final group by without having to go in and manually select the `-` value.

Ticket: EXP-746

Example:

https://github.com/user-attachments/assets/a92dc5f0-62bb-42f7-808c-51cd69d33aab