### PR TITLE
fix(dashboards): Increase allowed limit to 25 for categorical bar charts

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -357,7 +357,15 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     widget_type = serializers.ChoiceField(
         choices=DashboardWidgetTypes.as_text_choices(), required=False
     )
-    limit = serializers.IntegerField(min_value=1, max_value=20, required=False, allow_null=True)
+    limit = serializers.IntegerField(
+        min_value=1,
+        max_value=20,
+        required=False,
+        allow_null=True,
+        error_messages={
+            "max_value": "The maximum limit for this display type is {max_value}.",
+        },
+    )
     layout = LayoutField(required=False, allow_null=True)
     query_warnings: QueryWarning = {"queries": [], "columns": {}}
     dataset_source = serializers.ChoiceField(
@@ -551,7 +559,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 max_allowed = 10
             if widget_limit > max_allowed:
                 raise serializers.ValidationError(
-                    {"limit": f"Ensure this value is less than or equal to {max_allowed}."}
+                    {"limit": f"The maximum limit for this display type is {max_allowed}."}
                 )
 
         # Validate widget thresholds

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -540,13 +540,13 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             raise serializers.ValidationError(
                 {"limit": f"limit is required. The maximum limit is ${limit}."}
             )
-        # Validate limit based on display type: categorical bar charts allow up to 20,
+        # Validate limit based on display type: categorical bar charts allow up to 25,
         # all other chart types allow up to 10.
         widget_limit = data.get("limit")
         if widget_limit is not None:
             display_type = data.get("display_type")
             if display_type == DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART:
-                max_allowed = 20
+                max_allowed = 25
             else:
                 max_allowed = 10
             if widget_limit > max_allowed:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -357,7 +357,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     widget_type = serializers.ChoiceField(
         choices=DashboardWidgetTypes.as_text_choices(), required=False
     )
-    limit = serializers.IntegerField(min_value=1, max_value=10, required=False, allow_null=True)
+    limit = serializers.IntegerField(min_value=1, max_value=20, required=False, allow_null=True)
     layout = LayoutField(required=False, allow_null=True)
     query_warnings: QueryWarning = {"queries": [], "columns": {}}
     dataset_source = serializers.ChoiceField(
@@ -540,6 +540,20 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             raise serializers.ValidationError(
                 {"limit": f"limit is required. The maximum limit is ${limit}."}
             )
+        # Validate limit based on display type: categorical bar charts allow up to 20,
+        # all other chart types allow up to 10.
+        widget_limit = data.get("limit")
+        if widget_limit is not None:
+            display_type = data.get("display_type")
+            if display_type == DashboardWidgetDisplayTypes.CATEGORICAL_BAR_CHART:
+                max_allowed = 20
+            else:
+                max_allowed = 10
+            if widget_limit > max_allowed:
+                raise serializers.ValidationError(
+                    {"limit": f"Ensure this value is less than or equal to {max_allowed}."}
+                )
+
         # Validate widget thresholds
         thresholds = data.get("thresholds")
         if thresholds:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -357,15 +357,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     widget_type = serializers.ChoiceField(
         choices=DashboardWidgetTypes.as_text_choices(), required=False
     )
-    limit = serializers.IntegerField(
-        min_value=1,
-        max_value=20,
-        required=False,
-        allow_null=True,
-        error_messages={
-            "max_value": "The maximum limit for this display type is {max_value}.",
-        },
-    )
+    limit = serializers.IntegerField(min_value=1, required=False, allow_null=True)
     layout = LayoutField(required=False, allow_null=True)
     query_warnings: QueryWarning = {"queries": [], "columns": {}}
     dataset_source = serializers.ChoiceField(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1396,7 +1396,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "title": "Categorical Bar Widget",
                     "displayType": "categorical_bar",
                     "interval": "5m",
-                    "limit": 21,
+                    "limit": 26,
                     "queries": [
                         {
                             "name": "",
@@ -1412,7 +1412,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 400, response.data
-        assert b"The maximum limit for this display type is 20" in response.content
+        assert b"The maximum limit for this display type is 25" in response.content
 
     def test_add_widget_with_invalid_limit_below_minimum(self) -> None:
         data = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1357,7 +1357,62 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 400, response.data
-        assert b"Ensure this value is less than or equal to 10" in response.content
+        assert b"The maximum limit for this display type is 10" in response.content
+
+    def test_add_categorical_bar_widget_with_valid_limit(self) -> None:
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "title": "Categorical Bar Widget",
+                    "displayType": "categorical_bar",
+                    "interval": "5m",
+                    "limit": 20,
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        widgets = self.get_widgets(self.dashboard.id)
+        assert len(widgets) == 1
+        assert widgets[0].limit == 20
+
+    def test_add_categorical_bar_widget_with_invalid_limit_above_maximum(self) -> None:
+        data = {
+            "title": "First dashboard",
+            "widgets": [
+                {
+                    "title": "Categorical Bar Widget",
+                    "displayType": "categorical_bar",
+                    "interval": "5m",
+                    "limit": 21,
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 400, response.data
+        assert b"The maximum limit for this display type is 20" in response.content
 
     def test_add_widget_with_invalid_limit_below_minimum(self) -> None:
         data = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1318,7 +1318,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 {
                     "displayType": "categorical_bar",
                     "interval": "5m",
-                    "limit": 21,
+                    "limit": 26,
                     "title": "Categorical Bar Widget",
                     "queries": [
                         {
@@ -1334,7 +1334,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         }
         response = self.do_request("post", self.url, data=data)
         assert response.status_code == 400
-        assert b"The maximum limit for this display type is 20" in response.content
+        assert b"The maximum limit for this display type is 25" in response.content
 
     def test_add_widget_with_invalid_limit_below_minimum(self) -> None:
         data = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -1285,7 +1285,56 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         }
         response = self.do_request("post", self.url, data=data)
         assert response.status_code == 400
-        assert b"Ensure this value is less than or equal to 10" in response.content
+        assert b"The maximum limit for this display type is 10" in response.content
+
+    def test_add_categorical_bar_widget_with_valid_limit(self) -> None:
+        data = {
+            "title": "Dashboard from Post",
+            "widgets": [
+                {
+                    "displayType": "categorical_bar",
+                    "interval": "5m",
+                    "limit": 20,
+                    "title": "Categorical Bar Widget",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 201, response.data
+
+    def test_add_categorical_bar_widget_with_invalid_limit_above_maximum(self) -> None:
+        data = {
+            "title": "Dashboard from Post",
+            "widgets": [
+                {
+                    "displayType": "categorical_bar",
+                    "interval": "5m",
+                    "limit": 21,
+                    "title": "Categorical Bar Widget",
+                    "queries": [
+                        {
+                            "name": "",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 400
+        assert b"The maximum limit for this display type is 20" in response.content
 
     def test_add_widget_with_invalid_limit_below_minimum(self) -> None:
         data = {


### PR DESCRIPTION
We want to show a higher number of results for categorical bar charts. If it's not a bar chart, we have custom validation against a max limit of `10`, if it is then we can allow up to `20`.

I removed the `max_value` number from the field definition because we handle it in the validation function and I didn't want to duplicate the error message

Closes DAIN-1206