### PR TITLE
feat(preprod): [Backend] Allow staff to rerun size analysis comparisons

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -254,7 +254,9 @@ def cleanup_old_metrics(preprod_artifact: PreprodArtifact) -> CleanupStats:
             ).delete()
 
         if file_ids_to_delete:
-            stats.files_total_deleted, _ = File.objects.filter(id__in=file_ids_to_delete).delete()
+            for file in File.objects.filter(id__in=file_ids_to_delete):
+                file.delete()
+                stats.files_total_deleted += 1
 
     PreprodArtifactSizeMetrics.objects.create(
         preprod_artifact=preprod_artifact,

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -14,7 +14,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import StaffRequired
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
-from sentry.models.files.file import File
 from sentry.models.project import Project
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
@@ -48,7 +47,7 @@ def _delete_existing_comparisons(
     comparisons_qs: models.QuerySet[PreprodArtifactSizeComparison],
 ) -> tuple[int, int]:
     comparisons = list(comparisons_qs)
-    file_ids = [c.file_id for c in comparisons if c.file_id is not None]
+    files = [c.file for c in comparisons if c.file_id is not None]
 
     comparison_ids = [c.id for c in comparisons]
     with transaction.atomic(using=router.db_for_write(PreprodArtifactSizeComparison)):
@@ -57,8 +56,9 @@ def _delete_existing_comparisons(
         ).delete()
 
         files_deleted = 0
-        if file_ids:
-            files_deleted, _ = File.objects.filter(id__in=file_ids).delete()
+        for file in files:
+            file.delete()
+            files_deleted += 1
 
     return comparisons_deleted, files_deleted
 

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -14,6 +14,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.exceptions import StaffRequired
 from sentry.auth.staff import is_active_staff
 from sentry.auth.superuser import is_active_superuser
+from sentry.models.files.file import File
 from sentry.models.project import Project
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
@@ -47,7 +48,8 @@ def _delete_existing_comparisons(
     comparisons_qs: models.QuerySet[PreprodArtifactSizeComparison],
 ) -> tuple[int, int]:
     comparisons = list(comparisons_qs)
-    files = [c.file for c in comparisons if c.file_id is not None]
+    file_ids = [c.file_id for c in comparisons if c.file_id is not None]
+    files = list(File.objects.filter(id__in=file_ids))
 
     comparison_ids = [c.id for c in comparisons]
     with transaction.atomic(using=router.db_for_write(PreprodArtifactSizeComparison)):

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from django.db import router, transaction
+from django.db import models, router, transaction
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -11,6 +11,10 @@ from sentry import analytics, features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
+from sentry.api.exceptions import StaffRequired
+from sentry.auth.staff import is_active_staff
+from sentry.auth.superuser import is_active_superuser
+from sentry.models.files.file import File
 from sentry.models.project import Project
 from sentry.preprod.analytics import (
     PreprodArtifactApiSizeAnalysisCompareGetEvent,
@@ -38,6 +42,24 @@ from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
 
 logger = logging.getLogger(__name__)
+
+
+def _delete_existing_comparisons(
+    comparisons_qs: models.QuerySet[PreprodArtifactSizeComparison],
+) -> tuple[int, int]:
+    comparisons = list(comparisons_qs)
+    file_ids = [c.file_id for c in comparisons if c.file_id is not None]
+
+    comparison_ids = [c.id for c in comparisons]
+    comparisons_deleted, _ = PreprodArtifactSizeComparison.objects.filter(
+        id__in=comparison_ids
+    ).delete()
+
+    files_deleted = 0
+    if file_ids:
+        files_deleted, _ = File.objects.filter(id__in=file_ids).delete()
+
+    return comparisons_deleted, files_deleted
 
 
 @region_silo_endpoint
@@ -360,40 +382,56 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             base_size_analysis__in=base_size_metrics,
         )
         if existing_comparisons.exists():
-            # Build SizeAnalysisComparison models for each existing comparison
-            comparison_models = []
-            for comparison in existing_comparisons:
-                comparison_models.append(
-                    SizeAnalysisComparison(
-                        head_size_metric_id=comparison.head_size_analysis.id,
-                        base_size_metric_id=comparison.base_size_analysis.id,
-                        metrics_artifact_type=comparison.head_size_analysis.metrics_artifact_type,
-                        identifier=comparison.head_size_analysis.identifier,
-                        state=comparison.state,
-                        comparison_id=(
-                            comparison.id
-                            if comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
-                            else None
-                        ),
-                        error_code=(
-                            str(comparison.error_code)
-                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
-                            and comparison.error_code is not None
-                            else None
-                        ),
-                        error_message=(
-                            comparison.error_message
-                            if comparison.state == PreprodArtifactSizeComparison.State.FAILED
-                            else None
-                        ),
-                    )
+            if is_active_superuser(request) or is_active_staff(request):
+                comparisons_deleted, files_deleted = _delete_existing_comparisons(
+                    existing_comparisons
                 )
-            body = SizeAnalysisComparePOSTResponse(
-                status="exists",
-                message="A comparison already exists for the head and base size metrics.",
-                comparisons=comparison_models,
-            )
-            return Response(body.dict(), status=200)
+                logger.info(
+                    "preprod.size_analysis.compare.api.post.rerun_deleted_existing",
+                    extra={
+                        "head_artifact_id": head_artifact.id,
+                        "base_artifact_id": base_artifact.id,
+                        "comparisons_deleted": comparisons_deleted,
+                        "files_deleted": files_deleted,
+                        "user_id": request.user.id,
+                    },
+                )
+            elif request.user.is_staff:
+                raise StaffRequired
+            else:
+                comparison_models = []
+                for comparison in existing_comparisons:
+                    comparison_models.append(
+                        SizeAnalysisComparison(
+                            head_size_metric_id=comparison.head_size_analysis.id,
+                            base_size_metric_id=comparison.base_size_analysis.id,
+                            metrics_artifact_type=comparison.head_size_analysis.metrics_artifact_type,
+                            identifier=comparison.head_size_analysis.identifier,
+                            state=comparison.state,
+                            comparison_id=(
+                                comparison.id
+                                if comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+                                else None
+                            ),
+                            error_code=(
+                                str(comparison.error_code)
+                                if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                                and comparison.error_code is not None
+                                else None
+                            ),
+                            error_message=(
+                                comparison.error_message
+                                if comparison.state == PreprodArtifactSizeComparison.State.FAILED
+                                else None
+                            ),
+                        )
+                    )
+                body = SizeAnalysisComparePOSTResponse(
+                    status="exists",
+                    message="A comparison already exists for the head and base size metrics.",
+                    comparisons=comparison_models,
+                )
+                return Response(body.dict(), status=200)
 
         logger.info(
             "preprod.size_analysis.compare.api.post.creating_pending_comparisons",

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -51,13 +51,14 @@ def _delete_existing_comparisons(
     file_ids = [c.file_id for c in comparisons if c.file_id is not None]
 
     comparison_ids = [c.id for c in comparisons]
-    comparisons_deleted, _ = PreprodArtifactSizeComparison.objects.filter(
-        id__in=comparison_ids
-    ).delete()
+    with transaction.atomic(using=router.db_for_write(PreprodArtifactSizeComparison)):
+        comparisons_deleted, _ = PreprodArtifactSizeComparison.objects.filter(
+            id__in=comparison_ids
+        ).delete()
 
-    files_deleted = 0
-    if file_ids:
-        files_deleted, _ = File.objects.filter(id__in=file_ids).delete()
+        files_deleted = 0
+        if file_ids:
+            files_deleted, _ = File.objects.filter(id__in=file_ids).delete()
 
     return comparisons_deleted, files_deleted
 

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -80,7 +80,9 @@ def bulk_delete_artifacts(
     with transaction.atomic(using=router.db_for_write(PreprodArtifact)):
         files_deleted = 0
         if all_file_ids:
-            files_deleted, _ = File.objects.filter(id__in=all_file_ids).delete()
+            for file in File.objects.filter(id__in=all_file_ids):
+                file.delete()
+                files_deleted += 1
 
         _, deleted_by_model = PreprodArtifact.objects.filter(id__in=preprod_artifact_ids).delete()
 


### PR DESCRIPTION
Allow staff/superuser users to force-rerun size analysis comparisons that already exist via a new admin-only action in the build comparison header.

Backend: When a staff/superuser POSTs to the comparison endpoint and comparisons already exist, the endpoint now deletes the existing comparisons (and their associated File objects) and falls through to re-create them. Users with the staff option but not actively authenticated as staff get a StaffRequired error prompting re-authentication. Regular users continue to see the existing "already exists" response.