### PR TITLE
Rename Next.js Frontend Overview to Next.js Overview

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -8,7 +8,7 @@ import {MOBILE_VITALS_APP_STARTS_PREBUILT_CONFIG} from 'sentry/views/dashboards/
 import {MOBILE_VITALS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals';
 import {MOBILE_VITALS_SCREEN_LOADS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads';
 import {MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenRendering';
-import {NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextjsFrontendOverview/nextjsFrontendOverview';
+import {NEXTJS_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview';
 import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
 import {QUERIES_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/querySummary';
 import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';
@@ -30,7 +30,7 @@ export enum PrebuiltDashboardId {
   BACKEND_OVERVIEW = 12,
   MOBILE_SESSION_HEALTH = 13,
   FRONTEND_OVERVIEW = 14,
-  NEXTJS_FRONTEND_OVERVIEW = 15,
+  NEXTJS_OVERVIEW = 15,
 }
 
 export type PrebuiltDashboard = Omit<DashboardDetails, 'id'>;
@@ -55,6 +55,5 @@ export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard>
     MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG,
   [PrebuiltDashboardId.MOBILE_SESSION_HEALTH]: MOBILE_SESSION_HEALTH_PREBUILT_CONFIG,
   [PrebuiltDashboardId.FRONTEND_OVERVIEW]: FRONTEND_OVERVIEW_PREBUILT_CONFIG,
-  [PrebuiltDashboardId.NEXTJS_FRONTEND_OVERVIEW]:
-    NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.NEXTJS_OVERVIEW]: NEXTJS_OVERVIEW_PREBUILT_CONFIG,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/rageAndDeadClicks/rageAndDeadClicks.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/rageAndDeadClicks/rageAndDeadClicks.ts
@@ -1,0 +1,10 @@
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/rageAndDeadClicks/settings';
+
+export const RAGE_AND_DEAD_CLICKS_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: DASHBOARD_TITLE,
+  filters: {},
+  widgets: [],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/rageAndDeadClicks/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/rageAndDeadClicks/settings.ts
@@ -1,0 +1,3 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_TITLE = t('Rage and Dead Clicks');


### PR DESCRIPTION
## Summary

Renames "Next.js Frontend Overview" to "Next.js Overview" for consistency and adds the platformized version to the backend overview page.

## Changes

- Rename `nextjsFrontendOverview` directory to `nextJsOverview`
- Update dashboard title from "Next.js Frontend Overview" to "Next.js Overview"
- Rename `PlatformizedNextjsFrontendOverviewPage` to `PlatformizedNextJsOverviewPage`
- Rename `useHasPlatformizedNextjsFrontendOverview` to `useHasPlatformizedNextJsOverview`
- Update all imports and references across backend and frontend overview pages
- Add platformized Next.js overview page to backend overview page
- Simplify naming convention for consistency