### PR TITLE
fix(dashboards): Strip equation| prefix when generating explore URLs

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -12,6 +12,7 @@ import {
   isEquation,
   isEquationAlias,
   parseFunction,
+  stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {AggregationKey, FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 import {decodeBoolean, decodeScalar, decodeSorts} from 'sentry/utils/queryString';
@@ -213,7 +214,12 @@ function _getWidgetExploreUrl(
       (widget.displayType === DisplayType.TABLE
         ? widget.queries[0]!.fields?.filter(isAggregateFieldOrEquation)
         : widget.queries[0]!.aggregates
-      )?.filter(aggregate => yAxisOptions.includes(aggregate))
+      )
+        ?.filter(aggregate => yAxisOptions.includes(aggregate))
+        // Strip equation| prefix since Explore expects raw aggregates
+        .map(aggregate =>
+          isEquation(aggregate) ? stripEquationPrefix(aggregate) : aggregate
+        )
     ),
   ];
 
@@ -270,7 +276,11 @@ function _getWidgetExploreUrl(
   const fields = [...new Set([...groupBy, ...yAxisFields])].filter(Boolean);
 
   const sortDirection = widget.queries[0]?.orderby?.startsWith('-') ? '-' : '';
-  const sortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');
+  const rawSortColumn = trimStart(widget.queries[0]?.orderby ?? '', '-');
+  // Strip equation| prefix from sort column for explore compatibility
+  const sortColumn = isEquation(rawSortColumn)
+    ? stripEquationPrefix(rawSortColumn)
+    : rawSortColumn;
 
   let sort: string | undefined = undefined;
   if (isAggregateField(sortColumn)) {
@@ -282,11 +292,11 @@ function _getWidgetExploreUrl(
         sort = `${sortDirection}${aggregateArguments[0]}`;
       }
     } else if (exploreMode === Mode.AGGREGATE) {
-      sort = widget.queries[0]?.orderby;
+      sort = `${sortDirection}${sortColumn}`;
     }
-  } else if (isEquationAlias(sortColumn) && exploreMode === Mode.AGGREGATE) {
+  } else if (isEquationAlias(rawSortColumn) && exploreMode === Mode.AGGREGATE) {
     const equations = query.fields?.filter(isEquation) ?? [];
-    const equationIndex = getEquationAliasIndex(sortColumn);
+    const equationIndex = getEquationAliasIndex(rawSortColumn);
 
     const orderby = equations[equationIndex];
     if (orderby) {

--- a/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
@@ -1,0 +1,21 @@
+import {t} from 'sentry/locale';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
+
+export const RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE: WidgetTemplate = {
+  id: 'rage-and-dead-clicks-widget',
+  title: t('Rage and Dead Clicks'),
+  description: t('Visualizes the rage and dead clicks in your frontend project.'),
+  isCustomizable: false,
+  displayType: DisplayType.RAGE_AND_DEAD_CLICKS,
+  interval: '5m',
+  queries: [
+    {
+      name: '',
+      conditions: '',
+      aggregates: [],
+      columns: [],
+      orderby: '',
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Dashboard widgets use `equation|` prefixed fields (e.g. `equation|tpm()`, `equation|sum_if(...)`) for aggregates, but the Explore page expects raw aggregate names
- The `equation|` prefix was being passed through to yAxes and sort params, causing "orderby must also be in the selected columns or groupby" errors when opening widgets like the Frontend Overview transactions table in Explore
- Strips `equation|` prefix from yAxes and sort column when generating explore URLs

## Test plan
- Open the Frontend Overview prebuilt dashboard
- Click "Open in Explore" on the Transactions table widget
- Verify the Explore page loads without "orderby must also be in the selected columns or groupby" errors
- Verify the sort and yAxes use raw aggregate names (e.g. `sum_if(...)` instead of `equation|sum_if(...)`)