### PR TITLE
Rename Next.js Frontend Overview to Next.js Overview

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -8,7 +8,7 @@ import {MOBILE_VITALS_APP_STARTS_PREBUILT_CONFIG} from 'sentry/views/dashboards/
 import {MOBILE_VITALS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals';
 import {MOBILE_VITALS_SCREEN_LOADS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads';
 import {MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenRendering';
-import {NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextjsFrontendOverview/nextjsFrontendOverview';
+import {NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview';
 import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
 import {QUERIES_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/querySummary';
 import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -3,7 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextjsFrontendOverview/settings';
+import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings.ts
@@ -1,0 +1,3 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_TITLE = t('Next.js Overview');

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextjsFrontendOverview/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextjsFrontendOverview/settings.ts
@@ -1,3 +1,0 @@
-import {t} from 'sentry/locale';
-
-export const DASHBOARD_TITLE = t('Next.js Frontend Overview');

--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -64,6 +64,8 @@ import {LaravelOverviewPage} from 'sentry/views/insights/pages/platform/laravel'
 import {useIsLaravelInsightsAvailable} from 'sentry/views/insights/pages/platform/laravel/features';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
 import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
+import {PlatformizedNextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs/platformizedNextJsOverviewPage';
+import useHasPlatformizedNextJsOverview from 'sentry/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview';
 import {IssuesWidget} from 'sentry/views/insights/pages/platform/shared/issuesWidget';
 import {TransactionNameSearchBar} from 'sentry/views/insights/pages/transactionNameSearchBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
@@ -79,6 +81,7 @@ function BackendOverviewPage({datePageFilterProps}: BackendOverviewPageProps) {
   useOverviewPageTrackPageload();
   const isLaravelPageAvailable = useIsLaravelInsightsAvailable();
   const isNextJsPageEnabled = useIsNextJsInsightsAvailable();
+  const hasPlatformizedNextJsOverview = useHasPlatformizedNextJsOverview();
   const isNewBackendExperienceEnabled = useInsightsEap();
   const hasPlatformizedBackendOverview = useHasPlatformizedBackendOverview();
   if (hasPlatformizedBackendOverview) {
@@ -86,6 +89,9 @@ function BackendOverviewPage({datePageFilterProps}: BackendOverviewPageProps) {
   }
   if (isLaravelPageAvailable) {
     return <LaravelOverviewPage datePageFilterProps={datePageFilterProps} />;
+  }
+  if (isNextJsPageEnabled && hasPlatformizedNextJsOverview) {
+    return <PlatformizedNextJsOverviewPage />;
   }
   if (isNextJsPageEnabled) {
     return <NextJsOverviewPage datePageFilterProps={datePageFilterProps} />;

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -62,8 +62,8 @@ import useHasPlatformizedFrontendOverview from 'sentry/views/insights/pages/fron
 import {InsightsSpanTagProvider} from 'sentry/views/insights/pages/insightsSpanTagProvider';
 import {NextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs';
 import {useIsNextJsInsightsAvailable} from 'sentry/views/insights/pages/platform/nextjs/features';
-import {PlatformizedNextjsFrontendOverviewPage} from 'sentry/views/insights/pages/platform/nextjs/platformizedNextjsFrontendOverviewPage';
-import useHasPlatformizedNextjsFrontendOverview from 'sentry/views/insights/pages/platform/nextjs/useHasPlatformizedNextjsFrontendOverview';
+import {PlatformizedNextJsOverviewPage} from 'sentry/views/insights/pages/platform/nextjs/platformizedNextJsOverviewPage';
+import useHasPlatformizedNextJsOverview from 'sentry/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview';
 import {WebVitalsWidget} from 'sentry/views/insights/pages/platform/nextjs/webVitalsWidget';
 import {TransactionNameSearchBar} from 'sentry/views/insights/pages/transactionNameSearchBar';
 import {useOverviewPageTrackPageload} from 'sentry/views/insights/pages/useOverviewPageTrackAnalytics';
@@ -252,16 +252,15 @@ function FrontendOverviewPageWithProviders() {
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
 
   const hasPlatformizedFrontendOverview = useHasPlatformizedFrontendOverview();
-  const hasPlatformizedNextjsFrontendOverview =
-    useHasPlatformizedNextjsFrontendOverview();
+  const hasPlatformizedNextJsOverview = useHasPlatformizedNextJsOverview();
   const isNextJsPageEnabled = useIsNextJsInsightsAvailable();
   const useEap = useInsightsEap();
 
   let overviewPage = (
     <Am1FrontendOverviewPage datePageFilterProps={datePageFilterProps} />
   );
-  if (isNextJsPageEnabled && hasPlatformizedNextjsFrontendOverview) {
-    overviewPage = <PlatformizedNextjsFrontendOverviewPage />;
+  if (isNextJsPageEnabled && hasPlatformizedNextJsOverview) {
+    overviewPage = <PlatformizedNextJsOverviewPage />;
   } else if (isNextJsPageEnabled) {
     overviewPage = <NextJsOverviewPage datePageFilterProps={datePageFilterProps} />;
   } else if (useEap && hasPlatformizedFrontendOverview) {

--- a/static/app/views/insights/pages/platform/nextjs/platformizedNextJsOverviewPage.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/platformizedNextJsOverviewPage.tsx
@@ -1,7 +1,7 @@
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
-export function PlatformizedNextjsFrontendOverviewPage() {
+export function PlatformizedNextJsOverviewPage() {
   return (
     <PrebuiltDashboardRenderer
       prebuiltId={PrebuiltDashboardId.NEXTJS_FRONTEND_OVERVIEW}

--- a/static/app/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview.ts
+++ b/static/app/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview.ts
@@ -1,6 +1,6 @@
 import useOrganization from 'sentry/utils/useOrganization';
 
-export default function useHasPlatformizedNextjsFrontendOverview() {
+export default function useHasPlatformizedNextJsOverview() {
   const organization = useOrganization();
 
   return organization.features.includes(


### PR DESCRIPTION
## Summary

Renames "Next.js Frontend Overview" to "Next.js Overview" for consistency and adds the platformized version to the backend overview page. Next js overview is available to both frontend and backend

## Changes

- Rename `nextjsFrontendOverview` directory to `nextJsOverview`
- Update dashboard title from "Next.js Frontend Overview" to "Next.js Overview"
- Rename `PlatformizedNextjsFrontendOverviewPage` to `PlatformizedNextJsOverviewPage`
- Rename `useHasPlatformizedNextjsFrontendOverview` to `useHasPlatformizedNextJsOverview`
- Update all imports and references across backend and frontend overview pages
- Add platformized Next.js overview page to backend overview page