### PR TITLE
feat(dashboards): Migrate Mobile Vitals to prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -27,19 +27,20 @@ export function PrebuiltDashboardRenderer({
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
 
   // Merge the dashboard's built-in filters with any additional global filters.
-  // Overrides replace matching filters in-place (by tag key) to preserve order.
+  // Overrides replace matching filters in-place (by tag key + dataset) to preserve order.
   // Filters with no match in the base list are appended at the end.
   const mergedFilters: DashboardFilters = {...filters};
 
   if (additionalGlobalFilters) {
-    const overridesByKey = new Map(additionalGlobalFilters.map(f => [f.tag.key, f]));
+    const filterKey = (f: GlobalFilter) => `${f.tag.key}:${f.dataset}`;
+    const overridesByKey = new Map(additionalGlobalFilters.map(f => [filterKey(f), f]));
     const usedKeys = new Set<string>();
 
     const baseFilters = filters?.globalFilter ?? [];
     mergedFilters.globalFilter = baseFilters.map(f => {
-      const override = overridesByKey.get(f.tag.key);
+      const override = overridesByKey.get(filterKey(f));
       if (override) {
-        usedKeys.add(f.tag.key);
+        usedKeys.add(filterKey(f));
         return override;
       }
       return f;
@@ -47,7 +48,7 @@ export function PrebuiltDashboardRenderer({
 
     // Append any additional filters that didn't match a base filter
     for (const f of additionalGlobalFilters) {
-      if (!usedKeys.has(f.tag.key)) {
+      if (!usedKeys.has(filterKey(f))) {
         mergedFilters.globalFilter.push(f);
       }
     }

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -1,15 +1,23 @@
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import DashboardDetail from 'sentry/views/dashboards/detail';
-import {DashboardState, type DashboardDetails} from 'sentry/views/dashboards/types';
+import {
+  DashboardState,
+  type DashboardDetails,
+  type DashboardFilters,
+} from 'sentry/views/dashboards/types';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {PREBUILT_DASHBOARDS, type PrebuiltDashboardId} from './utils/prebuiltConfigs';
 
 type PrebuiltDashboardRendererProps = {
   prebuiltId: PrebuiltDashboardId;
+  additionalFilters?: DashboardFilters;
 };
 
-export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendererProps) {
+export function PrebuiltDashboardRenderer({
+  prebuiltId,
+  additionalFilters,
+}: PrebuiltDashboardRendererProps) {
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
     useGetPrebuiltDashboard(prebuiltId);
@@ -17,13 +25,27 @@ export function PrebuiltDashboardRenderer({prebuiltId}: PrebuiltDashboardRendere
   const {title, filters} = prebuiltDashboard;
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
 
+  const mergedFilters: DashboardFilters = {
+    ...filters,
+    ...additionalFilters,
+  };
+
+  if (additionalFilters?.globalFilter) {
+    const baseFilters = filters?.globalFilter ?? [];
+    const overrideKeys = new Set(additionalFilters.globalFilter.map(f => f.tag.key));
+    mergedFilters.globalFilter = [
+      ...baseFilters.filter(f => !overrideKeys.has(f.tag.key)),
+      ...additionalFilters.globalFilter,
+    ];
+  }
+
   const dashboard: DashboardDetails = {
     id: `prebuilt-dashboard-${prebuiltId}`,
     prebuiltId,
     title,
     widgets,
     dateCreated: '',
-    filters,
+    filters: mergedFilters,
     projects: undefined,
   };
 

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -4,6 +4,7 @@ import {
   DashboardState,
   type DashboardDetails,
   type DashboardFilters,
+  type GlobalFilter,
 } from 'sentry/views/dashboards/types';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
@@ -11,12 +12,12 @@ import {PREBUILT_DASHBOARDS, type PrebuiltDashboardId} from './utils/prebuiltCon
 
 type PrebuiltDashboardRendererProps = {
   prebuiltId: PrebuiltDashboardId;
-  additionalFilters?: DashboardFilters;
+  additionalGlobalFilters?: GlobalFilter[];
 };
 
 export function PrebuiltDashboardRenderer({
   prebuiltId,
-  additionalFilters,
+  additionalGlobalFilters,
 }: PrebuiltDashboardRendererProps) {
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
@@ -25,18 +26,31 @@ export function PrebuiltDashboardRenderer({
   const {title, filters} = prebuiltDashboard;
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
 
-  const mergedFilters: DashboardFilters = {
-    ...filters,
-    ...additionalFilters,
-  };
+  // Merge the dashboard's built-in filters with any additional global filters.
+  // Overrides replace matching filters in-place (by tag key) to preserve order.
+  // Filters with no match in the base list are appended at the end.
+  const mergedFilters: DashboardFilters = {...filters};
 
-  if (additionalFilters?.globalFilter) {
+  if (additionalGlobalFilters) {
+    const overridesByKey = new Map(additionalGlobalFilters.map(f => [f.tag.key, f]));
+    const usedKeys = new Set<string>();
+
     const baseFilters = filters?.globalFilter ?? [];
-    const overrideKeys = new Set(additionalFilters.globalFilter.map(f => f.tag.key));
-    mergedFilters.globalFilter = [
-      ...baseFilters.filter(f => !overrideKeys.has(f.tag.key)),
-      ...additionalFilters.globalFilter,
-    ];
+    mergedFilters.globalFilter = baseFilters.map(f => {
+      const override = overridesByKey.get(f.tag.key);
+      if (override) {
+        usedKeys.add(f.tag.key);
+        return override;
+      }
+      return f;
+    });
+
+    // Append any additional filters that didn't match a base filter
+    for (const f of additionalGlobalFilters) {
+      if (!usedKeys.has(f.tag.key)) {
+        mergedFilters.globalFilter.push(f);
+      }
+    }
   }
 
   const dashboard: DashboardDetails = {

--- a/static/app/views/insights/mobile/screens/utils/useHasDashboardsPlatformizedMobileVitals.ts
+++ b/static/app/views/insights/mobile/screens/utils/useHasDashboardsPlatformizedMobileVitals.ts
@@ -1,0 +1,13 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export default function useHasDashboardsPlatformizedMobileVitals() {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  if (location.query.usePlatformizedView === '1') {
+    return true;
+  }
+
+  return organization.features.includes('insights-mobile-vitals-dashboard-migration');
+}

--- a/static/app/views/insights/mobile/screens/utils/useTransactionDashboardFilters.ts
+++ b/static/app/views/insights/mobile/screens/utils/useTransactionDashboardFilters.ts
@@ -1,0 +1,20 @@
+import {useQueryState} from 'nuqs';
+
+import {FieldKind} from 'sentry/utils/fields';
+import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
+
+export function useTransactionGlobalFilters(): GlobalFilter[] | undefined {
+  const [transaction] = useQueryState('transaction');
+
+  if (!transaction) {
+    return undefined;
+  }
+
+  return [
+    {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'transaction', name: 'transaction', kind: FieldKind.TAG},
+      value: `transaction:${transaction}`,
+    },
+  ];
+}

--- a/static/app/views/insights/mobile/screens/utils/useTransactionDashboardFilters.ts
+++ b/static/app/views/insights/mobile/screens/utils/useTransactionDashboardFilters.ts
@@ -1,5 +1,6 @@
 import {useQueryState} from 'nuqs';
 
+import {escapeTagValue} from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {FieldKind} from 'sentry/utils/fields';
 import {WidgetType, type GlobalFilter} from 'sentry/views/dashboards/types';
 
@@ -14,7 +15,7 @@ export function useTransactionGlobalFilters(): GlobalFilter[] | undefined {
     {
       dataset: WidgetType.SPANS,
       tag: {key: 'transaction', name: 'transaction', kind: FieldKind.TAG},
-      value: `transaction:${transaction}`,
+      value: `transaction:${escapeTagValue(transaction)}`,
     },
   ];
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
@@ -1,33 +1,26 @@
-import {FieldKind} from 'sentry/utils/fields';
-import {useLocation} from 'sentry/utils/useLocation';
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
-import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedAppStartsOverview() {
-  const location = useLocation();
-  const transaction = location.query.transaction as string | undefined;
-
-  const additionalFilters: DashboardFilters | undefined = transaction
-    ? {
-        globalFilter: [
-          {
-            dataset: WidgetType.SPANS,
-            tag: {
-              key: 'transaction',
-              name: 'transaction',
-              kind: FieldKind.TAG,
-            },
-            value: `transaction:${transaction}`,
-          },
-        ],
-      }
-    : undefined;
+  const additionalGlobalFilters = useTransactionGlobalFilters();
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
 
   return (
-    <PrebuiltDashboardRenderer
-      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS}
-      additionalFilters={additionalFilters}
-    />
+    <ModulePageProviders
+      moduleName={ModuleName.MOBILE_VITALS}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer
+        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS}
+        additionalGlobalFilters={additionalGlobalFilters}
+      />
+    </ModulePageProviders>
   );
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
@@ -1,0 +1,33 @@
+import {FieldKind} from 'sentry/utils/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+export function PlatformizedAppStartsOverview() {
+  const location = useLocation();
+  const transaction = location.query.transaction as string | undefined;
+
+  const additionalFilters: DashboardFilters | undefined = transaction
+    ? {
+        globalFilter: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {
+              key: 'transaction',
+              name: 'transaction',
+              kind: FieldKind.TAG,
+            },
+            value: `transaction:${transaction}`,
+          },
+        ],
+      }
+    : undefined;
+
+  return (
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS}
+      additionalFilters={additionalFilters}
+    />
+  );
+}

--- a/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedAppStartsOverview.tsx
@@ -1,26 +1,14 @@
-import {DataCategory} from 'sentry/types/core';
-import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
-import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedAppStartsOverview() {
   const additionalGlobalFilters = useTransactionGlobalFilters();
-  const maxPickableDays = useMaxPickableDays({
-    dataCategories: [DataCategory.SPANS],
-  });
 
   return (
-    <ModulePageProviders
-      moduleName={ModuleName.MOBILE_VITALS}
-      maxPickableDays={maxPickableDays.maxPickableDays}
-    >
-      <PrebuiltDashboardRenderer
-        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS}
-        additionalGlobalFilters={additionalGlobalFilters}
-      />
-    </ModulePageProviders>
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_APP_STARTS}
+      additionalGlobalFilters={additionalGlobalFilters}
+    />
   );
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedOverview.tsx
@@ -1,0 +1,21 @@
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {ModuleName} from 'sentry/views/insights/types';
+
+export function PlatformizedMobileVitalsOverview() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
+  return (
+    <ModulePageProviders
+      moduleName={ModuleName.MOBILE_VITALS}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.MOBILE_VITALS} />
+    </ModulePageProviders>
+  );
+}

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
@@ -1,33 +1,26 @@
-import {FieldKind} from 'sentry/utils/fields';
-import {useLocation} from 'sentry/utils/useLocation';
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
-import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedScreenLoadsOverview() {
-  const location = useLocation();
-  const transaction = location.query.transaction as string | undefined;
-
-  const additionalFilters: DashboardFilters | undefined = transaction
-    ? {
-        globalFilter: [
-          {
-            dataset: WidgetType.SPANS,
-            tag: {
-              key: 'transaction',
-              name: 'transaction',
-              kind: FieldKind.TAG,
-            },
-            value: `transaction:${transaction}`,
-          },
-        ],
-      }
-    : undefined;
+  const additionalGlobalFilters = useTransactionGlobalFilters();
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
 
   return (
-    <PrebuiltDashboardRenderer
-      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS}
-      additionalFilters={additionalFilters}
-    />
+    <ModulePageProviders
+      moduleName={ModuleName.MOBILE_VITALS}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer
+        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS}
+        additionalGlobalFilters={additionalGlobalFilters}
+      />
+    </ModulePageProviders>
   );
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
@@ -1,26 +1,14 @@
-import {DataCategory} from 'sentry/types/core';
-import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
-import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedScreenLoadsOverview() {
   const additionalGlobalFilters = useTransactionGlobalFilters();
-  const maxPickableDays = useMaxPickableDays({
-    dataCategories: [DataCategory.SPANS],
-  });
 
   return (
-    <ModulePageProviders
-      moduleName={ModuleName.MOBILE_VITALS}
-      maxPickableDays={maxPickableDays.maxPickableDays}
-    >
-      <PrebuiltDashboardRenderer
-        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS}
-        additionalGlobalFilters={additionalGlobalFilters}
-      />
-    </ModulePageProviders>
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS}
+      additionalGlobalFilters={additionalGlobalFilters}
+    />
   );
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenLoadsOverview.tsx
@@ -1,0 +1,33 @@
+import {FieldKind} from 'sentry/utils/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+export function PlatformizedScreenLoadsOverview() {
+  const location = useLocation();
+  const transaction = location.query.transaction as string | undefined;
+
+  const additionalFilters: DashboardFilters | undefined = transaction
+    ? {
+        globalFilter: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {
+              key: 'transaction',
+              name: 'transaction',
+              kind: FieldKind.TAG,
+            },
+            value: `transaction:${transaction}`,
+          },
+        ],
+      }
+    : undefined;
+
+  return (
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_LOADS}
+      additionalFilters={additionalFilters}
+    />
+  );
+}

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
@@ -1,0 +1,33 @@
+import {FieldKind} from 'sentry/utils/fields';
+import {useLocation} from 'sentry/utils/useLocation';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+
+export function PlatformizedScreenRenderingOverview() {
+  const location = useLocation();
+  const transaction = location.query.transaction as string | undefined;
+
+  const additionalFilters: DashboardFilters | undefined = transaction
+    ? {
+        globalFilter: [
+          {
+            dataset: WidgetType.SPANS,
+            tag: {
+              key: 'transaction',
+              name: 'transaction',
+              kind: FieldKind.TAG,
+            },
+            value: `transaction:${transaction}`,
+          },
+        ],
+      }
+    : undefined;
+
+  return (
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING}
+      additionalFilters={additionalFilters}
+    />
+  );
+}

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
@@ -1,26 +1,14 @@
-import {DataCategory} from 'sentry/types/core';
-import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
-import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
-import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedScreenRenderingOverview() {
   const additionalGlobalFilters = useTransactionGlobalFilters();
-  const maxPickableDays = useMaxPickableDays({
-    dataCategories: [DataCategory.SPANS],
-  });
 
   return (
-    <ModulePageProviders
-      moduleName={ModuleName.MOBILE_VITALS}
-      maxPickableDays={maxPickableDays.maxPickableDays}
-    >
-      <PrebuiltDashboardRenderer
-        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING}
-        additionalGlobalFilters={additionalGlobalFilters}
-      />
-    </ModulePageProviders>
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING}
+      additionalGlobalFilters={additionalGlobalFilters}
+    />
   );
 }

--- a/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
+++ b/static/app/views/insights/mobile/screens/views/platformizedScreenRenderingOverview.tsx
@@ -1,33 +1,26 @@
-import {FieldKind} from 'sentry/utils/fields';
-import {useLocation} from 'sentry/utils/useLocation';
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
-import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+import {useTransactionGlobalFilters} from 'sentry/views/insights/mobile/screens/utils/useTransactionDashboardFilters';
+import {ModuleName} from 'sentry/views/insights/types';
 
 export function PlatformizedScreenRenderingOverview() {
-  const location = useLocation();
-  const transaction = location.query.transaction as string | undefined;
-
-  const additionalFilters: DashboardFilters | undefined = transaction
-    ? {
-        globalFilter: [
-          {
-            dataset: WidgetType.SPANS,
-            tag: {
-              key: 'transaction',
-              name: 'transaction',
-              kind: FieldKind.TAG,
-            },
-            value: `transaction:${transaction}`,
-          },
-        ],
-      }
-    : undefined;
+  const additionalGlobalFilters = useTransactionGlobalFilters();
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
 
   return (
-    <PrebuiltDashboardRenderer
-      prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING}
-      additionalFilters={additionalFilters}
-    />
+    <ModulePageProviders
+      moduleName={ModuleName.MOBILE_VITALS}
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer
+        prebuiltId={PrebuiltDashboardId.MOBILE_VITALS_SCREEN_RENDERING}
+        additionalGlobalFilters={additionalGlobalFilters}
+      />
+    </ModulePageProviders>
   );
 }

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -19,6 +19,10 @@ import {ScreenSummaryContentPage as AppStartPage} from 'sentry/views/insights/mo
 import useCrossPlatformProject from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 import {PlatformSelector} from 'sentry/views/insights/mobile/screenload/components/platformSelector';
 import {ScreenLoadSpansContent as ScreenLoadPage} from 'sentry/views/insights/mobile/screenload/views/screenLoadSpansPage';
+import useHasDashboardsPlatformizedMobileVitals from 'sentry/views/insights/mobile/screens/utils/useHasDashboardsPlatformizedMobileVitals';
+import {PlatformizedAppStartsOverview} from 'sentry/views/insights/mobile/screens/views/platformizedAppStartsOverview';
+import {PlatformizedScreenLoadsOverview} from 'sentry/views/insights/mobile/screens/views/platformizedScreenLoadsOverview';
+import {PlatformizedScreenRenderingOverview} from 'sentry/views/insights/mobile/screens/views/platformizedScreenRenderingOverview';
 import {ScreenSummaryContent as UiPage} from 'sentry/views/insights/mobile/ui/views/screenSummaryPage';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {ModuleName} from 'sentry/views/insights/types';
@@ -47,12 +51,17 @@ function ScreenDetailsPage() {
 
   const {transaction: transactionName} = location.query;
   const moduleName = ModuleName.MOBILE_VITALS;
+  const hasDashboardsPlatformizedMobileVitals =
+    useHasDashboardsPlatformizedMobileVitals();
 
   const tabs: Tab[] = [
     {
       key: 'app_start',
       label: t('App Start'),
       content: () => {
+        if (hasDashboardsPlatformizedMobileVitals) {
+          return <PlatformizedAppStartsOverview key="app_start" />;
+        }
         return <AppStartPage key="app_start" />;
       },
     },
@@ -60,14 +69,20 @@ function ScreenDetailsPage() {
       key: 'screen_load',
       label: t('Screen Load'),
       content: () => {
+        if (hasDashboardsPlatformizedMobileVitals) {
+          return <PlatformizedScreenLoadsOverview key="screen_load" />;
+        }
         return <ScreenLoadPage key="screen_load" />;
       },
     },
     {
       key: 'screen_rendering',
       label: t('Screen Rendering'),
-      featureBadge: 'experimental',
+      featureBadge: hasDashboardsPlatformizedMobileVitals ? undefined : 'experimental',
       content: () => {
+        if (hasDashboardsPlatformizedMobileVitals) {
+          return <PlatformizedScreenRenderingOverview key="screen_rendering" />;
+        }
         return <UiPage key="screen_rendering" />;
       },
     },

--- a/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screenDetailsPage.tsx
@@ -78,7 +78,7 @@ function ScreenDetailsPage() {
     {
       key: 'screen_rendering',
       label: t('Screen Rendering'),
-      featureBadge: hasDashboardsPlatformizedMobileVitals ? undefined : 'experimental',
+      featureBadge: 'experimental',
       content: () => {
         if (hasDashboardsPlatformizedMobileVitals) {
           return <PlatformizedScreenRenderingOverview key="screen_rendering" />;

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -42,6 +42,8 @@ import {
   type VitalItem,
   type VitalStatus,
 } from 'sentry/views/insights/mobile/screens/utils';
+import useHasDashboardsPlatformizedMobileVitals from 'sentry/views/insights/mobile/screens/utils/useHasDashboardsPlatformizedMobileVitals';
+import {PlatformizedMobileVitalsOverview} from 'sentry/views/insights/mobile/screens/views/platformizedOverview';
 import {ModuleName} from 'sentry/views/insights/types';
 
 function ScreensLandingPage() {
@@ -342,4 +344,13 @@ const Flex = styled('div')<{gap?: number}>`
   margin-bottom: ${space(1)};
 `;
 
-export default ScreensLandingPage;
+function PageWithProviders() {
+  const hasDashboardsPlatformizedMobileVitals =
+    useHasDashboardsPlatformizedMobileVitals();
+  if (hasDashboardsPlatformizedMobileVitals) {
+    return <PlatformizedMobileVitalsOverview />;
+  }
+  return <ScreensLandingPage />;
+}
+
+export default PageWithProviders;

--- a/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
+++ b/static/app/views/insights/mobile/screens/views/screensLandingPage.tsx
@@ -344,7 +344,7 @@ const Flex = styled('div')<{gap?: number}>`
   margin-bottom: ${space(1)};
 `;
 
-function PageWithProviders() {
+function ScreensLandingPageWithPlatformization() {
   const hasDashboardsPlatformizedMobileVitals =
     useHasDashboardsPlatformizedMobileVitals();
   if (hasDashboardsPlatformizedMobileVitals) {
@@ -353,4 +353,4 @@ function PageWithProviders() {
   return <ScreensLandingPage />;
 }
 
-export default PageWithProviders;
+export default ScreensLandingPageWithPlatformization;


### PR DESCRIPTION
Replaces the existing Mobile Vitals Insights views with prebuilt dashboards, gated behind the `insights-mobile-vitals-dashboard-migration` feature flag (or `?usePlatformizedView=1` query param).

Mobile Vitals has two levels: a top-level overview page, and a screen details page with three tabs (App Starts, Screen Loads, Screen Rendering). Each level gets its own prebuilt dashboard. The screen details tabs also need to forward the `transaction` URL query parameter as a dashboard global filter, so the prebuilt dashboard shows data scoped to the selected screen. To support this, `PrebuiltDashboardRenderer` accepts optional `additionalGlobalFilters` that replace matching filters in-place by tag key. Note: this only applies to direct URL access to those sub-Insights! Anyone who's using the top-level new Mobile Insights dashboard won't even be able to get them, because the screens list is linked to other pre-built dashboards