### PR TITLE
feat(preprod): [Frontend] Allow staff to rerun size analysis comparisons

### DIFF
--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -26,24 +26,10 @@ import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
-
-type ErrorDetail = string | {code?: string; message?: string} | null | undefined;
-
-function handleStaffPermissionError(responseDetail: ErrorDetail) {
-  if (typeof responseDetail !== 'string' && responseDetail?.code === 'staff-required') {
-    addErrorMessage(
-      t(
-        'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
-      )
-    );
-    setTimeout(() => {
-      window.location.href = '/_admin/';
-    }, 2000);
-    return;
-  }
-
-  addErrorMessage(t('Access denied. You may need to re-authenticate as staff.'));
-}
+import {
+  handleStaffPermissionError,
+  type StaffErrorDetail,
+} from 'sentry/views/preprod/utils/staffPermissionError';
 
 export default function BuildComparison() {
   const organization = useOrganization();
@@ -90,13 +76,13 @@ export default function BuildComparison() {
 
   const queryClient = useQueryClient();
   const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
-    void,
+    {status: string},
     RequestError
   >({
     mutationFn: () => {
       return fetchMutation({url: compareUrl, method: 'POST'});
     },
-    onSuccess: (response: any) => {
+    onSuccess: response => {
       if (response?.status === 'exists') {
         addErrorMessage(t('Comparison already exists'));
       } else {
@@ -106,7 +92,7 @@ export default function BuildComparison() {
     },
     onError: (error: RequestError) => {
       if (error.status === 403) {
-        handleStaffPermissionError(error.responseJSON?.detail as ErrorDetail);
+        handleStaffPermissionError(error.responseJSON?.detail as StaffErrorDetail);
         return;
       }
       addErrorMessage(t('Failed to rerun comparison'));

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -2,13 +2,20 @@ import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Placeholder from 'sentry/components/placeholder';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
+import {
+  fetchMutation,
+  useApiQuery,
+  useMutation,
+  useQueryClient,
+  type UseApiQueryResult,
+} from 'sentry/utils/queryClient';
 import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
@@ -18,6 +25,25 @@ import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/he
 import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
+
+type ErrorDetail = string | {code?: string; message?: string} | null | undefined;
+
+function handleStaffPermissionError(responseDetail: ErrorDetail) {
+  if (typeof responseDetail !== 'string' && responseDetail?.code === 'staff-required') {
+    addErrorMessage(
+      t(
+        'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
+      )
+    );
+    setTimeout(() => {
+      window.location.href = '/_admin/';
+    }, 2000);
+    return;
+  }
+
+  addErrorMessage(t('Access denied. You may need to re-authenticate as staff.'));
+}
 
 export default function BuildComparison() {
   const organization = useOrganization();
@@ -54,6 +80,38 @@ export default function BuildComparison() {
         enabled: !!projectId && !!headArtifactId,
       }
     );
+
+  const compareUrl = getCompareApiUrl({
+    organizationSlug: organization.slug,
+    projectId,
+    headArtifactId: headArtifactId!,
+    baseArtifactId: baseArtifactId!,
+  });
+
+  const queryClient = useQueryClient();
+  const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
+    void,
+    RequestError
+  >({
+    mutationFn: () => {
+      return fetchMutation({url: compareUrl, method: 'POST'});
+    },
+    onSuccess: (response: any) => {
+      if (response?.status === 'exists') {
+        addErrorMessage(t('Comparison already exists'));
+      } else {
+        addSuccessMessage(t('Comparison rerun triggered'));
+      }
+      queryClient.invalidateQueries({queryKey: [compareUrl]});
+    },
+    onError: (error: RequestError) => {
+      if (error.status === 403) {
+        handleStaffPermissionError(error.responseJSON?.detail as ErrorDetail);
+        return;
+      }
+      addErrorMessage(t('Failed to rerun comparison'));
+    },
+  });
 
   if (headBuildDetailsQuery.isLoading) {
     return (
@@ -103,6 +161,10 @@ export default function BuildComparison() {
           <BuildCompareHeaderContent
             buildDetails={headBuildDetailsQuery.data}
             projectId={projectId}
+            headArtifactId={headArtifactId}
+            baseArtifactId={baseArtifactId}
+            onRerunComparison={() => rerunComparison()}
+            isRerunning={isRerunning}
           />
         </Layout.Header>
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -41,7 +41,10 @@ import {
   type BuildDetailsApiResponse,
 } from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {ListBuildsApiResponse} from 'sentry/views/preprod/types/listBuildsTypes';
-import {getCompareBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {
+  getCompareApiUrl,
+  getCompareBuildPath,
+} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
   formattedPrimaryMetricDownloadSize,
   formattedPrimaryMetricInstallSize,
@@ -113,10 +116,13 @@ export function SizeCompareSelectionContent({
   >({
     mutationFn: ({headArtifactId, baseArtifactId}) => {
       return api.requestPromise(
-        `/projects/${organization.slug}/${projectId}/preprodartifacts/size-analysis/compare/${headArtifactId}/${baseArtifactId}/`,
-        {
-          method: 'POST',
-        }
+        getCompareApiUrl({
+          organizationSlug: organization.slug,
+          projectId,
+          headArtifactId,
+          baseArtifactId,
+        }),
+        {method: 'POST'}
       );
     },
     onSuccess: () => {

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -7,28 +7,11 @@ import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getListBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermissionError';
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
   projectId: string;
-}
-
-type ErrorDetail = string | {code?: string; message?: string} | null | undefined;
-
-function handleStaffPermissionError(responseDetail: ErrorDetail) {
-  if (typeof responseDetail !== 'string' && responseDetail?.code === 'staff-required') {
-    addErrorMessage(
-      t(
-        'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
-      )
-    );
-    setTimeout(() => {
-      window.location.href = '/_admin/';
-    }, 2000);
-    return;
-  }
-
-  addErrorMessage(t('Access denied. You may need to re-authenticate as staff.'));
 }
 
 export function useBuildDetailsActions({

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -48,6 +48,16 @@ export function getListBuildPath(params: {
   return `/organizations/${organizationSlug}/preprod/?project=${projectId}`;
 }
 
+export function getCompareApiUrl(params: {
+  baseArtifactId: string;
+  headArtifactId: string;
+  organizationSlug: string;
+  projectId: string;
+}): string {
+  const {organizationSlug, projectId, headArtifactId, baseArtifactId} = params;
+  return `/projects/${organizationSlug}/${projectId}/preprodartifacts/size-analysis/compare/${headArtifactId}/${baseArtifactId}/`;
+}
+
 export function formatBuildName(
   version: string | number | null | undefined,
   buildNumber: string | number | null | undefined

--- a/static/app/views/preprod/utils/staffPermissionError.ts
+++ b/static/app/views/preprod/utils/staffPermissionError.ts
@@ -1,0 +1,24 @@
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+
+export type StaffErrorDetail =
+  | string
+  | {code?: string; message?: string}
+  | null
+  | undefined;
+
+export function handleStaffPermissionError(responseDetail: StaffErrorDetail) {
+  if (typeof responseDetail !== 'string' && responseDetail?.code === 'staff-required') {
+    addErrorMessage(
+      t(
+        'Re-authenticate as staff first and then return to this page and try again. Redirecting...'
+      )
+    );
+    setTimeout(() => {
+      window.location.href = '/_admin/';
+    }, 2000);
+    return;
+  }
+
+  addErrorMessage(t('Access denied. You may need to re-authenticate as staff.'));
+}


### PR DESCRIPTION
Allow staff/superuser users to force-rerun size analysis comparisons that already exist via a new admin-only action in the build comparison header.

Frontend: Adds an admin-only "More actions" dropdown (visible to Sentry employees via useIsSentryEmployee) with a "Rerun Comparison" action. The mutation handles staff permission errors by redirecting to /_admin/ for re-authentication and differentiates "exists" responses from successful reruns with appropriate toast messages. Also centralizes the comparison API URL construction into a shared getCompareApiUrl utility, deduplicating it across buildComparison.tsx, sizeCompareMainContent.tsx, and sizeCompareSelectionContent.tsx.