### PR TITLE
fix(alerts): Consider all ESCALATING substatus transitions as 'has_escalated' in alerts

### DIFF
--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -93,6 +93,7 @@ class WorkflowEventData:
     event: GroupEvent | Activity
     group: Group
     group_state: GroupState | None = None
+    # True when an issue transitions to the ESCALATING substatus for any reason.
     has_escalated: bool | None = None
     workflow_env: Environment | None = None
 


### PR DESCRIPTION
Previously, 'snooze until count' didn't result in has_escalated being set, which meant that our escalation-focused conditions didn't trigger. 
This plugs that hole and documents the meaning a bit more clearly.

Fixes ISWF-608.
