### PR TITLE
fix(ui): disallow body scroll while drawer is open

### DIFF
--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -460,11 +460,6 @@ const SeerDrawerBody = styled(DrawerBody)`
   scroll-margin: 0 ${p => p.theme.space.xl};
   display: flex;
   flex-direction: column;
-  direction: rtl;
-
-  > * {
-    direction: ltr;
-  }
 `;
 
 const Header = styled('h3')`

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -118,15 +118,16 @@ export function GlobalDrawer({children}: any) {
 
   // If no config is set, the global drawer is closed.
   const isDrawerOpen = !!currentDrawerConfig;
-  const previousOverflowRef = useRef('');
+  const previousOverflowRef = useRef<string>(null);
   const openDrawer = useCallback<DrawerContextType['openDrawer']>((renderer, options) => {
-    previousOverflowRef.current = document.body.style.overflow;
+    previousOverflowRef.current ??= document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     overwriteDrawerConfig({renderer, options});
     options.onOpen?.();
   }, []);
   const closeDrawer = useCallback<DrawerContextType['closeDrawer']>(() => {
-    document.body.style.overflow = previousOverflowRef.current;
+    document.body.style.overflow = previousOverflowRef.current ?? '';
+    previousOverflowRef.current = null;
     overwriteDrawerConfig(undefined);
   }, []);
 

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -118,14 +118,17 @@ export function GlobalDrawer({children}: any) {
 
   // If no config is set, the global drawer is closed.
   const isDrawerOpen = !!currentDrawerConfig;
+  const previousOverflowRef = useRef('');
   const openDrawer = useCallback<DrawerContextType['openDrawer']>((renderer, options) => {
+    previousOverflowRef.current = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
     overwriteDrawerConfig({renderer, options});
     options.onOpen?.();
   }, []);
-  const closeDrawer = useCallback<DrawerContextType['closeDrawer']>(
-    () => overwriteDrawerConfig(undefined),
-    []
-  );
+  const closeDrawer = useCallback<DrawerContextType['closeDrawer']>(() => {
+    document.body.style.overflow = previousOverflowRef.current;
+    overwriteDrawerConfig(undefined);
+  }, []);
 
   const handleClose = useCallback(() => {
     currentDrawerConfig?.options?.onClose?.();


### PR DESCRIPTION
When a `drawer` is open, the `body` shouldn’t be scrollable as the drawer content is meant to “overlay” the content behind it.