### PR TITLE
feat(dashboards): Add customizable limit for categorical bar widgets

### DIFF
--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -144,7 +144,7 @@ function SortableWidget(props: Props) {
     },
     isMobile,
     windowWidth,
-    tableItemLimit: TABLE_ITEM_LIMIT,
+    tableItemLimit: widget.limit ?? TABLE_ITEM_LIMIT,
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     useTimeseriesVisualization,

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -19,6 +19,9 @@ export const MAX_WIDGETS = 30;
 
 export const DEFAULT_TABLE_LIMIT = 5;
 
+export const DEFAULT_CATEGORICAL_BAR_LIMIT = 20;
+export const MAX_CATEGORICAL_BAR_LIMIT = 25;
+
 export const DEFAULT_WIDGET_NAME = t('Custom Widget');
 
 export enum DisplayType {

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -325,6 +325,103 @@ describe('WidgetBuilderSortBySelector', () => {
       expect.anything()
     );
   });
+  it('renders a numeric limit input for categorical bar widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+          <WidgetBuilderSortBySelector />
+        </TraceItemAttributeProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          ...defaultRouterConfig,
+          location: {
+            pathname: defaultRouterConfig.location?.pathname ?? '/mock-pathname/',
+            query: {
+              displayType: 'categorical_bar',
+              fields: ['transaction.duration', 'count()'],
+              limit: 20,
+              dataset: 'spans',
+            },
+          },
+        },
+      }
+    );
+
+    const limitInput = await screen.findByRole('textbox', {name: 'Limit results'});
+    expect(limitInput).toBeInTheDocument();
+    expect(limitInput).toHaveValue('20');
+  });
+
+  it('does not render a limit input for table widgets', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+          <WidgetBuilderSortBySelector />
+        </TraceItemAttributeProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          ...defaultRouterConfig,
+          location: {
+            pathname: defaultRouterConfig.location?.pathname ?? '/mock-pathname/',
+            query: {
+              ...defaultRouterConfig.location?.query,
+              displayType: 'table',
+            },
+          },
+        },
+      }
+    );
+
+    expect(await screen.findByText('Sort by')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {name: 'Limit results'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('correctly handles categorical bar limit changes', async () => {
+    const mockNavigate = jest.fn();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    render(
+      <WidgetBuilderProvider>
+        <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+          <WidgetBuilderSortBySelector />
+        </TraceItemAttributeProvider>
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          ...defaultRouterConfig,
+          location: {
+            pathname: defaultRouterConfig.location?.pathname ?? '/mock-pathname/',
+            query: {
+              displayType: 'categorical_bar',
+              fields: ['transaction.duration', 'count()'],
+              limit: 20,
+              dataset: 'spans',
+            },
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('textbox', {name: 'Limit results'});
+
+    // Use the increment button to change the value
+    await userEvent.click(screen.getByRole('button', {name: 'Increase Limit results'}));
+
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({limit: 21}),
+      }),
+      expect.anything()
+    );
+  });
+
   it('sorts by equations table', async () => {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -325,7 +325,7 @@ describe('WidgetBuilderSortBySelector', () => {
       expect.anything()
     );
   });
-  it('renders a numeric limit input for categorical bar widgets', async () => {
+  it('renders a limit selector for categorical bar widgets', async () => {
     render(
       <WidgetBuilderProvider>
         <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
@@ -349,12 +349,10 @@ describe('WidgetBuilderSortBySelector', () => {
       }
     );
 
-    const limitInput = await screen.findByRole('textbox', {name: 'Limit results'});
-    expect(limitInput).toBeInTheDocument();
-    expect(limitInput).toHaveValue('20');
+    expect(await screen.findByText('Limit to 20 results')).toBeInTheDocument();
   });
 
-  it('does not render a limit input for table widgets', async () => {
+  it('does not render a limit selector for table widgets', async () => {
     render(
       <WidgetBuilderProvider>
         <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
@@ -377,9 +375,7 @@ describe('WidgetBuilderSortBySelector', () => {
     );
 
     expect(await screen.findByText('Sort by')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('textbox', {name: 'Limit results'})
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Limit to 5 results')).not.toBeInTheDocument();
   });
 
   it('correctly handles categorical bar limit changes', async () => {
@@ -409,14 +405,13 @@ describe('WidgetBuilderSortBySelector', () => {
       }
     );
 
-    await screen.findByRole('textbox', {name: 'Limit results'});
-
-    // Use the increment button to change the value
-    await userEvent.click(screen.getByRole('button', {name: 'Increase Limit results'}));
+    const limitSelector = await screen.findByText('Limit to 20 results');
+    await userEvent.click(limitSelector);
+    await userEvent.click(await screen.findByText('Limit to 15 results'));
 
     expect(mockNavigate).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        query: expect.objectContaining({limit: 21}),
+        query: expect.objectContaining({limit: 15}),
       }),
       expect.anything()
     );

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -75,23 +75,32 @@ function WidgetBuilderSortBySelector() {
     DisplayType.AREA,
   ].includes(displayType);
 
-  const isCategoricalBarWidget = displayType === DisplayType.CATEGORICAL_BAR;
-
-  const maxLimit = isTimeseriesChart
-    ? getResultsLimit(widget.queries.length, widget.queries[0]!.aggregates.length)
-    : isCategoricalBarWidget
-      ? MAX_CATEGORICAL_BAR_LIMIT
-      : 0;
+  let maxLimit: number;
+  switch (displayType) {
+    case DisplayType.LINE:
+    case DisplayType.BAR:
+    case DisplayType.AREA:
+      maxLimit = getResultsLimit(
+        widget.queries.length,
+        widget.queries[0]!.aggregates.length
+      );
+      break;
+    case DisplayType.CATEGORICAL_BAR:
+      maxLimit = MAX_CATEGORICAL_BAR_LIMIT;
+      break;
+    default:
+      maxLimit = 0;
+  }
 
   // handles when the maxLimit changes to a value less than the current selected limit
   useEffect(() => {
     if (!state.limit) {
       return;
     }
-    if ((isTimeseriesChart || isCategoricalBarWidget) && state.limit > maxLimit) {
+    if (maxLimit > 0 && state.limit > maxLimit) {
       dispatch({type: BuilderStateAction.SET_LIMIT, payload: maxLimit});
     }
-  }, [state.limit, maxLimit, dispatch, isTimeseriesChart, isCategoricalBarWidget]);
+  }, [state.limit, maxLimit, dispatch]);
 
   function handleSortByChange(newSortBy: string, sortDirection: 'asc' | 'desc') {
     dispatch({
@@ -118,7 +127,7 @@ function WidgetBuilderSortBySelector() {
           stacked
         >
           <Flex direction="column" gap="sm">
-            {(isTimeseriesChart || isCategoricalBarWidget) && state.limit && (
+            {maxLimit > 0 && state.limit && (
               <Select
                 disabled={disableSortDirection && disableSort}
                 name="resultsLimit"

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -1,12 +1,13 @@
 import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 
+import {NumberInput} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import {t, tn} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {SelectValue} from 'sentry/types/core';
 import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -14,7 +15,11 @@ import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEv
 import useOrganization from 'sentry/utils/useOrganization';
 import useTags from 'sentry/utils/useTags';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DisplayType,
+  MAX_CATEGORICAL_BAR_LIMIT,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {SortBySelectors} from 'sentry/views/dashboards/widgetBuilder/components/sortBySelectors';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
@@ -72,20 +77,21 @@ function WidgetBuilderSortBySelector() {
     DisplayType.AREA,
   ].includes(displayType);
 
-  const maxLimit = getResultsLimit(
-    widget.queries.length,
-    widget.queries[0]!.aggregates.length
-  );
+  const isCategoricalBarWidget = displayType === DisplayType.CATEGORICAL_BAR;
+
+  const maxLimit = isTimeseriesChart
+    ? getResultsLimit(widget.queries.length, widget.queries[0]!.aggregates.length)
+    : MAX_CATEGORICAL_BAR_LIMIT;
 
   // handles when the maxLimit changes to a value less than the current selected limit
   useEffect(() => {
     if (!state.limit) {
       return;
     }
-    if (state.limit > maxLimit) {
+    if (isTimeseriesChart && state.limit > maxLimit) {
       dispatch({type: BuilderStateAction.SET_LIMIT, payload: maxLimit});
     }
-  }, [state.limit, maxLimit, dispatch]);
+  }, [state.limit, maxLimit, dispatch, isTimeseriesChart]);
 
   function handleSortByChange(newSortBy: string, sortDirection: 'asc' | 'desc') {
     dispatch({
@@ -111,54 +117,67 @@ function WidgetBuilderSortBySelector() {
           flexibleControlStateSize
           stacked
         >
-          {isTimeseriesChart && state.limit && (
-            <ResultsLimitSelector
-              disabled={disableSortDirection && disableSort}
-              name="resultsLimit"
-              options={[...new Array(maxLimit).keys()].map(resultLimit => {
-                const value = resultLimit + 1;
-                return {
-                  label: tn('Limit to %s result', 'Limit to %s results', value),
-                  value,
-                };
-              })}
-              value={state.limit}
-              onChange={(option: SelectValue<number>) => {
-                dispatch({type: BuilderStateAction.SET_LIMIT, payload: option.value});
+          <Flex direction="column" gap="sm">
+            {isTimeseriesChart && state.limit && (
+              <ResultsLimitSelector
+                disabled={disableSortDirection && disableSort}
+                name="resultsLimit"
+                options={[...new Array(maxLimit).keys()].map(resultLimit => {
+                  const value = resultLimit + 1;
+                  return {
+                    label: tn('Limit to %s result', 'Limit to %s results', value),
+                    value,
+                  };
+                })}
+                value={state.limit}
+                onChange={(option: SelectValue<number>) => {
+                  dispatch({type: BuilderStateAction.SET_LIMIT, payload: option.value});
+                }}
+              />
+            )}
+            {isCategoricalBarWidget && state.limit && (
+              <NumberInput
+                aria-label={t('Limit results')}
+                min={1}
+                max={MAX_CATEGORICAL_BAR_LIMIT}
+                value={state.limit}
+                onChange={value => {
+                  dispatch({type: BuilderStateAction.SET_LIMIT, payload: value});
+                }}
+              />
+            )}
+            <SortBySelectors
+              displayType={displayType}
+              widgetType={state.dataset ?? WidgetType.ERRORS}
+              hasGroupBy={isTimeseriesChart && !!widget.queries[0]!.columns.length}
+              disableSortReason={disableSortReason}
+              disableSort={disableSort}
+              disableSortDirection={disableSortDirection}
+              widgetQuery={widget.queries[0]!}
+              values={{
+                sortDirection:
+                  state.sort?.[0]?.kind === 'asc'
+                    ? SortDirection.LOW_TO_HIGH
+                    : SortDirection.HIGH_TO_LOW,
+                sortBy: state.sort?.length ? state.sort.at(0)!.field : '',
               }}
+              onChange={({sortDirection, sortBy}) => {
+                const newSortDirection =
+                  sortDirection === SortDirection.HIGH_TO_LOW ? 'desc' : 'asc';
+                handleSortByChange(sortBy, newSortDirection);
+                trackAnalytics('dashboards_views.widget_builder.change', {
+                  builder_version: WidgetBuilderVersion.SLIDEOUT,
+                  field: 'sortBy.update',
+                  from: source,
+                  new_widget: !isEditing,
+                  value: '',
+                  widget_type: state.dataset ?? '',
+                  organization,
+                });
+              }}
+              tags={tags}
             />
-          )}
-          <SortBySelectors
-            displayType={displayType}
-            widgetType={state.dataset ?? WidgetType.ERRORS}
-            hasGroupBy={isTimeseriesChart && !!widget.queries[0]!.columns.length}
-            disableSortReason={disableSortReason}
-            disableSort={disableSort}
-            disableSortDirection={disableSortDirection}
-            widgetQuery={widget.queries[0]!}
-            values={{
-              sortDirection:
-                state.sort?.[0]?.kind === 'asc'
-                  ? SortDirection.LOW_TO_HIGH
-                  : SortDirection.HIGH_TO_LOW,
-              sortBy: state.sort?.length ? state.sort.at(0)!.field : '',
-            }}
-            onChange={({sortDirection, sortBy}) => {
-              const newSortDirection =
-                sortDirection === SortDirection.HIGH_TO_LOW ? 'desc' : 'asc';
-              handleSortByChange(sortBy, newSortDirection);
-              trackAnalytics('dashboards_views.widget_builder.change', {
-                builder_version: WidgetBuilderVersion.SLIDEOUT,
-                field: 'sortBy.update',
-                from: source,
-                new_widget: !isEditing,
-                value: '',
-                widget_type: state.dataset ?? '',
-                organization,
-              });
-            }}
-            tags={tags}
-          />
+          </Flex>
         </FieldGroup>
       </Tooltip>
     </Fragment>
@@ -167,6 +186,4 @@ function WidgetBuilderSortBySelector() {
 
 export default WidgetBuilderSortBySelector;
 
-const ResultsLimitSelector = styled(Select)`
-  margin-bottom: ${space(1)};
-`;
+const ResultsLimitSelector = styled(Select)``;

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -1,6 +1,5 @@
 import {Fragment, useEffect} from 'react';
 
-import {NumberInput} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -89,10 +88,10 @@ function WidgetBuilderSortBySelector() {
     if (!state.limit) {
       return;
     }
-    if (isTimeseriesChart && state.limit > maxLimit) {
+    if ((isTimeseriesChart || isCategoricalBarWidget) && state.limit > maxLimit) {
       dispatch({type: BuilderStateAction.SET_LIMIT, payload: maxLimit});
     }
-  }, [state.limit, maxLimit, dispatch, isTimeseriesChart]);
+  }, [state.limit, maxLimit, dispatch, isTimeseriesChart, isCategoricalBarWidget]);
 
   function handleSortByChange(newSortBy: string, sortDirection: 'asc' | 'desc') {
     dispatch({
@@ -119,7 +118,7 @@ function WidgetBuilderSortBySelector() {
           stacked
         >
           <Flex direction="column" gap="sm">
-            {isTimeseriesChart && state.limit && (
+            {(isTimeseriesChart || isCategoricalBarWidget) && state.limit && (
               <Select
                 disabled={disableSortDirection && disableSort}
                 name="resultsLimit"
@@ -133,18 +132,6 @@ function WidgetBuilderSortBySelector() {
                 value={state.limit}
                 onChange={(option: SelectValue<number>) => {
                   dispatch({type: BuilderStateAction.SET_LIMIT, payload: option.value});
-                }}
-              />
-            )}
-            {isCategoricalBarWidget && state.limit && (
-              <NumberInput
-                aria-label={t('Limit results')}
-                disabled={disableSortDirection && disableSort}
-                min={1}
-                max={MAX_CATEGORICAL_BAR_LIMIT}
-                value={state.limit}
-                onChange={value => {
-                  dispatch({type: BuilderStateAction.SET_LIMIT, payload: value});
                 }}
               />
             )}

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useEffect} from 'react';
-import styled from '@emotion/styled';
 
 import {NumberInput} from '@sentry/scraps/input';
 import {Flex} from '@sentry/scraps/layout';
@@ -81,7 +80,9 @@ function WidgetBuilderSortBySelector() {
 
   const maxLimit = isTimeseriesChart
     ? getResultsLimit(widget.queries.length, widget.queries[0]!.aggregates.length)
-    : MAX_CATEGORICAL_BAR_LIMIT;
+    : isCategoricalBarWidget
+      ? MAX_CATEGORICAL_BAR_LIMIT
+      : 0;
 
   // handles when the maxLimit changes to a value less than the current selected limit
   useEffect(() => {
@@ -119,7 +120,7 @@ function WidgetBuilderSortBySelector() {
         >
           <Flex direction="column" gap="sm">
             {isTimeseriesChart && state.limit && (
-              <ResultsLimitSelector
+              <Select
                 disabled={disableSortDirection && disableSort}
                 name="resultsLimit"
                 options={[...new Array(maxLimit).keys()].map(resultLimit => {
@@ -138,6 +139,7 @@ function WidgetBuilderSortBySelector() {
             {isCategoricalBarWidget && state.limit && (
               <NumberInput
                 aria-label={t('Limit results')}
+                disabled={disableSortDirection && disableSort}
                 min={1}
                 max={MAX_CATEGORICAL_BAR_LIMIT}
                 value={state.limit}
@@ -185,5 +187,3 @@ function WidgetBuilderSortBySelector() {
 }
 
 export default WidgetBuilderSortBySelector;
-
-const ResultsLimitSelector = styled(Select)``;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -19,6 +19,7 @@ import {
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {
+  DEFAULT_CATEGORICAL_BAR_LIMIT,
   DisplayType,
   WidgetType,
   type LinkedDashboard,
@@ -407,7 +408,7 @@ function useWidgetBuilderState(): {
 
             setQuery(query?.slice(0, 1), options);
             // Categorical bars show more categories than time-series groupings
-            setLimit(20, options);
+            setLimit(DEFAULT_CATEGORICAL_BAR_LIMIT, options);
           } else {
             setFields(columnsWithoutAlias, options);
             const nextAggregates = [
@@ -498,7 +499,7 @@ function useWidgetBuilderState(): {
               setSort([], options);
             }
             // Categorical bars show more categories than time-series groupings
-            setLimit(20, options);
+            setLimit(DEFAULT_CATEGORICAL_BAR_LIMIT, options);
           } else if (usesTimeSeriesData(nextDisplayType)) {
             setFields([], options);
             setYAxis(

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.spec.tsx
@@ -710,4 +710,51 @@ describe('useSpansTableQuery', () => {
       );
     });
   });
+
+  it('passes categorical bar limit as per_page', async () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.CATEGORICAL_BAR,
+      limit: 15,
+      queries: [
+        {
+          name: 'test',
+          fields: ['transaction', 'count()'],
+          aggregates: ['count()'],
+          columns: ['transaction'],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [{transaction: '/api/test', 'count()': 100}],
+      },
+    });
+
+    renderHook(
+      () =>
+        useSpansTableQuery({
+          widget,
+          organization,
+          pageFilters,
+          limit: 15,
+          enabled: true,
+        }),
+      {wrapper: createWrapper()}
+    );
+
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            per_page: 15,
+          }),
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Categorical bar widgets previously hard-coded their result limit to 20 with no way for users to change it. This PR re-uses the current dropdown input (1–25) in the widget builder's sort-by section so users can configure how many categories are displayed. The chosen value flows through to the `per_page` parameter on the outgoing `/events/` API request.

Closes DAIN-1191

**e.g.,**
<img width="660" height="134" alt="Screenshot 2026-02-10 at 3 11 02 PM" src="https://github.com/user-attachments/assets/4f62d72c-703e-430c-813c-8cdd316fbc5f" />

