### PR TITLE
chore(tracemetrics): Handle multi-aggregate view saving and dashboard creation

### DIFF
--- a/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.spec.tsx
@@ -2,7 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import type {Organization} from 'sentry/types/organization';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
-import {TraceMetricsConfig} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
+import {
+  formatTraceMetricsFunction,
+  TraceMetricsConfig,
+} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import type {WidgetQuery} from 'sentry/views/dashboards/types';
 
 describe('TraceMetricsConfig', () => {
@@ -10,6 +13,42 @@ describe('TraceMetricsConfig', () => {
   beforeEach(() => {
     organization = OrganizationFixture();
   });
+
+  describe('formatTraceMetricsFunction', () => {
+    it('formats a single parseable function string', () => {
+      expect(formatTraceMetricsFunction('avg(value,test_metric,millisecond,-)')).toBe(
+        'avg(test_metric)'
+      );
+    });
+
+    it('returns default value for unparseable string input', () => {
+      expect(formatTraceMetricsFunction('not-a-function', 'fallback')).toBe('fallback');
+    });
+
+    it('returns the raw value for unparseable string input when default is not provided', () => {
+      expect(formatTraceMetricsFunction('not-a-function')).toBe('not-a-function');
+    });
+
+    it('formats a single parseable function in an array', () => {
+      expect(formatTraceMetricsFunction(['avg(value,test_metric,millisecond,-)'])).toBe(
+        'avg(test_metric)'
+      );
+    });
+
+    it('formats multiple parseable functions in an array', () => {
+      expect(
+        formatTraceMetricsFunction([
+          'p50(value,test_metric,millisecond,-)',
+          'p75(value,test_metric,millisecond,-)',
+        ])
+      ).toBe('p50, p75(test_metric)');
+    });
+
+    it('handles unparseable function arrays gracefully', () => {
+      expect(formatTraceMetricsFunction(['not-a-function'])).toBe('(…)');
+    });
+  });
+
   describe('transformSeries', () => {
     it('uniquely identifies series with single yAxis and no groupings', () => {
       const data: EventsTimeSeriesResponse = {

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -171,9 +171,16 @@ function useTraceMetricsSearchBarDataProvider(
 }
 
 export function formatTraceMetricsFunction(
-  valueToParse: string,
+  valueToParse: string | string[],
   defaultValue?: string | ReactNode
 ) {
+  if (Array.isArray(valueToParse)) {
+    const parsedFunctions = valueToParse.map(v => parseFunction(v));
+    const functionNames = parsedFunctions.map(f => f?.name).join(', ');
+    const firstFunction = parsedFunctions[0];
+    return `${functionNames}(${firstFunction?.arguments[1] ?? '…'})`;
+  }
+
   const parsedFunction = parseFunction(valueToParse);
   if (parsedFunction) {
     return `${parsedFunction.name}(${parsedFunction.arguments[1] ?? '…'})`;

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.spec.tsx
@@ -85,6 +85,59 @@ describe('useAddMetricToDashboard', () => {
     );
   });
 
+  it('includes all yAxes when multiple visualizes are present', () => {
+    const yAxis1 = 'p50(value,metric.a,counter,-)';
+    const yAxis2 = 'p75(value,metric.a,counter,-)';
+    const visualize1 = new VisualizeFunction(yAxis1, {chartType: ChartType.BAR});
+    const visualize2 = new VisualizeFunction(yAxis2, {chartType: ChartType.LINE});
+    const metricQuery: BaseMetricQuery = {
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        cursor: '',
+        fields: [],
+        sortBys: [],
+        aggregateCursor: '',
+        aggregateFields: [visualize1, visualize2, {groupBy: 'project'}],
+        aggregateSortBys: [{field: yAxis1, kind: 'desc'}],
+      }),
+    };
+
+    const {result} = renderHookWithProviders(useAddMetricToDashboard, {
+      ...context,
+    });
+
+    act(() => {
+      result.current.addToDashboard(metricQuery);
+    });
+
+    expect(openAddToDashboardModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widgets: [
+          {
+            title: 'Custom Widget',
+            displayType: DisplayType.BAR,
+            interval: undefined,
+            limit: undefined,
+            widgetType: WidgetType.TRACEMETRICS,
+            queries: [
+              {
+                aggregates: [yAxis1, yAxis2],
+                columns: ['project'],
+                fields: ['project'],
+                conditions: 'release:1.2.3',
+                orderby: `-${yAxis1}`,
+                name: '',
+              },
+            ],
+          },
+        ],
+      })
+    );
+  });
+
   it('does not pass an orderby if there are no group bys', () => {
     const yAxis = 'avg(value,metric.a,counter,-)';
     const visualize = new VisualizeFunction(yAxis, {chartType: ChartType.BAR});

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -29,8 +29,8 @@ export function useAddMetricToDashboard() {
   const getEventView = useCallback(
     (metricQuery: BaseMetricQuery) => {
       const queryValues = metricQuery?.queryParams;
-      const visualize = queryValues?.aggregateFields?.find(isVisualize);
-      const yAxis = visualize?.yAxis;
+      const visualizes = queryValues?.aggregateFields?.filter(isVisualize);
+      const yAxes = visualizes?.map(v => v.yAxis);
       const fields = queryValues?.groupBys ?? [];
       const aggregateSortBys = queryValues?.aggregateSortBys ?? [];
 
@@ -42,7 +42,7 @@ export function useAddMetricToDashboard() {
         query: search.formatString(),
         version: 2,
         dataset: DiscoverDatasets.TRACEMETRICS,
-        yAxis: [yAxis ?? ''],
+        yAxis: yAxes,
       };
 
       const newEventView = EventView.fromNewQueryWithPageFilters(
@@ -50,7 +50,7 @@ export function useAddMetricToDashboard() {
         selection
       );
       newEventView.display =
-        CHART_TYPE_TO_DISPLAY_TYPE[visualize?.chartType ?? ChartType.LINE];
+        CHART_TYPE_TO_DISPLAY_TYPE[visualizes[0]?.chartType ?? ChartType.LINE];
 
       if (fields.length > 0) {
         newEventView.sorts = aggregateSortBys;

--- a/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
+++ b/static/app/views/explore/metrics/hooks/useAddMetricToDashboard.tsx
@@ -50,7 +50,7 @@ export function useAddMetricToDashboard() {
         selection
       );
       newEventView.display =
-        CHART_TYPE_TO_DISPLAY_TYPE[visualizes[0]?.chartType ?? ChartType.LINE];
+        CHART_TYPE_TO_DISPLAY_TYPE[visualizes?.[0]?.chartType ?? ChartType.LINE];
 
       if (fields.length > 0) {
         newEventView.sorts = aggregateSortBys;

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
@@ -61,7 +61,8 @@ export function useSaveMetricsMultiQuery() {
             return null;
           }
 
-          const yAxes = visualizes.map(v => v.yAxis); // There should only be one yAxis per metricQuery.
+          // There can be multiple yAxes per metricQuery, with multi-aggregate support.
+          const yAxes = visualizes.map(v => v.yAxis);
           const chartType = visualize.chartType;
 
           return {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -10,8 +10,12 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
+import {encodeMetricQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {useSaveAsMetricItems} from 'sentry/views/explore/metrics/useSaveAsMetricItems';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -24,7 +28,8 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled'],
+    features: ['tracemetrics-enabled',
+      'tracemetrics-overlay-charts-ui',],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
@@ -152,5 +157,79 @@ describe('useSaveAsMetricItems', () => {
 
     expect(saveAsItems.some(item => item.key === 'update-query')).toBe(false);
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
+  });
+
+  it('should return empty array when metrics saved queries UI is not enabled', () => {
+    const orgWithoutFeature = OrganizationFixture({
+      features: [],
+    });
+
+    const {result} = renderHook(
+      () =>
+        useSaveAsMetricItems({
+          interval: '5m',
+        }),
+      {
+        wrapper: function ({children}: {children?: React.ReactNode}) {
+          return (
+            <OrganizationContext.Provider value={orgWithoutFeature}>
+              <QueryClientProvider client={queryClient}>
+                <MockMetricQueryParamsContext>{children}</MockMetricQueryParamsContext>
+              </QueryClientProvider>
+            </OrganizationContext.Provider>
+          );
+        },
+      }
+    );
+
+    const saveAsItems = result.current;
+    expect(saveAsItems).toEqual([]);
+  });
+
+  it('formats add-to-dashboard submenu labels for multiple visualizes', () => {
+    const yAxis1 = 'p50(value,metric.a,counter,-)';
+    const yAxis2 = 'p75(value,metric.a,counter,-)';
+    const encodedMetricQuery = encodeMetricQueryParams({
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        cursor: '',
+        fields: [],
+        sortBys: [],
+        aggregateCursor: '',
+        aggregateFields: [new VisualizeFunction(yAxis1), new VisualizeFunction(yAxis2)],
+        aggregateSortBys: [{field: yAxis1, kind: 'desc'}],
+      }),
+    });
+
+    mockedUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          interval: '5m',
+          metric: [encodedMetricQuery],
+        },
+      })
+    );
+
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(),
+      initialProps: {interval: '5m'},
+    });
+
+    const addToDashboardItem = result.current.find(
+      item => item.key === 'add-to-dashboard'
+    ) as {children?: Array<{key: string; label: string}>} | undefined;
+
+    expect(addToDashboardItem).toBeDefined();
+    expect(addToDashboardItem?.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'add-to-dashboard-0',
+          label: 'A: p50, p75(metric.a)',
+        }),
+      ])
+    );
   });
 });

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -28,8 +28,7 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled',
-      'tracemetrics-overlay-charts-ui',],
+    features: ['tracemetrics-enabled', 'tracemetrics-overlay-charts-ui'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
@@ -157,33 +156,6 @@ describe('useSaveAsMetricItems', () => {
 
     expect(saveAsItems.some(item => item.key === 'update-query')).toBe(false);
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
-  });
-
-  it('should return empty array when metrics saved queries UI is not enabled', () => {
-    const orgWithoutFeature = OrganizationFixture({
-      features: [],
-    });
-
-    const {result} = renderHook(
-      () =>
-        useSaveAsMetricItems({
-          interval: '5m',
-        }),
-      {
-        wrapper: function ({children}: {children?: React.ReactNode}) {
-          return (
-            <OrganizationContext.Provider value={orgWithoutFeature}>
-              <QueryClientProvider client={queryClient}>
-                <MockMetricQueryParamsContext>{children}</MockMetricQueryParamsContext>
-              </QueryClientProvider>
-            </OrganizationContext.Provider>
-          );
-        },
-      }
-    );
-
-    const saveAsItems = result.current;
-    expect(saveAsItems).toEqual([]);
   });
 
   it('formats add-to-dashboard submenu labels for multiple visualizes', () => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -118,7 +118,9 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
               key: `add-to-dashboard-${index}`,
               label: `${getVisualizeLabel(index)}: ${
                 formatTraceMetricsFunction(
-                  metricQuery.queryParams.aggregateFields.find(isVisualize)?.yAxis ?? ''
+                  metricQuery.queryParams.aggregateFields
+                    .filter(isVisualize)
+                    .map(v => v.yAxis)
                 ) as string
               }`,
               onAction: () => {


### PR DESCRIPTION
This PR updates the save as button for metrics handling cases where users have multiple aggregates selected. 

The button is currently disabled both with a feature flag and if a user has multiple aggregates selected. Once we're happy with everything we can remove the extra check for multi-aggregate being selected and have it just be behind the flag.

Ticket: LOGS-564

|Before|After|
|---|---|
|<img width="484" height="220" alt="Screenshot 2026-03-04 at 09 10 08" src="https://github.com/user-attachments/assets/723523ca-65ae-4587-8b63-b06935e4f430" />|<img width="598" height="179" alt="Screenshot 2026-03-04 at 09 09 20" src="https://github.com/user-attachments/assets/222a2444-7a38-4e59-b92e-151a056ce69f" />|
|<img width="626" height="603" alt="Screenshot 2026-03-04 at 09 10 13" src="https://github.com/user-attachments/assets/3fda1cc7-d06c-4f1d-83a4-bff86bf0862c" />|<img width="628" height="611" alt="Screenshot 2026-03-04 at 09 09 37" src="https://github.com/user-attachments/assets/56fb5c62-5116-4c38-bd0e-587459add1cf" />|




