### PR TITLE
ref(mypy): Use removeprefix/removesuffix in make_module_ignores

### DIFF
--- a/tools/mypy_helpers/make_module_ignores.py
+++ b/tools/mypy_helpers/make_module_ignores.py
@@ -32,13 +32,9 @@ def main() -> int:
 
     mods = []
     for filename in sorted(filenames):
-        # TODO: removeprefix / removesuffix python 3.9+
-        if filename.endswith(".py"):
-            filename = filename[: -len(".py")]
-        if filename.startswith("src/"):
-            filename = filename[len("src/") :]
-        if filename.endswith("/__init__"):
-            filename = filename[: -len("/__init__")]
+        filename = filename.removesuffix(".py")
+        filename = filename.removeprefix("src/")
+        filename = filename.removesuffix("/__init__")
         mods.append(filename.replace("/", "."))
     mods_s = "".join(f'    "{mod}",\n' for mod in mods)
     codes_s = "".join(f'    "{code}",\n' for code in sorted(codes))


### PR DESCRIPTION
Replaces manual string slicing with Python 3.9+ `removeprefix()` and `removesuffix()` methods, removing the associated TODO comment. Should be safe since we're now using Python 3.13.