### PR TITLE
fix(auth): Mask SCIM token after 5-minute visibility window

### DIFF
--- a/src/sentry/auth/services/auth/model.py
+++ b/src/sentry/auth/services/auth/model.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from django.contrib.auth.models import AnonymousUser
 
     from sentry.auth.provider import Provider
+    from sentry.models.authprovider import ScimTokenDisplay
 
 
 class RpcApiKey(RpcModel):
@@ -203,6 +204,13 @@ class RpcAuthProvider(RpcModel):
         from sentry.models.authprovider import get_scim_token
 
         return get_scim_token(self.flags.scim_enabled, self.organization_id, self.provider)
+
+    def get_scim_token_for_display(self) -> Optional["ScimTokenDisplay"]:
+        from sentry.models.authprovider import get_scim_token_for_display
+
+        return get_scim_token_for_display(
+            self.flags.scim_enabled, self.organization_id, self.provider
+        )
 
 
 class RpcAuthIdentity(RpcModel):

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -263,12 +263,20 @@ def get_scim_token_for_display(
     if not scim_enabled:
         return None
 
-    tokens = SentryAppInstallationToken.objects.select_related("api_token").filter(
-        sentry_app_installation__sentryappinstallationforprovider__organization_id=organization_id,
-        sentry_app_installation__sentryappinstallationforprovider__provider=f"{provider}_scim",
+    tokens = list(
+        SentryAppInstallationToken.objects.select_related("api_token").filter(
+            sentry_app_installation__sentryappinstallationforprovider__organization_id=organization_id,
+            sentry_app_installation__sentryappinstallationforprovider__provider=f"{provider}_scim",
+        )
     )
     if not tokens:
         return None
+
+    if len(tokens) > 1:
+        logger.warning(
+            "Multiple SCIM tokens found for organization",
+            extra={"organization_id": organization_id, "token_count": len(tokens)},
+        )
 
     api_token = tokens[0].api_token
     is_visible = (

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -224,6 +224,64 @@ class AuthProvider(ReplicatedControlModel):
         sanitizer.set_string(json, SanitizableField(model_name, "provider"))
 
 
+class ScimTokenDisplay:
+    """
+    Represents a SCIM token for display purposes.
+
+    If the token was created more than TOKEN_VISIBILITY_WINDOW_SECONDS ago,
+    is_visible will be False and only the last 4 characters should be shown.
+    """
+
+    TOKEN_VISIBILITY_WINDOW_SECONDS = 300  # 5 minutes
+
+    def __init__(
+        self,
+        token: str | None,
+        token_last_characters: str | None,
+        is_visible: bool,
+    ):
+        self.token = token
+        self.token_last_characters = token_last_characters
+        self.is_visible = is_visible
+
+
+def get_scim_token_for_display(
+    scim_enabled: bool, organization_id: int, provider: str
+) -> ScimTokenDisplay | None:
+    """
+    Get SCIM token info for display in the UI with proper masking.
+
+    Tokens are only fully visible for 5 minutes after creation.
+    After that, only the last 4 characters are shown.
+
+    All models involved (SentryAppInstallationToken, ApiToken,
+    SentryAppInstallationForProvider) are control silo models,
+    so we can query directly without RPC.
+    """
+    from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
+
+    if not scim_enabled:
+        return None
+
+    tokens = SentryAppInstallationToken.objects.select_related("api_token").filter(
+        sentry_app_installation__sentryappinstallationforprovider__organization_id=organization_id,
+        sentry_app_installation__sentryappinstallationforprovider__provider=f"{provider}_scim",
+    )
+    if not tokens:
+        return None
+
+    api_token = tokens[0].api_token
+    is_visible = (
+        timezone.now() - api_token.date_added
+    ).total_seconds() < ScimTokenDisplay.TOKEN_VISIBILITY_WINDOW_SECONDS
+
+    return ScimTokenDisplay(
+        token=api_token.token if is_visible else None,
+        token_last_characters=api_token.token[-4:],
+        is_visible=is_visible,
+    )
+
+
 def get_scim_token(scim_enabled: bool, organization_id: int, provider: str) -> str | None:
     from sentry.sentry_apps.services.app import app_service
 

--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -66,14 +66,20 @@
       </div>
     </div>
 
-    {% if scim_api_token %}
+    {% if scim_token_display %}
     <div class="box">
       <div class="box-header">
         <h3>SCIM Information</h3>
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
-        <pre>{{ scim_api_token }}</pre>
+        {% if scim_token_display.is_visible %}
+        <pre>{{ scim_token_display.token }}</pre>
+        <p class="help-block">Your token is only available briefly after creation. Make sure to save this value!</p>
+        {% else %}
+        <pre>************{{ scim_token_display.token_last_characters }}</pre>
+        <p class="help-block">To generate a new token, disable and re-enable SCIM.</p>
+        {% endif %}
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>
         <p>See provider specific SCIM documentation <a href="https://docs.sentry.io/product/accounts/sso/#scim-provisioning">here</a>.</p>

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -225,6 +225,8 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
         pending_links_count = organization_service.count_members_without_sso(
             organization_id=organization.id
         )
+        scim_token_display = auth_provider.get_scim_token_for_display()
+
         context = {
             "form": form,
             "pending_links_count": pending_links_count,
@@ -234,7 +236,7 @@ class OrganizationAuthSettingsView(ControlSiloOrganizationView):
             ),
             "auth_provider": auth_provider,
             "provider_name": provider.name,
-            "scim_api_token": auth_provider.get_scim_token(),
+            "scim_token_display": scim_token_display,
             "scim_url": get_scim_url(auth_provider, organization),
             "content": response,
             "disabled": provider.is_partner,

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -811,3 +811,109 @@ class OrganizationAuthSettingsGenericSAML2Test(AuthProviderTestCase):
 
         assert actual.provider == self.auth_provider_inst.provider
         assert actual.flags == self.auth_provider_inst.flags
+
+
+@control_silo_test
+class OrganizationAuthSettingsScimTokenMaskingTest(AuthProviderTestCase):
+    """Tests for SCIM token masking security feature (VULN-789)."""
+
+    def create_org_and_auth_provider(self, provider_name="dummy"):
+        self.user.update(is_managed=True)
+        with assume_test_silo_mode(SiloMode.REGION):
+            organization = self.create_organization(name="foo", owner=self.user)
+
+        auth_provider = AuthProvider.objects.create(
+            organization_id=organization.id, provider=provider_name
+        )
+        AuthIdentity.objects.create(user=self.user, ident="foo", auth_provider=auth_provider)
+        return organization, auth_provider
+
+    def create_om_and_link_sso(self, organization):
+        with assume_test_silo_mode(SiloMode.REGION):
+            om = OrganizationMember.objects.get(user_id=self.user.id, organization=organization)
+            setattr(om.flags, "sso:linked", True)
+            om.save()
+        return om
+
+    def test_scim_token_visible_immediately_after_creation(self):
+        """SCIM token is fully visible within 5 minutes of creation."""
+        organization, auth_provider = self.create_org_and_auth_provider()
+        self.create_om_and_link_sso(organization)
+        path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
+
+        self.login_as(self.user, organization_id=organization.id)
+
+        with self.feature({"organizations:sso-basic": True}):
+            resp = self.client.post(
+                path,
+                {
+                    "op": "settings",
+                    "require_link": True,
+                    "enable_scim": True,
+                    "default_role": "member",
+                },
+            )
+            assert resp.status_code == 200
+
+            auth_provider = AuthProvider.objects.get(organization_id=organization.id)
+            assert auth_provider.flags.scim_enabled
+
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+
+            assert "scim_token_display" in resp.context
+            scim_token_display = resp.context["scim_token_display"]
+            assert scim_token_display is not None
+            assert scim_token_display.is_visible is True
+            assert scim_token_display.token is not None
+
+    def test_scim_token_masked_after_visibility_window(self):
+        """SCIM token is masked after 5 minutes."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from sentry.models.apitoken import ApiToken
+        from sentry.sentry_apps.models.sentry_app_installation_token import (
+            SentryAppInstallationToken,
+        )
+
+        organization, auth_provider = self.create_org_and_auth_provider()
+        self.create_om_and_link_sso(organization)
+        path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
+
+        self.login_as(self.user, organization_id=organization.id)
+
+        with self.feature({"organizations:sso-basic": True}):
+            resp = self.client.post(
+                path,
+                {
+                    "op": "settings",
+                    "require_link": True,
+                    "enable_scim": True,
+                    "default_role": "member",
+                },
+            )
+            assert resp.status_code == 200
+
+            auth_provider = AuthProvider.objects.get(organization_id=organization.id)
+            assert auth_provider.flags.scim_enabled
+
+            install_for_provider = SentryAppInstallationForProvider.objects.get(
+                organization_id=organization.id, provider="dummy_scim"
+            )
+            install_token = SentryAppInstallationToken.objects.get(
+                sentry_app_installation=install_for_provider.sentry_app_installation
+            )
+            old_date = timezone.now() - timedelta(minutes=10)
+            ApiToken.objects.filter(id=install_token.api_token_id).update(date_added=old_date)
+
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+
+            scim_token_display = resp.context["scim_token_display"]
+            assert scim_token_display is not None
+            assert scim_token_display.is_visible is False
+            assert scim_token_display.token is None
+            assert scim_token_display.token_last_characters is not None
+            assert len(scim_token_display.token_last_characters) == 4


### PR DESCRIPTION
SCIM tokens were displayed in full plaintext on the SSO settings page indefinitely, allowing any manager-role user to copy and misuse the token. Now tokens are only fully visible for 5 minutes after creation, then masked to show only the last 4 characters.

Fixes https://linear.app/getsentry/issue/VULN-789/
Based on @geoffg-sentry's previous pr https://github.com/getsentry/sentry/pull/106995. Afaict, creating a separate pr for rpc wasn't necessary, since the model and view are both on control

<!-- Describe your PR here. -->