### PR TITLE
fix(dashboards): Add empty fields to rage/dead clicks and server tree widgets

### DIFF
--- a/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/rageAndDeadClicksWidget.ts
@@ -16,6 +16,7 @@ export const RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE: WidgetTemplate = {
       aggregates: [],
       columns: [],
       orderby: '',
+      fields: [],
     },
   ],
 };

--- a/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
+++ b/static/app/views/dashboards/widgetLibrary/serverTreeWidget.ts
@@ -22,6 +22,7 @@ export const SERVER_TREE_WIDGET_TEMPLATE: WidgetTemplate = {
       conditions: '',
       aggregates: [],
       columns: [],
+      fields: [],
       orderby: '',
     },
   ],


### PR DESCRIPTION
## Summary
- Adds `fields: []` to the `RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE` and `SERVER_TREE_WIDGET_TEMPLATE` query definitions
- Without this, saving these widgets fails with `fields are required during creation.` because the `DashboardWidgetQuerySerializer` requires `fields` to be present during creation

## Test plan
- Open a dashboard and add a Rage and Dead Clicks widget → verify it saves successfully
- Open a dashboard and add a Server Tree widget → verify it saves successfully