### PR TITLE
fix(dashboard): frontend overview can't be cloned

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -183,7 +183,6 @@ const TRANSACTIONS_TABLE: Widget = {
   displayType: DisplayType.TABLE,
   widgetType: WidgetType.SPANS,
   interval: '5m',
-  limit: 50,
   tableWidths: TABLE_FIELDS.map(() => -1),
   queries: [
     {


### PR DESCRIPTION
When you try to clone the frontend overview table, the error "limit cannot be more then 10" occurred.

 To solve this we can just remove the limit entirely, the dashboard can fetch and display what it needs based on the widget height, not need to set limit at all. Widget validation will pass too