### PR TITLE
feat(autopilot): Add missing integrations count to detector log

### DIFF
--- a/src/sentry/autopilot/tasks/missing_sdk_integration.py
+++ b/src/sentry/autopilot/tasks/missing_sdk_integration.py
@@ -275,6 +275,7 @@ Example no init: `{{"missing_integrations": [], "finish_reason": "{MissingSdkInt
                 "repo_name": repo_name,
                 "run_id": run_id,
                 "finish_reason": finish_reason,
+                "missing_integrations_count": len(missing_integrations),
             },
         )
 


### PR DESCRIPTION
Add `missing_integrations_count` to the structured log output of the
missing SDK integration detector. This allows detection results to be
queried and aggregated by count in log search without needing to parse
the integrations list.