### PR TITLE
fix(attribute-breakdown): Pass query instead of grabbing from context

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.spec.tsx
@@ -8,9 +8,6 @@ import {
 
 import {closeModal} from 'sentry/actionCreators/modal';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
 
 import AttributeBreakdownViewerModal from './attributeBreakdownViewerModal';
 
@@ -33,31 +30,6 @@ const stubProps = {
   CloseButton: stubEl,
   closeModal: mockCloseModal,
 };
-
-const defaultQueryParams = new ReadableQueryParams({
-  aggregateCursor: '',
-  aggregateFields: [],
-  aggregateSortBys: [],
-  cursor: '',
-  extrapolate: false,
-  fields: [],
-  mode: Mode.SAMPLES,
-  query: '',
-  sortBys: [],
-});
-
-function Wrapper({children}: {children?: React.ReactNode}) {
-  return (
-    <QueryParamsContextProvider
-      isUsingDefaultFields
-      queryParams={defaultQueryParams}
-      setQueryParams={() => {}}
-      shouldManageFields={false}
-    >
-      {children}
-    </QueryParamsContextProvider>
-  );
-}
 
 describe('AttributeBreakdownViewerModal', () => {
   beforeEach(() => {
@@ -88,8 +60,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -102,8 +74,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       // Total values: 500 + 300 + 200 = 1000, cohortCount = 1000 => 100%
@@ -117,8 +89,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -131,8 +103,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       // Table should have column headers
@@ -159,8 +131,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={cohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('cell', {name: '25%'})).toBeInTheDocument();
@@ -174,8 +146,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={cohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -192,8 +164,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={attributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
@@ -230,8 +202,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -245,8 +217,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       // Cohort 1: (500 + 300) / 800 = 100%
@@ -262,8 +234,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByText('echarts mock')).toBeInTheDocument();
@@ -277,8 +249,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       // Table should have column headers
@@ -301,8 +273,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       // Table should have attribute values
@@ -319,8 +291,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={0}
           cohort2Total={0}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'browser.name'})).toBeInTheDocument();
@@ -339,8 +311,8 @@ describe('AttributeBreakdownViewerModal', () => {
           }}
           cohort1Total={mockCohort1Total}
           cohort2Total={mockCohort2Total}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       expect(screen.getByRole('heading', {name: 'empty.attribute'})).toBeInTheDocument();
@@ -366,8 +338,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -390,8 +362,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -408,8 +380,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -432,8 +404,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -457,8 +429,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -489,8 +461,8 @@ describe('AttributeBreakdownViewerModal', () => {
           mode="single"
           attributeDistribution={mockAttributeDistribution}
           cohortCount={mockCohortCount}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');
@@ -531,8 +503,8 @@ describe('AttributeBreakdownViewerModal', () => {
           attribute={mockAttribute}
           cohort1Total={800}
           cohort2Total={750}
-        />,
-        {additionalWrapper: Wrapper}
+          query=""
+        />
       );
 
       const cells = screen.getAllByRole('cell');

--- a/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeBreakdownViewerModal.tsx
@@ -22,7 +22,6 @@ import type {
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
-import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
@@ -37,6 +36,7 @@ type SingleModeOptions = {
   attributeDistribution: AttributeDistribution[number];
   cohortCount: number;
   mode: 'single';
+  query: string;
 };
 
 type ComparisonModeOptions = {
@@ -44,6 +44,7 @@ type ComparisonModeOptions = {
   cohort1Total: number;
   cohort2Total: number;
   mode: 'comparison';
+  query: string;
 };
 
 export type AttributeBreakdownViewerModalOptions =
@@ -246,9 +247,8 @@ function PopulationIndicatorComponent({
 }
 
 export default function AttributeBreakdownViewerModal(props: Props) {
-  const {Header, Body, mode} = props;
+  const {Header, Body, mode, query} = props;
   const {selection} = usePageFilters();
-  const query = useQueryParamsQuery();
 
   const theme = useTheme();
   const navigate = useNavigate();

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -10,6 +10,7 @@ import {IconExpand} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
+import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
 import {CHART_MAX_BAR_WIDTH} from './constants';
@@ -31,6 +32,7 @@ export function Chart({
   cohortCount: number;
   theme: Theme;
 }) {
+  const query = useQueryParamsQuery();
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
   const formatSingleModeTooltip = useFormatSingleModeTooltip();
@@ -118,6 +120,7 @@ export function Chart({
                 mode: 'single',
                 attributeDistribution,
                 cohortCount,
+                query,
               })
             }
           />

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -11,6 +11,7 @@ import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
+import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 
 import {
   CHART_BASELINE_SERIES_NAME,
@@ -38,6 +39,7 @@ export function Chart({
   cohort2Total: number;
   theme: Theme;
 }) {
+  const query = useQueryParamsQuery();
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
 
@@ -155,6 +157,7 @@ export function Chart({
                 attribute,
                 cohort1Total,
                 cohort2Total,
+                query,
               })
             }
           />


### PR DESCRIPTION
This PR fixes an issue where modals aren't wrapped in a specific context so it'll crash when trying to access it. To resolve this, we now pass the query value from where we call the modal.