### PR TITLE
cleanup(rules): Stop scheduling process_pending_batch

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -979,10 +979,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "buffer:sentry.tasks.process_buffer.process_pending",
         "schedule": timedelta(seconds=10),
     },
-    "flush-buffers-batch": {
-        "task": "buffer:sentry.tasks.process_buffer.process_pending_batch",
-        "schedule": task_crontab("*/1", "*", "*", "*", "*"),
-    },
     "flush-delayed-workflows": {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),


### PR DESCRIPTION
We no longer execute rules or delayed rules, so we can stop scheduling the flushing of the buffer for it.