### PR TITLE
chore(ACI): Add 'new' RPC methods for updating action on sentry app installation deletion

### DIFF
--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -32,6 +32,35 @@ class DatabaseBackedActionService(ActionService):
             dataconditiongroupaction__condition_group__organization_id=organization_id,
         ).update(status=status)
 
+    def update_action_status_for_sentry_app_installation(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_id: int,
+    ) -> None:
+        Action.objects.filter(
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
+            config__target_identifier=str(sentry_app_id),
+            type=Action.Type.SENTRY_APP,
+            dataconditiongroupaction__condition_group__organization_id=organization_id,
+        ).update(status=status)
+
+    def update_action_status_for_sentry_app_installation__region(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        organization_id: int,
+        sentry_app_id: int,
+    ) -> None:
+        Action.objects.filter(
+            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
+            config__target_identifier=str(sentry_app_id),
+            type=Action.Type.SENTRY_APP,
+            dataconditiongroupaction__condition_group__organization_id=organization_id,
+        ).update(status=status)
+
     def update_action_status_for_sentry_app_via_uuid(
         self,
         *,

--- a/src/sentry/workflow_engine/service/action/impl.py
+++ b/src/sentry/workflow_engine/service/action/impl.py
@@ -35,20 +35,6 @@ class DatabaseBackedActionService(ActionService):
     def update_action_status_for_sentry_app_installation(
         self,
         *,
-        organization_id: int,
-        status: int,
-        sentry_app_id: int,
-    ) -> None:
-        Action.objects.filter(
-            config__sentry_app_identifier=SentryAppIdentifier.SENTRY_APP_ID,
-            config__target_identifier=str(sentry_app_id),
-            type=Action.Type.SENTRY_APP,
-            dataconditiongroupaction__condition_group__organization_id=organization_id,
-        ).update(status=status)
-
-    def update_action_status_for_sentry_app_installation__region(
-        self,
-        *,
         region_name: str,
         status: int,
         organization_id: int,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -36,6 +36,29 @@ class ActionService(RpcService):
 
     @regional_rpc_method(resolve=ByOrganizationId())
     @abc.abstractmethod
+    def update_action_status_for_sentry_app_installation(
+        self,
+        *,
+        organization_id: int,
+        status: int,
+        sentry_app_id: int,
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByRegionName())
+    @abc.abstractmethod
+    def update_action_status_for_sentry_app_installation__region(
+        self,
+        *,
+        region_name: str,
+        status: int,
+        organization_id: int,
+        sentry_app_id: int,
+    ) -> None:
+        pass
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
     def update_action_status_for_sentry_app_via_uuid(
         self,
         *,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -34,20 +34,9 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByOrganizationId())
-    @abc.abstractmethod
-    def update_action_status_for_sentry_app_installation(
-        self,
-        *,
-        organization_id: int,
-        status: int,
-        sentry_app_id: int,
-    ) -> None:
-        pass
-
     @regional_rpc_method(resolve=ByRegionName())
     @abc.abstractmethod
-    def update_action_status_for_sentry_app_installation__region(
+    def update_action_status_for_sentry_app_installation(
         self,
         *,
         region_name: str,


### PR DESCRIPTION
Breaking out a piece of https://github.com/getsentry/sentry/pull/107982 as per https://github.com/getsentry/sentry/pull/107982#discussion_r2796135048 to create new RPC methods instead of renaming them.

A follow up PR will update the usage (in tests as well, seemed silly to duplicate the tests for this PR when I can just update the call) and a final one will remove the old one. 