### PR TITLE
ref(issue owners): Add test for non-project team

### DIFF
--- a/tests/sentry/issues/endpoints/test_project_ownership.py
+++ b/tests/sentry/issues/endpoints/test_project_ownership.py
@@ -332,6 +332,12 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp.status_code == 400
         assert resp.data == {"raw": ["Invalid rule owners: #faketeam"]}
 
+    def test_team_not_on_project(self) -> None:
+        self.create_team(organization=self.organization, slug="other-team", members=[self.user])
+        resp = self.client.put(self.path, {"raw": "*.js #other-team"})
+        assert resp.status_code == 400
+        assert resp.data == {"raw": ["Invalid rule owners: #other-team"]}
+
     def test_invalid_mixed(self) -> None:
         resp = self.client.put(
             self.path, {"raw": "*.js idont@exist.com admin@localhost #faketeam #tiger-team"}


### PR DESCRIPTION
This adds a test to our issue owners endpoint test suite, covering the case in which someone tries to add a rule involving a team they're on, but which is not associated with the project in question.

(This addition was prompted by a concern raised in another PR, but the purpose of that PR is unrelated enough to this that it seemed worth it to split this into its own change.)