### PR TITLE
ref(dashboards): Extract createPlottableFromTimeSeries to its own file

### DIFF
--- a/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToPlottables.tsx
@@ -7,11 +7,8 @@ import {
   type DataUnit,
 } from 'sentry/utils/discover/fields';
 import type {Widget} from 'sentry/views/dashboards/types';
-import {DisplayType} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
-import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
-import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
-import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
 import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
 import {convertEventsStatsToTimeSeriesData} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
 
@@ -77,25 +74,6 @@ function createEventsStatsFromSeries(
       tips: {columns: undefined, query: undefined},
     },
   };
-}
-
-function createPlottableFromTimeSeries(
-  timeSeries: TimeSeries,
-  widget: Widget
-): Plottable | null {
-  const shouldStack = widget.queries[0]?.columns.length! > 0;
-
-  const {displayType, title} = widget;
-  switch (displayType) {
-    case DisplayType.LINE:
-      return new Line(timeSeries);
-    case DisplayType.AREA:
-      return new Area(timeSeries);
-    case DisplayType.BAR:
-      return new Bars(timeSeries, {stack: shouldStack ? title : undefined});
-    default:
-      return null;
-  }
 }
 
 function mapAggregationTypeToValueTypeAndUnit(

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.spec.tsx
@@ -1,0 +1,51 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {DisplayType} from 'sentry/views/dashboards/types';
+import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+
+import {createPlottableFromTimeSeries} from './createPlottableFromTimeSeries';
+
+describe('createPlottableFromTimeSeries', () => {
+  const mockTimeSeries = {
+    yAxis: 'count()',
+    values: [
+      {timestamp: 1729796400000, value: 100, incomplete: false},
+      {timestamp: 1729800000000, value: 200, incomplete: false},
+    ],
+    meta: {
+      valueType: 'number' as const,
+      valueUnit: null,
+      interval: 3600,
+    },
+  };
+
+  it('creates Line instance for LINE display type', () => {
+    const widget = WidgetFixture({displayType: DisplayType.LINE});
+    const plottable = createPlottableFromTimeSeries(mockTimeSeries, widget);
+
+    expect(plottable).toBeInstanceOf(Line);
+  });
+
+  it('creates Area instance for AREA display type', () => {
+    const widget = WidgetFixture({displayType: DisplayType.AREA});
+    const plottable = createPlottableFromTimeSeries(mockTimeSeries, widget);
+
+    expect(plottable).toBeInstanceOf(Area);
+  });
+
+  it('creates Bars instance for BAR display type', () => {
+    const widget = WidgetFixture({displayType: DisplayType.BAR});
+    const plottable = createPlottableFromTimeSeries(mockTimeSeries, widget);
+
+    expect(plottable).toBeInstanceOf(Bars);
+  });
+
+  it('returns null for TABLE display type', () => {
+    const widget = WidgetFixture({displayType: DisplayType.TABLE});
+    const plottable = createPlottableFromTimeSeries(mockTimeSeries, widget);
+
+    expect(plottable).toBeNull();
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
@@ -1,0 +1,26 @@
+import type {Widget} from 'sentry/views/dashboards/types';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {Area} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/area';
+import {Bars} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/bars';
+import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/line';
+import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
+
+export function createPlottableFromTimeSeries(
+  timeSeries: TimeSeries,
+  widget: Widget
+): Plottable | null {
+  const shouldStack = widget.queries[0]?.columns.length! > 0;
+
+  const {displayType, title} = widget;
+  switch (displayType) {
+    case DisplayType.LINE:
+      return new Line(timeSeries);
+    case DisplayType.AREA:
+      return new Area(timeSeries);
+    case DisplayType.BAR:
+      return new Bars(timeSeries, {stack: shouldStack ? title : undefined});
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts `createPlottableFromTimeSeries` from `transformLegacySeriesToPlottables.tsx` into its own file in the plottables directory
- The helper now lives closer to the visualization widget code that consumes it
- `transformLegacySeriesToPlottables` re-imports from the new location, so all existing callers continue to work unchanged

## Test plan
- [x] Added unit tests for `createPlottableFromTimeSeries` covering LINE, AREA, BAR, and TABLE display types
- [x] Existing `transformLegacySeriesToPlottables` tests still pass
- [x] ESLint, Prettier, and Stylelint all pass