### PR TITLE
ref(skills) update to include abstraction approach

### DIFF
--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -256,6 +256,45 @@ const Title = styled('h2')`
 <Heading as="h3" size="xl">Large H3</Heading>
 ```
 
+## Creating Thin Abstractions
+
+> **⚠️ CRITICAL: ALWAYS prompt the user for confirmation before creating abstractions over layout primitives (`Container`, `Flex`, `Grid`, `Stack`) when the intent is to DRY (Don't Repeat Yourself) repeated props.**
+
+You can create thin abstractions over primitives with the purpose of improving the semantic structure by using meaningful names (e.g., `TableCell` vs generic `Flex`) and with the purpose of providing some default props. It is very important that you do this sparingly, and only when it is a net gain for readability. For example, if there are only two instances of the duplicated props, and they are placed next to each other, the price of the abstraction outweights the terseness.
+
+**Before creating an abstraction, you MUST:**
+
+1. Ask the user for confirmation
+2. Explain what abstraction you plan to create
+3. Justify why the abstraction is worth the added complexity
+4. Wait for explicit approval before proceeding
+
+```tsx
+import {Flex, type FlexProps} from '@sentry/scraps/layout';
+
+// ❌ Don't repeat the same props everywhere
+<Flex align="center" gap="xs" flex="1" padding="sm">Content 1</Flex>
+<Flex align="center" gap="xs" flex="1" padding="sm">Content 2</Flex>
+<Flex align="center" gap="xs" flex="1" padding="sm">Content 3</Flex>
+<Flex align="center" gap="xs" flex="1" padding="sm">Content 4</Flex>
+
+// ✅ Create a thin wrapper with default props (AFTER USER CONFIRMATION)
+function TableCell(props: FlexProps) {
+  return <Flex align="center" gap="md" {...props} />;
+}
+
+<TableCell>Content 1</TableCell>
+<TableCell>Content 2</TableCell>
+<TableCell align="start">Content 3</TableCell>{/* Can override defaults */}
+```
+
+**Key points:**
+
+- **ALWAYS prompt for user confirmation BEFORE creating the abstraction**
+- Extend the primitive's props type (`extends FlexProps`)
+- Set defaults on JSX component and spread `{...props}` to allow overrides
+- Don't use styled components - compose primitives instead
+
 ## General Guidelines
 
 ### 1. Use Responsive Props

--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -258,7 +258,7 @@ const Title = styled('h2')`
 
 ## Creating Thin Abstractions
 
-> **⚠️ CRITICAL: ALWAYS prompt the user for confirmation before creating abstractions over layout primitives (`Container`, `Flex`, `Grid`, `Stack`) when the intent is to DRY (Don't Repeat Yourself) repeated props.**
+> **⚠️ CRITICAL: ALWAYS prompt the user for confirmation before creating abstractions over layout primitives (`Container`, `Flex`, `Grid`, `Stack`, `Text`, `Heading`) when the intent is to DRY (Don't Repeat Yourself) repeated props.**
 
 You can create thin abstractions over primitives with the purpose of improving the semantic structure by using meaningful names (e.g., `TableCell` vs generic `Flex`) and with the purpose of providing some default props. It is very important that you do this sparingly, and only when it is a net gain for readability. For example, if there are only two instances of the duplicated props, and they are placed next to each other, the price of the abstraction outweights the terseness.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -710,9 +710,13 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/core/                          @getsentry/design-engineering
 /static/app/icons/                                    @getsentry/design-engineering
 /static/app/stories/                                  @getsentry/design-engineering
+
+# LLM Agent guidelines
 /static/.cursor/BUGBOT.md                             @getsentry/design-engineering
 /static/CLAUDE.md                                     @getsentry/design-engineering
 /static/AGENTS.md                                     @getsentry/design-engineering
+/.claude/skills/design-system/                        @getsentry/design-engineering
+
 /static/eslint/                                       @getsentry/design-engineering
 /scripts/analyze-styled.ts                            @getsentry/design-engineering
 ## End of Frontend Platform


### PR DESCRIPTION
Update design engineering skill to prompt users to create abstractions over layout components when there is value in DRY-ing the props or improving the semantics