### PR TITLE
fix(preprod): Use project id instead of slug in test assertion

### DIFF
--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -13,7 +13,7 @@ def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str =
     )
 
     path = f"/organizations/{organization.slug}/preprod/{view_type}/{preprod_artifact.id}"
-    query = f"project={preprod_artifact.project.slug}"
+    query = f"project={preprod_artifact.project.id}"
     return organization.absolute_url(path, query=query)
 
 
@@ -27,5 +27,5 @@ def get_preprod_artifact_comparison_url(
         id=preprod_artifact.project.organization_id
     )
     path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}/{base_artifact.id}"
-    query = f"project={preprod_artifact.project.slug}"
+    query = f"project={preprod_artifact.project.id}"
     return organization.absolute_url(path, query=query)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -549,7 +549,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.slug}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(
@@ -624,7 +624,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.slug}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -696,7 +696,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.slug}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -919,8 +919,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             {},
         )
 
-        android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}?project={self.project.slug}"
-        ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{ios_artifact.id}?project={self.project.slug}"
+        android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}?project={self.project.id}"
+        ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{ios_artifact.id}?project={self.project.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
 
         expected = f"""\
@@ -1266,7 +1266,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=[triggered_rule],
         )
 
-        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.slug}"
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
 
         expected = f"""\
@@ -1361,7 +1361,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.slug}"
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-download-absolute&expanded=rule-install-diff&expanded=rule-download-percent"
 
         expected = f"""\
@@ -1467,8 +1467,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        artifact1_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact1.id}?project={self.project.slug}"
-        artifact2_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact2.id}?project={self.project.slug}"
+        artifact1_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact1.id}?project={self.project.id}"
+        artifact2_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact2.id}?project={self.project.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1&expanded=rule-2"
 
         expected = f"""\
@@ -1570,8 +1570,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        failed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{failed_artifact.id}?project={self.project.slug}"
-        passed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{passed_artifact.id}?project={self.project.slug}"
+        failed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{failed_artifact.id}?project={self.project.id}"
+        passed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{passed_artifact.id}?project={self.project.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
 
         expected = f"""\


### PR DESCRIPTION
## Summary
- Fixes `test_assemble_with_vcs_params_without_head_ref` which was using `project.slug` instead of `project.id` in the expected artifact URL query param
- This was inconsistent with the actual endpoint behavior and the two other similar assertions in the same file

## Test plan
- [x] `pytest -svv --reuse-db tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py` — all 59 tests pass