### PR TITLE
ref(llm-detection): Make transaction_name LLM-generated instead of passed from Sentry ID-1356

### DIFF
--- a/src/sentry/autopilot/tasks/trace_instrumentation.py
+++ b/src/sentry/autopilot/tasks/trace_instrumentation.py
@@ -311,7 +311,6 @@ def run_trace_instrumentation_detector_for_project_task(
                 "project_id": project.id,
                 "project_slug": project.slug,
                 "trace_id": trace_id,
-                "transaction_name": trace_metadata.transaction_name,
                 "run_id": run_id,
                 "finish_reason": finish_reason,
                 "issue_count": len(issues),

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -16,7 +16,6 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
-from sentry.seer.sentry_data_models import TraceMetadata
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
@@ -75,21 +74,22 @@ def mark_traces_as_processed(trace_ids: list[str]) -> None:
 
 class DetectedIssue(BaseModel):
     # LLM generated fields
+    title: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     explanation: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     impact: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     evidence: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     missing_telemetry: str | None = Field(None, max_length=MAX_LLM_FIELD_LENGTH)
     offender_span_ids: list[str]
-    title: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
-    subcategory: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    transaction_name: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     category: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    subcategory: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     verification_reason: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
-    # context fields, not LLM generated
+    # context field, not LLM generated
     trace_id: str
-    transaction_name: str
 
 
-class TraceMetadataWithSpanCount(TraceMetadata):
+class TraceMetadataWithSpanCount(BaseModel):
+    trace_id: str
     span_count: int
 
 

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -16,6 +16,7 @@ from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
+from sentry.seer.explorer.utils import normalize_description
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
@@ -135,7 +136,7 @@ def create_issue_occurrence_from_detection(
     occurrence_id = uuid4().hex
     detection_time = datetime.now(UTC)
     trace_id = detected_issue.trace_id
-    transaction_name = detected_issue.transaction_name
+    transaction_name = normalize_description(detected_issue.transaction_name)
     title = detected_issue.title.lower().replace(" ", "-")
     fingerprint = [f"llm-detected-{title}-{transaction_name}"]
 

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -412,10 +412,6 @@ class TestGetProjectTopTransactionTracesForLLMDetection(
 
         assert len(evidence_traces) == 2
 
-        assert (
-            evidence_traces[0].trace_id == trace_id_2
-        )  # prevails over trace_id_1 because transaction span duration was higher
-        assert evidence_traces[0].transaction_name == "GET /api/users/<NUM>"
-
+        # trace_id_2 prevails over trace_id_1 because transaction span duration was higher
+        assert evidence_traces[0].trace_id == trace_id_2
         assert evidence_traces[1].trace_id == trace_id_3
-        assert evidence_traces[1].transaction_name == "POST /api/orders"


### PR DESCRIPTION
The transaction_name on the issue needs to be the transaction where the trace was found.
Currently, the detection flow picks 1 transaction per trace (the one with highest total time spent), and sends that transaction_name to Seer. But when Seer fetches the full trace waterfall, it gets ALL transactions in that trace.
So the LLM sees spans from multiple transactions but is only given context about one transaction_name, and we end up with issues tagged to one transaction that are attributed to a different transaction.

- Makes `transaction_name` an LLM-generated field on `DetectedIssue` instead of a context field passed from Sentry
- Simplifies `trace_data.py` by removing the intermediate `TraceMetadata` object