### PR TITLE
fix(dashboards): Exclude is_starred_transaction from explore URLs

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -278,7 +278,7 @@ function _getWidgetExploreUrl(
 
   let sort: string | undefined = undefined;
   if (sortColumn === SpanFields.IS_STARRED_TRANSACTION) {
-    // is_starred_transaction is a widget-only field, skip it in explore
+    // is_starred_transaction is not supported in explore
     sort = undefined;
   } else if (isAggregateField(sortColumn)) {
     if (exploreMode === Mode.SAMPLES) {

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -31,6 +31,7 @@ import {getLogsUrl} from 'sentry/views/explore/logs/utils';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getExploreMultiQueryUrl, getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
+import {SpanFields} from 'sentry/views/insights/types';
 
 function getTraceItemDatasetFromWidgetType(widgetType?: WidgetType): TraceItemDataset {
   switch (widgetType) {
@@ -255,9 +256,12 @@ function _getWidgetExploreUrl(
   let groupBy: string[] =
     defined(query.fields) && widget.displayType === DisplayType.TABLE
       ? query.fields.filter(
-          field => !isAggregateFieldOrEquation(field) && field !== 'timestamp'
+          field =>
+            !isAggregateFieldOrEquation(field) &&
+            field !== 'timestamp' &&
+            field !== SpanFields.IS_STARRED_TRANSACTION // starred transactions are not supported in explore
         )
-      : [...query.columns];
+      : query.columns.filter(column => column !== SpanFields.IS_STARRED_TRANSACTION);
   if (groupBy && groupBy.length === 0) {
     // Force the groupBy to be an array with a single empty string
     // so that qs.stringify appends the key to the URL. If the key
@@ -273,7 +277,10 @@ function _getWidgetExploreUrl(
   const sortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');
 
   let sort: string | undefined = undefined;
-  if (isAggregateField(sortColumn)) {
+  if (sortColumn === SpanFields.IS_STARRED_TRANSACTION) {
+    // is_starred_transaction is a widget-only field, skip it in explore
+    sort = undefined;
+  } else if (isAggregateField(sortColumn)) {
     if (exploreMode === Mode.SAMPLES) {
       // if the current sort is on an aggregation, then we should extract its argument
       // and try to sort on that in samples mode
@@ -392,7 +399,9 @@ function _getWidgetExploreUrlForMultipleQueries(
       sortBys: decodeSorts(query.orderby),
       yAxes: query.aggregates,
       fields: [],
-      groupBys: query.columns,
+      groupBys: query.columns.filter(
+        column => column !== SpanFields.IS_STARRED_TRANSACTION
+      ),
     })),
     interval: getWidgetInterval(widget, currentSelection.datetime),
     referrer,
@@ -410,7 +419,9 @@ export function getWidgetTableRowExploreUrlFunction(
     let fields: string[] = [];
     if (widget.queries[selectedQueryIndex]?.fields) {
       fields = widget.queries[selectedQueryIndex].fields.filter(
-        (field: string) => !isAggregateFieldOrEquation(field)
+        (field: string) =>
+          !isAggregateFieldOrEquation(field) &&
+          field !== SpanFields.IS_STARRED_TRANSACTION
       );
     }
 

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -396,7 +396,9 @@ function _getWidgetExploreUrlForMultipleQueries(
     queries: widget.queries.map(query => ({
       chartType: getChartType(widget.displayType),
       query: applyDashboardFilters(query.conditions, dashboardFilters) ?? '',
-      sortBys: decodeSorts(query.orderby),
+      sortBys: decodeSorts(query.orderby).filter(
+        s => s.field !== SpanFields.IS_STARRED_TRANSACTION
+      ),
       yAxes: query.aggregates,
       fields: [],
       groupBys: query.columns.filter(


### PR DESCRIPTION
## Summary
- The `is_starred_transaction` field is used internally by dashboard widgets to pin starred transactions to the top of tables, but is not supported in the Explore page
- Filters `is_starred_transaction` from group by columns, fields, and sort when generating explore URLs from dashboard widgets
- Applies to single-query, multi-query, and table row click explore URL generation

## Test plan
- Open a dashboard widget that includes `is_starred_transaction` in its fields/columns
- Click "Open in Explore" — the explore URL should not contain `is_starred_transaction` in groupBy, fields, or sort params
- Click a table row — the explore URL should not filter by `is_starred_transaction`