### PR TITLE
fix(trace-waterfall): Fix duration text overlap in trace waterfall

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.spec.tsx
@@ -1,0 +1,57 @@
+import {ThemeFixture} from 'sentry-fixture/theme';
+
+import {TraceTextMeasurer} from 'sentry/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer';
+
+const originalCreateElement = document.createElement;
+
+describe('TraceTextMeasurer', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sets canvas font using theme size and family', () => {
+    const theme = ThemeFixture();
+    const context: Partial<CanvasRenderingContext2D> & {font: string} = {
+      font: '',
+      measureText: jest.fn().mockReturnValue({width: 10}),
+    };
+
+    const canvas: Partial<HTMLCanvasElement> = {
+      width: 0,
+      height: 0,
+      getContext: jest.fn().mockReturnValue(context),
+    };
+
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === 'canvas') {
+        return canvas as HTMLCanvasElement;
+      }
+
+      return originalCreateElement.call(document, tagName);
+    });
+
+    // @ts-expect-error - we're assigning this so that we can call new without issue.
+    const _measurer = new TraceTextMeasurer(theme);
+
+    expect(context.font).toBe(`${theme.font.size.xs} ${theme.font.family.sans}`);
+  });
+
+  it('falls back to approximated duration widths without a canvas context', () => {
+    const canvas: Partial<HTMLCanvasElement> = {
+      getContext: jest.fn().mockReturnValue(null),
+    };
+
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName.toLowerCase() === 'canvas') {
+        return canvas as HTMLCanvasElement;
+      }
+
+      return originalCreateElement.call(document, tagName);
+    });
+
+    const measurer = new TraceTextMeasurer(ThemeFixture());
+
+    expect(measurer.duration.ms).toBe(2 * 6.5);
+    expect(measurer.measure('10ms')).toBe(2 * 6.5);
+  });
+});

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.tsx
@@ -31,7 +31,7 @@ export class TraceTextMeasurer {
     canvas.width = 50 * window.devicePixelRatio;
     canvas.height = 50 * window.devicePixelRatio;
 
-    ctx.font = '11px' + theme.font.family.sans;
+    ctx.font = `${theme.font.size.xs} ${theme.font.family.sans}`;
 
     this.dot = ctx.measureText('.').width;
     for (let i = 0; i < 10; i++) {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -577,5 +577,63 @@ describe('VirtualizedViewManger', () => {
         manager.transformXFromTimestamp(200) - 3 - Math.ceil(measuredWidth)
       );
     });
+
+    it('uses ceil(text_width) for near-right-edge fit checks before inside-right placement', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 100, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 100, 1], [0, 0, 100, 1]);
+
+      const measuredWidth = 50.3;
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(measuredWidth);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [40, 50.5],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(
+        manager.transformXFromTimestamp(40) - 3 - Math.ceil(measuredWidth)
+      );
+    });
+
+    it('uses ceil(text_width) for full-span fit checks before placing text inside', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 100, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 100, 1], [0, 0, 100, 1]);
+
+      const measuredWidth = 50.3;
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(measuredWidth);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [49.6, 50.5],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(manager.transformXFromTimestamp(100.1) + 3);
+    });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -429,4 +429,91 @@ describe('VirtualizedViewManger', () => {
       });
     });
   });
+
+  describe('computeSpanTextPlacement', () => {
+    it('uses ceil(text_width) when placing text outside on the left', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(10.2);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [800, 50],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(786);
+    });
+
+    it('keeps right-outside placement behavior unchanged', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(10.2);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [100, 50],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(0);
+      expect(textTransform).toBe(153);
+    });
+
+    it('uses ceil(text_width) when placing text inside on the right', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 950});
+
+      const measuredWidth = 200.2;
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(measuredWidth);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [900, 50],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(1);
+      expect(textTransform).toBe(
+        manager.transformXFromTimestamp(950) - 3 - Math.ceil(measuredWidth)
+      );
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -515,5 +515,67 @@ describe('VirtualizedViewManger', () => {
         manager.transformXFromTimestamp(950) - 3 - Math.ceil(measuredWidth)
       );
     });
+
+    it('uses ceil(text_width) for window-right placement when span covers the view', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+
+      const measuredWidth = 10.2;
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(measuredWidth);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [50, 200],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(1);
+      expect(textTransform).toBe(
+        manager.transformXFromTimestamp(200) - 3 - Math.ceil(measuredWidth)
+      );
+    });
+
+    it('uses ceil(text_width) for right-window-edge anchoring inside a partial span', () => {
+      const manager = new VirtualizedViewManager(
+        {
+          list: {width: 0},
+          span_list: {width: 1},
+        },
+        new TraceScheduler(),
+        new TraceView(),
+        ThemeFixture()
+      );
+
+      manager.view.setTraceSpace([0, 0, 1000, 1]);
+      manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 1000, 1]);
+      manager.view.setTraceView({width: 100, x: 100});
+
+      const measuredWidth = 10.2;
+      jest.spyOn(manager.text_measurer, 'measure').mockReturnValue(measuredWidth);
+
+      const node = {errors: new Set(), occurrences: new Set()} as any;
+      const [inside, textTransform] = manager.computeSpanTextPlacement(
+        node,
+        [150, 100],
+        '32.34ms'
+      );
+
+      expect(inside).toBe(1);
+      expect(textTransform).toBe(
+        manager.transformXFromTimestamp(200) - 3 - Math.ceil(measuredWidth)
+      );
+    });
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1151,13 +1151,13 @@ export class VirtualizedViewManager {
     // |---text|
     const right_inside =
       this.transformXFromTimestamp(span_space[0] + span_space[1]) -
-      text_width -
-      TEXT_PADDING;
+      TEXT_PADDING -
+      Math.ceil(text_width);
     // |text---|
     const left_inside = this.transformXFromTimestamp(span_space[0]) + TEXT_PADDING;
     /// text |---|
     const left_outside =
-      this.transformXFromTimestamp(text_left) - TEXT_PADDING - text_width;
+      this.transformXFromTimestamp(text_left) - TEXT_PADDING - Math.ceil(text_width);
 
     // Right edge of the window (when span extends beyond the view)
     const window_right =

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1208,7 +1208,7 @@ export class VirtualizedViewManager {
 
       // If the text fits inside the visible portion of the span, anchor it to the left
       // side of the window so that it is visible while the user pans the view
-      if (visible_width - TEXT_PADDING >= text_width) {
+      if (visible_width - TEXT_PADDING >= text_width_ceil) {
         return [1, window_left];
       }
 
@@ -1230,9 +1230,9 @@ export class VirtualizedViewManager {
         // origin and check if it fits into the distance of space right edge - span right edge. In practice
         // however, it seems that a magical number works just fine.
         span_right > this.view.trace_space.right * 0.9 &&
-        space_right / this.span_to_px[0] < text_width
+        space_right / this.span_to_px[0] < text_width_ceil
       ) {
-        if (full_span_px_width > text_width) {
+        if (full_span_px_width > text_width_ceil) {
           return [1, right_inside];
         }
         return [0, left_outside];
@@ -1241,14 +1241,14 @@ export class VirtualizedViewManager {
     }
 
     // If text fits inside the span
-    if (full_span_px_width > text_width) {
+    if (full_span_px_width > text_width_ceil) {
       const distance = span_right - this.view.trace_view.right;
       const visible_width =
         (span_space[1] - distance) / this.span_to_px[0] - TEXT_PADDING;
 
       // If the text fits inside the visible portion of the span, anchor it to the right
       // side of the window so that it is visible while the user pans the view
-      if (visible_width - TEXT_PADDING >= text_width) {
+      if (visible_width - TEXT_PADDING >= text_width_ceil) {
         return [1, window_right];
       }
 

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -1140,6 +1140,7 @@ export class VirtualizedViewManager {
     const text_anchor_left =
       span_space[0] > this.view.to_origin + this.view.trace_space.width * 0.5;
     const text_width = this.text_measurer.measure(text);
+    const text_width_ceil = Math.ceil(text_width);
 
     const timestamps = getIconTimestamps(node, span_space, icon_width_config_space);
     const text_left = Math.min(span_space[0], timestamps[0]!);
@@ -1152,19 +1153,19 @@ export class VirtualizedViewManager {
     const right_inside =
       this.transformXFromTimestamp(span_space[0] + span_space[1]) -
       TEXT_PADDING -
-      Math.ceil(text_width);
+      text_width_ceil;
     // |text---|
     const left_inside = this.transformXFromTimestamp(span_space[0]) + TEXT_PADDING;
     /// text |---|
     const left_outside =
-      this.transformXFromTimestamp(text_left) - TEXT_PADDING - Math.ceil(text_width);
+      this.transformXFromTimestamp(text_left) - TEXT_PADDING - text_width_ceil;
 
     // Right edge of the window (when span extends beyond the view)
     const window_right =
       this.transformXFromTimestamp(
         this.view.to_origin + this.view.trace_view.left + this.view.trace_view.width
       ) -
-      text_width -
+      text_width_ceil -
       TEXT_PADDING;
     const window_left =
       this.transformXFromTimestamp(this.view.to_origin + this.view.trace_view.left) +


### PR DESCRIPTION
## Summary
- Use `Math.ceil(text_width)` when computing span text placement to prevent sub-pixel rounding from causing duration labels to overlap with span bars
- Fix canvas font string to correctly use theme font size (`theme.font.size.xs`) with a space separator instead of a hardcoded `'11px'` concatenated without a space
- Add tests for `TraceTextMeasurer` and `computeSpanTextPlacement`

Fixes EXP-788

Before:
<img width="605" height="324" alt="Screenshot 2026-02-13 at 11 31 05" src="https://github.com/user-attachments/assets/d300d15f-70dd-4c68-b485-0dd777c853e5" />

After:
<img width="606" height="319" alt="Screenshot 2026-02-13 at 11 31 12" src="https://github.com/user-attachments/assets/c1e6a3b0-c89a-4815-ad82-b752dc3c3163" />