### PR TITLE
feat(dashboards): Legend breakdown rows default to opening in Explore

### DIFF
--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -142,7 +142,7 @@ export function getWidgetExploreUrl(
   );
 }
 
-function getChartType(displayType: DisplayType) {
+export function getChartType(displayType: DisplayType) {
   let chartType: ChartType = ChartType.LINE;
   switch (displayType) {
     case DisplayType.BAR:


### PR DESCRIPTION
## Summary
- When a legend breakdown row has no linked dashboard, clicking the label now navigates to Explore
- The Explore URL includes the widget's query conditions, the row-specific group-by filter, and span-based dashboard global filters
- Exported `getChartType` from `getWidgetExploreUrl.tsx` to reuse the display-type-to-chart-type mapping
- Linked dashboard URLs still take precedence when configured

This was primarily built to support the ssr widget in the next.js overview page, which links out to explore instead of another dashboard
<img width="284" height="379" alt="image" src="https://github.com/user-attachments/assets/dc47b787-60c8-4595-a711-dafac13772a6" />


## Test plan
- [ ] Verify legend breakdown rows for span widgets link to Explore with correct filters
- [ ] Verify linked dashboard rows still navigate to their linked dashboard
- [ ] Verify dashboard global filters are included in the Explore query