### PR TITLE
Prevent cross-org condition injection via conditionGroupId IDOR

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition.py
@@ -26,7 +26,6 @@ class AbstractDataConditionValidator(
     type = serializers.ChoiceField(choices=[(t.value, t.value) for t in Condition])
     comparison = serializers.JSONField(required=True)
     condition_result = serializers.JSONField(required=True)
-    condition_group_id = serializers.IntegerField(required=False)
 
     @abstractmethod
     def validate_comparison(self, value: Any) -> ComparisonType:

--- a/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/data_condition_group.py
@@ -63,8 +63,8 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
         conditions = validated_data.pop("conditions", None)
         if conditions:
             for condition_data in conditions:
-                if not condition_data.get("condition_group_id"):
-                    condition_data["condition_group_id"] = instance.id
+                # Always set condition_group_id programmatically to prevent cross-org IDOR
+                condition_data["condition_group_id"] = instance.id
                 self.update_or_create_condition(condition_data, context_org.id)
 
         # update the condition group
@@ -79,8 +79,8 @@ class BaseDataConditionGroupValidator(CamelSnakeSerializer[Any]):
             )
 
             for condition in validated_data["conditions"]:
-                if not condition.get("condition_group_id"):
-                    condition["condition_group_id"] = condition_group.id
+                # Always set condition_group_id programmatically to prevent cross-org IDOR
+                condition["condition_group_id"] = condition_group.id
                 condition_validator = BaseDataConditionValidator()
                 condition_validator.create(condition)
 

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -51,7 +51,6 @@ class MetricIssueComparisonConditionValidatorTest(BaseValidatorTest):
             "type": Condition.GREATER,
             "comparison": 100,
             "conditionResult": DetectorPriorityLevel.HIGH,
-            "conditionGroupId": self.data_condition_group.id,
         }
 
     def test(self) -> None:
@@ -61,7 +60,6 @@ class MetricIssueComparisonConditionValidatorTest(BaseValidatorTest):
             "comparison": 100.0,
             "condition_result": DetectorPriorityLevel.HIGH,
             "type": Condition.GREATER,
-            "condition_group_id": self.data_condition_group.id,
         }
 
     def test_invalid_condition(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -713,6 +713,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         # Workflow should be updated successfully, but the conditionGroupId should be ignored
         self.workflow.refresh_from_db()
+        assert self.workflow.when_condition_group is not None
         assert self.workflow.when_condition_group.organization_id == self.organization.id
 
         # Verify the other org's condition group was not modified

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -681,6 +681,87 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         other_action.refresh_from_db()
         assert other_action.config == original_config
 
+    def test_update_trigger_condition_from_different_organization(self) -> None:
+        """Test that conditionGroupId in trigger conditions cannot reference another org's group"""
+        other_org = self.create_organization()
+        other_dcg = DataConditionGroup.objects.create(
+            organization=other_org,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+        original_condition_count = other_dcg.conditions.count()
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "conditionGroupId": other_dcg.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+        )
+
+        # Workflow should be updated successfully, but the conditionGroupId should be ignored
+        self.workflow.refresh_from_db()
+        assert self.workflow.when_condition_group.organization_id == self.organization.id
+
+        # Verify the other org's condition group was not modified
+        other_dcg.refresh_from_db()
+        assert other_dcg.conditions.count() == original_condition_count
+
+    def test_update_action_filter_condition_from_different_organization(self) -> None:
+        """Test that conditionGroupId in action filter conditions cannot reference another org's group"""
+        other_org = self.create_organization()
+        other_dcg = DataConditionGroup.objects.create(
+            organization=other_org,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+        original_condition_count = other_dcg.conditions.count()
+
+        data = {
+            **self.valid_workflow,
+            "actionFilters": [
+                {
+                    "logicType": "any",
+                    "conditions": [
+                        {
+                            "conditionGroupId": other_dcg.id,
+                            "type": "first_seen_event",
+                            "comparison": True,
+                            "conditionResult": True,
+                        }
+                    ],
+                    "actions": [],
+                }
+            ],
+        }
+
+        self.get_success_response(
+            self.organization.slug,
+            self.workflow.id,
+            raw_data=data,
+        )
+
+        # Workflow should be updated successfully, but the conditionGroupId should be ignored
+        self.workflow.refresh_from_db()
+        action_filter_dcgs = self.workflow.workflowdataconditiongroup_set.all()
+        for dcg_wrapper in action_filter_dcgs:
+            assert dcg_wrapper.condition_group.organization_id == self.organization.id
+
+        # Verify the other org's condition group was not modified
+        other_dcg.refresh_from_db()
+        assert other_dcg.conditions.count() == original_condition_count
+
 
 @region_silo_test
 class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWorkflowTest):

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -15,7 +15,13 @@ from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import region_silo_test
-from sentry.workflow_engine.models import Action, DetectorWorkflow, Workflow, WorkflowFireHistory
+from sentry.workflow_engine.models import (
+    Action,
+    DataConditionGroup,
+    DetectorWorkflow,
+    Workflow,
+    WorkflowFireHistory,
+)
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.typings.notification_action import (
     ActionTarget,
@@ -969,6 +975,87 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             raw_data=self.valid_workflow,
             status_code=403,
         )
+
+    def test_create_trigger_condition_from_different_organization(self) -> None:
+        """Test that conditionGroupId in trigger conditions cannot reference another org's group"""
+        other_org = self.create_organization()
+        other_dcg = DataConditionGroup.objects.create(
+            organization=other_org,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+        original_condition_count = other_dcg.conditions.count()
+
+        data = {
+            **self.valid_workflow,
+            "triggers": {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "conditionGroupId": other_dcg.id,
+                        "type": "first_seen_event",
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+            },
+        }
+
+        response = self.get_success_response(
+            self.organization.slug,
+            raw_data=data,
+            status_code=201,
+        )
+
+        # Workflow should be created successfully, but the conditionGroupId should be ignored
+        new_workflow = Workflow.objects.get(id=response.data["id"])
+        assert new_workflow.when_condition_group.organization_id == self.organization.id
+
+        # Verify the other org's condition group was not modified
+        other_dcg.refresh_from_db()
+        assert other_dcg.conditions.count() == original_condition_count
+
+    def test_create_action_filter_condition_from_different_organization(self) -> None:
+        """Test that conditionGroupId in action filter conditions cannot reference another org's group"""
+        other_org = self.create_organization()
+        other_dcg = DataConditionGroup.objects.create(
+            organization=other_org,
+            logic_type=DataConditionGroup.Type.ALL,
+        )
+        original_condition_count = other_dcg.conditions.count()
+
+        data = {
+            **self.valid_workflow,
+            "actionFilters": [
+                {
+                    "logicType": "any",
+                    "conditions": [
+                        {
+                            "conditionGroupId": other_dcg.id,
+                            "type": "first_seen_event",
+                            "comparison": True,
+                            "conditionResult": True,
+                        }
+                    ],
+                    "actions": [],
+                }
+            ],
+        }
+
+        response = self.get_success_response(
+            self.organization.slug,
+            raw_data=data,
+            status_code=201,
+        )
+
+        # Workflow should be created successfully, but the conditionGroupId should be ignored
+        new_workflow = Workflow.objects.get(id=response.data["id"])
+        action_filter_dcgs = new_workflow.workflowdataconditiongroup_set.all()
+        for dcg_wrapper in action_filter_dcgs:
+            assert dcg_wrapper.condition_group.organization_id == self.organization.id
+
+        # Verify the other org's condition group was not modified
+        other_dcg.refresh_from_db()
+        assert other_dcg.conditions.count() == original_condition_count
 
 
 @region_silo_test

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1008,6 +1008,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
 
         # Workflow should be created successfully, but the conditionGroupId should be ignored
         new_workflow = Workflow.objects.get(id=response.data["id"])
+        assert new_workflow.when_condition_group is not None
         assert new_workflow.when_condition_group.organization_id == self.organization.id
 
         # Verify the other org's condition group was not modified


### PR DESCRIPTION
Fixing an IDOR in ActionFilters
- In BaseDataConditionGroupValidator, always set the condition_group_id so it's not overwriteable 
- Removed condition_group_id from AbstractDataConditionValidator serializer, silently drop it since user-input is not required here
- Tests for the changes