### PR TITLE
fix(backend-overview): Render Laravel page before other platformized pages

### DIFF
--- a/static/app/views/insights/pages/backend/backendOverviewPage.tsx
+++ b/static/app/views/insights/pages/backend/backendOverviewPage.tsx
@@ -84,14 +84,14 @@ function BackendOverviewPage({datePageFilterProps}: BackendOverviewPageProps) {
   const hasPlatformizedNextJsOverview = useHasPlatformizedNextJsOverview();
   const isNewBackendExperienceEnabled = useInsightsEap();
   const hasPlatformizedBackendOverview = useHasPlatformizedBackendOverview();
+  if (isLaravelPageAvailable) {
+    return <LaravelOverviewPage datePageFilterProps={datePageFilterProps} />;
+  }
   if (isNextJsPageEnabled && hasPlatformizedNextJsOverview) {
     return <PlatformizedNextJsOverviewPage />;
   }
   if (hasPlatformizedBackendOverview) {
     return <PlatformizedBackendOverviewPage />;
-  }
-  if (isLaravelPageAvailable) {
-    return <LaravelOverviewPage datePageFilterProps={datePageFilterProps} />;
   }
   if (isNextJsPageEnabled) {
     return <NextJsOverviewPage datePageFilterProps={datePageFilterProps} />;


### PR DESCRIPTION
## Summary
- Fixes rendering order in the backend overview page so the Laravel overview page is checked first, before the platformized Next.js and generic backend overview pages. Otherwise the platformized backend will be rendered before laravel
- Previously, the Laravel page could be unreachable if the Next.js or platformized backend conditions matched first