### PR TITLE
feat(dashboards): Hide context menu for non-editable widgets

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -143,6 +143,10 @@ export type Widget = {
   dashboardId?: string;
   datasetSource?: DatasetSource;
   description?: string;
+  /**
+   * Whether the widget is editable. If true, the context menu will not show edit options.
+   */
+  disableEdit?: boolean;
   exploreUrls?: null | string[];
   id?: string;
   layout?: WidgetLayout | null;

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -647,6 +647,6 @@ export const widgetFetchesOwnData = (widgetType: DisplayType) => {
 };
 
 // Custom widgets for prebuilt dashboards are not editable at this time
-export const isWidgetEditable = (widgetType: DisplayType) => {
-  return widgetType !== DisplayType.SERVER_TREE;
+export const isWidgetEditable = (widget: Widget) => {
+  return widget.displayType !== DisplayType.SERVER_TREE && !widget.disableEdit;
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -227,6 +227,7 @@ const TRANSACTIONS_TABLE: Widget = {
   interval: '5m',
   limit: 50,
   tableWidths: TABLE_FIELDS.map(() => -1),
+  disableEdit: true,
   queries: [
     {
       name: '',

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -189,6 +189,15 @@ export function getMenuOptions(
 ) {
   const menuOptions: MenuItemProps[] = [];
 
+  /**
+   * Many custom widets for prebuilt dashboards can not be configured, edited, or duplicated.
+   * Often they are not representable in explore too. To avoid any bad states in the UI, we hide the context menu entierely for widgets like this
+   * until we go through each custom each and confirm what works.
+   */
+  if (!isWidgetEditable(widget)) {
+    return menuOptions;
+  }
+
   const disableTransactionEdit =
     organization.features.includes('discover-saved-queries-deprecation') &&
     widget.widgetType === WidgetType.TRANSACTIONS;
@@ -292,11 +301,7 @@ export function getMenuOptions(
       to: issuesLocation,
     });
   }
-
-  if (
-    organization.features.includes('dashboards-edit') &&
-    isWidgetEditable(widget.displayType)
-  ) {
+  if (organization.features.includes('dashboards-edit')) {
     menuOptions.push({
       key: 'add-to-dashboard',
       label: t('Add to Dashboard'),


### PR DESCRIPTION
## Summary

Hides the widget context menu entirely for widgets that cannot be edited, configured, or duplicated. This prevents users from accessing non-functional options for custom widgets in prebuilt dashboards.

## Changes

- Added `disableEdit` property to the `Widget` type to mark widgets as non-editable
- Updated `isWidgetEditable()` to accept a `Widget` object and check both the display type and `disableEdit` flag
- Marked the transactions table widget in the frontend overview dashboard as non-editable
- Modified widget context menu to return empty options for non-editable widgets

## Context

Many custom widgets for prebuilt dashboards cannot be configured, edited, or duplicated. They're often not representable in Explore either. To avoid bad UI states, we're hiding the context menu entirely for these widgets until each custom widget can be reviewed and confirmed for functionality.