### PR TITLE
feat(preprod): Use dedicated preprod-snapshots feature flag for snapshot endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -87,7 +87,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
         """
 
         if not settings.IS_DEV and not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
+            "organizations:preprod-snapshots", project.organization, actor=request.user
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
 
@@ -109,7 +109,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
     def post(self, request: Request, project: Project) -> Response:
         if not settings.IS_DEV and not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
+            "organizations:preprod-snapshots", project.organization, actor=request.user
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -39,7 +39,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
@@ -75,7 +75,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
@@ -103,7 +103,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
@@ -125,7 +125,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 200
@@ -137,7 +137,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             # Missing images field
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
@@ -155,7 +155,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
@@ -173,7 +173,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             },
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400
@@ -194,7 +194,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def test_snapshot_invalid_json(self):
         url = self._get_create_url()
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, "invalid json", content_type="application/json")
 
         assert response.status_code == 400
@@ -210,7 +210,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = unauthenticated_client.post(url, data, format="json")
 
         assert response.status_code == 401
@@ -225,7 +225,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 403
@@ -238,7 +238,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "images": {},
         }
 
-        with self.feature("organizations:preprod-frontend-routes"):
+        with self.feature("organizations:preprod-snapshots"):
             response = self.client.post(url, data, format="json")
 
         assert response.status_code == 400


### PR DESCRIPTION
Switch the snapshot endpoint from the generic `preprod-frontend-routes` flag to the more specific `preprod-snapshots` flag. This enables independent control over snapshot API access without being tied to the broader frontend routes rollout.

Both the GET and POST handlers on `ProjectPreprodSnapshotEndpoint` are updated to check the new flag.