### PR TITLE
feat(preprod): Skip pre-commit fix apply for draft PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Apply any pre-commit fixed files
         # note: this runs "always" or else it's skipped when pre-commit fails
-        if: env.SECRET_ACCESS == 'true' && startsWith(github.ref, 'refs/pull') && always()
+        if: env.SECRET_ACCESS == 'true' && startsWith(github.ref, 'refs/pull') && !github.event.pull_request.draft && always()
         uses: getsentry/action-github-commit@31f6706ca1a7b9ad6d22c1b07bf3a92eabb05632 # v2.0.0
         with:
           github-token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Per [discussion in slack](https://sentry.slack.com/archives/CTJL7358X/p1770922252679449?thread_ts=1770920458.630239&cid=CTJL7358X), we'll skip pre-commit fix applies when the PR is in draft state. The `draft` field should be true for drafts from the GH docs: https://arc.net/l/quote/wldkbxlc