### PR TITLE
Turn on multiprocess debug logger to investigate consumers hanging

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3866,6 +3866,17 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Lists all the consumers we need verbose multiprocess logs for.
+# We observed some consumers hanging after restarts. We narrowed down the
+# issue to the shared memory manager initialization. Specifically,
+# the consumer hangs when the shared memory manager initializes a subprocess.
+register(
+    "consumer.verbose_multiprocessing_logs",
+    type=Sequence,
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Rate at which to forward events to eap_items. 1.0
 # means that 100% of projects will forward events to eap_items.

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -610,9 +610,15 @@ def basic_consumer(
         quantized_rebalance_delay_secs = options.get("sentry-metrics.synchronized-rebalance-delay")
 
     dump_stacktrace_on_shutdown = consumer_name in get("consumer.dump_stacktrace_on_shutdown", [])
+    verbvose_multiprocessing_logs = consumer_name in get(
+        "consumer.verbose_multiprocessing_logs", []
+    )
 
     run_processor_with_signals(
-        processor, quantized_rebalance_delay_secs, dump_stacktrace_on_shutdown
+        processor,
+        quantized_rebalance_delay_secs,
+        dump_stacktrace_on_shutdown,
+        verbvose_multiprocessing_logs,
     )
 
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -610,15 +610,13 @@ def basic_consumer(
         quantized_rebalance_delay_secs = options.get("sentry-metrics.synchronized-rebalance-delay")
 
     dump_stacktrace_on_shutdown = consumer_name in get("consumer.dump_stacktrace_on_shutdown", [])
-    verbvose_multiprocessing_logs = consumer_name in get(
-        "consumer.verbose_multiprocessing_logs", []
-    )
+    verbose_multiprocessing_logs = consumer_name in get("consumer.verbose_multiprocessing_logs", [])
 
     run_processor_with_signals(
         processor,
         quantized_rebalance_delay_secs,
         dump_stacktrace_on_shutdown,
-        verbvose_multiprocessing_logs,
+        verbose_multiprocessing_logs,
     )
 
 

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -3,6 +3,7 @@ import logging
 import signal
 import sys
 import time
+from multiprocessing.util import log_to_stderr
 from threading import Thread
 from typing import Any
 
@@ -49,6 +50,7 @@ def run_processor_with_signals(
     processor: StreamProcessor[Any],
     quantized_rebalance_delay_secs: int | None = None,
     dump_stacktrace_on_shutdown: bool = False,
+    verbose_multiprocessing_logs: bool = False,
 ) -> None:
     if quantized_rebalance_delay_secs:
         # delay startup for quantization
@@ -61,6 +63,10 @@ def run_processor_with_signals(
             args=(processor, quantized_rebalance_delay_secs, dump_stacktrace_on_shutdown),
         )
         t.start()
+
+    if verbose_multiprocessing_logs:
+        logger.info("Setting verbose multiprocessing logs")
+        log_to_stderr(logging.DEBUG)
 
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)


### PR DESCRIPTION
We observed some consumers hanging after restarts. 
We narrowed down the issue to the shared memory manager initialization. 
Specifically, the consumer hangs when the shared memory manager initializes a subprocess.

THis is the stacktrace we observe when the consumer hangs:

```
Thread MainThread (133959766682496):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/src/sentry/src/sentry/__main__.py", line 4, in <module>
    main()
  File "/usr/src/sentry/src/sentry/runner/main.py", line 143, in main
    func(**kwargs)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/src/sentry/src/sentry/runner/decorators.py", line 82, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/src/sentry/src/sentry/runner/decorators.py", line 34, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/usr/src/sentry/src/sentry/runner/commands/run.py", line 614, in basic_consumer
    run_processor_with_signals(
  File "/usr/src/sentry/src/sentry/utils/kafka.py", line 67, in run_processor_with_signals
    processor.run()
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/processor.py", line 351, in run
    self._run_once()
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/processor.py", line 452, in _run_once
    self.__message = self.__consumer.poll(timeout=1.0)
  File "/.venv/lib/python3.13/site-packages/arroyo/backends/kafka/consumer.py", line 467, in poll
    message: Optional[ConfluentMessage] = self.__consumer.poll(
  File "/.venv/lib/python3.13/site-packages/arroyo/backends/kafka/consumer.py", line 374, in assignment_callback
    on_assign(offsets)
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/processor.py", line 50, in wrapper
    return f(*args, **kwargs)
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/processor.py", line 233, in on_partitions_assigned
    _create_strategy(current_partitions)
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/processor.py", line 194, in _create_strategy
    self.__processor_factory.create_with_partitions(
  File "/usr/src/sentry/src/sentry/consumers/__init__.py", line 747, in create_with_partitions
    return self.inner.create_with_partitions(commit, partitions)
  File "/usr/src/sentry/src/sentry/issues/run.py", line 86, in create_with_partitions
    return self.create_parallel_worker(commit)
  File "/usr/src/sentry/src/sentry/issues/run.py", line 56, in create_parallel_worker
    return run_task_with_multiprocessing(
  File "/usr/src/sentry/src/sentry/utils/arroyo.py", line 211, in run_task_with_multiprocessing
    return ArroyoRunTaskWithMultiprocessing(pool=pool.pool, function=function, **kwargs)
  File "/.venv/lib/python3.13/site-packages/arroyo/processing/strategies/run_task_with_multiprocessing.py", line 566, in __init__
    self.__shared_memory_manager.start()
  File "/usr/local/lib/python3.13/multiprocessing/managers.py", line 569, in start
    self._address = reader.recv()
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 430, in _recv_bytes
    buf = self._recv(4)
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 395, in _recv
    chunk = read(handle, remaining)
```


This part 
```
  File "/usr/local/lib/python3.13/multiprocessing/managers.py", line 569, in start
    self._address = reader.recv()
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 430, in _recv_bytes
    buf = self._recv(4)
  File "/usr/local/lib/python3.13/multiprocessing/connection.py", line 395, in _recv
    chunk = read(handle, remaining)

```
is visible when the shared memory manager is waiting for the subprocess to show up after being created.

So we hope to see something interesting from the multiprocess logger.
