### PR TITLE
fix(seer-slack): Allow clicks on existing runs to handle gracefully

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -50,25 +50,25 @@ AUTOFIX_CONFIG: dict[AutofixStoppingPoint, AutofixStageConfig] = {
         heading=":mag:  *Root Cause Analysis*",
         label="Fix with Seer",
         working_text="Seer is analyzing the root cause...",
-        completed_text="Seer has analyzed the root cause.",
+        completed_text="Seer has already analyzed the root cause.",
     ),
     AutofixStoppingPoint.SOLUTION: AutofixStageConfig(
         heading=":test_tube:  *Proposed Solution*",
         label="Plan a Solution",
         working_text="Seer is working on the solution...",
-        completed_text="Seer has proposed a solution.",
+        completed_text="Seer has already proposed a solution.",
     ),
     AutofixStoppingPoint.CODE_CHANGES: AutofixStageConfig(
         heading=":pencil2:  *Code Change Suggestions*",
         label="Write Code Changes",
         working_text="Seer is writing the code...",
-        completed_text="Seer has written the code changes.",
+        completed_text="Seer has already written the code changes.",
     ),
     AutofixStoppingPoint.OPEN_PR: AutofixStageConfig(
         heading=":link:  *Pull Request*",
         label="Draft a PR",
         working_text="Seer is drafting a pull request...",
-        completed_text="Seer has drafted a pull request.",
+        completed_text="Seer has already drafted a pull request.",
     ),
 }
 
@@ -201,9 +201,6 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         extra_text: str | None = None,
         has_complete_stage: bool = True,
     ) -> list[Block]:
-        if has_complete_stage and data.current_point == AutofixStoppingPoint.OPEN_PR:
-            return []
-
         config = AUTOFIX_CONFIG[data.current_point]
         raw_text = config["completed_text"] if has_complete_stage else config["working_text"]
         markdown_text = f"_{raw_text}_"

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -201,6 +201,9 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         extra_text: str | None = None,
         has_complete_stage: bool = True,
     ) -> list[Block]:
+        if has_complete_stage and data.current_point == AutofixStoppingPoint.OPEN_PR:
+            return []
+
         config = AUTOFIX_CONFIG[data.current_point]
         raw_text = config["completed_text"] if has_complete_stage else config["working_text"]
         markdown_text = f"_{raw_text}_"

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypedDict
 
 import orjson
+from django.conf import settings
 from slack_sdk.models.blocks import (
     ActionsBlock,
     Block,
@@ -36,7 +37,8 @@ if TYPE_CHECKING:
 class AutofixStageConfig(TypedDict):
     heading: str
     label: str
-    working_text: str | None
+    working_text: str
+    completed_text: str
 
 
 MAX_STEPS = 10
@@ -48,21 +50,25 @@ AUTOFIX_CONFIG: dict[AutofixStoppingPoint, AutofixStageConfig] = {
         heading=":mag:  *Root Cause Analysis*",
         label="Fix with Seer",
         working_text="Seer is analyzing the root cause...",
+        completed_text="Seer has analyzed the root cause.",
     ),
     AutofixStoppingPoint.SOLUTION: AutofixStageConfig(
         heading=":test_tube:  *Proposed Solution*",
         label="Plan a Solution",
         working_text="Seer is working on the solution...",
+        completed_text="Seer has proposed a solution.",
     ),
     AutofixStoppingPoint.CODE_CHANGES: AutofixStageConfig(
         heading=":pencil2:  *Code Change Suggestions*",
         label="Write Code Changes",
         working_text="Seer is writing the code...",
+        completed_text="Seer has written the code changes.",
     ),
     AutofixStoppingPoint.OPEN_PR: AutofixStageConfig(
         heading=":link:  *Pull Request*",
         label="Draft a PR",
         working_text="Seer is drafting a pull request...",
+        completed_text="Seer has drafted a pull request.",
     ),
 }
 
@@ -128,11 +134,8 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
             project_id=data.project_id,
             group_link=data.group_link,
         )
-        action_elements: list[InteractiveElement] = []
-        if not data.has_progressed:
-            action_elements.append(link_button)
-
-        if not data.has_progressed and data.has_next_trigger:
+        action_elements: list[InteractiveElement] = [link_button]
+        if data.has_next_trigger:
             action_elements.append(
                 cls._render_autofix_button(data=SeerAutofixTrigger.from_update(data))
             )
@@ -172,8 +175,6 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         if action_elements:
             blocks.append(ActionsBlock(elements=action_elements))
 
-        if data.has_progressed and data.current_point != AutofixStoppingPoint.OPEN_PR:
-            blocks.extend(cls.render_footer_blocks(data=data))
         return SlackRenderable(blocks=blocks, text="Seer has an update on fixing the issue")
 
     @classmethod
@@ -198,18 +199,16 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         cls,
         data: SeerAutofixUpdate,
         extra_text: str | None = None,
-        stage_completed: bool = True,
+        has_complete_stage: bool = True,
     ) -> list[Block]:
-        rendered_point = data.next_point if stage_completed else data.current_point
-        if not rendered_point:
-            return []
-        config = AUTOFIX_CONFIG[rendered_point]
-        markdown_text = (
-            f"_{config['working_text']}_\n_{extra_text}_"
-            if extra_text
-            else f"_{config['working_text']}_"
-        )
-        return [
+        config = AUTOFIX_CONFIG[data.current_point]
+        raw_text = config["completed_text"] if has_complete_stage else config["working_text"]
+        markdown_text = f"_{raw_text}_"
+
+        if extra_text:
+            markdown_text += f"\n_{extra_text}_"
+
+        blocks: list[Block] = [
             SectionBlock(
                 text=MarkdownTextObject(text=markdown_text),
                 accessory=cls._render_link_button(
@@ -218,8 +217,12 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                     group_link=data.group_link,
                 ),
             ),
-            ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]),
         ]
+
+        if settings.DEBUG:
+            blocks.append(ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]))
+
+        return blocks
 
     @classmethod
     def render_autofix_button(cls, group: Group) -> InteractiveElement:

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -80,10 +80,6 @@ class SeerAutofixUpdate(NotificationData):
     source: NotificationSource = NotificationSource.SEER_AUTOFIX_UPDATE
 
     @property
-    def next_point(self) -> AutofixStoppingPoint | None:
-        return _get_next_stopping_point(self.current_point)
-
-    @property
     def has_next_trigger(self) -> bool:
         match self.current_point:
             case AutofixStoppingPoint.ROOT_CAUSE:

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -76,7 +76,6 @@ class SeerAutofixUpdate(NotificationData):
     changes: list[SeerAutofixCodeChange] = field(default_factory=list)
     pull_requests: list[SeerAutofixPullRequest] = field(default_factory=list)
     summary: str | None = None
-    has_progressed: bool = False
     source: NotificationSource = NotificationSource.SEER_AUTOFIX_UPDATE
 
     @property

--- a/src/sentry/seer/entrypoints/metrics.py
+++ b/src/sentry/seer/entrypoints/metrics.py
@@ -16,6 +16,7 @@ class SeerOperatorInteractionType(StrEnum):
     OPERATOR_CACHE_MIGRATE = "cache_migrate"
     ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR = "entrypoint_on_trigger_autofix_error"
     ENTRYPOINT_ON_TRIGGER_AUTOFIX_SUCCESS = "entrypoint_on_trigger_autofix_success"
+    ENTRYPOINT_ON_TRIGGER_AUTOFIX_ALREADY_EXISTS = "entrypoint_on_trigger_autofix_already_exists"
     ENTRYPOINT_CREATE_AUTOFIX_CACHE_PAYLOAD = "entrypoint_create_autofix_cache_payload"
     ENTRYPOINT_ON_AUTOFIX_UPDATE = "entrypoint_on_autofix_update"
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -8,7 +8,6 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.autofix.autofix import trigger_autofix as _trigger_autofix
 from sentry.seer.autofix.autofix import update_autofix
-from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.types import (
     AutofixCreatePRPayload,
     AutofixSelectRootCausePayload,
@@ -129,21 +128,10 @@ class SeerOperator[CachePayloadT]:
                 }
             )
             try:
-                existing_state = (
-                    get_autofix_state(
-                        run_id=run_id,
-                        organization_id=group.organization.id,
-                    )
-                    if run_id
-                    else get_autofix_state(
-                        group_id=group.id,
-                        organization_id=group.organization.id,
-                    )
+                existing_state = get_autofix_state(
+                    group_id=group.id, organization_id=group.organization.id
                 )
             except Exception as e:
-                lifecycle.record_failure(
-                    failure_reason="failed_to_get_autofix_state", extra={"error": str(e)}
-                )
                 with SeerOperatorEventLifecycleMetric(
                     interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,
                     entrypoint_key=self.entrypoint.key,
@@ -151,22 +139,25 @@ class SeerOperator[CachePayloadT]:
                     self.entrypoint.on_trigger_autofix_error(
                         error="Encountered an error while talking to Seer"
                     )
+                lifecycle.record_failure(failure_reason=e)
                 return
             if existing_state:
-                has_complete_stage = has_complete_stage_from_state(stopping_point, existing_state)
+                stopping_point_step = get_stopping_point_status(stopping_point, existing_state)
                 lifecycle.add_extras(
                     {
                         "existing_run_id": str(existing_state.run_id),
-                        "has_complete_stage": str(has_complete_stage),
+                        "existing_run_status": str(existing_state.status),
                     }
                 )
-                if existing_state.status == AutofixStatus.PROCESSING:
+                # For now, we don't support re-runs over slack -- it causes a confusing UX without
+                # reliably being able to edit messages.
+                if stopping_point_step:
                     with SeerOperatorEventLifecycleMetric(
                         interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ALREADY_EXISTS,
                         entrypoint_key=self.entrypoint.key,
                     ).capture():
                         self.entrypoint.on_trigger_autofix_already_exists(
-                            state=existing_state, has_complete_stage=has_complete_stage
+                            state=existing_state, step_state=stopping_point_step
                         )
                     return
 
@@ -325,35 +316,29 @@ def process_autofix_updates(
                     ept_lifecycle.record_failure(failure_reason=e)
 
 
-def has_complete_stage_from_state(
+def get_stopping_point_status(
     stopping_point: AutofixStoppingPoint, autofix_state: AutofixState
-) -> bool:
+) -> dict | None:
     """
-    Determines if a stopping point stage has been completed based on the autofix state.
-    The AutofixState type only somewhat matches the stopping points, so we have to check the keys of
-    each step, and the status of a matching step are the best mapping we have for
+    Gets the most recent matching step state from a given stopping point.
     """
+    # The most recent of a repeated step is at the end of the list, that's what we want to surface
+    steps = reversed(autofix_state.steps)
     match stopping_point:
         case AutofixStoppingPoint.ROOT_CAUSE:
-            return any(
-                step.get("key") == "root_cause_analysis"
-                and step.get("status") == AutofixStatus.COMPLETED
-                for step in autofix_state.steps
-            )
+            step = next((step for step in steps if step.get("key") == "root_cause_analysis"), {})
         case AutofixStoppingPoint.SOLUTION:
-            return any(
-                step.get("key") == "solution" and step.get("status") == AutofixStatus.COMPLETED
-                for step in autofix_state.steps
-            )
+            step = next((step for step in steps if step.get("key") == "solution"), {})
         case AutofixStoppingPoint.CODE_CHANGES:
-            return any(
-                step.get("key") == "changes" and step.get("status") == AutofixStatus.COMPLETED
-                for step in autofix_state.steps
-            )
+            step = next((step for step in steps if step.get("key") == "changes"), {})
         case AutofixStoppingPoint.OPEN_PR:
-            return any(
-                step.get("key") == "changes"
-                and step.get("status") == AutofixStatus.COMPLETED
-                and any(change.get("pull_request") for change in step.get("changes", []))
-                for step in autofix_state.steps
+            step = next(
+                (
+                    step
+                    for step in steps
+                    if step.get("key") == "changes"
+                    and any(change.get("pull_request") for change in step.get("changes", []))
+                ),
+                {},
             )
+    return step

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -144,9 +144,7 @@ class SeerOperator[CachePayloadT]:
                 lifecycle.add_extras(
                     {
                         "existing_run_id": str(existing_state.run_id),
-                        "has_complete_stage": str(
-                            has_complete_stage_from_state(stopping_point, existing_state)
-                        ),
+                        "has_complete_stage": str(has_complete_stage),
                     }
                 )
                 if existing_state.status == AutofixStatus.PROCESSING:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -319,28 +319,30 @@ def has_complete_stage_from_state(
 ) -> bool:
     """
     Determines if a stopping point stage has been completed based on the autofix state.
+    The AutofixState type only somewhat matches the stopping points, so we have to check the keys of
+    each step, and the status of a matching step are the best mapping we have for
     """
     match stopping_point:
         case AutofixStoppingPoint.ROOT_CAUSE:
             return any(
-                step.get("status") == AutofixStatus.COMPLETED
-                and step.get("key") == "root_cause_analysis"
+                step.get("key") == "root_cause_analysis"
+                and step.get("status") == AutofixStatus.COMPLETED
                 for step in autofix_state.steps
             )
         case AutofixStoppingPoint.SOLUTION:
             return any(
-                step.get("status") == AutofixStatus.COMPLETED and step.get("key") == "solution"
+                step.get("key") == "solution" and step.get("status") == AutofixStatus.COMPLETED
                 for step in autofix_state.steps
             )
         case AutofixStoppingPoint.CODE_CHANGES:
             return any(
-                step.get("status") == AutofixStatus.COMPLETED and step.get("key") == "changes"
+                step.get("key") == "changes" and step.get("status") == AutofixStatus.COMPLETED
                 for step in autofix_state.steps
             )
         case AutofixStoppingPoint.OPEN_PR:
             return any(
-                step.get("status") == AutofixStatus.COMPLETED
-                and step.get("key") == "changes"
+                step.get("key") == "changes"
+                and step.get("status") == AutofixStatus.COMPLETED
                 and any(change.get("pull_request") for change in step.get("changes", []))
                 for step in autofix_state.steps
             )

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -326,11 +326,21 @@ def get_stopping_point_status(
     steps = reversed(autofix_state.steps)
     match stopping_point:
         case AutofixStoppingPoint.ROOT_CAUSE:
-            step = next((step for step in steps if step.get("key") == "root_cause_analysis"), {})
+            step = next(
+                (
+                    step
+                    for step in steps
+                    if step.get("key") in {"root_cause_analysis", "root_cause_analysis_processing"}
+                ),
+                None,
+            )
         case AutofixStoppingPoint.SOLUTION:
-            step = next((step for step in steps if step.get("key") == "solution"), {})
+            step = next(
+                (step for step in steps if step.get("key") in {"solution", "solution_processing"}),
+                None,
+            )
         case AutofixStoppingPoint.CODE_CHANGES:
-            step = next((step for step in steps if step.get("key") == "changes"), {})
+            step = next((step for step in steps if step.get("key") == "changes"), None)
         case AutofixStoppingPoint.OPEN_PR:
             step = next(
                 (
@@ -339,6 +349,6 @@ def get_stopping_point_status(
                     if step.get("key") == "changes"
                     and any(change.get("pull_request") for change in step.get("changes", []))
                 ),
-                {},
+                None,
             )
     return step

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -128,17 +128,30 @@ class SeerOperator[CachePayloadT]:
                     "stopping_point": str(stopping_point),
                 }
             )
-            existing_state = (
-                get_autofix_state(
-                    run_id=run_id,
-                    organization_id=group.organization.id,
+            try:
+                existing_state = (
+                    get_autofix_state(
+                        run_id=run_id,
+                        organization_id=group.organization.id,
+                    )
+                    if run_id
+                    else get_autofix_state(
+                        group_id=group.id,
+                        organization_id=group.organization.id,
+                    )
                 )
-                if run_id
-                else get_autofix_state(
-                    group_id=group.id,
-                    organization_id=group.organization.id,
+            except Exception as e:
+                lifecycle.record_failure(
+                    failure_reason="failed_to_get_autofix_state", extra={"error": str(e)}
                 )
-            )
+                with SeerOperatorEventLifecycleMetric(
+                    interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,
+                    entrypoint_key=self.entrypoint.key,
+                ).capture():
+                    self.entrypoint.on_trigger_autofix_error(
+                        error="Encountered an error while talking to Seer"
+                    )
+                return
             if existing_state:
                 has_complete_stage = has_complete_stage_from_state(stopping_point, existing_state)
                 lifecycle.add_extras(

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -8,12 +8,13 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.autofix.autofix import trigger_autofix as _trigger_autofix
 from sentry.seer.autofix.autofix import update_autofix
+from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.types import (
     AutofixCreatePRPayload,
     AutofixSelectRootCausePayload,
     AutofixSelectSolutionPayload,
 )
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint, get_autofix_state
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.metrics import (
     SeerOperatorEventLifecycleMetric,
@@ -127,6 +128,37 @@ class SeerOperator[CachePayloadT]:
                     "stopping_point": str(stopping_point),
                 }
             )
+            existing_state = (
+                get_autofix_state(
+                    run_id=run_id,
+                    organization_id=group.organization.id,
+                )
+                if run_id
+                else get_autofix_state(
+                    group_id=group.id,
+                    organization_id=group.organization.id,
+                )
+            )
+            if existing_state:
+                has_complete_stage = has_complete_stage_from_state(stopping_point, existing_state)
+                lifecycle.add_extras(
+                    {
+                        "existing_run_id": str(existing_state.run_id),
+                        "has_complete_stage": str(
+                            has_complete_stage_from_state(stopping_point, existing_state)
+                        ),
+                    }
+                )
+                if existing_state.status == AutofixStatus.PROCESSING:
+                    with SeerOperatorEventLifecycleMetric(
+                        interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ALREADY_EXISTS,
+                        entrypoint_key=self.entrypoint.key,
+                    ).capture():
+                        self.entrypoint.on_trigger_autofix_already_exists(
+                            state=existing_state, has_complete_stage=has_complete_stage
+                        )
+                    return
+
             if not run_id:
                 raw_response = _trigger_autofix(
                     group=group,
@@ -280,3 +312,35 @@ def process_autofix_updates(
                     )
                 except Exception as e:
                     ept_lifecycle.record_failure(failure_reason=e)
+
+
+def has_complete_stage_from_state(
+    stopping_point: AutofixStoppingPoint, autofix_state: AutofixState
+) -> bool:
+    """
+    Determines if a stopping point stage has been completed based on the autofix state.
+    """
+    match stopping_point:
+        case AutofixStoppingPoint.ROOT_CAUSE:
+            return any(
+                step.get("status") == AutofixStatus.COMPLETED
+                and step.get("key") == "root_cause_analysis"
+                for step in autofix_state.steps
+            )
+        case AutofixStoppingPoint.SOLUTION:
+            return any(
+                step.get("status") == AutofixStatus.COMPLETED and step.get("key") == "solution"
+                for step in autofix_state.steps
+            )
+        case AutofixStoppingPoint.CODE_CHANGES:
+            return any(
+                step.get("status") == AutofixStatus.COMPLETED and step.get("key") == "changes"
+                for step in autofix_state.steps
+            )
+        case AutofixStoppingPoint.OPEN_PR:
+            return any(
+                step.get("status") == AutofixStatus.COMPLETED
+                and step.get("key") == "changes"
+                and any(change.get("pull_request") for change in step.get("changes", []))
+                for step in autofix_state.steps
+            )

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -60,9 +60,9 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         self.slack_request = slack_request
         self.group = group
         self.channel_id = slack_request.channel_id or ""
-        # Use the thread_ts if available, otherwise assume this is the channel message, so it will
-        # parent the thread later on.
         self.message_ts = slack_request.data["message"]["ts"]
+        # Use the thread_ts if available, otherwise this is a channel message, so it will
+        # be the parent of a future thread.
         self.thread_ts = slack_request.data["message"].get("thread_ts", self.message_ts)
         self.thread = SlackThreadDetails(thread_ts=self.thread_ts, channel_id=self.channel_id)
         self.organization_id = organization_id

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -159,10 +159,13 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
 
     def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
         # We don't include the user since we don't know that they started the original run.
+        has_complete_stage = (
+            False
+            if step_state.get("key") in {"root_cause_analysis_processing", "solution_processing"}
+            else step_state.get("status") == AutofixStatus.COMPLETED
+        )
         self._update_existing_message(
-            run_id=state.run_id,
-            has_complete_stage=step_state.get("status") == AutofixStatus.COMPLETED,
-            include_user=False,
+            run_id=state.run_id, has_complete_stage=has_complete_stage, include_user=False
         )
 
     def create_autofix_cache_payload(self) -> SlackEntrypointCachePayload:

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -9,7 +9,7 @@ from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.notifications.platform.templates.seer import SeerAutofixError, SeerAutofixUpdate
 from sentry.notifications.utils.actions import BlockKitMessageAction
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.slack.messaging import (
@@ -60,7 +60,10 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         self.slack_request = slack_request
         self.group = group
         self.channel_id = slack_request.channel_id or ""
-        self.thread_ts = slack_request.data["message"]["ts"]
+        # Use the thread_ts if available, otherwise assume this is the channel message, so it will
+        # parent the thread later on.
+        self.message_ts = slack_request.data["message"]["ts"]
+        self.thread_ts = slack_request.data["message"].get("thread_ts", self.message_ts)
         self.thread = SlackThreadDetails(thread_ts=self.thread_ts, channel_id=self.channel_id)
         self.organization_id = organization_id
         self.install = SlackIntegration(
@@ -118,6 +121,30 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             f"autofix:entrypoint:{SeerEntrypointKey.SLACK.value}:{group_id}:{stopping_point.value}"
         )
 
+    def _update_existing_message(
+        self, *, run_id: int, has_complete_stage: bool, include_user: bool
+    ) -> None:
+        """
+        Updates the clicked message as 'in-progress' with a given run_id.
+        """
+        data = SeerAutofixUpdate(
+            run_id=run_id,
+            organization_id=self.organization_id,
+            project_id=self.group.project_id,
+            group_id=self.group.id,
+            current_point=self.autofix_stopping_point,
+            group_link=self.get_group_link(self.group),
+        )
+        update_existing_message(
+            request=self.slack_request,
+            install=self.install,
+            channel_id=self.channel_id,
+            message_ts=self.message_ts,
+            data=data,
+            has_complete_stage=has_complete_stage,
+            slack_user_id=self.slack_request.user_id if include_user else None,
+        )
+
     def on_trigger_autofix_error(self, *, error: str) -> None:
         send_thread_update(
             install=self.install,
@@ -127,27 +154,19 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         )
 
     def on_trigger_autofix_success(self, *, run_id: int) -> None:
-        data = SeerAutofixUpdate(
-            run_id=run_id,
-            organization_id=self.organization_id,
-            project_id=self.group.project_id,
-            group_id=self.group.id,
-            current_point=self.autofix_stopping_point,
-            group_link=self.get_group_link(self.group),
-            has_progressed=True,
-        )
-        update_existing_message(
-            request=self.slack_request,
-            install=self.install,
-            channel_id=self.channel_id,
-            message_ts=self.thread_ts,
-            data=data,
-            slack_user_id=self.slack_request.user_id,
+        self._update_existing_message(run_id=run_id, has_complete_stage=False, include_user=True)
+
+    def on_trigger_autofix_already_exists(
+        self, *, state: AutofixState, has_complete_stage: bool
+    ) -> None:
+        # We don't include the user since we don't know that they started the original run.
+        self._update_existing_message(
+            run_id=state.run_id, has_complete_stage=has_complete_stage, include_user=False
         )
 
     def create_autofix_cache_payload(self) -> SlackEntrypointCachePayload:
         return SlackEntrypointCachePayload(
-            threads=[SlackThreadDetails(thread_ts=self.thread_ts, channel_id=self.channel_id)],
+            threads=[self.thread],
             organization_id=self.organization_id,
             integration_id=self.install.model.id,
             project_id=self.group.project_id,
@@ -173,7 +192,6 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
             "project_id": cache_payload["project_id"],
             "group_id": cache_payload["group_id"],
             "group_link": cache_payload["group_link"],
-            "has_progressed": False,
         }
 
         match event_type:

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -9,6 +9,7 @@ from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.notifications.platform.templates.seer import SeerAutofixError, SeerAutofixUpdate
 from sentry.notifications.utils.actions import BlockKitMessageAction
+from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.registry import entrypoint_registry
@@ -156,12 +157,12 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
     def on_trigger_autofix_success(self, *, run_id: int) -> None:
         self._update_existing_message(run_id=run_id, has_complete_stage=False, include_user=True)
 
-    def on_trigger_autofix_already_exists(
-        self, *, state: AutofixState, has_complete_stage: bool
-    ) -> None:
+    def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
         # We don't include the user since we don't know that they started the original run.
         self._update_existing_message(
-            run_id=state.run_id, has_complete_stage=has_complete_stage, include_user=False
+            run_id=state.run_id,
+            has_complete_stage=step_state.get("status") == AutofixStatus.COMPLETED,
+            include_user=False,
         )
 
     def create_autofix_cache_payload(self) -> SlackEntrypointCachePayload:

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -198,6 +198,7 @@ def update_existing_message(
     channel_id: str,
     message_ts: str,
     data: SeerAutofixUpdate,
+    has_complete_stage: bool,
     slack_user_id: str | None,
 ) -> None:
     from sentry.integrations.slack.message_builder.types import SlackAction
@@ -207,7 +208,7 @@ def update_existing_message(
             return None
         return elem
 
-    def remove_all_buttons_transformer(elem: dict[str, Any]) -> dict[str, Any] | None:
+    def remove_all_buttons_transformer(_elem: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
     with SlackEntrypointEventLifecycleMetric(
@@ -223,6 +224,8 @@ def update_existing_message(
             }
         )
 
+        # The RCA button is on an issue alert, so we just remove the trigger from the list of actions.
+        # Later updates only have autofix triggers, so we remove the whole actions block.
         transformer = (
             remove_autofix_button_transformer
             if data.current_point == AutofixStoppingPoint.ROOT_CAUSE
@@ -239,16 +242,11 @@ def update_existing_message(
         blocks = _transform_block_actions(original_blocks, transformer)
 
         parsed_blocks = [Block.parse(block) for block in blocks]
-        if slack_user_id:
-            parsed_blocks.extend(
-                SeerSlackRenderer.render_footer_blocks(
-                    data=data, extra_text=f"(ty <@{slack_user_id}>)", stage_completed=False
-                )
-            )
-        else:
-            parsed_blocks.extend(
-                SeerSlackRenderer.render_footer_blocks(data=data, stage_completed=False)
-            )
+        footer_extra_text = f"(ty <@{slack_user_id}>)" if slack_user_id else None
+        footer_blocks = SeerSlackRenderer.render_footer_blocks(
+            data=data, extra_text=footer_extra_text, has_complete_stage=has_complete_stage
+        )
+        parsed_blocks.extend(footer_blocks)
 
         renderable = SlackRenderable(
             blocks=[block for block in parsed_blocks if block is not None],

--- a/src/sentry/seer/entrypoints/slack/messaging.py
+++ b/src/sentry/seer/entrypoints/slack/messaging.py
@@ -224,8 +224,9 @@ def update_existing_message(
             }
         )
 
-        # The RCA button is on an issue alert, so we just remove the trigger from the list of actions.
-        # Later updates only have autofix triggers, so we remove the whole actions block.
+        # The RCA button is on an issue alert, so we just remove the button from the list of actions.
+        # Later updates only have autofix buttons (View, Start), so we remove the whole actions block.
+        # This is because we add the View button back to the footer, along with some status text.
         transformer = (
             remove_autofix_button_transformer
             if data.current_point == AutofixStoppingPoint.ROOT_CAUSE

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -31,11 +31,10 @@ class SeerEntrypoint[CachePayloadT](Protocol):
         """
         ...
 
-    def on_trigger_autofix_already_exists(
-        self, *, state: AutofixState, has_complete_stage: bool
-    ) -> None:
+    def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
         """
         Called when an autofix run already exists for the group.
+        Also passes the most recent state from the matching stopping_point step for convenience.
 
         Example Usage: Sending a 'run in progress' message, etc.
         """

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -2,6 +2,7 @@ from enum import StrEnum
 from typing import Any, Literal, Protocol, TypedDict
 
 from sentry.models.organization import Organization
+from sentry.seer.autofix.utils import AutofixState
 from sentry.sentry_apps.metrics import SentryAppEventType
 
 
@@ -27,6 +28,16 @@ class SeerEntrypoint[CachePayloadT](Protocol):
         Used by the operator (SeerOperator.has_access) to gate access prevent a workflow unless
         the organization has access to at least one entrypoint. The operator will check for
         seer-access prior to this check, so no need to repeat that check on the entrypoint.
+        """
+        ...
+
+    def on_trigger_autofix_already_exists(
+        self, *, state: AutofixState, has_complete_stage: bool
+    ) -> None:
+        """
+        Called when an autofix run already exists for the group.
+
+        Example Usage: Sending a 'run in progress' message, etc.
         """
         ...
 

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
 from slack_sdk.models.blocks import (
     ActionsBlock,
     ButtonElement,
@@ -24,7 +25,6 @@ class SeerSlackRendererTest(TestCase):
     def _create_update(
         self,
         current_point: AutofixStoppingPoint,
-        has_progressed: bool = False,
         summary: str | None = None,
         steps: list[str] | None = None,
         changes: list[SeerAutofixCodeChange] | None = None,
@@ -46,29 +46,22 @@ class SeerSlackRendererTest(TestCase):
     def test_render_footer_blocks_with_has_complete_stage(self) -> None:
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
         blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=True)
-        assert len(blocks) == 2
-        # The first block has the next stages working text and a link
-        config = AUTOFIX_CONFIG[AutofixStoppingPoint.SOLUTION]
-        working_text = config["working_text"]
-        assert working_text is not None
+        assert len(blocks) == 1
+        config = AUTOFIX_CONFIG[AutofixStoppingPoint.ROOT_CAUSE]
+        completed_text = config["completed_text"]
+        assert completed_text is not None
         section_block = blocks[0]
         assert isinstance(section_block, SectionBlock)
         assert section_block.text is not None
-        assert working_text in section_block.text.text
+        assert completed_text in section_block.text.text
         assert section_block.accessory is not None
         assert isinstance(section_block.accessory, LinkButtonElement)
         assert section_block.accessory.url == data.group_link
-        # The second block should be a context block with run_id
-        assert isinstance(blocks[1], ContextBlock)
-        context_element = blocks[1].elements[0]
-        assert isinstance(context_element, PlainTextObject)
-        assert f"Run ID: {MOCK_RUN_ID}" in context_element.text
 
     def test_render_footer_blocks_with_stage_not_completed(self) -> None:
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
         blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=False)
-        assert len(blocks) == 2
-        # The first block should contain the working text for the CURRENT stage
+        assert len(blocks) == 1
         config = AUTOFIX_CONFIG[AutofixStoppingPoint.ROOT_CAUSE]
         working_text = config["working_text"]
         assert working_text is not None
@@ -81,7 +74,7 @@ class SeerSlackRendererTest(TestCase):
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
         extra_text = "(ty <@U12345>)"
         blocks = SeerSlackRenderer.render_footer_blocks(data=data, extra_text=extra_text)
-        assert len(blocks) == 2
+        assert len(blocks) == 1
         section_block = blocks[0]
         assert isinstance(section_block, SectionBlock)
         assert section_block.text is not None
@@ -91,6 +84,16 @@ class SeerSlackRendererTest(TestCase):
         data = self._create_update(AutofixStoppingPoint.OPEN_PR)
         blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=True)
         assert len(blocks) == 0
+
+    @override_settings(DEBUG=True)
+    def test_render_footer_debug_block(self) -> None:
+        data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
+        blocks = SeerSlackRenderer.render_footer_blocks(data=data)
+        assert len(blocks) == 2
+        assert isinstance(blocks[1], ContextBlock)
+        context_element = blocks[1].elements[0]
+        assert isinstance(context_element, PlainTextObject)
+        assert f"Run ID: {MOCK_RUN_ID}" in context_element.text
 
     def test_render_autofix_button(self) -> None:
         element = SeerSlackRenderer.render_autofix_button(group=self.group)
@@ -124,30 +127,6 @@ class SeerSlackRendererTest(TestCase):
         # Second button is trigger for next stage
         assert isinstance(actions_block.elements[1], ButtonElement)
         assert actions_block.elements[1].value == AutofixStoppingPoint.SOLUTION.value
-
-    @patch(
-        "sentry.notifications.platform.templates.seer.organization_service.get_option",
-        return_value=True,
-    )
-    def test_render_autofix_update_with_progress_shows_footer(self, _mock_get_option: Mock) -> None:
-        data = self._create_update(current_point=AutofixStoppingPoint.ROOT_CAUSE)
-        renderable = SeerSlackRenderer._render_autofix_update(data)
-        # Should have footer blocks (section + context)
-        has_context_block = any(isinstance(b, ContextBlock) for b in renderable["blocks"])
-        assert has_context_block
-
-    @patch(
-        "sentry.notifications.platform.templates.seer.organization_service.get_option",
-        return_value=True,
-    )
-    def test_render_autofix_update_with_progress_no_action_buttons(
-        self, _mock_get_option: Mock
-    ) -> None:
-        data = self._create_update(current_point=AutofixStoppingPoint.ROOT_CAUSE)
-        renderable = SeerSlackRenderer._render_autofix_update(data)
-        # Should NOT have actions block (no buttons for progressed updates)
-        has_actions = any(isinstance(b, ActionsBlock) for b in renderable["blocks"])
-        assert not has_actions
 
     @patch(
         "sentry.notifications.platform.templates.seer.organization_service.get_option",

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -80,11 +80,6 @@ class SeerSlackRendererTest(TestCase):
         assert section_block.text is not None
         assert extra_text in section_block.text.text
 
-    def test_render_footer_blocks_returns_empty_for_open_pr_completed(self) -> None:
-        data = self._create_update(AutofixStoppingPoint.OPEN_PR)
-        blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=True)
-        assert len(blocks) == 0
-
     @override_settings(DEBUG=True)
     def test_render_footer_debug_block(self) -> None:
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -37,16 +37,15 @@ class SeerSlackRendererTest(TestCase):
             group_id=MOCK_GROUP_ID,
             current_point=current_point,
             group_link=f"https://sentry.io/issues/{MOCK_GROUP_ID}?seerDrawer=true",
-            has_progressed=has_progressed,
             summary=summary,
             steps=steps or [],
             changes=changes or [],
             pull_requests=pull_requests or [],
         )
 
-    def test_render_footer_blocks_with_stage_completed(self) -> None:
+    def test_render_footer_blocks_with_has_complete_stage(self) -> None:
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
-        blocks = SeerSlackRenderer.render_footer_blocks(data=data, stage_completed=True)
+        blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=True)
         assert len(blocks) == 2
         # The first block has the next stages working text and a link
         config = AUTOFIX_CONFIG[AutofixStoppingPoint.SOLUTION]
@@ -67,7 +66,7 @@ class SeerSlackRendererTest(TestCase):
 
     def test_render_footer_blocks_with_stage_not_completed(self) -> None:
         data = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
-        blocks = SeerSlackRenderer.render_footer_blocks(data=data, stage_completed=False)
+        blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=False)
         assert len(blocks) == 2
         # The first block should contain the working text for the CURRENT stage
         config = AUTOFIX_CONFIG[AutofixStoppingPoint.ROOT_CAUSE]
@@ -90,7 +89,7 @@ class SeerSlackRendererTest(TestCase):
 
     def test_render_footer_blocks_returns_empty_for_open_pr_completed(self) -> None:
         data = self._create_update(AutofixStoppingPoint.OPEN_PR)
-        blocks = SeerSlackRenderer.render_footer_blocks(data=data, stage_completed=True)
+        blocks = SeerSlackRenderer.render_footer_blocks(data=data, has_complete_stage=True)
         assert len(blocks) == 0
 
     def test_render_autofix_button(self) -> None:
@@ -109,7 +108,6 @@ class SeerSlackRendererTest(TestCase):
     ) -> None:
         data = self._create_update(
             current_point=AutofixStoppingPoint.ROOT_CAUSE,
-            has_progressed=False,
             summary="Test summary",
         )
         renderable = SeerSlackRenderer._render_autofix_update(data)
@@ -132,10 +130,7 @@ class SeerSlackRendererTest(TestCase):
         return_value=True,
     )
     def test_render_autofix_update_with_progress_shows_footer(self, _mock_get_option: Mock) -> None:
-        data = self._create_update(
-            current_point=AutofixStoppingPoint.ROOT_CAUSE,
-            has_progressed=True,
-        )
+        data = self._create_update(current_point=AutofixStoppingPoint.ROOT_CAUSE)
         renderable = SeerSlackRenderer._render_autofix_update(data)
         # Should have footer blocks (section + context)
         has_context_block = any(isinstance(b, ContextBlock) for b in renderable["blocks"])
@@ -148,10 +143,7 @@ class SeerSlackRendererTest(TestCase):
     def test_render_autofix_update_with_progress_no_action_buttons(
         self, _mock_get_option: Mock
     ) -> None:
-        data = self._create_update(
-            current_point=AutofixStoppingPoint.ROOT_CAUSE,
-            has_progressed=True,
-        )
+        data = self._create_update(current_point=AutofixStoppingPoint.ROOT_CAUSE)
         renderable = SeerSlackRenderer._render_autofix_update(data)
         # Should NOT have actions block (no buttons for progressed updates)
         has_actions = any(isinstance(b, ActionsBlock) for b in renderable["blocks"])
@@ -164,7 +156,6 @@ class SeerSlackRendererTest(TestCase):
     def test_render_autofix_update_open_pr_no_footer(self, _mock_get_option: Mock) -> None:
         data = self._create_update(
             current_point=AutofixStoppingPoint.OPEN_PR,
-            has_progressed=True,
             pull_requests=[{"pr_number": 123, "pr_url": "https://github.com/org/repo/pull/123"}],
         )
         renderable = SeerSlackRenderer._render_autofix_update(data)
@@ -179,7 +170,6 @@ class SeerSlackRendererTest(TestCase):
     def test_render_autofix_update_with_pull_requests(self, _mock_get_option: Mock) -> None:
         data = self._create_update(
             current_point=AutofixStoppingPoint.OPEN_PR,
-            has_progressed=False,
             pull_requests=[
                 {"pr_number": 123, "pr_url": "https://github.com/org/repo/pull/123"},
                 {"pr_number": 456, "pr_url": "https://github.com/org/repo/pull/456"},
@@ -207,10 +197,7 @@ class SeerSlackRendererTest(TestCase):
     def test_render_autofix_update_solution_no_next_trigger_when_coding_disabled(
         self, _mock_get_option: Mock
     ) -> None:
-        data = self._create_update(
-            current_point=AutofixStoppingPoint.SOLUTION,
-            has_progressed=False,
-        )
+        data = self._create_update(current_point=AutofixStoppingPoint.SOLUTION)
         renderable = SeerSlackRenderer._render_autofix_update(data)
         actions_block = None
         for block in renderable["blocks"]:

--- a/tests/sentry/notifications/platform/templates/test_seer.py
+++ b/tests/sentry/notifications/platform/templates/test_seer.py
@@ -73,19 +73,6 @@ class SeerAutofixUpdateTest(TestCase):
             group_link=f"https://sentry.io/issues/{MOCK_GROUP_ID}?seerDrawer=true",
         )
 
-    def test_next_point(self) -> None:
-        update = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
-        assert update.next_point == AutofixStoppingPoint.SOLUTION
-
-        update = self._create_update(AutofixStoppingPoint.SOLUTION)
-        assert update.next_point == AutofixStoppingPoint.CODE_CHANGES
-
-        update = self._create_update(AutofixStoppingPoint.CODE_CHANGES)
-        assert update.next_point == AutofixStoppingPoint.OPEN_PR
-
-        update = self._create_update(AutofixStoppingPoint.OPEN_PR)
-        assert update.next_point is None
-
     def test_has_next_trigger_simple(self) -> None:
         update = self._create_update(AutofixStoppingPoint.ROOT_CAUSE)
         assert update.has_next_trigger is True

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -30,14 +30,16 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
-        self.autofix_already_exists_states: list[AutofixState] = []
+        self.autofix_already_exists_states: list[tuple[AutofixState, bool]] = []
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
         return True
 
-    def on_trigger_autofix_already_exists(self, *, state: AutofixState) -> None:
-        self.autofix_already_exists_states.append(state)
+    def on_trigger_autofix_already_exists(
+        self, *, state: AutofixState, has_complete_stage: bool
+    ) -> None:
+        self.autofix_already_exists_states.append((state, has_complete_stage))
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         self.autofix_errors.append(error)
@@ -159,7 +161,7 @@ class SeerOperatorTest(TestCase):
         )
 
         mock_trigger_autofix_helper.assert_not_called()
-        assert self.entrypoint.autofix_already_exists_states == [existing_state]
+        assert self.entrypoint.autofix_already_exists_states == [(existing_state, False)]
         assert self.entrypoint.autofix_run_ids == []
         assert self.entrypoint.autofix_errors == []
 

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -30,16 +30,14 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
-        self.autofix_already_exists_states: list[tuple[AutofixState, bool]] = []
+        self.autofix_already_exists_states: list[tuple[AutofixState, dict]] = []
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
         return True
 
-    def on_trigger_autofix_already_exists(
-        self, *, state: AutofixState, has_complete_stage: bool
-    ) -> None:
-        self.autofix_already_exists_states.append((state, has_complete_stage))
+    def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
+        self.autofix_already_exists_states.append((state, step_state))
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         self.autofix_errors.append(error)
@@ -143,6 +141,7 @@ class SeerOperatorTest(TestCase):
     def test_trigger_autofix_already_exists(
         self, mock_get_autofix_state, mock_trigger_autofix_helper
     ):
+        existing_rca_step_state = {"key": "root_cause_analysis", "status": AutofixStatus.COMPLETED}
         existing_state = AutofixState(
             run_id=MOCK_RUN_ID,
             request={
@@ -153,6 +152,7 @@ class SeerOperatorTest(TestCase):
             },
             updated_at=datetime.now(),
             status=AutofixStatus.PROCESSING,
+            steps=[existing_rca_step_state],
         )
         mock_get_autofix_state.return_value = existing_state
 
@@ -161,7 +161,9 @@ class SeerOperatorTest(TestCase):
         )
 
         mock_trigger_autofix_helper.assert_not_called()
-        assert self.entrypoint.autofix_already_exists_states == [(existing_state, False)]
+        assert self.entrypoint.autofix_already_exists_states == [
+            (existing_state, existing_rca_step_state)
+        ]
         assert self.entrypoint.autofix_run_ids == []
         assert self.entrypoint.autofix_errors == []
 

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from typing import Any, TypedDict, cast
 from unittest.mock import Mock, patch
 
@@ -6,7 +7,8 @@ from rest_framework.response import Response
 
 from fixtures.seer.webhooks import MOCK_RUN_ID
 from sentry.models.organization import Organization
-from sentry.seer.autofix.utils import AutofixStoppingPoint
+from sentry.seer.autofix.constants import AutofixStatus
+from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint
 from sentry.seer.entrypoints.operator import SeerOperator, process_autofix_updates
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
@@ -28,10 +30,14 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
+        self.autofix_already_exists_states: list[AutofixState] = []
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
         return True
+
+    def on_trigger_autofix_already_exists(self, *, state: AutofixState) -> None:
+        self.autofix_already_exists_states.append(state)
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         self.autofix_errors.append(error)
@@ -97,7 +103,10 @@ class SeerOperatorTest(TestCase):
         "sentry.seer.entrypoints.operator._trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
-    def test_trigger_autofix_pathway(self, mock_trigger_autofix_helper, mock_update_autofix_helper):
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
+    def test_trigger_autofix_pathway(
+        self, _mock_get_autofix_state, mock_trigger_autofix_helper, mock_update_autofix_helper
+    ):
         self.operator.trigger_autofix(
             group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
         )
@@ -118,7 +127,8 @@ class SeerOperatorTest(TestCase):
         "sentry.seer.entrypoints.operator._trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
-    def test_trigger_autofix_success(self, mock_trigger_autofix_helper):
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
+    def test_trigger_autofix_success(self, _mock_get_autofix_state, mock_trigger_autofix_helper):
         self.operator.trigger_autofix(
             group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
         )
@@ -127,7 +137,64 @@ class SeerOperatorTest(TestCase):
         assert self.entrypoint.autofix_run_ids == [MOCK_RUN_ID]
 
     @patch("sentry.seer.entrypoints.operator._trigger_autofix")
-    def test_trigger_autofix_error(self, mock_trigger_autofix_helper):
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state")
+    def test_trigger_autofix_already_exists(
+        self, mock_get_autofix_state, mock_trigger_autofix_helper
+    ):
+        existing_state = AutofixState(
+            run_id=MOCK_RUN_ID,
+            request={
+                "organization_id": self.organization.id,
+                "project_id": self.project.id,
+                "issue": {"id": self.group.id, "title": "test"},
+                "repos": [],
+            },
+            updated_at=datetime.now(),
+            status=AutofixStatus.PROCESSING,
+        )
+        mock_get_autofix_state.return_value = existing_state
+
+        self.operator.trigger_autofix(
+            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+        )
+
+        mock_trigger_autofix_helper.assert_not_called()
+        assert self.entrypoint.autofix_already_exists_states == [existing_state]
+        assert self.entrypoint.autofix_run_ids == []
+        assert self.entrypoint.autofix_errors == []
+
+    @patch(
+        "sentry.seer.entrypoints.operator._trigger_autofix",
+        return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
+    )
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state")
+    def test_trigger_autofix_proceeds_when_completed(
+        self, mock_get_autofix_state, mock_trigger_autofix_helper
+    ):
+        existing_state = AutofixState(
+            run_id=MOCK_RUN_ID,
+            request={
+                "organization_id": self.organization.id,
+                "project_id": self.project.id,
+                "issue": {"id": self.group.id, "title": "test"},
+                "repos": [],
+            },
+            updated_at=datetime.now(),
+            status=AutofixStatus.COMPLETED,
+        )
+        mock_get_autofix_state.return_value = existing_state
+
+        self.operator.trigger_autofix(
+            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+        )
+
+        mock_trigger_autofix_helper.assert_called_once()
+        assert self.entrypoint.autofix_already_exists_states == []
+        assert self.entrypoint.autofix_run_ids == [MOCK_RUN_ID]
+
+    @patch("sentry.seer.entrypoints.operator._trigger_autofix")
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
+    def test_trigger_autofix_error(self, _mock_get_autofix_state, mock_trigger_autofix_helper):
         mock_trigger_autofix_helper.return_value = Response(
             {"detail": "Invalid request"}, status=400
         )
@@ -156,9 +223,13 @@ class SeerOperatorTest(TestCase):
         "sentry.seer.entrypoints.operator._trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
     @patch("sentry.seer.entrypoints.cache.SeerOperatorAutofixCache.populate_post_autofix_cache")
     def test_trigger_autofix_creates_cache_payload(
-        self, mock_populate_post_autofix_cache, _mock_trigger_autofix_helper
+        self,
+        mock_populate_post_autofix_cache,
+        _mock_get_autofix_state,
+        _mock_trigger_autofix_helper,
     ):
         self.operator.trigger_autofix(
             group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
@@ -236,7 +307,10 @@ class SeerOperatorTest(TestCase):
         )
 
     @patch("sentry.seer.entrypoints.operator.update_autofix")
-    def test_solution_stopping_point_sends_select_root_cause(self, mock_update_autofix):
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
+    def test_solution_stopping_point_sends_select_root_cause(
+        self, _mock_get_autofix_state, mock_update_autofix
+    ):
         mock_update_autofix.return_value = Response({"run_id": MOCK_RUN_ID}, status=202)
 
         self.operator.trigger_autofix(


### PR DESCRIPTION
Editing the messages has caused some issues, and we cannot set the 'is being automated' state with confidence since seer makes its own determination to change outgoing messages.

Instead, we'll just attach the green button if autofix is available and they have the feature, then if a run is in progress, let the user know. Will look into editing messages in a follow up, but this feels like a better UX.