### PR TITLE
ci: Disable PR comments for changelog preview

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,0 +1,19 @@
+name: Changelog Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  changelog-preview:
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    secrets: inherit

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -16,4 +16,6 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    with:
+      comment: false
     secrets: inherit


### PR DESCRIPTION
## Summary
- Switch changelog-preview workflow to status check mode by setting `comment: false`
- Partially reverts https://github.com/getsentry/sentry/pull/108055
- docs at https://craft.sentry.dev/github-actions/#status-check-mode