### PR TITLE
fix(mail): Sanitize user display names in invite and integration request emails

### DIFF
--- a/src/sentry/templates/sentry/emails/organization-invite-request.html
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.html
@@ -1,11 +1,12 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <h3>Request for Access</h3>
 
-  <p><strong>{{ inviter_name }}</strong> has requested to invite <strong>{{ email }}</strong> to the {{ organization_name }} organization.</p>
+  <p><strong>{{ inviter_name|sanitize_periods }}</strong> has requested to invite <strong>{{ email }}</strong> to the {{ organization_name }} organization.</p>
 
   <a href="{{ pending_requests_link }}" class="btn">View access requests</a>
 

--- a/src/sentry/templates/sentry/emails/organization-invite-request.txt
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.txt
@@ -1,6 +1,7 @@
+{% load sentry_helpers %}
 Request for Access
 
-{{ inviter_name }} has requested to invite {{ email }} to the {{ organization_name }} organization.
+{{ inviter_name|sanitize_periods }} has requested to invite {{ email }} to the {{ organization_name }} organization.
 
 View access requests by clicking the link below:
 

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.html
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.html
@@ -1,13 +1,14 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <p>
-    Seems like your team could use some new tools. {{ requester_name }} from
+    Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from
     {{ organization_name }} requested the installation of {{ integration_name }}.
     {% if message %}
-        They’ve included some additional context:
+        They've included some additional context:
         <pre>{{ message }}</pre>
     {% endif %}
   </p>
@@ -15,8 +16,8 @@
     <a href="{{ integration_link }}" class="btn">Install {{ integration_name }}</a>
   </p>
   <p>
-    If you’re not up for installation, you can
-    <a href="{{ requester_link }}">change {{ requester_name }}’s role</a>
+    If you're not up for installation, you can
+    <a href="{{ requester_link }}">change {{ requester_name|sanitize_periods }}'s role</a>
     to organization owner, manager, or admin. You can learn more about the
     wonderful world of permissions in
     <a href="https://docs.sentry.io/accounts/membership/">our docs</a>.

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.txt
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.txt
@@ -1,4 +1,5 @@
-Seems like your team could use some new tools. {{ requester_name }} from {{ organization_name }} requested the installation of {{ integration_name }}.
+{% load sentry_helpers %}
+Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name }} requested the installation of {{ integration_name }}.
 {% if message %}
 They’ve included some additional context:
     {{ message }}
@@ -7,7 +8,7 @@ Install {{ provider_name }} by clicking the link below:
 
     {{ provider_link }}
 
-If you’re not up for installation, you can change {{ requester_name }}’s role to organization owner, manager, or admin here: {{ requester_link }}.
+If you're not up for installation, you can change {{ requester_name|sanitize_periods }}'s role to organization owner, manager, or admin here: {{ requester_link }}.
 You can learn more about the wonderful world of permissions in our docs: https://docs.sentry.io/accounts/membership/.
 
 Let’s get integrated.


### PR DESCRIPTION
Apply the sanitize_periods template filter to user display names in organization invite request and integration request email templates. Both are triggerable by regular org members and send the attacker's display name to org owners/managers, where email clients can auto-link domain-like text as clickable URLs.

This probably isn't that much of a vulnerability, but it doesn't hurt to just add this sanitation.

Follow-up to https://github.com/getsentry/sentry/pull/108154. 

<!-- Describe your PR here. -->