### PR TITLE
fix(form): stabilize the SelectIndicatorsContainer component

### DIFF
--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -13,11 +13,7 @@ type FieldChildrenProps = {
   onBlur: () => void;
 };
 
-type FieldStateProps = {
-  indicator: React.JSX.Element | null;
-};
-
-const useFieldStateIndicator = () => {
+export const useFieldStateIndicator = () => {
   const field = useFieldContext();
   const hasValidationError = field.state.meta.isTouched && !field.state.meta.isValid;
   const status = useAutoSaveContext()?.status;
@@ -57,23 +53,19 @@ export const useHintTextId = () => {
 
 export function BaseField(
   props: BaseFieldProps & {
-    children: (props: FieldChildrenProps, state: FieldStateProps) => React.ReactNode;
+    children: (props: FieldChildrenProps) => React.ReactNode;
   }
 ) {
   const field = useFieldContext();
   const hasError = field.state.meta.isTouched && !field.state.meta.isValid;
-  const indicator = useFieldStateIndicator();
   const fieldId = useFieldId();
   const hintTextId = useHintTextId();
 
-  return props.children(
-    {
-      'aria-invalid': hasError,
-      'aria-describedby': hintTextId,
-      onBlur: field.handleBlur,
-      name: field.name,
-      id: fieldId,
-    },
-    {indicator}
-  );
+  return props.children({
+    'aria-invalid': hasError,
+    'aria-describedby': hintTextId,
+    onBlur: field.handleBlur,
+    name: field.name,
+    id: fieldId,
+  });
 }

--- a/static/app/components/core/form/field/inputField.tsx
+++ b/static/app/components/core/form/field/inputField.tsx
@@ -3,7 +3,7 @@ import {type InputProps} from '@sentry/scraps/input';
 import {InputGroup} from '@sentry/scraps/input/inputGroup';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {BaseField, type BaseFieldProps} from './baseField';
+import {BaseField, useFieldStateIndicator, type BaseFieldProps} from './baseField';
 
 export function InputField({
   onChange,
@@ -16,12 +16,13 @@ export function InputField({
     disabled?: boolean | string;
   }) {
   const autoSaveContext = useAutoSaveContext();
+  const indicator = useFieldStateIndicator();
   const isDisabled = !!disabled || autoSaveContext?.status === 'pending';
   const disabledReason = typeof disabled === 'string' ? disabled : undefined;
 
   return (
     <BaseField>
-      {(fieldProps, {indicator}) => {
+      {fieldProps => {
         const input = (
           <InputGroup>
             <InputGroup.Input

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -6,7 +6,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import type {SelectValue} from 'sentry/types/core';
 
-import {BaseField, type BaseFieldProps} from './baseField';
+import {BaseField, useFieldStateIndicator, type BaseFieldProps} from './baseField';
 
 function SelectInput({
   selectProps,
@@ -15,6 +15,18 @@ function SelectInput({
   selectProps: {'aria-invalid': boolean};
 }) {
   return <components.Input {...props} aria-invalid={selectProps['aria-invalid']} />;
+}
+
+function SelectIndicatorsContainer({
+  children,
+}: React.ComponentProps<typeof components.IndicatorsContainer>) {
+  const indicator = useFieldStateIndicator();
+  return (
+    <Flex padding="sm" gap="sm" align="center">
+      {indicator}
+      {children}
+    </Flex>
+  );
 }
 
 export function SelectField({
@@ -36,7 +48,7 @@ export function SelectField({
 
   return (
     <BaseField>
-      {({id, ...fieldProps}, {indicator}) => {
+      {({id, ...fieldProps}) => {
         const select = (
           <Select
             {...fieldProps}
@@ -46,14 +58,7 @@ export function SelectField({
             components={{
               ...props.components,
               Input: SelectInput,
-              IndicatorsContainer: ({
-                children,
-              }: React.ComponentProps<typeof components.IndicatorsContainer>) => (
-                <Flex padding="sm" gap="sm" align="center">
-                  {indicator}
-                  {children}
-                </Flex>
-              ),
+              IndicatorsContainer: SelectIndicatorsContainer,
             }}
             onChange={(option: SelectValue<string>) => onChange(option?.value ?? '')}
           />

--- a/static/app/components/core/form/field/switchField.tsx
+++ b/static/app/components/core/form/field/switchField.tsx
@@ -3,7 +3,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Switch, type SwitchProps} from '@sentry/scraps/switch';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {BaseField, type BaseFieldProps} from './baseField';
+import {BaseField, useFieldStateIndicator, type BaseFieldProps} from './baseField';
 
 export function SwitchField({
   onChange,
@@ -16,12 +16,13 @@ export function SwitchField({
     disabled?: boolean | string;
   }) {
   const autoSaveContext = useAutoSaveContext();
+  const indicator = useFieldStateIndicator();
   const isDisabled = !!disabled || autoSaveContext?.status === 'pending';
   const disabledReason = typeof disabled === 'string' ? disabled : undefined;
 
   return (
     <BaseField>
-      {(fieldProps, {indicator}) => {
+      {fieldProps => {
         const switchElement = (
           <Flex gap="sm" align="center" justify="between">
             <Switch


### PR DESCRIPTION
the inline component was making react re-mount the component, which (among other things) made the save animation show up again on each re-render.

to create a stable component, we can't rely on indicator passed in as a prop from baseField, but we can just invoke the hook directly. To streamline, all fields do it like this now.