### PR TITLE
fix(autopilot): Deduplicate repository configs in missing SDK integration detector

### DIFF
--- a/src/sentry/autopilot/tasks/missing_sdk_integration.py
+++ b/src/sentry/autopilot/tasks/missing_sdk_integration.py
@@ -85,7 +85,8 @@ def run_missing_sdk_integration_detector() -> None:
                 repository__status=ObjectStatus.ACTIVE,
                 repository__provider="integrations:github",
             )
-            .select_related("repository")
+            .order_by("repository__name")
+            .distinct("repository__name")
             .values("repository__name", "source_root")
         )
         for config in repo_configs:


### PR DESCRIPTION
Deduplicate `RepositoryProjectPathConfig` entries at query time using
PostgreSQL `DISTINCT ON` so that only one task is spawned per repository,
even when multiple code mappings exist for the same repo (e.g. different
stack/source roots).

Previously every `RepositoryProjectPathConfig` row produced its own child
task, which meant the same repository could be analyzed multiple times in
parallel for the same project.