### PR TITLE
feat(monitors-tables): Removing hardcoded column widths

### DIFF
--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -335,6 +335,10 @@ export default class GridEditable<
     // to prevent underflows.
 
     grid.style.gridTemplateColumns = `${prepend} ${widths.join(' ')}`;
+
+    // Setting the rendered grid height as a CSS variable so `GridResizer` can
+    // reliably span the full visible height even when rows grow (e.g. wrapped text).
+    grid.style.setProperty('--grid-editable-resizer-height', `${grid.offsetHeight}px`);
   }
 
   renderGridHead() {

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -178,8 +178,7 @@ export const GridHeadCellStatic = styled('th')`
   justify-content: center;
 
   &:first-child {
-    padding: ${p => p.theme.space.md} 0 ${p => p.theme.space.md}
-      ${p => p.theme.space['2xl']};
+    padding: ${p => `${p.theme.space.md} 0 ${p.theme.space.md} ${p.theme.space['2xl']}`};
   }
 `;
 
@@ -240,8 +239,7 @@ export const GridBodyCellStatic = styled(GridBodyCell)`
   /* Need to select the 2nd child to select the first cell
      as the first child is the interaction state layer */
   &:nth-child(2) {
-    padding: ${p => p.theme.space.md} 0 ${p => p.theme.space.md}
-      ${p => p.theme.space['2xl']};
+    padding: ${p => `${p.theme.space.md} 0 ${p.theme.space.md} ${p.theme.space['2xl']}`};
   }
 `;
 
@@ -288,11 +286,11 @@ export const GridResizer = styled('div')<{dataRows: number}>`
   height: ${p => {
     const numOfRows = p.dataRows;
     // 1px for the border
-    const totalRowHeight = numOfRows * (GRID_BODY_ROW_HEIGHT + 1);
-    const height = GRID_HEAD_ROW_HEIGHT + totalRowHeight;
+    const fixedBodyHeight = numOfRows * (GRID_BODY_ROW_HEIGHT + 1);
+    const fallbackTotalHeight = GRID_HEAD_ROW_HEIGHT + fixedBodyHeight;
 
-    return height;
-  }}px;
+    return `var(--grid-editable-resizer-height, ${fallbackTotalHeight}px)`;
+  }};
 
   padding-left: 5px;
   padding-right: 5px;

--- a/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeChecksGrid.tsx
@@ -9,7 +9,7 @@ import {DateTime} from 'sentry/components/dateTime';
 import Duration from 'sentry/components/duration';
 import Placeholder from 'sentry/components/placeholder';
 import type {GridColumnOrder} from 'sentry/components/tables/gridEditable';
-import GridEditable from 'sentry/components/tables/gridEditable';
+import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
@@ -81,18 +81,18 @@ export function UptimeChecksGrid({traceSampling, uptimeChecks}: Props) {
     <GridEditable
       emptyMessage={t('No matching uptime checks found')}
       data={uptimeChecks}
+      fit="max-content"
       columnOrder={[
-        {key: 'traceItemId', width: 100, name: t('ID')},
-        {key: 'timestamp', width: 150, name: t('Timestamp')},
-        {key: 'checkStatus', width: 230, name: t('Status')},
-        {key: 'httpStatusCode', width: 100, name: t('HTTP Code')},
-        {key: 'durationMs', width: 100, name: t('Duration')},
-        {key: 'regionName', width: 190, name: t('Region')},
-        {key: 'traceId', width: 100, name: t('Trace')},
+        {key: 'traceItemId', width: 95, name: t('ID')},
+        {key: 'timestamp', width: COL_WIDTH_UNDEFINED, name: t('Timestamp')},
+        {key: 'checkStatus', width: COL_WIDTH_UNDEFINED, name: t('Status')},
+        {key: 'httpStatusCode', width: COL_WIDTH_UNDEFINED, name: t('HTTP Code')},
+        {key: 'durationMs', width: COL_WIDTH_UNDEFINED, name: t('Duration')},
+        {key: 'regionName', width: COL_WIDTH_UNDEFINED, name: t('Region')},
+        {key: 'traceId', width: COL_WIDTH_UNDEFINED, name: t('Trace')},
       ]}
       columnSortBy={[]}
       grid={{
-        renderHeadCell: (col: GridColumnOrder) => <Cell>{col.name}</Cell>,
         renderBodyCell: (column, dataRow) => (
           <CheckInBodyCell
             column={column as GridColumnOrder<ColumnKey>}
@@ -217,7 +217,7 @@ function CheckInBodyCell({
 
       const badge =
         totalSpanCount === undefined ? (
-          <Placeholder height="20px" width="70px" />
+          <Placeholder height="20px" width="60px" />
         ) : hasOnlySystemSpans ? (
           <Tooltip
             isHoverable
@@ -296,9 +296,7 @@ const TimeCell = styled(Cell)`
 `;
 
 const TraceCell = styled(Cell)`
-  display: grid;
-  grid-template-columns: 65px max-content;
-  gap: ${space(1)};
+  gap: ${space(0.5)};
 `;
 
 const StatusCell = styled(Cell)<{color: string}>`

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
@@ -22,6 +22,7 @@ export function MonitorCheckInsGrid({checkIns, isLoading, project, hasMultiEnv}:
     <GridEditable<CheckIn, GridColumnOrder<CheckInCellKey>>
       isLoading={isLoading}
       emptyMessage={t('No check-ins have been recorded for this time period.')}
+      fit="max-content"
       data={checkIns}
       columnOrder={[
         {key: 'status', width: 120, name: t('Status')},

--- a/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
+++ b/static/app/views/insights/crons/components/monitorCheckInsGrid.tsx
@@ -1,5 +1,5 @@
 import type {GridColumnOrder} from 'sentry/components/tables/gridEditable';
-import GridEditable from 'sentry/components/tables/gridEditable';
+import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/tables/gridEditable';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import type {CheckIn, CheckInCellKey} from 'sentry/views/insights/crons/types';
@@ -25,13 +25,13 @@ export function MonitorCheckInsGrid({checkIns, isLoading, project, hasMultiEnv}:
       data={checkIns}
       columnOrder={[
         {key: 'status', width: 120, name: t('Status')},
-        {key: 'checkInId', width: 135, name: t('Check-In ID')},
-        {key: 'started', width: 200, name: t('Started')},
-        {key: 'completed', width: 240, name: t('Completed')},
-        {key: 'duration', width: 150, name: t('Duration')},
-        {key: 'issues', width: 160, name: t('Issues')},
+        {key: 'checkInId', width: COL_WIDTH_UNDEFINED, name: t('Check-In ID')},
+        {key: 'started', width: COL_WIDTH_UNDEFINED, name: t('Started')},
+        {key: 'completed', width: COL_WIDTH_UNDEFINED, name: t('Completed')},
+        {key: 'duration', width: COL_WIDTH_UNDEFINED, name: t('Duration')},
+        {key: 'issues', width: COL_WIDTH_UNDEFINED, name: t('Issues')},
         ...envColumn,
-        {key: 'expectedAt', width: 240, name: t('Expected At')},
+        {key: 'expectedAt', width: COL_WIDTH_UNDEFINED, name: t('Expected At')},
       ]}
       columnSortBy={[]}
       grid={{


### PR DESCRIPTION
Grideditable enforces a minwidth of 90px for the column. 

Having to horizontally scroll tables should be avoided 

<img width="1094" height="554" alt="Screenshot 2026-02-13 at 12 17 03 PM" src="https://github.com/user-attachments/assets/e2e638c3-ce53-4a7e-b8f4-6c8deaae4902" />
<img width="1308" height="290" alt="Screenshot 2026-02-13 at 12 17 15 PM" src="https://github.com/user-attachments/assets/cfe888bc-a715-4e11-aaf7-612b05a20d9b" />
<img width="276" height="708" alt="Screenshot 2026-02-13 at 12 18 37 PM" src="https://github.com/user-attachments/assets/4e570d2d-7b27-4fdd-8e4e-1512a5216bff" />

After: 
<img width="1145" height="420" alt="Screenshot 2026-02-13 at 12 25 02 PM" src="https://github.com/user-attachments/assets/2101471d-900c-426f-890b-ce6bf2360d6e" />
<img width="278" height="666" alt="Screenshot 2026-02-13 at 12 25 53 PM" src="https://github.com/user-attachments/assets/b5dd4df9-b493-4c75-8751-4166d6af3d93" />


