### PR TITLE
feat(dashboards): Add categorical bar chart template to Widget Library

### DIFF
--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -333,6 +333,29 @@ const getDefaultWidgets = (organization: Organization) => {
         },
       ],
     },
+    ...(organization.features.includes('dashboards-categorical-bar-charts')
+      ? [
+          {
+            id: 'error-count-by-transaction',
+            title: t('Error Count By Transaction'),
+            description: t('Compare error volume across your top transactions.'),
+            displayType: DisplayType.CATEGORICAL_BAR,
+            widgetType: WidgetType.ERRORS,
+            interval: '5m',
+            limit: 20,
+            queries: [
+              {
+                name: '',
+                conditions: '',
+                fields: ['transaction', 'count()'],
+                aggregates: ['count()'],
+                columns: ['transaction'],
+                orderby: '-count()',
+              },
+            ],
+          },
+        ]
+      : []),
   ];
 
   return isSelfHostedErrorsOnly

--- a/static/app/views/dashboards/widgetLibrary/widgetCard.tsx
+++ b/static/app/views/dashboards/widgetLibrary/widgetCard.tsx
@@ -11,6 +11,7 @@ export function getWidgetIcon(displayType: DisplayType): React.ReactNode {
       return <StyledIconMenu />;
     case DisplayType.BIG_NUMBER:
       return <StyledIconNumber />;
+    case DisplayType.CATEGORICAL_BAR:
     case DisplayType.BAR:
       return <StyledIconGraphBar />;
     case DisplayType.TOP_N:


### PR DESCRIPTION
Adds a pre-built "Error Count By Transaction" widget template to the Widget Library using the `CATEGORICAL_BAR` display type with the Errors dataset. Gated behind the `dashboards-categorical-bar-charts` feature flag.

Fixes [DAIN-1178](https://linear.app/getsentry/issue/DAIN-1178/add-a-pre-built-categorical-widget-to-the-widget-library)