### PR TITLE
feat(uptime-detector-ongoing-issues): Ignoring date selection for uptime ongoing issues

### DIFF
--- a/static/app/views/detectors/components/details/common/ongoingIssues.spec.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.spec.tsx
@@ -1,0 +1,103 @@
+import {UptimeDetectorFixture} from 'sentry-fixture/detectors';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {getUtcDateString} from 'sentry/utils/dates';
+
+import {DetectorDetailsOngoingIssues} from './ongoingIssues';
+
+describe('DetectorDetailsOngoingIssues', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+  });
+
+  it('renders issue list and view all link with default statsPeriod', async () => {
+    const detector = UptimeDetectorFixture({id: '1'});
+    const group = GroupFixture();
+
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      method: 'GET',
+      body: [group],
+    });
+
+    render(
+      <DetectorDetailsOngoingIssues detector={detector} dateTimeSelection={null} />,
+      {organization}
+    );
+
+    await waitFor(() =>
+      expect(issuesRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            query: `is:unresolved detector:${detector.id}`,
+            project: detector.projectId,
+            statsPeriod: '90d',
+            limit: 5,
+          }),
+        })
+      )
+    );
+
+    const viewAll = screen.getByTestId('view-all-ongoing-issues-button');
+    expect(viewAll).toBeInTheDocument();
+    expect(viewAll).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/?project=${detector.projectId}&query=is%3Aunresolved%20detector%3A${detector.id}&statsPeriod=90d`
+    );
+  });
+
+  it('renders issue list and view all link with datetime selection', async () => {
+    const detector = UptimeDetectorFixture({id: '2'});
+    const group = GroupFixture();
+
+    const start = '2026-02-01T00:00:00';
+    const end = '2026-02-02T00:00:00';
+
+    const issuesRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      method: 'GET',
+      body: [group],
+    });
+
+    render(
+      <DetectorDetailsOngoingIssues
+        detector={detector}
+        dateTimeSelection={{start, end, period: null, utc: null}}
+      />,
+      {organization}
+    );
+
+    await waitFor(() =>
+      expect(issuesRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'GET',
+          query: expect.objectContaining({
+            query: `is:unresolved detector:${detector.id}`,
+            project: detector.projectId,
+            start: getUtcDateString(start),
+            end: getUtcDateString(end),
+            limit: 5,
+          }),
+        })
+      )
+    );
+
+    const viewAll = screen.getByTestId('view-all-ongoing-issues-button');
+    expect(viewAll).toBeInTheDocument();
+    expect(viewAll).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/?end=${encodeURIComponent(end)}&project=${detector.projectId}&query=is%3Aunresolved%20detector%3A${detector.id}&start=${encodeURIComponent(start)}`
+    );
+  });
+});

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -2,14 +2,17 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import GroupList from 'sentry/components/issues/groupList';
-import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {getUtcDateString} from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type DetectorDetailsOngoingIssuesProps = {
+  // The time range used for the issues query.
+  // When null, the query uses the default set by the backend: 90d
+  dateTimeSelection: PageFilters['datetime'] | null;
   detector: Detector;
   // Extra query params to include in the issue details link.
   // Useful for feature-specific deep-linking.
@@ -18,19 +21,18 @@ type DetectorDetailsOngoingIssuesProps = {
 
 export function DetectorDetailsOngoingIssues({
   detector,
+  dateTimeSelection,
   issueLinkExtraQuery,
 }: DetectorDetailsOngoingIssuesProps) {
   const organization = useOrganization();
   const query = `is:unresolved detector:${detector.id}`;
-  const {selection} = usePageFilters();
+  const {start, end, period} = dateTimeSelection ?? {};
   const queryParams = {
     query,
     project: detector.projectId,
-    start: selection.datetime.start
-      ? getUtcDateString(selection.datetime.start)
-      : undefined,
-    end: selection.datetime.end ? getUtcDateString(selection.datetime.end) : undefined,
-    statsPeriod: selection.datetime.period ?? undefined,
+    start: start ? getUtcDateString(start) : undefined,
+    end: end ? getUtcDateString(end) : undefined,
+    statsPeriod: period ?? undefined,
   };
 
   return (

--- a/static/app/views/detectors/components/details/common/ongoingIssues.tsx
+++ b/static/app/views/detectors/components/details/common/ongoingIssues.tsx
@@ -11,13 +11,15 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 type DetectorDetailsOngoingIssuesProps = {
   // The time range used for the issues query.
-  // When null, the query uses the default set by the backend: 90d
+  // When null, the query uses 90d as the stats period.
   dateTimeSelection: PageFilters['datetime'] | null;
   detector: Detector;
   // Extra query params to include in the issue details link.
   // Useful for feature-specific deep-linking.
   issueLinkExtraQuery?: Record<string, string>;
 };
+
+const DEFAULT_STATS_PERIOD = '90d';
 
 export function DetectorDetailsOngoingIssues({
   detector,
@@ -26,7 +28,8 @@ export function DetectorDetailsOngoingIssues({
 }: DetectorDetailsOngoingIssuesProps) {
   const organization = useOrganization();
   const query = `is:unresolved detector:${detector.id}`;
-  const {start, end, period} = dateTimeSelection ?? {};
+  const {start, end, period} = dateTimeSelection ?? {period: DEFAULT_STATS_PERIOD};
+
   const queryParams = {
     query,
     project: detector.projectId,
@@ -40,6 +43,7 @@ export function DetectorDetailsOngoingIssues({
       title={t('Ongoing Issues')}
       trailingItems={
         <LinkButton
+          data-test-id="view-all-ongoing-issues-button"
           size="xs"
           to={{
             pathname: `/organizations/${organization.slug}/issues/`,

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -2,6 +2,7 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Placeholder from 'sentry/components/placeholder';
 import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
 import Section from 'sentry/components/workflowEngine/ui/section';
@@ -70,6 +71,7 @@ function ResolveSection({project}: {project: Project}) {
 export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsProps) {
   const organization = useOrganization();
   const canEdit = useCanEditDetectorWorkflowConnections({projectId: project.id});
+  const {selection} = usePageFilters();
 
   return (
     <DetailLayout>
@@ -87,7 +89,10 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
             message={t('This monitor is disabled and not creating issues.')}
           />
           <DatePageFilter />
-          <DetectorDetailsOngoingIssues detector={detector} />
+          <DetectorDetailsOngoingIssues
+            detector={detector}
+            dateTimeSelection={selection.datetime}
+          />
           <DetectorDetailsAutomations detector={detector} />
         </DetailLayout.Main>
         <DetailLayout.Sidebar>

--- a/static/app/views/detectors/components/details/uptime/index.tsx
+++ b/static/app/views/detectors/components/details/uptime/index.tsx
@@ -70,6 +70,7 @@ export function UptimeDetectorDetails({detector, project}: UptimeDetectorDetails
           <DetectorDetailsOngoingIssues
             detector={detector}
             issueLinkExtraQuery={{includeUptime: '1'}}
+            dateTimeSelection={null}
           />
           <Section title={t('Recent Check-Ins')}>
             <div>


### PR DESCRIPTION
Passing `null` leads to the consumers being a bit deliberate about their choice of time range. 