### PR TITLE
chore(widgets): Tweaks to categorical widget

### DIFF
--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -168,7 +168,8 @@ export function CategoricalSeriesWidgetVisualization(
       // @ts-expect-error: ECharts types `showMaxLabel` incorrect as a boolean, the documentation also allows `null`
       showMinLabel: null,
       rotate: shouldRotate ? ROTATED_LABEL_ANGLE : 0,
-      ...(shouldRotate ? {interval: 0, hideOverlap: false} : {}),
+      ...(shouldRotate ? {interval: 0} : {}),
+      hideOverlap: true,
       formatter: (value: string) => formattedLabels.get(value) ?? value,
     },
     axisLine: {

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -139,10 +139,15 @@ export function CategoricalSeriesWidgetVisualization(
 
     // If the categories are still too long after "smart" truncation, apply naive truncation
     const trimmedTotal = trimmed.reduce((sum, c) => sum + c.length, 0);
-    const truncateLength =
-      trimmedTotal > TOTAL_CHARACTER_THRESHOLD
-        ? TRUNCATED_LABEL_MAX_LENGTH
-        : (props.truncateCategoryLabels ?? true);
+
+    let truncateLength: number | boolean;
+    if (typeof props.truncateCategoryLabels === 'number') {
+      truncateLength = props.truncateCategoryLabels;
+    } else if (trimmedTotal > TOTAL_CHARACTER_THRESHOLD) {
+      truncateLength = TRUNCATED_LABEL_MAX_LENGTH;
+    } else {
+      truncateLength = props.truncateCategoryLabels ?? true;
+    }
 
     // NOTE: In the end, ECharts still applies its own legend overlap logic, and
     // might choose to hide some labels. By doing our own truncation and


### PR DESCRIPTION
This PR tweaks the categorical series widget to ensure that `hideOverlap` is always set to `true`, and if a user passes a number for `truncateCategoryLabels` we use that value over the default `TRUNCATED_LABEL_MAX_LENGTH`.