### PR TITLE
ref(explorer): always capture project page filters in snapshot

### DIFF
--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -906,10 +906,7 @@ function useAsciiSnapshot() {
     renderTextNodes(context, chartContainers);
 
     const projectSlugs: string[] = [];
-    const projectSelector = document.querySelector(
-      '[data-test-id="page-filter-project-selector"]'
-    );
-    if (projectSelector && selection.projects.length > 0) {
+    if (selection.projects.length > 0) {
       const projectIdToSlug = new Map(projects.map(p => [parseInt(p.id, 10), p.slug]));
       for (const projectId of selection.projects) {
         const slug = projectIdToSlug.get(projectId);


### PR DESCRIPTION
slack feedback surfaced the problem that many pages - e.g. transaction summary/insights - have project in URL filters but no project selector DOM element. We expect the number of pages with project filters that _dont_ apply to the data on the page is small/non-existent, so let's always include these