### PR TITLE
fix(search): Handle currency as numeric

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -825,7 +825,7 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
             key in self.config.numeric_keys
             or is_measurement(key)
             or is_span_op_breakdown(key)
-            or self.get_field_type(key) in ["number", "integer"]
+            or self.get_field_type(key) in ["number", "integer", "currency"]
             or self.is_duration_key(key)
             or self.is_size_key(key)
         )

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -531,6 +531,19 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         ]
 
     @patch("sentry.search.events.builder.base.BaseQueryBuilder.get_field_type")
+    def test_currency_filter(self, mock_type: MagicMock) -> None:
+        config = SearchConfig()
+        mock_type.return_value = "currency"
+
+        assert parse_search_query("ai.total_cost:>0.5", config=config) == [
+            SearchFilter(
+                key=SearchKey(name="ai.total_cost"),
+                operator=">",
+                value=SearchValue(0.5),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.base.BaseQueryBuilder.get_field_type")
     def test_aggregate_numeric_measurement_filter(self, mock_type: MagicMock) -> None:
         config = SearchConfig()
         mock_type.return_value = "number"


### PR DESCRIPTION
Currently we don't treat filter keys that have the currency type as a numeric so there are some issues when trying to filter with them, and wanting to utilize comparison operators like `<`, etc.

This PR updates the `is_numeric_key` to include currency keys as well.

Ticket: EXP-786