### PR TITLE
fix(mail): Apply enhanced privacy rules to activity notification emails

### DIFF
--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -171,7 +171,10 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
         return self.description_as_text(description, params, True, provider)
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
-        return f"{self.group.qualified_short_id} - {self.group.title}"
+        subject = f"{self.group.qualified_short_id}"
+        if not self.group.organization.flags.enhanced_privacy:
+            subject += f" - {self.group.title}"
+        return subject
 
     def description_as_text(
         self,

--- a/src/sentry/templates/sentry/emails/activity/generic.html
+++ b/src/sentry/templates/sentry/emails/activity/generic.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block preheader %}
-  {% if group %}
+  {% if group and not enhanced_privacy %}
     {% include "sentry/emails/_group.html" %}
   {% else %}
     {{ block.super }}
@@ -51,6 +51,11 @@
     <p>{{ html_description }}</p>
 
   {% endblock %}
+
+    {% if enhanced_privacy %}
+      <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
+        controls are enabled. For more details about this issue, <a href="{{ link }}">view this issue on Sentry</a>.</div>
+    {% endif %}
 
     {% if group and not enhanced_privacy %}
       {% include "sentry/emails/group_header.html" %}

--- a/src/sentry/templates/sentry/emails/activity/generic.txt
+++ b/src/sentry/templates/sentry/emails/activity/generic.txt
@@ -5,11 +5,15 @@
 {{ text_description }}
 
 
+{% if enhanced_privacy %}
+Details about this issue are not shown in this notification since enhanced privacy controls are enabled. For more details about this issue, view this issue on Sentry: {{ link }}
+{% else %}
 ## Issue Details
 
 {{ group.title }}
 
 {{ link }}
+{% endif %}
 {% include "sentry/emails/_suspect_commits.txt" %}{% if unsubscribe_link %}
 Unsubscribe: {{ unsubscribe_link }}{% endif %}
 

--- a/src/sentry/templates/sentry/emails/activity/generic.txt
+++ b/src/sentry/templates/sentry/emails/activity/generic.txt
@@ -4,7 +4,6 @@
 
 {{ text_description }}
 
-
 {% if enhanced_privacy %}
 Details about this issue are not shown in this notification since enhanced privacy controls are enabled. For more details about this issue, view this issue on Sentry: {{ link }}
 {% else %}
@@ -13,8 +12,7 @@ Details about this issue are not shown in this notification since enhanced priva
 {{ group.title }}
 
 {{ link }}
-{% endif %}
-{% include "sentry/emails/_suspect_commits.txt" %}{% if unsubscribe_link %}
+{% endif %}{% include "sentry/emails/_suspect_commits.txt" %}{% if unsubscribe_link %}
 Unsubscribe: {{ unsubscribe_link }}{% endif %}
 
 {% endautoescape %}

--- a/tests/sentry/notifications/notifications/organization_request/test_invite_request.py
+++ b/tests/sentry/notifications/notifications/organization_request/test_invite_request.py
@@ -1,0 +1,28 @@
+from django.core import mail
+
+from sentry.notifications.notifications.organization_request.invite_request import (
+    InviteRequestNotification,
+)
+from sentry.testutils.cases import TestCase
+
+
+class TestInviteRequestNotification(TestCase):
+    def test_sanitizes_periods_in_inviter_name(self) -> None:
+        owner = self.create_user("owner@example.com")
+        org = self.create_organization(owner=owner)
+        inviter = self.create_user(name="evil.com")
+        self.create_member(user=inviter, organization=org)
+
+        pending_member = self.create_member(
+            organization=org, email="newuser@example.com", role="member", inviter_id=inviter.id
+        )
+
+        notification = InviteRequestNotification(pending_member, inviter)
+
+        with self.tasks():
+            notification.send()
+
+        assert len(mail.outbox) == 1
+        # get_salutation_name() capitalizes the first letter
+        assert "Evil.com" not in mail.outbox[0].body
+        assert "Evil\u2060.com" in mail.outbox[0].body


### PR DESCRIPTION
When enhanced_privacy is enabled, activity emails (regression, etc.) still leaked sensitive information via the preheader, text body, and subject line. Hide group details behind the enhanced_privacy flag.

https://linear.app/getsentry/issue/RTC-736/apply-enhanced-security-email-rules-to-regression-emails

<!-- Describe your PR here. -->