### PR TITLE
fix(api): Fix rate units not populating for equation fields

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -2475,6 +2475,35 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
         assert meta["units"] == {"description": None, "tpm()": "1/minute"}
         assert meta["fields"] == {"description": "string", "tpm()": "rate"}
 
+    def test_equation_tpm_meta(self) -> None:
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "description": "foo",
+                        "sentry_tags": {"status": "success"},
+                        "is_segment": True,
+                    },
+                    start_ts=self.ten_mins_ago,
+                ),
+            ],
+        )
+
+        response = self.do_request(
+            {
+                "field": ["description", "equation|tpm()"],
+                "query": "",
+                "orderby": "description",
+                "project": self.project.id,
+                "dataset": "spans",
+            }
+        )
+
+        assert response.status_code == 200, response.content
+        meta = response.data["meta"]
+        assert meta["units"]["equation|tpm()"] == "1/minute"
+        assert meta["fields"]["equation|tpm()"] == "rate"
+
     def test_p75_if(self) -> None:
         self.store_spans(
             [


### PR DESCRIPTION
## Summary
- Equation fields (e.g. `equation|tpm()`) were returning `null` for their rate unit in the API response meta, causing the frontend to render values like `36.0undefined`
- `get_unit_and_type` used exact string matching against known rate functions, which didn't match equation-prefixed fields
- Extracted rate unit resolution into `_get_rate_unit()` which also checks for known rate functions within equation expressions