### PR TITLE
fix(workflow-engine): Remove unused has_reappeared from workflow event data

### DIFF
--- a/src/sentry/workflow_engine/tasks/actions.py
+++ b/src/sentry/workflow_engine/tasks/actions.py
@@ -56,7 +56,7 @@ def build_trigger_action_task_params(
         "group_id": event_data.event.group_id,
         "occurrence_id": occurrence_id,
         "group_state": event_data.group_state,
-        "has_reappeared": event_data.has_reappeared,
+        "has_reappeared": False,  # TODO: remove when deployed trigger_action task doesn't expect it
         "has_escalated": event_data.has_escalated,
     }
 
@@ -83,10 +83,10 @@ def trigger_action(
     group_id: int,
     occurrence_id: str | None,
     group_state: GroupState,
-    has_reappeared: bool,
     has_escalated: bool,
     detector_id: int | None = None,  # TODO: remove
     notification_uuid: str | None = None,
+    **kwargs: dict[str, object],
 ) -> None:
     import uuid
 
@@ -114,7 +114,6 @@ def trigger_action(
             workflow_id=workflow_id,
             occurrence_id=occurrence_id,
             group_state=group_state,
-            has_reappeared=has_reappeared,
             has_escalated=has_escalated,
         )
     elif activity_id is not None:

--- a/src/sentry/workflow_engine/tasks/utils.py
+++ b/src/sentry/workflow_engine/tasks/utils.py
@@ -69,7 +69,6 @@ def build_workflow_event_data_from_event(
     workflow_id: int | None = None,
     occurrence_id: str | None = None,
     group_state: GroupState | None = None,
-    has_reappeared: bool = False,
     has_escalated: bool = False,
 ) -> WorkflowEventData:
     """
@@ -99,7 +98,6 @@ def build_workflow_event_data_from_event(
         event=group_event,
         group=group,
         group_state=group_state,
-        has_reappeared=has_reappeared,
         has_escalated=has_escalated,
         workflow_env=workflow_env,
     )

--- a/src/sentry/workflow_engine/tasks/workflows.py
+++ b/src/sentry/workflow_engine/tasks/workflows.py
@@ -102,10 +102,8 @@ def process_workflows_event(
     group_id: int,
     occurrence_id: str | None,
     group_state: GroupState,
-    has_reappeared: bool,
     has_escalated: bool,
     start_timestamp_seconds: float | None = None,
-    project_id: int | None = None,  # TODO: remove
     **kwargs: dict[str, Any],
 ) -> None:
     from sentry.workflow_engine.processors.workflow import process_workflows
@@ -120,7 +118,6 @@ def process_workflows_event(
                 group_id=group_id,
                 occurrence_id=occurrence_id,
                 group_state=group_state,
-                has_reappeared=has_reappeared,
                 has_escalated=has_escalated,
             )
         except (RetryError, OSError) as e:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -93,7 +93,6 @@ class WorkflowEventData:
     event: GroupEvent | Activity
     group: Group
     group_state: GroupState | None = None
-    has_reappeared: bool | None = None
     has_escalated: bool | None = None
     workflow_env: Environment | None = None
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -28,7 +28,6 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
                     "is_new_group_environment": False,
                 }
             ),
-            has_reappeared=True,
             has_escalated=True,
         )
         self.dc = self.create_data_condition(
@@ -74,16 +73,10 @@ class TestExistingHighPriorityIssueCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_is_escalating(self) -> None:
-        self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=True)
+        self.event_data = replace(self.event_data, has_escalated=True)
         self.assert_passes(self.dc, self.event_data)
 
-        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=True)
-        self.assert_passes(self.dc, self.event_data)
-
-        self.event_data = replace(self.event_data, has_reappeared=False, has_escalated=False)
-        self.assert_does_not_pass(self.dc, self.event_data)
-
-        self.event_data = replace(self.event_data, has_reappeared=True, has_escalated=False)
+        self.event_data = replace(self.event_data, has_escalated=False)
         self.assert_does_not_pass(self.dc, self.event_data)
 
     def test_priority(self) -> None:

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -44,7 +44,6 @@ class TestReappearedEventCondition(ConditionTestCase):
         job = WorkflowEventData(
             event=self.group_event,
             group=self.group_event.group,
-            has_reappeared=False,
             has_escalated=True,
         )
         dc = self.create_data_condition(

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -118,7 +118,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
                 "is_regression": True,
                 "is_new_group_environment": False,
             },
-            has_reappeared=False,
             has_escalated=False,
         )
         mock_fire_actions.assert_called_once()
@@ -155,7 +154,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
                 "is_regression": True,
                 "is_new_group_environment": False,
             },
-            has_reappeared=False,
             has_escalated=False,
         )
 
@@ -195,7 +193,6 @@ class TestProcessWorkflows(BaseWorkflowTest):
                 "is_regression": True,
                 "is_new_group_environment": False,
             },
-            has_reappeared=False,
             has_escalated=False,
         )
 


### PR DESCRIPTION
has_reappeared hasn't been used for at least 6 months.
This removes it from all workflows code except for trigger_action param construction, since the deployed task expects complete parameters (though this change fixes that too).