### PR TITLE
bug(preprod): Attempt to patch comparison race condition

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -39,7 +39,11 @@ from sentry.preprod.models import (
 )
 from sentry.preprod.quotas import get_size_retention_cutoff
 from sentry.preprod.size_analysis.tasks import manual_size_analysis_comparison
-from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
+from sentry.preprod.size_analysis.utils import (
+    ComparisonValidationResult,
+    build_size_metrics_map,
+    can_compare_size_metrics,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -375,6 +379,15 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
         # Check if the size metrics can be compared
         validation_result = can_compare_size_metrics(head_size_metrics, base_size_metrics)
         if not validation_result.can_compare:
+            if (
+                validation_result.error_type
+                == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+            ):
+                body = SizeAnalysisComparePOSTResponse(
+                    status="processing",
+                    message=validation_result.error_message,
+                )
+                return Response(body.dict(), status=202)
             return Response(
                 {"detail": validation_result.error_message},
                 status=400,

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -332,22 +332,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
                 status=404,
             )
 
-        # Check if any of the size metrics are not completed
-        if (
-            head_size_metrics_qs.filter(
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
-            ).count()
-            == 0
-        ):
-            body = SizeAnalysisComparePOSTResponse(
-                status="processing",
-                message=f"Head PreprodArtifact with id {head_artifact_id} has no completed size metrics yet. Size analysis may still be processing. Please try again later.",
-            )
-            return Response(
-                body.dict(),
-                status=202,  # Accepted, processing not complete
-            )
-
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project=project,
@@ -356,21 +340,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             return Response(
                 {"detail": f"Base PreprodArtifact with id {base_artifact_id} has no size metrics."},
                 status=404,
-            )
-
-        if (
-            base_size_metrics_qs.filter(
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
-            ).count()
-            == 0
-        ):
-            body = SizeAnalysisComparePOSTResponse(
-                status="processing",
-                message=f"Base PreprodArtifact with id {base_artifact_id} has no completed size metrics yet. Size analysis may still be processing. Please try again later.",
-            )
-            return Response(
-                body.dict(),
-                status=202,  # Accepted, processing not complete
             )
 
         head_size_metrics = list(head_size_metrics_qs)

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -93,6 +93,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
@@ -100,6 +101,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
@@ -150,6 +152,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
@@ -157,6 +160,7 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
@@ -302,6 +306,7 @@ def manual_size_analysis_comparison(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")
@@ -313,6 +318,7 @@ def manual_size_analysis_comparison(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -93,7 +93,6 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
@@ -101,7 +100,6 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
@@ -152,7 +150,6 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         head_size_metrics = list(head_size_metrics_qs)
 
@@ -160,7 +157,6 @@ def compare_preprod_artifact_size_analysis(
             preprod_artifact_id__in=[artifact_id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         ).select_related("preprod_artifact", "preprod_artifact__mobile_app_info")
         base_size_metrics = list(base_size_metrics_qs)
 
@@ -306,7 +302,6 @@ def manual_size_analysis_comparison(
             preprod_artifact_id__in=[head_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")
@@ -318,7 +313,6 @@ def manual_size_analysis_comparison(
             preprod_artifact_id__in=[base_artifact.id],
             preprod_artifact__project__organization_id=org_id,
             preprod_artifact__project_id=project_id,
-            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
         )
         .select_related("preprod_artifact")
         .select_related("preprod_artifact__mobile_app_info")

--- a/src/sentry/preprod/size_analysis/utils.py
+++ b/src/sentry/preprod/size_analysis/utils.py
@@ -20,6 +20,7 @@ class ComparisonValidationResult:
         DIFFERENT_APP_IDS = "different_app_ids"
         DIFFERENT_BUILD_CONFIGURATIONS = "different_build_configurations"
         DIFFERENT_METRICS = "different_metrics"
+        NOT_ALL_COMPLETED = "not_all_completed"
 
     can_compare: bool
     error_message: str | None = None
@@ -34,34 +35,45 @@ def build_size_metrics_map(
 
 
 def can_compare_size_metrics(
-    head_metrics: list[PreprodArtifactSizeMetrics], base_metric: list[PreprodArtifactSizeMetrics]
+    head_metrics: list[PreprodArtifactSizeMetrics], base_metrics: list[PreprodArtifactSizeMetrics]
 ) -> ComparisonValidationResult:
-    if not head_metrics or not base_metric:
+    if not head_metrics or not base_metrics:
         return ComparisonValidationResult(
             can_compare=False,
             error_message="Head or base has no completed size metrics to compare.",
             error_type=ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH,
         )
 
+    all_metrics = head_metrics + base_metrics
+    incomplete = [
+        m for m in all_metrics if m.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
+    ]
+    if incomplete:
+        return ComparisonValidationResult(
+            can_compare=False,
+            error_message=f"{len(incomplete)} metric(s) have not completed size analysis yet.",
+            error_type=ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED,
+        )
+
     # Check that both lists have the same length
-    if len(head_metrics) != len(base_metric):
+    if len(head_metrics) != len(base_metrics):
         # TODO: Add ability to compare size metrics with different lengths
         logger.info(
             "preprod.size_analysis.compare.cannot_compare_size_metrics.different_length",
             extra={
                 "head_metrics_length": len(head_metrics),
-                "base_metric_length": len(base_metric),
+                "base_metrics_length": len(base_metrics),
             },
         )
         return ComparisonValidationResult(
             can_compare=False,
-            error_message=f"Head and base have different numbers of size metrics. Head has {len(head_metrics)} metric(s), base has {len(base_metric)} metric(s).",
+            error_message=f"Head and base have different numbers of size metrics. Head has {len(head_metrics)} metric(s), base has {len(base_metrics)} metric(s).",
             error_type=ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH,
         )
 
     # Build sets of (metrics_artifact_type, identifier) for both lists
     head_set = {(m.metrics_artifact_type, m.identifier) for m in head_metrics}
-    base_set = {(m.metrics_artifact_type, m.identifier) for m in base_metric}
+    base_set = {(m.metrics_artifact_type, m.identifier) for m in base_metrics}
 
     # Return True if the sets are equal (all metrics match on both dimensions)
     if head_set == base_set:
@@ -72,9 +84,9 @@ def can_compare_size_metrics(
     base_only = base_set - head_set
 
     head_artifact_types = {m.metrics_artifact_type for m in head_metrics}
-    base_artifact_types = {m.metrics_artifact_type for m in base_metric}
+    base_artifact_types = {m.metrics_artifact_type for m in base_metrics}
     head_identifiers = {m.identifier for m in head_metrics}
-    base_identifiers = {m.identifier for m in base_metric}
+    base_identifiers = {m.identifier for m in base_metrics}
 
     # Check if only identifiers differ (same artifact types)
     if head_artifact_types == base_artifact_types and head_identifiers != base_identifiers:

--- a/src/sentry/preprod/size_analysis/utils.py
+++ b/src/sentry/preprod/size_analysis/utils.py
@@ -36,6 +36,13 @@ def build_size_metrics_map(
 def can_compare_size_metrics(
     head_metrics: list[PreprodArtifactSizeMetrics], base_metric: list[PreprodArtifactSizeMetrics]
 ) -> ComparisonValidationResult:
+    if not head_metrics or not base_metric:
+        return ComparisonValidationResult(
+            can_compare=False,
+            error_message="Head or base has no completed size metrics to compare.",
+            error_type=ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH,
+        )
+
     # Check that both lists have the same length
     if len(head_metrics) != len(base_metric):
         # TODO: Add ability to compare size metrics with different lengths

--- a/src/sentry/preprod/size_analysis/utils.py
+++ b/src/sentry/preprod/size_analysis/utils.py
@@ -21,6 +21,7 @@ class ComparisonValidationResult:
         DIFFERENT_BUILD_CONFIGURATIONS = "different_build_configurations"
         DIFFERENT_METRICS = "different_metrics"
         NOT_ALL_COMPLETED = "not_all_completed"
+        METRICS_FAILED = "metrics_failed"
 
     can_compare: bool
     error_message: str | None = None
@@ -45,6 +46,22 @@ def can_compare_size_metrics(
         )
 
     all_metrics = head_metrics + base_metrics
+    failed_metrics = [
+        m
+        for m in all_metrics
+        if m.state
+        in (
+            PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+        )
+    ]
+    if failed_metrics:
+        return ComparisonValidationResult(
+            can_compare=False,
+            error_message=f"{len(failed_metrics)} metric(s) failed size analysis.",
+            error_type=ComparisonValidationResult.ErrorType.METRICS_FAILED,
+        )
+
     incomplete = [
         m for m in all_metrics if m.state != PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
     ]

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -548,8 +548,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_head_artifact_processing(self):
-        """Test POST endpoint returns 202 when head artifact size metrics are still processing"""
-        # Set head size metric to processing state
         self.head_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.head_size_metric.save()
 
@@ -558,15 +556,10 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.status_code == 202
         data = response.json()
         assert data["status"] == "processing"
-        assert (
-            f"Head PreprodArtifact with id {self.head_artifact.id} has no completed size metrics yet"
-            in data["message"]
-        )
+        assert "not completed size analysis yet" in data["message"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_base_artifact_processing(self):
-        """Test POST endpoint returns 202 when base artifact size metrics are still processing"""
-        # Set base size metric to processing state
         self.base_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.base_size_metric.save()
 
@@ -575,10 +568,7 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.status_code == 202
         data = response.json()
         assert data["status"] == "processing"
-        assert (
-            f"Base PreprodArtifact with id {self.base_artifact.id} has no completed size metrics yet"
-            in data["message"]
-        )
+        assert "not completed size analysis yet" in data["message"]
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_mixed_completed_and_pending_returns_202(self):

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -581,6 +581,31 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_comparison_mixed_completed_and_pending_returns_202(self):
+        self.create_preprod_artifact_size_metrics(
+            self.head_artifact,
+            analysis_file_id=self.head_analysis_file.id,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        self.create_preprod_artifact_size_metrics(
+            self.base_artifact,
+            analysis_file_id=self.base_analysis_file.id,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        response = self.client.post(self._get_url())
+
+        assert response.status_code == 202
+        data = response.json()
+        assert data["status"] == "processing"
+        assert "not completed size analysis yet" in data["message"]
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_existing_comparison(self):
         """Test POST endpoint returns existing comparison when comparison already exists"""
         # Create an existing comparison

--- a/tests/sentry/preprod/size_analysis/test_comparison_utils.py
+++ b/tests/sentry/preprod/size_analysis/test_comparison_utils.py
@@ -10,6 +10,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             )
@@ -19,6 +20,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=900,
                 max_download_size=450,
             )
@@ -44,6 +46,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=900,
                 max_download_size=450,
             )
@@ -61,6 +64,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             )
@@ -78,6 +82,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             ),
@@ -85,6 +90,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
                 identifier="com.example.watch",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=200,
                 max_download_size=100,
             ),
@@ -94,6 +100,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=900,
                 max_download_size=450,
             )
@@ -112,6 +119,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             )
@@ -121,6 +129,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app.debug",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=900,
                 max_download_size=450,
             )
@@ -141,6 +150,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             )
@@ -150,6 +160,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=200,
                 max_download_size=100,
             )
@@ -164,12 +175,70 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is not None
         assert "mismatched metrics" in result.error_message
 
+    def test_cannot_compare_when_metrics_not_completed(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+        assert result.error_message is not None
+        assert "not completed" in result.error_message
+
+    def test_cannot_compare_when_all_metrics_pending(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+        assert "2 metric(s)" in result.error_message
+
     def test_different_metrics_error_type(self):
         head_metrics = [
             PreprodArtifactSizeMetrics(
                 preprod_artifact_id=1,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
                 identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=1000,
                 max_download_size=500,
             )
@@ -179,6 +248,7 @@ class CanCompareSizeMetricsTest(TestCase):
                 preprod_artifact_id=2,
                 metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
                 identifier="com.different.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
                 max_install_size=200,
                 max_download_size=100,
             )

--- a/tests/sentry/preprod/size_analysis/test_comparison_utils.py
+++ b/tests/sentry/preprod/size_analysis/test_comparison_utils.py
@@ -30,6 +30,48 @@ class CanCompareSizeMetricsTest(TestCase):
         assert result.error_message is None
         assert result.error_type is None
 
+    def test_cannot_compare_empty_lists(self):
+        result = can_compare_size_metrics([], [])
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+        assert result.error_message is not None
+        assert "no completed size metrics" in result.error_message
+
+    def test_cannot_compare_empty_head(self):
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics([], base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+        assert result.error_message is not None
+
+    def test_cannot_compare_empty_base(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, [])
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+        assert result.error_message is not None
+
     def test_different_length_error_type(self):
         head_metrics = [
             PreprodArtifactSizeMetrics(

--- a/tests/sentry/preprod/size_analysis/test_comparison_utils.py
+++ b/tests/sentry/preprod/size_analysis/test_comparison_utils.py
@@ -230,7 +230,93 @@ class CanCompareSizeMetricsTest(TestCase):
 
         assert result.can_compare is False
         assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+        assert result.error_message is not None
         assert "2 metric(s)" in result.error_message
+
+    def test_cannot_compare_when_metric_failed(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+        assert result.error_message is not None
+        assert "failed" in result.error_message
+
+    def test_cannot_compare_when_metric_not_ran(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+        assert result.error_message is not None
+        assert "failed" in result.error_message
+
+    def test_failed_takes_priority_over_pending(self):
+        head_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=1,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+                max_install_size=1000,
+                max_download_size=500,
+            )
+        ]
+        base_metrics = [
+            PreprodArtifactSizeMetrics(
+                preprod_artifact_id=2,
+                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+                identifier="com.example.app",
+                state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+                max_install_size=900,
+                max_download_size=450,
+            )
+        ]
+
+        result = can_compare_size_metrics(head_metrics, base_metrics)
+
+        assert result.can_compare is False
+        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
 
     def test_different_metrics_error_type(self):
         head_metrics = [

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -315,10 +315,8 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
             # 2. For the head artifact (since should_update_status_check is True)
             assert mock_status_check_task.apply_async.call_count == 2
             calls = mock_status_check_task.apply_async.call_args_list
-            # First call should be for the base artifact
-            assert calls[0][1]["kwargs"]["preprod_artifact_id"] == base_artifact.id
-            # Second call should be for the head artifact
-            assert calls[1][1]["kwargs"]["preprod_artifact_id"] == head_artifact.id
+            called_artifact_ids = {c[1]["kwargs"]["preprod_artifact_id"] for c in calls}
+            assert called_artifact_ids == {base_artifact.id, head_artifact.id}
 
     def test_compare_preprod_artifact_size_analysis_no_matching_artifacts(self):
         """Test compare_preprod_artifact_size_analysis with no matching artifacts."""

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -577,6 +577,134 @@ class ComparePreprodArtifactSizeAnalysisTest(TestCase):
                 kwargs={"preprod_artifact_id": base_artifact.id, "caller": "compare_completion"}
             )
 
+    def test_compare_preprod_artifact_size_analysis_skips_pending_base_metrics(self):
+        """Test that automatic comparison skips when base artifact's metrics are still PENDING (race condition)."""
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="b" * 40,
+            base_sha="c" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        head_artifact = Factories.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = Factories.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+        # Base still PENDING (analysis hasn't completed yet)
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        with (
+            patch(
+                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+            ) as mock_run_comparison,
+            patch("sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"),
+        ):
+            compare_preprod_artifact_size_analysis(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                artifact_id=head_artifact.id,
+            )
+
+            mock_run_comparison.assert_not_called()
+
+        assert PreprodArtifactSizeComparison.objects.count() == 0
+
+    def test_compare_preprod_artifact_size_analysis_skips_pending_head_metrics_as_base(self):
+        """Test that automatic comparison skips when head artifact's metrics are PENDING (reverse race condition)."""
+        base_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+        head_commit = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="a" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+        )
+
+        base_artifact = Factories.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=base_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        head_artifact = Factories.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=head_commit,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+        # Head still PENDING (analysis hasn't completed yet)
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        with (
+            patch(
+                "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+            ) as mock_run_comparison,
+            patch("sentry.preprod.size_analysis.tasks.create_preprod_status_check_task"),
+        ):
+            compare_preprod_artifact_size_analysis(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                artifact_id=base_artifact.id,
+            )
+
+            mock_run_comparison.assert_not_called()
+
+        assert PreprodArtifactSizeComparison.objects.count() == 0
+
 
 class ManualSizeAnalysisComparisonTest(TestCase):
     def setUp(self):
@@ -618,6 +746,33 @@ class ManualSizeAnalysisComparisonTest(TestCase):
                 head_size_metrics,
                 base_size_metrics,
             )
+
+    def test_manual_size_analysis_comparison_skips_pending_metrics(self):
+        """Test manual comparison skips when metrics are not COMPLETED."""
+        head_metrics = self._create_size_metrics()
+        base_artifact = Factories.create_preprod_artifact(
+            project=self.project,
+            app_id="com.example.app",
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        # Base has PENDING metrics
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        with patch(
+            "sentry.preprod.size_analysis.tasks._run_size_analysis_comparison"
+        ) as mock_run_comparison:
+            manual_size_analysis_comparison(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=head_metrics.preprod_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+            mock_run_comparison.assert_not_called()
 
     def test_manual_size_analysis_comparison_nonexistent_head_metric(self):
         """Test manual_size_analysis_comparison with nonexistent head metric."""


### PR DESCRIPTION
## Summary

Fix race condition where two artifacts uploaded close together cause the first-to-complete's automatic comparison task to compare against the other's still-PENDING metrics, resulting in a permanently FAILED comparison.

## Root Cause

When two artifacts (head/base) are uploaded within minutes of each other, whichever finishes analysis first triggers `compare_preprod_artifact_size_analysis`. The "as base" path finds the other artifact as a head, fetches its size metrics (still PENDING, `analysis_file_id=None`), passes `can_compare_size_metrics` validation (which only checks types/identifiers), and then fails at `File.objects.get(id=None)` → `DoesNotExist` → comparison set to FAILED.

When the second artifact's analysis completes and its automatic comparison fires, `get_or_create` finds the existing FAILED comparison record. `_run_size_analysis_comparison` sees FAILED state, logs `existing_comparison`, and bails early. The customer is stuck with a FAILED comparison forever.

## Fix

- **Remove `state=COMPLETED` filter from all metric queries** in both `compare_preprod_artifact_size_analysis` and `manual_size_analysis_comparison` tasks. Metrics are now fetched regardless of state.
- **Add state validation to `can_compare_size_metrics()`** — a new `NOT_ALL_COMPLETED` error type rejects any metric set where not all metrics have reached COMPLETED state. This moves the validation from the query layer into the validation function, providing more robust handling when some artifacts complete while others remain pending.
- **Fix `base_metric` → `base_metrics` param naming** for consistency.
- **Fix flaky test** in `test_compare_preprod_artifact_size_analysis_success_as_base` where assertion depended on `set` iteration order.

## Test Plan

- [x] New test: `can_compare_size_metrics` rejects lists where some metrics are PENDING
- [x] New test: `can_compare_size_metrics` rejects lists where all metrics are PENDING
- [x] Existing race condition tests pass (PENDING metrics now returned by query but rejected by validation)
- [x] All 31 tests pass