### PR TITLE
fix(seer): Fix Seer onboarding so that users get to the Code-Review step first when its needed

### DIFF
--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useSeerOnboardingStep.tsx
@@ -21,10 +21,10 @@ export function useSeerOnboardingStep(): {initialStep: Steps; isPending: boolean
     if (hasSupportedScmIntegration) {
       if (isAutofixEnabled && isCodeReviewEnabled) {
         initialStep = Steps.WRAP_UP; // Next steps
-      } else if (!isAutofixEnabled || shouldShowConfigReminder) {
-        initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
       } else if (!isCodeReviewEnabled) {
         initialStep = Steps.SETUP_CODE_REVIEW; // Setup Code Review
+      } else if (!isAutofixEnabled || shouldShowConfigReminder) {
+        initialStep = Steps.SETUP_ROOT_CAUSE_ANALYSIS; // Setup Root Cause Analysis
       }
     } else {
       initialStep = Steps.CONNECT_GITHUB; // Connect GitHub


### PR DESCRIPTION
The order on the screen has Code Review before RCA, so we should return it first if that step is needed

<img width="922" height="612" alt="SCR-20260212-mogh" src="https://github.com/user-attachments/assets/2b3ea784-7dad-4c57-aa3f-7f51febe8e40" />

I broke this last week with #107703