### PR TITLE
fix(relay): Add back sessions EAP rollout rate

### DIFF
--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -20,6 +20,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.cardinality-limiter.error-sample-rate",
     "relay.metric-bucket-set-encodings",
     "relay.metric-bucket-distribution-encodings",
+    "relay.sessions-eap.rollout-rate",
     "relay.span-normalization.allowed_hosts",
     "relay.drop-transaction-attachments",
     "replay.relay-snuba-publishing-disabled.sample-rate",

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -42,6 +42,7 @@ def call_endpoint(client, relay, private_key):
         "relay.span-usage-metric": True,
         "relay.cardinality-limiter.mode": "passive",
         "replay.relay-snuba-publishing-disabled.sample-rate": 1.0,
+        "relay.sessions-eap.rollout-rate": 1.0,
         "relay.kafka.span-v2.sample-rate": 1.0,
         "relay.metric-bucket-distribution-encodings": {
             "custom": "array",


### PR DESCRIPTION
Assuming this was deleted by accident in https://github.com/getsentry/sentry/pull/107940/changes#diff-f4cbf00edd48ddc262e8f32e2603b55247c8afcb57fd54fdcfe8561aadff84bfL26