### PR TITLE
feat(onboarding): Register onboarding-copy-setup-instructions feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -253,6 +253,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:on-demand-metrics-ui-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Only enabled in sentry.io to enable onboarding flows.
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    # Enable copy setup instructions button on onboarding surfaces
+    manager.add("organizations:onboarding-copy-setup-instructions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new onboarding welcome and SDK setup UI
     manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit


### PR DESCRIPTION
## Summary
- Registers the `organizations:onboarding-copy-setup-instructions` feature flag in `temporary.py` using `FeatureHandlerStrategy.FLAGPOLE` with `api_expose=True`
- This flag gates the new "Copy setup instructions" button being added to onboarding surfaces in PR #108058

## Related
- Feature PR: #108058 (copy button implementation)
- Flagpole config: separate PR in [sentry-options-automator](https://github.com/getsentry/sentry-options-automator/pull/6452)

## Test plan
- Verify feature flag is registered and exposed to the API
- No functional changes — flag is not yet consumed until #108058 merges