### PR TITLE
chore(utils): Add sort keys encoder option for dumps

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1277,7 +1277,7 @@ class _ConfigBase:
 
     def __str__(self) -> str:
         try:
-            return utils.json.dumps(self.to_dict(), sort_keys=True)  # type: ignore[arg-type]
+            return utils.json.dumps(self.to_dict(), sort_keys=True)
         except Exception as e:
             return f"Content Error:{e}"
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -91,6 +91,13 @@ _default_encoder = JSONEncoder(
     default=better_default_encoder,
 )
 
+_default_sorted_encoder = JSONEncoder(
+    separators=(",", ":"),
+    ignore_nan=True,
+    default=better_default_encoder,
+    sort_keys=True,
+)
+
 _default_escaped_encoder = JSONEncoderForHTML(
     separators=(",", ":"),
     ignore_nan=True,
@@ -105,10 +112,12 @@ def dump(value: Any, fp: IO[str], **kwargs: NoReturn) -> None:
 
 
 # NoReturn here is to make this a mypy error to pass kwargs, since they are currently silently dropped
-def dumps(value: Any, escape: bool = False, **kwargs: NoReturn) -> str:
+def dumps(value: Any, escape: bool = False, sort_keys: bool = False, **kwargs: NoReturn) -> str:
     # Legacy use. Do not use. Use dumps_htmlsafe
     if escape:
         return _default_escaped_encoder.encode(value)
+    if sort_keys:
+        return _default_sorted_encoder.encode(value)
     return _default_encoder.encode(value)
 
 

--- a/src/sentry/workflow_engine/endpoints/organization_deduplicate_workflows.py
+++ b/src/sentry/workflow_engine/endpoints/organization_deduplicate_workflows.py
@@ -49,7 +49,7 @@ class WorkflowData:
                 )
             # Sort trigger conditions and action groups for consistent hashing
             trigger_conditions.sort(
-                key=lambda c: (c["type"], json.dumps(c["comparison"], sort_keys=True))  # type: ignore[arg-type]
+                key=lambda c: (c["type"], json.dumps(c["comparison"], sort_keys=True))
             )
 
             trigger_group = {
@@ -81,9 +81,9 @@ class WorkflowData:
 
             # Sort conditions and actions for consistent hashing
             group_conditions.sort(
-                key=lambda c: (c["type"], json.dumps(c["comparison"], sort_keys=True))  # type: ignore[arg-type]
+                key=lambda c: (c["type"], json.dumps(c["comparison"], sort_keys=True))
             )
-            group_actions.sort(key=lambda a: (a["type"], json.dumps(a["config"], sort_keys=True)))  # type: ignore[arg-type]
+            group_actions.sort(key=lambda a: (a["type"], json.dumps(a["config"], sort_keys=True)))
 
             action_groups.append(
                 {
@@ -93,7 +93,7 @@ class WorkflowData:
                 }
             )
 
-        action_groups.sort(key=lambda g: json.dumps(g, sort_keys=True))  # type: ignore[arg-type]
+        action_groups.sort(key=lambda g: json.dumps(g, sort_keys=True))
 
         workflow_data = {
             "action_groups": action_groups,
@@ -104,7 +104,7 @@ class WorkflowData:
             "trigger_group": trigger_group,
         }
 
-        return json.dumps(workflow_data, sort_keys=True)  # type: ignore[arg-type]
+        return json.dumps(workflow_data, sort_keys=True)
 
 
 def deduplicate_workflows(organization: Organization) -> None:

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -49,6 +49,10 @@ class JSONSerializationTest(TestCase):
     def test_translation(self) -> None:
         self.assertEqual(json.dumps(_("word")), '"word"')
 
+    def test_sort_keys(self) -> None:
+        res = {"z": 1, "a": 2, "m": 3}
+        self.assertEqual(json.dumps(res, sort_keys=True), '{"a":2,"m":3,"z":1}')
+
 
 class JSONHelpersTest(TestCase):
     def test_prune_empty_keys_simple(self) -> None:


### PR DESCRIPTION
For the `ThreadingService` [implementation](https://github.com/getsentry/sentry/pull/108158) we need the thread key computation to be deterministic. Unfortunately our demanded json module does not support a sort_keys flag (different from default json module). So we need to add a new encoder config as simplejson does have the API to support sorting keys but we just don't expose it in our dumps api. 