### PR TITLE
fix(hybridcloud) Increase deadline for parallel hook delivery

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -234,7 +234,8 @@ def drain_mailbox(payload_id: int) -> None:
 @instrumented_task(
     name="sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox_parallel",
     namespace=hybridcloud_control_tasks,
-    processing_deadline_duration=180,
+    # Give more time than the threadpool delivery deadline
+    processing_deadline_duration=int(BATCH_SCHEDULE_OFFSET.total_seconds() + 10),
     silo_mode=SiloMode.CONTROL,
 )
 def drain_mailbox_parallel(payload_id: int) -> None:


### PR DESCRIPTION
Having the task deadline = to the delivery deadline for the threadpool is resulting in tasks being killed by deadlines. By extending the task deadline we should have fewer tasks killed.

Refs SENTRY-42M6