### PR TITLE
feat(preprod): Add snapshots feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -368,6 +368,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod snapshots product feature
+    manager.add("organizations:preprod-snapshots", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables PR page
     manager.add("organizations:pr-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the playstation ingestion in relay


### PR DESCRIPTION
Register the `organizations:preprod-snapshots` feature flag to gate the
preprod snapshots product feature behind Flagpole with `api_expose=True`.

This enables frontend feature-gating for the upcoming snapshots visual
regression testing product within the preprod platform.

related flagpole PR: https://github.com/getsentry/sentry-options-automator/pull/6477