### PR TITLE
fix(onboarding): Await project deletion before navigating back

### DIFF
--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -65,7 +65,7 @@ export function useBackActions({
   }, [api, organization, onboardingContext, recentCreatedProject]);
 
   const backStepActions = useCallback(
-    ({
+    async ({
       prevStep,
       browserBackButton,
     }: {
@@ -105,7 +105,10 @@ export function useBackActions({
           platform: recentCreatedProject.slug,
           project_id: recentCreatedProject.id,
         });
-        deleteRecentCreatedProject();
+        // Await deletion so the projects store is updated before navigating
+        // back. Without this, re-selecting the same platform can see stale
+        // store data and skip project creation.
+        await deleteRecentCreatedProject();
       }
 
       if (!browserBackButton) {


### PR DESCRIPTION
## Summary

Fixes a flakey acceptance test `test_create_delete_create_same_platform` by awaiting the project deletion in the onboarding back action before navigating to the previous step.

The `deleteRecentCreatedProject()` call in `backStepActions` was fire-and-forget. When a user clicks Back and then re-selects the same platform, the projects store could still contain the old (about to be deleted) project. `useConfigureSdk` would see the stale entry, skip project creation, and navigate to the setup-docs page with data from a project that was being deleted — causing the test's `Project.objects.get()` to fail with `DoesNotExist`.

The race condition existed since the test was added (March 2025, PR #87869) but was consistently masked by timing. Recent React 19 / React Router upgrades likely shifted microtask scheduling enough to expose it.

The fix adds `await` to the deletion call so that `goToStep(prevStep)` only fires after the store has been updated. The browser-back-button path is unaffected since it never calls `goToStep`.

## Test plan

- [x] All 26 onboarding unit tests pass (`onboarding.spec.tsx`, `useConfigureSdk.spec.tsx`, `setupDocs.spec.tsx`)
- [x] ESLint clean
- [x] Pre-commit hooks pass
- [ ] CI acceptance test `test_create_delete_create_same_platform` passes consistently

Fixes SENTRY-TESTS-182Z
Fixes SENTRY-TESTS-1AFT