### PR TITLE
Span code linking

### DIFF
--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -327,6 +327,45 @@ def convert_stacktrace_frame_path_to_source_path(
             .lstrip("/")
         )
 
+    # Fallback: try to match paths using suffix logic for automatically generated mappings.
+    # This handles cases where the path format differs between error frames and span attributes.
+    # For example, .NET error frames use "/_/src/Project/File.cs" but span code.filepath is
+    # "src/Project/File.cs". Since code mappings are derived using suffix matching
+    # (_is_potential_match), we should resolve paths using the same flexible approach.
+    if stacktrace_path and code_mapping.automatically_generated:
+        normalized_stacktrace = stacktrace_path.replace("\\", "/")
+        
+        # For automatically generated mappings, if the exact prefix didn't match, check if
+        # the stacktrace path could be the repo-relative portion of a path that would have
+        # matched during code mapping derivation. This is determined by checking if the
+        # stacktrace shares path component overlap with what the mapping expects.
+        #
+        # Example: stack_root="/_/" source_root="" stacktrace="src/Project/File.cs"
+        # The original error frame was "/_/src/Project/File.cs" matching repo file
+        # "src/Project/File.cs", so we should accept "src/Project/File.cs" directly.
+        stacktrace_parts = [p for p in normalized_stacktrace.split("/") if p]
+        source_root_parts = [p for p in code_mapping.source_root.split("/") if p]
+        
+        if not source_root_parts:
+            # Empty source_root means files are at repo root. If the stacktrace has
+            # directory structure (not just a bare filename), it likely matches.
+            if len(stacktrace_parts) > 1:
+                return normalized_stacktrace.lstrip("/")
+        else:
+            # Non-empty source_root: check if stacktrace would fit in the source structure
+            # by verifying path component alignment
+            if len(stacktrace_parts) >= len(source_root_parts):
+                # Check if source_root is a prefix of stacktrace (already in right structure)
+                if stacktrace_parts[:len(source_root_parts)] == source_root_parts:
+                    return normalized_stacktrace.lstrip("/")
+                # Check if combining them makes sense (stacktrace is relative to source_root)
+                else:
+                    combined = (code_mapping.source_root.rstrip("/") + "/" + normalized_stacktrace).replace("\\", "/")
+                    return combined.lstrip("/")
+            else:
+                # Stacktrace has fewer parts than source_root, unlikely to match
+                pass
+
     return None
 
 

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -334,7 +334,7 @@ def convert_stacktrace_frame_path_to_source_path(
     # (_is_potential_match), we should resolve paths using the same flexible approach.
     if stacktrace_path and code_mapping.automatically_generated:
         normalized_stacktrace = stacktrace_path.replace("\\", "/")
-        
+
         # For automatically generated mappings, if the exact prefix didn't match, check if
         # the stacktrace path could be the repo-relative portion of a path that would have
         # matched during code mapping derivation. This is determined by checking if the
@@ -345,7 +345,7 @@ def convert_stacktrace_frame_path_to_source_path(
         # "src/Project/File.cs", so we should accept "src/Project/File.cs" directly.
         stacktrace_parts = [p for p in normalized_stacktrace.split("/") if p]
         source_root_parts = [p for p in code_mapping.source_root.split("/") if p]
-        
+
         if not source_root_parts:
             # Empty source_root means files are at repo root. If the stacktrace has
             # directory structure (not just a bare filename), it likely matches.
@@ -356,11 +356,13 @@ def convert_stacktrace_frame_path_to_source_path(
             # by verifying path component alignment
             if len(stacktrace_parts) >= len(source_root_parts):
                 # Check if source_root is a prefix of stacktrace (already in right structure)
-                if stacktrace_parts[:len(source_root_parts)] == source_root_parts:
+                if stacktrace_parts[: len(source_root_parts)] == source_root_parts:
                     return normalized_stacktrace.lstrip("/")
                 # Check if combining them makes sense (stacktrace is relative to source_root)
                 else:
-                    combined = (code_mapping.source_root.rstrip("/") + "/" + normalized_stacktrace).replace("\\", "/")
+                    combined = (
+                        code_mapping.source_root.rstrip("/") + "/" + normalized_stacktrace
+                    ).replace("\\", "/")
                     return combined.lstrip("/")
             else:
                 # Stacktrace has fewer parts than source_root, unlikely to match

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -481,7 +481,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
     ) -> None:
         """
         Test .NET span code.filepath matching when code mapping was derived from error frames.
-        
+
         Error frames use "/_/src/Project/File.cs" but span code.filepath uses
         "src/Project/File.cs" (without the /_/ prefix). The code mapping should still match
         via suffix logic for automatically generated mappings.
@@ -495,7 +495,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             source_root="",
             automatically_generated=True,
         )
-        
+
         # Span with code.filepath that doesn't have the /_/ prefix
         assert (
             convert_stacktrace_frame_path_to_source_path(
@@ -512,7 +512,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
     ) -> None:
         """
         Test that suffix matching only applies to automatically generated mappings.
-        
+
         User-created mappings should not use suffix matching fallback to avoid
         unintended matches.
         """
@@ -525,7 +525,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             source_root="",
             automatically_generated=False,  # User-created mapping
         )
-        
+
         # Span path without the /_/ prefix should NOT match user-created mappings
         assert (
             convert_stacktrace_frame_path_to_source_path(
@@ -551,7 +551,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             source_root="src/",
             automatically_generated=True,
         )
-        
+
         # Span path that should combine with source_root
         assert (
             convert_stacktrace_frame_path_to_source_path(
@@ -566,7 +566,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
     def test_convert_stacktrace_frame_path_to_source_path_bare_filename_no_match(self) -> None:
         """
         Test that bare filenames (single component) don't match via suffix logic.
-        
+
         This prevents overly broad matches for simple filenames.
         """
         dotnet_code_mapping = self.create_code_mapping(
@@ -577,7 +577,7 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             source_root="",
             automatically_generated=True,
         )
-        
+
         # Bare filename should not match via suffix logic (needs directory structure)
         assert (
             convert_stacktrace_frame_path_to_source_path(

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -476,6 +476,119 @@ class TestConvertStacktraceFramePathToSourcePath(TestCase):
             == "src/sentry/folder/file.rs"
         )
 
+    def test_convert_stacktrace_frame_path_to_source_path_dotnet_span_without_prefix(
+        self,
+    ) -> None:
+        """
+        Test .NET span code.filepath matching when code mapping was derived from error frames.
+        
+        Error frames use "/_/src/Project/File.cs" but span code.filepath uses
+        "src/Project/File.cs" (without the /_/ prefix). The code mapping should still match
+        via suffix logic for automatically generated mappings.
+        """
+        # Create a code mapping that would be auto-generated from .NET error frames
+        dotnet_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="/_/",
+            source_root="",
+            automatically_generated=True,
+        )
+        
+        # Span with code.filepath that doesn't have the /_/ prefix
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(filename="src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"),
+                code_mapping=dotnet_code_mapping,
+                platform="csharp",
+                sdk_name="sentry.dotnet",
+            )
+            == "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        )
+
+    def test_convert_stacktrace_frame_path_to_source_path_dotnet_span_non_auto_no_match(
+        self,
+    ) -> None:
+        """
+        Test that suffix matching only applies to automatically generated mappings.
+        
+        User-created mappings should not use suffix matching fallback to avoid
+        unintended matches.
+        """
+        # Create a user-generated code mapping (not automatically generated)
+        dotnet_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="/_/",
+            source_root="",
+            automatically_generated=False,  # User-created mapping
+        )
+        
+        # Span path without the /_/ prefix should NOT match user-created mappings
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(filename="src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"),
+                code_mapping=dotnet_code_mapping,
+                platform="csharp",
+                sdk_name="sentry.dotnet",
+            )
+            is None
+        )
+
+    def test_convert_stacktrace_frame_path_to_source_path_dotnet_with_source_root(
+        self,
+    ) -> None:
+        """
+        Test .NET span matching with non-empty source_root.
+        """
+        dotnet_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="/_/",
+            source_root="src/",
+            automatically_generated=True,
+        )
+        
+        # Span path that should combine with source_root
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(filename="NuGetTrends.Scheduler/DailyDownloadWorker.cs"),
+                code_mapping=dotnet_code_mapping,
+                platform="csharp",
+                sdk_name="sentry.dotnet",
+            )
+            == "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        )
+
+    def test_convert_stacktrace_frame_path_to_source_path_bare_filename_no_match(self) -> None:
+        """
+        Test that bare filenames (single component) don't match via suffix logic.
+        
+        This prevents overly broad matches for simple filenames.
+        """
+        dotnet_code_mapping = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="/_/",
+            source_root="",
+            automatically_generated=True,
+        )
+        
+        # Bare filename should not match via suffix logic (needs directory structure)
+        assert (
+            convert_stacktrace_frame_path_to_source_path(
+                frame=EventFrame(filename="File.cs"),
+                code_mapping=dotnet_code_mapping,
+                platform="csharp",
+                sdk_name="sentry.dotnet",
+            )
+            is None
+        )
+
 
 class TestGetSortedCodeMappingConfigs(TestCase):
     def setUp(self) -> None:

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -450,9 +450,22 @@ class ProjectStacktraceLinkTestDotnetSpans(BaseProjectStacktraceLink):
     def test_dotnet_user_created_mapping_requires_exact_match(self) -> None:
         """
         Test that user-created mappings still require exact prefix match (no suffix fallback).
+
+        This test creates a fresh project without the auto-generated mapping from setUp,
+        ensuring we only test user-created mapping behavior.
         """
+        # Create a new project without any existing code mappings
+        test_project = self.create_project(
+            name="user-mapping-test",
+            organization=self.organization,
+            teams=[self.create_team(organization=self.organization)],
+        )
+
         # Create a user-created (not auto-generated) code mapping
-        user_mapping = self._create_code_mapping(
+        self.create_code_mapping(
+            organization_integration=self.oi,
+            project=test_project,
+            repo=self.repo,
             stack_root="/_/",
             source_root="",
             automatically_generated=False,
@@ -462,7 +475,7 @@ class ProjectStacktraceLinkTestDotnetSpans(BaseProjectStacktraceLink):
         filepath = "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
         response = self.get_success_response(
             self.organization.slug,
-            self.project.slug,
+            test_project.slug,
             qs_params={"file": filepath, "platform": "csharp"},
         )
 

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_link.py
@@ -390,3 +390,103 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
             # trace of the user generated code mappings is chosen
             assert response.data["config"] == self.expected_configurations(cm)
             assert response.data["sourceUrl"] == f"https://github.com/getsentry/sentry/{src_path}"
+
+
+class ProjectStacktraceLinkTestDotnetSpans(BaseProjectStacktraceLink):
+    """Test .NET span code.filepath linking when code mappings were derived from error frames."""
+
+    def setUp(self) -> None:
+        BaseProjectStacktraceLink.setUp(self)
+        # Create an auto-generated code mapping as would be derived from .NET error frames
+        # Error frames have abs_path like "/_/src/Project/File.cs"
+        self.dotnet_code_mapping = self._create_code_mapping(
+            stack_root="/_/",
+            source_root="",
+            automatically_generated=True,
+        )
+
+    @patch.object(ExampleIntegration, "get_stacktrace_link")
+    def test_dotnet_span_without_prefix_matches(self, mock_integration: MagicMock) -> None:
+        """
+        Test that .NET span code.filepath (without /_/ prefix) matches code mapping
+        derived from error frames (with /_/ prefix).
+        """
+        # Span sends code.filepath without the /_/ prefix
+        filepath = "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        mock_integration.return_value = f"{example_base_url}/{filepath}"
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": filepath, "platform": "csharp"},
+        )
+
+        assert response.data["config"] == self.expected_configurations(self.dotnet_code_mapping)
+        assert response.data["sourceUrl"] == f"{example_base_url}/{filepath}"
+        assert response.data["error"] is None
+        mock_integration.assert_called_once_with(self.repo, filepath, "master", None)
+
+    @patch.object(ExampleIntegration, "get_stacktrace_link")
+    def test_dotnet_span_with_prefix_still_matches(self, mock_integration: MagicMock) -> None:
+        """
+        Test that error frames with /_/ prefix still match (backwards compatibility).
+        """
+        # Error frame sends with /_/ prefix (traditional behavior)
+        filepath = "/_/src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        expected_source = "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        mock_integration.return_value = f"{example_base_url}/{expected_source}"
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": filepath, "platform": "csharp"},
+        )
+
+        assert response.data["config"] == self.expected_configurations(self.dotnet_code_mapping)
+        assert response.data["sourceUrl"] == f"{example_base_url}/{expected_source}"
+        assert response.data["error"] is None
+        mock_integration.assert_called_once_with(self.repo, expected_source, "master", None)
+
+    def test_dotnet_user_created_mapping_requires_exact_match(self) -> None:
+        """
+        Test that user-created mappings still require exact prefix match (no suffix fallback).
+        """
+        # Create a user-created (not auto-generated) code mapping
+        user_mapping = self._create_code_mapping(
+            stack_root="/_/",
+            source_root="",
+            automatically_generated=False,
+        )
+
+        # Span without /_/ prefix should NOT match user-created mapping
+        filepath = "src/NuGetTrends.Scheduler/DailyDownloadWorker.cs"
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": filepath, "platform": "csharp"},
+        )
+
+        # Should get stack_root_mismatch because user mapping requires exact prefix
+        assert response.data["config"] is None
+        assert response.data["sourceUrl"] is None
+        assert response.data["error"] == "stack_root_mismatch"
+
+    @patch.object(ExampleIntegration, "get_stacktrace_link")
+    def test_dotnet_bare_filename_no_suffix_match(self, mock_integration: MagicMock) -> None:
+        """
+        Test that bare filenames don't match via suffix logic (too broad).
+        """
+        # Bare filename without directory structure
+        filepath = "File.cs"
+
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": filepath, "platform": "csharp"},
+        )
+
+        # Should get stack_root_mismatch because bare filename is too generic
+        assert response.data["config"] is None
+        assert response.data["sourceUrl"] is None
+        assert response.data["error"] == "stack_root_mismatch"
+        mock_integration.assert_not_called()


### PR DESCRIPTION
<!-- Fixes ID-1349 -->

### Problem

Source code linking for span `code.filepath` attributes (e.g., .NET DB query sources) silently failed to render. This was primarily due to a path format mismatch: auto-generated code mappings were derived from error frames with `/_/` prefixes (e.g., `/_/src/File.cs`), while span `code.filepath` attributes used repo-relative paths without this prefix (e.g., `src/File.cs`). The existing path resolution logic in `convert_stacktrace_frame_path_to_source_path` only performed exact prefix matching, causing these spans to not link.

### Solution

This PR modifies `convert_stacktrace_frame_path_to_source_path` to include a flexible path component matching fallback for *automatically generated* code mappings. If an exact `stack_root` prefix match fails, the function now attempts to match the `stacktrace_path` as a repo-relative path, aligning the resolution logic with how these mappings are initially derived.

This fallback:
*   Applies only to `automatically_generated` code mappings.
*   Ensures user-created mappings still require exact prefix matches.
*   Prevents overly broad matches by not linking bare filenames (e.g., `File.cs`) without directory structure.

### Impact

Users with .NET projects (and potentially other platforms with similar path differences) will now see "Open this line in GitHub" links for relevant spans in the trace waterfall and other views, improving source code navigation.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [ID-1349](https://linear.app/getsentry/issue/ID-1349/source-code-linking-doesnt-work-for-span-codefilepath-when-code)

<p><a href="https://cursor.com/background-agent?bcId=bc-fbced47d-641c-4009-9d9d-a405cf233eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbced47d-641c-4009-9d9d-a405cf233eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

