### PR TITLE
fix(seer): Fix seer onboarding to show the final summary step as the user progresses through the wizard

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Stack} from '@sentry/scraps/layout';
@@ -29,9 +29,11 @@ export default function SeerOnboardingSeatBased() {
   const {isPending, initialStep} = useSeerOnboardingStep();
   const navigate = useNavigate();
 
+  const initialStepRef = useRef(initialStep);
+
   useEffect(() => {
     // GuidedSteps only returns the step number
-    if (!isPending && initialStep === Steps.WRAP_UP) {
+    if (!isPending && initialStepRef.current === Steps.WRAP_UP) {
       // users should not be linked to onboarding page after it's been completed, but just in case,
       // redirect them to Seer settings page.
       navigate(normalizeUrl(`/settings/${organization.slug}/seer/`), {replace: true});

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingSeatBased.tsx
@@ -29,7 +29,12 @@ export default function SeerOnboardingSeatBased() {
   const {isPending, initialStep} = useSeerOnboardingStep();
   const navigate = useNavigate();
 
-  const initialStepRef = useRef(initialStep);
+  const initialStepRef = useRef<Steps | undefined>(undefined);
+  useEffect(() => {
+    if (!isPending && initialStepRef.current === undefined) {
+      initialStepRef.current = initialStep;
+    }
+  }, [initialStep, isPending]);
 
   useEffect(() => {
     // GuidedSteps only returns the step number


### PR DESCRIPTION
Instead of redirecting if the current step is WRAP_UP, we'll save the initial step that was picked when the user landed on the page. If the initial-initial step was WRAP_UP then we redirect, but if they landed on the page at SETUP_CODE_REVIEW or something, there's no redirect even once they get to the end of the steps.

Fixes CW-808