### PR TITLE
feat(icons): update icon sizes to Figma scale

### DIFF
--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -66,8 +66,8 @@ SvgIcon.ICON_DIRECTION_TO_ROTATION_ANGLE = ICON_DIRECTION_TO_ROTATION_ANGLE;
 const ICON_SIZES: Record<IconSize, string> = {
   '2xs': '8px',
   xs: '12px',
-  sm: '14px',
-  md: '16px',
+  sm: '16px',
+  md: '20px',
   lg: '24px',
   xl: '32px',
   '2xl': '72px',

--- a/static/app/icons/svgIcon.tsx
+++ b/static/app/icons/svgIcon.tsx
@@ -64,6 +64,7 @@ SvgIcon.ICON_DIRECTION_TO_ROTATION_ANGLE = ICON_DIRECTION_TO_ROTATION_ANGLE;
  * could be achieved via a small wrapper around the Container component.
  */
 const ICON_SIZES: Record<IconSize, string> = {
+  '2xs': '8px',
   xs: '12px',
   sm: '14px',
   md: '16px',

--- a/static/app/utils/theme/types.tsx
+++ b/static/app/utils/theme/types.tsx
@@ -78,7 +78,7 @@ export type BorderVariant = Exclude<SemanticVariant, 'neutral'> | 'primary' | 'm
 /**
  * Icon size constraint.
  */
-export type IconSize = SizeRange<'xs', '2xl'>;
+export type IconSize = SizeRange<'2xs', '2xl'>;
 
 /**
  * Form element size constraint.


### PR DESCRIPTION
The scale is off by one (2xs needs to become xs), but I will correct that using a codemod in a separate pass before updating the actual scale.