### PR TITLE
fix(aci): Alert form env selector should set initial data correctly

### DIFF
--- a/static/app/components/workflowEngine/form/environmentSelector.spec.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.spec.tsx
@@ -1,8 +1,7 @@
-import {useState} from 'react';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
+import Form from 'sentry/components/forms/form';
 import {EnvironmentSelector} from 'sentry/components/workflowEngine/form/environmentSelector';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
@@ -16,23 +15,11 @@ describe('EnvironmentSelector', () => {
     });
     ProjectsStore.loadInitialData(projects);
 
-    const mockOnChange = jest.fn();
-
-    function Component() {
-      const [environment, setEnvironment] = useState('');
-
-      return (
-        <EnvironmentSelector
-          value={environment}
-          onChange={value => {
-            setEnvironment(value);
-            mockOnChange(value);
-          }}
-        />
-      );
-    }
-
-    render(<Component />);
+    render(
+      <Form initialData={{environment: ''}}>
+        <EnvironmentSelector />
+      </Form>
+    );
 
     // Open list
     await userEvent.click(screen.getByRole('button', {name: 'All Environments'}));
@@ -71,6 +58,5 @@ describe('EnvironmentSelector', () => {
 
     // Trigger label is updated
     expect(screen.getByRole('button', {name: 'prod'})).toBeInTheDocument();
-    expect(mockOnChange).toHaveBeenCalledWith('prod');
   });
 });

--- a/static/app/components/workflowEngine/form/environmentSelector.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.tsx
@@ -53,7 +53,7 @@ export function EnvironmentSelector() {
       sizeLimit={20}
       multiple={false}
       value={value ?? ''}
-      onChange={selected => form?.setValue('environment', selected.value)}
+      onChange={selected => form?.setValue('environment', selected.value || null)}
     />
   );
 }

--- a/static/app/components/workflowEngine/form/environmentSelector.tsx
+++ b/static/app/components/workflowEngine/form/environmentSelector.tsx
@@ -1,17 +1,16 @@
-import {useMemo} from 'react';
+import {useContext, useMemo} from 'react';
 
 import type {SelectOption, SelectOptionOrSection} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 
+import FormContext from 'sentry/components/forms/formContext';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import useProjects from 'sentry/utils/useProjects';
 
-interface EnvironmentSelectorProps {
-  onChange: (value: string) => void;
-  value: string;
-}
-
-export function EnvironmentSelector({value, onChange}: EnvironmentSelectorProps) {
+export function EnvironmentSelector() {
+  const value = useFormField<string | null>('environment');
+  const {form} = useContext(FormContext);
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
 
   const options = useMemo<Array<SelectOptionOrSection<string>>>(() => {
@@ -53,8 +52,8 @@ export function EnvironmentSelector({value, onChange}: EnvironmentSelectorProps)
       disabled={!projectsLoaded}
       sizeLimit={20}
       multiple={false}
-      value={value}
-      onChange={selected => onChange(selected.value)}
+      value={value ?? ''}
+      onChange={selected => form?.setValue('environment', selected.value)}
     />
   );
 }

--- a/static/app/views/automations/components/automationForm.tsx
+++ b/static/app/views/automations/components/automationForm.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -23,12 +23,6 @@ export default function AutomationForm({model}: {model: FormModel}) {
     [model]
   );
 
-  const [environment, setEnvironment] = useState<string>('');
-  const updateEnvironment = (env: string) => {
-    setEnvironment(env);
-    model.setValue('environment', env || null);
-  };
-
   useSetAutomaticAutomationName();
 
   return (
@@ -48,7 +42,7 @@ export default function AutomationForm({model}: {model: FormModel}) {
             )}
           </Text>
         </Flex>
-        <EnvironmentSelector value={environment} onChange={updateEnvironment} />
+        <EnvironmentSelector />
       </Card>
       <Card>
         <Heading as="h2" size="lg">


### PR DESCRIPTION
Fixes ISWF-2083

Environment was keeping its own state instead of reading from the form state, which caused it to always show "All environments" on first load regardless of the actual workflow data.