### PR TITLE
perf(preprod): Add timing metric around snapshot transaction block

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -138,8 +138,8 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "preprod.snapshot.transaction_duration",
                 sample_rate=1.0,
                 tags={
-                    "has_vcs": str(bool(head_sha and provider and head_repo_name and head_ref)),
-                    "organization_id_value": str(project.organization_id),
+                    "has_vcs": bool(head_sha and provider and head_repo_name and head_ref),
+                    "organization_id_value": project.organization_id,
                 },
             ),
             transaction.atomic(router.db_for_write(PreprodArtifact)),

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -24,6 +24,7 @@ from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +131,19 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         base_ref = data.get("base_ref")
         pr_number = data.get("pr_number")
 
-        with transaction.atomic(router.db_for_write(PreprodArtifact)):
+        # has_vcs tag differentiates transactions that include a CommitComparison
+        # lookup from those that skip it, so we can isolate their latency on dashboards.
+        with (
+            metrics.timer(
+                "preprod.snapshot.transaction_duration",
+                sample_rate=1.0,
+                tags={
+                    "has_vcs": str(bool(head_sha and provider and head_repo_name and head_ref)),
+                    "organization_id_value": str(project.organization_id),
+                },
+            ),
+            transaction.atomic(router.db_for_write(PreprodArtifact)),
+        ):
             commit_comparison = None
             if head_sha and provider and head_repo_name and head_ref:
                 commit_comparison, _ = CommitComparison.objects.get_or_create(


### PR DESCRIPTION
Wraps the atomic transaction in the preprod snapshot upload endpoint with
a `metrics.timer` to track how long the combined DB writes + objectstore
put takes. This lets us monitor for potential slowdowns before they become
problematic (e.g. objectstore writes inside the transaction causing
timeouts).

Uses the parenthesized multi-context manager pattern to avoid adding an
extra indentation level. Tags with `has_vcs` (to differentiate
transactions that include a `CommitComparison` lookup) and
`organization_id_value` for dashboard filtering.