### PR TITLE
feat(trace-items): Update trace item search with dynamic keys

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -672,7 +672,9 @@ const ListBoxOverlay = styled(Overlay)`
   min-width: 200px;
   width: 600px;
   max-width: fit-content;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 `;
 
 const DescriptionOverlay = styled(Overlay)`

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -320,15 +320,17 @@ function OverlayContent<T extends SelectOptionOrSectionWithKey<string>>({
             <LoadingIndicator size={24} style={{margin: 0}} />
           </Flex>
         ) : (
-          <ListBox
-            {...listBoxProps}
-            ref={listBoxRef}
-            listState={state}
-            hasSearch={!!filterValue}
-            hiddenOptions={hiddenOptions}
-            overlayIsOpen={isOpen}
-            size="sm"
-          />
+          <ListBoxPane>
+            <ListBox
+              {...listBoxProps}
+              ref={listBoxRef}
+              listState={state}
+              hasSearch={!!filterValue}
+              hiddenOptions={hiddenOptions}
+              overlayIsOpen={isOpen}
+              size="sm"
+            />
+          </ListBoxPane>
         )}
         {isLoading && anyItemsShowing ? (
           <Flex justify="center" align="center" height="32px" width="100%">
@@ -675,6 +677,12 @@ const ListBoxOverlay = styled(Overlay)`
   display: flex;
   flex-direction: column;
   overflow: hidden;
+`;
+
+const ListBoxPane = styled('div')`
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 `;
 
 const DescriptionOverlay = styled(Overlay)`

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -30,7 +30,7 @@ function mockSpanTags({
   mockedTags,
 }: {
   mockedTags: Array<{key: string; name: string}>;
-  type: 'string' | 'number';
+  type: 'string' | 'number' | 'boolean';
 }) {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/trace-items/attributes/`,
@@ -86,6 +86,8 @@ describe('SpansSearchBar', () => {
 
     mockSpanTags({type: 'number', mockedTags: []});
     mockSpanTagValues({type: 'number', tagKey: 'span.op', mockedValues: []});
+
+    mockSpanTags({type: 'boolean', mockedTags: []});
   });
 
   it('renders the initial query conditions', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -34,6 +34,10 @@ describe('QueryFilterBuilder', () => {
       url: '/organizations/org-slug/recent-searches/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
   });
 
   it('renders a dataset-specific query filter bar', async () => {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -1,9 +1,29 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/components/pageFilters/store';
 import {FieldKind} from 'sentry/utils/fields';
-import {useTraceItemSearchQueryBuilderProps} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
+import {
+  useTraceItemSearchQueryBuilderProps,
+  type TraceItemSearchQueryBuilderProps,
+} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {TraceItemDataset} from 'sentry/views/explore/types';
+
+const defaultInitialProps: TraceItemSearchQueryBuilderProps = {
+  itemType: TraceItemDataset.SPANS,
+  booleanAttributes: {},
+  booleanSecondaryAliases: {},
+  numberAttributes: {},
+  numberSecondaryAliases: {},
+  stringAttributes: {},
+  stringSecondaryAliases: {},
+  initialQuery: '',
+  searchSource: 'test',
+};
+const organization = OrganizationFixture({
+  features: ['search-query-builder-explicit-boolean-filters'],
+});
 
 describe('useTraceItemSearchQueryBuilderProps', () => {
   beforeEach(() => {
@@ -20,43 +40,185 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
     });
   });
 
-  it('wires boolean attributes into filter keys, aliases, and sections', () => {
-    const booleanAttributes = {
-      'feature.enabled': {
-        key: 'feature.enabled',
-        name: 'feature.enabled',
-        kind: FieldKind.BOOLEAN,
-      },
-    };
-    const booleanSecondaryAliases = {
-      'feature.enabled_alias': {
-        key: 'feature.enabled_alias',
-        name: 'feature.enabled_alias',
-        kind: FieldKind.BOOLEAN,
-      },
-    };
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
 
-    const {result} = renderHookWithProviders(
-      () =>
-        useTraceItemSearchQueryBuilderProps({
-          itemType: TraceItemDataset.SPANS,
-          booleanAttributes,
-          booleanSecondaryAliases,
-          numberAttributes: {},
-          numberSecondaryAliases: {},
-          stringAttributes: {},
-          stringSecondaryAliases: {},
-          initialQuery: '',
-          searchSource: 'test',
-        }),
-      {
-        organization: {
-          features: ['search-query-builder-explicit-boolean-filters'],
+  it('wires boolean attributes into filter keys, aliases, and sections', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        booleanAttributes: {
+          'feature.enabled': {
+            key: 'feature.enabled',
+            name: 'feature.enabled',
+            kind: FieldKind.BOOLEAN,
+          },
         },
-      }
-    );
+        booleanSecondaryAliases: {
+          'feature.enabled_alias': {
+            key: 'feature.enabled_alias',
+            name: 'feature.enabled_alias',
+            kind: FieldKind.BOOLEAN,
+          },
+        },
+      },
+      organization,
+    });
 
     expect(result.current.filterKeys['feature.enabled']).toBeDefined();
     expect(result.current.filterKeyAliases?.['feature.enabled_alias']).toBeDefined();
+  });
+
+  it('wires number attributes into filter keys and aliases', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        numberAttributes: {
+          'transaction.duration': {
+            key: 'transaction.duration',
+            name: 'transaction.duration',
+            kind: FieldKind.MEASUREMENT,
+          },
+        },
+        numberSecondaryAliases: {
+          'transaction.duration_alias': {
+            key: 'transaction.duration_alias',
+            name: 'transaction.duration_alias',
+            kind: FieldKind.MEASUREMENT,
+          },
+        },
+      },
+      organization,
+    });
+
+    expect(result.current.filterKeys['transaction.duration']).toBeDefined();
+    expect(result.current.filterKeyAliases?.['transaction.duration_alias']).toBeDefined();
+  });
+
+  it('wires string attributes into filter keys and aliases', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        stringAttributes: {
+          'log.message': {
+            key: 'log.message',
+            name: 'log.message',
+            kind: FieldKind.TAG,
+          },
+        },
+        stringSecondaryAliases: {
+          'log.message_alias': {
+            key: 'log.message_alias',
+            name: 'log.message_alias',
+            kind: FieldKind.TAG,
+          },
+        },
+      },
+      organization,
+    });
+
+    expect(result.current.filterKeys['log.message']).toBeDefined();
+    expect(result.current.filterKeyAliases?.['log.message_alias']).toBeDefined();
+  });
+
+  it('merges all secondary alias types into filterKeyAliases', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        booleanSecondaryAliases: {
+          'feature.enabled_alias': {
+            key: 'feature.enabled_alias',
+            name: 'feature.enabled_alias',
+            kind: FieldKind.BOOLEAN,
+          },
+        },
+        numberSecondaryAliases: {
+          'transaction.duration_alias': {
+            key: 'transaction.duration_alias',
+            name: 'transaction.duration_alias',
+            kind: FieldKind.MEASUREMENT,
+          },
+        },
+        stringSecondaryAliases: {
+          'log.message_alias': {
+            key: 'log.message_alias',
+            name: 'log.message_alias',
+            kind: FieldKind.TAG,
+          },
+        },
+      },
+      organization,
+    });
+
+    expect(result.current.filterKeyAliases).toMatchObject({
+      'feature.enabled_alias': expect.any(Object),
+      'transaction.duration_alias': expect.any(Object),
+      'log.message_alias': expect.any(Object),
+    });
+  });
+
+  it('exposes getTagKeys and allows unsupported filters when async keys are enabled', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: defaultInitialProps,
+      organization,
+    });
+
+    expect(result.current.getTagKeys).toEqual(expect.any(Function));
+    expect(result.current.disallowUnsupportedFilters).toBe(false);
+  });
+
+  it('getTagKeys fetches keys across string, number, and boolean attributes', async () => {
+    const stringMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [{key: 'log.message', name: 'log.message'}],
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.attributeType === 'string' && query.itemType === TraceItemDataset.SPANS
+          );
+        },
+      ],
+    });
+    const numberMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [{key: 'log.duration', name: 'log.duration'}],
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.attributeType === 'number' && query.itemType === TraceItemDataset.SPANS
+          );
+        },
+      ],
+    });
+    const booleanMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [{key: 'log.flag', name: 'log.flag'}],
+      match: [
+        (_url, options) => {
+          const query = options?.query || {};
+          return (
+            query.attributeType === 'boolean' && query.itemType === TraceItemDataset.SPANS
+          );
+        },
+      ],
+    });
+
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: defaultInitialProps,
+      organization,
+    });
+    const tags = await result.current.getTagKeys?.('search-query');
+
+    expect(stringMock).toHaveBeenCalled();
+    expect(numberMock).toHaveBeenCalled();
+    expect(booleanMock).toHaveBeenCalled();
+    expect(tags?.map(tag => tag.key)).toEqual([
+      'log.message',
+      'log.duration',
+      'log.flag',
+    ]);
   });
 });

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -12,6 +12,7 @@ import type {AggregationKey} from 'sentry/utils/fields';
 import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {getHasTag} from 'sentry/utils/tag';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
+import {useGetTraceItemAttributeTagKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeTagKeys';
 import {useGetTraceItemAttributeValues} from 'sentry/views/explore/hooks/useGetTraceItemAttributeValues';
 import {LOGS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/logs/constants';
 import {TRACEMETRICS_FILTER_KEY_SECTIONS} from 'sentry/views/explore/metrics/constants';
@@ -124,6 +125,12 @@ export function useTraceItemSearchQueryBuilderProps({
     booleanAttributes,
   });
 
+  const getTagKeys = useGetTraceItemAttributeTagKeys({
+    itemType,
+    projects,
+    extraTags: functionTags,
+  });
+
   return useMemo(
     () => ({
       placeholder: placeholderText,
@@ -138,7 +145,8 @@ export function useTraceItemSearchQueryBuilderProps({
       filterKeySections,
       getSuggestedFilterKey: getSuggestedAttribute,
       getTagValues: getTraceItemAttributeValues,
-      disallowUnsupportedFilters: true,
+      getTagKeys,
+      disallowUnsupportedFilters: !getTagKeys,
       disallowFreeText,
       disallowLogicalOperators,
       recentSearches: itemTypeToRecentSearches(itemType),
@@ -164,6 +172,7 @@ export function useTraceItemSearchQueryBuilderProps({
       filterTags,
       getFilterTokenWarning,
       getSuggestedAttribute,
+      getTagKeys,
       getTraceItemAttributeValues,
       initialQuery,
       itemType,

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.spec.tsx
@@ -1,0 +1,151 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import {FieldKind} from 'sentry/utils/fields';
+import {useGetTraceItemAttributeTagKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeTagKeys';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+function mockTraceItemAttributeKeysByType({
+  attributeType,
+  body,
+  itemType = TraceItemDataset.LOGS,
+}: {
+  attributeType: 'string' | 'number' | 'boolean';
+  body: Array<{key: string; kind: FieldKind; name: string}>;
+  itemType?: TraceItemDataset;
+}) {
+  return MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/trace-items/attributes/',
+    body,
+    match: [
+      (_url, options) => {
+        const query = options?.query || {};
+        return query.itemType === itemType && query.attributeType === attributeType;
+      },
+    ],
+  });
+}
+
+describe('useGetTraceItemAttributeTagKeys', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {
+        period: '14d',
+        start: null,
+        end: null,
+        utc: false,
+      },
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches and merges string, number, and boolean keys', async () => {
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'string',
+      body: [{key: 'log.field', name: 'log.field', kind: FieldKind.TAG}],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'number',
+      body: [{key: 'log.duration', name: 'log.duration', kind: FieldKind.MEASUREMENT}],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'boolean',
+      body: [{key: 'log.flag', name: 'log.flag', kind: FieldKind.BOOLEAN}],
+    });
+
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeTagKeys, {
+      initialProps: {
+        itemType: TraceItemDataset.LOGS,
+      },
+    });
+
+    const tags = await result.current('search-query');
+
+    expect(tags).toHaveLength(3);
+    expect(tags).toMatchObject([
+      {key: 'log.field', name: 'log.field', kind: FieldKind.TAG},
+      {key: 'log.duration', name: 'log.duration', kind: FieldKind.MEASUREMENT},
+      {key: 'log.flag', name: 'log.flag', kind: FieldKind.BOOLEAN},
+    ]);
+  });
+
+  it('deduplicates extraTags when keys overlap fetched keys', async () => {
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'string',
+      body: [{key: 'log.field', name: 'log.field', kind: FieldKind.TAG}],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'number',
+      body: [{key: 'log.duration', name: 'log.duration', kind: FieldKind.MEASUREMENT}],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'boolean',
+      body: [{key: 'log.flag', name: 'log.flag', kind: FieldKind.BOOLEAN}],
+    });
+
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeTagKeys, {
+      initialProps: {
+        itemType: TraceItemDataset.LOGS,
+        extraTags: {
+          'log.duration': {
+            key: 'log.duration',
+            name: 'log.duration from extra',
+            kind: FieldKind.MEASUREMENT,
+          },
+        },
+      },
+    });
+
+    const tags = await result.current('search-query');
+
+    expect(tags.filter(tag => tag.key === 'log.duration')).toHaveLength(1);
+  });
+
+  it('appends extraTags that are not in fetched results', async () => {
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'string',
+      body: [{key: 'log.field', name: 'log.field', kind: FieldKind.TAG}],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'number',
+      body: [],
+    });
+    mockTraceItemAttributeKeysByType({
+      attributeType: 'boolean',
+      body: [],
+    });
+
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeTagKeys, {
+      initialProps: {
+        itemType: TraceItemDataset.LOGS,
+        extraTags: {
+          'function.count()': {
+            key: 'function.count()',
+            name: 'function.count()',
+            kind: FieldKind.FUNCTION,
+          },
+        },
+      },
+    });
+
+    const tags = await result.current('search-query');
+
+    expect(tags).toHaveLength(2);
+    expect(tags).toMatchObject([
+      {key: 'log.field', name: 'log.field', kind: FieldKind.TAG},
+      {
+        key: 'function.count()',
+        name: 'function.count()',
+        kind: FieldKind.FUNCTION,
+      },
+    ]);
+  });
+});

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -44,9 +44,6 @@ export function useGetTraceItemAttributeTagKeys({
         getBooleanKeys(searchQuery),
       ]);
       const fetched = [...Object.values(s), ...Object.values(n), ...Object.values(b)];
-      if (!extraTagValues.length) {
-        return fetched;
-      }
       const fetchedKeySet = new Set(fetched.map(t => t.key));
       return [...fetched, ...extraTagValues.filter(t => !fetchedKeySet.has(t.key))];
     },

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -1,0 +1,55 @@
+import {useCallback, useMemo} from 'react';
+
+import type {GetTagKeys} from 'sentry/components/searchQueryBuilder';
+import type {PageFilters} from 'sentry/types/core';
+import type {Tag, TagCollection} from 'sentry/types/group';
+import {useGetTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useGetTraceItemAttributeKeys';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
+
+export function useGetTraceItemAttributeTagKeys({
+  itemType,
+  projects,
+  extraTags,
+}: {
+  itemType: TraceItemDataset;
+  extraTags?: TagCollection;
+  projects?: PageFilters['projects'];
+}): GetTagKeys {
+  const getStringKeys = useGetTraceItemAttributeKeys({
+    traceItemType: itemType,
+    type: 'string',
+    projectIds: projects,
+  });
+  const getNumberKeys = useGetTraceItemAttributeKeys({
+    traceItemType: itemType,
+    type: 'number',
+    projectIds: projects,
+  });
+  const getBooleanKeys = useGetTraceItemAttributeKeys({
+    traceItemType: itemType,
+    type: 'boolean',
+    projectIds: projects,
+  });
+
+  const extraTagValues = useMemo(
+    () => (extraTags ? Object.values(extraTags) : []),
+    [extraTags]
+  );
+
+  return useCallback(
+    async (searchQuery: string): Promise<Tag[]> => {
+      const [s, n, b] = await Promise.all([
+        getStringKeys(searchQuery),
+        getNumberKeys(searchQuery),
+        getBooleanKeys(searchQuery),
+      ]);
+      const fetched = [...Object.values(s), ...Object.values(n), ...Object.values(b)];
+      if (!extraTagValues.length) {
+        return fetched;
+      }
+      const fetchedKeySet = new Set(fetched.map(t => t.key));
+      return [...fetched, ...extraTagValues.filter(t => !fetchedKeySet.has(t.key))];
+    },
+    [getStringKeys, getNumberKeys, getBooleanKeys, extraTagValues]
+  );
+}

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeTagKeys.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback} from 'react';
 
 import type {GetTagKeys} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
@@ -31,11 +31,6 @@ export function useGetTraceItemAttributeTagKeys({
     projectIds: projects,
   });
 
-  const extraTagValues = useMemo(
-    () => (extraTags ? Object.values(extraTags) : []),
-    [extraTags]
-  );
-
   return useCallback(
     async (searchQuery: string): Promise<Tag[]> => {
       const [s, n, b] = await Promise.all([
@@ -45,8 +40,11 @@ export function useGetTraceItemAttributeTagKeys({
       ]);
       const fetched = [...Object.values(s), ...Object.values(n), ...Object.values(b)];
       const fetchedKeySet = new Set(fetched.map(t => t.key));
-      return [...fetched, ...extraTagValues.filter(t => !fetchedKeySet.has(t.key))];
+      return [
+        ...fetched,
+        ...Object.values(extraTags ?? []).filter(t => !fetchedKeySet.has(t.key)),
+      ];
     },
-    [getStringKeys, getNumberKeys, getBooleanKeys, extraTagValues]
+    [getStringKeys, getNumberKeys, getBooleanKeys, extraTags]
   );
 }

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -57,6 +57,13 @@ describe('MultiQueryModeContent', () => {
       match: [MockApiClient.matchQuery({attributeType: 'number'})],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      method: 'GET',
+      body: [],
+      match: [MockApiClient.matchQuery({attributeType: 'boolean'})],
+    });
+
     eventsRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',

--- a/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
+++ b/static/app/views/insights/queues/components/messageSpanSamplesPanel.spec.tsx
@@ -234,32 +234,28 @@ describe('messageSpanSamplesPanel', () => {
         }),
       })
     );
-    expect(traceItemAttributesMock).toHaveBeenNthCalledWith(
-      1,
+    expect(traceItemAttributesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
       expect.objectContaining({
         method: 'GET',
-        query: {
+        query: expect.objectContaining({
           attributeType: 'number',
           itemType: 'spans',
           project: [],
           statsPeriod: '10d',
-          substringMatch: undefined,
-        },
+        }),
       })
     );
-    expect(traceItemAttributesMock).toHaveBeenNthCalledWith(
-      2,
+    expect(traceItemAttributesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
       expect.objectContaining({
         method: 'GET',
-        query: {
+        query: expect.objectContaining({
           attributeType: 'string',
           itemType: 'spans',
           project: [],
           statsPeriod: '10d',
-          substringMatch: undefined,
-        },
+        }),
       })
     );
     expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();
@@ -346,32 +342,28 @@ describe('messageSpanSamplesPanel', () => {
         }),
       })
     );
-    expect(traceItemAttributesMock).toHaveBeenNthCalledWith(
-      1,
+    expect(traceItemAttributesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
       expect.objectContaining({
         method: 'GET',
-        query: {
+        query: expect.objectContaining({
           attributeType: 'number',
           itemType: 'spans',
           project: [],
           statsPeriod: '10d',
-          substringMatch: undefined,
-        },
+        }),
       })
     );
-    expect(traceItemAttributesMock).toHaveBeenNthCalledWith(
-      2,
+    expect(traceItemAttributesMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/trace-items/attributes/`,
       expect.objectContaining({
         method: 'GET',
-        query: {
+        query: expect.objectContaining({
           attributeType: 'string',
           itemType: 'spans',
           project: [],
           statsPeriod: '10d',
-          substringMatch: undefined,
-        },
+        }),
       })
     );
     expect(screen.getByRole('table', {name: 'Span Samples'})).toBeInTheDocument();

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -545,6 +545,7 @@ describe('ReleasesList', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
+
     render(<ReleasesList />, {
       organization,
       initialRouterConfig: {
@@ -620,6 +621,7 @@ describe('ReleasesList', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
+
     const {router} = render(<ReleasesList />, {
       organization: organizationWithDistribution,
       initialRouterConfig: {
@@ -681,6 +683,17 @@ describe('ReleasesList', () => {
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'POST',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
 
@@ -769,6 +782,7 @@ describe('ReleasesList', () => {
       url: `/organizations/${organization.slug}/trace-items/attributes/`,
       body: [],
     });
+
     const {router} = render(<ReleasesList />, {
       organization,
       initialRouterConfig: {


### PR DESCRIPTION
This PR updates the `useTraceItemSearchQueryBuilderProps` to utilize the new functionality added in #107769, to dynamically fetch attribute keys based off of the users input. This enables users to access all potential attributes and removes issues where users could be limited if they had more than 3000 unique attributes.

As part of moving to using dynamic keys, we currently don't have a way to validate that all keys are "valid", however that work will be coming shortly.

Ticket: EXP-777