### PR TITLE
feat(occurrences on eap): Implement the `type` attribute for filtering error/issue platform events

### DIFF
--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -48,7 +48,7 @@ from sentry.shared_integrations.exceptions import (
     UnknownHostError,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.occurrences_rpc import Occurrences
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.users.models.identity import Identity
 from sentry.utils import metrics
@@ -541,6 +541,7 @@ class PRCommentWorkflow(ABC):
                 limit=5,
                 referrer=self.referrer.value,
                 config=SearchResolverConfig(),
+                occurrence_category=OccurrenceCategory.ERROR,
             )
             return [
                 {"group_id": row["group_id"], "event_count": row["count()"]}

--- a/src/sentry/issues/related/trace_connected.py
+++ b/src/sentry/issues/related/trace_connected.py
@@ -14,7 +14,7 @@ from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.occurrences_rpc import Occurrences
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import bulk_snuba_queries
 
@@ -103,6 +103,7 @@ def _trace_connected_issues_eap(
             limit=100,
             referrer=Referrer.API_ISSUES_RELATED_ISSUES.value,
             config=SearchResolverConfig(),
+            occurrence_category=OccurrenceCategory.ERROR,
         )
         group_ids: set[int] = set()
         for row in result["data"]:

--- a/src/sentry/issues/suspect_flags.py
+++ b/src/sentry/issues/suspect_flags.py
@@ -11,6 +11,7 @@ from sentry.models.project import Project
 from sentry.search.eap.occurrences.common_queries import count_occurrences
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.seer.workflows.compare import KeyedValueCount, keyed_rrf_score_with_filter
+from sentry.snuba.occurrences_rpc import OccurrenceCategory
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
@@ -316,6 +317,7 @@ def _query_error_counts_eap(
         referrer=Referrer.ISSUES_SUSPECT_FLAGS_QUERY_ERROR_COUNTS.value,
         group_id=group_id,
         environments=environments,
+        occurrence_category=OccurrenceCategory.ERROR,
     )
 
 

--- a/src/sentry/issues/suspect_tags.py
+++ b/src/sentry/issues/suspect_tags.py
@@ -10,6 +10,7 @@ from sentry.models.project import Project
 from sentry.search.eap.occurrences.common_queries import count_occurrences
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.seer.workflows.compare import KeyedValueCount, keyed_kl_score
+from sentry.snuba.occurrences_rpc import OccurrenceCategory
 from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import raw_snql_query
 
@@ -287,6 +288,7 @@ def _query_error_counts_eap(
         referrer=Referrer.ISSUES_SUSPECT_TAGS_QUERY_ERROR_COUNTS.value,
         group_id=group_id,
         environments=environments,
+        occurrence_category=OccurrenceCategory.ERROR,
     )
 
 

--- a/src/sentry/search/eap/occurrences/attributes.py
+++ b/src/sentry/search/eap/occurrences/attributes.py
@@ -45,6 +45,11 @@ OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
                 internal_name="transaction",
                 search_type="string",
             ),
+            ResolvedAttribute(
+                public_alias="type",
+                internal_name="type",
+                search_type="string",
+            ),
         ]
     )
 }

--- a/src/sentry/search/eap/occurrences/common_queries.py
+++ b/src/sentry/search/eap/occurrences/common_queries.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
-from sentry.snuba.occurrences_rpc import Occurrences
+from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ def count_occurrences(
     referrer: str,
     group_id: int | None = None,
     environments: Sequence[Environment] | None = None,
+    occurrence_category: OccurrenceCategory | None = None,
 ) -> int:
     """
     Count the number of occurrences in EAP matching the given filters.
@@ -32,6 +33,7 @@ def count_occurrences(
         referrer: Referrer string for the query
         group_id: Optional group ID to filter by
         environments: Optional list of environments to filter by
+        occurrence_category: Optional occurrence category filter
 
     Returns:
         The count of matching occurrences, or 0 if the query fails
@@ -56,6 +58,7 @@ def count_occurrences(
             limit=1,
             referrer=referrer,
             config=SearchResolverConfig(),
+            occurrence_category=occurrence_category,
         )
 
         if result["data"]:

--- a/tests/sentry/snuba/test_occurrences_rpc.py
+++ b/tests/sentry/snuba/test_occurrences_rpc.py
@@ -196,6 +196,35 @@ class OccurrencesRPCTest(TestCase):
         assert resolved_column.public_alias == "min(timestamp)"
         assert resolved_column.search_type == "string"  # timestamp is processed as string
 
+    def test_type_attribute(self) -> None:
+        resolved_column, virtual_context = self.resolver.resolve_column("type")
+        assert resolved_column.proto_definition == AttributeKey(
+            name="type", type=AttributeKey.Type.TYPE_STRING
+        )
+        assert virtual_context is None
+
+    def test_type_filter_query(self) -> None:
+        where, having, _ = self.resolver.resolve_query("type:error")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="type", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="error"),
+            )
+        )
+        assert having is None
+
+    def test_type_negation_filter_query(self) -> None:
+        where, having, _ = self.resolver.resolve_query("!type:generic")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="type", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_NOT_EQUALS,
+                value=AttributeValue(val_str="generic"),
+            )
+        )
+        assert having is None
+
 
 class OccurrencesTimeseriesTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Adds a `type` attribute to the EAP occurrence definitions, making it queryable via the search resolver. The `OccurrenceCategory` enum provides an API in the `Occurrences` RPC class for consumers to filter their queries down to either error events (`error`) or issue platform events (`generic`). The default behavior will continue to be querying all occurrence trace items as a whole.

Applies `OccurrenceCategory.ERROR` as the filter to all existing EAP callsites where we want to query errors only.