### PR TITLE
fix(autofix): Gate repos_not_found log on non-empty set

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -240,14 +240,15 @@ def _launch_agents_for_repos(
 
     # Repos that were in the repos but not in the autofix state
     repos_not_found = repos - autofix_state_repos
-    logger.warning(
-        "coding_agent.post.repos_not_found",
-        extra={
-            "organization_id": organization.id,
-            "run_id": run_id,
-            "repos_not_found": repos_not_found,
-        },
-    )
+    if repos_not_found:
+        logger.warning(
+            "coding_agent.post.repos_not_found",
+            extra={
+                "organization_id": organization.id,
+                "run_id": run_id,
+                "repos_not_found": repos_not_found,
+            },
+        )
 
     validated_repos = repos - repos_not_found
 


### PR DESCRIPTION
The `coding_agent.post.repos_not_found` warning was being logged unconditionally on every coding agent POST, even when the set of missing repos was empty. This was noisy and made it harder to find actual instances where repos referenced in the analysis weren't connected.

Now the warning only fires when there are actually repos that couldn't be found.