### PR TITLE
feat(github): Add mailbox bucketing for GitHub webhooks

### DIFF
--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -215,6 +215,13 @@ class BaseRequestParser(ABC):
             )
             return str(integration.id)
 
+        return self._build_bucketed_identifier(integration, data)
+
+    def _build_bucketed_identifier(
+        self, integration: RpcIntegration | Integration, data: dict[str, Any]
+    ) -> str:
+        """Compute a sub-mailbox identifier from mailbox_bucket_id, falling back to
+        the integration-level mailbox when no bucket ID is available."""
         mailbox_bucket_id = self.mailbox_bucket_id(data)
         if mailbox_bucket_id is None:
             metrics.incr(

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -209,15 +209,27 @@ class BaseRequestParser(ABC):
             cache.set(use_buckets_key, 1, timeout=ONE_DAY)
             use_buckets = True
         if not use_buckets:
+            metrics.incr(
+                "hybridcloud.webhookpayload.mailbox_routing",
+                tags={"provider": self.provider, "bucketed": "false"},
+            )
             return str(integration.id)
 
         mailbox_bucket_id = self.mailbox_bucket_id(data)
         if mailbox_bucket_id is None:
+            metrics.incr(
+                "hybridcloud.webhookpayload.mailbox_routing",
+                tags={"provider": self.provider, "bucketed": "false"},
+            )
             return str(integration.id)
 
         # Split high volume integrations into 100 buckets.
         # 100 is arbitrary but we can't leave it unbounded.
         bucket_number = mailbox_bucket_id % 100
+        metrics.incr(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={"provider": self.provider, "bucketed": "true"},
+        )
 
         return f"{integration.id}:{bucket_number}"
 

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -64,20 +64,7 @@ class GithubRequestParser(BaseRequestParser):
             )
             return str(integration.id)
 
-        mailbox_bucket_id = self.mailbox_bucket_id(data)
-        if mailbox_bucket_id is None:
-            metrics.incr(
-                "hybridcloud.webhookpayload.mailbox_routing",
-                tags={"provider": self.provider, "bucketed": "false"},
-            )
-            return str(integration.id)
-
-        bucket_number = mailbox_bucket_id % 100
-        metrics.incr(
-            "hybridcloud.webhookpayload.mailbox_routing",
-            tags={"provider": self.provider, "bucketed": "true"},
-        )
-        return f"{integration.id}:{bucket_number}"
+        return self._build_bucketed_identifier(integration, data)
 
     def should_route_to_control_silo(
         self, parsed_event: Mapping[str, Any], request: HttpRequest

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -34,6 +34,19 @@ class GithubRequestParser(BaseRequestParser):
         """Overridden in GithubEnterpriseRequestParser"""
         return get_github_external_id(event)
 
+    def mailbox_bucket_id(self, data: Mapping[str, Any]) -> int | None:
+        """Hash on repository ID to distribute webhooks across sub-mailboxes.
+
+        GitHub webhook payloads include repository.id for most event types.
+        Installation events are routed to control silo and don't reach this path.
+        """
+        repository = data.get("repository")
+        if isinstance(repository, dict):
+            repo_id = repository.get("id")
+            if isinstance(repo_id, int):
+                return repo_id
+        return None
+
     def should_route_to_control_silo(
         self, parsed_event: Mapping[str, Any], request: HttpRequest
     ) -> bool:
@@ -100,7 +113,9 @@ class GithubRequestParser(BaseRequestParser):
                 self.try_forward_to_codecov(event=event)
 
         response = self.get_response_from_webhookpayload(
-            regions=regions, identifier=integration.id, integration_id=integration.id
+            regions=regions,
+            identifier=self.get_mailbox_identifier(integration, event),
+            integration_id=integration.id,
         )
 
         return response

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -17,6 +17,7 @@ from sentry.integrations.github.webhook import (
 from sentry.integrations.github.webhook_types import GITHUB_WEBHOOK_TYPE_HEADER, GithubWebhookType
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.silo.base import control_silo_function
 from sentry.utils import metrics
@@ -40,14 +41,43 @@ class GithubRequestParser(BaseRequestParser):
         GitHub webhook payloads include repository.id for most event types.
         Installation events are routed to control silo and don't reach this path.
         """
-        if not options.get("github.webhook.mailbox-bucketing.enabled"):
-            return None
         repository = data.get("repository")
         if isinstance(repository, dict):
             repo_id = repository.get("id")
             if isinstance(repo_id, int):
                 return repo_id
         return None
+
+    def get_mailbox_identifier(
+        self, integration: RpcIntegration | Integration, data: dict[str, Any]
+    ) -> str:
+        """Override to gate bucketing on an options flag for safe rollout and revert.
+
+        When disabled (default), all webhooks route to a single mailbox per integration.
+        When enabled, webhooks are distributed across sub-mailboxes by repository ID,
+        bypassing the rate-limit auto-switch used by the base class.
+        """
+        if not options.get("github.webhook.mailbox-bucketing.enabled"):
+            metrics.incr(
+                "hybridcloud.webhookpayload.mailbox_routing",
+                tags={"provider": self.provider, "bucketed": "false"},
+            )
+            return str(integration.id)
+
+        mailbox_bucket_id = self.mailbox_bucket_id(data)
+        if mailbox_bucket_id is None:
+            metrics.incr(
+                "hybridcloud.webhookpayload.mailbox_routing",
+                tags={"provider": self.provider, "bucketed": "false"},
+            )
+            return str(integration.id)
+
+        bucket_number = mailbox_bucket_id % 100
+        metrics.incr(
+            "hybridcloud.webhookpayload.mailbox_routing",
+            tags={"provider": self.provider, "bucketed": "true"},
+        )
+        return f"{integration.id}:{bucket_number}"
 
     def should_route_to_control_silo(
         self, parsed_event: Mapping[str, Any], request: HttpRequest

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -40,6 +40,8 @@ class GithubRequestParser(BaseRequestParser):
         GitHub webhook payloads include repository.id for most event types.
         Installation events are routed to control silo and don't reach this path.
         """
+        if not options.get("github.webhook.mailbox-bucketing.enabled"):
+            return None
         repository = data.get("repository")
         if isinstance(repository, dict):
             repo_id = repository.get("id")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -722,6 +722,11 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "github.webhook.mailbox-bucketing.enabled",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # GitHub Console SDK App (separate app for repository invitations)
 register("github-console-sdk-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 import responses
 from django.db import router, transaction
@@ -291,6 +293,129 @@ class GithubRequestParserTest(TestCase):
             mailbox_name=f"github:{integration.id}",
             region_names=[region.name],
             destination_types={DestinationType.SENTRY_REGION: 1},
+        )
+
+
+@control_silo_test
+class GithubRequestParserMailboxBucketingTest(TestCase):
+    factory = RequestFactory()
+    path = reverse("sentry-integration-github-webhook")
+
+    def get_response(self, req: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    def get_integration(self) -> Integration:
+        return self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            provider="github",
+        )
+
+    def test_mailbox_bucket_id_returns_repo_id(self) -> None:
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 35129377}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) == 35129377
+
+    def test_mailbox_bucket_id_returns_none_without_repository(self) -> None:
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        assert parser.mailbox_bucket_id({"installation": {"id": "1"}}) is None
+
+    def test_mailbox_bucket_id_handles_malformed_payload(self) -> None:
+        request = self.factory.post(
+            self.path,
+            data={},
+            content_type="application/json",
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+
+        assert parser.mailbox_bucket_id({"repository": "not-a-dict"}) is None
+        assert parser.mailbox_bucket_id({"repository": {"id": "not-an-int"}}) is None
+        assert parser.mailbox_bucket_id({"repository": {}}) is None
+        assert parser.mailbox_bucket_id({}) is None
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    def test_webhook_outbox_creation_with_bucketing(self) -> None:
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 35129377}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+
+        with mock.patch(
+            "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
+            return_value=True,
+        ):
+            parser = GithubRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        # 35129377 % 100 = 77
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}:77",
+            region_names=[region.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    def test_webhook_outbox_creation_without_bucketing(self) -> None:
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 35129377}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    def test_webhook_without_repository_falls_back_to_single_mailbox(self) -> None:
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
+        )
+
+        with mock.patch(
+            "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
+            return_value=True,
+        ):
+            parser = GithubRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
         )
 
 

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -319,19 +319,7 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
-        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
-            assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) == 35129377
-
-    def test_mailbox_bucket_id_returns_none_when_option_disabled(self) -> None:
-        request = self.factory.post(
-            self.path,
-            data={"installation": {"id": "1"}, "repository": {"id": 35129377}},
-            content_type="application/json",
-            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
-        )
-        parser = GithubRequestParser(request=request, response_handler=self.get_response)
-        # Default is disabled; should always return None regardless of payload
-        assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) is None
+        assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) == 35129377
 
     def test_mailbox_bucket_id_returns_none_without_repository(self) -> None:
         request = self.factory.post(
@@ -341,8 +329,7 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
-        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
-            assert parser.mailbox_bucket_id({"installation": {"id": "1"}}) is None
+        assert parser.mailbox_bucket_id({"installation": {"id": "1"}}) is None
 
     def test_mailbox_bucket_id_handles_malformed_payload(self) -> None:
         request = self.factory.post(
@@ -352,11 +339,10 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
-        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
-            assert parser.mailbox_bucket_id({"repository": "not-a-dict"}) is None
-            assert parser.mailbox_bucket_id({"repository": {"id": "not-an-int"}}) is None
-            assert parser.mailbox_bucket_id({"repository": {}}) is None
-            assert parser.mailbox_bucket_id({}) is None
+        assert parser.mailbox_bucket_id({"repository": "not-a-dict"}) is None
+        assert parser.mailbox_bucket_id({"repository": {"id": "not-an-int"}}) is None
+        assert parser.mailbox_bucket_id({"repository": {}}) is None
+        assert parser.mailbox_bucket_id({}) is None
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_regions(region_config)
@@ -369,13 +355,7 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
 
-        with (
-            override_options({"github.webhook.mailbox-bucketing.enabled": True}),
-            mock.patch(
-                "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
-                return_value=True,
-            ),
-        ):
+        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
             parser = GithubRequestParser(request=request, response_handler=self.get_response)
             response = parser.get_response()
 

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -319,7 +319,19 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
-        assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) == 35129377
+        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
+            assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) == 35129377
+
+    def test_mailbox_bucket_id_returns_none_when_option_disabled(self) -> None:
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 35129377}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        # Default is disabled; should always return None regardless of payload
+        assert parser.mailbox_bucket_id({"repository": {"id": 35129377}}) is None
 
     def test_mailbox_bucket_id_returns_none_without_repository(self) -> None:
         request = self.factory.post(
@@ -329,7 +341,8 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.INSTALLATION.value},
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
-        assert parser.mailbox_bucket_id({"installation": {"id": "1"}}) is None
+        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
+            assert parser.mailbox_bucket_id({"installation": {"id": "1"}}) is None
 
     def test_mailbox_bucket_id_handles_malformed_payload(self) -> None:
         request = self.factory.post(
@@ -339,10 +352,11 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
         )
         parser = GithubRequestParser(request=request, response_handler=self.get_response)
 
-        assert parser.mailbox_bucket_id({"repository": "not-a-dict"}) is None
-        assert parser.mailbox_bucket_id({"repository": {"id": "not-an-int"}}) is None
-        assert parser.mailbox_bucket_id({"repository": {}}) is None
-        assert parser.mailbox_bucket_id({}) is None
+        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
+            assert parser.mailbox_bucket_id({"repository": "not-a-dict"}) is None
+            assert parser.mailbox_bucket_id({"repository": {"id": "not-an-int"}}) is None
+            assert parser.mailbox_bucket_id({"repository": {}}) is None
+            assert parser.mailbox_bucket_id({}) is None
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_regions(region_config)
@@ -355,9 +369,12 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
         )
 
-        with mock.patch(
-            "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
-            return_value=True,
+        with (
+            override_options({"github.webhook.mailbox-bucketing.enabled": True}),
+            mock.patch(
+                "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
+                return_value=True,
+            ),
         ):
             parser = GithubRequestParser(request=request, response_handler=self.get_response)
             response = parser.get_response()

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 import responses
 from django.db import router, transaction
@@ -400,10 +398,7 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
             headers={"X-GITHUB-EVENT": GithubWebhookType.ISSUE.value},
         )
 
-        with mock.patch(
-            "sentry.integrations.middleware.hybrid_cloud.parser.ratelimiter.is_limited",
-            return_value=True,
-        ):
+        with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
             parser = GithubRequestParser(request=request, response_handler=self.get_response)
             response = parser.get_response()
 


### PR DESCRIPTION
- Introduced `mailbox_bucket_id` method to hash on repository ID, allowing distribution of webhooks across sub-mailboxes.
- Added unit tests to validate the new method's behavior with various payload scenarios, including valid repository IDs, absence of repository data, and malformed payloads.
- Enhanced webhook response handling to incorporate mailbox bucketing logic.

This change improves the handling of GitHub webhooks by ensuring better distribution across mailboxes, enhancing scalability and performance.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
