### PR TITLE
Tombstones by issue group id

### DIFF
--- a/src/sentry/issues/endpoints/group_tombstone.py
+++ b/src/sentry/issues/endpoints/group_tombstone.py
@@ -27,9 +27,18 @@ class GroupTombstoneEndpoint(ProjectEndpoint):
 
         :pparam string organization_id: the ID of the organization.
         :pparam string project_id: the ID of the project to get the tombstones for
+        :qparam int issue_group_id: optional group ID to filter tombstones by their previous group ID
         :auth: required
         """
         queryset = GroupTombstone.objects.filter(project=project)
+
+        # Filter by issue_group_id if provided
+        issue_group_id = request.GET.get("issue_group_id")
+        if issue_group_id:
+            try:
+                queryset = queryset.filter(previous_group_id=int(issue_group_id))
+            except (ValueError, TypeError):
+                return Response({"detail": "Invalid issue_group_id parameter"}, status=400)
 
         return self.paginate(
             request=request,

--- a/tests/sentry/issues/endpoints/test_group_tombstone.py
+++ b/tests/sentry/issues/endpoints/test_group_tombstone.py
@@ -36,3 +36,78 @@ class GroupTombstoneTest(APITestCase):
         response = self.client.get(path)
         assert response.status_code == 200, response
         assert response.data[0]["message"] == group.message
+
+    def test_filter_by_issue_group_id(self) -> None:
+        self.user = self.create_user("foo@example.com")
+        self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.login_as(self.user)
+
+        # Create two groups and their tombstones
+        group1 = self.create_group(project=self.project, message="First group")
+        tombstone1 = GroupTombstone.objects.create(
+            project_id=group1.project_id,
+            level=group1.level,
+            message=group1.message,
+            culprit=group1.culprit,
+            data=group1.data,
+            previous_group_id=group1.id,
+        )
+
+        group2 = self.create_group(project=self.project, message="Second group")
+        tombstone2 = GroupTombstone.objects.create(
+            project_id=group2.project_id,
+            level=group2.level,
+            message=group2.message,
+            culprit=group2.culprit,
+            data=group2.data,
+            previous_group_id=group2.id,
+        )
+
+        path = reverse(
+            "sentry-api-0-group-tombstones",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+
+        # Test filtering by first group's ID
+        response = self.client.get(path, {"issue_group_id": group1.id})
+        assert response.status_code == 200, response
+        assert len(response.data) == 1
+        assert response.data[0]["message"] == group1.message
+        assert response.data[0]["id"] == str(tombstone1.id)
+
+        # Test filtering by second group's ID
+        response = self.client.get(path, {"issue_group_id": group2.id})
+        assert response.status_code == 200, response
+        assert len(response.data) == 1
+        assert response.data[0]["message"] == group2.message
+        assert response.data[0]["id"] == str(tombstone2.id)
+
+        # Test filtering by non-existent group ID
+        response = self.client.get(path, {"issue_group_id": 999999})
+        assert response.status_code == 200, response
+        assert len(response.data) == 0
+
+    def test_filter_by_invalid_issue_group_id(self) -> None:
+        self.user = self.create_user("foo@example.com")
+        self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
+        self.login_as(self.user)
+
+        path = reverse(
+            "sentry-api-0-group-tombstones",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+
+        # Test with invalid (non-numeric) issue_group_id
+        response = self.client.get(path, {"issue_group_id": "invalid"})
+        assert response.status_code == 400, response
+        assert response.data["detail"] == "Invalid issue_group_id parameter"


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR introduces the ability to filter `GroupTombstone` records by their `previous_group_id` via the API.

**Why:**
Users need a way to programmatically associate tombstones with their original issues after deletion or discard. This allows for more precise management and cleanup of deleted issues through the API.

**How:**
An optional `issue_group_id` query parameter has been added to the `/api/0/projects/{org-slug}/{project-slug}/tombstones/` endpoint. When provided, the endpoint filters tombstones by their `previous_group_id`. Error handling for invalid parameter values and corresponding tests have also been added.

**Usage:**
`GET /api/0/projects/{org-slug}/{project-slug}/tombstones/?issue_group_id={group_id}`

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1348](https://linear.app/getsentry/issue/ID-1348/allow-finding-tombstones-by-issue-group-id)

<p><a href="https://cursor.com/background-agent?bcId=bc-2041bed5-ca23-4c73-b913-969983667297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2041bed5-ca23-4c73-b913-969983667297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

