### PR TITLE
fix(explore): Use unique keys for column editor

### DIFF
--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -170,7 +170,7 @@ export function ColumnEditorModal({
             {editableColumns.map((column, i) => {
               return (
                 <ColumnEditorRow
-                  key={column.id}
+                  key={`${column.column}-${column.id}`}
                   canDelete={editableColumns.length > 1}
                   required={requiredTags?.includes(column.column)}
                   column={column}


### PR DESCRIPTION
Fixing a bug with the column editor where it was just using index based React keys, so it would get confused and play an undo animation. The fix, need a unique key.