### PR TITLE
chore(query-builder): Remove old boolean token experience

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {
@@ -25,7 +24,6 @@ import {getKeyLabel} from 'sentry/components/searchSyntax/utils';
 import {space} from 'sentry/styles/space';
 import type {TagCollection} from 'sentry/types/group';
 import {getFieldDefinition as defaultGetFieldDefinition} from 'sentry/utils/fields';
-import useOrganization from 'sentry/utils/useOrganization';
 
 export type FormattedQueryProps = {
   query: string;
@@ -78,23 +76,11 @@ function Filter({token}: {token: TokenResult<Token.FILTER>}) {
 }
 
 function Boolean({token}: {token: TokenResult<Token.LOGIC_BOOLEAN>}) {
-  const hasConditionalsSelect = useOrganization().features.includes(
-    'search-query-builder-add-boolean-operator-select'
-  );
-
-  if (hasConditionalsSelect) {
-    const label = token.text.toUpperCase();
-    return (
-      <FilterWrapper aria-label={label}>
-        <Text variant="muted">{label}</Text>
-      </FilterWrapper>
-    );
-  }
-
+  const label = token.text.toUpperCase();
   return (
-    <Flex align="center">
-      <Text variant="muted">{token.text}</Text>
-    </Flex>
+    <FilterWrapper aria-label={label}>
+      <Text variant="muted">{label}</Text>
+    </FilterWrapper>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -897,48 +897,27 @@ describe('SearchQueryBuilder', () => {
     });
 
     describe('logic ops', () => {
-      describe('flag disabled', () => {
-        it('can remove logic ops by clicking the delete button', async () => {
-          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
+      it('can remove logic selector by clicking the delete button', async () => {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
 
-          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-          await userEvent.click(screen.getByRole('gridcell', {name: 'Delete OR'}));
+        expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Remove logic operator: OR'})
+        );
 
-          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
-        });
+        expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
       });
 
-      describe('flag enabled', () => {
-        it('can remove logic selector by clicking the delete button', async () => {
-          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
-            organization: {
-              features: ['search-query-builder-add-boolean-operator-select'],
-            },
-          });
+      it('can select a different logic operator', async () => {
+        render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />);
 
-          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-          await userEvent.click(
-            screen.getByRole('button', {name: 'Remove logic operator: OR'})
-          );
+        expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit logic operator: OR'})
+        );
+        await userEvent.click(screen.getByRole('option', {name: 'AND'}));
 
-          expect(screen.queryByRole('row', {name: 'OR'})).not.toBeInTheDocument();
-        });
-
-        it('can select a different logic operator', async () => {
-          render(<SearchQueryBuilder {...defaultProps} initialQuery="OR" />, {
-            organization: {
-              features: ['search-query-builder-add-boolean-operator-select'],
-            },
-          });
-
-          expect(screen.getByRole('row', {name: 'OR'})).toBeInTheDocument();
-          await userEvent.click(
-            screen.getByRole('button', {name: 'Edit logic operator: OR'})
-          );
-          await userEvent.click(screen.getByRole('option', {name: 'AND'}));
-
-          expect(screen.getByRole('row', {name: 'AND'})).toBeInTheDocument();
-        });
+        expect(screen.getByRole('row', {name: 'AND'})).toBeInTheDocument();
       });
     });
 

--- a/static/app/components/searchQueryBuilder/tokens/boolean.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/boolean.tsx
@@ -15,7 +15,6 @@ import {
   BaseGridCell,
   FilterWrapper,
 } from 'sentry/components/searchQueryBuilder/tokens/components';
-import {DeletableToken} from 'sentry/components/searchQueryBuilder/tokens/deletableToken';
 import {UnstyledButton} from 'sentry/components/searchQueryBuilder/tokens/filter/unstyledButton';
 import {useFilterButtonProps} from 'sentry/components/searchQueryBuilder/tokens/filter/useFilterButtonProps';
 import {GridInvalidTokenTooltip} from 'sentry/components/searchQueryBuilder/tokens/invalidTokenTooltip';
@@ -27,47 +26,12 @@ import type {
 import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
-import useOrganization from 'sentry/utils/useOrganization';
 
 type SearchQueryBuilderBooleanProps = {
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
   token: TokenResult<Token.LOGIC_BOOLEAN>;
 };
-
-export function SearchQueryBuilderBoolean({
-  item,
-  state,
-  token,
-}: SearchQueryBuilderBooleanProps) {
-  const showBooleanOpSelector = useOrganization().features.includes(
-    'search-query-builder-add-boolean-operator-select'
-  );
-
-  if (showBooleanOpSelector) {
-    return <SearchQueryBuilderBooleanSelect item={item} state={state} token={token} />;
-  }
-
-  return <SearchQueryBuilderBooleanDeletable item={item} state={state} token={token} />;
-}
-
-function SearchQueryBuilderBooleanDeletable({
-  item,
-  state,
-  token,
-}: SearchQueryBuilderBooleanProps) {
-  return (
-    <DeletableToken
-      item={item}
-      state={state}
-      token={token}
-      label={token.value}
-      invalid={token.invalid}
-    >
-      {token.text}
-    </DeletableToken>
-  );
-}
 
 function FilterDelete({token, state, item}: SearchQueryBuilderBooleanProps) {
   const {dispatch, disabled} = useSearchQueryBuilder();
@@ -93,7 +57,7 @@ const LOGIC_OPERATOR_OPTIONS = [
   {value: 'OR', label: 'OR'},
 ];
 
-function SearchQueryBuilderBooleanSelect({
+export function SearchQueryBuilderBoolean({
   item,
   state,
   token,


### PR DESCRIPTION
This PR is the initial chore as part of the removal of the `search-query-builder-add-boolean-operator-select` flag.

Ticket: EXP-781