### PR TITLE
feat(dashboards): make ssr file widget and dead/rage click cloneable

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -651,16 +651,12 @@ export const widgetFetchesOwnData = (widgetType: DisplayType) => {
   return widgetTypesThatFetchOwnData.includes(widgetType);
 };
 
-// Custom widgets for prebuilt dashboards that do not have menu options
-export const widgetHasMenuOptions = (widgetType: DisplayType) => {
+// Custom widgets from the widget library that are not editable but still have menu options
+export const isWidgetEditable = (widgetType: DisplayType) => {
   const nonEditableWidgetTypes = [
     DisplayType.SERVER_TREE,
     DisplayType.RAGE_AND_DEAD_CLICKS,
+    DisplayType.WHEEL,
   ];
   return !nonEditableWidgetTypes.includes(widgetType);
-};
-
-// Custom widgets from the widget library that are not editable but still have menu options
-export const isWidgetEditable = (widgetType: DisplayType) => {
-  return widgetType !== DisplayType.WHEEL;
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -5,6 +5,7 @@ import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/type
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {SERVER_TREE_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/serverTreeWidget';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
 import {WEB_VITALS_OPS} from 'sentry/views/insights/pages/frontend/settings';
@@ -244,19 +245,7 @@ const SERVER_TRANSACTIONS_TABLE: Widget = {
 };
 
 const SERVER_TREE_WIDGET: Widget = {
-  id: 'server-tree-widget',
-  title: t('Server Tree'),
-  displayType: DisplayType.SERVER_TREE,
-  interval: '5m',
-  queries: [
-    {
-      name: '',
-      conditions: '',
-      aggregates: [],
-      columns: [],
-      orderby: '',
-    },
-  ],
+  ...SERVER_TREE_WIDGET_TEMPLATE,
   layout: {
     x: 0,
     y: 9,

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -5,6 +5,7 @@ import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/type
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/rageAndDeadClicksWidget';
 import {SERVER_TREE_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/serverTreeWidget';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {OVERVIEW_PAGE_ALLOWED_OPS as BACKEND_OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
@@ -101,21 +102,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
 const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
     SCORE_BREAKDOWN_WHEEL_WIDGET,
-    {
-      id: 'rage-and-dead-clicks-widget',
-      title: t('Rage and Dead Clicks'),
-      displayType: DisplayType.RAGE_AND_DEAD_CLICKS,
-      interval: '5m',
-      queries: [
-        {
-          name: '',
-          conditions: '',
-          aggregates: [],
-          columns: [],
-          orderby: '',
-        },
-      ],
-    },
+    RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE,
     {
       id: 'slow-ssr-widget',
       title: t('Slow SSR'),

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -32,7 +32,6 @@ import {
   isUsingPerformanceScore,
   isWidgetEditable,
   performanceScoreTooltip,
-  widgetHasMenuOptions,
 } from 'sentry/views/dashboards/utils';
 import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
@@ -294,10 +293,7 @@ export function getMenuOptions(
     });
   }
 
-  if (
-    organization.features.includes('dashboards-edit') &&
-    widgetHasMenuOptions(widget.displayType)
-  ) {
+  if (organization.features.includes('dashboards-edit')) {
     menuOptions.push({
       key: 'add-to-dashboard',
       label: t('Add to Dashboard'),

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -4,8 +4,10 @@ import type {Organization} from 'sentry/types/organization';
 import {TOP_N} from 'sentry/utils/discover/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {SERVER_TREE_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/serverTreeWidget';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
+import {hasPlatformizedNextJsOverviewWidget} from 'sentry/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview';
 
 const getDefaultWidgets = (organization: Organization) => {
   const isSelfHostedErrorsOnly = ConfigStore.get('isSelfHostedErrorsOnly');
@@ -289,6 +291,11 @@ const getDefaultWidgets = (organization: Organization) => {
     },
     SCORE_BREAKDOWN_WHEEL_WIDGET,
   ];
+
+  if (hasPlatformizedNextJsOverviewWidget(organization)) {
+    spanWidgets.push(SERVER_TREE_WIDGET_TEMPLATE);
+  }
+
   const errorsWidgets: WidgetTemplate[] = [
     {
       id: 'issue-for-review',

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -4,6 +4,7 @@ import type {Organization} from 'sentry/types/organization';
 import {TOP_N} from 'sentry/utils/discover/types';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import {hasDatasetSelector} from 'sentry/views/dashboards/utils';
+import {RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/rageAndDeadClicksWidget';
 import {SERVER_TREE_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/serverTreeWidget';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
@@ -294,6 +295,7 @@ const getDefaultWidgets = (organization: Organization) => {
 
   if (hasPlatformizedNextJsOverviewWidget(organization)) {
     spanWidgets.push(SERVER_TREE_WIDGET_TEMPLATE);
+    spanWidgets.push(RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE);
   }
 
   const errorsWidgets: WidgetTemplate[] = [

--- a/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
@@ -1,0 +1,21 @@
+import {t} from 'sentry/locale';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
+
+export const RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE: WidgetTemplate = {
+  id: 'rage-and-dead-clicks-widget',
+  title: t('Rage and Dead Clicks'),
+  description: t('Visualizes the rage and dead clicks in your frontend project.'),
+  isCustomizable: false,
+  displayType: DisplayType.RAGE_AND_DEAD_CLICKS,
+  interval: '5m',
+  queries: [
+    {
+      name: '',
+      conditions: '',
+      aggregates: [],
+      columns: [],
+      orderby: '',
+    },
+  ],
+};

--- a/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
@@ -3,8 +3,8 @@ import {DisplayType} from 'sentry/views/dashboards/types';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 
 /**
- * Shared widget definitions for Web Vitals
- * Used in both the prebuilt Web Vitals dashboard and the widget library
+ * Shared widget definitions for Next.js Overview dashboard
+ * Used in both the prebuilt Next.js Overview dashboard and the widget library
  */
 
 export const SERVER_TREE_WIDGET_TEMPLATE: WidgetTemplate = {

--- a/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
@@ -1,0 +1,28 @@
+import {t} from 'sentry/locale';
+import {DisplayType} from 'sentry/views/dashboards/types';
+import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
+
+/**
+ * Shared widget definitions for Web Vitals
+ * Used in both the prebuilt Web Vitals dashboard and the widget library
+ */
+
+export const SERVER_TREE_WIDGET_TEMPLATE: WidgetTemplate = {
+  id: 'server-tree-widget',
+  title: t('SSR File Tree'),
+  description: t(
+    'Visualizes the file tree of the server-rendered components in your Next.js project.'
+  ),
+  isCustomizable: false,
+  displayType: DisplayType.SERVER_TREE,
+  interval: '5m',
+  queries: [
+    {
+      name: '',
+      conditions: '',
+      aggregates: [],
+      columns: [],
+      orderby: '',
+    },
+  ],
+};

--- a/static/app/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview.ts
+++ b/static/app/views/insights/pages/platform/nextjs/useHasPlatformizedNextJsOverview.ts
@@ -1,8 +1,13 @@
+import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export default function useHasPlatformizedNextJsOverview() {
   const organization = useOrganization();
 
+  return hasPlatformizedNextJsOverviewWidget(organization);
+}
+
+export function hasPlatformizedNextJsOverviewWidget(organization: Organization) {
   return organization.features.includes(
     'insights-nextjs-frontend-overview-dashboard-migration'
   );


### PR DESCRIPTION
1. Make both server tree and rage/dead clicks clone able, but not editable via the widget context menu
2. put server tree and rage/dead clicks widget into widget library

There will be a backend change to allow these widget types to be saved