### PR TITLE
feat(discover): Add conditional functions and tpm to allowed arithmetic functions

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -206,7 +206,6 @@ class ArithmeticVisitor(NodeVisitor):
         "p99_if",
         "sum_if",
         "avg_if",
-        "count_if",
         "division_if",
         "failure_rate_if",
     }

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -197,6 +197,18 @@ class ArithmeticVisitor(NodeVisitor):
         "percentile_range",
         "performance_score",
         "opportunity_score",
+        # Frontend overview uses these functions
+        "tpm",
+        "p50_if",
+        "p75_if",
+        "p90_if",
+        "p95_if",
+        "p99_if",
+        "sum_if",
+        "avg_if",
+        "count_if",
+        "division_if",
+        "failure_rate_if",
     }
 
     def __init__(self, max_operators: int | None, custom_measurements: set[str] | None):

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -232,7 +232,7 @@ const TRANSACTIONS_TABLE: Widget = {
       name: '',
       conditions: TABLE_QUERY.formatString(),
       aggregates: [
-        'equation|tpm()',
+        'tpm()',
         `p50_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
         `p75_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
         `p95_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -232,7 +232,7 @@ const TRANSACTIONS_TABLE: Widget = {
       name: '',
       conditions: TABLE_QUERY.formatString(),
       aggregates: [
-        'tpm()',
+        'equation|tpm()',
         `p50_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
         `p75_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,
         `p95_if(${SpanFields.SPAN_DURATION},${SpanFields.IS_TRANSACTION},equals,true)`,

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -246,6 +246,9 @@ def test_field_values(a, op, b) -> None:
         ("p50(transaction.duration)", "/", "p100(transaction.duration)"),
         ("count_if(user.email,equals,test@example.com)", "/", 2),
         (100, "-", 'count_if(some_tag,notEquals,"something(really)annoying,like\\"this\\"")'),
+        ("p50_if(span.duration,is_transaction,equals,true)", "/", 2),
+        ("tpm()", "+", "failure_rate_if(is_transaction,equals,true)"),
+        ("avg_if(span.duration,is_transaction,equals,true)", "*", 100),
         (
             "performance_score(measurements.score.lcp)",
             "+",


### PR DESCRIPTION
## Summary

Adds support for conditional aggregate functions and transactions per minute (tpm) to the arithmetic operations allowed in Discover queries and dashboard equations. Following the pattern https://github.com/getsentry/sentry/pull/107941/

## Changes

- Added `tpm` function for transactions per minute calculations
- Added conditional aggregate functions with `_if` suffix:
  - Percentiles: `p50_if`, `p75_if`, `p90_if`, `p95_if`, `p99_if`
  - Aggregates: `sum_if`, `avg_if`, `count_if`
  - Custom: `division_if`, `failure_rate_if`

## Context

The frontend overview dashboard uses these functions in its widget equations. Without these being added to the allowed functions list, equations using these functions would fail validation.