### PR TITLE
fix(seer): Fix label on Settings > Seer > Projects table to align with details page

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -32,7 +32,7 @@ interface Props {
 
 const COLUMNS = [
   {title: t('Project'), key: 'project', sortKey: 'project'},
-  {title: t('Root Cause Analysis'), key: 'fixes'},
+  {title: t('Auto-Triggered Fixes'), key: 'fixes'},
   {
     title: (organization: Organization) => (
       <Flex gap="sm" align="center">


### PR DESCRIPTION
**The table is updated**

<img width="636" height="228" alt="SCR-20260211-iwly" src="https://github.com/user-attachments/assets/c9eddd6e-2ccd-41db-81ec-b7a0394808d9" />

**This matches the setting on the details page**
<img width="653" height="162" alt="SCR-20260211-iwsx" src="https://github.com/user-attachments/assets/b1b6c1de-2139-4e92-9a4b-dc0c92749392" />
