### PR TITLE
feat(preprod): Add Size Analysis detector

### DIFF
--- a/src/sentry/preprod/grouptype.py
+++ b/src/sentry/preprod/grouptype.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import sentry.preprod.size_analysis.grouptype  # noqa: F401,F403
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.types.group import PriorityLevel
+
+# We have to import sentry.preprod.size_analysis.grouptype above.
+# grouptype modules in root packages (src/sentry/*) are auto imported
+# but more deeply nested ones are not.
 
 
 @dataclass(frozen=True)

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone as dt_timezone
+from typing import Any, NotRequired, TypeAlias, TypedDict
+from uuid import uuid4
+
+from sentry.issues.grouptype import GroupCategory, GroupType
+from sentry.issues.issue_occurrence import IssueEvidence
+from sentry.types.group import PriorityLevel
+from sentry.utils import metrics
+from sentry.workflow_engine.endpoints.validators.base import BaseDetectorTypeValidator
+from sentry.workflow_engine.handlers.detector.base import (
+    BaseDetectorHandler,
+    DetectorOccurrence,
+    GroupedDetectorEvaluationResult,
+)
+from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.processors.data_condition_group import (
+    ProcessedDataConditionGroup,
+    process_data_condition_group,
+)
+from sentry.workflow_engine.types import (
+    DetectorEvaluationResult,
+    DetectorPriorityLevel,
+    DetectorSettings,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SizeAnalysisValue(TypedDict):
+    head_install_size_bytes: int
+    head_download_size_bytes: int
+    base_install_size_bytes: NotRequired[int | None]
+    base_download_size_bytes: NotRequired[int | None]
+
+
+SizeAnalysisDataPacket = DataPacket[SizeAnalysisValue]
+
+# The value extracted from a data packet and evaluated against conditions.
+# int for absolute values (bytes), float for relative diffs (ratios).
+SizeAnalysisEvaluation: TypeAlias = int | float
+
+
+class PreprodSizeAnalysisDetectorHandler(
+    BaseDetectorHandler[SizeAnalysisValue, SizeAnalysisEvaluation]
+):
+    def evaluate_impl(self, data_packet: SizeAnalysisDataPacket) -> GroupedDetectorEvaluationResult:
+        value = self.extract_value(data_packet)
+        evaluation, priority = self._evaluate_conditions(value)
+        if evaluation is None or priority is None:
+            return GroupedDetectorEvaluationResult(result={}, tainted=False)
+
+        detector_occurrence, event_data = self.create_occurrence(evaluation, data_packet, priority)
+        occurrence = detector_occurrence.to_issue_occurrence(
+            occurrence_id=event_data["event_id"],
+            project_id=self.detector.project_id,
+            status=priority,
+            additional_evidence_data={},
+            fingerprint=[uuid4().hex],
+        )
+        result = DetectorEvaluationResult(
+            group_key=None,
+            is_triggered=True,
+            priority=priority,
+            event_data=event_data,
+            result=occurrence,
+        )
+        return GroupedDetectorEvaluationResult(result={None: result}, tainted=False)
+
+    def _evaluate_conditions(
+        self, value: SizeAnalysisEvaluation
+    ) -> tuple[ProcessedDataConditionGroup | None, DetectorPriorityLevel | None]:
+        if not self.condition_group:
+            metrics.incr("workflow_engine.detector.skipping_invalid_condition_group")
+            return None, None
+
+        condition_evaluation, _ = process_data_condition_group(self.condition_group, value)
+        if not condition_evaluation.logic_result.triggered:
+            return None, None
+
+        priorities = [
+            condition_result.result
+            for condition_result in condition_evaluation.condition_results
+            if isinstance(condition_result.result, DetectorPriorityLevel)
+        ]
+        if not priorities:
+            return None, None
+
+        return condition_evaluation, max(priorities)
+
+    def _extract_head(self, data_packet: SizeAnalysisDataPacket) -> int:
+        measurement = self.detector.config["measurement"]
+        match measurement:
+            case "install_size":
+                return data_packet.packet["head_install_size_bytes"]
+            case "download_size":
+                return data_packet.packet["head_download_size_bytes"]
+            case _:
+                raise ValueError(f"Unknown measurement: {measurement}")
+
+    def _extract_base(self, data_packet: SizeAnalysisDataPacket) -> int:
+        measurement = self.detector.config["measurement"]
+        match measurement:
+            case "install_size":
+                base = data_packet.packet.get("base_install_size_bytes")
+            case "download_size":
+                base = data_packet.packet.get("base_download_size_bytes")
+            case _:
+                raise ValueError(f"Unknown measurement: {measurement}")
+        if base is None:
+            raise ValueError(f"Missing base value for measurement: {measurement}")
+        return base
+
+    def extract_value(self, data_packet: SizeAnalysisDataPacket) -> SizeAnalysisEvaluation:
+        threshold_type = self.detector.config["threshold_type"]
+        match threshold_type:
+            case "absolute_threshold":
+                return self._extract_head(data_packet)
+            case "absolute_diff":
+                return self._extract_head(data_packet) - self._extract_base(data_packet)
+            case "relative_diff":
+                base = self._extract_base(data_packet)
+                return (self._extract_head(data_packet) - base) / base
+            case _:
+                raise ValueError(f"Unknown threshold_type: {threshold_type}")
+
+    def create_occurrence(
+        self,
+        evaluation_result: ProcessedDataConditionGroup,
+        data_packet: SizeAnalysisDataPacket,
+        priority: DetectorPriorityLevel,
+    ) -> tuple[DetectorOccurrence, dict[str, Any]]:
+        current_timestamp = datetime.now(dt_timezone.utc)
+
+        occurrence = DetectorOccurrence(
+            issue_title="size",
+            subtitle="A preprod static analysis issue was detected",
+            evidence_display=[
+                IssueEvidence(
+                    name="Source",
+                    value=data_packet.source_id,
+                    important=True,
+                )
+            ],
+            type=PreprodSizeAnalysisGroupType,
+            level="warning",
+            culprit="",
+            priority=priority,
+        )
+
+        event_data = {
+            "event_id": uuid4().hex,
+            "project_id": self.detector.project_id,
+            "platform": "android",
+            "received": current_timestamp.timestamp(),
+            "timestamp": current_timestamp.timestamp(),
+            "tags": {},
+        }
+
+        return occurrence, event_data
+
+    def extract_dedupe_value(self, data_packet: SizeAnalysisDataPacket) -> int:
+        raise NotImplementedError
+
+
+class PreprodSizeAnalysisDetectorValidator(BaseDetectorTypeValidator):
+    pass
+
+
+@dataclass(frozen=True)
+class PreprodSizeAnalysisGroupType(GroupType):
+    type_id = 11003
+    slug = "preprod_size_analysis"
+    description = "Size Analysis"
+    category = GroupCategory.PREPROD.value
+    category_v2 = GroupCategory.PREPROD.value
+    default_priority = PriorityLevel.LOW
+    released = False
+    enable_auto_resolve = True
+    enable_escalation_detection = False
+    detector_settings = DetectorSettings(
+        handler=PreprodSizeAnalysisDetectorHandler,
+        validator=PreprodSizeAnalysisDetectorValidator,
+        config_schema={
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "Configuration for preprod static analysis detector",
+            "type": "object",
+            "properties": {
+                "threshold_type": {
+                    "type": "string",
+                    "enum": ["absolute_diff", "absolute_threshold", "relative_diff"],
+                    "description": "The type of threshold to apply",
+                },
+                "measurement": {
+                    "type": "string",
+                    "enum": ["install_size", "download_size"],
+                    "description": "The measurement to track",
+                },
+            },
+            "required": ["threshold_type", "measurement"],
+            "additionalProperties": False,
+        },
+    )

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from sentry.preprod.size_analysis.grouptype import (
+    PreprodSizeAnalysisDetectorHandler,
+    PreprodSizeAnalysisDetectorValidator,
+    PreprodSizeAnalysisGroupType,
+    SizeAnalysisDataPacket,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+from sentry.workflow_engine.models import DataPacket
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.detector import process_detectors
+from sentry.workflow_engine.types import DetectorPriorityLevel
+
+
+@region_silo_test
+class PreprodSizeAnalysisDetectorValidatorTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.context = {
+            "organization": self.project.organization,
+            "project": self.project,
+            "request": self.make_request(),
+        }
+
+    def test_create_detector(self):
+        condition_group = self.create_data_condition_group(organization=self.project.organization)
+        data = {
+            "name": "Test Detector",
+            "type": PreprodSizeAnalysisGroupType.slug,
+            "conditionGroup": {
+                "logicType": condition_group.logic_type,
+                "conditions": [
+                    {
+                        "type": Condition.GREATER,
+                        "comparison": 100,
+                        "conditionResult": DetectorPriorityLevel.HIGH,
+                    },
+                ],
+            },
+            "config": {
+                "threshold_type": "absolute_threshold",
+                "measurement": "install_size",
+            },
+        }
+        detector = PreprodSizeAnalysisDetectorValidator(data=data, context=self.context)
+        assert detector.is_valid(), detector.errors
+        detector.save()
+
+
+@region_silo_test
+class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=self.condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+
+    def test_evaluate_creates_occurrence_when_condition_met(self):
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            workflow_condition_group=self.condition_group,
+        )
+
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert None in evaluation_result
+        result = evaluation_result[None]
+        assert result.priority == DetectorPriorityLevel.HIGH
+        assert result.result is not None
+
+    def test_evaluate_no_occurrence_when_condition_not_met(self):
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            workflow_condition_group=self.condition_group,
+        )
+
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 500,
+                "head_download_size_bytes": 200,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert evaluation_result == {}
+
+    def test_evaluate_returns_highest_matched_priority(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=500000,
+            condition_result=DetectorPriorityLevel.MEDIUM,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # Value exceeds both thresholds — should return HIGH (the max)
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert None in evaluation_result
+        assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate_returns_medium_when_only_medium_condition_met(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=500000,
+            condition_result=DetectorPriorityLevel.MEDIUM,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=10000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # Value exceeds MEDIUM threshold but not HIGH
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 750000,
+                "head_download_size_bytes": 200,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert None in evaluation_result
+        assert evaluation_result[None].priority == DetectorPriorityLevel.MEDIUM
+
+    def test_evaluate_no_occurrence_when_no_condition_group(self):
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+        )
+
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert evaluation_result == {}
+
+    def test_evaluate_absolute_diff(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=100000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # head - base = 5000000 - 4000000 = 1000000 > 100000
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+                "base_install_size_bytes": 4000000,
+                "base_download_size_bytes": 1800000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert None in evaluation_result
+        assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate_absolute_diff_no_trigger_when_below_threshold(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=100000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # head - base = 5000000 - 4950000 = 50000 < 100000
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+                "base_install_size_bytes": 4950000,
+                "base_download_size_bytes": 1800000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert evaluation_result == {}
+
+    def test_evaluate_relative_diff(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        # Trigger when relative diff > 0.1 (10%)
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=0.1,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "relative_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # (5000000 - 4000000) / 4000000 = 0.25 > 0.1
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+                "base_install_size_bytes": 4000000,
+                "base_download_size_bytes": 1800000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert None in evaluation_result
+        assert evaluation_result[None].priority == DetectorPriorityLevel.HIGH
+
+    def test_evaluate_relative_diff_no_trigger_when_below_threshold(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        # Trigger when relative diff > 0.1 (10%)
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=0.1,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "relative_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        # (5000000 - 4900000) / 4900000 ≈ 0.02 < 0.1
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+                "base_install_size_bytes": 4900000,
+                "base_download_size_bytes": 1800000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        evaluation_result = handler.evaluate(data_packet)
+
+        assert evaluation_result == {}
+
+    def test_evaluate_diff_raises_when_base_missing(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=100000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_diff", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        data_packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+            },
+        )
+        handler = PreprodSizeAnalysisDetectorHandler(detector)
+        with pytest.raises(ValueError, match="Missing base value"):
+            handler.evaluate(data_packet)
+
+
+@region_silo_test
+class PreprodSizeAnalysisDetectorHandlerIntegrationTest(TestCase):
+    def test_e2e(self):
+        condition_group = self.create_data_condition_group(
+            organization=self.project.organization,
+        )
+        self.create_data_condition(
+            condition_group=condition_group,
+            type=Condition.GREATER,
+            comparison=1000000,
+            condition_result=DetectorPriorityLevel.HIGH,
+        )
+        detector = self.create_detector(
+            name="test-detector",
+            type=PreprodSizeAnalysisGroupType.slug,
+            project=self.project,
+            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            workflow_condition_group=condition_group,
+        )
+
+        packet: SizeAnalysisDataPacket = DataPacket(
+            source_id="test",
+            packet={
+                "head_install_size_bytes": 5000000,
+                "head_download_size_bytes": 2000000,
+            },
+        )
+
+        with mock.patch(
+            "sentry.workflow_engine.processors.detector.produce_occurrence_to_kafka"
+        ) as mock_produce_occurrence_to_kafka:
+            process_detectors(packet, [detector])
+
+        assert mock_produce_occurrence_to_kafka.call_count == 1


### PR DESCRIPTION
Add PreprodSizeAnalysisGroupType (type_id=11003) with detector handler
and validators that integrate with the workflow engine to emit issues
when build size thresholds are exceeded.

- PreprodSizeAnalysisDetectorHandler: evaluates DataPackets from size
  comparisons and produces IssueOccurrences
- PreprodSizeAnalysisDetectorValidato validate detector creation via the API
- Register the GroupType import in preprod/grouptype.py

PRs:
- #108208 Add size_analysis detector (this PR)
- #108209 Hook size analysis detector to diff
- #108210 Add new issue type to frontend
- #108211 Add size monitor UI

[Design doc](https://www.notion.so/sentry/Size-Monitors-3068b10e4b5d805ca57de084d1b4eba6)

This stack of PRs is missing a handful of important features:
- Filters
- Detailed data on the occurrence
- Some UI polish

but it works end to end. 
