### PR TITLE
fix(spans,logs): Adjust collapse buttons placement

### DIFF
--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -404,12 +404,14 @@ export const LogsSidebarCollapseButton = styled(Button)<{sidebarOpen: boolean}>`
   ${p =>
     p.sidebarOpen &&
     css`
-      margin-left: -13px;
+      margin-left: -17px;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
 
       &::after {
         border-left-color: ${p.theme.tokens.border.primary};
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
       }
     `}
 `;

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -390,12 +390,14 @@ const ChevronButton = styled(Button)<{expanded: boolean}>`
   ${p =>
     p.expanded &&
     css`
-      margin-left: -13px;
+      margin-left: -17px;
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
 
       &::after {
         border-left-color: ${p.theme.tokens.border.primary};
-        border-top-left-radius: 0px;
-        border-bottom-left-radius: 0px;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
       }
     `}
 `;


### PR DESCRIPTION
The collapse button in logs and spans were a little off

Before:

<img width="300" height="729" alt="Screenshot 2026-02-11 at 11 41 13" src="https://github.com/user-attachments/assets/444f61cb-6090-4575-a944-1e8ed8b0c6d4" />

After:

<img width="300" height="526" alt="Screenshot 2026-02-11 at 13 33 20" src="https://github.com/user-attachments/assets/e8ce8dc6-aa7a-4a09-955e-d4dff13b0b7b" />

I also adapted the box shadow of the button:

Before:

<img width="182" height="135" alt="Screenshot 2026-02-11 at 13 44 15" src="https://github.com/user-attachments/assets/c76ec191-b8dd-4782-a20d-a402cc45a4a0" />


After:

<img width="198" height="145" alt="Screenshot 2026-02-11 at 13 44 25" src="https://github.com/user-attachments/assets/5f70fa23-71a7-4445-afd8-55a676fd0148" />

