### PR TITLE
feat(dashboards): add `staleTime` to underlying widget queries

### DIFF
--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -36,6 +36,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type ErrorsAndTransactionsSeriesResponse =
@@ -219,7 +220,7 @@ export function useErrorsAndTransactionsSeriesQuery(
     queries: queryKeys.map((queryKey, queryIndex) => ({
       queryKey,
       queryFn: createQueryFn(queryIndex),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -448,7 +449,7 @@ export function useErrorsAndTransactionsTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -28,6 +28,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type ErrorsSeriesResponse =
@@ -128,7 +129,7 @@ export function useErrorsSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -301,7 +302,7 @@ export function useErrorsTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
@@ -21,6 +21,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
@@ -139,7 +140,7 @@ export function useIssuesSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -306,7 +307,7 @@ export function useIssuesTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -28,6 +28,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type LogsSeriesResponse =
@@ -133,7 +134,7 @@ export function useLogsSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -290,7 +291,7 @@ export function useLogsTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       // Retry on 429 status codes up to 10 times, unless queue handles it
       retry: hasQueueFeature

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -17,6 +17,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type MobileAppSizeSeriesResponse = EventsStats | MultiSeriesEventsStats;
@@ -126,7 +127,7 @@ export function useMobileAppSizeSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       // Retry on 429 status codes up to 10 times, unless queue handles it
       retry: hasQueueFeature

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
@@ -16,6 +16,7 @@ import {getWidgetInterval} from 'sentry/views/dashboards/utils';
 import {useWidgetQueryQueue} from 'sentry/views/dashboards/utils/widgetQueryQueue';
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {applyDashboardFiltersToWidget} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {requiresCustomReleaseSorting} from 'sentry/views/dashboards/widgetCard/releaseWidgetQueries';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
@@ -131,7 +132,7 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
     queries: queryKeys.map(({queryKey, useSessionAPI}) => ({
       queryKey,
       queryFn: createQueryFn(useSessionAPI),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -324,7 +325,7 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
     queries: queryKeys.map(({queryKey, useSessionAPI}) => ({
       queryKey,
       queryFn: createQueryFn(useSessionAPI),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
@@ -36,6 +36,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {STARRED_SEGMENT_TABLE_QUERY_KEY} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -161,7 +162,7 @@ export function useSpansSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -382,7 +383,7 @@ export function useSpansTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -22,6 +22,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type TraceMetricsSeriesResponse = EventsTimeSeriesResponse;
@@ -147,7 +148,7 @@ export function useTraceMetricsSeriesQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFn(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false
@@ -324,7 +325,7 @@ export function useTraceMetricsTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       retry: hasQueueFeature
         ? false

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -32,6 +32,7 @@ import {
   applyDashboardFiltersToWidget,
   getReferrer,
 } from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {getWidgetStaleTime} from 'sentry/views/dashboards/widgetCard/hooks/utils/getStaleTime';
 import {getRetryDelay} from 'sentry/views/insights/common/utils/retryHandlers';
 
 type TransactionsSeriesResponse =
@@ -200,7 +201,7 @@ export function useTransactionsSeriesQuery(
     queries: queryKeys.map((queryKey, queryIndex) => ({
       queryKey,
       queryFn: createQueryFn(queryIndex),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       // Retry on 429 status codes up to 10 times, unless queue handles it
       retry: hasQueueFeature
@@ -412,7 +413,7 @@ export function useTransactionsTableQuery(
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),
-      staleTime: 0,
+      staleTime: getWidgetStaleTime(pageFilters),
       enabled,
       // Retry on 429 status codes up to 10 times, unless queue handles it
       retry: hasQueueFeature

--- a/static/app/views/dashboards/widgetCard/hooks/utils/getStaleTime.ts
+++ b/static/app/views/dashboards/widgetCard/hooks/utils/getStaleTime.ts
@@ -1,0 +1,12 @@
+import type {PageFilters} from 'sentry/types/core';
+import {defined} from 'sentry/utils';
+import {getStaleTimeForRelativePeriodTable} from 'sentry/views/insights/common/queries/useSpansQuery';
+
+export function getWidgetStaleTime(pageFilters: PageFilters) {
+  const {start, end, period} = pageFilters.datetime;
+  const usesRelativeDateRange = !defined(start) && !defined(end) && defined(period);
+  if (usesRelativeDateRange) {
+    return getStaleTimeForRelativePeriodTable(period);
+  }
+  return Infinity;
+}

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -484,7 +484,7 @@ function mergeIntervals(first: Interval[], second: Interval[]) {
   return target;
 }
 
-function getStaleTimeForRelativePeriodTable(statsPeriod: string | undefined) {
+export function getStaleTimeForRelativePeriodTable(statsPeriod: string | undefined) {
   if (!defined(statsPeriod)) {
     return Infinity;
   }


### PR DESCRIPTION
Adds `staleTime` to the underlying widget queries to that we can best utilize react queries native caching. We're using insights `getStaleTimeForRelativePeriodTable` inorder to get a good stale time based on the selection (so that small selections aren't cached as long) the staleTimes are set as follows
< 7 day query -> 0 seconds
7 - 30 day query -> 10 seconds
30-60 day query -> 60 seconds
\> 60 day query -> 5 minutes

This should make the ui feel more snappy and also somewhat minimize rate limiting problems because we're making less requests.