### PR TITLE
fix(api docs): Fix typo in API docs example

### DIFF
--- a/src/sentry/apidocs/examples/explore_saved_query_examples.py
+++ b/src/sentry/apidocs/examples/explore_saved_query_examples.py
@@ -98,7 +98,8 @@ SAVED_QUERIES = [
         "query": "span.op:cache.get",
         "fields": [
             "span.op",
-            "span.durationtimestamp",
+            "span.duration",
+            "timestamp",
         ],
         "range": "24h",
         "orderby": "-timestamp",


### PR DESCRIPTION
Fixing a typo in the `fields` list for this API docs example.