### PR TITLE
fix(dashboards): fix issue where initial widget library selection does not load properly

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -136,6 +136,13 @@ function AddToDashboardModal({
   // Check if we have multiple widgets to adjust UI accordingly
   const hasMultipleWidgets = widgets.length > 1;
 
+  // Check if the widget is a static widget from a widget template
+  const widgetTemplates = getTopNConvertedDefaultWidgets(organization);
+  const widgetTemplate = widgetTemplates.find(w => w.displayType === widget.displayType);
+  const shouldOpenWidgetLibrary =
+    !isWidgetEditable(widget.displayType) ||
+    (widgetTemplate && widgetTemplate.isCustomizable === false);
+
   const handleWidgetTableSort = (sort: Sort) => {
     const newOrderBy = `${sort.kind === 'desc' ? '-' : ''}${sort.field}`;
     setOrderBy(newOrderBy);
@@ -207,16 +214,6 @@ function AddToDashboardModal({
       page === 'builder' ? `${dashboardsPath}${builderSuffix}` : dashboardsPath;
 
     const widgetAsQueryParams = convertWidgetToBuilderStateParams(widget);
-
-    // For non-customizable widgets (e.g., Performance Score), open the widget library
-    // instead of the widget builder
-    const widgetTemplates = getTopNConvertedDefaultWidgets(organization);
-    const widgetTemplate = widgetTemplates.find(
-      w => w.displayType === widget.displayType
-    );
-    const shouldOpenWidgetLibrary =
-      !isWidgetEditable(widget.displayType) ||
-      (widgetTemplate && widgetTemplate.isCustomizable === false);
 
     navigate(
       normalizeUrl({
@@ -557,7 +554,9 @@ function AddToDashboardModal({
               disabled={!canSubmit}
               tooltipProps={{title: canSubmit ? undefined : SELECT_DASHBOARD_MESSAGE}}
             >
-              {t('Open in Widget Builder')}
+              {shouldOpenWidgetLibrary
+                ? t('Open in Widget Library')
+                : t('Open in Widget Builder')}
             </Button>
           )}
         </StyledButtonBar>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -163,7 +163,7 @@ describe('WidgetTemplatesList', () => {
   });
 
   it('should pre-select widget based on widgetTemplateId query parameter', async () => {
-    mockGetTopNConvertedDefaultWidgets.mockReturnValueOnce([
+    mockGetTopNConvertedDefaultWidgets.mockReturnValue([
       {
         id: 'duration-distribution',
         title: 'Duration Distribution',

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -46,7 +46,7 @@ function WidgetTemplatesList({
         0,
         widgets.findIndex(w => w.id === widgetTemplateId)
       )
-    : 0;
+    : null;
   const [selectedWidget, setSelectedWidget] = useState<number | null>(
     initialSelectedIndex
   );
@@ -56,12 +56,14 @@ function WidgetTemplatesList({
   const api = useApi();
 
   useEffect(() => {
-    const initialWidget = widgets[initialSelectedIndex];
-    if (initialWidget) {
-      dispatch({
-        type: BuilderStateAction.SET_STATE,
-        payload: convertWidgetToBuilderStateParams(initialWidget),
-      });
+    if (initialSelectedIndex !== null) {
+      const initialWidget = widgets[initialSelectedIndex];
+      if (initialWidget) {
+        dispatch({
+          type: BuilderStateAction.SET_STATE,
+          payload: convertWidgetToBuilderStateParams(initialWidget),
+        });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.tsx
@@ -56,6 +56,17 @@ function WidgetTemplatesList({
   const api = useApi();
 
   useEffect(() => {
+    const initialWidget = widgets[initialSelectedIndex];
+    if (initialWidget) {
+      dispatch({
+        type: BuilderStateAction.SET_STATE,
+        payload: convertWidgetToBuilderStateParams(initialWidget),
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     trackAnalytics('dashboards_views.widget_builder.templates.open', {
       organization,
     });


### PR DESCRIPTION
When opening the widget library with an initial selection provided in the url parameters, fixes a state issue that causes the visualization to not load properly. Adds a `useEffect` to dispatch the initial `SET_STATE` event for the selected widget template.