### PR TITLE
fix(autofix): Only require repos for manual rca

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -143,12 +143,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
       noAutofixQuota ||
       // needs to configure repos
       !aiConfig.seerReposLinked ||
-      // needs to have autofix enabled for this group's project
-      !aiConfig.autofixEnabled ||
-      // needs to enable autofix
-      !data?.isAutofixEnabled ||
-      // catch all, ensure seer is configured
-      !data?.isSeerConfigured
+      !data?.hasSupportedScmIntegration
     ) {
       return (
         <SeerDrawerContainer className="seer-drawer-container">


### PR DESCRIPTION
It doesn't make sense to require users to configure autofix automations in order to use autofix manually. Remove those checks and let users run it manually.
