### PR TITLE
Seer drawer direction property

### DIFF
--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -460,11 +460,6 @@ const SeerDrawerBody = styled(DrawerBody)`
   scroll-margin: 0 ${p => p.theme.space.xl};
   display: flex;
   flex-direction: column;
-  direction: rtl;
-
-  > * {
-    direction: ltr;
-  }
 `;
 
 const Header = styled('h3')`


### PR DESCRIPTION
<!-- Describe your PR here. -->
Removes `direction: rtl` and `direction: ltr` overrides from `SeerDrawerBody` in `explorerSeerDrawer.tsx`. This CSS was causing the scrollbar to appear in the middle of the page on some systems, rather than on the right edge.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/C087YQX2WH2/p1770802337781919?thread_ts=1770802337.781919&cid=C087YQX2WH2)

<p><a href="https://cursor.com/background-agent?bcId=bc-0ac45f89-b004-519e-9496-6b1920ea2b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ac45f89-b004-519e-9496-6b1920ea2b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

