### PR TITLE
ref(preprod): Narrow transaction scope in snapshot endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -154,48 +154,44 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 commit_comparison=commit_comparison,
             )
 
+            manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
+
             snapshot_metrics = PreprodSnapshotMetrics.objects.create(
                 preprod_artifact=artifact,
                 image_count=len(images),
+                extras={"manifest_key": manifest_key},
             )
 
-            logger.info(
-                "Created preprod artifact for snapshots",
-                extra={
-                    "preprod_artifact_id": artifact.id,
-                    "project_id": project.id,
-                    "organization_id": project.organization_id,
-                    "head_sha": head_sha,
-                },
-            )
+        logger.info(
+            "Created preprod artifact for snapshots",
+            extra={
+                "preprod_artifact_id": artifact.id,
+                "project_id": project.id,
+                "organization_id": project.organization_id,
+                "head_sha": head_sha,
+            },
+        )
 
-            session = get_preprod_session(project.organization_id, project.id)
-            manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
+        session = get_preprod_session(project.organization_id, project.id)
+        manifest = SnapshotManifest(images=images)
+        manifest_json = manifest.json(exclude_none=True)
+        session.put(manifest_json.encode(), key=manifest_key)
 
-            manifest = SnapshotManifest(images=images)
-            manifest_json = manifest.json(exclude_none=True)
-            session.put(manifest_json.encode(), key=manifest_key)
+        logger.info(
+            "Stored snapshot manifest",
+            extra={
+                "preprod_artifact_id": artifact.id,
+                "snapshot_metrics_id": snapshot_metrics.id,
+                "manifest_key": manifest_key,
+                "image_count": len(images),
+            },
+        )
 
-            extras = snapshot_metrics.extras or {}
-            extras["manifest_key"] = manifest_key
-            snapshot_metrics.extras = extras
-            snapshot_metrics.save(update_fields=["extras"])
-
-            logger.info(
-                "Stored snapshot manifest",
-                extra={
-                    "preprod_artifact_id": artifact.id,
-                    "snapshot_metrics_id": snapshot_metrics.id,
-                    "manifest_key": manifest_key,
-                    "image_count": len(images),
-                },
-            )
-
-            return Response(
-                {
-                    "artifactId": str(artifact.id),
-                    "snapshotMetricsId": str(snapshot_metrics.id),
-                    "imageCount": snapshot_metrics.image_count,
-                },
-                status=200,
-            )
+        return Response(
+            {
+                "artifactId": str(artifact.id),
+                "snapshotMetricsId": str(snapshot_metrics.id),
+                "imageCount": snapshot_metrics.image_count,
+            },
+            status=200,
+        )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -170,20 +170,13 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             session.put(manifest_json.encode(), key=manifest_key)
 
         logger.info(
-            "Created preprod artifact for snapshots",
-            extra={
-                "preprod_artifact_id": artifact.id,
-                "project_id": project.id,
-                "organization_id": project.organization_id,
-                "head_sha": head_sha,
-            },
-        )
-
-        logger.info(
-            "Stored snapshot manifest",
+            "Created preprod artifact and stored snapshot manifest",
             extra={
                 "preprod_artifact_id": artifact.id,
                 "snapshot_metrics_id": snapshot_metrics.id,
+                "project_id": project.id,
+                "organization_id": project.organization_id,
+                "head_sha": head_sha,
                 "manifest_key": manifest_key,
                 "image_count": len(images),
             },

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -162,6 +162,13 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 extras={"manifest_key": manifest_key},
             )
 
+            # Write manifest inside the transaction so that a failed objectstore
+            # write rolls back the DB records, ensuring both succeed or neither does.
+            session = get_preprod_session(project.organization_id, project.id)
+            manifest = SnapshotManifest(images=images)
+            manifest_json = manifest.json(exclude_none=True)
+            session.put(manifest_json.encode(), key=manifest_key)
+
         logger.info(
             "Created preprod artifact for snapshots",
             extra={
@@ -171,11 +178,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "head_sha": head_sha,
             },
         )
-
-        session = get_preprod_session(project.organization_id, project.id)
-        manifest = SnapshotManifest(images=images)
-        manifest_json = manifest.json(exclude_none=True)
-        session.put(manifest_json.encode(), key=manifest_key)
 
         logger.info(
             "Stored snapshot manifest",


### PR DESCRIPTION
(Keep the objectstore call in the PG transaction so that if it fails, the PG change rolls back)

Move logger calls and response
construction outside the `transaction.atomic` block in the snapshot
POST endpoint. This avoids holding a DB connection open while performing
slow remote I/O to object storage.

Also passes `extras={"manifest_key": manifest_key}` directly to
`PreprodSnapshotMetrics.objects.create()` instead of creating the record
and then calling `.save()` separately, eliminating one DB round-trip.

