### PR TITLE
feat(ai-insights): support span.name

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/api/endpoints/organization_ai_conversation_details.py
@@ -30,6 +30,7 @@ AI_CONVERSATION_ATTRIBUTES = [
     "span.op",
     "span.status",
     "span.description",
+    "span.name",
     "span.duration",
     "transaction",
     "is_transaction",

--- a/static/app/views/insights/pages/agents/hooks/useAgentSpanSearchProps.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAgentSpanSearchProps.tsx
@@ -29,7 +29,9 @@ export function useAgentSpanSearchProps() {
       },
       searchSource: 'agent-monitoring',
 
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement
+        ? ['span.description', 'span.name']
+        : undefined,
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
@@ -1,7 +1,7 @@
 import {SpanFields} from 'sentry/views/insights/types';
 
-import type {AITraceSpanNode} from './types';
 import {hasError} from './aiTraceNodes';
+import type {AITraceSpanNode} from './types';
 
 function makeNode({
   errorCount = 0,

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.spec.tsx
@@ -1,0 +1,44 @@
+import {SpanFields} from 'sentry/views/insights/types';
+
+import type {AITraceSpanNode} from './types';
+import {hasError} from './aiTraceNodes';
+
+function makeNode({
+  errorCount = 0,
+  spanStatus,
+  status,
+}: {
+  errorCount?: number;
+  spanStatus?: unknown;
+  status?: unknown;
+} = {}): AITraceSpanNode {
+  const attributes: Record<string, unknown> = {};
+
+  if (spanStatus !== undefined) {
+    attributes[SpanFields.SPAN_STATUS] = spanStatus;
+  }
+  if (status !== undefined) {
+    attributes.status = status;
+  }
+
+  return {
+    errors: new Set(Array.from({length: errorCount}, (_, index) => index)),
+    attributes,
+  } as unknown as AITraceSpanNode;
+}
+
+describe('hasError', () => {
+  it('returns true when node has explicit errors', () => {
+    expect(hasError(makeNode({errorCount: 1}))).toBe(true);
+  });
+
+  it('uses span.status as authoritative when present', () => {
+    const node = makeNode({spanStatus: 'ok', status: 'error'});
+    expect(hasError(node)).toBe(false);
+  });
+
+  it('falls back to legacy status when span.status is missing', () => {
+    const node = makeNode({status: 'error'});
+    expect(hasError(node)).toBe(true);
+  });
+});

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -91,17 +91,27 @@ export const getIsAiAgentNode = createGetIsAiNode(getIsAiAgentSpan);
 export const getIsAiGenerationNode = createGetIsAiNode(getIsAiGenerationSpan);
 export const getIsExecuteToolNode = createGetIsAiNode(getIsExecuteToolSpan);
 
+export function getStringAttr(node: AITraceSpanNode, field: string): string | undefined {
+  const val = getTraceNodeAttribute(field, node);
+  return typeof val === 'string' ? val : undefined;
+}
+
+export function getNumberAttr(node: AITraceSpanNode, field: string): number | undefined {
+  const val = getTraceNodeAttribute(field, node);
+  if (typeof val === 'number') {
+    return val;
+  }
+  if (typeof val === 'string') {
+    const num = Number(val);
+    return Number.isFinite(num) ? num : undefined;
+  }
+  return undefined;
+}
+
 export function hasError(node: AITraceSpanNode): boolean {
-  if (node.errors.size > 0) {
-    return true;
-  }
-  const spanStatus = node.attributes?.[SpanFields.SPAN_STATUS] as string | undefined;
-  if (spanStatus && typeof spanStatus === 'string') {
-    return spanStatus.includes('error');
-  }
-  const status = node.attributes?.status;
-  if (status && typeof status === 'string') {
-    return status.includes('error');
-  }
-  return false;
+  return (
+    node.errors.size > 0 ||
+    !!getStringAttr(node, SpanFields.SPAN_STATUS)?.includes('error') ||
+    !!getStringAttr(node, 'status')?.includes('error')
+  );
 }

--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -109,9 +109,15 @@ export function getNumberAttr(node: AITraceSpanNode, field: string): number | un
 }
 
 export function hasError(node: AITraceSpanNode): boolean {
-  return (
-    node.errors.size > 0 ||
-    !!getStringAttr(node, SpanFields.SPAN_STATUS)?.includes('error') ||
-    !!getStringAttr(node, 'status')?.includes('error')
-  );
+  if (node.errors.size > 0) {
+    return true;
+  }
+
+  const spanStatus = getStringAttr(node, SpanFields.SPAN_STATUS);
+  if (spanStatus) {
+    // Preserve precedence: when span.status exists, legacy status should not override it.
+    return spanStatus.includes('error');
+  }
+
+  return !!getStringAttr(node, 'status')?.includes('error');
 }

--- a/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
@@ -14,7 +14,11 @@ import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import {getExploreUrl} from 'sentry/views/explore/utils';
-import {hasError} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {
+  getNumberAttr,
+  getStringAttr,
+  hasError,
+} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {formatLLMCosts} from 'sentry/views/insights/pages/agents/utils/formatLLMCosts';
 import {
   getIsAiGenerationSpan,
@@ -38,7 +42,7 @@ interface ConversationAggregates {
 }
 
 function getGenAiOpType(node: AITraceSpanNode): string | undefined {
-  return node.attributes?.[SpanFields.GEN_AI_OPERATION_TYPE] as string | undefined;
+  return getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
 }
 
 function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
@@ -53,8 +57,8 @@ function calculateAggregates(nodes: AITraceSpanNode[]): ConversationAggregates {
 
     if (getIsAiGenerationSpan(opType)) {
       llmCalls++;
-      totalTokens += Number(node.attributes?.[SpanFields.GEN_AI_USAGE_TOTAL_TOKENS] ?? 0);
-      totalCost += Number(node.attributes?.[SpanFields.GEN_AI_COST_TOTAL_TOKENS] ?? 0);
+      totalTokens += getNumberAttr(node, SpanFields.GEN_AI_USAGE_TOTAL_TOKENS) ?? 0;
+      totalCost += getNumberAttr(node, SpanFields.GEN_AI_COST_TOTAL_TOKENS) ?? 0;
     } else if (getIsExecuteToolSpan(opType)) {
       toolCalls++;
     }

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -43,6 +43,7 @@ interface ConversationApiSpan {
   'gen_ai.response.text'?: string;
   'gen_ai.tool.name'?: string;
   'gen_ai.usage.total_tokens'?: number;
+  'span.name'?: string;
   'user.email'?: string;
   'user.id'?: string;
   'user.ip'?: string;
@@ -83,7 +84,7 @@ function createNodeFromApiSpan(
     event_type: 'span',
     is_transaction: false,
     op: apiSpan['span.op'],
-    description: apiSpan['span.description'],
+    description: apiSpan['span.description'] || apiSpan['span.name'],
     start_timestamp: apiSpan['precise.start_ts'],
     end_timestamp: apiSpan['precise.finish_ts'],
     project_id: apiSpan['project.id'],
@@ -94,7 +95,7 @@ function createNodeFromApiSpan(
     sdk_name: '',
     transaction: '',
     transaction_id: '',
-    name: apiSpan['span.description'],
+    name: apiSpan['span.name'] || apiSpan['span.description'],
     errors: [],
     occurrences: [],
     additional_attributes: {

--- a/static/app/views/insights/pages/conversations/hooks/useFocusedToolSpan.ts
+++ b/static/app/views/insights/pages/conversations/hooks/useFocusedToolSpan.ts
@@ -1,5 +1,6 @@
 import {useEffect, useRef} from 'react';
 
+import {getStringAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {getIsExecuteToolSpan} from 'sentry/views/insights/pages/agents/utils/query';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -34,12 +35,8 @@ export function useFocusedToolSpan({
     }
 
     const toolSpan = nodes.find(node => {
-      const opType = node.attributes?.[SpanFields.GEN_AI_OPERATION_TYPE] as
-        | string
-        | undefined;
-      const toolName = node.attributes?.[SpanFields.GEN_AI_TOOL_NAME] as
-        | string
-        | undefined;
+      const opType = getStringAttr(node, SpanFields.GEN_AI_OPERATION_TYPE);
+      const toolName = getStringAttr(node, SpanFields.GEN_AI_TOOL_NAME);
       return getIsExecuteToolSpan(opType) && toolName === focusedTool;
     });
 

--- a/static/app/views/insights/pages/conversations/overview.tsx
+++ b/static/app/views/insights/pages/conversations/overview.tsx
@@ -116,7 +116,9 @@ function ConversationsContent({datePageFilterProps}: ConversationsOverviewPagePr
         unsetCursor();
       },
       searchSource: 'conversations',
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement
+        ? ['span.description', 'span.name']
+        : undefined,
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -1,4 +1,7 @@
-import {hasError} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
+import {
+  getStringAttr,
+  hasError,
+} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import {
   getIsAiGenerationSpan,
   getIsExecuteToolSpan,
@@ -261,8 +264,4 @@ export function extractTextFromMessage(msg: RequestMessage): string | null {
   }
 
   return null;
-}
-
-function getStringAttr(node: AITraceSpanNode, field: SpanFields): string | undefined {
-  return node.attributes?.[field] as string | undefined;
 }

--- a/static/app/views/insights/pages/mcp/hooks/useMcpSpanSearchProps.tsx
+++ b/static/app/views/insights/pages/mcp/hooks/useMcpSpanSearchProps.tsx
@@ -29,7 +29,9 @@ export function useMcpSpanSearchProps() {
       },
       searchSource: 'mcp-monitoring',
 
-      replaceRawSearchKeys: hasRawSearchReplacement ? ['span.description'] : undefined,
+      replaceRawSearchKeys: hasRawSearchReplacement
+        ? ['span.description', 'span.name']
+        : undefined,
       matchKeySuggestions: [
         {key: 'trace', valuePattern: /^[0-9a-fA-F]{32}$/},
         {key: 'id', valuePattern: /^[0-9a-fA-F]{16}$/},


### PR DESCRIPTION
- closed [TET-1908: Support span.name in agent monitoring/conversations](https://linear.app/getsentry/issue/TET-1908/support-spanname-in-agent-monitoringconversations)
- adds fallbacks from `span.description` to `span.name` in Agent monitoring and AI Conversations
- partially refactors `getNodeInfo` 