### PR TITLE
fix(mail): Sanitize user display names in team access request emails

### DIFF
--- a/src/sentry/templates/sentry/emails/request-team-access.html
+++ b/src/sentry/templates/sentry/emails/request-team-access.html
@@ -1,14 +1,15 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <h3>Request for Access</h3>
 
   {% if requester %}
-    <p>{{ requester }} is requesting to add <strong>{{ name }}</strong> to the <strong>#{{ team.slug }}</strong> team.</p>
+    <p>{{ requester|sanitize_periods }} is requesting to add <strong>{{ name|sanitize_periods }}</strong> to the <strong>#{{ team.slug }}</strong> team.</p>
   {% else %}
-     <p><strong>{{ name }}</strong> is requesting access to the #{{ team.slug }} team on Sentry.</p>
+     <p><strong>{{ name|sanitize_periods }}</strong> is requesting access to the #{{ team.slug }} team on Sentry.</p>
   {% endif %}
 
   <p>Accept or decline this request in the <a href="{{ url }}">pending requests panel</a>.</p>

--- a/src/sentry/templates/sentry/emails/request-team-access.txt
+++ b/src/sentry/templates/sentry/emails/request-team-access.txt
@@ -1,7 +1,8 @@
+{% load sentry_helpers %}
 {% if requester %}
-{{ requester }} is requesting to add {{ name }} to the #{{ team.slug }} team.
+{{ requester|sanitize_periods }} is requesting to add {{ name|sanitize_periods }} to the #{{ team.slug }} team.
 {% else %}
-{{ name }} is requesting access to the #{{ team.slug }} team on Sentry.
+{{ name|sanitize_periods }} is requesting access to the #{{ team.slug }} team on Sentry.
 {% endif %}
 
 You can accept or decline this request in via the pending requests panel:


### PR DESCRIPTION
User display names containing domain-like text (e.g. "Visit evil.com") were rendered unsanitized in team access request emails, allowing email clients to auto-link them as clickable URLs. Apply the existing sanitize_periods template filter to break domain pattern detection, matching the approach already used for organization names in other email templates.

Fixes https://linear.app/getsentry/issue/VULN-123/sentryio-hyperlink-injection-on-request-access-via-name-and-brute

<!-- Describe your PR here. -->