### PR TITLE
chore(seer): Remove the `setupAcknowledgement` response from `/issues/$id/autofix/update/` and `/seer/setup-check/`

### DIFF
--- a/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
+++ b/static/app/components/events/autofix/autofixChanges.analytics.spec.tsx
@@ -72,10 +72,6 @@ describe('AutofixChanges', () => {
       url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -128,10 +124,6 @@ describe('AutofixChanges', () => {
       url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: true,
@@ -183,10 +175,6 @@ describe('AutofixChanges', () => {
       url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: true,
@@ -243,10 +231,6 @@ describe('AutofixChanges', () => {
       url: '/organizations/org-slug/issues/123/autofix/setup/?check_write_access=true',
       method: 'GET',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: true,

--- a/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixSetupWriteAccessModal.spec.tsx
@@ -10,10 +10,6 @@ describe('AutofixSetupWriteAccessModal', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/autofix/setup/?check_write_access=true',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: false,
@@ -61,10 +57,6 @@ describe('AutofixSetupWriteAccessModal', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/autofix/setup/?check_write_access=true',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: true,

--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -21,10 +21,6 @@ export interface AutofixSetupResponse {
     reason: string | null;
   };
   seerReposLinked: boolean;
-  setupAcknowledgement: {
-    orgHasAcknowledged: boolean;
-    userHasAcknowledged: boolean;
-  };
   githubWriteIntegration?: {
     ok: boolean;
     repos: AutofixSetupRepoDefinition[];
@@ -60,10 +56,7 @@ export function useAutofixSetup(
   return {
     ...queryData,
     autofixEnabled: Boolean(queryData.data?.autofixEnabled),
-    canStartAutofix: Boolean(
-      queryData.data?.integration.ok &&
-      queryData.data?.setupAcknowledgement.orgHasAcknowledged
-    ),
+    canStartAutofix: Boolean(queryData.data?.integration.ok),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration?.ok),
     hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),
     seerReposLinked: Boolean(queryData.data?.seerReposLinked),

--- a/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
+++ b/static/app/components/events/autofix/useOrganizationSeerSetup.tsx
@@ -12,10 +12,6 @@ interface OrganizationSeerSetupResponse {
     hasAutofixQuota: boolean;
     hasScannerQuota: boolean;
   };
-  setupAcknowledgement: {
-    orgHasAcknowledged: boolean;
-    userHasAcknowledged: boolean;
-  };
 }
 
 export function makeOrganizationSeerSetupQueryKey(orgSlug: string): ApiQueryKey {
@@ -53,10 +49,5 @@ export function useOrganizationSeerSetup(
       hasScannerQuota: Boolean(queryData.data?.billing?.hasScannerQuota),
     },
     areAiFeaturesAllowed,
-    setupAcknowledgement: {
-      orgHasAcknowledged: Boolean(
-        queryData.data?.setupAcknowledgement?.orgHasAcknowledged
-      ),
-    },
   };
 }

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -7,20 +7,14 @@ import FeedbackItemUsername from 'sentry/components/feedback/feedbackItem/feedba
 describe('FeedbackItemUsername', () => {
   let seerSetupMock: any;
 
-  const mockSeerSetup = (overrides: any = {}) => {
+  const mockSeerSetup = () => {
     return MockApiClient.addMockResponse({
       url: '/organizations/org-slug/seer/setup-check/',
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-          ...overrides.setupAcknowledgement,
-        },
         billing: {
           hasAutofixQuota: false,
           hasScannerQuota: false,
         },
-        ...overrides,
       },
     });
   };
@@ -142,9 +136,7 @@ describe('FeedbackItemUsername', () => {
 
   describe('AI summary functionality', () => {
     it('should display summary and include it in email subject when AI summary is enabled', async () => {
-      seerSetupMock = mockSeerSetup({
-        setupAcknowledgement: {orgHasAcknowledged: true},
-      });
+      seerSetupMock = mockSeerSetup();
 
       const issue = FeedbackIssueFixture({
         metadata: {
@@ -178,34 +170,21 @@ describe('FeedbackItemUsername', () => {
         description: 'AI features are disabled',
         features: ['user-feedback-ai-titles'],
         summary: 'Login issue with payment flow',
-        seerSetupOverrides: {setupAcknowledgement: {orgHasAcknowledged: true}},
       },
       {
         description: 'user feedback AI titles are disabled',
         features: ['gen-ai-features'],
         summary: 'Login issue with payment flow',
-        seerSetupOverrides: {setupAcknowledgement: {orgHasAcknowledged: true}},
-      },
-      {
-        description: 'organization has not acknowledged AI setup',
-        features: ['user-feedback-ai-titles', 'gen-ai-features'],
-        summary: 'Login issue with payment flow',
-        seerSetupOverrides: {
-          setupAcknowledgement: {
-            orgHasAcknowledged: false,
-          },
-        },
       },
       {
         description: 'AI features enabled but summary is null',
         features: ['user-feedback-ai-titles', 'gen-ai-features'],
         summary: null,
-        seerSetupOverrides: {setupAcknowledgement: {orgHasAcknowledged: true}},
       },
     ])(
       'should not display summary or include it in email subject when $description',
-      async ({features, summary, seerSetupOverrides}) => {
-        seerSetupMock = mockSeerSetup(seerSetupOverrides);
+      async ({features, summary}) => {
+        seerSetupMock = mockSeerSetup();
 
         const issue = FeedbackIssueFixture({
           metadata: {

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -25,7 +25,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const email = feedbackIssue.metadata.contact_email;
 
   const organization = useOrganization();
-  const {setupAcknowledgement, areAiFeaturesAllowed} = useOrganizationSeerSetup();
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const nameOrEmail = name || email;
   const isSameNameAndEmail = name === email;
 
@@ -33,9 +33,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
 
   const summary = feedbackIssue.metadata.summary;
   const isAiSummaryEnabled =
-    areAiFeaturesAllowed &&
-    setupAcknowledgement.orgHasAcknowledged &&
-    organization.features.includes('user-feedback-ai-titles');
+    areAiFeaturesAllowed && organization.features.includes('user-feedback-ai-titles');
 
   const userNodeId = useId();
 

--- a/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.spec.tsx
@@ -60,9 +60,6 @@ describe('FeedbackCategories', () => {
     mockUseNavigate.mockReturnValue(mockNavigate);
     mockUseLocation.mockReturnValue(mockLocation);
     mockUseOrganizationSeerSetup.mockReturnValue({
-      setupAcknowledgement: {
-        orgHasAcknowledged: true,
-      },
       isPending: false,
     } as any);
   });
@@ -109,34 +106,6 @@ describe('FeedbackCategories', () => {
         body: {
           categories: [],
           numFeedbacksContext: 15,
-          success: true,
-        },
-        statusCode: 200,
-      });
-
-      const {container} = render(<FeedbackCategories />, {
-        organization: mockOrganization,
-      });
-
-      await waitForElementToBeRemoved(() => screen.queryByTestId('loading-placeholder'));
-
-      expect(container).toBeEmptyDOMElement();
-    });
-
-    it('renders empty state when org has not acknowledged', async () => {
-      mockUseOrganizationSeerSetup.mockReturnValue({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-        },
-        isPending: false,
-      } as any);
-
-      // Mock API to return categories
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/feedback-categories/',
-        body: {
-          categories: mockCategories,
-          numFeedbacksContext: 35,
           success: true,
         },
         statusCode: 200,

--- a/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackCategories.tsx
@@ -42,8 +42,7 @@ export default function FeedbackCategories() {
   // if we are showing this component, gen-ai-features must be true
   // and org.hideAiFeatures must be false,
   // but we still need to check that their seer acknowledgement exists
-  const {setupAcknowledgement, isPending: isOrgSeerSetupPending} =
-    useOrganizationSeerSetup();
+  const {isPending: isOrgSeerSetupPending} = useOrganizationSeerSetup();
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -51,7 +50,7 @@ export default function FeedbackCategories() {
 
   useEffect(() => {
     // Analytics for the rendered state. Should match the conditions below.
-    if (isPending || isOrgSeerSetupPending || !setupAcknowledgement.orgHasAcknowledged) {
+    if (isPending || isOrgSeerSetupPending) {
       return;
     }
     if (isError) {
@@ -77,7 +76,6 @@ export default function FeedbackCategories() {
     isError,
     tooFewFeedbacks,
     categories,
-    setupAcknowledgement.orgHasAcknowledged,
     isPending,
     isOrgSeerSetupPending,
   ]);
@@ -94,13 +92,7 @@ export default function FeedbackCategories() {
 
   // The assumption is that if categories are enabled, then summaries are definitely enabled.
   // Both are wrapped in a parent component. Summary has its own states for these cases, so we can just return null.
-  if (
-    isError ||
-    tooFewFeedbacks ||
-    !categories ||
-    categories.length === 0 ||
-    !setupAcknowledgement.orgHasAcknowledged
-  ) {
+  if (isError || tooFewFeedbacks || !categories || categories.length === 0) {
     return null;
   }
 

--- a/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummary.tsx
@@ -1,12 +1,10 @@
 import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
-import {Link} from '@sentry/scraps/link';
-
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import useFeedbackSummary from 'sentry/components/feedback/list/useFeedbackSummary';
 import Placeholder from 'sentry/components/placeholder';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -16,8 +14,7 @@ export default function FeedbackSummary() {
   // if we are showing this component, gen-ai-features must be true
   // and org.hideAiFeatures must be false,
   // but we still need to check that their seer acknowledgement exists
-  const {setupAcknowledgement, isPending: isOrgSeerSetupPending} =
-    useOrganizationSeerSetup();
+  const {isPending: isOrgSeerSetupPending} = useOrganizationSeerSetup();
   const organization = useOrganization();
 
   useEffect(() => {
@@ -25,11 +22,7 @@ export default function FeedbackSummary() {
     if (isPending || isOrgSeerSetupPending) {
       return;
     }
-    if (!setupAcknowledgement.orgHasAcknowledged) {
-      trackAnalytics('feedback.summary.seer-cta-rendered', {
-        organization,
-      });
-    } else if (isError) {
+    if (isError) {
       trackAnalytics('feedback.summary.summary-error', {
         organization,
       });
@@ -42,28 +35,10 @@ export default function FeedbackSummary() {
         organization,
       });
     }
-  }, [
-    organization,
-    isError,
-    tooFewFeedbacks,
-    setupAcknowledgement.orgHasAcknowledged,
-    isPending,
-    isOrgSeerSetupPending,
-  ]);
+  }, [organization, isError, tooFewFeedbacks, isPending, isOrgSeerSetupPending]);
 
   if (isPending || isOrgSeerSetupPending) {
     return <LoadingPlaceholder />;
-  }
-
-  if (!setupAcknowledgement.orgHasAcknowledged) {
-    return (
-      <SummaryContent>
-        {tct(
-          'Seer access is required to see feedback summaries. Please view the [link:Seer settings page] for more information.',
-          {link: <Link to={`/settings/${organization.slug}/seer/`} />}
-        )}
-      </SummaryContent>
-    );
   }
 
   if (isError) {

--- a/static/app/components/group/groupSummary.spec.tsx
+++ b/static/app/components/group/groupSummary.spec.tsx
@@ -45,10 +45,6 @@ describe('GroupSummary', () => {
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       method: 'GET',
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {
           ok: true,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -59,11 +59,11 @@ describe('AskSeerComboBox', () => {
       body: {status: 'ok', queries: [{query: 'span.duration:>30s'}]},
     });
 
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/seer/setup-check/',
-      method: 'GET',
-      body: {setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true}},
-    });
+    // MockApiClient.addMockResponse({
+    //   url: '/organizations/org-slug/seer/setup-check/',
+    //   method: 'GET',
+    //   body: {},
+    // });
   });
 
   it('renders the search input', async () => {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox.spec.tsx
@@ -58,12 +58,6 @@ describe('AskSeerComboBox', () => {
       method: 'POST',
       body: {status: 'ok', queries: [{query: 'span.duration:>30s'}]},
     });
-
-    // MockApiClient.addMockResponse({
-    //   url: '/organizations/org-slug/seer/setup-check/',
-    //   method: 'GET',
-    //   body: {},
-    // });
   });
 
   it('renders the search input', async () => {

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react';
 import * as Sentry from '@sentry/react';
 
-import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
 import type {
   GetTagValues,
   SearchQueryBuilderProps,
@@ -55,7 +54,8 @@ interface SearchQueryBuilderContextData {
   filterKeySections: FilterKeySection[];
   filterKeys: TagCollection;
   focusOverride: FocusOverride | null;
-  gaveSeerConsent: boolean;
+  // @deprecated: remove this, it's constant now
+  gaveSeerConsent: true;
   getFieldDefinition: (key: string, kind?: FieldKind) => FieldDefinition | null;
   getSuggestedFilterKey: (key: string) => string | null;
   getTagValues: GetTagValues;
@@ -140,8 +140,6 @@ export function SearchQueryBuilderProvider({
     Boolean(enableAISearchProp) &&
     !organization.hideAiFeatures &&
     organization.features.includes('gen-ai-features');
-
-  const {setupAcknowledgement} = useOrganizationSeerSetup({enabled: enableAISearch});
 
   const [displayAskSeerState, setDisplayAskSeerState] = useState(false);
   const displayAskSeer = enableAISearch ? displayAskSeerState : false;
@@ -271,7 +269,7 @@ export function SearchQueryBuilderProvider({
       replaceRawSearchKeys,
       matchKeySuggestions,
       filterKeyAliases,
-      gaveSeerConsent: setupAcknowledgement.orgHasAcknowledged,
+      gaveSeerConsent: true,
       currentInputValueRef,
       displayAskSeerFeedback,
       setDisplayAskSeerFeedback,
@@ -307,7 +305,6 @@ export function SearchQueryBuilderProvider({
     namespace,
     replaceRawSearchKeys,
     searchSource,
-    setupAcknowledgement.orgHasAcknowledged,
     size,
     stableFieldDefinitionGetter,
     stableFilterKeys,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -4868,12 +4868,7 @@ describe('SearchQueryBuilder', () => {
     it('renders ask seer button when user has given consent', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
-        }),
+        body: AutofixSetupFixture({}),
       });
 
       render(<SearchQueryBuilder {...defaultProps} enableAISearch />, {
@@ -4896,12 +4891,10 @@ describe('SearchQueryBuilder', () => {
           url: `/organizations/org-slug/prompts-activity/`,
           method: 'PUT',
         });
-        MockApiClient.addMockResponse({
-          url: `/organizations/org-slug/seer/setup-check/`,
-          body: AutofixSetupFixture({
-            setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
-          }),
-        });
+        // MockApiClient.addMockResponse({
+        //   url: `/organizations/org-slug/seer/setup-check/`,
+        //   body: AutofixSetupFixture({}),
+        // });
         MockApiClient.addMockResponse({
           url: '/organizations/org-slug/recent-searches/',
           method: 'POST',
@@ -5034,15 +5027,11 @@ describe('SearchQueryBuilder', () => {
     describe('free text', () => {
       it('displays ask seer button when searching free text', async () => {
         const mockOnSearch = jest.fn();
-        MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/seer/setup-check/',
-          body: AutofixSetupFixture({
-            setupAcknowledgement: {
-              orgHasAcknowledged: true,
-              userHasAcknowledged: true,
-            },
-          }),
-        });
+        // MockApiClient.addMockResponse({
+        //   url: '/organizations/org-slug/seer/setup-check/',
+        //   body: AutofixSetupFixture({
+        //   }),
+        // });
 
         render(
           <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,
@@ -5065,15 +5054,11 @@ describe('SearchQueryBuilder', () => {
     describe('consent flow changes enabled', () => {
       it('renders tooltip', async () => {
         const mockOnSearch = jest.fn();
-        MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/seer/setup-check/',
-          body: AutofixSetupFixture({
-            setupAcknowledgement: {
-              orgHasAcknowledged: true,
-              userHasAcknowledged: true,
-            },
-          }),
-        });
+        // MockApiClient.addMockResponse({
+        //   url: '/organizations/org-slug/seer/setup-check/',
+        //   body: AutofixSetupFixture({
+        //   }),
+        // });
 
         render(
           <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1,6 +1,5 @@
 import type {ComponentProps} from 'react';
 import {destroyAnnouncer} from '@react-aria/live-announcer';
-import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 
 import {
   act,
@@ -4866,11 +4865,6 @@ describe('SearchQueryBuilder', () => {
 
   describe('ask seer', () => {
     it('renders ask seer button when user has given consent', async () => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({}),
-      });
-
       render(<SearchQueryBuilder {...defaultProps} enableAISearch />, {
         organization: {
           features: ['gen-ai-features'],
@@ -4891,10 +4885,6 @@ describe('SearchQueryBuilder', () => {
           url: `/organizations/org-slug/prompts-activity/`,
           method: 'PUT',
         });
-        // MockApiClient.addMockResponse({
-        //   url: `/organizations/org-slug/seer/setup-check/`,
-        //   body: AutofixSetupFixture({}),
-        // });
         MockApiClient.addMockResponse({
           url: '/organizations/org-slug/recent-searches/',
           method: 'POST',
@@ -5027,12 +5017,6 @@ describe('SearchQueryBuilder', () => {
     describe('free text', () => {
       it('displays ask seer button when searching free text', async () => {
         const mockOnSearch = jest.fn();
-        // MockApiClient.addMockResponse({
-        //   url: '/organizations/org-slug/seer/setup-check/',
-        //   body: AutofixSetupFixture({
-        //   }),
-        // });
-
         render(
           <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,
           {
@@ -5054,11 +5038,6 @@ describe('SearchQueryBuilder', () => {
     describe('consent flow changes enabled', () => {
       it('renders tooltip', async () => {
         const mockOnSearch = jest.fn();
-        // MockApiClient.addMockResponse({
-        //   url: '/organizations/org-slug/seer/setup-check/',
-        //   body: AutofixSetupFixture({
-        //   }),
-        // });
 
         render(
           <SearchQueryBuilder {...defaultProps} enableAISearch onSearch={mockOnSearch} />,

--- a/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.spec.tsx
@@ -10,28 +10,11 @@ describe('useActiveReplayTab', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/seer/setup-check/',
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
-      }),
+      body: AutofixSetupFixture({}),
     });
   });
 
   describe('when AI features are allowed', () => {
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
-        }),
-      });
-    });
-
     describe('AI summary tab is default', () => {
       it('should use AI summary as a default', () => {
         const {result} = renderHookWithProviders(useActiveReplayTab, {
@@ -99,18 +82,6 @@ describe('useActiveReplayTab', () => {
   });
 
   describe('when AI features are not allowed', () => {
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: false,
-            userHasAcknowledged: false,
-          },
-        }),
-      });
-    });
-
     describe('breadcrumbs tab is default', () => {
       it('should use Breadcrumbs as a default', () => {
         const {result} = renderHookWithProviders(useActiveReplayTab, {

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -103,10 +103,9 @@ function useTrackAnalytics({
   const chartError = timeseriesResult.error?.message ?? '';
   const query_status = tableError || chartError ? 'error' : 'success';
 
-  const {setupAcknowledgement: seerSetup, isLoading: isLoadingSeerSetup} =
-    useOrganizationSeerSetup({
-      enabled: !organization.hideAiFeatures,
-    });
+  const {isLoading: isLoadingSeerSetup} = useOrganizationSeerSetup({
+    enabled: !organization.hideAiFeatures,
+  });
 
   useEffect(() => {
     if (
@@ -123,9 +122,7 @@ function useTrackAnalytics({
     const columns = aggregatesTableResult.eventView.getColumns() as unknown as string[];
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup?.orgHasAcknowledged
-        ? 'given'
-        : 'not_given';
+      : 'given';
 
     const dataScanned = aggregatesTableResult.result.meta?.dataScanned ?? '';
     const yAxes = visualizes.map(visualize => visualize.yAxis);
@@ -198,7 +195,6 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup?.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -219,9 +215,7 @@ function useTrackAnalytics({
     const search = new MutableSearch(query);
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup?.orgHasAcknowledged
-        ? 'given'
-        : 'not_given';
+      : 'given';
 
     const dataScanned = spansTableResult.result.meta?.dataScanned ?? '';
     const yAxes = visualizes.map(visualize => visualize.yAxis);
@@ -289,7 +283,6 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup?.orgHasAcknowledged,
     spansTableResult.result.data?.length,
     spansTableResult.result.isPending,
     spansTableResult.result.meta?.dataScanned,
@@ -312,9 +305,7 @@ function useTrackAnalytics({
     const search = new MutableSearch(query);
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup?.orgHasAcknowledged
-        ? 'given'
-        : 'not_given';
+      : 'given';
 
     const yAxes = visualizes.map(visualize => visualize.yAxis);
 
@@ -380,7 +371,6 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup?.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
@@ -415,9 +405,7 @@ function useTrackAnalytics({
         .length ?? 0;
     const gaveSeerConsent = organization.hideAiFeatures
       ? 'gen_ai_features_disabled'
-      : seerSetup?.orgHasAcknowledged
-        ? 'given'
-        : 'not_given';
+      : 'given';
 
     const yAxes = visualizes.map(visualize => visualize.yAxis);
 
@@ -461,12 +449,11 @@ function useTrackAnalytics({
     query,
     queryType,
     query_status,
-    seerSetup?.orgHasAcknowledged,
     timeseriesResult.data,
     timeseriesResult.isPending,
     title,
     tracesTableResult?.result.data?.data,
-    tracesTableResult?.result.isPending,
+    tracesTableResult?.result?.isPending,
     tracesTableResultDefined,
     visualizes,
   ]);

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -53,12 +53,7 @@ describe('MultiQueryModeContent', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/setup-check/`,
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
-      }),
+      body: AutofixSetupFixture({}),
     });
 
     MockApiClient.addMockResponse({
@@ -1167,6 +1162,10 @@ describe('MultiQueryModeContent', () => {
         projects: [],
         environment: [],
       },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/setup-check/`,
+      body: AutofixSetupFixture({}),
     });
 
     MockApiClient.addMockResponse({

--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -1,5 +1,3 @@
-import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -52,15 +50,6 @@ describe('ExploreContent', () => {
       url: `/organizations/${organization.slug}/traces/`,
       method: 'GET',
       body: {},
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/setup-check/`,
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
-      }),
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/trace-items/attributes/`,

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -401,13 +401,6 @@ describe('SpansTabContent', () => {
   });
 
   describe('Ask Seer', () => {
-    beforeEach(() => {
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({}),
-      });
-    });
-
     describe('when the AI features are disabled', () => {
       it('does not display the Ask Seer combobox', async () => {
         render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -111,12 +111,7 @@ describe('SpansTabContent', () => {
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/setup-check/`,
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
-      }),
+      body: AutofixSetupFixture({}),
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
@@ -409,12 +404,7 @@ describe('SpansTabContent', () => {
     beforeEach(() => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/seer/setup-check/',
-        body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
-        }),
+        body: AutofixSetupFixture({}),
       });
     });
 

--- a/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewSidebar.spec.tsx
@@ -91,10 +91,6 @@ describe('PageOverviewSidebar', () => {
       url: '/organizations/org-slug/seer/setup-check/',
       method: 'GET',
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         billing: {
           hasAutofixQuota: true,
           hasScannerQuota: true,

--- a/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
+++ b/static/app/views/insights/browser/webVitals/utils/useHasSeerWebVitalsSuggestions.tsx
@@ -29,12 +29,11 @@ export function useHasSeerWebVitalsSuggestions(selectedProject?: Project) {
     codeMappingRepos?.some(repo => repo.provider.includes('github'))
   );
 
-  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
 
   return (
     organization.features.includes('performance-web-vitals-seer-suggestions') &&
     areAiFeaturesAllowed &&
-    setupAcknowledgement.orgHasAcknowledged &&
     hasConfiguredRepos &&
     hasGithubRepos
   );

--- a/static/app/views/issueDetails/groupSidebar.spec.tsx
+++ b/static/app/views/issueDetails/groupSidebar.spec.tsx
@@ -88,10 +88,6 @@ describe('GroupSidebar', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.spec.tsx
@@ -90,10 +90,6 @@ describe('GroupDetailsLayout', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -47,15 +47,10 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
   const hasAutofix = isAutofixEnabled && areAiFeaturesAllowed && !isSampleError;
   const hasGithubIntegration = !!autofixSetupData?.integration.ok;
 
-  const orgNeedsGenAiAcknowledgement =
-    !autofixSetupData?.setupAcknowledgement.orgHasAcknowledged &&
-    (isSummaryEnabled || isAutofixEnabled) &&
-    areAiFeaturesAllowed;
-
   return {
     hasSummary,
     hasAutofix,
-    orgNeedsGenAiAcknowledgement,
+    orgNeedsGenAiAcknowledgement: false,
     hasResources,
     isAutofixSetupLoading,
     areAiFeaturesAllowed,

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -108,10 +108,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -168,38 +164,6 @@ describe('SeerDrawer', () => {
     });
   });
 
-  it('renders consent state if not consented', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
-        integration: {ok: false, reason: null},
-        githubWriteIntegration: {ok: false, repos: []},
-      }),
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {autofix: null},
-    });
-
-    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
-      organization,
-    });
-
-    expect(screen.getByTestId('ai-setup-loading-indicator')).toBeInTheDocument();
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('ai-setup-loading-indicator')
-    );
-
-    expect(screen.getByText(mockEvent.id)).toBeInTheDocument();
-
-    expect(screen.getByTestId('ai-setup-data-consent')).toBeInTheDocument();
-  });
-
   it('renders issue summary if consent flow is removed and there is no autofix quota', async () => {
     const orgWithConsentFlowRemoved = OrganizationFixture({
       hideAiFeatures: false,
@@ -208,10 +172,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: false, reason: null},
         githubWriteIntegration: {ok: false, repos: []},
         billing: {hasAutofixQuota: false},
@@ -269,10 +229,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: false, reason: null},
         githubWriteIntegration: {ok: false, repos: []},
       }),
@@ -325,45 +281,11 @@ describe('SeerDrawer', () => {
     expect(await screen.findByRole('button', {name: 'Start Over'})).toBeInTheDocument();
   });
 
-  it('hides ButtonBarWrapper when AI consent is needed', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
-        integration: {ok: true, reason: null},
-        githubWriteIntegration: {ok: true, repos: []},
-      }),
-    });
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {autofix: null},
-    });
-
-    render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
-      organization,
-    });
-
-    await waitForElementToBeRemoved(() =>
-      screen.queryByTestId('ai-setup-loading-indicator')
-    );
-
-    // AutofixFeedback component should not be rendered when consent is needed
-    expect(screen.queryByRole('button', {name: 'Give Feedback'})).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Start Over'})).not.toBeInTheDocument();
-  });
-
   it('shows ButtonBarWrapper but hides Start Over button when hasAutofix is false', async () => {
     // Mock AI consent as okay but no autofix capability
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -404,10 +326,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -437,10 +355,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -532,10 +446,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: false, reason: null},
         githubWriteIntegration: {ok: false, repos: []},
       }),
@@ -571,10 +481,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -600,10 +506,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -630,10 +532,6 @@ describe('SeerDrawer', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),

--- a/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSection.spec.tsx
@@ -37,10 +37,6 @@ describe('SeerSection', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),
@@ -105,34 +101,6 @@ describe('SeerSection', () => {
   });
 
   describe('Seer button text', () => {
-    it('shows "Fix it for me" when Seer needs setup and no run already', async () => {
-      const customOrganization = OrganizationFixture({
-        hideAiFeatures: false,
-        features: ['gen-ai-features'],
-      });
-
-      MockApiClient.addMockResponse({
-        url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
-        body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: false,
-            userHasAcknowledged: false,
-          },
-          integration: {ok: false, reason: null},
-          githubWriteIntegration: {ok: false, repos: []},
-        }),
-      });
-
-      render(<SeerSection event={mockEvent} group={mockGroup} project={mockProject} />, {
-        organization: customOrganization,
-      });
-
-      expect(
-        await screen.findByText('Meet Seer, the AI debugging agent.')
-      ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Fix with Seer'})).toBeInTheDocument();
-    });
-
     it('shows issue summary and "Fix with Seer" when consent flow is removed and there is no autofix quota', async () => {
       const orgWithConsentFlowRemoved = OrganizationFixture({
         hideAiFeatures: false,
@@ -142,10 +110,6 @@ describe('SeerSection', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
           integration: {ok: true, reason: null},
           githubWriteIntegration: {ok: true, repos: []},
           billing: {hasAutofixQuota: false},
@@ -175,10 +139,6 @@ describe('SeerSection', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
           integration: {ok: false, reason: null},
           githubWriteIntegration: {ok: false, repos: []},
         }),
@@ -205,10 +165,6 @@ describe('SeerSection', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
           integration: {ok: true, reason: null},
           githubWriteIntegration: {ok: true, repos: []},
         }),
@@ -243,10 +199,6 @@ describe('SeerSection', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
         body: AutofixSetupFixture({
-          setupAcknowledgement: {
-            orgHasAcknowledged: true,
-            userHasAcknowledged: true,
-          },
           integration: {ok: true, reason: null},
           githubWriteIntegration: {ok: true, repos: []},
         }),

--- a/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sidebar.spec.tsx
@@ -53,10 +53,6 @@ describe('StreamlinedSidebar', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/autofix/setup/`,
       body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
       }),

--- a/static/app/views/replays/detail/ai/replaySummaryContext.tsx
+++ b/static/app/views/replays/detail/ai/replaySummaryContext.tsx
@@ -31,12 +31,10 @@ export function ReplaySummaryContextProvider({
   replay: ReplayReader;
 }) {
   const organization = useOrganization();
-  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const mobileProject = replay.isVideoReplay();
   const hasAiSummary =
-    organization.features.includes('replay-ai-summaries') &&
-    areAiFeaturesAllowed &&
-    setupAcknowledgement.orgHasAcknowledged;
+    organization.features.includes('replay-ai-summaries') && areAiFeaturesAllowed;
   const hasMobileSummary = organization.features.includes('replay-ai-summaries-mobile');
 
   const summaryResult = useReplaySummary(replay, {

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.tsx
@@ -138,11 +138,7 @@ describe('projectPerformance', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/seer/setup-check/',
       method: 'GET',
-      body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-        },
-      },
+      body: {},
     });
   });
 

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -45,10 +45,6 @@ describe('ProjectSeer', () => {
       url: `/organizations/${organization.slug}/seer/setup-check/`,
       method: 'GET',
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         billing: {
           hasAutofixQuota: true,
           hasScannerQuota: true,
@@ -436,10 +432,6 @@ describe('ProjectSeer', () => {
       url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
       method: 'GET',
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         billing: {
           hasAutofixQuota: true,
           hasScannerQuota: true,
@@ -585,7 +577,6 @@ describe('ProjectSeer', () => {
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
-          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
         },
       });
@@ -665,7 +656,6 @@ describe('ProjectSeer', () => {
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
-          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
         },
       });
@@ -774,7 +764,6 @@ describe('ProjectSeer', () => {
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
-          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
         },
       });
@@ -865,7 +854,6 @@ describe('ProjectSeer', () => {
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
-          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
         },
       });
@@ -989,7 +977,6 @@ describe('ProjectSeer', () => {
         url: `/organizations/${orgWithCursorFeature.slug}/seer/setup-check/`,
         method: 'GET',
         body: {
-          setupAcknowledgement: {orgHasAcknowledged: true, userHasAcknowledged: true},
           billing: {hasAutofixQuota: true, hasScannerQuota: true},
         },
       });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -432,11 +432,10 @@ function ProjectSeer({
   organization: Organization;
   project: Project;
 }) {
-  const {setupAcknowledgement, billing, isLoading} = useOrganizationSeerSetup();
+  const {billing, isLoading} = useOrganizationSeerSetup();
 
   const needsSetup =
-    !setupAcknowledgement.orgHasAcknowledged ||
-    (!billing.hasAutofixQuota && organization.features.includes('seer-billing'));
+    !billing.hasAutofixQuota && organization.features.includes('seer-billing');
 
   if (organization.hideAiFeatures) {
     return <NoAccess />;

--- a/static/app/views/settings/projectUserFeedback/index.spec.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.spec.tsx
@@ -8,15 +8,10 @@ describe('ProjectUserFeedback', () => {
   const url = `/projects/${organization.slug}/${project.slug}/`;
   let seerSetupMock: any;
 
-  const mockSeerSetup = (overrides: any = {}) => {
+  const mockSeerSetup = () => {
     return MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/setup-check/`,
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-          ...overrides.setupAcknowledgement,
-        },
         billing: {
           hasAutofixQuota: false,
           hasScannerQuota: false,
@@ -63,36 +58,7 @@ describe('ProjectUserFeedback', () => {
 
   it('cannot toggle spam detection when the user does not have the spam feature flag', () => {
     organization.features.push('gen-ai-features');
-    seerSetupMock = mockSeerSetup({setupAcknowledgement: {orgHasAcknowledged: true}});
-
-    render(<ProjectUserFeedback />, {
-      organization,
-      outletContext: {project},
-    });
-
-    expect(
-      screen.queryByRole('checkbox', {name: 'Enable Spam Detection'})
-    ).not.toBeInTheDocument();
-  });
-
-  it('cannot toggle spam detection when the user does not have ai features', () => {
-    organization.features.push('user-feedback-spam-ingest');
-    seerSetupMock = mockSeerSetup({setupAcknowledgement: {orgHasAcknowledged: false}});
-
-    render(<ProjectUserFeedback />, {
-      organization,
-      outletContext: {project},
-    });
-
-    expect(
-      screen.queryByRole('checkbox', {name: 'Enable Spam Detection'})
-    ).not.toBeInTheDocument();
-  });
-
-  it('cannot toggle spam detection when the user does not seer acknowledged', () => {
-    organization.features.push('user-feedback-spam-ingest');
-    organization.features.push('gen-ai-features');
-    seerSetupMock = mockSeerSetup({setupAcknowledgement: {orgHasAcknowledged: false}});
+    seerSetupMock = mockSeerSetup();
 
     render(<ProjectUserFeedback />, {
       organization,
@@ -107,7 +73,7 @@ describe('ProjectUserFeedback', () => {
   it('can toggle spam detection', async () => {
     organization.features.push('user-feedback-spam-ingest');
     organization.features.push('gen-ai-features');
-    seerSetupMock = mockSeerSetup({setupAcknowledgement: {orgHasAcknowledged: true}});
+    seerSetupMock = mockSeerSetup();
 
     render(<ProjectUserFeedback />, {
       organization,

--- a/static/app/views/settings/projectUserFeedback/index.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.tsx
@@ -21,8 +21,8 @@ import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSet
 export default function ProjectUserFeedback() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-  const {areAiFeaturesAllowed, setupAcknowledgement} = useOrganizationSeerSetup();
-  const hasAiEnabled = areAiFeaturesAllowed && setupAcknowledgement.orgHasAcknowledged;
+  const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
+  const hasAiEnabled = areAiFeaturesAllowed;
 
   const handleClick = () => {
     Sentry.showReportDialog({

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -50,9 +50,7 @@ function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const hasAutofixQuota = isGroupMode
     ? groupSetup.hasAutofixQuota
     : orgSetup.billing.hasAutofixQuota;
-  const orgHasAcknowledged = isGroupMode
-    ? setupData?.setupAcknowledgement.orgHasAcknowledged
-    : orgSetup.setupAcknowledgement.orgHasAcknowledged;
+  const orgHasAcknowledged = true;
   const refetch = isGroupMode ? groupSetup.refetch : orgSetup.refetch;
 
   // Get the appropriate Seer category (SEER_USER for seat-based, SEER_AUTOFIX for legacy)

--- a/static/gsApp/components/ai/aiSetupDataConsent.spec.tsx
+++ b/static/gsApp/components/ai/aiSetupDataConsent.spec.tsx
@@ -8,51 +8,10 @@ import AiSetupDataConsent from './AiSetupDataConsent';
 describe('AiSetupDataConsent', () => {
   const organization = OrganizationFixture();
 
-  it('renders Enable Seer button if nobody in org has acknowledged', async () => {
+  it('renders Try Seer button', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues/1/autofix/setup/',
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: false,
-          userHasAcknowledged: false,
-        },
-      }),
-    });
-    const promptsUpdateMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/prompts-activity/`,
-      method: 'PUT',
-    });
-
-    render(<AiSetupDataConsent groupId="1" />);
-
-    expect(await screen.findByRole('button', {name: 'Enable Seer'})).toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', {name: 'Enable Seer'}));
-
-    await waitFor(() => {
-      expect(promptsUpdateMock).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.objectContaining({
-          data: {
-            feature: 'seer_autofix_setup_acknowledged',
-            organization_id: organization.id,
-            project_id: undefined,
-            status: 'dismissed',
-          },
-        })
-      );
-    });
-  });
-
-  it('renders Try Seer button if org has acknowledged but not the user', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/1/autofix/setup/',
-      body: AutofixSetupFixture({
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: false,
-        },
-      }),
+      body: AutofixSetupFixture({}),
     });
     const promptsUpdateMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/prompts-activity/`,

--- a/static/gsApp/views/seerAutomation/index.spec.tsx
+++ b/static/gsApp/views/seerAutomation/index.spec.tsx
@@ -13,10 +13,6 @@ describe('SeerAutomation', () => {
       url: '/organizations/org-slug/seer/setup-check/',
       method: 'GET',
       body: {
-        setupAcknowledgement: {
-          orgHasAcknowledged: true,
-          userHasAcknowledged: true,
-        },
         billing: {
           hasAutofixQuota: true,
           hasScannerQuota: true,

--- a/static/gsApp/views/seerAutomation/index.tsx
+++ b/static/gsApp/views/seerAutomation/index.tsx
@@ -14,7 +14,7 @@ import AiSetupDataConsent from 'getsentry/components/ai/AiSetupDataConsent';
 
 export default function SeerAutomationRoot() {
   const organization = useOrganization();
-  const {isLoading, billing, setupAcknowledgement} = useOrganizationSeerSetup();
+  const {isLoading, billing} = useOrganizationSeerSetup();
 
   if (organization.hideAiFeatures) {
     return <NoAccess />;
@@ -33,14 +33,11 @@ export default function SeerAutomationRoot() {
   }
 
   // Check if setup is needed
-  const needsOrgAcknowledgement = !setupAcknowledgement.orgHasAcknowledged;
   const needsBilling =
     !billing.hasAutofixQuota && organization.features.includes('seer-billing');
 
-  const needsSetup = needsOrgAcknowledgement || needsBilling;
-
   // Show setup screen if needed
-  if (needsSetup) {
+  if (needsBilling) {
     return (
       <Fragment>
         <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />

--- a/tests/js/fixtures/autofixSetupFixture.ts
+++ b/tests/js/fixtures/autofixSetupFixture.ts
@@ -10,10 +10,6 @@ export function AutofixSetupFixture(
       reason: null,
     },
     seerReposLinked: true,
-    setupAcknowledgement: {
-      orgHasAcknowledged: true,
-      userHasAcknowledged: true,
-    },
     githubWriteIntegration: {
       ok: true,
       repos: [],


### PR DESCRIPTION
In #107955 we removed the flag `gen-ai-consent-flow-removal` because it's enabled for 100% of orgs. This caused the `setupAcknowledgement` response payload to return True as a constant. Therefore we can cleanup more of the frontend that relies on fetching that data!

Followup to https://github.com/getsentry/sentry/pull/107955