### PR TITLE
chore(seer): Remove the triage signals flag completely from the backend

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -529,7 +529,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:trace-view-v1", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to show link to previous/next traces
     manager.add("organizations:trace-view-linked-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-
     # Enable feature to load new tracing onboarding ui
     manager.add("organizations:tracing-onboarding-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to expose export csv button in trace explorer
@@ -732,7 +731,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:span-v2-attachment-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables experimental trace attachment processing in Relay.
     manager.add("projects:trace-attachment-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-
     # Enable the new Replay pipeline in Relay.
     manager.add("organizations:new-replay-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -529,8 +529,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:trace-view-v1", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to show link to previous/next traces
     manager.add("organizations:trace-view-linked-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable organization-level Triage signals V0 for Seer Automation page
-    manager.add("organizations:triage-signals-v0-org", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable feature to load new tracing onboarding ui
     manager.add("organizations:tracing-onboarding-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to expose export csv button in trace explorer
@@ -733,8 +732,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:span-v2-attachment-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables experimental trace attachment processing in Relay.
     manager.add("projects:trace-attachment-processing", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable Triage signals V0 for AI powered issue classification in sentry
-    manager.add("projects:triage-signals-v0", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
     # Enable the new Replay pipeline in Relay.
     manager.add("organizations:new-replay-processing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -361,18 +361,6 @@ def run_automation(
             if times_seen < 10:
                 return
 
-        try:
-            times_seen = group.times_seen_with_pending
-        except (AssertionError, AttributeError):
-            times_seen = group.times_seen
-        logger.info(
-            "Seat-based tier: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
-            group.id,
-            group.project.slug,
-            source.value,
-            times_seen,
-        )
-
     user_id = user.id if user else None
     auto_run_source = auto_run_source_map.get(source, "unknown_source")
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -349,7 +349,7 @@ def run_automation(
     if source == SeerAutomationSource.ISSUE_DETAILS:
         return
 
-    # Check event count for ALERT source with triage-signals-v0-org
+    # Check event count for ALERT source with seat-based tier
     if is_seer_seat_based_tier_enabled(group.organization):
         if source == SeerAutomationSource.ALERT:
             # Use times_seen_with_pending if available (set by post_process), otherwise fall back
@@ -366,7 +366,7 @@ def run_automation(
         except (AssertionError, AttributeError):
             times_seen = group.times_seen
         logger.info(
-            "Triage signals V0: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
+            "Seat-based tier: %s: run_automation called: project_slug=%s, source=%s, times_seen=%s",
             group.id,
             group.project.slug,
             source.value,

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -471,9 +471,6 @@ def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     """
     Check if organization has Seer seat-based pricing via billing.
     """
-    if features.has("organizations:triage-signals-v0-org", organization):
-        return True
-
     cache_key = get_seer_seat_based_tier_cache_key(organization.id)
     cached_value = cache.get(cache_key)
     if cached_value is not None:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1559,7 +1559,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
 
         generate_summary_and_run_automation.delay(group.id, trigger_path="old_seer_automation")
     else:
-        # Triage signals V0 behaviour
+        # Seat-based tier behaviour
         # If event count < 10, only generate summary (no automation)
         if group.times_seen_with_pending < 10:
             # Check if summary exists in cache
@@ -1591,7 +1591,7 @@ def kick_off_seer_automation(job: PostProcessJob) -> None:
             if group.first_seen < (timezone.now() - timedelta(days=14)):
                 return
 
-            # Triage signals will not run issues if they are not fixable at MEDIUM threshold
+            # Will not run issues if they are not fixable at MEDIUM threshold
             if group.seer_fixability_score is not None:
                 if (
                     group.seer_fixability_score < FixabilityScoreThresholds.MEDIUM.value

--- a/tests/sentry/core/endpoints/test_team_projects.py
+++ b/tests/sentry/core/endpoints/test_team_projects.py
@@ -504,54 +504,60 @@ class TeamProjectsCreateTest(APITestCase, TestCase):
             project=project, key="sentry:autofix_automation_tuning"
         ).exists()
 
-    def test_project_autofix_tuning_defaults_to_medium_with_triage_signals_flag(self) -> None:
+    @patch("sentry.seer.similarity.utils.is_seer_seat_based_tier_enabled", return_value=True)
+    def test_project_autofix_tuning_defaults_to_medium_with_seat_based_tier(
+        self, mock_seat_based_tier
+    ) -> None:
         # Ensure no org-level default is set
         self.organization.delete_option("sentry:default_autofix_automation_tuning")
-        with self.feature("organizations:triage-signals-v0-org"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.team.slug,
-                name="Project With Flag",
-                slug="project-with-flag",
-                platform="python",
-                status_code=201,
-            )
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="Project With Flag",
+            slug="project-with-flag",
+            platform="python",
+            status_code=201,
+        )
         project = Project.objects.get(id=response.data["id"])
         autofix_tuning = ProjectOption.objects.get_value(
             project=project, key="sentry:autofix_automation_tuning"
         )
         assert autofix_tuning == "medium"
 
-    def test_project_autofix_tuning_respects_explicit_off_even_with_flag(self) -> None:
-        # Org explicitly sets "off" - should be respected even with feature flag
+    @patch("sentry.seer.similarity.utils.is_seer_seat_based_tier_enabled", return_value=True)
+    def test_project_autofix_tuning_respects_explicit_off_even_with_seat_based_tier(
+        self, mock_seat_based_tier
+    ) -> None:
+        # Org explicitly sets "off" - should be respected even with seat-based tier
         self.organization.update_option("sentry:default_autofix_automation_tuning", "off")
-        with self.feature("organizations:triage-signals-v0-org"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.team.slug,
-                name="Project Explicit Off",
-                slug="project-explicit-off",
-                platform="python",
-                status_code=201,
-            )
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="Project Explicit Off",
+            slug="project-explicit-off",
+            platform="python",
+            status_code=201,
+        )
         project = Project.objects.get(id=response.data["id"])
         autofix_tuning = ProjectOption.objects.get_value(
             project=project, key="sentry:autofix_automation_tuning"
         )
         assert autofix_tuning == "off"
 
-    def test_project_autofix_tuning_flag_overrides_non_off_org_default(self) -> None:
-        # Org sets "high" but feature flag overrides to "medium"
+    @patch("sentry.seer.similarity.utils.is_seer_seat_based_tier_enabled", return_value=True)
+    def test_project_autofix_tuning_seat_based_tier_overrides_non_off_org_default(
+        self, mock_seat_based_tier
+    ) -> None:
+        # Org sets "high" but seat-based tier overrides to "medium"
         self.organization.update_option("sentry:default_autofix_automation_tuning", "high")
-        with self.feature("organizations:triage-signals-v0-org"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.team.slug,
-                name="Project Flag Override",
-                slug="project-flag-override",
-                platform="python",
-                status_code=201,
-            )
+        response = self.get_success_response(
+            self.organization.slug,
+            self.team.slug,
+            name="Project Flag Override",
+            slug="project-flag-override",
+            platform="python",
+            status_code=201,
+        )
         project = Project.objects.get(id=response.data["id"])
         autofix_tuning = ProjectOption.objects.get_value(
             project=project, key="sentry:autofix_automation_tuning"

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -394,12 +394,6 @@ class TestIsSeerSeatBasedTierEnabled(TestCase):
         super().tearDown()
         cache.delete(f"seer:seat-based-tier:{self.organization.id}")
 
-    def test_returns_true_when_triage_signals_enabled(self):
-        """Test returns True when triage-signals-v0-org feature flag is enabled."""
-        with self.feature("organizations:triage-signals-v0-org"):
-            result = is_seer_seat_based_tier_enabled(self.organization)
-            assert result is True
-
     @patch("sentry.seer.autofix.utils.features.has")
     def test_returns_true_when_seat_based_seer_enabled(self, mock_features_has):
         """Test returns True when seat-based-seer-enabled feature flag is enabled and caches the result."""

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -776,16 +776,15 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     )
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=False)
     def test_without_seat_based_tier(
         self,
-        mock_seat_based,
         mock_state,
         mock_triggering,
         mock_rate,
         mock_trigger,
         mock_seat_based_tier,
     ):
+        mock_seat_based_tier.return_value = False
         with self.feature({"organizations:gen-ai-features": True}):
             run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -770,6 +770,10 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
+    @patch(
+        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
+        return_value=False,
+    )
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
     @patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=False)
@@ -778,6 +782,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         mock_seat_based,
         mock_state,
         mock_triggering,
+        mock_rate,
         mock_trigger,
         mock_seat_based_tier,
     ):

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -777,8 +777,16 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    def test_without_feature_flag(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger, mock_seat_based_tier
+    @patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=False)
+    def test_without_seat_based_tier(
+        self,
+        mock_seat_based,
+        mock_gen,
+        mock_budget,
+        mock_state,
+        mock_rate,
+        mock_trigger,
+        mock_seat_based_tier,
     ):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -708,13 +708,21 @@ class TestGetStoppingPointFromFixability:
         assert _get_stopping_point_from_fixability(score) == expected
 
 
-@with_feature({"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True})
+@with_feature({"organizations:gen-ai-features": True})
 class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.seat_based_tier_patcher = patch(
+            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
+        )
+        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
+
+    def tearDown(self) -> None:
+        self.seat_based_tier_patcher.stop()
+        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
@@ -787,9 +795,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
             scores=SummarizeIssueScores(fixability_score=0.80),
         )
 
-        with self.feature(
-            {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": False}
-        ):
+        with self.feature({"organizations:gen-ai-features": True}):
             run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_called_once()
@@ -922,13 +928,21 @@ class TestApplyUserPreferenceUpperBound:
         assert result == expected
 
 
-@with_feature({"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True})
+@with_feature({"organizations:gen-ai-features": True})
 class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.seat_based_tier_patcher = patch(
+            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
+        )
+        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
+
+    def tearDown(self) -> None:
+        self.seat_based_tier_patcher.stop()
+        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary._fetch_user_preference")
@@ -1028,14 +1042,21 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
 
 
 @with_feature("organizations:gen-ai-features")
-@with_feature("organizations:triage-signals-v0-org")
 class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.seat_based_tier_patcher = patch(
+            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
+        )
+        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
         self.user = self.create_user()
+
+    def tearDown(self) -> None:
+        self.seat_based_tier_patcher.stop()
+        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
@@ -1044,7 +1065,7 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     def test_alert_skips_automation_below_threshold(
         self, mock_budget, mock_state, mock_fixability, mock_trigger
     ):
-        """Alert automation should skip when event count < 10 with triage-signals-v0-org"""
+        """Alert automation should skip when event count < 10"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_budget.return_value = True
         mock_state.return_value = None
@@ -1074,7 +1095,7 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     def test_alert_runs_automation_above_threshold(
         self, mock_budget, mock_state, mock_fixability, mock_trigger, mock_rate_limit
     ):
-        """Alert automation should run when event count >= 10 with triage-signals-v0"""
+        """Alert automation should run when event count >= 10"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_budget.return_value = True
         mock_state.return_value = None

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -708,21 +708,14 @@ class TestGetStoppingPointFromFixability:
         assert _get_stopping_point_from_fixability(score) == expected
 
 
+@patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=True)
 @with_feature({"organizations:gen-ai-features": True})
 class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.seat_based_tier_patcher = patch(
-            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
-        )
-        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
-
-    def tearDown(self) -> None:
-        self.seat_based_tier_patcher.stop()
-        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch(
@@ -733,7 +726,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_high_fixability_code_changes(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
+        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger, mock_seat_based_tier
     ):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
@@ -759,7 +752,7 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_medium_fixability_solution(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger
+        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger, mock_seat_based_tier
     ):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
@@ -784,7 +777,9 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    def test_without_feature_flag(self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger):
+    def test_without_feature_flag(
+        self, mock_gen, mock_budget, mock_state, mock_rate, mock_trigger, mock_seat_based_tier
+    ):
         self.project.update_option("sentry:autofix_automation_tuning", "always")
         mock_gen.return_value = SummarizeIssueResponse(
             group_id=str(self.group.id),
@@ -804,7 +799,9 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
-    def test_skips_when_autofix_in_progress(self, mock_state, mock_triggering, mock_trigger):
+    def test_skips_when_autofix_in_progress(
+        self, mock_state, mock_triggering, mock_trigger, mock_seat_based_tier
+    ):
         """run_automation skips triggering autofix when one is already in progress"""
         mock_state.return_value = {"status": "in_progress"}
 
@@ -928,21 +925,14 @@ class TestApplyUserPreferenceUpperBound:
         assert result == expected
 
 
+@patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=True)
 @with_feature({"organizations:gen-ai-features": True})
 class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.seat_based_tier_patcher = patch(
-            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
-        )
-        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
-
-    def tearDown(self) -> None:
-        self.seat_based_tier_patcher.stop()
-        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
     @patch("sentry.seer.autofix.issue_summary._fetch_user_preference")
@@ -954,7 +944,14 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_user_preference_limits_high_fixability(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
+        self,
+        mock_gen,
+        mock_budget,
+        mock_state,
+        mock_rate,
+        mock_fetch,
+        mock_trigger,
+        mock_seat_based_tier,
     ):
         """High fixability (OPEN_PR) limited by user preference (SOLUTION)"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -986,7 +983,14 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_fixability_limits_permissive_user_preference(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
+        self,
+        mock_gen,
+        mock_budget,
+        mock_state,
+        mock_rate,
+        mock_fetch,
+        mock_trigger,
+        mock_seat_based_tier,
     ):
         """Medium fixability (ROOT_CAUSE) used despite user allowing OPEN_PR"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -1018,7 +1022,14 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     def test_no_user_preference_uses_fixability_only(
-        self, mock_gen, mock_budget, mock_state, mock_rate, mock_fetch, mock_trigger
+        self,
+        mock_gen,
+        mock_budget,
+        mock_state,
+        mock_rate,
+        mock_fetch,
+        mock_trigger,
+        mock_seat_based_tier,
     ):
         """When user has no preference, use fixability score alone"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -1041,29 +1052,22 @@ class TestRunAutomationWithUpperBound(APITestCase, SnubaTestCase):
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.OPEN_PR
 
 
+@patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=True)
 @with_feature("organizations:gen-ai-features")
 class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.seat_based_tier_patcher = patch(
-            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
-        )
-        self.seat_based_tier_patcher.start()
         self.group = self.create_group()
         event_data = load_data("python")
         self.event = self.store_event(data=event_data, project_id=self.project.id)
         self.user = self.create_user()
-
-    def tearDown(self) -> None:
-        self.seat_based_tier_patcher.stop()
-        super().tearDown()
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task")
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
     def test_alert_skips_automation_below_threshold(
-        self, mock_budget, mock_state, mock_fixability, mock_trigger
+        self, mock_budget, mock_state, mock_fixability, mock_trigger, mock_seat_based_tier
     ):
         """Alert automation should skip when event count < 10"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")
@@ -1093,7 +1097,13 @@ class TestRunAutomationAlertEventCount(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state")
     @patch("sentry.seer.autofix.issue_summary.quotas.backend.check_seer_quota")
     def test_alert_runs_automation_above_threshold(
-        self, mock_budget, mock_state, mock_fixability, mock_trigger, mock_rate_limit
+        self,
+        mock_budget,
+        mock_state,
+        mock_fixability,
+        mock_trigger,
+        mock_rate_limit,
+        mock_seat_based_tier,
     ):
         """Alert automation should run when event count >= 10"""
         self.project.update_option("sentry:autofix_automation_tuning", "always")

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -770,34 +770,17 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         assert mock_trigger.call_args[1]["stopping_point"] == AutofixStoppingPoint.ROOT_CAUSE
 
     @patch("sentry.seer.autofix.issue_summary._trigger_autofix_task.delay")
-    @patch(
-        "sentry.seer.autofix.issue_summary.is_seer_autotriggered_autofix_rate_limited_and_increment",
-        return_value=False,
-    )
+    @patch("sentry.seer.autofix.issue_summary.is_group_triggering_automation", return_value=True)
     @patch("sentry.seer.autofix.issue_summary.get_autofix_state", return_value=None)
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.seer.autofix.issue_summary.is_seer_seat_based_tier_enabled", return_value=False)
     def test_without_seat_based_tier(
         self,
         mock_seat_based,
-        mock_gen,
-        mock_budget,
         mock_state,
-        mock_rate,
+        mock_triggering,
         mock_trigger,
         mock_seat_based_tier,
     ):
-        self.project.update_option("sentry:autofix_automation_tuning", "always")
-        mock_gen.return_value = SummarizeIssueResponse(
-            group_id=str(self.group.id),
-            headline="h",
-            whats_wrong="w",
-            trace="t",
-            possible_cause="c",
-            scores=SummarizeIssueScores(fixability_score=0.80),
-        )
-
         with self.feature({"organizations:gen-ai-features": True}):
             run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2977,12 +2977,21 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
 
 
 class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
-    """Tests for the triage signals V0 flow behind the organizations:triage-signals-v0-org feature flag."""
+    """Tests for the triage signals V0 flow."""
+
+    def setUp(self):
+        super().setUp()
+        self.seat_based_tier_patcher = patch(
+            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
+        )
+        self.seat_based_tier_patcher.start()
+
+    def tearDown(self):
+        self.seat_based_tier_patcher.stop()
+        super().tearDown()
 
     @patch("sentry.tasks.autofix.generate_issue_summary_only.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_less_than_10_no_cache(self, mock_generate_summary_only):
         """Test that with event count < 10 and no cached summary, we generate summary only (no automation)."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3008,9 +3017,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         mock_generate_summary_only.assert_called_once_with(group.id)
 
     @patch("sentry.tasks.autofix.generate_issue_summary_only.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_less_than_10_with_cache(self, mock_generate_summary_only):
         """Test that with event count < 10 and cached summary exists, we do nothing."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3041,9 +3048,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         return_value=True,
     )
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_with_cache(
         self, mock_run_automation, mock_has_repos
     ):
@@ -3090,9 +3095,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         return_value=True,
     )
     @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_no_cache(
         self,
         mock_generate_summary_and_run_automation,
@@ -3137,9 +3140,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         return_value=False,
     )
     @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_skips_without_connected_repos(
         self,
         mock_generate_summary_and_run_automation,
@@ -3177,9 +3178,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         mock_generate_summary_and_run_automation.assert_not_called()
 
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_skips_with_seer_last_triggered(
         self, mock_run_automation
     ):
@@ -3223,9 +3222,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         mock_run_automation.assert_not_called()
 
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_skips_with_existing_fixability_score(
         self, mock_run_automation
     ):
@@ -3271,9 +3268,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.autofix.generate_summary_and_run_automation.delay")
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
-    @with_feature(
-        {"organizations:gen-ai-features": True, "organizations:triage-signals-v0-org": True}
-    )
+    @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_skips_automation_for_old_issues(
         self,
         mock_run_automation,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2976,23 +2976,15 @@ class KickOffSeerAutomationTestMixin(BasePostProcessGroupMixin):
         mock_generate_summary_and_run_automation.assert_not_called()
 
 
+@patch("sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True)
 class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
     """Tests for the triage signals V0 flow."""
 
-    def setUp(self):
-        super().setUp()
-        self.seat_based_tier_patcher = patch(
-            "sentry.seer.autofix.utils.is_seer_seat_based_tier_enabled", return_value=True
-        )
-        self.seat_based_tier_patcher.start()
-
-    def tearDown(self):
-        self.seat_based_tier_patcher.stop()
-        super().tearDown()
-
     @patch("sentry.tasks.autofix.generate_issue_summary_only.delay")
     @with_feature({"organizations:gen-ai-features": True})
-    def test_triage_signals_event_count_less_than_10_no_cache(self, mock_generate_summary_only):
+    def test_triage_signals_event_count_less_than_10_no_cache(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
         """Test that with event count < 10 and no cached summary, we generate summary only (no automation)."""
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -3018,7 +3010,9 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
 
     @patch("sentry.tasks.autofix.generate_issue_summary_only.delay")
     @with_feature({"organizations:gen-ai-features": True})
-    def test_triage_signals_event_count_less_than_10_with_cache(self, mock_generate_summary_only):
+    def test_triage_signals_event_count_less_than_10_with_cache(
+        self, mock_generate_summary_only, mock_seat_based_tier
+    ):
         """Test that with event count < 10 and cached summary exists, we do nothing."""
         self.project.update_option("sentry:seer_scanner_automation", True)
         event = self.create_event(
@@ -3050,7 +3044,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
     @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_with_cache(
-        self, mock_run_automation, mock_has_repos
+        self, mock_run_automation, mock_has_repos, mock_seat_based_tier
     ):
         """Test that with event count >= 10 and cached summary exists, we run automation directly."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3100,6 +3094,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         self,
         mock_generate_summary_and_run_automation,
         mock_has_repos,
+        mock_seat_based_tier,
     ):
         """Test that with event count >= 10 and no cached summary, we generate summary + run automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3145,6 +3140,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         self,
         mock_generate_summary_and_run_automation,
         mock_has_repos,
+        mock_seat_based_tier,
     ):
         """Test that with event count >= 10 but no connected repos, we skip automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3180,7 +3176,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
     @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_skips_with_seer_last_triggered(
-        self, mock_run_automation
+        self, mock_run_automation, mock_seat_based_tier
     ):
         """Test that with event count >= 10 and seer_autofix_last_triggered set, we skip automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3224,7 +3220,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
     @patch("sentry.tasks.autofix.run_automation_only_task.delay")
     @with_feature({"organizations:gen-ai-features": True})
     def test_triage_signals_event_count_gte_10_skips_with_existing_fixability_score(
-        self, mock_run_automation
+        self, mock_run_automation, mock_seat_based_tier
     ):
         """Test that with event count >= 10 and seer_fixability_score below MEDIUM threshold, we skip automation."""
         self.project.update_option("sentry:seer_scanner_automation", True)
@@ -3273,6 +3269,7 @@ class TriageSignalsV0TestMixin(BasePostProcessGroupMixin):
         self,
         mock_run_automation,
         mock_generate_summary_and_run_automation,
+        mock_seat_based_tier,
     ):
         """Test that automation is skipped for issues older than 14 days."""
         self.project.update_option("sentry:seer_scanner_automation", True)


### PR DESCRIPTION
## PR Details
+ Removed the triage signals flag wherever it was used.
+ Removed a log line that is no longer needed. 
+ Follow up to this PR - https://github.com/getsentry/sentry/pull/107914
+ I have an PR to options automator too that I will merge in after this one: https://github.com/getsentry/sentry-options-automator/pull/6436
