### PR TITLE
feat(preprod): Add size monitor UI

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -59,6 +59,15 @@ export const mobile: PlatformKey[] = [
   'cocoa-swift',
 ];
 
+export const android: PlatformKey[] = ['android', 'java-android'];
+
+export const apple: PlatformKey[] = [
+  'apple-ios',
+  'apple-macos',
+  'cocoa-objc',
+  'cocoa-swift',
+];
+
 // Mirrors `BACKEND` in src/sentry/utils/platform_categories.py
 // When changing this file, make sure to keep src/sentry/utils/platform_categories.py in sync.
 export const backend: PlatformKey[] = [

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1661,6 +1661,10 @@ function buildRoutes(): RouteObject[] {
         path: 'uptime/',
         component: make(() => import('sentry/views/detectors/list/uptime')),
       },
+      {
+        path: 'mobile-builds/',
+        component: make(() => import('sentry/views/detectors/list/mobileBuild')),
+      },
     ],
   };
 

--- a/static/app/types/workflowEngine/detectors.tsx
+++ b/static/app/types/workflowEngine/detectors.tsx
@@ -16,6 +16,12 @@ import type {
   UptimeMonitorMode,
 } from 'sentry/views/alerts/rules/uptime/types';
 import type {Monitor, MonitorConfig} from 'sentry/views/insights/crons/types';
+import type {
+  MetricType as PreprodMeasurement,
+  MeasurementType as PreprodThresholdType,
+} from 'sentry/views/settings/project/preprod/types';
+
+export type {PreprodMeasurement, PreprodThresholdType};
 
 /**
  * See SnubaQuerySerializer
@@ -84,7 +90,8 @@ export type DetectorType =
   | 'metric_issue'
   | 'monitor_check_in_failure'
   | 'uptime_domain_failure'
-  | 'issue_stream';
+  | 'issue_stream'
+  | 'preprod_size_analysis';
 
 /**
  * Configuration for static/threshold-based detection
@@ -165,12 +172,27 @@ export interface IssueStreamDetector extends BaseDetector {
   readonly type: 'issue_stream';
 }
 
+/**
+ * Configuration for preprod/mobile builds detection
+ */
+interface PreprodDetectorConfig {
+  measurement: PreprodMeasurement;
+  thresholdType: PreprodThresholdType;
+}
+
+export interface PreprodDetector extends BaseDetector {
+  readonly conditionGroup: MetricConditionGroup | null;
+  readonly config: PreprodDetectorConfig;
+  readonly type: 'preprod_size_analysis';
+}
+
 export type Detector =
   | MetricDetector
   | UptimeDetector
   | CronDetector
   | ErrorDetector
-  | IssueStreamDetector;
+  | IssueStreamDetector
+  | PreprodDetector;
 
 interface UpdateConditionGroupPayload {
   conditions: Array<Omit<MetricCondition, 'id'>>;
@@ -228,6 +250,15 @@ export interface CronDetectorUpdatePayload extends BaseDetectorUpdatePayload {
     name: string;
   }>;
   type: 'monitor_check_in_failure';
+}
+
+export interface PreprodDetectorUpdatePayload extends BaseDetectorUpdatePayload {
+  conditionGroup: UpdateConditionGroupPayload;
+  config: {
+    measurement: PreprodMeasurement;
+    thresholdType: PreprodThresholdType;
+  };
+  type: 'preprod_size_analysis';
 }
 
 export interface MetricConditionGroup {

--- a/static/app/views/detectors/components/details/index.tsx
+++ b/static/app/views/detectors/components/details/index.tsx
@@ -9,6 +9,7 @@ import {CronDetectorDetails} from 'sentry/views/detectors/components/details/cro
 import {ErrorDetectorDetails} from 'sentry/views/detectors/components/details/error';
 import {FallbackDetectorDetails} from 'sentry/views/detectors/components/details/fallback';
 import {MetricDetectorDetails} from 'sentry/views/detectors/components/details/metric';
+import {MobileBuildDetectorDetails} from 'sentry/views/detectors/components/details/mobileBuild';
 import {UptimeDetectorDetails} from 'sentry/views/detectors/components/details/uptime';
 
 type DetectorDetailsContentProps = {
@@ -47,6 +48,12 @@ export function DetectorDetailsContent({detector, project}: DetectorDetailsConte
             {t('Issue stream monitors do not support detail views.')}
           </Alert>
         </Alert.Container>
+      );
+    case 'preprod_size_analysis':
+      return (
+        <PageFiltersContainer>
+          <MobileBuildDetectorDetails detector={detector} project={project} />
+        </PageFiltersContainer>
       );
     default:
       unreachable(detectorType);

--- a/static/app/views/detectors/components/details/mobileBuild/detect.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/detect.tsx
@@ -1,0 +1,173 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex, Grid} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {FilterWrapper} from 'sentry/components/searchQueryBuilder/formattedQuery';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import {t} from 'sentry/locale';
+import {
+  DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
+import type {
+  MetricCondition,
+  PreprodDetector,
+} from 'sentry/types/workflowEngine/detectors';
+import {PriorityDot} from 'sentry/views/detectors/components/priorityDot';
+import {
+  bytesToMB,
+  getDisplayUnit,
+  getMeasurementLabel,
+  getMetricLabel,
+} from 'sentry/views/settings/project/preprod/types';
+
+function getConditionLabel({condition}: {condition: MetricCondition}) {
+  switch (condition.conditionResult) {
+    case DetectorPriorityLevel.OK:
+      return t('Resolved');
+    case DetectorPriorityLevel.LOW:
+      return t('Low');
+    case DetectorPriorityLevel.MEDIUM:
+      return t('Medium');
+    case DetectorPriorityLevel.HIGH:
+      return t('High');
+    default:
+      return t('Unknown');
+  }
+}
+
+function formatComparisonValue(
+  comparison: MetricCondition['comparison'],
+  thresholdType: PreprodDetector['config']['thresholdType']
+): string {
+  if (typeof comparison !== 'number') {
+    return '';
+  }
+  if (thresholdType === 'relative_diff') {
+    return String(comparison);
+  }
+  return String(bytesToMB(comparison));
+}
+
+function getConditionDescription({
+  condition,
+  thresholdType,
+}: {
+  condition: MetricCondition;
+  thresholdType: PreprodDetector['config']['thresholdType'];
+}) {
+  const comparisonValue = formatComparisonValue(condition.comparison, thresholdType);
+  const unit = getDisplayUnit(thresholdType);
+
+  if (condition.conditionResult === DetectorPriorityLevel.OK) {
+    return t('Below or equal to %(value)s%(unit)s', {
+      value: comparisonValue,
+      unit,
+    });
+  }
+
+  return t('Above %(value)s%(unit)s', {
+    value: comparisonValue,
+    unit,
+  });
+}
+
+function DetectorPriorities({detector}: {detector: PreprodDetector}) {
+  const conditions = detector.conditionGroup?.conditions || [];
+
+  return (
+    <Grid columns="auto 1fr" gap="sm lg" align="start">
+      {conditions.map((condition, index) => (
+        <Fragment key={index}>
+          <Flex align="center" gap="sm">
+            <PriorityDot
+              priority={
+                condition.conditionResult === DetectorPriorityLevel.OK
+                  ? 'resolved'
+                  : DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL[
+                      condition.conditionResult as keyof typeof DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL
+                    ]
+              }
+            />
+            <Text>{getConditionLabel({condition})}</Text>
+          </Flex>
+          <Text>
+            {getConditionDescription({
+              condition,
+              thresholdType: detector.config.thresholdType,
+            })}
+          </Text>
+        </Fragment>
+      ))}
+    </Grid>
+  );
+}
+
+export function MobileBuildDetectorDetailsDetect({
+  detector,
+}: {
+  detector: PreprodDetector;
+}) {
+  const filters: Array<{key: string; value: string}> = [];
+
+  return (
+    <Container>
+      <Flex direction="column" gap="md">
+        <Flex gap="xs" align="baseline">
+          <Heading as="h4">{t('Measurement:')}</Heading>
+          <Value>{getMetricLabel(detector.config.measurement)}</Value>
+        </Flex>
+        <Flex gap="xs" align="baseline">
+          <Heading as="h4">{t('Threshold Type:')}</Heading>
+          <Value>{getMeasurementLabel(detector.config.thresholdType)}</Value>
+        </Flex>
+        {filters.length > 0 && (
+          <Fragment>
+            <Heading as="h4">{t('Filters:')}</Heading>
+            <Query>
+              {filters.map((filter, index) => (
+                <Fragment key={index}>
+                  <Label>
+                    <Text variant="muted">{filter.key}</Text>
+                  </Label>
+                  <Value>
+                    <Flex>
+                      <FilterWrapper>{filter.value}</FilterWrapper>
+                    </Flex>
+                  </Value>
+                </Fragment>
+              ))}
+            </Query>
+          </Fragment>
+        )}
+        <Flex gap="xs" align="baseline">
+          <Heading as="h4">{t('Threshold:')}</Heading>
+          <Value>{t('Static threshold')}</Value>
+        </Flex>
+        <DetectorPriorities detector={detector} />
+      </Flex>
+    </Container>
+  );
+}
+
+const Query = styled('dl')`
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: ${p => p.theme.space.sm} ${p => p.theme.space.xs};
+  margin: 0;
+  align-items: baseline;
+`;
+
+const Label = styled('dt')`
+  color: ${p => p.theme.tokens.content.secondary};
+  justify-self: flex-end;
+  margin: 0;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+`;
+
+const Value = styled('dl')`
+  word-break: break-all;
+  margin: 0;
+`;

--- a/static/app/views/detectors/components/details/mobileBuild/index.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/index.tsx
@@ -1,0 +1,41 @@
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import DetailLayout from 'sentry/components/workflowEngine/layout/detail';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
+import {DetectorDetailsAutomations} from 'sentry/views/detectors/components/details/common/automations';
+import {DisabledAlert} from 'sentry/views/detectors/components/details/common/disabledAlert';
+import {DetectorDetailsHeader} from 'sentry/views/detectors/components/details/common/header';
+import {DetectorDetailsOpenPeriodIssues} from 'sentry/views/detectors/components/details/common/openPeriodIssues';
+import {MobileBuildDetectorDetailsSidebar} from 'sentry/views/detectors/components/details/mobileBuild/sidebar';
+
+type MobileBuildDetectorDetailsProps = {
+  detector: PreprodDetector;
+  project: Project;
+};
+
+export function MobileBuildDetectorDetails({
+  detector,
+  project,
+}: MobileBuildDetectorDetailsProps) {
+  return (
+    <DetailLayout>
+      <DetectorDetailsHeader detector={detector} project={project} />
+      <DetailLayout.Body>
+        <DetailLayout.Main>
+          <DisabledAlert
+            detector={detector}
+            message={t('This monitor is disabled and not creating issues.')}
+          />
+          <ErrorBoundary mini>
+            <DetectorDetailsOpenPeriodIssues detector={detector} />
+          </ErrorBoundary>
+          <DetectorDetailsAutomations detector={detector} />
+        </DetailLayout.Main>
+        <DetailLayout.Sidebar>
+          <MobileBuildDetectorDetailsSidebar detector={detector} />
+        </DetailLayout.Sidebar>
+      </DetailLayout.Body>
+    </DetailLayout>
+  );
+}

--- a/static/app/views/detectors/components/details/mobileBuild/sidebar.tsx
+++ b/static/app/views/detectors/components/details/mobileBuild/sidebar.tsx
@@ -1,0 +1,36 @@
+import {Fragment} from 'react';
+
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
+import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
+import {DetectorDetailsAssignee} from 'sentry/views/detectors/components/details/common/assignee';
+import {DetectorDetailsDescription} from 'sentry/views/detectors/components/details/common/description';
+import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
+import {MobileBuildDetectorDetailsDetect} from 'sentry/views/detectors/components/details/mobileBuild/detect';
+
+interface MobileBuildDetectorDetailsSidebarProps {
+  detector: PreprodDetector;
+}
+
+export function MobileBuildDetectorDetailsSidebar({
+  detector,
+}: MobileBuildDetectorDetailsSidebarProps) {
+  return (
+    <Fragment>
+      <Section title={t('Detect')}>
+        <ErrorBoundary mini>
+          <MobileBuildDetectorDetailsDetect detector={detector} />
+        </ErrorBoundary>
+      </Section>
+      <DetectorDetailsAssignee owner={detector.owner} />
+      <DetectorDetailsDescription description={detector.description} />
+      <DetectorExtraDetails>
+        <DetectorExtraDetails.DateCreated detector={detector} />
+        <DetectorExtraDetails.CreatedBy detector={detector} />
+        <DetectorExtraDetails.LastModified detector={detector} />
+        <DetectorExtraDetails.Environment detector={detector} />
+      </DetectorExtraDetails>
+    </Fragment>
+  );
+}

--- a/static/app/views/detectors/components/detectorLink.tsx
+++ b/static/app/views/detectors/components/detectorLink.tsx
@@ -18,6 +18,7 @@ import type {
   Detector,
   MetricCondition,
   MetricDetector,
+  PreprodDetector,
   UptimeDetector,
 } from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
@@ -189,6 +190,15 @@ function CronDetectorDetails({detector}: {detector: CronDetector}) {
   return <DetailItem>{scheduleAsText(config)}</DetailItem>;
 }
 
+function PreprodDetectorDetails({detector}: {detector: PreprodDetector}) {
+  const {measurement, thresholdType} = detector.config;
+  return (
+    <DetailItem>
+      {measurement} {thresholdType}
+    </DetailItem>
+  );
+}
+
 function Details({detector}: {detector: Detector}) {
   const detectorType = detector.type;
   switch (detectorType) {
@@ -198,6 +208,8 @@ function Details({detector}: {detector: Detector}) {
       return <UptimeDetectorDetails detector={detector} />;
     case 'monitor_check_in_failure':
       return <CronDetectorDetails detector={detector} />;
+    case 'preprod_size_analysis':
+      return <PreprodDetectorDetails detector={detector} />;
     case 'error':
     case 'issue_stream':
       return null;

--- a/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
+++ b/static/app/views/detectors/components/forms/common/detectorIssuePreview.tsx
@@ -1,0 +1,97 @@
+import {useTheme} from '@emotion/react';
+
+import {Flex, Grid} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import ErrorLevel from 'sentry/components/events/errorLevel';
+import ShortId from 'sentry/components/group/inboxBadges/shortId';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import Section from 'sentry/components/workflowEngine/ui/section';
+import {t} from 'sentry/locale';
+import type {AvatarProject} from 'sentry/types/project';
+
+interface DetectorIssuePreviewProps {
+  issueTitle: string;
+  subtitle: string;
+  project?: AvatarProject;
+}
+
+export function DetectorIssuePreview({
+  issueTitle,
+  project,
+  subtitle,
+}: DetectorIssuePreviewProps) {
+  const theme = useTheme();
+  const projectSlug = project?.slug ?? 'project';
+  const shortId = `${projectSlug.toUpperCase()}-D3M0`;
+  return (
+    <Container>
+      <Section
+        title={t('Preview')}
+        description={t(
+          'Given your configurations, this is a sample of the kind of issue you can expect this Monitor to produce.'
+        )}
+      >
+        <Grid
+          radius="lg"
+          columns="1fr repeat(5, auto)"
+          border="primary"
+          justify="center"
+          align="center"
+        >
+          <Flex
+            style={{borderTopLeftRadius: theme.radius.lg}}
+            borderBottom="primary"
+            padding="md"
+            background="secondary"
+          >
+            <Flex marginLeft="2xl">
+              <Text bold>{t('Issue')}</Text>
+            </Flex>
+          </Flex>
+          <Flex borderBottom="primary" padding="md" background="secondary">
+            <Text bold>{t('Last Seen')}</Text>
+          </Flex>
+          <Flex borderBottom="primary" padding="md" background="secondary">
+            <Text bold>{t('Age')}</Text>
+          </Flex>
+          <Flex borderBottom="primary" padding="md" background="secondary">
+            <Text bold>{t('Events')}</Text>
+          </Flex>
+          <Flex borderBottom="primary" padding="md" background="secondary">
+            <Text bold>{t('Users')}</Text>
+          </Flex>
+          <Flex
+            style={{borderTopRightRadius: theme.radius.lg}}
+            borderBottom="primary"
+            padding="md"
+            background="secondary"
+          >
+            <Text bold>{t('Assignee')}</Text>
+          </Flex>
+
+          <Flex align="start" gap="md" marginLeft="2xl" padding="md">
+            <Flex direction="column" gap="sm">
+              <Text bold>{issueTitle}</Text>
+              <Flex align="center" gap="xs">
+                <ErrorLevel level="error" />
+                {subtitle}
+              </Flex>
+              <Flex align="center" gap="xs">
+                {project && <ProjectBadge project={project} avatarSize={14} hideName />}
+                <Text size="sm" variant="muted">
+                  <ShortId shortId={shortId} />
+                </Text>
+              </Flex>
+            </Flex>
+          </Flex>
+          <Text align="center">4hr ago</Text>
+          <Text align="center">2min</Text>
+          <Text align="center">1</Text>
+          <Text align="center">1.2k</Text>
+        </Grid>
+      </Section>
+    </Container>
+  );
+}

--- a/static/app/views/detectors/components/forms/common/getDetectorAnalyticsPayload.ts
+++ b/static/app/views/detectors/components/forms/common/getDetectorAnalyticsPayload.ts
@@ -2,6 +2,7 @@ import type {
   CronDetector,
   Detector,
   MetricDetector,
+  PreprodDetector,
   SnubaQuery,
   UptimeDetector,
 } from 'sentry/types/workflowEngine/detectors';
@@ -27,10 +28,15 @@ type ErrorDetectorAnalytics = {
   detector_type: Extract<Detector['type'], 'error' | 'issue_stream'>;
 };
 
+type PreprodDetectorAnalytics = {
+  detector_type: PreprodDetector['type'];
+};
+
 type DetectorAnalyticsPayload =
   | MetricDetectorAnalytics
   | UptimeDetectorAnalytics
   | MonitorDetectorAnalytics
+  | PreprodDetectorAnalytics
   | ErrorDetectorAnalytics;
 
 export function getDetectorAnalyticsPayload(
@@ -56,6 +62,9 @@ export function getDetectorAnalyticsPayload(
         cron_schedule_type: monitorConfig?.schedule_type,
         detector_type: detector.type,
       };
+    }
+    case 'preprod_size_analysis': {
+      return {detector_type: detector.type};
     }
     default:
       return {detector_type: detector.type};

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -5,6 +5,7 @@ import LoadingError from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   EditExistingCronDetectorForm,
   NewCronDetectorForm,
@@ -17,6 +18,10 @@ import {
   EditExistingMetricDetectorForm,
   NewMetricDetectorForm,
 } from 'sentry/views/detectors/components/forms/metric/metric';
+import {
+  EditExistingPreprodDetectorForm,
+  NewPreprodDetectorForm,
+} from 'sentry/views/detectors/components/forms/mobileBuild';
 import {
   EditExistingUptimeDetectorForm,
   NewUptimeDetectorForm,
@@ -35,6 +40,8 @@ function PlaceholderForm() {
 }
 
 export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
+  const organization = useOrganization();
+
   switch (detectorType) {
     case 'metric_issue':
       return <NewMetricDetectorForm />;
@@ -46,6 +53,11 @@ export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
       return <NewCronDetectorForm />;
     case 'issue_stream':
       return <PlaceholderForm />;
+    case 'preprod_size_analysis':
+      if (!organization.features.includes('preprod-size-monitors-frontend')) {
+        return <PlaceholderForm />;
+      }
+      return <NewPreprodDetectorForm />;
     default:
       unreachable(detectorType);
       return <PlaceholderForm />;
@@ -69,6 +81,8 @@ export function EditExistingDetectorForm({detector}: {detector: Detector}) {
           <Alert variant="danger">{t('Issue stream monitors can not be edited.')}</Alert>
         </Alert.Container>
       );
+    case 'preprod_size_analysis':
+      return <EditExistingPreprodDetectorForm detector={detector} />;
     default:
       unreachable(detectorType);
       return <PlaceholderForm />;

--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -1,0 +1,223 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import NumberField from 'sentry/components/forms/fields/numberField';
+import SegmentedRadioField from 'sentry/components/forms/fields/segmentedRadioField';
+import {Container} from 'sentry/components/workflowEngine/ui/container';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {
+  DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
+import useProjects from 'sentry/utils/useProjects';
+import {
+  PREPROD_DETECTOR_FORM_FIELDS,
+  usePreprodDetectorFormField,
+} from 'sentry/views/detectors/components/forms/mobileBuild/mobileBuildFormData';
+import {PriorityDot} from 'sentry/views/detectors/components/priorityDot';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
+import {
+  getMetricLabelForPlatform,
+  guessPlatformForProject,
+  MEASUREMENT_OPTIONS,
+  METRIC_OPTIONS,
+} from 'sentry/views/settings/project/preprod/types';
+
+function getMetricOptions(platform: Platform | undefined): Array<[string, string]> {
+  return METRIC_OPTIONS.map(({value}) => [
+    value,
+    getMetricLabelForPlatform(value, platform),
+  ]);
+}
+
+function getThresholdTypeOptions(): Array<[string, string, string]> {
+  return MEASUREMENT_OPTIONS.map(({value, label, description}) => [
+    value,
+    label,
+    description,
+  ]);
+}
+
+export function MobileBuildDetectSection() {
+  const thresholdType =
+    usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.thresholdType) ?? 'absolute';
+  const projectId = usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.projectId);
+  const {projects} = useProjects();
+
+  const project = projects.find(p => p.id === projectId);
+  const maybePlatform = project ? guessPlatformForProject(project) : undefined;
+
+  const metricOptions = useMemo(() => getMetricOptions(maybePlatform), [maybePlatform]);
+  const thresholdTypeOptions = useMemo(getThresholdTypeOptions, []);
+
+  return (
+    <Fragment>
+      <Container>
+        <Stack gap="md">
+          <Heading as="h3">{t('Choose Your Measurement')}</Heading>
+          <MetricField
+            name={PREPROD_DETECTOR_FORM_FIELDS.measurement}
+            choices={metricOptions}
+            inline={false}
+            flexibleControlStateSize
+            preserveOnUnmount
+          />
+        </Stack>
+      </Container>
+
+      <Container>
+        <Stack gap="lg">
+          <section>
+            <Heading as="h3">{t('Issue Detection')}</Heading>
+            <MeasurementField
+              name={PREPROD_DETECTOR_FORM_FIELDS.thresholdType}
+              choices={thresholdTypeOptions}
+              inline={false}
+              flexibleControlStateSize
+              preserveOnUnmount
+            />
+          </section>
+
+          <ThresholdSection thresholdType={thresholdType} />
+        </Stack>
+      </Container>
+    </Fragment>
+  );
+}
+
+function ThresholdSection({
+  thresholdType,
+}: {
+  thresholdType: 'absolute' | 'absolute_diff' | 'relative_diff';
+}) {
+  const isPercentage = thresholdType === 'relative_diff';
+
+  return (
+    <section>
+      <DefineThresholdParagraph>
+        <Text bold>{t('Define threshold & set priority')}</Text>
+        <Text variant="muted">
+          {t('Issues will be created when the query value passes the set threshold.')}
+        </Text>
+      </DefineThresholdParagraph>
+      <Stack marginTop="md" gap="xl">
+        <PriorityRow priority={DetectorPriorityLevel.HIGH} isPercentage={isPercentage} />
+        <PriorityRow priority={DetectorPriorityLevel.LOW} isPercentage={isPercentage} />
+      </Stack>
+    </section>
+  );
+}
+
+type SupportedPriorityLevel = Extract<
+  DetectorPriorityLevel,
+  DetectorPriorityLevel.HIGH | DetectorPriorityLevel.LOW
+>;
+
+function PriorityRow({
+  priority,
+  isPercentage,
+}: {
+  isPercentage: boolean;
+  priority: SupportedPriorityLevel;
+}) {
+  let required: boolean;
+  let priorityLabel: string;
+  let thresholdFieldName: string;
+  switch (priority) {
+    case DetectorPriorityLevel.HIGH:
+      priorityLabel = t('High priority');
+      thresholdFieldName = PREPROD_DETECTOR_FORM_FIELDS.highThreshold;
+      required = true;
+      break;
+    case DetectorPriorityLevel.LOW:
+      priorityLabel = t('Low priority');
+      thresholdFieldName = PREPROD_DETECTOR_FORM_FIELDS.lowThreshold;
+      required = false;
+      break;
+    default:
+      return null;
+  }
+
+  return (
+    <Flex align="center" gap="md">
+      <PriorityDot priority={DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL[priority]} />
+      <PriorityLabel>
+        {priorityLabel}
+        {required && <RequiredAsterisk>*</RequiredAsterisk>}
+      </PriorityLabel>
+      <Flex align="center" gap="md">
+        <ThresholdField
+          name={thresholdFieldName}
+          placeholder="-"
+          hideLabel
+          inline
+          required={required}
+          preserveOnUnmount
+        />
+        <ThresholdSuffix>{isPercentage ? '%' : 'MB'}</ThresholdSuffix>
+      </Flex>
+    </Flex>
+  );
+}
+
+const MetricField = styled(SegmentedRadioField)`
+  padding-left: 0;
+  padding-block: ${space(1)};
+  border-bottom: none;
+  max-width: 420px;
+
+  > div {
+    padding: 0;
+  }
+`;
+
+const MeasurementField = styled(SegmentedRadioField)`
+  padding-left: 0;
+  padding-block: ${space(1)};
+  border-bottom: none;
+  max-width: 840px;
+
+  > div {
+    padding: 0;
+  }
+`;
+
+const DefineThresholdParagraph = styled('div')`
+  display: flex;
+  gap: ${p => p.theme.space.sm};
+  flex-direction: column;
+  margin-bottom: ${p => p.theme.space.sm};
+  padding-top: ${p => p.theme.space.lg};
+  margin-top: ${p => p.theme.space.md};
+  border-top: 1px solid ${p => p.theme.tokens.border.primary};
+`;
+
+const PriorityLabel = styled('span')`
+  min-width: 120px;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+`;
+
+const RequiredAsterisk = styled('span')`
+  color: ${p => p.theme.tokens.content.danger};
+  margin-left: ${space(0.25)};
+`;
+
+const ThresholdField = styled(NumberField)`
+  padding: 0;
+  margin: 0;
+  border: none;
+
+  > div {
+    padding: 0;
+    width: 10ch;
+  }
+`;
+
+const ThresholdSuffix = styled('span')`
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.md};
+`;

--- a/static/app/views/detectors/components/forms/mobileBuild/index.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/index.tsx
@@ -1,0 +1,57 @@
+import {useTheme} from '@emotion/react';
+
+import {Stack} from '@sentry/scraps/layout';
+
+import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
+import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
+import {DescribeSection} from 'sentry/views/detectors/components/forms/common/describeSection';
+import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
+import {MobileBuildDetectSection} from 'sentry/views/detectors/components/forms/mobileBuild/detectSection';
+import {
+  PREPROD_DEFAULT_FORM_DATA,
+  preprodFormDataToEndpointPayload,
+  preprodSavedDetectorToFormData,
+} from 'sentry/views/detectors/components/forms/mobileBuild/mobileBuildFormData';
+import {MobileBuildPreviewSection} from 'sentry/views/detectors/components/forms/mobileBuild/previewSection';
+import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
+
+function MobileBuildDetectorForm() {
+  const theme = useTheme();
+
+  return (
+    <Stack gap="2xl" maxWidth={theme.breakpoints.lg}>
+      <MobileBuildDetectSection />
+      <MobileBuildPreviewSection />
+      <AssignSection />
+      <DescribeSection />
+      <AutomateSection />
+    </Stack>
+  );
+}
+
+export function NewPreprodDetectorForm() {
+  return (
+    <NewDetectorLayout
+      detectorType="preprod_size_analysis"
+      formDataToEndpointPayload={preprodFormDataToEndpointPayload}
+      initialFormData={PREPROD_DEFAULT_FORM_DATA}
+      environment={false}
+    >
+      <MobileBuildDetectorForm />
+    </NewDetectorLayout>
+  );
+}
+
+export function EditExistingPreprodDetectorForm({detector}: {detector: PreprodDetector}) {
+  return (
+    <EditDetectorLayout
+      detector={detector}
+      formDataToEndpointPayload={preprodFormDataToEndpointPayload}
+      savedDetectorToFormData={preprodSavedDetectorToFormData}
+      environment={false}
+    >
+      <MobileBuildDetectorForm />
+    </EditDetectorLayout>
+  );
+}

--- a/static/app/views/detectors/components/forms/mobileBuild/mobileBuildFormData.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/mobileBuildFormData.tsx
@@ -1,0 +1,140 @@
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+  DetectorPriorityLevel,
+} from 'sentry/types/workflowEngine/dataConditions';
+import type {
+  PreprodDetector,
+  PreprodDetectorUpdatePayload,
+  PreprodMeasurement,
+  PreprodThresholdType,
+} from 'sentry/types/workflowEngine/detectors';
+import {bytesToMB, mbToBytes} from 'sentry/views/settings/project/preprod/types';
+
+interface PreprodDetectorFormData {
+  description: string | null;
+  highThreshold: string;
+  lowThreshold: string;
+  measurement: PreprodMeasurement;
+  name: string;
+  owner: string;
+  projectId: string;
+  thresholdType: PreprodThresholdType;
+  workflowIds: string[];
+}
+
+type PreprodDetectorFormFieldName = keyof PreprodDetectorFormData;
+
+export const PREPROD_DETECTOR_FORM_FIELDS = {
+  name: 'name',
+  projectId: 'projectId',
+  owner: 'owner',
+  description: 'description',
+  workflowIds: 'workflowIds',
+  measurement: 'measurement',
+  thresholdType: 'thresholdType',
+  highThreshold: 'highThreshold',
+  lowThreshold: 'lowThreshold',
+} satisfies Record<PreprodDetectorFormFieldName, PreprodDetectorFormFieldName>;
+
+export const PREPROD_DEFAULT_FORM_DATA: Partial<PreprodDetectorFormData> = {
+  measurement: 'install_size',
+  thresholdType: 'absolute',
+  highThreshold: '',
+  lowThreshold: '',
+};
+
+export function usePreprodDetectorFormField<T extends PreprodDetectorFormFieldName>(
+  name: T
+): PreprodDetectorFormData[T] | undefined {
+  return useFormField(name);
+}
+
+function createPreprodConditions(
+  data: PreprodDetectorFormData
+): PreprodDetectorUpdatePayload['conditionGroup']['conditions'] {
+  const conditions: PreprodDetectorUpdatePayload['conditionGroup']['conditions'] = [];
+  const isPercentage = data.thresholdType === 'relative_diff';
+  const conditionType = DataConditionType.GREATER;
+
+  if (data.highThreshold) {
+    conditions.push({
+      type: conditionType,
+      comparison: isPercentage
+        ? parseFloat(data.highThreshold)
+        : mbToBytes(parseFloat(data.highThreshold)),
+      conditionResult: DetectorPriorityLevel.HIGH,
+    });
+  }
+  if (data.lowThreshold) {
+    conditions.push({
+      type: conditionType,
+      comparison: isPercentage
+        ? parseFloat(data.lowThreshold)
+        : mbToBytes(parseFloat(data.lowThreshold)),
+      conditionResult: DetectorPriorityLevel.LOW,
+    });
+  }
+
+  return conditions;
+}
+
+export function preprodFormDataToEndpointPayload(
+  data: PreprodDetectorFormData
+): PreprodDetectorUpdatePayload {
+  const conditions = createPreprodConditions(data);
+
+  return {
+    name: data.name || 'New Monitor',
+    type: 'preprod_size_analysis',
+    projectId: data.projectId,
+    owner: data.owner || null,
+    description: data.description || null,
+    workflowIds: data.workflowIds || [],
+    conditionGroup: {
+      logicType: DataConditionGroupLogicType.ANY,
+      conditions,
+    },
+    config: {
+      measurement: data.measurement,
+      thresholdType: data.thresholdType,
+    },
+  };
+}
+
+function conditionToThreshold(
+  comparison: number | unknown,
+  isPercentage: boolean
+): string {
+  if (typeof comparison !== 'number') {
+    return '';
+  }
+  return String(isPercentage ? comparison : bytesToMB(comparison));
+}
+
+export function preprodSavedDetectorToFormData(
+  detector: PreprodDetector
+): PreprodDetectorFormData {
+  const conditions = detector.conditionGroup?.conditions || [];
+  const isPercentage = detector.config.thresholdType === 'relative_diff';
+
+  const highCondition = conditions.find(
+    c => c.conditionResult === DetectorPriorityLevel.HIGH
+  );
+  const lowCondition = conditions.find(
+    c => c.conditionResult === DetectorPriorityLevel.LOW
+  );
+
+  return {
+    name: detector.name,
+    projectId: detector.projectId,
+    owner: detector.owner ? `${detector.owner.type}:${detector.owner.id}` : '',
+    description: detector.description || null,
+    workflowIds: detector.workflowIds,
+    measurement: detector.config.measurement,
+    thresholdType: detector.config.thresholdType,
+    highThreshold: conditionToThreshold(highCondition?.comparison, isPercentage),
+    lowThreshold: conditionToThreshold(lowCondition?.comparison, isPercentage),
+  };
+}

--- a/static/app/views/detectors/components/forms/mobileBuild/previewSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/previewSection.tsx
@@ -1,0 +1,47 @@
+import {t} from 'sentry/locale';
+import useProjects from 'sentry/utils/useProjects';
+import {DetectorIssuePreview} from 'sentry/views/detectors/components/forms/common/detectorIssuePreview';
+import {
+  PREPROD_DETECTOR_FORM_FIELDS,
+  usePreprodDetectorFormField,
+} from 'sentry/views/detectors/components/forms/mobileBuild/mobileBuildFormData';
+import {
+  getMetricLabelForPlatform,
+  guessPlatformForProject,
+} from 'sentry/views/settings/project/preprod/types';
+
+export function MobileBuildPreviewSection() {
+  const measurement =
+    usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.measurement) ??
+    'install_size';
+  const highThreshold = usePreprodDetectorFormField(
+    PREPROD_DETECTOR_FORM_FIELDS.highThreshold
+  );
+  const thresholdType = usePreprodDetectorFormField(
+    PREPROD_DETECTOR_FORM_FIELDS.thresholdType
+  );
+  const projectId = usePreprodDetectorFormField(PREPROD_DETECTOR_FORM_FIELDS.projectId);
+  const {projects} = useProjects();
+
+  const project = projects.find(p => p.id === projectId);
+  const maybePlatform = project && guessPlatformForProject(project);
+  const metricLabel = getMetricLabelForPlatform(measurement, maybePlatform);
+
+  const isPercentage = thresholdType === 'relative_diff';
+  const thresholdUnit = isPercentage ? '%' : 'MB';
+
+  const threshold = Number(highThreshold);
+  const regression = isPercentage ? 0.05 : 1;
+  const actual = threshold === undefined ? undefined : threshold + regression;
+
+  const actualDisplay = actual ? `${actual} ${thresholdUnit}` : '\u2026';
+  const thresholdDisplay = highThreshold ? `${threshold} ${thresholdUnit}` : '\u2026';
+
+  return (
+    <DetectorIssuePreview
+      issueTitle={t('%s threshold exceeded', metricLabel)}
+      project={project}
+      subtitle={t('%s > %s Threshold', actualDisplay, thresholdDisplay)}
+    />
+  );
+}

--- a/static/app/views/detectors/list/mobileBuild.tsx
+++ b/static/app/views/detectors/list/mobileBuild.tsx
@@ -1,0 +1,36 @@
+import Feature from 'sentry/components/acl/feature';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import WorkflowEngineListLayout from 'sentry/components/workflowEngine/layout/list';
+import {t} from 'sentry/locale';
+import {DetectorListActions} from 'sentry/views/detectors/list/common/detectorListActions';
+import {DetectorListContent} from 'sentry/views/detectors/list/common/detectorListContent';
+import {DetectorListHeader} from 'sentry/views/detectors/list/common/detectorListHeader';
+import {useDetectorListQuery} from 'sentry/views/detectors/list/common/useDetectorListQuery';
+
+const TITLE = t('Mobile Build Monitors');
+const DESCRIPTION = t(
+  'Mobile build monitors track app build sizes and detect regressions in your mobile applications.'
+);
+const DOCS_URL = 'https://docs.sentry.io/product/app-starts/app-size/';
+
+export default function MobileBuildDetectorsList() {
+  const detectorListQuery = useDetectorListQuery({
+    detectorFilter: 'preprod_size_analysis',
+  });
+
+  return (
+    <Feature features="organizations:preprod-size-monitors-frontend">
+      <SentryDocumentTitle title={TITLE}>
+        <WorkflowEngineListLayout
+          actions={<DetectorListActions detectorType="preprod_size_analysis" />}
+          title={TITLE}
+          description={DESCRIPTION}
+          docsUrl={DOCS_URL}
+        >
+          <DetectorListHeader showTypeFilter={false} />
+          <DetectorListContent {...detectorListQuery} />
+        </WorkflowEngineListLayout>
+      </SentryDocumentTitle>
+    </Feature>
+  );
+}

--- a/static/app/views/detectors/utils/detectorTypeConfig.tsx
+++ b/static/app/views/detectors/utils/detectorTypeConfig.tsx
@@ -41,6 +41,11 @@ const DETECTOR_TYPE_CONFIG: Record<DetectorType, DetectorTypeConfig> = {
     label: t('Issue Stream'),
     systemCreatedNotice: () => t('This monitor is managed by Sentry'),
   },
+  preprod_size_analysis: {
+    label: t('Mobile Builds'),
+    path: 'mobile-builds',
+    userCreateable: true,
+  },
 };
 
 export function isValidDetectorType(detectorType: DetectorType) {

--- a/static/app/views/detectors/utils/getDetectorEnvironment.tsx
+++ b/static/app/views/detectors/utils/getDetectorEnvironment.tsx
@@ -16,6 +16,7 @@ export function getDetectorEnvironment(detector: Detector): string | null {
       return null;
     case 'error':
     case 'issue_stream':
+    case 'preprod_size_analysis':
       return null;
     default:
       unreachable(detectorType);


### PR DESCRIPTION
Add list, detail, and create/edit views for the preprod_size_analysis
detector type ("Mobile Builds"). Users can configure a metric
(install/download size), measurement (absolute/diff/relative), optional
build filters, and priority thresholds. Includes a live preview section,
detector type selection form, and routes at /detectors/mobile-builds/.

PRs:
- #108208 Add size_analysis detector
- #108209 Hook size analysis detector to diff
- #108210 Add new issue type to frontend
- #108211 Add size monitor UI (this PR)

[Design doc](https://www.notion.so/sentry/Size-Monitors-3068b10e4b5d805ca57de084d1b4eba6)