### PR TITLE
fix(perf-cli): Pass detector-specific settings in `sentry performance` commands 

### DIFF
--- a/src/sentry/runner/commands/performance.py
+++ b/src/sentry/runner/commands/performance.py
@@ -56,7 +56,7 @@ def detect(path: str, detector_class: str | None, verbose: int) -> None:
             if verbose > 1:
                 click.echo(f"Event ID: {data['event_id']}")
 
-            detectors = [cls(settings, data) for cls in detector_classes]
+            detectors = [cls(settings[cls.settings_key], data) for cls in detector_classes]
 
             for detector in detectors:
                 if verbose > 0:
@@ -112,7 +112,8 @@ def timeit(filename: str, detector_class: str, n: int) -> None:
     with open(filename) as file:
         data = json.loads(file.read())
 
-    detector = performance_detection.__dict__[detector_class](settings, data)
+    detector_cls = performance_detection.__dict__[detector_class]
+    detector = detector_cls(settings[detector_cls.settings_key], data)
 
     def detect() -> None:
         performance_detection.run_detector_on_data(detector, data)


### PR DESCRIPTION
changes in https://github.com/getsentry/sentry/pull/107387 didn't touch the CLI commands, this pr makes the necessary changes so the CLI commands work 