### PR TITLE
chore: Update MCP server URL with org scope and experimental flag

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "sentry": {
-      "url": "https://mcp.sentry.dev/mcp"
+      "url": "https://mcp.sentry.dev/mcp/sentry?experimental=1"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "sentry": {
       "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
+      "url": "https://mcp.sentry.dev/mcp/sentry?experimental=1"
     }
   }
 }


### PR DESCRIPTION
Update the Sentry MCP server URL to scope it to the `sentry` organization and enable experimental features.

Changes the URL from `https://mcp.sentry.dev/mcp` to `https://mcp.sentry.dev/mcp/sentry?experimental=1`.