### PR TITLE
fix(admin): fix customers api endpoint to respect new cells architecture

### DIFF
--- a/static/gsAdmin/components/debounceSearch.tsx
+++ b/static/gsAdmin/components/debounceSearch.tsx
@@ -49,7 +49,7 @@ function DebounceSearch({
   const api = useApi();
 
   const debouncedSearch = useRef(
-    debounce(async (searchHost, value) => {
+    debounce(async (searchHost, searchPath, value) => {
       // Avoid slow-fetch race conditions
       api.clear();
       setError('');
@@ -61,7 +61,7 @@ function DebounceSearch({
             query: [queryParam, value].filter(v => v).join(':'),
             per_page: 10,
           };
-          const results = await api.requestPromise(path, {
+          const results = await api.requestPromise(searchPath, {
             method: 'GET',
             host: searchHost,
             data: queryParams,
@@ -81,9 +81,9 @@ function DebounceSearch({
       value ? setLoading(true) : setLoading(false);
       value ? setShowResults(true) : setShowResults(false);
       setQuery(value);
-      debouncedSearch(host, value);
+      debouncedSearch(host, path, value);
     },
-    [host, debouncedSearch]
+    [host, path, debouncedSearch]
   );
 
   useEffect(() => {
@@ -120,7 +120,7 @@ function DebounceSearch({
     setLoading(false);
     setQueryResults([]);
     setShowResults(false);
-  }, [escapePress, debouncedSearch, api, host]);
+  }, [escapePress, debouncedSearch, api, host, path]);
 
   const renderSuggestion = (item: any, idx: number) => {
     return (

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -20,6 +20,7 @@ export default function HomePage() {
   const regions = ConfigStore.get('regions');
   const [oldSplash, setOldSplash] = useState(false);
   const [regionUrl, setRegionUrl] = useState(regions[0]!.url);
+  const selectedRegion = regions.find((region: any) => region.url === regionUrl);
 
   const buildOrgPath = (org: any) => `/_admin/customers/${org.slug}/`;
   const orgSelect = (org: any) => {
@@ -127,7 +128,11 @@ export default function HomePage() {
         <SearchLabel>Organizations</SearchLabel>
         <DebounceSearch
           host={regionUrl}
-          path="/customers/"
+          path={
+            selectedRegion
+              ? `/_admin/cells/${selectedRegion.name}/customers/`
+              : '/customers/'
+          }
           onSelectResult={orgSelect}
           onSearch={orgSubmit}
           suggestionContent={renderOrgSuggestion}


### PR DESCRIPTION
- With the new cells architecture, API URLs have changed - some of the APIs that _admin calls therefore 404, breaking some of the admin flows
- This PR fixes the problem by routing debounced searches to the respective cells if applicable

Before:
<img width="299" height="231" alt="image" src="https://github.com/user-attachments/assets/c142ff5b-47d8-497c-8784-8dcb0eab477f" />


Afterwards: shows a dropdown with orgs - omitted the image for obvious reasons