### PR TITLE
fix(oauth): Add distributed lock to refresh token exchange to prevent race condition

### DIFF
--- a/src/sentry/sentry_apps/token_exchange/manual_refresher.py
+++ b/src/sentry/sentry_apps/token_exchange/manual_refresher.py
@@ -7,6 +7,7 @@ from django.utils.functional import cached_property
 from sentry import analytics
 from sentry.analytics.events.sentry_app_token_exchanged import SentryAppTokenExchangedEvent
 from sentry.hybridcloud.models.outbox import OutboxDatabaseError, OutboxFlushError
+from sentry.locks import locks
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.metrics import (
@@ -20,6 +21,7 @@ from sentry.sentry_apps.token_exchange.util import SENSITIVE_CHARACTER_LIMIT, to
 from sentry.sentry_apps.token_exchange.validator import Validator
 from sentry.sentry_apps.utils.errors import SentryAppIntegratorError, SentryAppSentryError
 from sentry.users.models.user import User
+from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger("sentry.token-exchange")
 
@@ -48,10 +50,33 @@ class ManualTokenRefresher:
             lifecycle.add_extras(context)
 
             try:
+                installation = self.installation
+                if installation.api_token is None:
+                    raise SentryAppIntegratorError(
+                        message="Installation does not have a token",
+                        status_code=401,
+                        webhook_context={"installation_uuid": self.install.uuid},
+                    )
+
+                lock = locks.get(
+                    ApiToken.get_lock_key(installation.api_token_id),
+                    duration=10,
+                    name="api_token_refresh",
+                )
+
+                try:
+                    lock_context = lock.acquire()
+                except UnableToAcquireLock:
+                    raise SentryAppIntegratorError(
+                        message="Token refresh already in progress",
+                        status_code=409,
+                        webhook_context=context,
+                    )
+
                 token = None
-                with transaction.atomic(router.db_for_write(ApiToken)):
+                with lock_context, transaction.atomic(router.db_for_write(ApiToken)):
                     self._validate()
-                    self._delete_existing_token()
+                    self.installation.api_token.delete()
 
                     token = self._create_new_token()
                     self._record_token_exchange()
@@ -74,17 +99,6 @@ class ManualTokenRefresher:
             except SentryAppIntegratorError as e:
                 lifecycle.record_halt(halt_reason=e)
                 raise
-
-    def _delete_existing_token(self) -> None:
-        # An installation must have a token to be refreshed
-        # Lack of token indicates the api grant hasn't been exchanged yet
-        if self.installation.api_token is None:
-            raise SentryAppIntegratorError(
-                message="Installation does not have a token",
-                status_code=401,
-                webhook_context={"installation_uuid": self.install.uuid},
-            )
-        self.installation.api_token.delete()
 
     def _record_token_exchange(self) -> None:
         analytics.record(

--- a/src/sentry/sentry_apps/token_exchange/manual_refresher.py
+++ b/src/sentry/sentry_apps/token_exchange/manual_refresher.py
@@ -73,11 +73,18 @@ class ManualTokenRefresher:
                         webhook_context=context,
                     )
 
+                original_token_id = installation.api_token_id
                 token = None
                 with lock_context, transaction.atomic(router.db_for_write(ApiToken)):
                     self._validate()
                     # Re-fetch to verify token still exists inside lock
                     installation.refresh_from_db()
+                    if installation.api_token_id != original_token_id:
+                        raise SentryAppIntegratorError(
+                            message="Token was already refreshed",
+                            status_code=409,
+                            webhook_context=context,
+                        )
                     if installation.api_token is None:
                         raise SentryAppIntegratorError(
                             message="Installation does not have a token",

--- a/src/sentry/sentry_apps/token_exchange/manual_refresher.py
+++ b/src/sentry/sentry_apps/token_exchange/manual_refresher.py
@@ -76,7 +76,15 @@ class ManualTokenRefresher:
                 token = None
                 with lock_context, transaction.atomic(router.db_for_write(ApiToken)):
                     self._validate()
-                    self.installation.api_token.delete()
+                    # Re-fetch to verify token still exists inside lock
+                    installation.refresh_from_db()
+                    if installation.api_token is None:
+                        raise SentryAppIntegratorError(
+                            message="Installation does not have a token",
+                            status_code=401,
+                            webhook_context={"installation_uuid": self.install.uuid},
+                        )
+                    installation.api_token.delete()
 
                     token = self._create_new_token()
                     self._record_token_exchange()

--- a/tests/sentry/sentry_apps/token_exchange/test_manual_refresher.py
+++ b/tests/sentry/sentry_apps/token_exchange/test_manual_refresher.py
@@ -314,6 +314,30 @@ class TestManualRefresher(TestCase):
         )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_race_condition_on_token_refresh(self, mock_record: MagicMock) -> None:
+        from sentry.locks import locks
+
+        lock = locks.get(
+            ApiToken.get_lock_key(self.token.id),
+            duration=10,
+            name="api_token_refresh",
+        )
+        lock.acquire()
+
+        with pytest.raises(SentryAppIntegratorError) as e:
+            self.refresher.run()
+
+        assert e.value.message == "Token refresh already in progress"
+        assert e.value.status_code == 409
+
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.STARTED, outcome_count=1
+        )
+        assert_count_of_metric(
+            mock_record=mock_record, outcome=EventLifecycleOutcome.HALTED, outcome_count=1
+        )
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_handles_installation_with_no_existing_token(self, mock_record: MagicMock) -> None:
         # Delete the existing token from the installation
         self.install.update(api_token=None)


### PR DESCRIPTION
Addresses VULN-724: concurrent refresh token requests could generate multiple valid access token/refresh token pairs. Applies the same lock pattern used for authorization code exchange to all three refresh token paths

https://linear.app/getsentry/issue/VULN-724/race-condition-for-access-tokenrefresh-token-generation-in-sentry
