### PR TITLE
chore(ACI): Remove all references of sentry_app_identifier

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -57,7 +57,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
             sentry_app_ids = [
                 int(action.config.get("target_identifier"))
                 for action in actions
-                if action.config.get("sentry_app_identifier") is not None
+                if action.type == Action.Type.SENTRY_APP.value
             ]
             install_contexts = app_service.get_component_contexts(
                 filter={"app_ids": sentry_app_ids, "organization_id": organization_id},

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -6,7 +6,6 @@ from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.transformers import TargetTypeConfigTransformer
 from sentry.workflow_engine.types import ActionHandler, ActionInvocation, ConfigTransformer
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @action_handler_registry.register(Action.Type.SENTRY_APP)
@@ -23,10 +22,6 @@ class SentryAppActionHandler(ActionHandler):
             "target_type": {
                 "type": ["integer"],
                 "enum": [ActionTarget.SENTRY_APP.value],
-            },
-            "sentry_app_identifier": {
-                "type": ["string"],
-                "enum": [*SentryAppIdentifier],
             },
         },
         "required": ["target_type", "target_identifier"],

--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -25,7 +25,7 @@ class SentryAppActionHandler(ActionHandler):
             },
         },
         "required": ["target_type", "target_identifier"],
-        "additionalProperties": False,
+        "additionalProperties": True,
     }
 
     data_schema = {

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -95,7 +95,6 @@ def process_sentry_app_installation_deletes(
         region_name=region_name,
         status=ObjectStatus.DISABLED,
         sentry_app_id=payload["sentry_app_id"],
-        organization_id=payload["organization_id"],
     )
 
 

--- a/src/sentry/receivers/outbox/control.py
+++ b/src/sentry/receivers/outbox/control.py
@@ -95,6 +95,7 @@ def process_sentry_app_installation_deletes(
         region_name=region_name,
         status=ObjectStatus.DISABLED,
         sentry_app_id=payload["sentry_app_id"],
+        organization_id=payload["organization_id"],
     )
 
 

--- a/src/sentry/receivers/outbox/region.py
+++ b/src/sentry/receivers/outbox/region.py
@@ -34,7 +34,6 @@ from sentry.relocation.services.relocation_export.service import control_relocat
 from sentry.sentry_apps.services.app.service import app_service
 from sentry.types.region import get_local_region
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,6 @@ def update_sentry_app_action_data(
         action = Action.objects.get(
             id=shard_identifier,
             type=Action.Type.SENTRY_APP,
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
         )
         installs = app_service.get_many(
             filter={
@@ -80,7 +78,6 @@ def update_sentry_app_action_data(
             return
 
         action.config["target_identifier"] = str(installs[0].sentry_app.id)
-        action.config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_ID
         action.save()
 
     except Action.DoesNotExist:

--- a/src/sentry/sentry_apps/models/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/models/sentry_app_installation.py
@@ -165,7 +165,6 @@ class SentryAppInstallation(ReplicatedControlModel, ParanoidModel):
                 category=OutboxCategory.SENTRY_APP_INSTALLATION_DELETE,
                 region_name=region_name,
                 payload={
-                    "uuid": self.uuid,
                     "sentry_app_id": self.sentry_app_id,
                     "organization_id": self.organization_id,
                 },

--- a/src/sentry/workflow_engine/migration_helpers/alert_rule.py
+++ b/src/sentry/workflow_engine/migration_helpers/alert_rule.py
@@ -19,7 +19,7 @@ from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.integrations.opsgenie.client import OPSGENIE_DEFAULT_PRIORITY
 from sentry.integrations.pagerduty.client import PAGERDUTY_DEFAULT_SEVERITY
-from sentry.notifications.models.notificationaction import ActionService, ActionTarget
+from sentry.notifications.models.notificationaction import ActionService
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.users.services.user import RpcUser
 from sentry.workflow_engine.migration_helpers.utils import get_workflow_name
@@ -41,11 +41,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
-from sentry.workflow_engine.typings.notification_action import (
-    OnCallDataBlob,
-    SentryAppDataBlob,
-    SentryAppIdentifier,
-)
+from sentry.workflow_engine.typings.notification_action import OnCallDataBlob, SentryAppDataBlob
 
 logger = logging.getLogger(__name__)
 
@@ -155,14 +151,11 @@ def get_target_identifier(
 def build_action_config(
     target_display: str | None, target_identifier: str | None, target_type: int
 ) -> dict[str, str | int | None]:
-    base_config = {
+    return {
         "target_display": target_display,
         "target_identifier": target_identifier,
         "target_type": target_type,
     }
-    if target_type == ActionTarget.SENTRY_APP.value:
-        base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_ID
-    return base_config
 
 
 def get_detector_trigger(

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -42,6 +42,7 @@ class DatabaseBackedActionService(ActionService):
             dataconditiongroupaction__condition_group__organization_id=organization_id,
         ).update(status=status)
 
+
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -1,6 +1,5 @@
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.service.action.service import ActionService
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 class DatabaseBackedActionService(ActionService):

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -42,7 +42,6 @@ class DatabaseBackedActionService(ActionService):
             dataconditiongroupaction__condition_group__organization_id=organization_id,
         ).update(status=status)
 
-
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -1,10 +1,6 @@
-import logging
-
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.service.action.service import ActionService
 from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
-
-logger = logging.getLogger(__name__)
 
 
 class DatabaseBackedActionService(ActionService):
@@ -41,7 +37,6 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_id: int,
     ) -> None:
         Action.objects.filter(
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
             config__target_identifier=str(sentry_app_id),
             type=Action.Type.SENTRY_APP,
             dataconditiongroupaction__condition_group__organization_id=organization_id,
@@ -55,7 +50,6 @@ class DatabaseBackedActionService(ActionService):
         sentry_app_id: int,
     ) -> None:
         Action.objects.filter(
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
             config__target_identifier=str(sentry_app_id),
             type=Action.Type.SENTRY_APP,
         ).update(status=status)

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -39,8 +39,8 @@ class ActionService(RpcService):
     def update_action_status_for_sentry_app_installation(
         self,
         *,
-        organization_id: int,
         status: int,
+        organization_id: int,
         sentry_app_id: int,
     ) -> None:
         pass

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -36,7 +36,7 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abc.abstractmethod
-    def update_action_status_for_sentry_app_via_uuid(
+    def update_action_status_for_sentry_app_installation(
         self,
         *,
         organization_id: int,
@@ -47,7 +47,7 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
-    def update_action_status_for_sentry_app_via_uuid__region(
+    def update_action_status_for_sentry_app_installation__region(
         self,
         *,
         region_name: str,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -39,6 +39,7 @@ class ActionService(RpcService):
     def update_action_status_for_sentry_app_installation(
         self,
         *,
+        region_name: str,
         status: int,
         organization_id: int,
         sentry_app_id: int,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -34,6 +34,29 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
+    def update_action_status_for_sentry_app_via_uuid(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_id: int,
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
+    def update_action_status_for_sentry_app_via_uuid__region(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        organization_id: int,
+        sentry_app_id: int,
+    ) -> None:
+        pass
+
     @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
     def update_action_status_for_sentry_app_installation(

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -34,7 +34,7 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByOrganizationId())
+    @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
     def update_action_status_for_sentry_app_installation(
         self,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -47,30 +47,6 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
-    def update_action_status_for_sentry_app_installation__region(
-        self,
-        *,
-        region_name: str,
-        status: int,
-        organization_id: int,
-        sentry_app_id: int,
-    ) -> None:
-        pass
-
-    @regional_rpc_method(resolve=ByRegionName())
-    @abc.abstractmethod
-    def update_action_status_for_sentry_app_installation(
-        self,
-        *,
-        region_name: str,
-        status: int,
-        organization_id: int,
-        sentry_app_id: int,
-    ) -> None:
-        pass
-
-    @regional_rpc_method(resolve=ByRegionName())
-    @abc.abstractmethod
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
         *,

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -39,15 +39,6 @@ class FallthroughChoiceType(Enum):
 EXCLUDED_ACTION_DATA_KEYS = ["uuid", "id"]
 
 
-class SentryAppIdentifier(StrEnum):
-    """
-    SentryAppIdentifier is an enum that represents the identifier for a Sentry app.
-    """
-
-    SENTRY_APP_INSTALLATION_UUID = "sentry_app_installation_uuid"
-    SENTRY_APP_ID = "sentry_app_id"
-
-
 class ActionType(StrEnum):
     SLACK = "slack"
     MSTEAMS = "msteams"
@@ -244,8 +235,6 @@ class BaseActionTranslator(ABC):
             "target_type": self.target_type if self.target_type is not None else None,
         }
         if self.action_type == ActionType.SENTRY_APP:
-            base_config["sentry_app_identifier"] = SentryAppIdentifier.SENTRY_APP_ID
-
             installs = app_service.get_many(
                 filter={
                     "uuids": [self.target_identifier],

--- a/tests/sentry/deletions/test_sentry_app.py
+++ b/tests/sentry/deletions/test_sentry_app.py
@@ -12,7 +12,6 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test, create_test_regions
 from sentry.users.models.user import User
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @control_silo_test(regions=create_test_regions("us", "de"))
@@ -78,7 +77,6 @@ class TestSentryAppDeletionTask(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -92,7 +90,6 @@ class TestSentryAppDeletionTask(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": "1212121212",
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/deletions/test_sentry_app_installations.py
+++ b/tests/sentry/deletions/test_sentry_app_installations.py
@@ -21,7 +21,6 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @control_silo_test
@@ -124,7 +123,6 @@ class TestSentryAppInstallationDeletionTask(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.install.sentry_app_id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -134,7 +132,6 @@ class TestSentryAppInstallationDeletionTask(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": "1234567890",
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
+++ b/tests/sentry/notifications/notification_action/metric_alert_registry/test_sentry_app_metric_alert_handler.py
@@ -22,7 +22,6 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel, WorkflowEventData
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -43,7 +42,6 @@ class TestSentryAppMetricAlertHandler(MetricAlertHandlerBase):
             config={
                 "target_identifier": str(self.sentry_app.id),
                 "target_type": ActionTarget.SENTRY_APP.value,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
 

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -42,7 +42,6 @@ from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
     ActionFieldMappingKeys,
     EmailActionHelper,
-    SentryAppIdentifier,
     TicketingActionDataBlobHelper,
 )
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -667,7 +666,6 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             data={"settings": data_blob},
             config={
                 "target_identifier": target_id,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
@@ -688,7 +686,6 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             },
             config={
                 "target_identifier": target_id,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP.value,
             },
         )
@@ -713,7 +710,6 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": target_id,
                 "target_type": ActionTarget.SENTRY_APP.value,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
 
@@ -732,7 +728,6 @@ class TestSentryAppIssueAlertHandler(BaseWorkflowTest):
             config={
                 "target_identifier": target_id,
                 "target_type": ActionTarget.SENTRY_APP.value,
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
         blob = self.handler.build_rule_action_blob(action, self.org2.id)

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -21,7 +21,6 @@ from sentry.testutils.silo import control_silo_test
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
 from sentry.workflow_engine.models.action import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 class SentryAppInstallationDetailsTest(APITestCase):
@@ -130,7 +129,6 @@ class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.installation2.sentry_app_id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_details.py
@@ -25,7 +25,6 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.workflow_engine.models.action import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 class SentryAppDetailsTest(APITestCase):
@@ -947,7 +946,6 @@ class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.internal_integration.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -24,11 +24,7 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
 )
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
-from sentry.workflow_engine.typings.notification_action import (
-    ActionTarget,
-    ActionType,
-    SentryAppIdentifier,
-)
+from sentry.workflow_engine.typings.notification_action import ActionTarget, ActionType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest, ProjectAccessTestMixin
 
 
@@ -149,7 +145,6 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
                 "actions": [
                     {
                         "config": {
-                            "sentryAppIdentifier": SentryAppIdentifier.SENTRY_APP_ID,
                             "targetIdentifier": str(self.sentry_app.id),
                             "targetType": ActionType.SENTRY_APP,
                         },
@@ -170,7 +165,6 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert response.status_code == 200
         assert action.type == Action.Type.SENTRY_APP
         assert action.config == {
-            "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             "target_identifier": str(self.sentry_app.id),
             "target_type": ActionTarget.SENTRY_APP.value,
         }

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -23,11 +23,7 @@ from sentry.workflow_engine.models import (
     WorkflowFireHistory,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.typings.notification_action import (
-    ActionTarget,
-    ActionType,
-    SentryAppIdentifier,
-)
+from sentry.workflow_engine.typings.notification_action import ActionTarget, ActionType
 from tests.sentry.workflow_engine.test_base import (
     BaseWorkflowTest,
     MockActionValidatorTranslator,
@@ -711,7 +707,6 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
                 "actions": [
                     {
                         "config": {
-                            "sentryAppIdentifier": SentryAppIdentifier.SENTRY_APP_ID,
                             "targetIdentifier": str(self.sentry_app.id),
                             "targetType": ActionType.SENTRY_APP,
                         },
@@ -748,7 +743,6 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
                 "actions": [
                     {
                         "config": {
-                            "sentryAppIdentifier": SentryAppIdentifier.SENTRY_APP_ID,
                             "targetIdentifier": str(self.sentry_app.id),
                             "targetType": ActionType.SENTRY_APP,
                         },
@@ -792,7 +786,6 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
                 "actions": [
                     {
                         "config": {
-                            "sentryAppIdentifier": SentryAppIdentifier.SENTRY_APP_ID,
                             "targetIdentifier": str(sentry_app.id),
                             "targetType": ActionType.SENTRY_APP,
                         },

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
@@ -8,7 +8,7 @@ from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.workflow_engine.endpoints.validators.base import BaseActionValidator
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.types import WorkflowEventData
-from sentry.workflow_engine.typings.notification_action import ActionType, SentryAppIdentifier
+from sentry.workflow_engine.typings.notification_action import ActionType
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -27,7 +27,6 @@ class TestSentryAppActionValidator(BaseWorkflowTest):
         self.valid_data = {
             "type": Action.Type.SENTRY_APP,
             "config": {
-                "sentryAppIdentifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "targetType": ActionType.SENTRY_APP,
                 "targetIdentifier": str(self.sentry_app.id),
             },
@@ -105,7 +104,6 @@ class TestSentryAppActionValidator(BaseWorkflowTest):
         self.valid_data = {
             "type": Action.Type.SENTRY_APP,
             "config": {
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "targetType": ActionType.SENTRY_APP,
                 "target_identifier": str(sentry_app.id),
             },

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_alert_rule.py
@@ -71,7 +71,6 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
@@ -252,7 +251,6 @@ def assert_sentry_app_action_migrated(
 ) -> None:
     # Verify target_identifier is the string representation of sentry_app_id
     assert action.config.get("target_identifier") == str(alert_rule_trigger_action.sentry_app_id)
-    assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
 
     # Verify data blob has correct structure for Sentry apps
     if not alert_rule_trigger_action.sentry_app_config:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -21,7 +21,6 @@ from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
     SentryAppDataBlob,
-    SentryAppIdentifier,
     TicketDataBlob,
     TicketFieldMappingKeys,
     issue_alert_action_translator_mapping,
@@ -1103,7 +1102,6 @@ class TestNotificationActionMigrationUtils(TestCase):
         for action in actions:
             assert action.type == Action.Type.SENTRY_APP
             assert action.config.get("target_identifier") == str(install.sentry_app.id)
-            assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
 
     def test_dry_run_flag(self) -> None:
         """Test that the dry_run flag prevents database writes."""

--- a/tests/sentry/workflow_engine/migrations/test_0106_migrate_actions_sentry_app_data.py
+++ b/tests/sentry/workflow_engine/migrations/test_0106_migrate_actions_sentry_app_data.py
@@ -1,3 +1,4 @@
+import pytest
 from django.db import connections
 from django.db.migrations.executor import MigrationExecutor
 
@@ -7,9 +8,9 @@ from sentry.testutils.cases import TestMigrations
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
+@pytest.mark.skip
 class TestMigrateActionsSentryAppData(TestMigrations):
     migrate_from = "0105_add_incident_identifer_index"
     migrate_to = "0106_migrate_actions_sentry_app_data"
@@ -29,7 +30,6 @@ class TestMigrateActionsSentryAppData(TestMigrations):
             config={
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": str(self.installation.uuid),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
             },
         )
         self.sentry_app_id_action = Action.objects.create(
@@ -37,7 +37,6 @@ class TestMigrateActionsSentryAppData(TestMigrations):
             config={
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
 
@@ -51,7 +50,6 @@ class TestMigrateActionsSentryAppData(TestMigrations):
             config={
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": str(self.installation2.uuid),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_INSTALLATION_UUID,
             },
         )
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -59,7 +57,6 @@ class TestMigrateActionsSentryAppData(TestMigrations):
 
     def validate_action(self, action: Action) -> None:
         action.refresh_from_db()
-        assert action.config.get("sentry_app_identifier") == SentryAppIdentifier.SENTRY_APP_ID
         assert action.config.get("target_identifier") == str(self.sentry_app.id)
         assert action.config.get("target_type") == ActionTarget.SENTRY_APP
 

--- a/tests/sentry/workflow_engine/processors/test_action_deduplication.py
+++ b/tests/sentry/workflow_engine/processors/test_action_deduplication.py
@@ -8,7 +8,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.action import get_unique_active_actions
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @region_silo_test
@@ -393,7 +392,6 @@ class TestActionDeduplication(TestCase):
             config={
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": "action-123",
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
 
@@ -402,7 +400,6 @@ class TestActionDeduplication(TestCase):
             config={
                 "target_type": ActionTarget.SENTRY_APP,
                 "target_identifier": "action-123",
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
             },
         )
 

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -283,7 +283,7 @@ class TestActionService(TestCase):
         dcg = self.create_data_condition_group(organization=org2)
         self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
 
-        action_service.update_action_status_for_sentry_app_via_uuid(
+        action_service.update_action_status_for_sentry_app_installation(
             organization_id=self.organization.id,
             sentry_app_id=sentry_app_installation.sentry_app.id,
             status=ObjectStatus.DISABLED,

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -5,7 +5,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_regions
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.service.action.service import action_service
-from sentry.workflow_engine.typings.notification_action import SentryAppIdentifier
 
 
 @all_silo_test(regions=create_test_regions("us"))
@@ -140,7 +139,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -177,7 +175,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -222,7 +219,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
             status=ObjectStatus.DISABLED,
@@ -259,7 +255,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -276,7 +271,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -305,7 +299,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )
@@ -313,7 +306,6 @@ class TestActionService(TestCase):
             type=Action.Type.SENTRY_APP,
             config={
                 "target_identifier": str(self.sentry_app_2.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
                 "target_type": ActionTarget.SENTRY_APP,
             },
         )

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -295,51 +295,6 @@ class TestActionService(TestCase):
             assert sentry_app_id_action.status == ObjectStatus.DISABLED
             assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
 
-    def test_update_action_status_for_sentry_app__sentry_app_id__region(self) -> None:
-        sentry_app_installation = self.create_sentry_app_installation(
-            slug=self.sentry_app.slug,
-            organization=self.organization,
-        )
-        sentry_app_id_action = self.create_action(
-            type=Action.Type.SENTRY_APP,
-            config={
-                "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
-                "target_type": ActionTarget.SENTRY_APP,
-            },
-        )
-        dcg = self.create_data_condition_group()
-        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg)
-
-        # make a new org to ensure we are not disabling actions related to the same sentry app
-        org2 = self.create_organization()
-        self.create_sentry_app_installation(
-            slug=self.sentry_app.slug,
-            organization=org2,
-        )
-        sentry_app_id_action2 = self.create_action(
-            type=Action.Type.SENTRY_APP,
-            config={
-                "target_identifier": str(self.sentry_app.id),
-                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
-                "target_type": ActionTarget.SENTRY_APP,
-            },
-        )
-        dcg = self.create_data_condition_group(organization=org2)
-        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
-
-        action_service.update_action_status_for_sentry_app_installation(
-            region_name="us",
-            sentry_app_id=sentry_app_installation.sentry_app.id,
-            organization_id=self.organization.id,
-            status=ObjectStatus.DISABLED,
-        )
-        with assume_test_silo_mode(SiloMode.REGION):
-            sentry_app_id_action.refresh_from_db()
-            sentry_app_id_action2.refresh_from_db()
-            assert sentry_app_id_action.status == ObjectStatus.DISABLED
-            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
-
     def test_update_action_status_for_sentry_app__via_sentry_app_id(self) -> None:
         self.create_sentry_app_installation(
             slug=self.sentry_app_2.slug,

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -266,6 +266,51 @@ class TestActionService(TestCase):
         dcg = self.create_data_condition_group()
         self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg)
 
+        # make a new org to ensure we are not disabling actions related to the same sentry app based on a different installation being removed
+        org2 = self.create_organization()
+        self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=org2,
+        )
+        sentry_app_id_action2 = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group(organization=org2)
+        self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
+
+        action_service.update_action_status_for_sentry_app_via_uuid(
+            organization_id=self.organization.id,
+            sentry_app_id=sentry_app_installation.sentry_app.id,
+            status=ObjectStatus.DISABLED,
+        )
+
+        with assume_test_silo_mode(SiloMode.REGION):
+            sentry_app_id_action.refresh_from_db()
+            sentry_app_id_action2.refresh_from_db()
+            assert sentry_app_id_action.status == ObjectStatus.DISABLED
+            assert sentry_app_id_action2.status == ObjectStatus.ACTIVE
+
+    def test_update_action_status_for_sentry_app__sentry_app_id__region(self) -> None:
+        sentry_app_installation = self.create_sentry_app_installation(
+            slug=self.sentry_app.slug,
+            organization=self.organization,
+        )
+        sentry_app_id_action = self.create_action(
+            type=Action.Type.SENTRY_APP,
+            config={
+                "target_identifier": str(self.sentry_app.id),
+                "sentry_app_identifier": SentryAppIdentifier.SENTRY_APP_ID,
+                "target_type": ActionTarget.SENTRY_APP,
+            },
+        )
+        dcg = self.create_data_condition_group()
+        self.create_data_condition_group_action(action=sentry_app_id_action, condition_group=dcg)
+
         # make a new org to ensure we are not disabling actions related to the same sentry app
         org2 = self.create_organization()
         self.create_sentry_app_installation(

--- a/tests/sentry/workflow_engine/service/test_action_service.py
+++ b/tests/sentry/workflow_engine/service/test_action_service.py
@@ -278,6 +278,7 @@ class TestActionService(TestCase):
         self.create_data_condition_group_action(action=sentry_app_id_action2, condition_group=dcg)
 
         action_service.update_action_status_for_sentry_app_installation(
+            region_name="us",
             organization_id=self.organization.id,
             sentry_app_id=sentry_app_installation.sentry_app.id,
             status=ObjectStatus.DISABLED,


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/107887 and https://github.com/getsentry/sentry/pull/107982 to fully remove all references of `sentry_app_identifier` to prepare for running a migration to remove it from the database. 