### PR TITLE
ref(ts): Narrow division() cartesian product in SpanResponse

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -476,6 +476,14 @@ type CustomResponseFields = {
   [SpanFields.RESOURCE_RENDER_BLOCKING_STATUS]: '' | 'non-blocking' | 'blocking';
 };
 
+// Fields that are used as arguments to division() queries.
+// Kept narrow to avoid a cartesian product explosion in SpanResponseRaw.
+// See the comment on the division() line below for details.
+type DivisibleSpanFields =
+  | SpanFields.MOBILE_FROZEN_FRAMES
+  | SpanFields.MOBILE_TOTAL_FRAMES
+  | SpanFields.MOBILE_SLOW_FRAMES;
+
 type SpanResponseRaw = {
   [Property in SpanNumberFields as `${Aggregate}(${Property})`]: number;
 } & {
@@ -496,7 +504,12 @@ type SpanResponseRaw = {
       | `${Property}(${string},${string},${string})`
       | `${Property}(${string},${string},${string},${string})`]: number;
     // TODO: We should allow a nicer way to define functions with multiple arguments and different arg types
-  } & Record<`division(${SpanNumberFields},${SpanNumberFields})`, number> & {
+    // Subset of SpanNumberFields that are actually used in division() queries.
+    // Previously this was Record<`division(${SpanNumberFields},${SpanNumberFields})`, number>
+    // which produced a 56×56 = 3,136 key cartesian product. In practice only
+    // mobile frame rate fields are divided, so we restrict the domain here.
+    // If you need to divide a new field, add it to DivisibleSpanFields below.
+  } & Record<`division(${DivisibleSpanFields},${DivisibleSpanFields})`, number> & {
     // TODO: This should include all valid HTTP codes or just all integers
     [Property in HttpResponseFunctions as `${Property}(${number})`]: number;
   } & {


### PR DESCRIPTION
`Record<`division(${SpanNumberFields},${SpanNumberFields})`, number>` produces a 56×56 = 3,136 key cartesian product. In practice only mobile frame rate fields are ever divided (slow_frames, frozen_frames, total_frames — 2 combinations used today).

Replace with a narrow `DivisibleSpanFields` subset (3×3 = 9 keys). Autocomplete and `Pick<SpanResponse, 'division(...)'>` still work for the fields that are actually used. To divide a new field, add it to `DivisibleSpanFields`.

| Checker | Before | After  | Improvement |
|---------|--------|--------|-------------|
| tsc     | ~75s   | ~61s   | ~14s (19%)  |
| tsgo    | 8.3s   | 6.5s   | ~1.8s (22%) |
