### PR TITLE
chore(explore): Update trace item attribute hooks to remove context

### DIFF
--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -41,11 +41,19 @@ type TypedTraceItemAttributesStatus = {
 type TypedTraceItemAttributesResult = TypedTraceItemAttributes &
   TypedTraceItemAttributesStatus;
 
+type TraceItemAttributeType = 'number' | 'string' | 'boolean';
+
+export type TraceItemAttributeResult = {
+  attributes: TagCollection;
+  isLoading: boolean;
+  secondaryAliases: TagCollection;
+};
+
 const TraceItemAttributeContext = createContext<
   TypedTraceItemAttributesResult | undefined
 >(undefined);
 
-type TraceItemAttributeConfig = {
+export type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
   projects?: Project[];
@@ -53,10 +61,19 @@ type TraceItemAttributeConfig = {
   search?: string;
 };
 
+const DISABLED_CONFIG: TraceItemAttributeConfig = {
+  enabled: false,
+  traceItemType: TraceItemDataset.SPANS,
+};
+
 type TraceItemAttributeProviderProps = {
   children: React.ReactNode;
 } & TraceItemAttributeConfig;
 
+/**
+ * @deprecated Use `useTraceItemAttributes` with a config argument instead
+ * of wrapping children in a provider.
+ */
 export function TraceItemAttributeProvider({
   children,
   traceItemType,
@@ -86,7 +103,7 @@ function useTraceItemAttributeConfig({
   projects,
   search,
   query,
-}: TraceItemAttributeConfig) {
+}: TraceItemAttributeConfig): TypedTraceItemAttributesResult {
   const organization = useOrganization();
   const hasBooleanFilters = organization.features.includes(
     'search-query-builder-explicit-boolean-filters'
@@ -206,7 +223,7 @@ function useTraceItemAttributeConfig({
 
 function processTraceItemAttributes(
   typedAttributesResult: TypedTraceItemAttributesResult,
-  type?: 'number' | 'string' | 'boolean',
+  type?: TraceItemAttributeType,
   hiddenKeys?: string[]
 ) {
   if (type === 'boolean') {
@@ -242,24 +259,89 @@ function processTraceItemAttributes(
   };
 }
 
-export function useTraceItemAttributes(
-  type?: 'number' | 'string' | 'boolean',
-  hiddenKeys?: string[]
+function isTraceItemAttributeConfig(
+  value: TraceItemAttributeConfig | TraceItemAttributeType | undefined
+): value is TraceItemAttributeConfig {
+  return typeof value === 'object' && value !== null;
+}
+
+function isTraceItemAttributeType(
+  value: TraceItemAttributeType | string[] | undefined
+): value is TraceItemAttributeType {
+  return value === 'boolean' || value === 'number' || value === 'string';
+}
+
+function resolveTraceItemAttributeArgs(
+  configOrType: TraceItemAttributeConfig | TraceItemAttributeType | undefined,
+  typeOrHiddenKeys: TraceItemAttributeType | string[] | undefined,
+  maybeHiddenKeys: string[] | undefined
 ) {
-  const typedAttributesResult = useContext(TraceItemAttributeContext);
+  if (isTraceItemAttributeConfig(configOrType)) {
+    return {
+      isConfigMode: true,
+      config: configOrType,
+      type: isTraceItemAttributeType(typeOrHiddenKeys) ? typeOrHiddenKeys : undefined,
+      hiddenKeys: maybeHiddenKeys,
+    };
+  }
+
+  return {
+    isConfigMode: false,
+    config: DISABLED_CONFIG,
+    type: configOrType,
+    hiddenKeys: Array.isArray(typeOrHiddenKeys) ? typeOrHiddenKeys : undefined,
+  };
+}
+
+export function useTraceItemAttributes(
+  config: TraceItemAttributeConfig,
+  type?: TraceItemAttributeType,
+  hiddenKeys?: string[]
+): TraceItemAttributeResult;
+
+/**
+ * @deprecated Pass a `TraceItemAttributeConfig` as the first argument instead
+ * of relying on `TraceItemAttributeProvider` context.
+ */
+export function useTraceItemAttributes(
+  type?: TraceItemAttributeType,
+  hiddenKeys?: string[]
+): TraceItemAttributeResult;
+
+export function useTraceItemAttributes(
+  configOrType?: TraceItemAttributeConfig | TraceItemAttributeType,
+  typeOrHiddenKeys?: TraceItemAttributeType | string[],
+  maybeHiddenKeys?: string[]
+): TraceItemAttributeResult {
+  const args = resolveTraceItemAttributeArgs(
+    configOrType,
+    typeOrHiddenKeys,
+    maybeHiddenKeys
+  );
+
+  // Always call both to satisfy React hooks rules of unconditional calls.
+  // When in context mode, useTraceItemAttributeConfig runs with enabled: false (no API calls).
+  // When in config mode, useContext just returns undefined harmlessly.
+  const contextResult = useContext(TraceItemAttributeContext);
+  const configResult = useTraceItemAttributeConfig(args.config);
+
+  const typedAttributesResult = args.isConfigMode ? configResult : contextResult;
 
   if (typedAttributesResult === undefined) {
     throw new Error(
-      'useTraceItemAttributes must be used within a TraceItemAttributeProvider'
+      'useTraceItemAttributes must be used within a TraceItemAttributeProvider or called with a config'
     );
   }
 
-  return processTraceItemAttributes(typedAttributesResult, type, hiddenKeys);
+  return processTraceItemAttributes(typedAttributesResult, args.type, args.hiddenKeys);
 }
 
+/**
+ * @deprecated Use `useTraceItemAttributes` with a config argument instead.
+ */
 export function useTraceItemAttributesWithConfig(
   config: TraceItemAttributeConfig,
-  type?: 'number' | 'string' | 'boolean',
+  type?: TraceItemAttributeType,
   hiddenKeys?: string[]
 ) {
   const typedAttributesResult = useTraceItemAttributeConfig(config);


### PR DESCRIPTION
This PR is the initial step in working to remove the `TraceItemAttributeContext` so that we can tidy things up and remove some duplicate code.

Ticket: EXP-726