### PR TITLE
fix(storybook): rendering without type-loader

### DIFF
--- a/static/app/stories/moduleExports.tsx
+++ b/static/app/stories/moduleExports.tsx
@@ -5,7 +5,7 @@ import {Heading} from '@sentry/scraps/text';
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 
 export function ModuleExports(props: {exports: TypeLoader.TypeLoaderResult['exports']}) {
-  if (!props.exports?.exports) return null;
+  if (!props.exports?.exports || !props.exports.module) return null;
 
   const lines = [];
   // canonical source: @sentry/scraps/<component> (no deep imports)

--- a/static/app/types/type-loader.d.ts
+++ b/static/app/types/type-loader.d.ts
@@ -9,8 +9,8 @@ declare namespace TypeLoader {
   interface TypeLoaderResult {
     props?: Record<string, TypeLoader.ComponentDocWithFilename>;
     exports?: {
-      module: string;
-      exports: Record<string, {name: string; typeOnly: boolean}>;
+      module?: string;
+      exports?: Record<string, {name: string; typeOnly: boolean}>;
     };
   }
 }


### PR DESCRIPTION
mdx files are crashing locally when running with `pnpm run dev-ui`, it only works when run with `pnpm run dev-ui-storybook`, which sets `STORYBOOK_TYPES=1` and therefore takes a lot longer to start.

This PR fixes the runtime exception encountered when opening an mdx story when run without STORYBOOK_TYPES.