### PR TITLE
fix(dynamic-sampling): transaction management error

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1408,6 +1408,16 @@ register("relay.drop-transaction-metrics", default=[], flags=FLAG_AUTOMATOR_MODI
 # Relay should emit a usage metric to track total spans.
 register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# When True, schedule_invalidate_project_config calls the invalidation callback
+# directly when outside an atomic block, instead of going through
+# transaction.on_commit(). This fixes TransactionManagementError in the
+# taskworker where autocommit is off.
+register(
+    "relay.invalidation-direct-outside-atomic",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Killswitch for the Relay cardinality limiter, one of `enabled`, `disabled`, `passive`.
 # In `passive` mode Relay's cardinality limiter is active but it does not enforce the limits.
 register(

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -4,6 +4,7 @@ import time
 import sentry_sdk
 from django.db import router, transaction
 
+from sentry import options
 from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.silo.base import SiloMode
@@ -318,18 +319,23 @@ def schedule_invalidate_project_config(
     ) as span:
         span.set_tag("transaction_db", transaction_db)
 
-        from django.db import connections
+        use_direct_call = False
+        if options.get("relay.invalidation-direct-outside-atomic"):
+            from django.db import connections
 
-        conn = connections[transaction_db]
-        if conn.in_atomic_block:
+            conn = connections[transaction_db]
+            if not conn.in_atomic_block:
+                # No active transaction (autocommit or manual-transaction mode
+                # like in the taskworker). Execute immediately — this is what
+                # on_commit() does in autocommit mode anyway.
+                use_direct_call = True
+
+        if use_direct_call:
+            callback()
+        else:
             # Inside a transaction — defer until commit so the invalidation
             # sees the committed state.
             transaction.on_commit(callback, using=transaction_db)
-        else:
-            # No active transaction (autocommit or manual-transaction mode
-            # like in the taskworker). Execute immediately — this is what
-            # on_commit() does in autocommit mode anyway.
-            callback()
 
 
 def _schedule_invalidate_project_config(

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 import sentry_sdk
-from django.db import router, transaction
+from django.db import connections, router, transaction
 
 from sentry import options
 from sentry.models.organization import Organization
@@ -305,37 +305,27 @@ def schedule_invalidate_project_config(
     if transaction_db is None:
         transaction_db = router.db_for_write(Project)
 
-    callback = lambda: _schedule_invalidate_project_config(
-        trigger=trigger,
-        trigger_details=trigger_details,
-        organization_id=organization_id,
-        project_id=project_id,
-        public_key=public_key,
-        countdown=countdown,
-    )
+    def _do_schedule():
+        _schedule_invalidate_project_config(
+            trigger=trigger,
+            trigger_details=trigger_details,
+            organization_id=organization_id,
+            project_id=project_id,
+            public_key=public_key,
+            countdown=countdown,
+        )
 
     with sentry_sdk.start_span(
         op="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
     ) as span:
         span.set_tag("transaction_db", transaction_db)
-
-        use_direct_call = False
-        if options.get("relay.invalidation-direct-outside-atomic"):
-            from django.db import connections
-
-            conn = connections[transaction_db]
-            if not conn.in_atomic_block:
-                # No active transaction (autocommit or manual-transaction mode
-                # like in the taskworker). Execute immediately — this is what
-                # on_commit() does in autocommit mode anyway.
-                use_direct_call = True
-
-        if use_direct_call:
-            callback()
+        if (
+            options.get("relay.invalidation-direct-outside-atomic")
+            and not connections[transaction_db].in_atomic_block
+        ):
+            _do_schedule()
         else:
-            # Inside a transaction — defer until commit so the invalidation
-            # sees the committed state.
-            transaction.on_commit(callback, using=transaction_db)
+            transaction.on_commit(_do_schedule, using=transaction_db)
 
 
 def _schedule_invalidate_project_config(

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -304,25 +304,32 @@ def schedule_invalidate_project_config(
     if transaction_db is None:
         transaction_db = router.db_for_write(Project)
 
+    callback = lambda: _schedule_invalidate_project_config(
+        trigger=trigger,
+        trigger_details=trigger_details,
+        organization_id=organization_id,
+        project_id=project_id,
+        public_key=public_key,
+        countdown=countdown,
+    )
+
     with sentry_sdk.start_span(
         op="relay.projectconfig_cache.invalidation.schedule_after_db_transaction",
     ) as span:
         span.set_tag("transaction_db", transaction_db)
 
-        # XXX(iker): updating a lot of organizations or projects in a single
-        # database transaction causes the `on_commit` list to grow considerably
-        # and may cause memory leaks.
-        transaction.on_commit(
-            lambda: _schedule_invalidate_project_config(
-                trigger=trigger,
-                trigger_details=trigger_details,
-                organization_id=organization_id,
-                project_id=project_id,
-                public_key=public_key,
-                countdown=countdown,
-            ),
-            using=transaction_db,
-        )
+        from django.db import connections
+
+        conn = connections[transaction_db]
+        if conn.in_atomic_block:
+            # Inside a transaction — defer until commit so the invalidation
+            # sees the committed state.
+            transaction.on_commit(callback, using=transaction_db)
+        else:
+            # No active transaction (autocommit or manual-transaction mode
+            # like in the taskworker). Execute immediately — this is what
+            # on_commit() does in autocommit mode anyway.
+            callback()
 
 
 def _schedule_invalidate_project_config(

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -469,9 +469,7 @@ class TestInvalidationTask:
             trigger="test", project_id=default_project.id, countdown=2
         )
 
-        # Outside an atomic block, the callback is called directly
-        # (on_commit is only used inside a transaction).
-        assert oncommit.call_count == 0
+        assert oncommit.call_count == 1
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == mock.call(
             trigger="test",
@@ -538,6 +536,7 @@ def test_invalidate_hierarchy(
 
 
 @django_db_all(transaction=True)
+@override_options({"relay.invalidation-direct-outside-atomic": True})
 def test_schedule_invalidate_project_config_without_autocommit(default_project):
     """
     Regression test: schedule_invalidate_project_config must not raise

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -2,7 +2,8 @@ import contextlib
 from unittest import mock
 
 import pytest
-from django.db import router, transaction
+from django.db import connections, router, transaction
+from django.db.transaction import TransactionManagementError
 
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.models.options.project_option import ProjectOption
@@ -536,17 +537,37 @@ def test_invalidate_hierarchy(
 
 
 @django_db_all(transaction=True)
-@override_options({"relay.invalidation-direct-outside-atomic": True})
-def test_schedule_invalidate_project_config_without_autocommit(default_project):
+@override_options({"relay.invalidation-direct-outside-atomic": False})
+def test_schedule_invalidate_project_config_without_autocommit_option_off(default_project):
     """
-    Regression test: schedule_invalidate_project_config must not raise
-    TransactionManagementError when called without autocommit and outside
-    an atomic block, as happens in the taskworker.
+    Without the option, the old behavior is preserved: on_commit() is called
+    unconditionally, which raises TransactionManagementError when autocommit
+    is off and there is no active atomic block.
+    """
+    conn = connections["default"]
+    conn.ensure_connection()
+    try:
+        conn.set_autocommit(False)
+        with pytest.raises(TransactionManagementError):
+            schedule_invalidate_project_config(
+                project_id=default_project.id,
+                trigger="test",
+            )
+    finally:
+        conn.rollback()
+        conn.set_autocommit(True)
+
+
+@django_db_all(transaction=True)
+@override_options({"relay.invalidation-direct-outside-atomic": True})
+def test_schedule_invalidate_project_config_without_autocommit_option_on(default_project):
+    """
+    Regression test: with the option enabled, schedule_invalidate_project_config
+    must not raise TransactionManagementError when called without autocommit and
+    outside an atomic block, as happens in the taskworker.
 
     See: https://sentry.sentry.io/issues/7223923952/
     """
-    from django.db import connections
-
     conn = connections["default"]
     conn.ensure_connection()
     try:

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -469,7 +469,9 @@ class TestInvalidationTask:
             trigger="test", project_id=default_project.id, countdown=2
         )
 
-        assert oncommit.call_count == 1
+        # Outside an atomic block, the callback is called directly
+        # (on_commit is only used inside a transaction).
+        assert oncommit.call_count == 0
         assert schedule_inner.call_count == 1
         assert schedule_inner.call_args == mock.call(
             trigger="test",
@@ -533,3 +535,38 @@ def test_invalidate_hierarchy(
     assert len(calls) == 1
     cache = redis_cache.get(default_projectkey)
     assert cache["disabled"] is False
+
+
+@django_db_all(transaction=True)
+def test_schedule_invalidate_project_config_without_autocommit(default_project):
+    """
+    Regression test: schedule_invalidate_project_config must not raise
+    TransactionManagementError when called without autocommit and outside
+    an atomic block, as happens in the taskworker.
+
+    See: https://sentry.sentry.io/issues/7223923952/
+    """
+    from django.db import connections
+
+    conn = connections["default"]
+    conn.ensure_connection()
+    try:
+        conn.set_autocommit(False)
+        with mock.patch("sentry.tasks.relay._schedule_invalidate_project_config") as mock_schedule:
+            schedule_invalidate_project_config(
+                project_id=default_project.id,
+                trigger="test",
+            )
+            # The callback should have been called directly (not via on_commit)
+            assert mock_schedule.call_count == 1
+            mock_schedule.assert_called_once_with(
+                trigger="test",
+                trigger_details=None,
+                organization_id=None,
+                project_id=default_project.id,
+                public_key=None,
+                countdown=5,
+            )
+    finally:
+        conn.rollback()
+        conn.set_autocommit(True)


### PR DESCRIPTION
Bug explanation: 
 - When in a transaction, in_atomic_block is true for the connection object
 - When in_atomic_block is true, but autocommit is off, Django does not know when changes will be committed, so we cannot register the callback

Fix:
- If not in a transaction, call the scheduling function directly
- If in a transaction, call it as a callback via on_commit 

Fixes SENTRY-5GVE
Fixes SENTRY-5HMP
Fixes SENTRY-5HMN
Closes TET-1724