### PR TITLE
fix(dashboards): Fix issue with Web Vitals prebuilt dashboard slideout not correctly linking to next prebuilt Page Summary dashboard

### DIFF
--- a/static/app/views/dashboards/utils/useWidgetSlideout.tsx
+++ b/static/app/views/dashboards/utils/useWidgetSlideout.tsx
@@ -21,7 +21,12 @@ function getSlideoutComponent(
     case SlideoutId.INP:
     case SlideoutId.CLS:
     case SlideoutId.TTFB:
-      return <WebVitalsDetailPanel webVital={slideOutId as WebVitals} />;
+      return (
+        <WebVitalsDetailPanel
+          webVital={slideOutId as WebVitals}
+          dashboardFilters={dashboardFilters}
+        />
+      );
     case SlideoutId.LCP_SUMMARY:
     case SlideoutId.FCP_SUMMARY:
     case SlideoutId.INP_SUMMARY:

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -19,6 +19,10 @@ import {PageAlert, PageAlertProvider} from 'sentry/utils/performance/contexts/pa
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
+import type {DashboardFilters} from 'sentry/views/dashboards/types';
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {getLinkedDashboardUrl} from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
+import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 import {WebVitalStatusLineChart} from 'sentry/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
 import {WebVitalDescription} from 'sentry/views/insights/browser/webVitals/components/webVitalDescription';
@@ -51,7 +55,13 @@ const sort: GridColumnSortBy<keyof Row> = {key: 'count()', order: 'desc'};
 
 const MAX_ROWS = 10;
 
-export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
+export function WebVitalsDetailPanel({
+  webVital,
+  dashboardFilters,
+}: {
+  webVital: WebVitals | null;
+  dashboardFilters?: DashboardFilters;
+}) {
   const location = useLocation();
   const organization = useOrganization();
   const moduleUrl = useModuleURL(ModuleName.VITAL);
@@ -59,6 +69,8 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
   const subregions = decodeList(
     location.query[SpanFields.USER_GEO_SUBREGION]
   ) as SubregionCode[];
+
+  const {dashboard: linkedWebVitalsSummaryDashboard} = useGetPrebuiltDashboard(7);
 
   const {data: projectData} = useProjectRawWebVitalsQuery({browserTypes, subregions});
   const {data: projectScoresData} = useProjectWebVitalsScoresQuery({
@@ -184,19 +196,38 @@ export function WebVitalsDetailPanel({webVital}: {webVital: WebVitals | null}) {
       return <AlignRight>{value}</AlignRight>;
     }
     if (key === 'transaction') {
+      const linkedDashboardUrl =
+        dashboardFilters !== undefined && linkedWebVitalsSummaryDashboard?.id
+          ? getLinkedDashboardUrl({
+              linkedDashboard: {
+                dashboardId: linkedWebVitalsSummaryDashboard.id,
+                field: SpanFields.TRANSACTION,
+                additionalGlobalFilterDatasetTargets: [WidgetType.ISSUE],
+              },
+              organizationSlug: organization.slug,
+              field: 'transaction',
+              value: row.transaction,
+              widgetType: WidgetType.TRANSACTIONS,
+              dashboardFilters,
+              locationQuery: location.query,
+            })
+          : undefined;
+
       return (
         <NoOverflow>
           <Link
-            to={{
-              ...location,
-              pathname: `${moduleUrl}/overview/`,
-              query: {
-                ...location.query,
-                transaction: row.transaction,
-                webVital,
-                project: row['project.id'],
-              },
-            }}
+            to={
+              linkedDashboardUrl || {
+                ...location,
+                pathname: `${moduleUrl}/overview/`,
+                query: {
+                  ...location.query,
+                  transaction: row.transaction,
+                  webVital,
+                  project: row['project.id'],
+                },
+              }
+            }
           >
             {row.transaction}
           </Link>

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -22,6 +22,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardFilters} from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {getLinkedDashboardUrl} from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 import {WebVitalStatusLineChart} from 'sentry/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart';
 import {PerformanceBadge} from 'sentry/views/insights/browser/webVitals/components/performanceBadge';
@@ -70,7 +71,9 @@ export function WebVitalsDetailPanel({
     location.query[SpanFields.USER_GEO_SUBREGION]
   ) as SubregionCode[];
 
-  const {dashboard: linkedWebVitalsSummaryDashboard} = useGetPrebuiltDashboard(7);
+  const {dashboard: linkedWebVitalsSummaryDashboard} = useGetPrebuiltDashboard(
+    dashboardFilters === undefined ? undefined : PrebuiltDashboardId.WEB_VITALS_SUMMARY
+  );
 
   const {data: projectData} = useProjectRawWebVitalsQuery({browserTypes, subregions});
   const {data: projectScoresData} = useProjectWebVitalsScoresQuery({
@@ -210,6 +213,7 @@ export function WebVitalsDetailPanel({
               widgetType: WidgetType.TRANSACTIONS,
               dashboardFilters,
               locationQuery: location.query,
+              projectIdOverride: String(row['project.id']),
             })
           : undefined;
 

--- a/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalsDetailPanel.tsx
@@ -210,7 +210,7 @@ export function WebVitalsDetailPanel({
               organizationSlug: organization.slug,
               field: 'transaction',
               value: row.transaction,
-              widgetType: WidgetType.TRANSACTIONS,
+              widgetType: WidgetType.SPANS,
               dashboardFilters,
               locationQuery: location.query,
               projectIdOverride: String(row['project.id']),


### PR DESCRIPTION
Updates the `WebVitalsDetailPanel` to link to the prebuilt Page Summary dashboard when visiting from a dashboard context.