### PR TITLE
feat(form): SwitchField

### DIFF
--- a/static/app/components/core/form/field/autoSaveField.spec.tsx
+++ b/static/app/components/core/form/field/autoSaveField.spec.tsx
@@ -1,0 +1,280 @@
+import {z} from 'zod';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {AutoSaveField} from '@sentry/scraps/form';
+
+const stringSchema = z.object({
+  name: z.string(),
+});
+
+const booleanSchema = z.object({
+  enabled: z.boolean(),
+});
+
+const optionalBooleanSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
+const nullableBooleanSchema = z.object({
+  enabled: z.boolean().nullable(),
+});
+
+const refinedBooleanSchema = z.object({
+  enabled: z
+    .boolean()
+    .nullable()
+    .refine(b => b !== null, 'Boolean required'),
+});
+
+interface StringFieldProps {
+  mutationFn: (data: {name: string}) => Promise<{name: string}>;
+  initialValue?: string;
+}
+
+function StringFieldForm({mutationFn, initialValue = ''}: StringFieldProps) {
+  return (
+    <AutoSaveField
+      name="name"
+      schema={stringSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label="Name">
+          <field.Input value={field.state.value} onChange={field.handleChange} />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+interface BooleanFieldProps {
+  mutationFn: (data: {enabled: boolean}) => Promise<{enabled: boolean}>;
+  initialValue?: boolean;
+}
+
+function BooleanFieldForm({mutationFn, initialValue = false}: BooleanFieldProps) {
+  return (
+    <AutoSaveField
+      name="enabled"
+      schema={booleanSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label="Enabled">
+          <field.Switch checked={field.state.value} onChange={field.handleChange} />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+interface OptionalBooleanFieldProps {
+  mutationFn: (data: {
+    enabled: boolean | undefined;
+  }) => Promise<{enabled: boolean | undefined}>;
+  initialValue?: boolean;
+}
+
+function OptionalBooleanFieldForm({
+  mutationFn,
+  initialValue = false,
+}: OptionalBooleanFieldProps) {
+  return (
+    <AutoSaveField
+      name="enabled"
+      schema={optionalBooleanSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label="Enabled">
+          <field.Switch
+            checked={field.state.value ?? false}
+            onChange={field.handleChange}
+          />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+interface NullableBooleanFieldProps {
+  mutationFn: (data: {enabled: boolean | null}) => Promise<{enabled: boolean | null}>;
+  initialValue?: boolean | null;
+}
+
+function NullableBooleanFieldForm({
+  mutationFn,
+  initialValue = false,
+}: NullableBooleanFieldProps) {
+  return (
+    <AutoSaveField
+      name="enabled"
+      schema={nullableBooleanSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label="Enabled">
+          <field.Switch
+            checked={field.state.value ?? false}
+            onChange={field.handleChange}
+          />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+interface RefinedBooleanFieldProps {
+  mutationFn: (data: {enabled: boolean}) => Promise<{enabled: boolean}>;
+  initialValue?: boolean;
+}
+
+function RefinedBooleanFieldForm({
+  mutationFn,
+  initialValue = false,
+}: RefinedBooleanFieldProps) {
+  return (
+    <AutoSaveField
+      name="enabled"
+      schema={refinedBooleanSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label="Enabled">
+          <field.Switch
+            checked={field.state.value ?? false}
+            onChange={field.handleChange}
+          />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+describe('AutoSaveField', () => {
+  describe('string fields save on blur', () => {
+    it('does not trigger mutation on change', async () => {
+      const mutationFn = jest.fn((data: {name: string}) => Promise.resolve(data));
+
+      render(<StringFieldForm mutationFn={mutationFn} />);
+
+      const input = screen.getByRole('textbox');
+      await userEvent.type(input, 'test');
+
+      // Mutation should not be called yet (only on blur)
+      expect(mutationFn).not.toHaveBeenCalled();
+    });
+
+    it('triggers mutation on blur', async () => {
+      const mutationFn = jest.fn((data: {name: string}) => Promise.resolve(data));
+
+      render(<StringFieldForm mutationFn={mutationFn} />);
+
+      const input = screen.getByRole('textbox');
+      await userEvent.type(input, 'test');
+      await userEvent.tab();
+
+      await waitFor(() => {
+        expect(mutationFn).toHaveBeenCalledWith({name: 'test'});
+      });
+    });
+
+    it('does not trigger mutation on blur if value unchanged', async () => {
+      const mutationFn = jest.fn((data: {name: string}) => Promise.resolve(data));
+
+      render(<StringFieldForm mutationFn={mutationFn} initialValue="initial" />);
+
+      const input = screen.getByRole('textbox');
+      input.focus();
+      await userEvent.tab();
+
+      // Wait a bit to ensure no mutation is triggered
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(mutationFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('boolean fields save on change', () => {
+    it('triggers mutation immediately on change', async () => {
+      const mutationFn = jest.fn((data: {enabled: boolean}) => Promise.resolve(data));
+
+      render(<BooleanFieldForm mutationFn={mutationFn} initialValue={false} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await userEvent.click(checkbox);
+
+      await waitFor(() => {
+        expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+      });
+    });
+
+    it('does not require blur to trigger mutation', async () => {
+      const mutationFn = jest.fn(() => new Promise<{enabled: boolean}>(() => {}));
+
+      render(<BooleanFieldForm mutationFn={mutationFn} initialValue={false} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await userEvent.click(checkbox);
+
+      // Mutation should be called immediately without blur
+      expect(
+        await screen.findByRole('status', {name: 'Saving enabled'})
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('optional boolean fields save on change', () => {
+    it('triggers mutation immediately on change', async () => {
+      const mutationFn = jest.fn((data: {enabled: boolean | undefined}) =>
+        Promise.resolve(data)
+      );
+
+      render(<OptionalBooleanFieldForm mutationFn={mutationFn} initialValue={false} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await userEvent.click(checkbox);
+
+      await waitFor(() => {
+        expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+      });
+    });
+  });
+
+  describe('nullable boolean fields save on change', () => {
+    it('triggers mutation immediately on change', async () => {
+      const mutationFn = jest.fn((data: {enabled: boolean | null}) =>
+        Promise.resolve(data)
+      );
+
+      render(<NullableBooleanFieldForm mutationFn={mutationFn} initialValue={false} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await userEvent.click(checkbox);
+
+      await waitFor(() => {
+        expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+      });
+    });
+  });
+
+  describe('refined boolean fields save on change', () => {
+    it('triggers mutation immediately on change for refined boolean schemas', async () => {
+      const mutationFn = jest.fn((data: {enabled: boolean}) => Promise.resolve(data));
+
+      render(<RefinedBooleanFieldForm mutationFn={mutationFn} initialValue={false} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      await userEvent.click(checkbox);
+
+      await waitFor(() => {
+        expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+      });
+    });
+  });
+});

--- a/static/app/components/core/form/field/autoSaveField.tsx
+++ b/static/app/components/core/form/field/autoSaveField.tsx
@@ -114,12 +114,12 @@ interface AutoSaveFieldProps<
 /**
  * Checks if a Zod schema field is a boolean type (including optional/nullable booleans).
  */
-function isBooleanField(fieldSchema: z.ZodTypeAny): boolean {
+function isBooleanField(fieldSchema: z.core.$ZodType): boolean {
   if (fieldSchema instanceof ZodBoolean) {
     return true;
   }
   if (fieldSchema instanceof ZodOptional || fieldSchema instanceof ZodNullable) {
-    return isBooleanField(fieldSchema.unwrap() as z.ZodTypeAny);
+    return isBooleanField(fieldSchema.unwrap());
   }
   return false;
 }
@@ -134,7 +134,7 @@ export function AutoSaveField<
   const mutation = useMutation(mutationOptions);
 
   // Boolean fields (like switches) save on change, others save on blur
-  const fieldSchema = schema.shape[name] as z.ZodTypeAny | undefined;
+  const fieldSchema = schema.shape[name];
   const saveOnChange = fieldSchema ? isBooleanField(fieldSchema) : false;
 
   const form = useScrapsForm({

--- a/static/app/components/core/form/field/autoSaveField.tsx
+++ b/static/app/components/core/form/field/autoSaveField.tsx
@@ -2,7 +2,7 @@ import {useId} from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type {DeepKeys, DeepValue, FieldApi} from '@tanstack/react-form';
 import {useMutation, type UseMutationOptions} from '@tanstack/react-query';
-import type {z} from 'zod';
+import {ZodBoolean, ZodNullable, ZodOptional, type z} from 'zod';
 
 import {AutoSaveContextProvider} from '@sentry/scraps/form/autoSaveContext';
 import {useScrapsForm, type BoundFieldComponents} from '@sentry/scraps/form/scrapsForm';
@@ -111,6 +111,19 @@ interface AutoSaveFieldProps<
   schema: TSchema;
 }
 
+/**
+ * Checks if a Zod schema field is a boolean type (including optional/nullable booleans).
+ */
+function isBooleanField(fieldSchema: z.ZodTypeAny): boolean {
+  if (fieldSchema instanceof ZodBoolean) {
+    return true;
+  }
+  if (fieldSchema instanceof ZodOptional || fieldSchema instanceof ZodNullable) {
+    return isBooleanField(fieldSchema.unwrap() as z.ZodTypeAny);
+  }
+  return false;
+}
+
 export function AutoSaveField<
   TSchema extends z.ZodObject<z.ZodRawShape>,
   TFieldName extends Extract<keyof z.infer<TSchema>, string>,
@@ -119,6 +132,10 @@ export function AutoSaveField<
 
   const id = useId();
   const mutation = useMutation(mutationOptions);
+
+  // Boolean fields (like switches) save on change, others save on blur
+  const fieldSchema = schema.shape[name] as z.ZodTypeAny | undefined;
+  const saveOnChange = fieldSchema ? isBooleanField(fieldSchema) : false;
 
   const form = useScrapsForm({
     formId: `${name}-${id}-(auto-save)`,
@@ -129,13 +146,21 @@ export function AutoSaveField<
     validators: {
       onChange: schema.pick({[name]: true}) as never,
     },
-    listeners: {
-      onBlur: ({formApi, fieldApi}) => {
-        if (!fieldApi.state.meta.isDefaultValue) {
-          void formApi.handleSubmit();
+    listeners: saveOnChange
+      ? {
+          onChange: ({formApi, fieldApi}) => {
+            if (!fieldApi.state.meta.isDefaultValue) {
+              void formApi.handleSubmit();
+            }
+          },
         }
-      },
-    },
+      : {
+          onBlur: ({formApi, fieldApi}) => {
+            if (!fieldApi.state.meta.isDefaultValue) {
+              void formApi.handleSubmit();
+            }
+          },
+        },
     onSubmit: ({value}) => {
       return mutation.mutateAsync(value);
     },

--- a/static/app/components/core/form/field/switchField.spec.tsx
+++ b/static/app/components/core/form/field/switchField.spec.tsx
@@ -1,0 +1,238 @@
+import {z} from 'zod';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {AutoSaveField, defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+
+interface TestFormProps {
+  label: string;
+  defaultValue?: boolean;
+  disabled?: boolean | string;
+  hintText?: string;
+  required?: boolean;
+  validator?: z.ZodObject<{enabled: z.ZodBoolean}>;
+}
+
+function TestForm({
+  label,
+  hintText,
+  required,
+  defaultValue = false,
+  disabled,
+  validator,
+}: TestFormProps) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      enabled: defaultValue,
+    },
+    validators: validator ? {onBlur: validator} : undefined,
+  });
+
+  return (
+    <form.AppForm>
+      <form.AppField name="enabled">
+        {field => (
+          <field.Layout.Row label={label} hintText={hintText} required={required}>
+            <field.Switch
+              checked={field.state.value}
+              onChange={field.handleChange}
+              disabled={disabled}
+            />
+          </field.Layout.Row>
+        )}
+      </form.AppField>
+    </form.AppForm>
+  );
+}
+
+const testSchema = z.object({
+  enabled: z.boolean(),
+});
+
+interface AutoSaveTestFormProps {
+  mutationFn: (data: {enabled: boolean}) => Promise<{enabled: boolean}>;
+  initialValue?: boolean;
+  label?: string;
+}
+
+function AutoSaveTestForm({
+  mutationFn,
+  initialValue = false,
+  label = 'Enable Feature',
+}: AutoSaveTestFormProps) {
+  return (
+    <AutoSaveField
+      name="enabled"
+      schema={testSchema}
+      initialValue={initialValue}
+      mutationOptions={{mutationFn}}
+    >
+      {field => (
+        <field.Layout.Row label={label}>
+          <field.Switch checked={field.state.value} onChange={field.handleChange} />
+        </field.Layout.Row>
+      )}
+    </AutoSaveField>
+  );
+}
+
+describe('SwitchField', () => {
+  it('renders with a label', () => {
+    render(<TestForm label="Enable Feature" />);
+
+    expect(screen.getByText('Enable Feature')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('displays checked state correctly', () => {
+    render(<TestForm label="Enable Feature" defaultValue />);
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('displays unchecked state correctly', () => {
+    render(<TestForm label="Enable Feature" defaultValue={false} />);
+
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('toggles on click', async () => {
+    render(<TestForm label="Enable Feature" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+  });
+});
+
+describe('SwitchField disabled', () => {
+  it('is disabled when disabled prop is true', () => {
+    render(<TestForm label="Enable Feature" disabled />);
+
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('shows tooltip with reason when disabled is a string', async () => {
+    render(<TestForm label="Enable Feature" disabled="Feature not available" />);
+
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+
+    // Hover on the switch to trigger tooltip
+    await userEvent.hover(screen.getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Feature not available')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('SwitchField auto-save', () => {
+  it('shows spinner when auto-save is pending', async () => {
+    const mutationFn = jest.fn(() => new Promise<{enabled: boolean}>(() => {}));
+
+    render(<AutoSaveTestForm mutationFn={mutationFn} initialValue={false} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+
+    expect(
+      await screen.findByRole('status', {name: 'Saving enabled'})
+    ).toBeInTheDocument();
+    expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+  });
+
+  it('shows checkmark when auto-save succeeds', async () => {
+    const mutationFn = jest.fn((data: {enabled: boolean}) => Promise.resolve(data));
+
+    render(<AutoSaveTestForm mutationFn={mutationFn} initialValue={false} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+
+    // Wait for mutation to succeed - there are 2 checkmark icons:
+    // one inside the Switch toggle and one as the success indicator
+    await waitFor(() => {
+      const checkmarks = screen.getAllByTestId('icon-check-mark');
+      expect(checkmarks.length).toBeGreaterThan(1);
+    });
+    expect(mutationFn).toHaveBeenCalledWith({enabled: true});
+  });
+
+  it('disables switch while auto-save is pending', async () => {
+    const mutationFn = jest.fn(() => new Promise<{enabled: boolean}>(() => {}));
+
+    render(<AutoSaveTestForm mutationFn={mutationFn} initialValue={false} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(checkbox).toBeDisabled();
+    });
+  });
+
+  it('does not trigger mutation when toggling back to initial value', async () => {
+    const mutationFn = jest.fn((data: {enabled: boolean}) => Promise.resolve(data));
+
+    render(<AutoSaveTestForm mutationFn={mutationFn} initialValue={false} />);
+
+    const checkbox = screen.getByRole('checkbox');
+    // Toggle on then off - ends up at initial value
+    await userEvent.click(checkbox);
+    // First click triggers mutation
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+
+    // Clear mock to check next behavior
+    mutationFn.mockClear();
+    await userEvent.click(checkbox);
+
+    // Second click back to initial value should not trigger mutation
+    expect(mutationFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('SwitchField keyboard navigation', () => {
+  it('can be toggled with Space key', async () => {
+    render(<TestForm label="Enable Feature" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    checkbox.focus();
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.keyboard(' ');
+
+    expect(checkbox).toBeChecked();
+  });
+});
+
+describe('SwitchField a11y', () => {
+  it('focuses the switch when clicking on the label', async () => {
+    render(<TestForm label="Enable Feature" />);
+
+    await userEvent.click(screen.getByText('Enable Feature'));
+
+    expect(screen.getByRole('checkbox')).toHaveFocus();
+  });
+
+  it('includes required text for screen readers when required is true', () => {
+    render(<TestForm label="Enable Feature" required />);
+
+    expect(screen.getByText('(required)')).toBeInTheDocument();
+  });
+
+  it('renders hint text', () => {
+    render(<TestForm label="Enable Feature" hintText="Toggle to enable this feature" />);
+
+    expect(screen.getByText('Toggle to enable this feature')).toBeInTheDocument();
+  });
+
+  it('has aria-invalid false by default', () => {
+    render(<TestForm label="Enable Feature" />);
+
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-invalid', 'false');
+  });
+});

--- a/static/app/components/core/form/field/switchField.tsx
+++ b/static/app/components/core/form/field/switchField.tsx
@@ -1,0 +1,45 @@
+import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
+import {Flex} from '@sentry/scraps/layout';
+import {Switch, type SwitchProps} from '@sentry/scraps/switch';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {BaseField, type BaseFieldProps} from './baseField';
+
+export function SwitchField({
+  onChange,
+  disabled,
+  ...props
+}: BaseFieldProps &
+  Omit<SwitchProps, 'checked' | 'onChange' | 'onBlur' | 'disabled'> & {
+    checked: boolean;
+    onChange: (value: boolean) => void;
+    disabled?: boolean | string;
+  }) {
+  const autoSaveContext = useAutoSaveContext();
+  const isDisabled = !!disabled || autoSaveContext?.status === 'pending';
+  const disabledReason = typeof disabled === 'string' ? disabled : undefined;
+
+  return (
+    <BaseField>
+      {(fieldProps, {indicator}) => {
+        const switchElement = (
+          <Flex gap="sm" align="center">
+            <Switch
+              {...fieldProps}
+              {...props}
+              disabled={isDisabled}
+              onChange={e => onChange(e.target.checked)}
+            />
+            {indicator}
+          </Flex>
+        );
+
+        if (disabledReason) {
+          return <Tooltip title={disabledReason}>{switchElement}</Tooltip>;
+        }
+
+        return switchElement;
+      }}
+    </BaseField>
+  );
+}

--- a/static/app/components/core/form/field/switchField.tsx
+++ b/static/app/components/core/form/field/switchField.tsx
@@ -23,7 +23,7 @@ export function SwitchField({
     <BaseField>
       {(fieldProps, {indicator}) => {
         const switchElement = (
-          <Flex gap="sm" align="center">
+          <Flex gap="sm" align="center" justify="between">
             <Switch
               {...fieldProps}
               {...props}

--- a/static/app/components/core/form/form.stories.tsx
+++ b/static/app/components/core/form/form.stories.tsx
@@ -35,6 +35,7 @@ const baseUserSchema = z.object({
   firstName: z.string().optional(),
   lastName: z.string().min(2, 'Last name must be at least 2 characters'),
   secret: z.string().optional(),
+  notifications: z.boolean().optional(),
   address: z.object({
     street: z.string().min(1, 'Street is required'),
     city: z.string().min(1, 'City is required'),
@@ -175,6 +176,22 @@ function AutoSaveExample() {
           </field.Layout.Stack>
         )}
       </AutoSaveField>
+
+      <AutoSaveField
+        name="notifications"
+        schema={baseUserSchema}
+        initialValue={user.data?.notifications ?? false}
+        mutationOptions={userMutationOptions(client)}
+      >
+        {field => (
+          <field.Layout.Stack label="Email Notifications:">
+            <field.Switch
+              checked={field.state.value ?? false}
+              onChange={field.handleChange}
+            />
+          </field.Layout.Stack>
+        )}
+      </AutoSaveField>
     </FieldGroup>
   );
 }
@@ -230,6 +247,19 @@ function BasicForm() {
             {field => (
               <field.Layout.Row label="Age:" hintText="Minimum 13" required>
                 <field.Number value={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
+          <form.AppField name="notifications">
+            {field => (
+              <field.Layout.Row
+                label="Email Notifications:"
+                hintText="Receive email updates"
+              >
+                <field.Switch
+                  checked={field.state.value ?? false}
+                  onChange={field.handleChange}
+                />
               </field.Layout.Row>
             )}
           </form.AppField>

--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -14,6 +14,7 @@ import {FieldGroup} from '@sentry/scraps/form/layout/fieldGroup';
 import {InputField} from './field/inputField';
 import {NumberField} from './field/numberField';
 import {SelectField} from './field/selectField';
+import {SwitchField} from './field/switchField';
 import {fieldContext, formContext, useFormContext} from './formContext';
 
 export const defaultFormOptions = formOptions({
@@ -34,6 +35,7 @@ const fieldComponents = {
   Input: InputField,
   Number: NumberField,
   Select: SelectField,
+  Switch: SwitchField,
   Meta: FieldMeta,
   Layout: FieldLayout,
 } as const;


### PR DESCRIPTION
A new `<field.Switch>`, which renders the core switch component as a form field