### PR TITLE
ref(insights): Remove Simplify<> from SpanResponse to speed up type-checking

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -1,5 +1,3 @@
-import type {Simplify} from 'type-fest';
-
 import type {PlatformKey} from 'sentry/types/project';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
@@ -476,7 +474,7 @@ type CustomResponseFields = {
   [SpanFields.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
 };
 
-type SpanResponseRaw = {
+export type SpanResponse = {
   [Property in SpanNumberFields as `${Aggregate}(${Property})`]: number;
 } & {
   [Property in SpanFunctions as `${Property}()`]: number;
@@ -513,7 +511,6 @@ type SpanResponseRaw = {
     [Property in SpanFields as `${SpanFunction.COUNT_IF}(${Property},${string},${string})`]: number;
   };
 
-export type SpanResponse = Simplify<SpanResponseRaw>;
 export type SpanProperty = keyof SpanResponse;
 
 export type SpanQueryFilters = Partial<Record<SpanStringFields, string>> & {
@@ -542,7 +539,7 @@ type NoArgErrorFunction =
   | ErrorFunction.EPM
   | ErrorFunction.LAST_SEEN;
 
-type ErrorResponseRaw = {
+export type ErrorResponse = {
   [Property in ErrorStringFields as `${Property}`]: string;
 } & {
   [Property in ErrorNumberFields as `${Property}`]: number;
@@ -550,7 +547,6 @@ type ErrorResponseRaw = {
   [Property in NoArgErrorFunction as `${Property}()`]: number;
 };
 
-export type ErrorResponse = Simplify<ErrorResponseRaw>;
 export type ErrorProperty = keyof ErrorResponse;
 
 // Maps the subregion code to the subregion name according to UN m49 standard


### PR DESCRIPTION
`Simplify<>` (added in #93478 for tooltip readability) forces eager flattening of the full ~4,700-key intersection. Removing it lets the checker resolve properties lazily.

Same treatment for `ErrorResponse` (tiny type, just for consistency).

| Checker | Before | After | Improvement |
|---------|--------|-------|-------------|
| tsc     | 71.0s  | 62.5s | -8.5s (12%) |
| tsgo    | 8.7s   | 6.7s  | -2.0s (23%) |

Tradeoff: IDE hover tooltips will show the raw intersection instead of a flat object.

The `division(SpanNumberFields, SpanNumberFields)` cartesian product (56²=3,136 keys) could save another ~8s on tsc by collapsing to `division(${string}, ${string})`, but that changes `Pick` behavior so left it alone.
