### PR TITLE
feat(seer-explorer): In `trigger_autofix_explorer`, send `project_id` when calling `start_run()`

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -170,7 +170,7 @@ def trigger_autofix_explorer(
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata = {"group_id": group.id, "project_id": group.project.id}
+        metadata: dict[str, int | str] = {"group_id": group.id, "project_id": group.project.id}
         if stopping_point:
             metadata["stopping_point"] = stopping_point.value
         run_id = client.start_run(

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -156,6 +156,7 @@ def trigger_autofix_explorer(
     config = STEP_CONFIGS[step]
     client = SeerExplorerClient(
         organization=group.organization,
+        project=group.project,
         user=None,  # No user personalization for autofix
         category_key="autofix",
         category_value=str(group.id),
@@ -170,9 +171,9 @@ def trigger_autofix_explorer(
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata: dict[str, int | str] = {"group_id": group.id, "project_id": group.project.id}
+        metadata = None
         if stopping_point:
-            metadata["stopping_point"] = stopping_point.value
+            metadata = {"stopping_point": stopping_point.value, "group_id": group.id}
         run_id = client.start_run(
             prompt=prompt,
             prompt_metadata=prompt_metadata,

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -170,9 +170,9 @@ def trigger_autofix_explorer(
     artifact_schema = config.artifact_schema
 
     if run_id is None:
-        metadata = None
+        metadata = {"group_id": group.id, "project_id": group.project.id}
         if stopping_point:
-            metadata = {"stopping_point": stopping_point.value, "group_id": group.id}
+            metadata["stopping_point"] = stopping_point.value
         run_id = client.start_run(
             prompt=prompt,
             prompt_metadata=prompt_metadata,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from rest_framework.request import Request
 
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
@@ -164,6 +165,7 @@ class SeerExplorerClient:
         Args:
             organization: Sentry organization
             user: User for permission checks and user-specific context (can be User, AnonymousUser, or None)
+            project: Optional project for project-specific contexts (e.g. autofix for an issue)
             category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "trace-analyzer"). Must be provided together with category_value. Makes it easy to retrieve runs for your feature later.
             category_value: Optional category value for filtering/grouping runs (e.g., issue ID, trace ID). Must be provided together with category_key. Makes it easy to retrieve a specific run for your feature later.
             custom_tools: Optional list of `ExplorerTool` classes to make available as tools to the agent. Each tool must inherit from ExplorerTool, define a params_model (Pydantic BaseModel), and implement execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).
@@ -177,6 +179,7 @@ class SeerExplorerClient:
         self,
         organization: Organization,
         user: User | AnonymousUser | None = None,
+        project: Project | None = None,
         category_key: str | None = None,
         category_value: str | None = None,
         custom_tools: list[type[ExplorerTool[Any]]] | None = None,
@@ -187,6 +190,7 @@ class SeerExplorerClient:
     ):
         self.organization = organization
         self.user = user
+        self.project = project
         self.custom_tools = custom_tools or []
         self.on_completion_hook = on_completion_hook
         self.intelligence_level = intelligence_level
@@ -260,6 +264,9 @@ class SeerExplorerClient:
             "is_interactive": self.is_interactive,
             "enable_coding": self.enable_coding,
         }
+
+        if self.project:
+            payload["project_id"] = self.project.id
 
         if prompt_metadata:
             payload["query_metadata"] = prompt_metadata

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -165,7 +165,7 @@ class SeerExplorerClient:
         Args:
             organization: Sentry organization
             user: User for permission checks and user-specific context (can be User, AnonymousUser, or None)
-            project: Optional project for project-specific contexts (e.g. autofix for an issue)
+            project: Optional project for project-scoped runs (e.g. autofix for an issue)
             category_key: Optional category key for filtering/grouping runs (e.g., "bug-fixer", "trace-analyzer"). Must be provided together with category_value. Makes it easy to retrieve runs for your feature later.
             category_value: Optional category value for filtering/grouping runs (e.g., issue ID, trace ID). Must be provided together with category_key. Makes it easy to retrieve a specific run for your feature later.
             custom_tools: Optional list of `ExplorerTool` classes to make available as tools to the agent. Each tool must inherit from ExplorerTool, define a params_model (Pydantic BaseModel), and implement execute(). Tools are automatically given access to the organization context. Tool classes must be module-level (not nested classes).

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -7,7 +7,6 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_explorer,
     trigger_coding_agent_handoff,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, SeerRunState
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
@@ -307,47 +306,19 @@ class TestTriggerAutofixExplorer(TestCase):
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_trigger_autofix_explorer_passes_metadata_without_stopping_point(
+    def test_trigger_autofix_explorer_passes_project_to_client(
         self, mock_client_class, mock_broadcast
     ):
-        """start_run receives group_id and project_id in metadata even without stopping_point."""
+        """SeerExplorerClient is constructed with project from the group."""
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = 123
 
         trigger_autofix_explorer(group=self.group, step=AutofixStep.ROOT_CAUSE, run_id=None)
 
-        mock_client.start_run.assert_called_once()
-        call_kwargs = mock_client.start_run.call_args.kwargs
-        assert call_kwargs["metadata"] == {
-            "group_id": self.group.id,
-            "project_id": self.group.project.id,
-        }
-
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_trigger_autofix_explorer_passes_metadata_with_stopping_point(
-        self, mock_client_class, mock_broadcast
-    ):
-        """start_run receives group_id, project_id, and stopping_point in metadata."""
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = 123
-
-        trigger_autofix_explorer(
-            group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
-            run_id=None,
-            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
-        )
-
-        mock_client.start_run.assert_called_once()
-        call_kwargs = mock_client.start_run.call_args.kwargs
-        assert call_kwargs["metadata"] == {
-            "group_id": self.group.id,
-            "project_id": self.group.project.id,
-            "stopping_point": AutofixStoppingPoint.ROOT_CAUSE.value,
-        }
+        mock_client_class.assert_called_once()
+        call_kwargs = mock_client_class.call_args.kwargs
+        assert call_kwargs["project"] == self.group.project
 
 
 class TestTriggerCodingAgentHandoff(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -7,6 +7,7 @@ from sentry.seer.autofix.autofix_agent import (
     trigger_autofix_explorer,
     trigger_coding_agent_handoff,
 )
+from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, SeerRunState
 from sentry.sentry_apps.utils.webhooks import SeerActionType
 from sentry.testutils.cases import TestCase
@@ -303,6 +304,50 @@ class TestTriggerAutofixExplorer(TestCase):
         call_kwargs = mock_broadcast.call_args.kwargs
         assert call_kwargs["event_name"] == SeerActionType.SOLUTION_STARTED.value
         assert call_kwargs["payload"]["run_id"] == 67890
+
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_autofix_explorer_passes_metadata_without_stopping_point(
+        self, mock_client_class, mock_broadcast
+    ):
+        """start_run receives group_id and project_id in metadata even without stopping_point."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_explorer(group=self.group, step=AutofixStep.ROOT_CAUSE, run_id=None)
+
+        mock_client.start_run.assert_called_once()
+        call_kwargs = mock_client.start_run.call_args.kwargs
+        assert call_kwargs["metadata"] == {
+            "group_id": self.group.id,
+            "project_id": self.group.project.id,
+        }
+
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_trigger_autofix_explorer_passes_metadata_with_stopping_point(
+        self, mock_client_class, mock_broadcast
+    ):
+        """start_run receives group_id, project_id, and stopping_point in metadata."""
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            run_id=None,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
+        )
+
+        mock_client.start_run.assert_called_once()
+        call_kwargs = mock_client.start_run.call_args.kwargs
+        assert call_kwargs["metadata"] == {
+            "group_id": self.group.id,
+            "project_id": self.group.project.id,
+            "stopping_point": AutofixStoppingPoint.ROOT_CAUSE.value,
+        }
 
 
 class TestTriggerCodingAgentHandoff(TestCase):


### PR DESCRIPTION
This will allow us to filter explorer runs by project if available.

Requires [seer migration](https://github.com/getsentry/seer/pull/4841) and [seer endpoint update](https://github.com/getsentry/seer/pull/4838/changes)
