### PR TITLE
Feedback issue webhooks

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -671,8 +671,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable downsampled date page filter
     manager.add("organizations:downsampled-date-page-filter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
-    # Enable feature flag to send expanded sentry apps webhooks (issue.created for all group categories)
-    manager.add("organizations:expanded-sentry-apps-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable using paginated projects endpoint for Jira integration
     manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single trace summary

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1179,14 +1179,7 @@ def process_resource_change_bounds(job: PostProcessJob) -> None:
 
 
 def should_process_resource_change_bounds(job: PostProcessJob) -> bool:
-    # Feature flag check for expanded sentry apps webhooks
-    has_expanded_sentry_apps_webhooks = features.has(
-        "organizations:expanded-sentry-apps-webhooks", job["event"].project.organization
-    )
     group_category = job["event"].group.issue_category
-
-    if group_category != GroupCategory.ERROR and not has_expanded_sentry_apps_webhooks:
-        return False
 
     supported_group_categories = [
         GroupCategory(category)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1728,40 +1728,7 @@ class TestExpandedSentryAppsWebhooks(TestCase):
         )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_cron_issue_without_feature_flag(
-        self, mock_record: MagicMock, safe_urlopen: MagicMock
-    ) -> None:
-        """Test that CRON issues don't send webhooks without the feature flag"""
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "monitor check-in failure",
-                "timestamp": before_now(minutes=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
-        assert event.group is not None
-
-        # Set to CRON category (type_id = 4001, MonitorIncidentType)
-        with assume_test_silo_mode(SiloMode.REGION):
-            event.group.update(type=4001)
-
-        with self.tasks():
-            post_process_group(
-                is_new=True,
-                is_regression=False,
-                is_new_group_environment=False,
-                cache_key=write_event_to_cache(event),
-                group_id=event.group_id,
-                project_id=self.project.id,
-                eventstream_type=EventStreamEventType.Generic.value,
-            )
-
-        assert not safe_urlopen.called
-
-    @with_feature("organizations:expanded-sentry-apps-webhooks")
-    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
-    def test_cron_issue_with_feature_flag(
+    def test_cron_issue_sends_webhook(
         self, mock_record: MagicMock, safe_urlopen: MagicMock
     ) -> None:
         event = self.store_event(

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -3988,9 +3988,8 @@ class PostProcessGroupFeedbackTest(
     def test_group_last_seen_buffer(self) -> None:
         pass
 
-    @with_feature("organizations:expanded-sentry-apps-webhooks")
     @patch("sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound.delay")
-    def test_feedback_sends_webhook_with_feature_flag(self, mock_delay: MagicMock) -> None:
+    def test_feedback_sends_webhook(self, mock_delay: MagicMock) -> None:
         sentry_app = self.create_sentry_app(
             organization=self.organization, events=["issue.created"]
         )
@@ -4012,28 +4011,6 @@ class PostProcessGroupFeedbackTest(
         mock_delay.assert_called_once_with(
             action="created", sender="Group", instance_id=event.group.id
         )
-
-    @patch("sentry.sentry_apps.tasks.sentry_apps.process_resource_change_bound.delay")
-    def test_feedback_no_webhook_without_feature_flag(self, mock_delay: MagicMock) -> None:
-        sentry_app = self.create_sentry_app(
-            organization=self.organization, events=["issue.created"]
-        )
-        self.create_sentry_app_installation(organization=self.organization, slug=sentry_app.slug)
-
-        event = self.create_event(
-            data={},
-            project_id=self.project.id,
-            feedback_type=FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE,
-        )
-
-        self.call_post_process_group(
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=False,
-            event=event,
-        )
-
-        assert not mock_delay.called
 
 
 class ProcessDataForwardingTest(BasePostProcessGroupMixin, SnubaTestCase):


### PR DESCRIPTION
This PR enables webhooks for feedback issues and other non-ERROR issue categories by removing a redundant feature flag check.

Previously, the `organizations:expanded-sentry-apps-webhooks` feature flag redundantly gated webhooks for non-ERROR issue categories in `should_process_resource_change_bounds`, even when those categories were explicitly configured in `sentry-apps.expanded-webhook-categories`. This prevented webhooks for categories like FEEDBACK and CRON from being sent without the flag.

This change removes the `organizations:expanded-sentry-apps-webhooks` feature flag and its corresponding check, making `sentry-apps.expanded-webhook-categories` the sole control for expanded webhook triggers.

Addresses #89436.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/CD4NYFD34/p1770825351577569?thread_ts=1770825351.577569&cid=CD4NYFD34)

<p><a href="https://cursor.com/background-agent?bcId=bc-8ca425a8-580a-5ba5-a626-70a5550bfc21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ca425a8-580a-5ba5-a626-70a5550bfc21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

