### PR TITLE
fix(admin): Handle GitHub Copilot identity category in admin user page

### DIFF
--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -169,6 +169,7 @@ export enum UserIdentityCategory {
   SOCIAL_IDENTITY = 'social-identity',
   GLOBAL_IDENTITY = 'global-identity',
   ORG_IDENTITY = 'org-identity',
+  GITHUB_COPILOT_IDENTITY = 'github-copilot-identity',
 }
 
 export enum UserIdentityStatus {

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -39,12 +39,15 @@ function identityLabel(identity: UserIdentityConfig) {
   }
 
   let text: string;
-  if (identity.category === UserIdentityCategory.GLOBAL_IDENTITY) {
+  if (
+    identity.category === UserIdentityCategory.GLOBAL_IDENTITY ||
+    identity.category === UserIdentityCategory.GITHUB_COPILOT_IDENTITY
+  ) {
     text = identity.isLogin ? 'Global Login' : 'App Integration';
   } else if (identity.category === UserIdentityCategory.SOCIAL_IDENTITY) {
     text = 'Legacy Integration';
   } else {
-    throw new Error('Invalid category');
+    text = identity.category;
   }
   return <span style={{fontVariant: 'small-caps'}}>{text}</span>;
 }


### PR DESCRIPTION
The backend added a `github-copilot-identity` category for GitHub Copilot identities (stored via a separate RPC service in getsentry), but the frontend `identityLabel` function only handled three categories and threw `Error: Invalid category` on anything else. This crashes the admin user page for any user with a Copilot identity linked.

Adds the new enum value to `UserIdentityCategory` and displays Copilot identities like global identities ("App Integration" since `isLogin` is false). Also replaces the `throw` with a graceful fallback that renders the raw category string, so future new categories won't crash the page.