### PR TITLE
ref(explorer): remove esc keyboard shortcut for interruptRun

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -526,11 +526,8 @@ function ExplorerPanel() {
   }, [
     isVisible,
     isMenuOpen,
-    isPolling,
     readOnly,
     focusedBlockIndex,
-    interruptRun,
-    interruptRequested,
     isMinimized,
     isFileApprovalPending,
     isQuestionPending,

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -488,10 +488,7 @@ function ExplorerPanel() {
       const isPrintableChar = e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey;
 
       if (e.key === 'Escape') {
-        if (isPolling && !readOnly && !interruptRequested && !isFileApprovalPending) {
-          e.preventDefault();
-          interruptRun();
-        } else if (readOnly || !isFileApprovalPending) {
+        if (readOnly || !isFileApprovalPending) {
           // Don't minimize if file approval is pending (Escape is used to reject)
           e.preventDefault();
           setIsMinimized(true);


### PR DESCRIPTION
the esc key is so commonly used to minimize the panel, I often find myself accidentally interrupting my run instead, reopening my panel after a while to see it was stopped. I think the button is enough for interruptions