### PR TITLE
fix(logs): Only show Set Up Logs button when applicable

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -89,6 +89,7 @@ function LogsHeader() {
   const title = useQueryParamsTitle();
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(pageId);
+  const onboardingProject = useOnboardingProject({property: 'hasLogs'});
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
@@ -120,7 +121,7 @@ function LogsHeader() {
               },
             }}
           />
-          <SetupLogsButton />
+          {defined(onboardingProject) && <SetupLogsButton />}
         </Grid>
       </Layout.HeaderActions>
     </Layout.Header>


### PR DESCRIPTION
Should be hidden for projects that have received a log. Similar to logic above for rendering the onboarding state.

Resolves JAVASCRIPT-3766