### PR TITLE
fix(insights): Fix wrong render order in backend overview page

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -84,14 +84,14 @@ function BackendOverviewPage({datePageFilterProps}: BackendOverviewPageProps) {
   const hasPlatformizedNextJsOverview = useHasPlatformizedNextJsOverview();
   const isNewBackendExperienceEnabled = useInsightsEap();
   const hasPlatformizedBackendOverview = useHasPlatformizedBackendOverview();
+  if (isNextJsPageEnabled && hasPlatformizedNextJsOverview) {
+    return <PlatformizedNextJsOverviewPage />;
+  }
   if (hasPlatformizedBackendOverview) {
     return <PlatformizedBackendOverviewPage />;
   }
   if (isLaravelPageAvailable) {
     return <LaravelOverviewPage datePageFilterProps={datePageFilterProps} />;
-  }
-  if (isNextJsPageEnabled && hasPlatformizedNextJsOverview) {
-    return <PlatformizedNextJsOverviewPage />;
   }
   if (isNextJsPageEnabled) {
     return <NextJsOverviewPage datePageFilterProps={datePageFilterProps} />;


### PR DESCRIPTION
## Summary
- Fixes the render order in `BackendOverviewPage` so that the platformized Next.js overview check runs before the generic backend overview check
- Previously, Next.js projects would incorrectly render `PlatformizedBackendOverviewPage` instead of `PlatformizedNextJsOverviewPage` because the backend check matched first

## Test plan
- Verify that Next.js projects with `hasPlatformizedNextJsOverview` enabled render `PlatformizedNextJsOverviewPage`
- Verify that non-Next.js projects with `hasPlatformizedBackendOverview` enabled still render `PlatformizedBackendOverviewPage`
- Verify that Laravel projects still render `LaravelOverviewPage`