### PR TITLE
feat(aci): Add issue type condition to new Alerts UI

### DIFF
--- a/static/app/types/workflowEngine/dataConditions.tsx
+++ b/static/app/types/workflowEngine/dataConditions.tsx
@@ -24,6 +24,7 @@ export enum DataConditionType {
   EXISTING_HIGH_PRIORITY_ISSUE = 'existing_high_priority_issue',
   FIRST_SEEN_EVENT = 'first_seen_event',
   ISSUE_CATEGORY = 'issue_category',
+  ISSUE_TYPE = 'issue_type',
   ISSUE_OCCURRENCES = 'issue_occurrences',
   LATEST_ADOPTED_RELEASE = 'latest_adopted_release',
   LATEST_RELEASE = 'latest_release',

--- a/static/app/views/automations/components/actionFilters/issueType.tsx
+++ b/static/app/views/automations/components/actionFilters/issueType.tsx
@@ -1,0 +1,88 @@
+import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
+import {t, tct} from 'sentry/locale';
+import type {SelectValue} from 'sentry/types/core';
+import {getIssueTitleFromType, VISIBLE_ISSUE_TYPES} from 'sentry/types/group';
+import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
+import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
+import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
+
+const INCLUDE_CHOICES = [
+  {value: true, label: t('equal to')},
+  {value: false, label: t('not equal to')},
+];
+
+type IssueTypeChoice = {
+  label: string;
+  value: string;
+};
+
+const ISSUE_TYPE_CHOICES: IssueTypeChoice[] = VISIBLE_ISSUE_TYPES.map(value => ({
+  value,
+  label: getIssueTitleFromType(value) ?? value,
+}));
+
+export function IssueTypeDetails({condition}: {condition: DataCondition}) {
+  const include = condition.comparison.include ?? true;
+  const includeLabel =
+    INCLUDE_CHOICES.find(choice => choice.value === include)?.label ?? '';
+
+  return tct('Issue type is [include] [type]', {
+    include: includeLabel,
+    type:
+      ISSUE_TYPE_CHOICES.find(choice => choice.value === condition.comparison.value)
+        ?.label || condition.comparison.value,
+  });
+}
+
+export function IssueTypeNode() {
+  return tct('Issue type is [include] [type]', {
+    include: <IncludeField />,
+    type: <TypeField />,
+  });
+}
+
+function IncludeField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
+  return (
+    <AutomationBuilderSelect
+      name={`${condition_id}.comparison.include`}
+      aria-label={t('Include or exclude')}
+      value={condition.comparison.include ?? true}
+      options={INCLUDE_CHOICES}
+      onChange={(option: SelectValue<boolean>) => {
+        onUpdate({comparison: {...condition.comparison, include: option.value}});
+        removeError(condition.id);
+      }}
+    />
+  );
+}
+
+function TypeField() {
+  const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
+  const {removeError} = useAutomationBuilderErrorContext();
+
+  return (
+    <AutomationBuilderSelect
+      name={`${condition_id}.comparison.value`}
+      aria-label={t('Issue type')}
+      value={condition.comparison.value}
+      options={ISSUE_TYPE_CHOICES}
+      onChange={(option: SelectValue<string>) => {
+        onUpdate({comparison: {...condition.comparison, value: option.value}});
+        removeError(condition.id);
+      }}
+    />
+  );
+}
+
+export function validateIssueTypeCondition({
+  condition,
+}: ValidateDataConditionProps): string | undefined {
+  if (condition.comparison.value === undefined || condition.comparison.value === null) {
+    return t('You must select an issue type.');
+  }
+  return undefined;
+}

--- a/static/app/views/automations/components/dataConditionNodes.tsx
+++ b/static/app/views/automations/components/dataConditionNodes.tsx
@@ -64,6 +64,11 @@ import {
 } from 'sentry/views/automations/components/actionFilters/issuePriority';
 import {IssuePriorityDeescalating} from 'sentry/views/automations/components/actionFilters/issuePriorityDeescalating';
 import {
+  IssueTypeDetails,
+  IssueTypeNode,
+  validateIssueTypeCondition,
+} from 'sentry/views/automations/components/actionFilters/issueType';
+import {
   LatestAdoptedReleaseDetails,
   LatestAdoptedReleaseNode,
   validateLatestAdoptedReleaseCondition,
@@ -200,6 +205,15 @@ export const dataConditionNodesMap = new Map<DataConditionType, DataConditionNod
       dataCondition: IssueCategoryNode,
       details: IssueCategoryDetails,
       validate: validateIssueCategoryCondition,
+    },
+  ],
+  [
+    DataConditionType.ISSUE_TYPE,
+    {
+      label: t('Issue type'),
+      dataCondition: IssueTypeNode,
+      details: IssueTypeDetails,
+      validate: validateIssueTypeCondition,
     },
   ],
   [


### PR DESCRIPTION
Ref ISWF-1991

Adds frontend support for the issue type condition in the new alerts UI. This won't show up until we start returning the condition from the backend, but we need to support it in the UI first.

<img width="1106" height="424" alt="CleanShot 2026-02-12 at 13 11 52@2x" src="https://github.com/user-attachments/assets/e409f7a9-48ca-4115-a9f8-b6b3e441e149" />
