### PR TITLE
ref(seer): Replace requests library with urllib3 connection pools

### DIFF
--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TypedDict
 
-import requests
-from django.conf import settings
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
@@ -15,7 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 from sentry.utils.cache import cache
@@ -84,23 +85,23 @@ class SeerModelsEndpoint(Endpoint):
         path = "/v1/models"
 
         try:
-            response = requests.get(
-                f"{settings.SEER_AUTOFIX_URL}{path}",
-                headers={
-                    "content-type": "application/json;charset=utf-8",
-                    **sign_with_seer_secret(b""),
-                },
+            response = make_signed_seer_api_request(
+                seer_autofix_default_connection_pool,
+                path,
+                b"",
                 timeout=5,
+                method="GET",
             )
-            response.raise_for_status()
+            if response.status >= 400:
+                raise Exception(f"Seer request failed with status {response.status}")
 
             data = response.json()
             cache.set(SEER_MODELS_CACHE_KEY, data, SEER_MODELS_CACHE_TIMEOUT)
             return Response(data, status=200)
 
-        except requests.exceptions.Timeout:
+        except TimeoutError:
             logger.warning("Timeout when fetching models from Seer")
             raise SeerTimeoutError()
-        except (requests.exceptions.RequestException, json.JSONDecodeError):
+        except (Exception, json.JSONDecodeError):
             logger.exception("Error fetching models from Seer")
             raise SeerConnectionError()

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -6,9 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import orjson
-import requests
 import sentry_sdk
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
 from rest_framework.response import Response
@@ -33,10 +31,11 @@ from sentry.seer.autofix.types import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    autofix_connection_pool,
     get_autofix_repos_from_project_code_mappings,
 )
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.ourlogs import OurLogs
@@ -464,16 +463,14 @@ def _call_autofix(
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        autofix_connection_pool,
+        path,
+        body,
     )
 
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
     return response.json().get("run_id")
 
@@ -721,15 +718,13 @@ def update_autofix(
     path = "/v1/automation/autofix/update"
     data = AutofixUpdateRequest(organization_id=organization_id, run_id=run_id, payload=payload)
     body = orjson.dumps(data)
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={"content-type": "application/json;charset=utf-8", **sign_with_seer_secret(body)},
+    response = make_signed_seer_api_request(
+        autofix_connection_pool,
+        path,
+        body,
     )
 
-    try:
-        response.raise_for_status()
-    except Exception:
+    if response.status >= 400:
         return Response({"detail": "Failed to update autofix run"}, status=500)
 
     try:

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from typing import Any
 
 import orjson
-import requests
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -26,6 +25,7 @@ from sentry.seer.autofix.constants import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    autofix_connection_pool,
     get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
@@ -34,7 +34,10 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
-from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_summarization_default_connection_pool,
+)
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.base import instrumented_task
@@ -86,16 +89,15 @@ def _fetch_user_preference(project_id: int) -> str | None:
         path = "/v1/project-preference"
         body = orjson.dumps({"project_id": project_id})
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
             timeout=5,
         )
-        response.raise_for_status()
+
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         result = response.json()
         preference = result.get("preference")
@@ -253,16 +255,15 @@ def _call_seer(
     )
 
     # Route to summarization URL
-    response = requests.post(
-        f"{settings.SEER_SUMMARIZATION_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        path,
+        body,
         timeout=30,
     )
-    response.raise_for_status()
+
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
     return SummarizeIssueResponse.validate(response.json())
 

--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -4,10 +4,11 @@ import logging
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_anomaly_detection_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +35,11 @@ def compare_distributions(
             "meta": meta,
         }
     )
-    response = requests.post(
-        f"{settings.SEER_ANOMALY_DETECTION_URL}/v1/workflows/compare/cohort",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_anomaly_detection_default_connection_pool,
+        "/v1/workflows/compare/cohort",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import orjson
-import requests
 import sentry_sdk
 from django.conf import settings
 from rest_framework.request import Request
@@ -27,7 +26,10 @@ from sentry.seer.autofix.utils import (
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -84,16 +86,14 @@ def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         repos_and_access.append({**repo, "ok": response.json().get("has_access", False)})
 

--- a/src/sentry/seer/endpoints/group_autofix_update.py
+++ b/src/sentry/seer/endpoints/group_autofix_update.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
@@ -16,11 +15,12 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
-
-from rest_framework.request import Request
 
 
 @region_silo_endpoint
@@ -60,16 +60,14 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         group.update(seer_autofix_last_triggered=timezone.now())
 

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,7 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +49,14 @@ def generate_title_from_query(query: str) -> str | None:
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/llm/generate",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/llm/generate",
+        body,
         timeout=10,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     data = response.json()
     return data.get("content")
 
@@ -100,7 +99,7 @@ class IssueViewTitleGenerateEndpoint(OrganizationEndpoint):
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
             return Response({"title": title.strip()})
-        except requests.RequestException:
+        except Exception:
             logger.exception("Failed to call Seer LLM proxy")
             return Response(
                 {"detail": "Failed to generate title"},

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -14,7 +12,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,13 @@ class OrganizationSeerExplorerUpdateEndpoint(OrganizationEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         return Response(status=202, data=response.json())

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,7 +16,10 @@ from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.seer.models import PreferenceResponse, SeerProjectPreference
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -141,16 +142,14 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         return Response(status=204)
 
@@ -162,16 +161,14 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         result = response.json()
 

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -19,9 +18,20 @@ from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.explorer.client_utils import collect_user_org_context
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class SeerHTTPError(Exception):
+    """Exception raised when Seer API returns an HTTP error status."""
+
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        super().__init__(message)
 
 
 class SearchAgentStartSerializer(serializers.Serializer):
@@ -91,16 +101,14 @@ def send_search_agent_start_request(
 
     body = orjson.dumps(body_dict)
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/start",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/start",
+        body,
         timeout=30,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise SeerHTTPError(response.status, f"Seer request failed with status {response.status}")
     return response.json()
 
 
@@ -200,13 +208,13 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
             # Return the run_id for polling
             return Response({"run_id": run_id})
 
-        except requests.HTTPError as e:
+        except SeerHTTPError as e:
             logger.exception(
                 "search_agent.start_error",
                 extra={
                     "organization_id": organization.id,
                     "project_ids": project_ids,
-                    "status_code": e.response.status_code if e.response is not None else None,
+                    "status_code": e.status_code,
                 },
             )
             return Response(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
@@ -18,7 +17,10 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,16 +33,14 @@ def fetch_search_agent_state(run_id: int, organization_id: int) -> dict[str, Any
     """
     body = orjson.dumps({"run_id": run_id, "organization_id": organization_id})
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/state",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/state",
+        body,
         timeout=10,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 
@@ -119,24 +119,6 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
             # Return the session data directly from Seer
             return Response(data)
 
-        except requests.HTTPError as e:
-            if e.response is not None and e.response.status_code == 404:
-                logger.warning(
-                    "search_agent.state_not_found",
-                    extra={"run_id": run_id_int},
-                )
-                return Response(
-                    {"session": None},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-            logger.exception(
-                "search_agent.state_error",
-                extra={"run_id": run_id_int},
-            )
-            return Response(
-                {"detail": "Failed to fetch run state"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
         except Exception:
             logger.exception(
                 "search_agent.state_error",

--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
@@ -17,7 +16,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +39,13 @@ def send_translate_request(
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/translate",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.exceptions import ParseError
@@ -16,7 +15,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,15 +43,13 @@ def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/create-cache",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/create-cache",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
 
 @region_silo_endpoint

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -18,7 +17,10 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,15 +84,13 @@ def send_translate_agentic_request(
 
     body = orjson.dumps(body_dict)
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/translate-agentic",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate-agentic",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -5,13 +5,12 @@ import time
 from typing import Any, Literal
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from pydantic import BaseModel
 from rest_framework.request import Request
 
 from sentry.models.organization import Organization
+from sentry.seer.autofix.utils import autofix_connection_pool
 from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
@@ -26,7 +25,7 @@ from sentry.seer.explorer.on_completion_hook import (
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -293,16 +292,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
         return result["run_id"]
 
@@ -372,16 +369,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
         return result["run_id"]
 
@@ -460,16 +455,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
 
         runs = [ExplorerRun(**run) for run in result.get("data", [])]
@@ -512,15 +505,13 @@ class SeerExplorerClient:
             },
         }
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         # Poll until PR creation completes
         start_time = time.time()

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -12,8 +12,6 @@ import time
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 
@@ -22,9 +20,10 @@ from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.seer.autofix.utils import autofix_connection_pool
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User as SentryUser
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user_option import user_option_service
@@ -131,16 +130,14 @@ def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        autofix_connection_pool,
+        path,
+        body,
     )
 
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     data = response.json()
 
     session = data.get("session")

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import logging
-from random import random
 from typing import Any
 from urllib.parse import urlparse
 
@@ -9,10 +8,24 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
-from sentry import options
+from sentry.net.http import connection_from_url
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+# Default connection pools for different Seer services
+# These can be reused across multiple requests to the same service
+seer_autofix_default_connection_pool = connection_from_url(
+    settings.SEER_AUTOFIX_URL,
+)
+
+seer_summarization_default_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+)
+
+seer_anomaly_detection_default_connection_pool = connection_from_url(
+    settings.SEER_ANOMALY_DETECTION_URL,
+)
 
 
 @sentry_sdk.tracing.trace
@@ -23,6 +36,7 @@ def make_signed_seer_api_request(
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
     metric_tags: dict[str, Any] | None = None,
+    method: str = "POST",
 ) -> BaseHTTPResponse:
     host = connection_pool.host
     if connection_pool.port:
@@ -45,7 +59,7 @@ def make_signed_seer_api_request(
         tags={"endpoint": parsed.path, **(metric_tags or {})},
     ):
         return connection_pool.urlopen(
-            "POST",
+            method,
             parsed.path,
             body=body,
             headers={"content-type": "application/json;charset=utf-8", **auth_headers},
@@ -55,16 +69,16 @@ def make_signed_seer_api_request(
 
 def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     auth_headers: dict[str, str] = {}
-    if random() < options.get("seer.api.use-shared-secret"):
-        if settings.SEER_API_SHARED_SECRET:
-            signature = hmac.new(
-                settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-                body,
-                hashlib.sha256,
-            ).hexdigest()
-            auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
-        else:
-            logger.warning(
-                "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
-            )
+    if settings.SEER_API_SHARED_SECRET:
+        signature = hmac.new(
+            settings.SEER_API_SHARED_SECRET.encode("utf-8"),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
+    else:
+        # TODO(jstanley): remove this once the shared secret is confirmed to always be set
+        logger.warning(
+            "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
+        )
     return auth_headers

--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 
 def trigger_supergroups_embedding(
@@ -21,13 +22,11 @@ def trigger_supergroups_embedding(
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        path,
+        body,
         timeout=5,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -3,15 +3,16 @@ from datetime import timedelta
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.organization import Organization
 from sentry.seer.models import SummarizeTraceResponse
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_summarization_default_connection_pool,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.cache import cache
@@ -80,14 +81,12 @@ def _call_seer(
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = requests.post(
-        f"{settings.SEER_SUMMARIZATION_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        path,
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
     return SummarizeTraceResponse.validate(response.json())

--- a/src/sentry/tasks/seer.py
+++ b/src/sentry/tasks/seer.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
@@ -40,15 +41,13 @@ def cleanup_seer_repository_preferences(
     )
 
     try:
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         logger.info(
             "cleanup_seer_repository_preferences.success",
             extra={

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -5,16 +5,17 @@ from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta
 
 import orjson
-import requests
 import sentry_sdk
-from django.conf import settings
 from django.utils import timezone as django_timezone
 
 from sentry import features, options
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.options.rollout import in_rollout_group
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.statistical_detectors import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
@@ -227,17 +228,15 @@ def run_explorer_index_for_projects(
     path = "/v1/automation/explorer/index"
 
     try:
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
             timeout=30,
         )
-        response.raise_for_status()
-    except requests.RequestException as e:
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
+    except Exception as e:
         logger.exception(
             "Failed to schedule explorer index tasks in seer",
             extra={


### PR DESCRIPTION
Replace direct usage of the requests library with make_signed_seer_api_request()
using urllib3 connection pools across all Seer integration code. This centralizes
HTTP client configuration and enables connection pooling for better performance.

Previously, each Seer endpoint and client made direct requests using the requests
library, which scattered HTTP configuration across 22 files and didn't support
connection pooling. By consolidating all HTTP calls through a single function with
reusable connection pools, we gain reduced latency, centralized authentication, and
consistent error handling across all Seer API calls.