### PR TITLE
fix(slack-seer): Simplify blocks, remove skipping steps and excess checks

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -62,9 +62,7 @@ from sentry.notifications.utils.participants import (
     get_suspect_commit_users,
 )
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
-from sentry.seer.autofix.issue_summary import is_group_triggering_automation
 from sentry.seer.entrypoints.operator import SeerOperator
-from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
@@ -509,18 +507,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self._is_compact = features.has(
             "organizations:slack-compact-alerts", self.group.organization
         )
-        self._has_seer_slack_access = SeerOperator.has_access(
-            organization=self.group.project.organization, entrypoint_key=SeerEntrypointKey.SLACK
-        )
-        self._is_triggering_automation = False
-        if self._has_seer_slack_access:
-            try:
-                self._is_triggering_automation = is_group_triggering_automation(self.group)
-            except Exception:
-                # The helper raises value errors in some cases for permission issues. We don't
-                # want to stop building the notification if that happens, just assume it is not
-                # triggering an automation.
-                pass
+        self._has_autofix = SeerOperator.can_trigger_autofix(group=self.group)
 
     def get_title_block(
         self,
@@ -702,10 +689,6 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         if self._is_compact and summary_text:
             blocks.append(self.get_context_block(summary_text))
 
-        if self._has_seer_slack_access and self._is_triggering_automation:
-            status_text = SeerSlackRenderer.render_status_text(group=self.group)
-            blocks.append(self.get_context_block(status_text))
-
         if not self._is_compact and len(suggested_assignees) > 0:
             blocks.append(self.get_suggested_assignees_block(suggested_assignees))
 
@@ -851,7 +834,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     )
                 )
 
-        if self._has_seer_slack_access and not self._is_triggering_automation:
+        if self._has_autofix:
             autofix_button = SeerSlackRenderer.render_autofix_button(group=self.group)
             # We have to coerce this since we're not using the proper SlackSDK client to emit this
             # notification yet, it just takes JSON.

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -63,6 +63,7 @@ from sentry.notifications.utils.participants import (
 )
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
 from sentry.seer.entrypoints.operator import SeerOperator
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.types.actor import Actor
@@ -507,7 +508,9 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         self._is_compact = features.has(
             "organizations:slack-compact-alerts", self.group.organization
         )
-        self._has_autofix = SeerOperator.can_trigger_autofix(group=self.group)
+        self._has_autofix = SeerOperator.has_access(
+            organization=self.group.organization, entrypoint_key=SeerEntrypointKey.SLACK
+        ) and SeerOperator.can_trigger_autofix(group=self.group)
 
     def get_title_block(
         self,

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -115,7 +115,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 SectionBlock(text=data.error_title),
                 SectionBlock(text=MarkdownTextObject(text=f">{data.error_message}")),
             ],
-            text=f"Error while Seer was attempting a fix: {data.error_title}",
+            text=f"Seer encountered an error: {data.error_title}",
         )
 
     @classmethod
@@ -175,7 +175,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
 
         if data.has_progressed and data.current_point != AutofixStoppingPoint.OPEN_PR:
             blocks.extend(cls.render_footer_blocks(data=data))
-        return SlackRenderable(blocks=blocks, text="Seer has an update on fixing the issue!")
+        return SlackRenderable(blocks=blocks, text="Seer has an update on fixing the issue")
 
     @classmethod
     def _render_link_button(

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -236,14 +236,3 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
             )
         )
-
-    @classmethod
-    def render_status_text(cls, group: Group) -> str:
-        """
-        Returns mrkdwn text for the Seer running context block.
-        The entire text is a link to the issue page.
-        """
-        from sentry.seer.entrypoints.integrations.slack import SlackEntrypoint
-
-        group_link = SlackEntrypoint.get_group_link(group)
-        return f"<{group_link}|:hourglass: Seer is running a root cause analysis...>"

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -77,7 +77,6 @@ class SeerAutofixUpdate(NotificationData):
     pull_requests: list[SeerAutofixPullRequest] = field(default_factory=list)
     summary: str | None = None
     has_progressed: bool = False
-    automation_stopping_point: AutofixStoppingPoint | None = None
     source: NotificationTemplateSource = NotificationTemplateSource.SEER_AUTOFIX_UPDATE
 
     @property

--- a/src/sentry/seer/autofix/types.py
+++ b/src/sentry/seer/autofix/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import Any, Literal, TypedDict
 
 
 class AutofixPostResponse(TypedDict):
@@ -18,7 +18,6 @@ class AutofixStateResponse(TypedDict):
 class AutofixSelectRootCausePayload(TypedDict):
     type: Literal["select_root_cause"]
     cause_id: int
-    stopping_point: NotRequired[Literal["solution", "code_changes", "open_pr"]]
 
 
 class AutofixSelectSolutionPayload(TypedDict):

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -487,23 +487,28 @@ def is_seer_seat_based_tier_enabled(organization: Organization) -> bool:
     return has_seat_based_seer
 
 
-def is_issue_eligible_for_seer_automation(group: Group) -> bool:
-    """Check if Seer automation is allowed for a given group based on permissions and issue type."""
-    from sentry import quotas
+def is_issue_category_eligible(group: Group) -> bool:
+    """Check if the issue category is eligible for Seer."""
     from sentry.issues.grouptype import GroupCategory
 
-    # check currently supported issue categories for Seer
-    if group.issue_category not in [
+    return group.issue_category in [
         GroupCategory.ERROR,
         GroupCategory.PERFORMANCE,
         GroupCategory.MOBILE,
         GroupCategory.FRONTEND,
         GroupCategory.DB_QUERY,
         GroupCategory.HTTP_CLIENT,
-    ] or group.issue_category in [
+    ] and group.issue_category not in [
         GroupCategory.REPLAY,
         GroupCategory.FEEDBACK,
-    ]:
+    ]
+
+
+def is_issue_eligible_for_seer_automation(group: Group) -> bool:
+    """Check if Seer automation is allowed for a given group based on permissions and issue type."""
+    from sentry import quotas
+
+    if not is_issue_category_eligible(group):
         return False
 
     if not features.has("organizations:gen-ai-features", group.organization):

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -491,17 +491,14 @@ def is_issue_category_eligible(group: Group) -> bool:
     """Check if the issue category is eligible for Seer."""
     from sentry.issues.grouptype import GroupCategory
 
-    return group.issue_category in [
+    return group.issue_category in {
         GroupCategory.ERROR,
         GroupCategory.PERFORMANCE,
         GroupCategory.MOBILE,
         GroupCategory.FRONTEND,
         GroupCategory.DB_QUERY,
         GroupCategory.HTTP_CLIENT,
-    ] and group.issue_category not in [
-        GroupCategory.REPLAY,
-        GroupCategory.FEEDBACK,
-    ]
+    }
 
 
 def is_issue_eligible_for_seer_automation(group: Group) -> bool:

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -28,11 +28,6 @@ from sentry.notifications.platform.templates.seer import SeerAutofixError, SeerA
 from sentry.notifications.platform.types import NotificationData, NotificationProviderKey
 from sentry.notifications.utils.actions import BlockKitMessageAction
 from sentry.organizations.services.organization.service import organization_service
-from sentry.seer.autofix.issue_summary import (
-    STOPPING_POINT_HIERARCHY,
-    get_automation_stopping_point,
-    is_group_triggering_automation,
-)
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
@@ -66,7 +61,6 @@ class SlackEntrypointCachePayload(TypedDict):
     integration_id: int
     group_link: str
     threads: list[SlackThreadDetails]
-    automation_stopping_point: AutofixStoppingPoint | None
 
 
 @entrypoint_registry.register(key=SeerEntrypointKey.SLACK)
@@ -179,7 +173,6 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             project_id=self.group.project_id,
             group_id=self.group.id,
             group_link=self.get_group_link(self.group),
-            automation_stopping_point=None,
         )
 
     @staticmethod
@@ -257,22 +250,9 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                 logger.info("seer.entrypoint.slack.unsupported_event_type", extra=logging_ctx)
                 return
 
-        # Determine whether an automation has progressed beyond the current stopping point
-        automation_stopping_point = cache_payload["automation_stopping_point"]
-        if automation_stopping_point:
-            data_kwargs["has_progressed"] = (
-                STOPPING_POINT_HIERARCHY[automation_stopping_point]
-                > STOPPING_POINT_HIERARCHY[data_kwargs["current_point"]]
-            )
-            logging_ctx["automation_stopping_point"] = str(automation_stopping_point)
-        logging_ctx["has_progressed"] = data_kwargs.get("has_progressed", False)
-
         # Special case for solution stopping point, we progress beyond it if coding is enabled
         # (if triggered manually, we always respect automation stopping point)
-        if (
-            data_kwargs["current_point"] == AutofixStoppingPoint.SOLUTION
-            and not automation_stopping_point
-        ):
+        if data_kwargs["current_point"] == AutofixStoppingPoint.SOLUTION:
             has_coding_enabled = organization_service.get_option(
                 organization_id=cache_payload["organization_id"],
                 key="sentry:enable_seer_coding",
@@ -542,19 +522,6 @@ def handle_prepare_autofix_update(
         stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
     )
 
-    try:
-        automation_stopping_point = (
-            get_automation_stopping_point(group) if is_group_triggering_automation(group) else None
-        )
-    except Exception:
-        logger.exception(
-            "seer.entrypoint.slack.prepare_autofix.get_stopping_point_error", extra=logging_ctx
-        )
-        automation_stopping_point = None
-
-    if automation_stopping_point:
-        logging_ctx["automation_stopping_point"] = str(automation_stopping_point)
-
     lock = locks.get(lock_key, duration=10, name="autofix_entrypoint_slack")
     try:
         with lock.blocking_acquire(initial_delay=0.1, timeout=3):
@@ -579,7 +546,6 @@ def handle_prepare_autofix_update(
                     project_id=group.project_id,
                     group_id=group.id,
                     group_link=SlackEntrypoint.get_group_link(group),
-                    automation_stopping_point=automation_stopping_point,
                 ),
             )
     except UnableToAcquireLock:
@@ -591,14 +557,10 @@ def handle_prepare_autofix_update(
             "cache_key": cache_result["key"],
             "cache_source": cache_result["source"],
             "thread_count": len(threads),
-            "has_automation": bool(automation_stopping_point),
             **logging_ctx,
         },
     )
     metrics.incr(
         "seer.entrypoint.slack.prepare_autofix.cache_populated",
-        tags={
-            "cache_source": cache_result["source"],
-            "has_automation": str(bool(automation_stopping_point)),
-        },
+        tags={"cache_source": cache_result["source"]},
     )

--- a/src/sentry/seer/entrypoints/integrations/slack.py
+++ b/src/sentry/seer/entrypoints/integrations/slack.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 from slack_sdk.models.blocks.blocks import Block
 
 from sentry import features
-from sentry.constants import (
-    ENABLE_SEER_CODING_DEFAULT,
-    ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
-    ObjectStatus,
-)
+from sentry.constants import ENABLE_SEER_ENHANCED_ALERTS_DEFAULT, ObjectStatus
 from sentry.integrations.services.integration.service import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.locks import locks
@@ -27,7 +23,6 @@ from sentry.notifications.platform.slack.renderers.seer import SeerSlackRenderer
 from sentry.notifications.platform.templates.seer import SeerAutofixError, SeerAutofixUpdate
 from sentry.notifications.platform.types import NotificationData, NotificationProviderKey
 from sentry.notifications.utils.actions import BlockKitMessageAction
-from sentry.organizations.services.organization.service import organization_service
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
@@ -250,17 +245,6 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                 logger.info("seer.entrypoint.slack.unsupported_event_type", extra=logging_ctx)
                 return
 
-        # Special case for solution stopping point, we progress beyond it if coding is enabled
-        # (if triggered manually, we always respect automation stopping point)
-        if data_kwargs["current_point"] == AutofixStoppingPoint.SOLUTION:
-            has_coding_enabled = organization_service.get_option(
-                organization_id=cache_payload["organization_id"],
-                key="sentry:enable_seer_coding",
-            )
-            if has_coding_enabled is None:
-                has_coding_enabled = ENABLE_SEER_CODING_DEFAULT
-            data_kwargs["has_progressed"] = has_coding_enabled
-
         data = SeerAutofixUpdate(**data_kwargs)
         schedule_all_thread_updates(
             threads=cache_payload["threads"],
@@ -460,7 +444,6 @@ def update_existing_message(
         if data.current_point == AutofixStoppingPoint.ROOT_CAUSE
         else remove_all_buttons_transformer
     )
-
     try:
         message_data = request.data["message"]
         original_blocks = message_data["blocks"]

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from rest_framework.response import Response
 
+from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.autofix.autofix import trigger_autofix as _trigger_autofix
@@ -80,6 +81,25 @@ class SeerOperator[CachePayloadT]:
         return any(
             entrypoint_cls.has_access(organization=organization)
             for entrypoint_cls in entrypoint_registry.registrations.values()
+        )
+
+    @classmethod
+    def can_trigger_autofix(cls, *, group: Group) -> bool:
+        """
+        Checks if a group is permitted to trigger autofix.
+        Validates Seer access for the organization, the issue category, and autofix quota.
+        """
+        from sentry import quotas
+        from sentry.seer.autofix.utils import is_issue_category_eligible
+        from sentry.seer.seer_setup import has_seer_access
+
+        return (
+            has_seer_access(group.organization)
+            and is_issue_category_eligible(group)
+            and quotas.backend.check_seer_quota(
+                org_id=group.organization.id,
+                data_category=DataCategory.SEER_AUTOFIX,
+            )
         )
 
     def trigger_autofix(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -139,12 +139,7 @@ class SeerOperator[CachePayloadT]:
             if stopping_point == AutofixStoppingPoint.SOLUTION:
                 # TODO(Leander): We need to figure out a way to get the real cause_id for this.
                 # Probably need to add it to the root cause webhook from seer's side.
-                payload = AutofixSelectRootCausePayload(
-                    type="select_root_cause",
-                    cause_id=0,
-                    # XXX: Continue from solution to code changes automatically.
-                    stopping_point=AutofixStoppingPoint.CODE_CHANGES.value,
-                )
+                payload = AutofixSelectRootCausePayload(type="select_root_cause", cause_id=0)
             elif stopping_point == AutofixStoppingPoint.CODE_CHANGES:
                 payload = AutofixSelectSolutionPayload(type="select_solution")
             elif stopping_point == AutofixStoppingPoint.OPEN_PR:

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -100,13 +100,6 @@ class SeerSlackRendererTest(TestCase):
         assert element.text.text == "Fix with Seer"
         assert element.value == AutofixStoppingPoint.ROOT_CAUSE.value
 
-    def test_render_status_text(self) -> None:
-        text = SeerSlackRenderer.render_status_text(group=self.group)
-        assert ":hourglass: Seer is running a root cause analysis..." in text
-        assert "seerDrawer=true" in text
-        assert text.startswith("<")
-        assert text.endswith(">")
-
     @patch(
         "sentry.notifications.platform.templates.seer.organization_service.get_option",
         return_value=True,

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -239,7 +239,7 @@ class SeerOperatorTest(TestCase):
         )
 
     @patch("sentry.seer.entrypoints.operator.update_autofix")
-    def test_solution_stopping_point_continues_to_code_changes(self, mock_update_autofix):
+    def test_solution_stopping_point_sends_select_root_cause(self, mock_update_autofix):
         mock_update_autofix.return_value = Response({"run_id": MOCK_RUN_ID}, status=202)
 
         self.operator.trigger_autofix(
@@ -254,7 +254,7 @@ class SeerOperatorTest(TestCase):
         assert call_kwargs["organization_id"] == self.group.organization.id
         payload = call_kwargs["payload"]
         assert payload["type"] == "select_root_cause"
-        assert payload["stopping_point"] == "code_changes"
+        assert payload["cause_id"] == 0
 
     def test_can_trigger_autofix_returns_false_without_seer_access(self):
         assert SeerOperator.can_trigger_autofix(group=self.group) is False

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -264,7 +264,6 @@ class SeerOperatorTest(TestCase):
         with self.feature(
             {
                 "organizations:gen-ai-features": True,
-                "organizations:gen-ai-consent-flow-removal": True,
             }
         ):
             assert SeerOperator.can_trigger_autofix(group=self.group) is True
@@ -277,7 +276,6 @@ class SeerOperatorTest(TestCase):
         with self.feature(
             {
                 "organizations:gen-ai-features": True,
-                "organizations:gen-ai-consent-flow-removal": True,
             }
         ):
             assert SeerOperator.can_trigger_autofix(group=feedback_group) is False
@@ -287,7 +285,6 @@ class SeerOperatorTest(TestCase):
         with self.feature(
             {
                 "organizations:gen-ai-features": True,
-                "organizations:gen-ai-consent-flow-removal": True,
             }
         ):
             assert SeerOperator.can_trigger_autofix(group=self.group) is False

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -255,3 +255,39 @@ class SeerOperatorTest(TestCase):
         payload = call_kwargs["payload"]
         assert payload["type"] == "select_root_cause"
         assert payload["stopping_point"] == "code_changes"
+
+    def test_can_trigger_autofix_returns_false_without_seer_access(self):
+        assert SeerOperator.can_trigger_autofix(group=self.group) is False
+
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    def test_can_trigger_autofix_returns_true_when_all_conditions_met(self, mock_quota):
+        with self.feature(
+            {
+                "organizations:gen-ai-features": True,
+                "organizations:gen-ai-consent-flow-removal": True,
+            }
+        ):
+            assert SeerOperator.can_trigger_autofix(group=self.group) is True
+
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    def test_can_trigger_autofix_returns_false_for_ineligible_category(self, mock_quota):
+        from sentry.issues.grouptype import FeedbackGroup
+
+        feedback_group = self.create_group(project=self.project, type=FeedbackGroup.type_id)
+        with self.feature(
+            {
+                "organizations:gen-ai-features": True,
+                "organizations:gen-ai-consent-flow-removal": True,
+            }
+        ):
+            assert SeerOperator.can_trigger_autofix(group=feedback_group) is False
+
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
+    def test_can_trigger_autofix_returns_false_without_quota(self, mock_quota):
+        with self.feature(
+            {
+                "organizations:gen-ai-features": True,
+                "organizations:gen-ai-consent-flow-removal": True,
+            }
+        ):
+            assert SeerOperator.can_trigger_autofix(group=self.group) is False


### PR DESCRIPTION
This pr simplifies a few things:
- We no longer auto-continue from solution to coding -- it conflicted with the UI, and automations were also conflicting.
- We no longer check for coding enablement when determining has_progressed, `has_next_trigger` does this already
- Simplifies the issue alert message builder without checking for current automations -- this has to be revisited since we don't update messages from start signals yet
- Validate the issue can actually have autofix applied before rendering button (no more seer on Rage Clicks & Feedback)
- Slight update to copy for errors, and text