### PR TITLE
chore(aci): Allow metric issue types to be enabled in the issue stream detector vis the `workflow-engine-metric-issue-ui` flag

### DIFF
--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -364,7 +364,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert not result.data.triggered_workflows
         assert result.msg == "Environment for event not found"
 
-        mock_incr.assert_called_once_with(
+        mock_incr.assert_any_call(
             "workflow_engine.process_workflows.error", 1, tags={"detector_type": "error"}
         )
         mock_logger.exception.assert_called_once_with(


### PR DESCRIPTION
This ties the flags for enabling the ui for these metric issues to allowing the issue stream detector the process them.
