### PR TITLE
chore(ai-conversations): Clean up 100% sampling from the AI conversations endpoint

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -88,8 +88,6 @@ SAMPLED_TASKS = {
 SAMPLED_ROUTES = {
     "/_warmup/": 0.0,
     "/api/0/auth/validate/": 0.0,
-    # Temporary: 100% sampling for ai-conversations endpoint debugging (sentry org)
-    "/api/0/organizations/sentry/ai-conversations/": 1.0,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:


### PR DESCRIPTION
We no longer need it, if we will need it, we can instrument it again

closes [TET-1910: Clean up 100% sampling of conversation endpoints](https://linear.app/getsentry/issue/TET-1910/clean-up-100percent-sampling-of-conversation-endpoints)