### PR TITLE
feat(dashboards): Adds Performance Score Wheel widget to widget library

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, SlideoutId, WidgetType} from 'sentry/views/dashboards/types';
 import {type PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -53,48 +54,7 @@ export const WEB_VITALS_PREBUILT_CONFIG: PrebuiltDashboard = {
   },
   widgets: [
     {
-      id: 'score-breakdown-wheel',
-      description: t('The overall performance rating of this page.'),
-      title: t('Performance Score'),
-      displayType: DisplayType.WHEEL,
-      widgetType: WidgetType.SPANS,
-      interval: '5m',
-      queries: [
-        {
-          name: '',
-          conditions: DEFAULT_QUERY_FILTER,
-          fields: [
-            'performance_score(measurements.score.lcp)',
-            'performance_score(measurements.score.fcp)',
-            'performance_score(measurements.score.inp)',
-            'performance_score(measurements.score.cls)',
-            'performance_score(measurements.score.ttfb)',
-            'performance_score(measurements.score.total)',
-            'count_scores(measurements.score.total)',
-            'count_scores(measurements.score.lcp)',
-            'count_scores(measurements.score.fcp)',
-            'count_scores(measurements.score.inp)',
-            'count_scores(measurements.score.cls)',
-            'count_scores(measurements.score.ttfb)',
-          ],
-          aggregates: [],
-          columns: [
-            'performance_score(measurements.score.lcp)',
-            'performance_score(measurements.score.fcp)',
-            'performance_score(measurements.score.inp)',
-            'performance_score(measurements.score.cls)',
-            'performance_score(measurements.score.ttfb)',
-            'performance_score(measurements.score.total)',
-            'count_scores(measurements.score.total)',
-            'count_scores(measurements.score.lcp)',
-            'count_scores(measurements.score.fcp)',
-            'count_scores(measurements.score.inp)',
-            'count_scores(measurements.score.cls)',
-            'count_scores(measurements.score.ttfb)',
-          ],
-          orderby: '',
-        },
-      ],
+      ...SCORE_BREAKDOWN_WHEEL_WIDGET,
       layout: {
         y: 0,
         w: 2,

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -22,6 +22,7 @@ jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
       displayType: 'line',
       widgetType: 'transactions-like',
       queries: [],
+      isCustomizable: true,
     },
   ]),
 }));

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -94,26 +94,28 @@ function WidgetTemplatesList({
                 <WidgetDescription>{widget.description}</WidgetDescription>
                 {selectedWidget === index && (
                   <Flex marginTop="xl" gap="2xl">
-                    <Button
-                      size="sm"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setOpenWidgetTemplates(false);
-                        setCustomizeFromLibrary(true);
-                        // reset preview when customizing templates
-                        setIsPreviewDraggable(false);
-                        trackAnalytics(
-                          'dashboards_views.widget_builder.templates.customize',
-                          {
-                            title: widget.title,
-                            widget_type: widget.widgetType ?? '',
-                            organization,
-                          }
-                        );
-                      }}
-                    >
-                      {t('Customize')}
-                    </Button>
+                    {widget.isCustomizable && (
+                      <Button
+                        size="sm"
+                        onClick={e => {
+                          e.stopPropagation();
+                          setOpenWidgetTemplates(false);
+                          setCustomizeFromLibrary(true);
+                          // reset preview when customizing templates
+                          setIsPreviewDraggable(false);
+                          trackAnalytics(
+                            'dashboards_views.widget_builder.templates.customize',
+                            {
+                              title: widget.title,
+                              widget_type: widget.widgetType ?? '',
+                              organization,
+                            }
+                          );
+                        }}
+                      >
+                        {t('Customize')}
+                      </Button>
+                    )}
                     <Button
                       size="sm"
                       onClick={e => {

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -2,17 +2,14 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
 import {TOP_N} from 'sentry/utils/discover/types';
-import type {Widget} from 'sentry/views/dashboards/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
-
-type WidgetTemplate = Widget & {
-  description: string;
-};
+import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
+import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 
 const getDefaultWidgets = (organization: Organization) => {
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
-  const transactionsWidgets = [
+  const transactionsWidgets: WidgetTemplate[] = [
     {
       id: 'duration-distribution',
       title: t('Duration Distribution'),
@@ -20,6 +17,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.LINE,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -46,6 +44,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TOP_N,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -65,6 +64,7 @@ const getDefaultWidgets = (organization: Organization) => {
       widgetType: WidgetType.RELEASE,
       interval: '5m',
       limit: 8,
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -83,6 +83,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.RELEASE,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -101,6 +102,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -119,6 +121,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.BIG_NUMBER,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -139,6 +142,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.BAR,
       widgetType: WidgetType.TRANSACTIONS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -157,7 +161,7 @@ const getDefaultWidgets = (organization: Organization) => {
       ],
     },
   ];
-  const spanWidgets = [
+  const spanWidgets: WidgetTemplate[] = [
     {
       id: 'duration-distribution',
       title: t('Duration Distribution'),
@@ -165,6 +169,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.LINE,
       widgetType: WidgetType.SPANS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -183,6 +188,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TOP_N,
       widgetType: WidgetType.SPANS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -202,6 +208,7 @@ const getDefaultWidgets = (organization: Organization) => {
       widgetType: WidgetType.RELEASE,
       interval: '5m',
       limit: 8,
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -220,6 +227,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.RELEASE,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -238,6 +246,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.SPANS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -256,6 +265,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.BAR,
       widgetType: WidgetType.SPANS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: 'Slow Transactions',
@@ -277,8 +287,9 @@ const getDefaultWidgets = (organization: Organization) => {
         },
       ],
     },
+    SCORE_BREAKDOWN_WHEEL_WIDGET,
   ];
-  const errorsWidgets = [
+  const errorsWidgets: WidgetTemplate[] = [
     {
       id: 'issue-for-review',
       title: t('Issues For Review'),
@@ -286,6 +297,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TABLE,
       widgetType: WidgetType.ISSUE,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -304,6 +316,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.TOP_N,
       widgetType: WidgetType.ERRORS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',
@@ -322,6 +335,7 @@ const getDefaultWidgets = (organization: Organization) => {
       displayType: DisplayType.LINE,
       widgetType: WidgetType.ERRORS,
       interval: '5m',
+      isCustomizable: true,
       queries: [
         {
           name: '',

--- a/static/app/views/dashboards/widgetLibrary/types.tsx
+++ b/static/app/views/dashboards/widgetLibrary/types.tsx
@@ -1,0 +1,5 @@
+import type {Widget} from 'sentry/views/dashboards/types';
+
+export type WidgetTemplate = Widget & {
+  isCustomizable: boolean;
+};

--- a/static/app/views/dashboards/widgetLibrary/types.tsx
+++ b/static/app/views/dashboards/widgetLibrary/types.tsx
@@ -1,5 +1,6 @@
 import type {Widget} from 'sentry/views/dashboards/types';
 
 export type WidgetTemplate = Widget & {
+  description: string;
   isCustomizable: boolean;
 };

--- a/static/app/views/dashboards/widgetLibrary/webVitalsWidgets.tsx
+++ b/static/app/views/dashboards/widgetLibrary/webVitalsWidgets.tsx
@@ -1,0 +1,58 @@
+import {t} from 'sentry/locale';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
+import {DEFAULT_QUERY_FILTER} from 'sentry/views/insights/browser/webVitals/settings';
+
+/**
+ * Shared widget definitions for Web Vitals
+ * Used in both the prebuilt Web Vitals dashboard and the widget library
+ */
+
+export const SCORE_BREAKDOWN_WHEEL_WIDGET: WidgetTemplate = {
+  id: 'score-breakdown-wheel',
+  description: t(
+    'Tracks the overall performance rating of the pages in your selected project.'
+  ),
+  title: t('Performance Score'),
+  isCustomizable: false,
+  displayType: DisplayType.WHEEL,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  limit: 1,
+  queries: [
+    {
+      name: '',
+      conditions: DEFAULT_QUERY_FILTER,
+      fields: [
+        'performance_score(measurements.score.lcp)',
+        'performance_score(measurements.score.fcp)',
+        'performance_score(measurements.score.inp)',
+        'performance_score(measurements.score.cls)',
+        'performance_score(measurements.score.ttfb)',
+        'performance_score(measurements.score.total)',
+        'count_scores(measurements.score.total)',
+        'count_scores(measurements.score.lcp)',
+        'count_scores(measurements.score.fcp)',
+        'count_scores(measurements.score.inp)',
+        'count_scores(measurements.score.cls)',
+        'count_scores(measurements.score.ttfb)',
+      ],
+      aggregates: [],
+      columns: [
+        'performance_score(measurements.score.lcp)',
+        'performance_score(measurements.score.fcp)',
+        'performance_score(measurements.score.inp)',
+        'performance_score(measurements.score.cls)',
+        'performance_score(measurements.score.ttfb)',
+        'performance_score(measurements.score.total)',
+        'count_scores(measurements.score.total)',
+        'count_scores(measurements.score.lcp)',
+        'count_scores(measurements.score.fcp)',
+        'count_scores(measurements.score.inp)',
+        'count_scores(measurements.score.cls)',
+        'count_scores(measurements.score.ttfb)',
+      ],
+      orderby: '',
+    },
+  ],
+};


### PR DESCRIPTION
- Adds a `WidgetTemplate` type with `isCustomizable` attribute that controls whether a widget from the library can be customized in the builder. This is set to `true` for all current existing widgets in the library.
- Adds `SCORE_BREAKDOWN_WHEEL_WIDGET` to the widget library. 


TODO: Add guard on non customizable widgets created through the widget library to prevent editing after creation