### PR TITLE
fix(frontend): include react config for our pipeline asset response

### DIFF
--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -7,6 +7,7 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
 from sentry.utils import json
+from sentry.web.client_config import get_client_config
 from sentry.web.helpers import render_to_response
 
 
@@ -22,5 +23,9 @@ def render_react_view(
     return render_to_response(
         template="sentry/bases/react_pipeline.html",
         request=request,
-        context={"pipelineName": pipeline_name, "props": json.dumps(props)},
+        context={
+            "pipelineName": pipeline_name,
+            "props": json.dumps(props),
+            "react_config": get_client_config(request),
+        },
     )

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -8,6 +8,7 @@ from django.http.response import HttpResponseBase
 
 from sentry.utils import json
 from sentry.web.client_config import get_client_config
+from sentry.web.frontend.base import determine_active_organization
 from sentry.web.helpers import render_to_response
 
 
@@ -26,6 +27,6 @@ def render_react_view(
         context={
             "pipelineName": pipeline_name,
             "props": json.dumps(props),
-            "react_config": get_client_config(request),
+            "react_config": get_client_config(request, determine_active_organization(request)),
         },
     )


### PR DESCRIPTION
When trying to set up a Github app integration locally on my dev box, the popup window infinitely loads with our asset loading animation. Inspecting the browser dev tools shows a bunch of `ChunkLoadError` when loading asset chunks, I think because it's trying to load from `/_assets/chunks/...` instead of `/_static/dist/sentry/chunks/...`. My theory is it's only happening on this page (that I can tell) because most other pages use `ReactPageView` which correctly passes the `react_config`.