### PR TITLE
feat(dashboards): add rage and dead click widget

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -29,6 +29,7 @@ export enum DisplayType {
   BIG_NUMBER = 'big_number',
   DETAILS = 'details',
   SERVER_TREE = 'server_tree',
+  RAGE_AND_DEAD_CLICKS = 'rage_and_dead_clicks',
   TOP_N = 'top_n',
   WHEEL = 'wheel',
   CATEGORICAL_BAR = 'categorical_bar',

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -643,10 +643,18 @@ export const usesTimeSeriesData = (displayType?: DisplayType) => {
 // Custom widgets that fetch their own data (and don't use genericWidgetQueries)
 // handle error state and loading state on their own
 export const widgetFetchesOwnData = (widgetType: DisplayType) => {
-  return widgetType === DisplayType.SERVER_TREE;
+  const widgetTypesThatFetchOwnData = [
+    DisplayType.SERVER_TREE,
+    DisplayType.RAGE_AND_DEAD_CLICKS,
+  ];
+  return widgetTypesThatFetchOwnData.includes(widgetType);
 };
 
 // Custom widgets for prebuilt dashboards are not editable at this time
 export const isWidgetEditable = (widgetType: DisplayType) => {
-  return widgetType !== DisplayType.SERVER_TREE;
+  const nonEditableWidgetTypes = [
+    DisplayType.SERVER_TREE,
+    DisplayType.RAGE_AND_DEAD_CLICKS,
+  ];
+  return !nonEditableWidgetTypes.includes(widgetType);
 };

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -637,6 +637,7 @@ export const usesTimeSeriesData = (displayType?: DisplayType) => {
     DisplayType.SERVER_TREE,
     DisplayType.TABLE,
     DisplayType.WHEEL,
+    DisplayType.RAGE_AND_DEAD_CLICKS,
   ].includes(displayType);
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -143,6 +143,21 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       ],
     },
     {
+      id: 'rage-and-dead-clicks-widget',
+      title: t('Rage and Dead Clicks'),
+      displayType: DisplayType.RAGE_AND_DEAD_CLICKS,
+      interval: '5m',
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          aggregates: [],
+          columns: [],
+          orderby: '',
+        },
+      ],
+    },
+    {
       id: 'slow-ssr-widget',
       title: t('Slow SSR'),
       displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -83,6 +83,7 @@ import type {
 } from 'sentry/views/dashboards/widgets/common/types';
 import {DetailsWidgetVisualization} from 'sentry/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
+import {RageAndDeadClicksWidgetVisualization} from 'sentry/views/dashboards/widgets/rageAndDeadClicksWidget/rageAndDeadClicksVisualization';
 import {ServerTreeWidgetVisualization} from 'sentry/views/dashboards/widgets/serverTreeWidget/serverTreeWidgetVisualization';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {
@@ -228,6 +229,10 @@ function WidgetCardChart(props: WidgetCardChartProps) {
 
   if (widget.displayType === DisplayType.SERVER_TREE) {
     return <ServerTreeComponent dashboardFilters={dashboardFilters} />;
+  }
+
+  if (widget.displayType === DisplayType.RAGE_AND_DEAD_CLICKS) {
+    return <RageAndDeadClicksWidgetVisualization />;
   }
 
   if (widget.displayType === DisplayType.WHEEL) {

--- a/static/app/views/dashboards/widgets/rageAndDeadClicksWidget/rageAndDeadClicksVisualization.tsx
+++ b/static/app/views/dashboards/widgets/rageAndDeadClicksWidget/rageAndDeadClicksVisualization.tsx
@@ -1,0 +1,5 @@
+import {DeadRageClicksWidget} from 'sentry/views/insights/pages/platform/nextjs/deadRageClickWidget';
+
+export function RageAndDeadClicksWidgetVisualization() {
+  return <DeadRageClicksWidget visulizationOnly />;
+}

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -16,7 +16,7 @@ import {SelectorLink} from 'sentry/views/replays/selectors/selectorLink';
 import {transformSelectorQuery} from 'sentry/views/replays/selectors/utils';
 import type {DeadRageSelectorItem} from 'sentry/views/replays/types';
 
-export function DeadRageClicksWidget() {
+export function DeadRageClicksWidget({visulizationOnly}: {visulizationOnly?: boolean}) {
   const organization = useOrganization();
   const hasReplays = organization.features.includes('session-replay-ui');
   const {isLoading, error, data} = useDeadRageSelectors({
@@ -63,6 +63,10 @@ export function DeadRageClicksWidget() {
       }}
     />
   );
+
+  if (visulizationOnly) {
+    return visualization;
+  }
 
   return (
     <Widget

--- a/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/deadRageClickWidget.tsx
@@ -30,39 +30,34 @@ export function DeadRageClicksWidget({visulizationOnly}: {visulizationOnly?: boo
 
   const isEmpty = !isLoading && data.length === 0;
 
-  if (!hasReplays) {
-    return (
-      <Widget
-        Title={<Widget.WidgetTitle title={t('Rage & Dead Clicks')} />}
-        Visualization={
-          <FeatureWrapper>
-            <FeatureDisabled
-              features="organizations:session-replay-ui"
-              featureName={t('Replays')}
-              hideHelpToggle
-            />
-          </FeatureWrapper>
+  let visualization = (
+    <FeatureWrapper>
+      <FeatureDisabled
+        features="organizations:session-replay-ui"
+        featureName={t('Replays')}
+        hideHelpToggle
+      />
+    </FeatureWrapper>
+  );
+
+  if (hasReplays) {
+    visualization = (
+      <WidgetVisualizationStates
+        isLoading={isLoading}
+        error={error}
+        isEmpty={isEmpty}
+        emptyMessage={
+          <GenericWidgetEmptyStateWarning
+            message={t('Rage or dead clicks may not be listed due to the filters above')}
+          />
         }
+        VisualizationType={DeadRageClickWidgetVisualization}
+        visualizationProps={{
+          items: data,
+        }}
       />
     );
   }
-
-  const visualization = (
-    <WidgetVisualizationStates
-      isLoading={isLoading}
-      error={error}
-      isEmpty={isEmpty}
-      emptyMessage={
-        <GenericWidgetEmptyStateWarning
-          message={t('Rage or dead clicks may not be listed due to the filters above')}
-        />
-      }
-      VisualizationType={DeadRageClickWidgetVisualization}
-      visualizationProps={{
-        items: data,
-      }}
-    />
-  );
 
   if (visulizationOnly) {
     return visualization;


### PR DESCRIPTION
1. Create rage and dead click widget, the global filters aren't applied to this widget
<img width="644" height="460" alt="image" src="https://github.com/user-attachments/assets/b40fbc04-01b3-40e5-8231-516804c7d73d" />

2. Add rage and dead click widget to nextjs page
