### PR TITLE
feat(preprod): Allow staff to rerun size analysis comparisons

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from django.db import router, transaction
+from django.db import models, router, transaction
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,6 +11,10 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.exceptions import StaffRequired
+from sentry.auth.staff import has_staff_option, is_active_staff
+from sentry.auth.superuser import is_active_superuser
+from sentry.models.files.file import File
 from sentry.models.project import Project
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
@@ -38,6 +42,26 @@ from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 
 logger = logging.getLogger(__name__)
+
+
+def _delete_existing_comparisons(
+    comparisons_qs: models.QuerySet[PreprodArtifactSizeComparison],
+) -> tuple[int, int]:
+    comparisons = list(comparisons_qs)
+    file_ids = [c.file_id for c in comparisons if c.file_id is not None]
+
+    comparison_ids = [c.id for c in comparisons]
+    using = router.db_for_write(PreprodArtifactSizeComparison)
+    with transaction.atomic(using=using):
+        comparisons_deleted, _ = PreprodArtifactSizeComparison.objects.filter(
+            id__in=comparison_ids
+        ).delete()
+
+    files_deleted = 0
+    if file_ids:
+        files_deleted, _ = File.objects.filter(id__in=file_ids).delete()
+
+    return comparisons_deleted, files_deleted
 
 
 @region_silo_endpoint
@@ -360,40 +384,56 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             base_size_analysis__in=base_size_metrics,
         )
         if existing_comparisons.exists():
-            # Build SizeAnalysisComparison models for each existing comparison
-            comparison_models = []
-            for comparison in existing_comparisons:
-                comparison_models.append(
-                    SizeAnalysisComparison(
-                        head_size_metric_id=comparison.head_size_analysis.id,
-                        base_size_metric_id=comparison.base_size_analysis.id,
-                        metrics_artifact_type=comparison.head_size_analysis.metrics_artifact_type,
-                        identifier=comparison.head_size_analysis.identifier,
-                        state=comparison.state,
-                        comparison_id=(
-                            comparison.id
-                            if comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
-                            else None
-                        ),
-                        error_code=(
-                            str(comparison.error_code)
-                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
-                            and comparison.error_code is not None
-                            else None
-                        ),
-                        error_message=(
-                            comparison.error_message
-                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
-                            else None
-                        ),
-                    )
+            if is_active_superuser(request) or is_active_staff(request):
+                comparisons_deleted, files_deleted = _delete_existing_comparisons(
+                    existing_comparisons
                 )
-            body = SizeAnalysisComparePOSTResponse(
-                status="exists",
-                message="A comparison already exists for the head and base size metrics.",
-                comparisons=comparison_models,
-            )
-            return Response(body.dict(), status=200)
+                logger.info(
+                    "preprod.size_analysis.compare.api.post.rerun_deleted_existing",
+                    extra={
+                        "head_artifact_id": head_artifact.id,
+                        "base_artifact_id": base_artifact.id,
+                        "comparisons_deleted": comparisons_deleted,
+                        "files_deleted": files_deleted,
+                        "user_id": request.user.id,
+                    },
+                )
+            elif has_staff_option(request.user):
+                raise StaffRequired
+            else:
+                comparison_models = []
+                for comparison in existing_comparisons:
+                    comparison_models.append(
+                        SizeAnalysisComparison(
+                            head_size_metric_id=comparison.head_size_analysis.id,
+                            base_size_metric_id=comparison.base_size_analysis.id,
+                            metrics_artifact_type=comparison.head_size_analysis.metrics_artifact_type,
+                            identifier=comparison.head_size_analysis.identifier,
+                            state=comparison.state,
+                            comparison_id=(
+                                comparison.id
+                                if comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+                                else None
+                            ),
+                            error_code=(
+                                str(comparison.error_code)
+                                if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                                and comparison.error_code is not None
+                                else None
+                            ),
+                            error_message=(
+                                comparison.error_message
+                                if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                                else None
+                            ),
+                        )
+                    )
+                body = SizeAnalysisComparePOSTResponse(
+                    status="exists",
+                    message="A comparison already exists for the head and base size metrics.",
+                    comparisons=comparison_models,
+                )
+                return Response(body.dict(), status=200)
 
         logger.info(
             "preprod.size_analysis.compare.api.post.creating_pending_comparisons",

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -2,13 +2,20 @@ import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import {
+  fetchMutation,
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+  type UseApiQueryResult,
+} from 'sentry/utils/queryClient';
 import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -18,6 +25,25 @@ import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/he
 import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+
+type ErrorDetail = string | {code?: string; message?: string} | null | undefined;
+
+function handleStaffPermissionError(responseDetail: ErrorDetail) {
+  if (typeof responseDetail !== 'string' && responseDetail?.code === 'staff-required') {
+    addErrorMessage(
+      t(
+        'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
+      )
+    );
+    setTimeout(() => {
+      window.location.href = '/_admin/';
+    }, 2000);
+    return;
+  }
+
+  addErrorMessage(t('Access denied. You may need to re-authenticate as staff.'));
+}
 
 export default function BuildComparison() {
   const organization = useOrganization();
@@ -54,6 +80,38 @@ export default function BuildComparison() {
         enabled: !!projectId && !!headArtifactId,
       }
     );
+
+  const compareUrl = getCompareApiUrl({
+    organizationSlug: organization.slug,
+    projectId,
+    headArtifactId: headArtifactId!,
+    baseArtifactId: baseArtifactId!,
+  });
+
+  const queryClient = useQueryClient();
+  const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
+    void,
+    RequestError
+  >({
+    mutationFn: () => {
+      return fetchMutation({url: compareUrl, method: 'POST'});
+    },
+    onSuccess: (response: any) => {
+      if (response?.status === 'exists') {
+        addErrorMessage(t('Comparison already exists'));
+      } else {
+        addSuccessMessage(t('Comparison rerun triggered'));
+      }
+      queryClient.invalidateQueries({queryKey: [compareUrl]});
+    },
+    onError: (error: RequestError) => {
+      if (error.status === 403) {
+        handleStaffPermissionError(error.responseJSON?.detail as ErrorDetail);
+        return;
+      }
+      addErrorMessage(t('Failed to rerun comparison'));
+    },
+  });
 
   if (headBuildDetailsQuery.isLoading) {
     return (
@@ -103,6 +161,10 @@ export default function BuildComparison() {
           <BuildCompareHeaderContent
             buildDetails={headBuildDetailsQuery.data}
             projectId={projectId}
+            headArtifactId={headArtifactId}
+            baseArtifactId={baseArtifactId}
+            onRerunComparison={() => rerunComparison()}
+            isRerunning={isRerunning}
           />
         </Layout.Header>
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -41,7 +41,10 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
-import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {
+  getCompareApiUrl,
+  getCompareBuildPath,
+} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -113,10 +116,13 @@ export function SizeCompareSelectionContent({
   >({
     mutationFn: ({headArtifactId, baseArtifactId}) => {
       return api.requestPromise(
-        `/projects/${organization.slug}/${projectId}/preprodartifacts/size-analysis/compare/${headArtifactId}/${baseArtifactId}/`,
-        {
-          method: 'POST',
-        }
+        getCompareApiUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId,
+          baseArtifactId,
+        }),
+        {method: 'POST'}
       );
     },
     onSuccess: () => {

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -48,6 +48,16 @@ export function getListBuildPath(params: {
   return `/organizations/${organizationSlug}/preprod/?project=${projectId}`;
 }
 
+export function getCompareApiUrl(params: {
+  baseArtifactId: string;
+  headArtifactId: string;
+  organizationSlug: string;
+  projectId: string;
+}): string {
+  const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
+  return `/projects/${organizationSlug}/${projectId}/preprodartifacts/size-analysis/compare/${headArtifactId}/${baseArtifactId}/`;
+}
+
 export function formatBuildName(
   version: string | number | null | undefined,
   buildNumber: string | number | null | undefined


### PR DESCRIPTION
Allow staff/superuser users to force-rerun size analysis comparisons that already exist via a new admin-only action in the build comparison header.

**Backend**: When a staff/superuser POSTs to the comparison endpoint and comparisons already exist, the endpoint now deletes the existing comparisons (and their associated `File` objects) and falls through to re-create them. Users with the staff option but not actively authenticated as staff get a `StaffRequired` error prompting re-authentication. Regular users continue to see the existing "already exists" response.

**Frontend**: Adds an admin-only "More actions" dropdown (visible to Sentry employees via `useIsSentryEmployee`) with a "Rerun Comparison" action. The mutation handles staff permission errors by redirecting to `/_admin/` for re-authentication and differentiates "exists" responses from successful reruns with appropriate toast messages. Also centralizes the comparison API URL construction into a shared `getCompareApiUrl` utility, deduplicating it across `buildComparison.tsx`, `sizeCompareMainContent.tsx`, and `sizeCompareSelectionContent.tsx`.