### PR TITLE
feat(seer): Include occurrence data when serializing events in get_issue_and_event_details_v2

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1056,18 +1056,30 @@ def get_issue_and_event_details_v2(
                 tenant_ids={"organization_id": organization_id},
             )
         else:
-            events_result = eventstore.backend.get_events(
-                filter=eventstore.Filter(
-                    event_ids=[event_id],
-                    organization_id=organization_id,
-                    project_ids=project_ids,
-                ),
-                limit=1,
-                tenant_ids={"organization_id": organization_id},
-            )
-            event = events_result[0] if events_result else None
+            # Error events live in Events, occurrence events in IssuePlatform;
+            # we don't know which dataset holds this event_id until we query.
+            event = None
+            for dataset in (Dataset.Events, Dataset.IssuePlatform):
+                events_result = eventstore.backend.get_events(
+                    filter=eventstore.Filter(
+                        event_ids=[event_id],
+                        organization_id=organization_id,
+                        project_ids=project_ids,
+                    ),
+                    limit=1,
+                    tenant_ids={"organization_id": organization_id},
+                    dataset=dataset,
+                )
+                if events_result:
+                    event = events_result[0]
+                    break
 
         group = event.group if event else None
+
+    # Convert Event to GroupEvent so the occurrence (if any) can be lazy-loaded
+    # from nodestore via the occurrence_id in snuba_data during serialization.
+    if event is not None and group is not None and isinstance(event, Event):
+        event = event.for_group(group)
 
     if group is None:
         logger.warning(

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -49,7 +49,7 @@ from sentry.testutils.cases import (
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.samples import load_data
-from tests.sentry.issues.test_utils import OccurrenceTestMixin, SearchIssueTestMixin
+from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 
 def _get_utc_iso_without_timezone(dt: datetime) -> str:
@@ -996,7 +996,7 @@ def _validate_event_timeseries(timeseries: dict, expected_total: int | None = No
 
 
 class TestGetIssueAndEventDetailsV2(
-    APITransactionTestCase, SnubaTestCase, OccurrenceTestMixin, SpanTestCase
+    APITransactionTestCase, SnubaTestCase, SearchIssueTestMixin, SpanTestCase
 ):
     """Integration tests for the get_issue_and_event_details RPC."""
 
@@ -1324,8 +1324,108 @@ class TestGetIssueAndEventDetailsV2(
             include_issue=False,
         )
 
+    @patch("sentry.seer.explorer.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.explorer.tools.get_all_tags_overview")
+    def test_get_ie_details_from_issue_id_with_occurrence(self, mock_get_tags, mock_get_timeseries):
+        """Test that occurrence data is included when fetching by issue_id."""
+        mock_get_timeseries.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_get_tags.return_value = {"tags_overview": [{"key": "test_tag", "top_values": []}]}
 
-class TestGetIssueAndEventResponse(APITransactionTestCase, SnubaTestCase, OccurrenceTestMixin):
+        occurrence, group_info = self.process_occurrence(
+            event_data={
+                "timestamp": before_now(minutes=5).isoformat(),
+                "project_id": self.project.id,
+                "platform": "python",
+            },
+            project_id=self.project.id,
+        )
+        assert group_info is not None
+        group = group_info.group
+
+        result = get_issue_and_event_details_v2(
+            organization_id=self.organization.id,
+            issue_id=str(group.id),
+            include_issue=True,
+        )
+
+        assert result is not None
+        self._assert_occurrence_in_response(result, occurrence)
+
+    @patch("sentry.seer.explorer.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.explorer.tools.get_all_tags_overview")
+    def test_get_ie_details_from_event_id_with_occurrence_single_project(
+        self, mock_get_tags, mock_get_timeseries
+    ):
+        """Test that occurrence data is included when fetching by event_id (single project)."""
+        mock_get_timeseries.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_get_tags.return_value = {"tags_overview": [{"key": "test_tag", "top_values": []}]}
+
+        occurrence, group_info = self.process_occurrence(
+            event_data={
+                "timestamp": before_now(minutes=5).isoformat(),
+                "project_id": self.project.id,
+                "platform": "python",
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_issue_and_event_details_v2(
+            organization_id=self.organization.id,
+            event_id=occurrence.event_id,
+            project_slug=self.project.slug,
+            include_issue=True,
+        )
+
+        assert result is not None
+        assert result["event_id"] == occurrence.event_id
+        self._assert_occurrence_in_response(result, occurrence)
+
+    @patch("sentry.seer.explorer.tools._get_issue_event_timeseries")
+    @patch("sentry.seer.explorer.tools.get_all_tags_overview")
+    def test_get_ie_details_from_event_id_with_occurrence_multi_project(
+        self, mock_get_tags, mock_get_timeseries
+    ):
+        """Test that occurrence data is included when fetching by event_id (multi project)."""
+        mock_get_timeseries.return_value = ({"count()": {"data": []}}, "6h", "15m")
+        mock_get_tags.return_value = {"tags_overview": [{"key": "test_tag", "top_values": []}]}
+
+        # Create a second project so the multi-project code path is exercised.
+        self.create_project(organization=self.organization)
+
+        occurrence, group_info = self.process_occurrence(
+            event_data={
+                "timestamp": before_now(minutes=5).isoformat(),
+                "project_id": self.project.id,
+                "platform": "python",
+            },
+            project_id=self.project.id,
+        )
+
+        result = get_issue_and_event_details_v2(
+            organization_id=self.organization.id,
+            event_id=occurrence.event_id,
+            include_issue=True,
+        )
+
+        assert result is not None
+        assert result["event_id"] == occurrence.event_id
+        self._assert_occurrence_in_response(result, occurrence)
+
+    def _assert_occurrence_in_response(self, result, occurrence):
+        occ = result["event"]["occurrence"]
+        assert occ is not None
+        assert occ["id"] == occurrence.id
+        assert occ["issueTitle"] == occurrence.issue_title
+        assert occ["subtitle"] == occurrence.subtitle
+        assert occ["evidenceData"] == {"test": 123}
+        assert len(occ["evidenceDisplay"]) == len(occurrence.evidence_display)
+        for serialized, original in zip(occ["evidenceDisplay"], occurrence.evidence_display):
+            assert serialized["name"] == original.name
+            assert serialized["value"] == original.value
+            assert serialized["important"] == original.important
+
+
+class TestGetIssueAndEventResponse(APITransactionTestCase, SnubaTestCase, SearchIssueTestMixin):
     """Unit tests for the util that derives a response from an event and group."""
 
     @patch("sentry.seer.explorer.tools.get_all_tags_overview")


### PR DESCRIPTION
Convert Event to GroupEvent in the event_id path so the occurrence can be lazy-loaded from nodestore during serialization. Also fix the multi-project event_id path to try both Events and IssuePlatform datasets, since occurrence events only exist in IssuePlatform.

<!-- Describe your PR here. -->