### PR TITLE
ref(scraps): replace all deprecated space() usages in scraps

### DIFF
--- a/static/app/components/core/alert/alert.tsx
+++ b/static/app/components/core/alert/alert.tsx
@@ -10,7 +10,6 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {IconCheckmark, IconChevron, IconInfo, IconNot, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import PanelProvider from 'sentry/utils/panelProvider';
 import type {AlertVariant} from 'sentry/utils/theme';
@@ -306,7 +305,7 @@ function AlertIcon({variant}: {variant: AlertProps['variant']}): React.ReactNode
  */
 const Container = styled('div')`
   > div {
-    margin-bottom: ${space(2)};
+    margin-bottom: ${p => p.theme.space.xl};
   }
 `;
 

--- a/static/app/components/core/alert/alertLink.tsx
+++ b/static/app/components/core/alert/alertLink.tsx
@@ -6,7 +6,6 @@ import {Alert, type AlertProps} from '@sentry/scraps/alert';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {IconChevron} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 
 interface BaseAlertLinkProps extends Pick<
   AlertProps,
@@ -142,7 +141,7 @@ function textDecorationStyles({
  */
 const Container = styled('div')`
   > a {
-    margin-bottom: ${space(2)};
+    margin-bottom: ${p => p.theme.space.xl};
   }
 `;
 

--- a/static/app/components/core/badge/tag.tsx
+++ b/static/app/components/core/badge/tag.tsx
@@ -6,7 +6,6 @@ import {Button} from '@sentry/scraps/button';
 import {IconClose} from 'sentry/icons';
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {TagVariant} from 'sentry/utils/theme';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -61,7 +60,7 @@ const TagPill = styled('div')<{
   display: inline-flex;
   align-items: center;
   border-radius: ${p => p.theme.radius.xs};
-  padding: 0 ${space(1)};
+  padding: 0 ${p => p.theme.space.md};
 
   /* @TODO(jonasbadalic): We need to override button colors because they wrongly default to a blue color... */
   button,
@@ -119,18 +118,18 @@ const Text = styled('div')`
   /* @TODO(jonasbadalic): Some occurrences pass other things than strings into the children prop. */
   display: flex;
   align-items: center;
-  gap: ${space(0.5)};
+  gap: ${p => p.theme.space.xs};
 `;
 
 const IconWrapper = styled('span')`
-  margin-right: ${space(0.5)};
+  margin-right: ${p => p.theme.space.xs};
   display: inline-flex;
   align-items: center;
   gap: inherit;
 `;
 
 const DismissButton = styled(Button)`
-  margin-left: ${space(0.5)};
-  margin-right: -${space(0.5)};
+  margin-left: ${p => p.theme.space.xs};
+  margin-right: -${p => p.theme.space.xs};
   border: none;
 `;

--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -8,7 +8,6 @@ import {Container} from '@sentry/scraps/layout';
 
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {getPrismLanguage, loadPrismLanguage} from 'sentry/utils/prism';
 // eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
@@ -245,7 +244,7 @@ const Header = styled('div')<{isFloating: boolean}>`
   ${p =>
     p.isFloating
       ? css`
-          gap: ${space(0.25)};
+          gap: ${p.theme.space['2xs']};
           justify-content: flex-end;
           position: absolute;
           top: 0;
@@ -253,11 +252,11 @@ const Header = styled('div')<{isFloating: boolean}>`
           width: max-content;
           height: max-content;
           max-height: 100%;
-          padding: ${space(0.5)};
+          padding: ${p.theme.space.xs};
         `
       : css`
-          gap: ${space(0.75)};
-          padding: ${space(0.5)} ${space(0.5)} 0 ${space(1)};
+          gap: ${p.theme.space.sm};
+          padding: ${p.theme.space.xs} ${p.theme.space.xs} 0 ${p.theme.space.md};
           border-bottom: solid 1px ${p.theme.tokens.border.primary};
         `}
 `;
@@ -281,7 +280,7 @@ const Tab = styled('button')<{isSelected: boolean}>`
   margin: 0;
   border: none;
   background: none;
-  padding: ${space(1)} ${space(1)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.md};
   color: var(--prism-comment);
   ${p =>
     p.isSelected

--- a/static/app/components/core/compactSelect/composite.tsx
+++ b/static/app/components/core/compactSelect/composite.tsx
@@ -5,7 +5,6 @@ import {Item} from '@react-stately/collections';
 import type {DistributedOmit} from 'type-fest';
 
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 import type {ControlProps} from './control';
 import {Control} from './control';
@@ -156,18 +155,18 @@ function Region<Value extends SelectKey>({
 const RegionsWrap = styled('div')`
   min-height: 0;
   overflow: auto;
-  padding: ${space(0.5)} 0;
+  padding: ${p => p.theme.space.xs} 0;
 
   /* Add 1px to top padding if preceded by menu header, to account for the header's
   shadow border */
   [data-menu-has-header='true'] > div > & {
-    padding-top: calc(${space(0.5)} + 1px);
+    padding-top: calc(${p => p.theme.space.xs} + 1px);
   }
 
   /* Add 1px to bottom padding if succeeded by menu footer, to account for the footer's
   shadow border */
   [data-menu-has-footer='true'] > div > & {
-    padding-bottom: calc(${space(0.5)} + 1px);
+    padding-bottom: calc(${p => p.theme.space.xs} + 1px);
   }
 
   /* Remove padding inside lists */

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -27,7 +27,6 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 import type {UseOverlayProps} from 'sentry/utils/useOverlay';
 import useOverlay from 'sentry/utils/useOverlay';
@@ -587,17 +586,18 @@ const StyledBadge = styled(Badge)`
   top: auto;
 `;
 
-const headerVerticalPadding: Record<NonNullable<ControlProps['size']>, string> = {
-  xs: space(0.25),
-  sm: space(0.5),
-  md: space(0.75),
-};
 const MenuHeader = styled('div')<{size: NonNullable<ControlProps['size']>}>`
   position: relative;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: ${p => headerVerticalPadding[p.size]} ${space(1.5)};
+  padding: ${p =>
+      p.size === 'xs'
+        ? p.theme.space['2xs']
+        : p.size === 'sm'
+          ? p.theme.space.xs
+          : p.theme.space.sm}
+    ${p => p.theme.space.lg};
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   box-shadow: 0 1px 0 ${p => p.theme.tokens.border.transparent.neutral.muted};
 
@@ -616,14 +616,14 @@ const MenuHeader = styled('div')<{size: NonNullable<ControlProps['size']>}>`
 const MenuHeaderTrailingItems = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  gap: ${space(0.5)};
+  gap: ${p => p.theme.space.xs};
 `;
 
 const MenuTitle = styled('span')`
   font-size: inherit; /* Inherit font size from MenuHeader */
   font-weight: ${p => p.theme.font.weight.sans.medium};
   white-space: nowrap;
-  margin-right: ${space(2)};
+  margin-right: ${p => p.theme.space.xl};
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
@@ -638,19 +638,19 @@ const ClearButton = styled(Button)`
   font-size: inherit; /* Inherit font size from MenuHeader */
   font-weight: ${p => p.theme.font.weight.sans.regular};
   color: ${p => p.theme.tokens.content.secondary};
-  padding: 0 ${space(0.5)};
-  margin: -${space(0.25)} -${space(0.5)};
+  padding: 0 ${p => p.theme.space.xs};
+  margin: -${p => p.theme.space['2xs']} -${p => p.theme.space.xs};
 `;
 
 const SearchInput = styled(InputGroup.Input)`
   appearance: none;
-  width: calc(100% - ${space(0.5)} * 2);
-  margin: ${space(0.5)} ${space(0.5)};
+  width: calc(100% - ${p => p.theme.space.xs} * 2);
+  margin: ${p => p.theme.space.xs} ${p => p.theme.space.xs};
 
   /* Add 1px to top margin if immediately preceded by menu header, to account for the
   header's shadow border. Account for InputGroup wrapper div. */
   [data-menu-has-header='true'] > * > & {
-    margin-top: calc(${space(0.5)} + 1px);
+    margin-top: calc(${p => p.theme.space.xs} + 1px);
   }
 `;
 const withUnits = (value: unknown) => (typeof value === 'string' ? value : `${value}px`);
@@ -692,6 +692,6 @@ const StyledPositionWrapper = styled(PositionWrapper, {
 const MenuFooter = styled('div')`
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   box-shadow: 0 -1px 0 ${p => p.theme.tokens.border.transparent.neutral.muted};
-  padding: ${space(1)} ${space(1.5)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   z-index: 2;
 `;

--- a/static/app/components/core/compactSelect/gridList/option.tsx
+++ b/static/app/components/core/compactSelect/gridList/option.tsx
@@ -12,7 +12,6 @@ import {LeadWrap} from '@sentry/scraps/compactSelect';
 import {InnerWrap, MenuListItem} from '@sentry/scraps/menuListItem';
 
 import {IconCheckmark} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 import type {FormSize} from 'sentry/utils/theme';
 
 export interface GridListOptionProps extends AriaGridListItemOptions {
@@ -140,6 +139,6 @@ export function GridListOption({node, listState, size}: GridListOptionProps) {
 
 const StyledMenuListItem = styled(MenuListItem)`
   > ${InnerWrap} {
-    padding-left: ${space(1)};
+    padding-left: ${p => p.theme.space.md};
   }
 `;

--- a/static/app/components/core/compactSelect/listBox/option.tsx
+++ b/static/app/components/core/compactSelect/listBox/option.tsx
@@ -15,7 +15,6 @@ import {
 } from '@sentry/scraps/menuListItem';
 
 import {IconCheckmark} from 'sentry/icons';
-import {space} from 'sentry/styles/space';
 
 export interface ListBoxOptionProps extends AriaOptionProps {
   item: Node<any>;
@@ -128,6 +127,6 @@ export function ListBoxOption({
 
 const StyledMenuListItem = styled(MenuListItem)`
   > ${InnerWrap} {
-    padding-left: ${space(1)};
+    padding-left: ${p => p.theme.space.md};
   }
 `;

--- a/static/app/components/core/compactSelect/styles.tsx
+++ b/static/app/components/core/compactSelect/styles.tsx
@@ -8,22 +8,20 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {Flex, type FlexProps} from '@sentry/scraps/layout';
 
-import {space} from 'sentry/styles/space';
-
 export const ListWrap = styled('ul')`
   margin: 0;
-  padding: ${space(0.5)} 0;
+  padding: ${p => p.theme.space.xs} 0;
 
   /* Add 1px to top padding if preceded by menu header, to account for the header's
   shadow border */
   [data-menu-has-header='true'] > div > &:first-of-type {
-    padding-top: calc(${space(0.5)} + 1px);
+    padding-top: calc(${p => p.theme.space.xs} + 1px);
   }
 
   /* Add 1px to bottom padding if succeeded by menu footer, to account for the footer's
   shadow border */
   [data-menu-has-footer='true'] > div > &:last-of-type {
-    padding-bottom: calc(${space(0.5)} + 1px);
+    padding-bottom: calc(${p => p.theme.space.xs} + 1px);
   }
 
   /* Remove top padding if preceded by search input, since search input already has
@@ -55,13 +53,13 @@ export const ListLabel = styled('p')`
   color: ${p => p.theme.tokens.content.secondary};
   text-transform: uppercase;
   white-space: nowrap;
-  margin: ${space(0.5)} ${space(1.5)};
-  padding-right: ${space(1)};
+  margin: ${p => p.theme.space.xs} ${p => p.theme.space.lg};
+  padding-right: ${p => p.theme.space.md};
 `;
 
 export const ListSeparator = styled('div')`
   border-top: solid 1px ${p => p.theme.tokens.border.secondary};
-  margin: ${space(0.5)} ${space(1.5)};
+  margin: ${p => p.theme.space.xs} ${p => p.theme.space.lg};
 
   :first-child {
     display: none;
@@ -82,7 +80,7 @@ export const SectionHeader = styled('div')`
   align-items: center;
   box-sizing: content-box;
   height: 1.5em;
-  padding: ${space(0.25)} ${space(1.5)};
+  padding: ${p => p.theme.space['2xs']} ${p => p.theme.space.lg};
 
   /* Remove top padding if this is the first section in a headerless menu (selected
   with li:nth-of-type(2) because the first list item is a hidden separator) */
@@ -103,12 +101,12 @@ export const SectionTitle = styled('p')`
   white-space: nowrap;
 
   margin: 0;
-  padding-right: ${space(4)};
+  padding-right: ${p => p.theme.space['3xl']};
 `;
 
 export const SectionToggleButton = styled(Button)<{visible: boolean}>`
-  padding: 0 ${space(0.5)};
-  margin: 0 -${space(0.5)} 0 ${space(2)};
+  padding: 0 ${p => p.theme.space.xs};
+  margin: 0 -${p => p.theme.space.xs} 0 ${p => p.theme.space.xl};
   font-weight: ${p => p.theme.font.weight.sans.regular};
   font-size: ${p => p.theme.font.size.sm};
   color: ${p => p.theme.tokens.content.secondary};
@@ -140,7 +138,7 @@ export const SectionToggleButton = styled(Button)<{visible: boolean}>`
 export const SectionSeparator = styled('li')`
   list-style-type: none;
   border-top: solid 1px ${p => p.theme.tokens.border.secondary};
-  margin: ${space(0.5)} ${space(1.5)};
+  margin: ${p => p.theme.space.xs} ${p => p.theme.space.lg};
 
   &:first-of-type {
     display: none;
@@ -168,7 +166,7 @@ export function LeadWrap(props: FlexProps) {
 export const EmptyMessage = styled('p')`
   text-align: center;
   color: ${p => p.theme.tokens.content.secondary};
-  padding: ${space(1)} ${space(1.5)} ${space(1.5)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg} ${p => p.theme.space.lg};
   margin: 0;
 
   /* Message should only be displayed when _all_ preceding lists are empty */
@@ -181,8 +179,8 @@ export const EmptyMessage = styled('p')`
 
 export const SizeLimitMessage = styled('li')`
   border-top: solid 1px ${p => p.theme.tokens.border.secondary};
-  margin: ${space(0.5)} ${space(1.5)} ${space(0.5)};
-  padding: ${space(0.75)} ${space(1)} 0;
+  margin: ${p => p.theme.space.xs} ${p => p.theme.space.lg} ${p => p.theme.space.xs};
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md} 0;
 
   font-size: ${p => p.theme.font.size.sm};
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/components/core/input/inputGroup.tsx
+++ b/static/app/components/core/input/inputGroup.tsx
@@ -11,7 +11,6 @@ import styled from '@emotion/styled';
 
 import type {InputProps} from '@sentry/scraps/input';
 
-import {space} from 'sentry/styles/space';
 import type {FormSize, StrictCSSObject, Theme} from 'sentry/utils/theme';
 
 // There is a cycle here if we import textarea from scraps.
@@ -32,7 +31,7 @@ const InputItemsWrap = styled('div')`
   display: grid;
   grid-auto-flow: column;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
 
   /* Do not use transform here to do alignment as it will create a new stacking
    * context, breaking things like dropdown menus */

--- a/static/app/components/core/input/numberInput.tsx
+++ b/static/app/components/core/input/numberInput.tsx
@@ -13,7 +13,6 @@ import {InputGroup} from '@sentry/scraps/input';
 
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 
 interface NumberInputProps
   extends
@@ -107,14 +106,14 @@ const StepWrap = styled('div')<{size?: NonNullable<NumberInputProps['size']>}>`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: ${space(1.5)};
+  width: ${p => p.theme.space.lg};
   height: ${p => (p.size === 'xs' ? '1rem' : '1.25rem')};
 `;
 
 const StepButton = styled(Button)`
   display: flex;
   height: 50%;
-  padding: 0 ${space(0.25)};
+  padding: 0 ${p => p.theme.space['2xs']};
   min-height: 0;
   color: ${p => p.theme.tokens.content.secondary};
 `;

--- a/static/app/components/core/menuListItem/menuListItem.mdx
+++ b/static/app/components/core/menuListItem/menuListItem.mdx
@@ -17,7 +17,6 @@ import styled from '@emotion/styled';
 import {MenuListItem} from '@sentry/scraps/menuListItem';
 
 import * as Storybook from 'sentry/stories';
-import {space} from 'sentry/styles/space';
 
 import documentation from '!!type-loader!@sentry/scraps/menuListItem';
 
@@ -263,7 +262,7 @@ const CustomMenu = () => {
 For more information, see the [WAI-ARIA Menu practices](https://www.w3.org/WAI/ARIA/apg/patterns/menu/).
 
 export const Container = styled('div')`
-  margin-top: ${space(0.5)};
+  margin-top: ${p => p.theme.space.xs};
   border: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.radius.md};
 `;

--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -12,7 +12,6 @@ import type {TooltipProps} from '@sentry/scraps/tooltip';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
-import {space} from 'sentry/styles/space';
 import type {FormSize, Theme} from 'sentry/utils/theme';
 
 /**
@@ -47,15 +46,15 @@ function getTextColor({
  * Returns the appropriate vertical padding based on the size prop. To be used
  * as top/bottom padding/margin in InnerWrap
  */
-const getVerticalPadding = (size?: FormSize) => {
+const getVerticalPadding = (size: FormSize | undefined, theme: Theme) => {
   switch (size) {
     case 'xs':
-      return space(0.5);
+      return theme.space.xs;
     case 'sm':
-      return space(0.75);
+      return theme.space.sm;
     case 'md':
     default:
-      return space(1);
+      return theme.space.md;
   }
 };
 
@@ -72,9 +71,9 @@ const StyledInnerWrap = styled('div', {
 }>`
   display: flex;
   position: relative;
-  padding: 0 ${space(1)} 0 ${space(1.5)};
-  padding-top: ${p => getVerticalPadding(p.size)};
-  padding-bottom: ${p => getVerticalPadding(p.size)};
+  padding: 0 ${p => p.theme.space.md} 0 ${p => p.theme.space.lg};
+  padding-top: ${p => getVerticalPadding(p.size, p.theme)};
+  padding-bottom: ${p => getVerticalPadding(p.size, p.theme)};
   border-radius: ${p => p.theme.radius.md};
   box-sizing: border-box;
 
@@ -119,7 +118,7 @@ const StyledContentWrap = styled('div')<{
   width: 100%;
   min-width: 0;
   display: flex;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   justify-content: space-between;
   padding: 0;
 `;
@@ -129,8 +128,8 @@ const StyledLeadingItems = styled('div')<{
   size?: FormSize;
 }>`
   display: flex;
-  gap: ${space(1)};
-  margin-right: ${space(1)};
+  gap: ${p => p.theme.space.md};
+  margin-right: ${p => p.theme.space.md};
   flex-shrink: 0;
   align-items: flex-start;
 
@@ -408,9 +407,9 @@ const MenuItemWrap = styled('li')`
   position: static;
   list-style-type: none;
   margin: 0;
-  padding: 0 ${space(0.5)};
+  padding: 0 ${p => p.theme.space.xs};
   cursor: pointer;
-  scroll-margin: ${space(0.5)} 0;
+  scroll-margin: ${p => p.theme.space.xs} 0;
 
   &:focus {
     outline: none;
@@ -428,8 +427,8 @@ const TrailingItems = styled('div')<{disabled: boolean}>`
   display: flex;
   align-items: center;
   height: 1.4em;
-  gap: ${space(1)};
-  margin-right: ${space(0.5)};
+  gap: ${p => p.theme.space.md};
+  margin-right: ${p => p.theme.space.xs};
 
   ${p => p.disabled && `opacity: 0.5;`}
 `;

--- a/static/app/components/core/segmentedControl/segmentedControl.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.tsx
@@ -15,7 +15,6 @@ import {DO_NOT_USE_getButtonStyles} from '@sentry/scraps/button';
 import type {TooltipProps} from '@sentry/scraps/tooltip';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {space} from 'sentry/styles/space';
 import type {FormSize, Theme} from 'sentry/utils/theme';
 
 type Priority = 'default' | 'primary';
@@ -327,7 +326,7 @@ const LabelWrap = styled('span')<{
   display: grid;
   grid-auto-flow: column;
   align-items: center;
-  gap: ${p => (p.size === 'xs' ? space(0.5) : space(0.75))};
+  gap: ${p => (p.size === 'xs' ? p.theme.space.xs : p.theme.space.sm)};
   z-index: 1;
   color: ${p => getTextColor(p)};
 `;

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -24,7 +24,6 @@ import {
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconChevron, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Choices, SelectValue} from 'sentry/types/core';
 import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
 import PanelProvider from 'sentry/utils/panelProvider';
@@ -184,7 +183,7 @@ const getStylesConfig = ({
       alignItems: 'center',
       marginLeft: 0,
       marginRight: 0,
-      width: `calc(100% - ${theme.form[size].paddingLeft}px - ${space(0.5)})`,
+      width: `calc(100% - ${theme.form[size].paddingLeft}px - ${theme.space.xs})`,
     }),
     placeholder: (provided, state) => ({
       ...provided,
@@ -244,7 +243,7 @@ const getStylesConfig = ({
       fontWeight: 600,
       color: theme.tokens.content.secondary,
       marginBottom: 0,
-      padding: `${space(0.5)} ${space(1.5)}`,
+      padding: `${theme.space.xs} ${theme.space.lg}`,
       ':empty': {
         display: 'none',
       },
@@ -257,14 +256,14 @@ const getStylesConfig = ({
       },
       ':not(:last-of-type)': {
         position: 'relative',
-        marginBottom: space(1),
+        marginBottom: theme.space.md,
       },
       // Add divider between sections
       ':not(:last-of-type)::after': {
         content: '""',
         position: 'absolute',
-        left: space(1.5),
-        right: space(1.5),
+        left: theme.space.lg,
+        right: theme.space.lg,
         bottom: 0,
         borderBottom: `solid 1px ${theme.tokens.border.secondary}`,
       },
@@ -380,7 +379,7 @@ function SingleValue(props: React.ComponentProps<typeof selectComponents.SingleV
 const SingleValueWrap = styled('div')`
   display: grid;
   grid-auto-flow: column;
-  gap: ${space(1)};
+  gap: ${p => p.theme.space.md};
   align-items: center;
 `;
 

--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -6,8 +6,6 @@ import {motion, type Transition} from 'framer-motion';
 
 import {BoundaryContextProvider} from '@sentry/scraps/boundaryContext';
 
-import {space} from 'sentry/styles/space';
-
 const RIGHT_SIDE_PANEL_WIDTH = '50vw';
 const LEFT_SIDE_PANEL_WIDTH = '40vw';
 const PANEL_HEIGHT = '50vh';
@@ -136,10 +134,10 @@ const _SlideOverPanel = styled(motion.div, {
 }>`
   position: fixed;
 
-  top: ${p => (p.position === 'left' ? '54px' : space(2))};
-  right: ${p => (p.position === 'left' ? space(2) : 0)};
-  bottom: ${space(2)};
-  left: ${p => (p.position === 'left' ? 0 : space(2))};
+  top: ${p => (p.position === 'left' ? '54px' : p.theme.space.xl)};
+  right: ${p => (p.position === 'left' ? p.theme.space.xl : 0)};
+  bottom: ${p => p.theme.space.xl};
+  left: ${p => (p.position === 'left' ? 0 : p.theme.space.xl)};
 
   overflow: auto;
   pointer-events: auto;

--- a/static/app/components/core/slider/slider.tsx
+++ b/static/app/components/core/slider/slider.tsx
@@ -1,8 +1,6 @@
 import {useState, type CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
-import {space} from 'sentry/styles/space';
-
 interface BaseProps extends Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
   'type' | 'value' | 'onChange' | 'defaultValue'
@@ -260,8 +258,8 @@ const SliderOutput = styled('output')`
 const SliderLabel = styled('span')`
   font-size: inherit;
   display: block;
-  min-width: calc(3ch + ${space(0.5)});
-  padding-inline: ${space(0.5)};
+  min-width: calc(3ch + ${p => p.theme.space.xs});
+  padding-inline: ${p => p.theme.space.xs};
   width: min-content;
   text-align: center;
   background: ${p => p.theme.tokens.background.accent.vibrant};

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -16,7 +16,6 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 import type {TabListItemProps} from './item';
@@ -50,7 +49,7 @@ const StyledTabListWrap = styled('ul', {
           height: 100%;
           grid-auto-flow: row;
           align-content: start;
-          padding-right: ${space(0.5)};
+          padding-right: ${p.theme.space.xs};
         `};
 `;
 
@@ -91,7 +90,7 @@ function useOverflowTabs({
     const options = {
       root: tabListRef.current,
       // Negative right margin to account for overflow menu's trigger button
-      rootMargin: `0px -42px 1px ${space(1)}`,
+      rootMargin: `0px -42px 1px ${theme.space.md}`,
       // Use 0.95 rather than 1 because of a bug in Edge (Windows) where the intersection
       // ratio may unexpectedly drop to slightly below 1 (0.999…) on page scroll.
       threshold: 0.95,
@@ -331,7 +330,7 @@ const TabListWrap = StyledTabListWrap;
 const TabListOverflowWrap = StyledTabListOverflowWrap;
 
 const OverflowMenuTrigger = styled(OverlayTrigger.IconButton)`
-  padding-left: ${space(1)};
-  padding-right: ${space(1)};
+  padding-left: ${p => p.theme.space.md};
+  padding-right: ${p => p.theme.space.md};
   color: ${p => p.theme.tokens.interactive.link.neutral.rest};
 `;

--- a/static/app/components/core/tooltip/tooltip.mdx
+++ b/static/app/components/core/tooltip/tooltip.mdx
@@ -16,7 +16,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import * as Storybook from 'sentry/stories';
-import {space} from 'sentry/styles/space';
 
 import documentation from '!!type-loader!@sentry/scraps/tooltip/index';
 
@@ -40,11 +39,11 @@ To create a basic tooltip, wrap any element with `<Tooltip>` and provide the `ti
 Tooltips can be positioned in different directions using the `position` prop. Available positions include `top`, `bottom`, `left`, and `right`.
 
 <Storybook.Demo>
-  <Flex direction="column" gap={space(1)} align="center">
+  <Flex direction="column" gap="md" align="center">
     <Tooltip title="Top tooltip" position="top" forceVisible>
       <Button>Top</Button>
     </Tooltip>
-    <Flex gap={space(1)}>
+    <Flex gap="md">
       <Tooltip title="Left tooltip" position="left" forceVisible>
         <Button>Left</Button>
       </Tooltip>
@@ -77,7 +76,7 @@ Tooltips can be positioned in different directions using the `position` prop. Av
 By default, tooltips hide when you move your cursor toward them. For interactive tooltips that contain clickable content, use the `isHoverable` prop to allow users to hover over the tooltip itself.
 
 <Storybook.Demo>
-  <Flex gap={space(1)}>
+  <Flex gap="md">
     <Tooltip title="You can hover over this tooltip" isHoverable>
       <Button>Hoverable</Button>
     </Tooltip>
@@ -100,7 +99,7 @@ By default, tooltips hide when you move your cursor toward them. For interactive
 Control the maximum width of tooltips using the `maxWidth` prop. The default maximum width is 225px.
 
 <Storybook.Demo>
-  <Flex gap={space(1)}>
+  <Flex gap="md">
     <Tooltip title="This tooltip has a very long message that will wrap to multiple lines by default">
       <Button>Default width</Button>
     </Tooltip>
@@ -129,7 +128,7 @@ Control the maximum width of tooltips using the `maxWidth` prop. The default max
 Tooltips can display rich content including formatted text, multiple lines, and React elements.
 
 <Storybook.Demo>
-  <Flex gap={space(1)}>
+  <Flex gap="md">
     <Tooltip
       title={
         <div>
@@ -192,7 +191,7 @@ Tooltips can display rich content including formatted text, multiple lines, and 
 Tooltips can be disabled entirely using the `disabled` prop, which prevents them from showing on hover.
 
 <Storybook.Demo>
-  <Flex gap={space(1)}>
+  <Flex gap="md">
     <Tooltip title="This tooltip is enabled">
       <Button>Enabled tooltip</Button>
     </Tooltip>
@@ -216,7 +215,7 @@ Tooltips can be disabled entirely using the `disabled` prop, which prevents them
 For text that may or may not overflow, use the `showOnlyOnOverflow` prop to conditionally show tooltips only when content is truncated.
 
 <Storybook.Demo>
-  <Flex direction="column" gap={space(1)}>
+  <Flex direction="column" gap="md">
     <div style={{width: 200}}>
       <Tooltip
         title="This text is long and will be truncated with overflow"

--- a/static/app/components/core/tooltip/tooltip.tsx
+++ b/static/app/components/core/tooltip/tooltip.tsx
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 import {AnimatePresence} from 'framer-motion';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
-import {space} from 'sentry/styles/space';
 import type {UseHoverOverlayProps} from 'sentry/utils/useHoverOverlay';
 import {useHoverOverlay} from 'sentry/utils/useHoverOverlay';
 
@@ -112,7 +111,7 @@ export function Tooltip({
 const TooltipContent = styled(Overlay, {
   shouldForwardProp: prop => prop !== 'maxWidth',
 })<{maxWidth?: number}>`
-  padding: ${space(1)} ${space(1.5)};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   overflow-wrap: break-word;
   max-width: ${p => p.maxWidth ?? 225}px;
   color: ${p => p.theme.tokens.content.primary};


### PR DESCRIPTION
fixes DE-904

in an effort to get us closer to _not_ import from `sentry/` at all in `scraps`, this PR removes all calls to the deprecated `space()` function and uses `theme.space` tokens instead.