### PR TITLE
refactor(onboarding): Extract tab selection state into context providers

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -6,6 +6,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import OnboardingAdditionalFeatures from 'sentry/components/events/featureFlags/onboarding/onboardingAdditionalFeatures';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
+import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {useSourcePackageRegistries} from 'sentry/components/onboarding/gettingStartedDoc/useSourcePackageRegistries';
@@ -87,18 +88,20 @@ export function FeatureFlagOnboardingLayout({
 
   return (
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
-      <Wrapper>
-        <Steps>
-          {steps.map(step => (
-            <Step key={step.title ?? step.type} {...step} />
-          ))}
-          <StyledLinkButton to="/issues/" priority="primary">
-            {t('Take me to Issues')}
-          </StyledLinkButton>
-        </Steps>
-        <Divider />
-        <OnboardingAdditionalFeatures organization={organization} />
-      </Wrapper>
+      <TabSelectionScope>
+        <Wrapper>
+          <Steps>
+            {steps.map((step, index) => (
+              <Step key={step.title ?? step.type} stepIndex={index} {...step} />
+            ))}
+            <StyledLinkButton to="/issues/" priority="primary">
+              {t('Take me to Issues')}
+            </StyledLinkButton>
+          </Steps>
+          <Divider />
+          <OnboardingAdditionalFeatures organization={organization} />
+        </Wrapper>
+      </TabSelectionScope>
     </AuthTokenGeneratorProvider>
   );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
@@ -71,6 +71,10 @@ export function AuthTokenGeneratorProvider({
   );
 }
 
+export function useAuthToken() {
+  return useContext(AuthTokenGeneratorContext).authToken;
+}
+
 export function AuthTokenGenerator() {
   const {authToken, isLoading, generateAuthToken} = useContext(AuthTokenGeneratorContext);
 

--- a/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/authTokenGenerator.tsx
@@ -71,10 +71,6 @@ export function AuthTokenGeneratorProvider({
   );
 }
 
-export function useAuthToken() {
-  return useContext(AuthTokenGeneratorContext).authToken;
-}
-
 export function AuthTokenGenerator() {
   const {authToken, isLoading, generateAuthToken} = useContext(AuthTokenGeneratorContext);
 

--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/utils.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/utils.tsx
@@ -2,6 +2,7 @@ import type {
   BlockRenderers,
   ContentBlock,
 } from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
+import {BlockPathProvider} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 
 export enum ContentBlockCssVariables {
   BLOCK_SPACING = '--block-spacing',
@@ -22,6 +23,13 @@ export function renderBlocks(
 
     // The index actually works well as a key here
     // as long as the conditional block is used instead of JS logic to edit the blocks array
-    return <RendererComponent {...block} key={index} />;
+    // BlockPathProvider extends the block path context so that tabbed
+    // code blocks deeper in the tree (e.g. inside conditionals) get
+    // unique keys like "2_1" instead of colliding with top-level "1".
+    return (
+      <BlockPathProvider index={index} key={index}>
+        <RendererComponent {...block} />
+      </BlockPathProvider>
+    );
   });
 }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCodeSnippet.tsx
@@ -5,6 +5,7 @@ import beautify from 'js-beautify';
 import {CodeBlock} from '@sentry/scraps/code';
 
 import {AuthTokenGenerator} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
+import {useRegisteredTabSelection} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {PACKAGE_LOADING_PLACEHOLDER} from 'sentry/utils/gettingStartedDocs/getPackageVersion';
 
 interface OnboardingCodeSnippetProps extends Omit<
@@ -100,9 +101,9 @@ export function TabbedCodeSnippet({
   onCopy,
   onSelectAndCopy,
 }: TabbedCodeSnippetProps) {
-  const [selectedTabValue, setSelectedTabValue] = useState(tabs[0]!.value);
-  const selectedTab = tabs.find(tab => tab.value === selectedTabValue) ?? tabs[0]!;
-  const {code, language, filename} = selectedTab;
+  const [selectedTabValue, setSelectedTabValue] = useRegisteredTabSelection(tabs);
+  const resolvedTab = tabs.find(tab => tab.value === selectedTabValue) ?? tabs[0]!;
+  const {code, language, filename} = resolvedTab;
 
   return (
     <OnboardingCodeSnippet
@@ -111,7 +112,7 @@ export function TabbedCodeSnippet({
       onSelectAndCopy={onSelectAndCopy}
       tabs={tabs}
       selectedTab={selectedTabValue}
-      onTabClick={value => setSelectedTabValue(value)}
+      onTabClick={setSelectedTabValue}
       filename={filename}
     >
       {code}

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -8,6 +8,7 @@ import HookOrDefault from 'sentry/components/hookOrDefault';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
+import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   ProductSolution,
@@ -156,62 +157,64 @@ export function OnboardingLayout({
 
   return (
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
-      <Wrapper>
-        <Stack gap="xl">
-          {introduction && <Introduction>{introduction}</Introduction>}
-          {configType === 'onboarding' && (
-            <ProductSelectionAvailabilityHook
-              organization={organization}
-              platform={platformKey}
-              onChange={onProductSelectionChange}
-              onLoad={onProductSelectionLoad}
-            />
+      <TabSelectionScope>
+        <Wrapper>
+          <Stack gap="xl">
+            {introduction && <Introduction>{introduction}</Introduction>}
+            {configType === 'onboarding' && (
+              <ProductSelectionAvailabilityHook
+                organization={organization}
+                platform={platformKey}
+                onChange={onProductSelectionChange}
+                onLoad={onProductSelectionLoad}
+              />
+            )}
+            {platformOptions ? (
+              <PlatformOptionsControl
+                platformOptions={platformOptions}
+                onChange={onPlatformOptionsChange}
+              />
+            ) : null}
+          </Stack>
+          <Divider withBottomMargin />
+          <div>
+            {steps.map((step, index) => (
+              <StyledStep key={step.title ?? step.type} stepIndex={index} {...step} />
+            ))}
+          </div>
+          {nextSteps.length > 0 && (
+            <Fragment>
+              <Divider />
+              <h4>{t('Additional Information')}</h4>
+              <List symbol="bullet">
+                {nextSteps
+                  .filter((step): step is Exclude<typeof step, null> => step !== null)
+                  .map(step => (
+                    <ListItem key={step.name}>
+                      <ExternalLink
+                        href={step.link}
+                        onClick={() =>
+                          trackAnalytics('onboarding.next_step_clicked', {
+                            organization,
+                            platform: platformKey,
+                            project_id: project.id,
+                            products: activeProductSelection,
+                            step: step.name,
+                            newOrg: newOrg ?? false,
+                          })
+                        }
+                      >
+                        {step.name}
+                      </ExternalLink>
+                      {': '}
+                      {step.description}
+                    </ListItem>
+                  ))}
+              </List>
+            </Fragment>
           )}
-          {platformOptions ? (
-            <PlatformOptionsControl
-              platformOptions={platformOptions}
-              onChange={onPlatformOptionsChange}
-            />
-          ) : null}
-        </Stack>
-        <Divider withBottomMargin />
-        <div>
-          {steps.map(step => (
-            <StyledStep key={step.title ?? step.type} {...step} />
-          ))}
-        </div>
-        {nextSteps.length > 0 && (
-          <Fragment>
-            <Divider />
-            <h4>{t('Additional Information')}</h4>
-            <List symbol="bullet">
-              {nextSteps
-                .filter((step): step is Exclude<typeof step, null> => step !== null)
-                .map(step => (
-                  <ListItem key={step.name}>
-                    <ExternalLink
-                      href={step.link}
-                      onClick={() =>
-                        trackAnalytics('onboarding.next_step_clicked', {
-                          organization,
-                          platform: platformKey,
-                          project_id: project.id,
-                          products: activeProductSelection,
-                          step: step.name,
-                          newOrg: newOrg ?? false,
-                        })
-                      }
-                    >
-                      {step.name}
-                    </ExternalLink>
-                    {': '}
-                    {step.description}
-                  </ListItem>
-                ))}
-            </List>
-          </Fragment>
-        )}
-      </Wrapper>
+        </Wrapper>
+      </TabSelectionScope>
     </AuthTokenGeneratorProvider>
   );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.spec.tsx
@@ -1,0 +1,275 @@
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import type {CodeSnippetTab} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
+import {TabbedCodeSnippet} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCodeSnippet';
+import {
+  BlockPathProvider,
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
+
+const PACKAGE_MANAGER_TABS: CodeSnippetTab[] = [
+  {label: 'npm', value: 'npm', code: 'npm install @sentry/node', language: 'bash'},
+  {label: 'yarn', value: 'yarn', code: 'yarn add @sentry/node', language: 'bash'},
+  {label: 'pnpm', value: 'pnpm', code: 'pnpm add @sentry/node', language: 'bash'},
+];
+
+const MODULE_FORMAT_TABS: CodeSnippetTab[] = [
+  {
+    label: 'ESM',
+    value: 'ESM',
+    code: 'import * as Sentry from "@sentry/node"',
+    language: 'javascript',
+  },
+  {
+    label: 'CJS',
+    value: 'CJS',
+    code: 'const Sentry = require("@sentry/node")',
+    language: 'javascript',
+  },
+];
+
+function GuidedStepsWithTabs() {
+  return (
+    <TabSelectionScope>
+      <GuidedSteps>
+        <GuidedSteps.Step stepKey="install" title="Install">
+          <StepIndexProvider index={0}>
+            <TabbedCodeSnippet tabs={PACKAGE_MANAGER_TABS} />
+          </StepIndexProvider>
+          <GuidedSteps.ButtonWrapper>
+            <GuidedSteps.NextButton size="md" />
+          </GuidedSteps.ButtonWrapper>
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="configure" title="Configure">
+          <StepIndexProvider index={1}>
+            <TabbedCodeSnippet tabs={MODULE_FORMAT_TABS} />
+          </StepIndexProvider>
+          <GuidedSteps.ButtonWrapper>
+            <GuidedSteps.BackButton size="md" />
+            <GuidedSteps.NextButton size="md" />
+          </GuidedSteps.ButtonWrapper>
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="verify" title="Verify">
+          <StepIndexProvider index={2}>
+            <TabbedCodeSnippet tabs={PACKAGE_MANAGER_TABS} />
+          </StepIndexProvider>
+          <GuidedSteps.ButtonWrapper>
+            <GuidedSteps.BackButton size="md" />
+          </GuidedSteps.ButtonWrapper>
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    </TabSelectionScope>
+  );
+}
+
+describe('TabSelectionScope with GuidedSteps', () => {
+  it('defaults to the first tab', () => {
+    render(<GuidedStepsWithTabs />);
+
+    // npm tab is selected by default (first tab)
+    expect(screen.getByText('npm install @sentry/node')).toBeInTheDocument();
+  });
+
+  it('persists tab selection after navigating forward and back', async () => {
+    render(<GuidedStepsWithTabs />);
+
+    // Select yarn in step 0
+    await userEvent.click(screen.getByRole('button', {name: 'yarn'}));
+    expect(screen.getByText('yarn add @sentry/node')).toBeInTheDocument();
+
+    // Navigate to step 1 (Configure)
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    // Step 1 shows ESM by default
+    expect(
+      screen.getByText('import * as Sentry from "@sentry/node"')
+    ).toBeInTheDocument();
+
+    // Navigate back to step 0 (Install)
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+    // yarn selection should be preserved
+    expect(screen.getByText('yarn add @sentry/node')).toBeInTheDocument();
+  });
+
+  it('maintains independent selections per step', async () => {
+    render(<GuidedStepsWithTabs />);
+
+    // Select pnpm in step 0 (Install)
+    await userEvent.click(screen.getByRole('button', {name: 'pnpm'}));
+    expect(screen.getByText('pnpm add @sentry/node')).toBeInTheDocument();
+
+    // Navigate to step 1 (Configure) and select CJS
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    await userEvent.click(screen.getByRole('button', {name: 'CJS'}));
+    expect(
+      screen.getByText('const Sentry = require("@sentry/node")')
+    ).toBeInTheDocument();
+
+    // Navigate to step 2 (Verify) — same tabs as step 0 but different step index
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    // Step 2 should default to npm (independent from step 0's pnpm selection)
+    expect(screen.getByText('npm install @sentry/node')).toBeInTheDocument();
+
+    // Navigate back to step 1 — CJS should still be selected
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+    expect(
+      screen.getByText('const Sentry = require("@sentry/node")')
+    ).toBeInTheDocument();
+
+    // Navigate back to step 0 — pnpm should still be selected
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+    expect(screen.getByText('pnpm add @sentry/node')).toBeInTheDocument();
+  });
+
+  it('does not show code from unselected tabs', async () => {
+    render(<GuidedStepsWithTabs />);
+
+    // Default is npm
+    expect(screen.getByText('npm install @sentry/node')).toBeInTheDocument();
+    expect(screen.queryByText('yarn add @sentry/node')).not.toBeInTheDocument();
+    expect(screen.queryByText('pnpm add @sentry/node')).not.toBeInTheDocument();
+
+    // Switch to yarn
+    await userEvent.click(screen.getByRole('button', {name: 'yarn'}));
+    expect(screen.queryByText('npm install @sentry/node')).not.toBeInTheDocument();
+    expect(screen.getByText('yarn add @sentry/node')).toBeInTheDocument();
+    expect(screen.queryByText('pnpm add @sentry/node')).not.toBeInTheDocument();
+  });
+});
+
+// Simulates dotnet's INSTALL step: two tabbed code blocks with identical
+// labels ("Package Manager" / ".NET Core CLI") but different code content.
+const DOTNET_SDK_TABS: CodeSnippetTab[] = [
+  {
+    label: 'Package Manager',
+    value: 'Package Manager',
+    code: 'Install-Package Sentry',
+    language: 'shell',
+  },
+  {
+    label: '.NET Core CLI',
+    value: '.NET Core CLI',
+    code: 'dotnet add package Sentry',
+    language: 'shell',
+  },
+];
+
+const DOTNET_PROFILING_TABS: CodeSnippetTab[] = [
+  {
+    label: 'Package Manager',
+    value: 'Package Manager',
+    code: 'Install-Package Sentry.Profiling',
+    language: 'shell',
+  },
+  {
+    label: '.NET Core CLI',
+    value: '.NET Core CLI',
+    code: 'dotnet add package Sentry.Profiling',
+    language: 'shell',
+  },
+];
+
+describe('identical labels in same step', () => {
+  it('maintains independent selections for tab groups with same labels but different code', async () => {
+    render(
+      <TabSelectionScope>
+        <StepIndexProvider index={0}>
+          <BlockPathProvider index={0}>
+            <div data-test-id="sdk-tabs">
+              <TabbedCodeSnippet tabs={DOTNET_SDK_TABS} />
+            </div>
+          </BlockPathProvider>
+          <BlockPathProvider index={1}>
+            <div data-test-id="profiling-tabs">
+              <TabbedCodeSnippet tabs={DOTNET_PROFILING_TABS} />
+            </div>
+          </BlockPathProvider>
+        </StepIndexProvider>
+      </TabSelectionScope>
+    );
+
+    const sdkSection = within(screen.getByTestId('sdk-tabs'));
+    const profilingSection = within(screen.getByTestId('profiling-tabs'));
+
+    // Both default to "Package Manager" (first tab)
+    expect(sdkSection.getByText('Install-Package Sentry')).toBeInTheDocument();
+    expect(
+      profilingSection.getByText('Install-Package Sentry.Profiling')
+    ).toBeInTheDocument();
+
+    // Switch SDK tabs to ".NET Core CLI"
+    await userEvent.click(sdkSection.getByRole('button', {name: '.NET Core CLI'}));
+
+    // SDK section switched, profiling section unchanged
+    expect(sdkSection.getByText('dotnet add package Sentry')).toBeInTheDocument();
+    expect(
+      profilingSection.getByText('Install-Package Sentry.Profiling')
+    ).toBeInTheDocument();
+
+    // Switch profiling tabs to ".NET Core CLI"
+    await userEvent.click(profilingSection.getByRole('button', {name: '.NET Core CLI'}));
+
+    // Both now show ".NET Core CLI" independently
+    expect(sdkSection.getByText('dotnet add package Sentry')).toBeInTheDocument();
+    expect(
+      profilingSection.getByText('dotnet add package Sentry.Profiling')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('TabbedCodeSnippet without TabSelectionScope', () => {
+  it('allows tab switching via local state fallback', async () => {
+    render(<TabbedCodeSnippet tabs={PACKAGE_MANAGER_TABS} />);
+
+    // Default is npm (first tab)
+    expect(screen.getByText('npm install @sentry/node')).toBeInTheDocument();
+
+    // Switch to yarn — should work even without TabSelectionScope
+    await userEvent.click(screen.getByRole('button', {name: 'yarn'}));
+    expect(screen.getByText('yarn add @sentry/node')).toBeInTheDocument();
+    expect(screen.queryByText('npm install @sentry/node')).not.toBeInTheDocument();
+
+    // Switch to pnpm
+    await userEvent.click(screen.getByRole('button', {name: 'pnpm'}));
+    expect(screen.getByText('pnpm add @sentry/node')).toBeInTheDocument();
+    expect(screen.queryByText('yarn add @sentry/node')).not.toBeInTheDocument();
+  });
+});
+
+describe('TabSelectionScope isolation', () => {
+  it('isolates selections between separate TabSelectionScope instances', async () => {
+    render(
+      <div>
+        <div data-test-id="scope-a">
+          <TabSelectionScope>
+            <StepIndexProvider index={0}>
+              <TabbedCodeSnippet tabs={PACKAGE_MANAGER_TABS} />
+            </StepIndexProvider>
+          </TabSelectionScope>
+        </div>
+        <div data-test-id="scope-b">
+          <TabSelectionScope>
+            <StepIndexProvider index={0}>
+              <TabbedCodeSnippet tabs={PACKAGE_MANAGER_TABS} />
+            </StepIndexProvider>
+          </TabSelectionScope>
+        </div>
+      </div>
+    );
+
+    const scopeA = within(screen.getByTestId('scope-a'));
+    const scopeB = within(screen.getByTestId('scope-b'));
+
+    // Both default to npm
+    expect(scopeA.getByText('npm install @sentry/node')).toBeInTheDocument();
+    expect(scopeB.getByText('npm install @sentry/node')).toBeInTheDocument();
+
+    // Select yarn in scope A
+    await userEvent.click(scopeA.getByRole('button', {name: 'yarn'}));
+
+    // Scope A shows yarn, scope B still shows npm
+    expect(scopeA.getByText('yarn add @sentry/node')).toBeInTheDocument();
+    expect(scopeB.getByText('npm install @sentry/node')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.tsx
@@ -1,0 +1,160 @@
+/**
+ * Scoped store for tracking selected code tabs across onboarding snippets.
+ *
+ * Tab selections live as React state in `TabSelectionScope`, keyed by
+ * deriveTabKey. This lets selections persist across component
+ * mount/unmount cycles (e.g. when GuidedSteps navigates between steps)
+ * and isolates selections per guide instance, preventing cross-guide
+ * contamination when multiple guides render simultaneously.
+ */
+
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
+
+type TabSelectionsState = {
+  selections: ReadonlyMap<string, string>;
+  setSelection: (key: string, value: string) => void;
+};
+
+const TabRegistryContext = createContext<TabSelectionsState | null>(null);
+
+const StepIndexContext = createContext<number | undefined>(undefined);
+
+/**
+ * Tracks the position of a content block within the step's content tree.
+ * Builds a path like "1" (top-level block 1) or "2_1" (block 1 inside
+ * conditional block 2). Used to disambiguate tabbed code blocks that
+ * share identical labels within the same step.
+ */
+const BlockPathContext = createContext<string>('');
+
+/**
+ * Provides the current step index to descendant TabbedCodeSnippets.
+ * Rendered by the Step component so that tab selection keys include the
+ * step index, preventing collisions when different steps have tabs with
+ * identical labels.
+ */
+export function StepIndexProvider({
+  index,
+  children,
+}: {
+  children: React.ReactNode;
+  index: number;
+}) {
+  return <StepIndexContext.Provider value={index}>{children}</StepIndexContext.Provider>;
+}
+
+/**
+ * Wraps a content block to extend the block path with its index.
+ * Used by renderBlocks to build nested paths like "2_1" for blocks
+ * inside conditional blocks.
+ */
+export function BlockPathProvider({
+  index,
+  children,
+}: {
+  children: React.ReactNode;
+  index: number;
+}) {
+  const parentPath = useContext(BlockPathContext);
+  const path = parentPath ? `${parentPath}_${index}` : `${index}`;
+  return <BlockPathContext.Provider value={path}>{children}</BlockPathContext.Provider>;
+}
+
+/**
+ * Derives a stable key from a set of tab labels, optionally prefixed
+ * with a step index and block path for disambiguation.
+ *
+ * The block path differentiates multiple tabbed blocks with identical
+ * labels within the same step (e.g. dotnet install step has two
+ * "Package Manager / .NET Core CLI" tab groups at paths "1" and "2_1").
+ *
+ * Used to match component-side selections with content-block-side
+ * lookups in stepsToMarkdown.
+ */
+export function deriveTabKey(
+  tabs: ReadonlyArray<{label: string}>,
+  stepIndex?: number,
+  blockPath?: string
+): string {
+  const labelPart = tabs.map(t => t.label).join('\0');
+  const pathPart = blockPath ? `\x01${blockPath}` : '';
+  const base = `${labelPart}${pathPart}`;
+  return stepIndex === undefined ? base : `${stepIndex}:${base}`;
+}
+
+/**
+ * Scopes tab selections to a specific guide instance.
+ * Every onboarding surface should wrap its content with this provider.
+ */
+export function TabSelectionScope({children}: {children: React.ReactNode}) {
+  const [selections, setSelections] = useState<ReadonlyMap<string, string>>(
+    () => new Map()
+  );
+
+  const setSelection = useCallback((key: string, value: string) => {
+    setSelections(prev => {
+      const next = new Map(prev);
+      next.set(key, value);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(() => ({selections, setSelection}), [selections, setSelection]);
+
+  return (
+    <TabRegistryContext.Provider value={value}>{children}</TabRegistryContext.Provider>
+  );
+}
+
+/**
+ * Manages tab selection state for a TabbedCodeSnippet, backed by the
+ * nearest TabSelectionScope. The selection survives component
+ * unmount/remount (e.g. when GuidedSteps navigates between steps)
+ * because state lives in the provider, not in the component.
+ *
+ * Falls back to local useState when no TabSelectionScope is present,
+ * preserving backward compatibility for standalone TabbedCodeSnippets.
+ *
+ * Returns [selectedValue, setSelectedValue] like useState.
+ */
+export function useRegisteredTabSelection(
+  tabs: ReadonlyArray<{label: string; value: string}>
+): [string, (value: string) => void] {
+  const ctx = useContext(TabRegistryContext);
+  const stepIndex = useContext(StepIndexContext);
+  const blockPath = useContext(BlockPathContext);
+  const key = deriveTabKey(tabs, stepIndex, blockPath || undefined);
+
+  // Local fallback when no TabSelectionScope is present (e.g.
+  // screensLandingPage.tsx renders TabbedCodeSnippet standalone).
+  const [localValue, setLocalValue] = useState(tabs[0]!.value);
+
+  const storedValue = ctx ? ctx.selections.get(key) : localValue;
+  const selectedValue = storedValue
+    ? (tabs.find(t => t.value === storedValue)?.value ?? tabs[0]!.value)
+    : tabs[0]!.value;
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      if (ctx) {
+        ctx.setSelection(key, newValue);
+      } else {
+        setLocalValue(newValue);
+      }
+    },
+    [ctx, key]
+  );
+
+  return [selectedValue, setValue];
+}
+
+/**
+ * Returns the scope's tab selections map for use in stepsToMarkdown.
+ * Keys are derived from tab labels via deriveTabKey.
+ */
+export function useTabSelectionsMap(): ReadonlyMap<string, string> {
+  const ctx = useContext(TabRegistryContext);
+  return ctx?.selections ?? _emptyMap;
+}
+
+const _emptyMap: ReadonlyMap<string, string> = new Map();

--- a/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/selectedCodeTabContext.tsx
@@ -71,7 +71,7 @@ export function BlockPathProvider({
  * Used to match component-side selections with content-block-side
  * lookups in stepsToMarkdown.
  */
-export function deriveTabKey(
+function deriveTabKey(
   tabs: ReadonlyArray<{label: string}>,
   stepIndex?: number,
   blockPath?: string
@@ -147,14 +147,3 @@ export function useRegisteredTabSelection(
 
   return [selectedValue, setValue];
 }
-
-/**
- * Returns the scope's tab selections map for use in stepsToMarkdown.
- * Keys are derived from tab labels via deriveTabKey.
- */
-export function useTabSelectionsMap(): ReadonlyMap<string, string> {
-  const ctx = useContext(TabRegistryContext);
-  return ctx?.selections ?? _emptyMap;
-}
-
-const _emptyMap: ReadonlyMap<string, string> = new Map();

--- a/static/app/components/onboarding/gettingStartedDoc/step.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/step.tsx
@@ -6,6 +6,7 @@ import {Button} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
 
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {StepIndexProvider} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {
   StepType,
   type OnboardingStep,
@@ -27,13 +28,19 @@ export function Step({
   onOptionalToggleClick,
   collapsible = false,
   trailingItems,
+  stepIndex,
   ...props
-}: Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> & OnboardingStep) {
+}: Omit<React.HTMLAttributes<HTMLDivElement>, 'content'> &
+  // stepIndex is required so StepIndexProvider can disambiguate tab
+  // selection keys across steps (used by the Copy as Markdown feature).
+  OnboardingStep & {stepIndex: number}) {
   const [showOptionalConfig, setShowOptionalConfig] = useState(false);
 
   const config = (
     <ContentWrapper>
-      <ContentBlocksRenderer contentBlocks={content} />
+      <StepIndexProvider index={stepIndex}>
+        <ContentBlocksRenderer contentBlocks={content} />
+      </StepIndexProvider>
     </ContentWrapper>
   );
 

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -11,6 +11,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import useDrawer from 'sentry/components/globalDrawer';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -333,13 +334,13 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   ];
 
   return (
-    <Fragment>
+    <TabSelectionScope>
       {performanceDocs.introduction && (
         <Introduction>{performanceDocs.introduction(docParams)}</Introduction>
       )}
       <Steps>
-        {steps.map(step => {
-          return <Step key={step.title ?? step.type} {...step} />;
+        {steps.map((step, index) => {
+          return <Step key={step.title ?? step.type} stepIndex={index} {...step} />;
         })}
       </Steps>
       <EventWaiter
@@ -353,7 +354,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       >
         {() => (received ? <EventReceivedIndicator /> : <EventWaitingIndicator />)}
       </EventWaiter>
-    </Fragment>
+    </TabSelectionScope>
   );
 }
 

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -11,6 +11,7 @@ import IdBadge from 'sentry/components/idBadge';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DeprecatedPlatformInfo} from 'sentry/components/onboarding/gettingStartedDoc/deprecatedPlatformInfo';
+import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   DocsPageLocation,
@@ -359,14 +360,16 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
   const steps = [...doc.install(docParams), ...doc.configure(docParams)];
 
   return (
-    <Wrapper>
-      {doc.introduction && <Introduction>{doc.introduction(docParams)}</Introduction>}
-      <Steps>
-        {steps.map(step => {
-          return <Step key={step.title ?? step.type} {...step} />;
-        })}
-      </Steps>
-    </Wrapper>
+    <TabSelectionScope>
+      <Wrapper>
+        {doc.introduction && <Introduction>{doc.introduction(docParams)}</Introduction>}
+        <Steps>
+          {steps.map((step, index) => {
+            return <Step key={step.title ?? step.type} stepIndex={index} {...step} />;
+          })}
+        </Steps>
+      </Wrapper>
+    </TabSelectionScope>
   );
 }
 

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -5,6 +5,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
+import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
@@ -102,49 +103,50 @@ export function ReplayOnboardingLayout({
     />
   );
 
+  // TODO(aknaus): Move inserting the toggle into the docs definitions
+  // once the content blocks migration is done. This logic here is very brittle.
+  const transformedSteps = steps.map(step => {
+    if (step.type !== StepType.CONFIGURE || hideMaskBlockToggles) {
+      return step;
+    }
+
+    if (step.content) {
+      const codeIndex = step.content?.findIndex(b => b.type === 'code');
+      if (codeIndex === -1) {
+        return step;
+      }
+      const newContent = [...step.content];
+      if (codeIndex !== undefined) {
+        newContent.splice(codeIndex, 0, {
+          type: 'custom',
+          bottomMargin: false,
+          content: replayConfigToggle,
+        });
+      }
+      return {
+        ...step,
+        content: newContent,
+      };
+    }
+
+    return {
+      ...step,
+      codeHeader: replayConfigToggle,
+    };
+  });
+
   return (
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
-      <Wrapper>
-        {introduction && <Stack margin="0 0 xl 0">{introduction}</Stack>}
-        <Stack gap="lg">
-          {steps
-            // TODO(aknaus): Move inserting the toggle into the docs definitions
-            // once the content blocks migration is done. This logic here is very brittle.
-            .map(step => {
-              if (step.type !== StepType.CONFIGURE || hideMaskBlockToggles) {
-                return step;
-              }
-
-              if (step.content) {
-                // Insert the feedback config toggle before the code block
-                const codeIndex = step.content?.findIndex(b => b.type === 'code');
-                if (codeIndex === -1) {
-                  return step;
-                }
-                const newContent = [...step.content];
-                if (codeIndex !== undefined) {
-                  newContent.splice(codeIndex, 0, {
-                    type: 'custom',
-                    bottomMargin: false,
-                    content: replayConfigToggle,
-                  });
-                }
-                return {
-                  ...step,
-                  content: newContent,
-                };
-              }
-
-              return {
-                ...step,
-                codeHeader: replayConfigToggle,
-              };
-            })
-            .map(step => (
-              <Step key={step.title ?? step.type} {...step} />
+      <TabSelectionScope>
+        <Wrapper>
+          {introduction && <Stack margin="0 0 xl 0">{introduction}</Stack>}
+          <Stack gap="lg">
+            {transformedSteps.map((step, index) => (
+              <Step key={step.title ?? step.type} stepIndex={index} {...step} />
             ))}
-        </Stack>
-      </Wrapper>
+          </Stack>
+        </Wrapper>
+      </TabSelectionScope>
     </AuthTokenGeneratorProvider>
   );
 }

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -10,6 +10,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
   DocsParams,
@@ -167,63 +171,67 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
 
   return (
     <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-      <div>
-        <HeaderWrapper>
-          <Title>{t('Get Started with Sentry Issues')}</Title>
-          <Description>
-            {t('Your code sleuth eagerly awaits its first mission.')}
-          </Description>
-          <Image src={waitingForEventImg} />
-        </HeaderWrapper>
-        <Divider />
-        <Body>
-          <Setup>
-            <SetupTitle project={project} />
-            <GuidedSteps
-              initialStep={decodeInteger(location.query.guidedStep)}
-              onStepChange={step => {
-                navigate({
-                  pathname: location.pathname,
-                  query: {
-                    ...location.query,
-                    guidedStep: step,
-                  },
-                });
-              }}
-            >
-              {steps.map((step, index) => {
-                const title = step.title ?? StepTitles[step.type ?? 'install'];
-                const isLastStep = index === steps.length - 1;
-                return (
-                  <GuidedSteps.Step key={index} stepKey={title} title={title}>
-                    <ContentBlocksRenderer
-                      contentBlocks={step.content}
-                      spacing={space(1)}
-                    />
-                    <GuidedSteps.ButtonWrapper>
-                      <GuidedSteps.BackButton size="md" />
-                      <GuidedSteps.NextButton size="md" />
-                      {isLastStep && <WaitingIndicator project={project} />}
-                    </GuidedSteps.ButtonWrapper>
-                    {/* This spacer ensures the whole pulse effect is visible, as the parent has overflow: hidden */}
-                    {isLastStep && <PulseSpacer />}
-                  </GuidedSteps.Step>
-                );
-              })}
-            </GuidedSteps>
-          </Setup>
-          <Preview>
-            <BodyTitle>{t('Preview a Sentry Issue')}</BodyTitle>
-            <ArcadeWrapper>
-              <Arcade
-                src="https://demo.arcade.software/bQko6ZTRFMyTm6fJaDzs?embed"
-                loading="lazy"
-                allowFullScreen
-              />
-            </ArcadeWrapper>
-          </Preview>
-        </Body>
-      </div>
+      <TabSelectionScope>
+        <div>
+          <HeaderWrapper>
+            <Title>{t('Get Started with Sentry Issues')}</Title>
+            <Description>
+              {t('Your code sleuth eagerly awaits its first mission.')}
+            </Description>
+            <Image src={waitingForEventImg} />
+          </HeaderWrapper>
+          <Divider />
+          <Body>
+            <Setup>
+              <SetupTitle project={project} />
+              <GuidedSteps
+                initialStep={decodeInteger(location.query.guidedStep)}
+                onStepChange={step => {
+                  navigate({
+                    pathname: location.pathname,
+                    query: {
+                      ...location.query,
+                      guidedStep: step,
+                    },
+                  });
+                }}
+              >
+                {steps.map((step, index) => {
+                  const title = step.title ?? StepTitles[step.type ?? 'install'];
+                  const isLastStep = index === steps.length - 1;
+                  return (
+                    <GuidedSteps.Step key={index} stepKey={title} title={title}>
+                      <StepIndexProvider index={index}>
+                        <ContentBlocksRenderer
+                          contentBlocks={step.content}
+                          spacing={space(1)}
+                        />
+                      </StepIndexProvider>
+                      <GuidedSteps.ButtonWrapper>
+                        <GuidedSteps.BackButton size="md" />
+                        <GuidedSteps.NextButton size="md" />
+                        {isLastStep && <WaitingIndicator project={project} />}
+                      </GuidedSteps.ButtonWrapper>
+                      {/* This spacer ensures the whole pulse effect is visible, as the parent has overflow: hidden */}
+                      {isLastStep && <PulseSpacer />}
+                    </GuidedSteps.Step>
+                  );
+                })}
+              </GuidedSteps>
+            </Setup>
+            <Preview>
+              <BodyTitle>{t('Preview a Sentry Issue')}</BodyTitle>
+              <ArcadeWrapper>
+                <Arcade
+                  src="https://demo.arcade.software/bQko6ZTRFMyTm6fJaDzs?embed"
+                  loading="lazy"
+                  allowFullScreen
+                />
+              </ArcadeWrapper>
+            </Preview>
+          </Body>
+        </div>
+      </TabSelectionScope>
     </AuthTokenGeneratorProvider>
   );
 }

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -11,6 +11,10 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   ProductSolution,
@@ -116,41 +120,47 @@ function OnboardingPanel({
     <Panel>
       <PanelBody>
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-          <div>
-            <HeaderWrapper>
-              <HeaderText>
-                <Title>{t('Your Source for Log-ical Data')}</Title>
-                <SubTitle>
-                  {t(
-                    "It's about time we offered something a bit more robust than breadcrumbs. With logs, you'll be able to have a lot more control and context over all your data."
-                  )}
-                </SubTitle>
-                <BulletList>
-                  <li>{t('Access logs in real time and query them by any attribute')}</li>
-                  <li>
-                    {t('Correlate your logs with errors and traces for full context')}
-                  </li>
-                  <li>{t('Build alerts and dashboard widgets based on log queries')}</li>
-                </BulletList>
-              </HeaderText>
-              <Image src={connectDotsImg} />
-            </HeaderWrapper>
-            <Divider />
-            <Body>
-              <Setup>
-                {children}
-                <LogDrainsLink project={project} />
-              </Setup>
-              <Preview>
-                <BodyTitle>{t('Preview a Sentry Log')}</BodyTitle>
-                <Arcade
-                  src="https://demo.arcade.software/dLjHGrPJITrt7JKpmX5V?embed"
-                  loading="lazy"
-                  allowFullScreen
-                />
-              </Preview>
-            </Body>
-          </div>
+          <TabSelectionScope>
+            <div>
+              <HeaderWrapper>
+                <HeaderText>
+                  <Title>{t('Your Source for Log-ical Data')}</Title>
+                  <SubTitle>
+                    {t(
+                      "It's about time we offered something a bit more robust than breadcrumbs. With logs, you'll be able to have a lot more control and context over all your data."
+                    )}
+                  </SubTitle>
+                  <BulletList>
+                    <li>
+                      {t('Access logs in real time and query them by any attribute')}
+                    </li>
+                    <li>
+                      {t('Correlate your logs with errors and traces for full context')}
+                    </li>
+                    <li>
+                      {t('Build alerts and dashboard widgets based on log queries')}
+                    </li>
+                  </BulletList>
+                </HeaderText>
+                <Image src={connectDotsImg} />
+              </HeaderWrapper>
+              <Divider />
+              <Body>
+                <Setup>
+                  {children}
+                  <LogDrainsLink project={project} />
+                </Setup>
+                <Preview>
+                  <BodyTitle>{t('Preview a Sentry Log')}</BodyTitle>
+                  <Arcade
+                    src="https://demo.arcade.software/dLjHGrPJITrt7JKpmX5V?embed"
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </Preview>
+              </Body>
+            </div>
+          </TabSelectionScope>
         </AuthTokenGeneratorProvider>
       </PanelBody>
     </Panel>
@@ -321,7 +331,9 @@ function Onboarding({organization, project}: OnboardingProps) {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
             <GuidedSteps.Step key={title} stepKey={title} title={title}>
-              <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              <StepIndexProvider index={index}>
+                <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              </StepIndexProvider>
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -10,6 +10,10 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   ProductSolution,
@@ -64,32 +68,34 @@ function OnboardingPanel({
     <Panel>
       <PanelBody>
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-          <div>
-            <HeaderWrapper>
-              <HeaderText>
-                <Title>{t('Measure what matters with Metrics')}</Title>
-                <SubTitle>
-                  {t(
-                    'Track application metrics with powerful aggregation and visualization capabilities. Metrics will be connected to your errors, logs and spans enabling easier debugging'
-                  )}
-                </SubTitle>
-                {isUnsupportedPlatform && <div>{children}</div>}
-              </HeaderText>
-              <Image src={connectDotsImg} />
-            </HeaderWrapper>
-            <Divider />
-            <Body isUnsupportedPlatform={isUnsupportedPlatform}>
-              {!isUnsupportedPlatform && <Setup>{children}</Setup>}
-              <Preview isUnsupportedPlatform={isUnsupportedPlatform}>
-                <BodyTitle>{t('Preview a Sentry Metric')}</BodyTitle>
-                <Arcade
-                  src="https://demo.arcade.software/wNDJOXTJw64xiuVi7Hp6?embed"
-                  loading="lazy"
-                  allowFullScreen
-                />
-              </Preview>
-            </Body>
-          </div>
+          <TabSelectionScope>
+            <div>
+              <HeaderWrapper>
+                <HeaderText>
+                  <Title>{t('Measure what matters with Metrics')}</Title>
+                  <SubTitle>
+                    {t(
+                      'Track application metrics with powerful aggregation and visualization capabilities. Metrics will be connected to your errors, logs and spans enabling easier debugging'
+                    )}
+                  </SubTitle>
+                  {isUnsupportedPlatform && <div>{children}</div>}
+                </HeaderText>
+                <Image src={connectDotsImg} />
+              </HeaderWrapper>
+              <Divider />
+              <Body isUnsupportedPlatform={isUnsupportedPlatform}>
+                {!isUnsupportedPlatform && <Setup>{children}</Setup>}
+                <Preview isUnsupportedPlatform={isUnsupportedPlatform}>
+                  <BodyTitle>{t('Preview a Sentry Metric')}</BodyTitle>
+                  <Arcade
+                    src="https://demo.arcade.software/wNDJOXTJw64xiuVi7Hp6?embed"
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </Preview>
+              </Body>
+            </div>
+          </TabSelectionScope>
         </AuthTokenGeneratorProvider>
       </PanelBody>
     </Panel>
@@ -257,7 +263,9 @@ function Onboarding({organization, project}: OnboardingProps) {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
             <GuidedSteps.Step key={title} stepKey={title} title={title}>
-              <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              <StepIndexProvider index={index}>
+                <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              </StepIndexProvider>
               {index === steps.length - 1 ? (
                 <GuidedSteps.ButtonWrapper>
                   <GuidedSteps.BackButton size="md" />

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -10,6 +10,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import type {
   DocsParams,
@@ -111,18 +115,22 @@ function WaitingIndicator({project}: {project: Project}) {
 function StepRenderer({
   project,
   step,
+  stepIndex,
   isLastStep,
 }: {
   isLastStep: boolean;
   project: Project;
   step: OnboardingStep;
+  stepIndex: number;
 }) {
   return (
     <GuidedSteps.Step
       stepKey={step.type || step.title}
       title={step.title || (step.type && StepTitles[step.type])}
     >
-      <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+      <StepIndexProvider index={stepIndex}>
+        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+      </StepIndexProvider>
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />
@@ -145,49 +153,51 @@ function OnboardingPanel({
     <Panel>
       <PanelBody>
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-          <div>
-            <HeaderWrapper>
-              <HeaderText>
-                <Title>{t('Monitor MCP Servers')}</Title>
-                <SubTitle>
-                  {t(
-                    'Monitor MCP server connections, resource access, tool executions, and errors across your entire pipeline—from client requests to server responses.'
-                  )}
-                </SubTitle>
-                <BulletList>
-                  <li>
+          <TabSelectionScope>
+            <div>
+              <HeaderWrapper>
+                <HeaderText>
+                  <Title>{t('Monitor MCP Servers')}</Title>
+                  <SubTitle>
                     {t(
-                      'Trace complete request flows to identify where connections are breaking'
+                      'Monitor MCP server connections, resource access, tool executions, and errors across your entire pipeline—from client requests to server responses.'
                     )}
-                  </li>
-                  <li>
-                    {t(
-                      'Debug resource requests and server responses when data is outdated or malformed'
-                    )}
-                  </li>
-                  <li>
-                    {t(
-                      'Identify performance bottlenecks in server startup, resource fetching, or tool execution'
-                    )}
-                  </li>
-                </BulletList>
-              </HeaderText>
-              <Image src={emptyTraceImg} />
-            </HeaderWrapper>
-            <Divider />
+                  </SubTitle>
+                  <BulletList>
+                    <li>
+                      {t(
+                        'Trace complete request flows to identify where connections are breaking'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Debug resource requests and server responses when data is outdated or malformed'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Identify performance bottlenecks in server startup, resource fetching, or tool execution'
+                      )}
+                    </li>
+                  </BulletList>
+                </HeaderText>
+                <Image src={emptyTraceImg} />
+              </HeaderWrapper>
+              <Divider />
 
-            <Body>
-              <Setup>{children}</Setup>
-              <Preview>
-                <BodyTitle>{t('Preview MCP Insights')}</BodyTitle>
-                <Arcade
-                  src="https://demo.arcade.software/dMIA7maXWbgcaAGP79ah?embed"
-                  loading="lazy"
-                  allowFullScreen
-                />
-              </Preview>
-            </Body>
-          </div>
+              <Body>
+                <Setup>{children}</Setup>
+                <Preview>
+                  <BodyTitle>{t('Preview MCP Insights')}</BodyTitle>
+                  <Arcade
+                    src="https://demo.arcade.software/dMIA7maXWbgcaAGP79ah?embed"
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </Preview>
+              </Body>
+            </div>
+          </TabSelectionScope>
         </AuthTokenGeneratorProvider>
       </PanelBody>
     </Panel>
@@ -314,7 +324,7 @@ export function Onboarding() {
     ...(mcpDocs.install?.(docParams) || []),
     ...(mcpDocs.configure?.(docParams) || []),
     ...(mcpDocs.verify?.(docParams) || []),
-  ];
+  ].filter(s => !s.collapsible);
 
   return (
     <OnboardingPanel project={project}>
@@ -324,17 +334,15 @@ export function Onboarding() {
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <GuidedSteps>
-        {steps
-          // Only show non-optional steps
-          .filter(step => !step.collapsible)
-          .map((step, index) => (
-            <StepRenderer
-              key={index}
-              project={project}
-              step={step}
-              isLastStep={index === steps.length - 1}
-            />
-          ))}
+        {steps.map((step, index) => (
+          <StepRenderer
+            key={index}
+            project={project}
+            step={step}
+            stepIndex={index}
+            isLastStep={index === steps.length - 1}
+          />
+        ))}
       </GuidedSteps>
     </OnboardingPanel>
   );

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -28,6 +28,10 @@ import FeatureTourModal, {
 } from 'sentry/components/modals/featureTourModal';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
   ProductSolution,
@@ -349,48 +353,50 @@ function OnboardingPanel({
     <Panel>
       <PanelBody>
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-          <div>
-            <HeaderWrapper>
-              <HeaderText>
-                <Title>{t('Query for Traces, Get Answers')}</Title>
-                <SubTitle>
-                  {t(
-                    'You can query and aggregate spans to create metrics that help you debug busted API calls, slow image loads, or any other metrics you’d like to track.'
-                  )}
-                </SubTitle>
-                <BulletList>
-                  <li>
+          <TabSelectionScope>
+            <div>
+              <HeaderWrapper>
+                <HeaderText>
+                  <Title>{t('Query for Traces, Get Answers')}</Title>
+                  <SubTitle>
                     {t(
-                      'Find traces tied to a user complaint and pinpoint exactly what broke'
+                      'You can query and aggregate spans to create metrics that help you debug busted API calls, slow image loads, or any other metrics you’d like to track.'
                     )}
-                  </li>
-                  <li>
-                    {t(
-                      'Debug persistent issues by investigating API payloads, cache sizes, user tokens, and more'
-                    )}
-                  </li>
-                  <li>
-                    {t(
-                      'Track any span attribute as a metric to catch slowdowns before they escalate'
-                    )}
-                  </li>
-                </BulletList>
-              </HeaderText>
-              <Image src={emptyTraceImg} />
-            </HeaderWrapper>
-            <Divider />
-            <Body>
-              <Setup>{children}</Setup>
-              <Preview>
-                <BodyTitle>{t('Preview a Sentry Trace')}</BodyTitle>
-                <Arcade
-                  src="https://demo.arcade.software/BPVB65UiYCxixEw8bnmj?embed"
-                  loading="lazy"
-                  allowFullScreen
-                />
-              </Preview>
-            </Body>
-          </div>
+                  </SubTitle>
+                  <BulletList>
+                    <li>
+                      {t(
+                        'Find traces tied to a user complaint and pinpoint exactly what broke'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Debug persistent issues by investigating API payloads, cache sizes, user tokens, and more'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Track any span attribute as a metric to catch slowdowns before they escalate'
+                      )}
+                    </li>
+                  </BulletList>
+                </HeaderText>
+                <Image src={emptyTraceImg} />
+              </HeaderWrapper>
+              <Divider />
+              <Body>
+                <Setup>{children}</Setup>
+                <Preview>
+                  <BodyTitle>{t('Preview a Sentry Trace')}</BodyTitle>
+                  <Arcade
+                    src="https://demo.arcade.software/BPVB65UiYCxixEw8bnmj?embed"
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </Preview>
+              </Body>
+            </div>
+          </TabSelectionScope>
         </AuthTokenGeneratorProvider>
       </PanelBody>
     </Panel>
@@ -593,7 +599,9 @@ export function Onboarding({organization, project}: OnboardingProps) {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
             <GuidedSteps.Step key={title} stepKey={title} title={title}>
-              <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              <StepIndexProvider index={index}>
+                <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+              </StepIndexProvider>
               {index === steps.length - 1 ? (
                 <Fragment>
                   {eventWaitingIndicator}

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -8,6 +8,10 @@ import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
+import {
+  StepIndexProvider,
+  TabSelectionScope,
+} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {StepTitles} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
   DocsPageLocation,
@@ -89,11 +93,13 @@ function WaitingIndicator({
 function StepRenderer({
   project,
   step,
+  stepIndex,
   isLastStep,
 }: {
   isLastStep: boolean;
   project: Project;
   step: OnboardingStep;
+  stepIndex: number;
 }) {
   const {type, title} = step;
   const api = useApi();
@@ -101,7 +107,9 @@ function StepRenderer({
 
   return (
     <GuidedSteps.Step stepKey={type || title} title={title || (type && StepTitles[type])}>
-      <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+      <StepIndexProvider index={stepIndex}>
+        <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
+      </StepIndexProvider>
       <GuidedSteps.ButtonWrapper>
         <GuidedSteps.BackButton size="md" />
         <GuidedSteps.NextButton size="md" />
@@ -135,48 +143,50 @@ function OnboardingPanel({
     <Panel>
       <PanelBody>
         <AuthTokenGeneratorProvider projectSlug={project?.slug}>
-          <div>
-            <HeaderWrapper>
-              <HeaderText>
-                <Title>{t('Find Slow Code')}</Title>
-                <SubTitle>
-                  {t(
-                    'Use aggregated profiling data to find the slowest code paths in your app and to identify functions that have regressed in performance.'
-                  )}
-                </SubTitle>
-                <BulletList>
-                  <li>
+          <TabSelectionScope>
+            <div>
+              <HeaderWrapper>
+                <HeaderText>
+                  <Title>{t('Find Slow Code')}</Title>
+                  <SubTitle>
                     {t(
-                      'Find and optimize resource-intensive code paths that cause excessive infrastructure cost for running your backend services'
+                      'Use aggregated profiling data to find the slowest code paths in your app and to identify functions that have regressed in performance.'
                     )}
-                  </li>
-                  <li>
-                    {t(
-                      'Debug unresponsive interactions and janky scrolling in your mobile and browser apps'
-                    )}
-                  </li>
-                  <li>
-                    {t(
-                      'Augment traces & spans with function-level visibility into the code that is causing increased latency'
-                    )}
-                  </li>
-                </BulletList>
-              </HeaderText>
-              <Image src={emptyTraceImg} />
-            </HeaderWrapper>
-            <Divider />
-            <Body>
-              <Setup>{children}</Setup>
-              <Preview>
-                <BodyTitle>{t('Preview a Sentry Profile')}</BodyTitle>
-                <Arcade
-                  src="https://demo.arcade.software/BSKubAMPPaF4N5hujNbi?embed"
-                  loading="lazy"
-                  allowFullScreen
-                />
-              </Preview>
-            </Body>
-          </div>
+                  </SubTitle>
+                  <BulletList>
+                    <li>
+                      {t(
+                        'Find and optimize resource-intensive code paths that cause excessive infrastructure cost for running your backend services'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Debug unresponsive interactions and janky scrolling in your mobile and browser apps'
+                      )}
+                    </li>
+                    <li>
+                      {t(
+                        'Augment traces & spans with function-level visibility into the code that is causing increased latency'
+                      )}
+                    </li>
+                  </BulletList>
+                </HeaderText>
+                <Image src={emptyTraceImg} />
+              </HeaderWrapper>
+              <Divider />
+              <Body>
+                <Setup>{children}</Setup>
+                <Preview>
+                  <BodyTitle>{t('Preview a Sentry Profile')}</BodyTitle>
+                  <Arcade
+                    src="https://demo.arcade.software/BSKubAMPPaF4N5hujNbi?embed"
+                    loading="lazy"
+                    allowFullScreen
+                  />
+                </Preview>
+              </Body>
+            </div>
+          </TabSelectionScope>
         </AuthTokenGeneratorProvider>
       </PanelBody>
     </Panel>
@@ -287,7 +297,7 @@ export function Onboarding() {
     ...profilingDocs.install(docParams),
     ...profilingDocs.configure(docParams),
     ...profilingDocs.verify(docParams),
-  ];
+  ].filter(s => !s.collapsible);
 
   return (
     <OnboardingPanel project={project}>
@@ -295,17 +305,15 @@ export function Onboarding() {
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <ContinuousProfilingBillingRequirementBanner project={project} />
       <GuidedSteps>
-        {steps
-          // Only show non-optional steps
-          .filter(step => !step.collapsible)
-          .map((step, index) => (
-            <StepRenderer
-              key={index}
-              project={project}
-              step={step}
-              isLastStep={index === steps.length - 1}
-            />
-          ))}
+        {steps.map((step, index) => (
+          <StepRenderer
+            key={index}
+            project={project}
+            step={step}
+            stepIndex={index}
+            isLastStep={index === steps.length - 1}
+          />
+        ))}
       </GuidedSteps>
     </OnboardingPanel>
   );


### PR DESCRIPTION
## Summary

Hoists tab selection state from individual tabbed code snippet components up to a guide-level React context, making it possible for other consumers to read the full set of tab selections for a guide.

### Why this change is needed

Each onboarding guide contains tabbed code snippets (e.g. npm / yarn / pnpm). Previously, each `TabbedCodeSnippet` component managed its own selection in local React state. This worked for rendering the UI, but meant there was no centralized place to read what the user had selected across all the tabbed sections in a guide.

The upcoming Copy as Markdown feature (#108058) needs to reassemble complete setup instructions — including code blocks not currently visible (e.g. collapsed `GuidedSteps`) — with the user's tab selections applied. That requires guide-level awareness of every tabbed section's state, which individual component state can't provide.

### What this PR introduces

- **`TabSelectionScope`** — A guide-level React context that tracks the selection state of every tabbed code section within its tree.
- **`StepIndexProvider` / `BlockPathContext`** — Provide positional context so each tabbed section gets a unique key via `deriveTabKey`, even when labels are identical across steps.
- **`useRegisteredTabSelection`** — Each tabbed code section registers itself with the scope on mount and reads its selection from the shared context (replacing local state).
- **`useTabSelectionsMap`** — Exposes the full selection map for the current scope, enabling downstream consumers to reassemble instructions with all selections applied.

All onboarding surfaces (sidebars, drawer layouts, page-level panels) are wrapped with `TabSelectionScope`.

This is a pure refactor — no user-facing changes. The copy-as-markdown feature (#108058) stacks on top of this.

## Test plan

- [x] `selectedCodeTabContext.spec.tsx` — 7 tests passing
- [x] Verify tab selections still work correctly in onboarding guides
- [x] Verify sidebar/drawer onboarding guides still render correctly