### PR TITLE
feat(uptime): Register uptime-ai-assertion-suggestions feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -559,6 +559,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:unlimited-auto-triggered-autofix-runs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables view hierarchy attachment scrubbing
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable AI-powered assertion suggestions for uptime monitors
+    manager.add("organizations:uptime-ai-assertion-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable email notifications when auto-detected uptime monitors graduate from onboarding
     manager.add("organizations:uptime-auto-detected-monitor-emails", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable task-based retry for out-of-order uptime results


### PR DESCRIPTION
## Summary
- Registers a new dedicated FLAGPOLE feature flag `uptime-ai-assertion-suggestions` for AI-powered assertion suggestions on uptime monitors
- Enables independent rollout control separate from the broad `gen-ai-features` flag
- Frontend usage is on branch `jaygoss/uptime-assertions-ai`

## Test plan
- [ ] Verify flag registration by checking `sentry features list` includes the new flag
- [ ] Confirm `api_expose=True` allows frontend to access the flag