### PR TITLE
fix(aci): Better handling for eventType when creating metric alert/monitor URLs

### DIFF
--- a/static/app/views/explore/logs/logsGraph.tsx
+++ b/static/app/views/explore/logs/logsGraph.tsx
@@ -18,7 +18,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {
   DashboardWidgetSource,
@@ -281,7 +281,7 @@ function ContextMenu({
         organization,
         dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
         interval,
-        eventTypes: 'trace_item_log',
+        eventTypes: [EventTypes.TRACE_ITEM_LOG],
       }),
       onAction: () => {
         trackAnalytics('logs.save_as', {

--- a/static/app/views/explore/logs/useSaveAsItems.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.tsx
@@ -22,7 +22,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {
   DashboardWidgetSource,
   DEFAULT_WIDGET_NAME,
@@ -140,7 +140,7 @@ export function useSaveAsItems({
           organization,
           dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
           interval,
-          eventTypes: 'trace_item_log',
+          eventTypes: [EventTypes.TRACE_ITEM_LOG],
         }),
         onAction: () => {
           trackAnalytics('logs.save_as', {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -696,7 +696,6 @@ describe('ExploreToolbar', () => {
     expect(router.location.query).toEqual({
       aggregate: 'count(span.duration)',
       dataset: 'events_analytics_platform',
-      eventTypes: 'transaction',
       interval: '1h',
       project: 'proj-slug',
       query: '',

--- a/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.spec.tsx
@@ -21,7 +21,7 @@ describe('getAlertsUrl', () => {
       pageFilters,
     });
     expect(url).toBe(
-      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&eventTypes=transaction&interval=1h&project=project-slug&query=span.category%3Adb&statsPeriod=7d'
+      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=avg%28d%3Aspans%2Fduration%40millisecond%29&dataset=generic_metrics&interval=1h&project=project-slug&query=span.category%3Adb&statsPeriod=7d'
     );
   });
   it('should return a url to an EAP alert rule', () => {
@@ -37,7 +37,7 @@ describe('getAlertsUrl', () => {
       dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
     });
     expect(url).toBe(
-      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=count%28span.duration%29&dataset=events_analytics_platform&eventTypes=transaction&interval=1h&project=project-slug&query=span.op%3Ahttp.client&statsPeriod=7d'
+      '/organizations/orgSlug/issues/alerts/new/metric/?aggregate=count%28span.duration%29&dataset=events_analytics_platform&interval=1h&project=project-slug&query=span.op%3Ahttp.client&statsPeriod=7d'
     );
   });
 });

--- a/static/app/views/insights/common/utils/getAlertsUrl.tsx
+++ b/static/app/views/insights/common/utils/getAlertsUrl.tsx
@@ -4,7 +4,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
-import {Dataset} from 'sentry/views/alerts/rules/metric/types';
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {getMetricMonitorUrl} from 'sentry/views/insights/common/utils/getMetricMonitorUrl';
 
 export function getAlertsUrl({
@@ -16,14 +16,14 @@ export function getAlertsUrl({
   name,
   interval,
   dataset = Dataset.GENERIC_METRICS,
-  eventTypes = 'transaction',
+  eventTypes,
   referrer,
 }: {
   aggregate: string;
   organization: Organization;
   pageFilters: PageFilters;
   dataset?: Dataset;
-  eventTypes?: string;
+  eventTypes?: EventTypes[];
   interval?: string;
   name?: string;
   project?: Project;
@@ -56,6 +56,7 @@ export function getAlertsUrl({
       name,
       query,
       referrer,
+      eventTypes,
     });
     return `${loc.pathname}?${qs.stringify(loc.query)}`;
   }

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.spec.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.spec.tsx
@@ -1,0 +1,87 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {getMetricMonitorUrl} from 'sentry/views/insights/common/utils/getMetricMonitorUrl';
+
+describe('getMetricMonitorUrl', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+  const project = ProjectFixture({id: '123'});
+
+  it('errors count', () => {
+    const url = getMetricMonitorUrl({
+      aggregate: 'count()',
+      dataset: Dataset.ERRORS,
+      organization,
+      project,
+      query: 'is:unresolved',
+    });
+
+    expect(url).toEqual({
+      pathname: '/organizations/org-slug/monitors/new/settings',
+      query: {
+        detectorType: 'metric_issue',
+        project: '123',
+        dataset: DetectorDataset.ERRORS,
+        aggregate: 'count()',
+        environment: undefined,
+        query: 'is:unresolved',
+        name: undefined,
+        referrer: undefined,
+      },
+    });
+  });
+
+  it('uses spans detector dataset for EAP spans count', () => {
+    const url = getMetricMonitorUrl({
+      aggregate: 'count(span.duration)',
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+      organization,
+      project,
+      query: 'span.op:http.client',
+    });
+
+    expect(url.pathname).toBe('/organizations/org-slug/monitors/new/settings');
+    expect(url.query.dataset).toBe(DetectorDataset.SPANS);
+  });
+
+  it('uses logs detector dataset for EAP logs count', () => {
+    const url = getMetricMonitorUrl({
+      aggregate: 'count()',
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+      organization,
+      project,
+      query: 'event.type:trace_item_log',
+      eventTypes: [EventTypes.TRACE_ITEM_LOG],
+    });
+
+    expect(url.pathname).toBe('/organizations/org-slug/monitors/new/settings');
+    expect(url.query.dataset).toBe(DetectorDataset.LOGS);
+  });
+
+  it('uses metrics detector dataset for EAP metrics', () => {
+    const url = getMetricMonitorUrl({
+      aggregate: 'count()',
+      dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+      eventTypes: [EventTypes.TRACE_ITEM_METRIC],
+      organization,
+      project,
+    });
+
+    expect(url.pathname).toBe('/organizations/org-slug/monitors/new/settings');
+    expect(url.query.dataset).toBe(DetectorDataset.METRICS);
+  });
+
+  it('uses releases detector dataset for metrics dataset', () => {
+    const url = getMetricMonitorUrl({
+      aggregate: 'count()',
+      dataset: Dataset.METRICS,
+      organization,
+      project,
+    });
+
+    expect(url.pathname).toBe('/organizations/org-slug/monitors/new/settings');
+    expect(url.query.dataset).toBe(DetectorDataset.RELEASES);
+  });
+});

--- a/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
+++ b/static/app/views/insights/common/utils/getMetricMonitorUrl.tsx
@@ -17,6 +17,13 @@ type Params = {
   referrer?: string;
 };
 
+const DEFAULT_EAP_EVENT_TYPES = [EventTypes.TRACE_ITEM_SPAN];
+
+function getEapEventTypesFromQuery(query: string): EventTypes[] {
+  const parsed = parseEventTypesFromQuery(query, DEFAULT_EAP_EVENT_TYPES);
+  return parsed.eventTypes;
+}
+
 export function getMetricMonitorUrl({
   aggregate,
   dataset,
@@ -26,15 +33,12 @@ export function getMetricMonitorUrl({
   environment,
   query,
   referrer,
-  eventTypes,
+  eventTypes: incomingEventTypes,
 }: Params) {
   let detectorDataset = getDetectorDataset(dataset, []);
   if (dataset === Dataset.EVENTS_ANALYTICS_PLATFORM) {
-    const defaultTypes: EventTypes[] = [EventTypes.TRACE_ITEM_SPAN];
-    const parsed = parseEventTypesFromQuery(query ?? '', defaultTypes);
-    const typesToUse =
-      eventTypes && eventTypes.length > 0 ? eventTypes : parsed.eventTypes;
-    detectorDataset = getDetectorDataset(dataset, typesToUse);
+    const eventTypes = incomingEventTypes ?? getEapEventTypesFromQuery(query ?? '');
+    detectorDataset = getDetectorDataset(dataset, eventTypes);
   }
   const queryParams = {
     detectorType: 'metric_issue',


### PR DESCRIPTION
Fixes ISWF-2079

When attempting to create a monitor from the explore logs page, `getMetricMonitorUrl` was not converting the logs event type to the correct detector dataset, defaulting to spans and causing an error.