### PR TITLE
ref(seer): Add method param to signed API

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3380,13 +3380,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Controls the rate of using the sentry api shared secret for communicating to sentry.
-register(
-    "seer.api.use-shared-secret",
-    default=0.0,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 register(
     "similarity.backfill_nodestore_use_multithread",
     default=False,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3380,6 +3380,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Controls the rate of using the sentry api shared secret for communicating to sentry.
+# DEPRECATED: will be removed after the shared secret is confirmed to always be set.
+register(
+    "seer.api.use-shared-secret",
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 register(
     "similarity.backfill_nodestore_use_multithread",
     default=False,

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -8,24 +8,9 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
-from sentry.net.http import connection_from_url
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
-
-# Default connection pools for different Seer services
-# These can be reused across multiple requests to the same service
-seer_autofix_default_connection_pool = connection_from_url(
-    settings.SEER_AUTOFIX_URL,
-)
-
-seer_summarization_default_connection_pool = connection_from_url(
-    settings.SEER_SUMMARIZATION_URL,
-)
-
-seer_anomaly_detection_default_connection_pool = connection_from_url(
-    settings.SEER_ANOMALY_DETECTION_URL,
-)
 
 
 @sentry_sdk.tracing.trace
@@ -79,6 +64,6 @@ def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     else:
         # TODO(jstanley): remove this once the shared secret is confirmed to always be set
         logger.warning(
-            "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
+            "settings.SEER_API_SHARED_SECRET is not set. Unable to add auth headers for call to Seer."
         )
     return auth_headers

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import logging
-from random import random
 from typing import Any
 from urllib.parse import urlparse
 
@@ -9,10 +8,24 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
-from sentry import options
+from sentry.net.http import connection_from_url
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+# Default connection pools for different Seer services
+# These can be reused across multiple requests to the same service
+seer_autofix_default_connection_pool = connection_from_url(
+    settings.SEER_AUTOFIX_URL,
+)
+
+seer_summarization_default_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+)
+
+seer_anomaly_detection_default_connection_pool = connection_from_url(
+    settings.SEER_ANOMALY_DETECTION_URL,
+)
 
 
 @sentry_sdk.tracing.trace
@@ -23,6 +36,7 @@ def make_signed_seer_api_request(
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
     metric_tags: dict[str, Any] | None = None,
+    method: str = "POST",
 ) -> BaseHTTPResponse:
     host = connection_pool.host
     if connection_pool.port:
@@ -45,7 +59,7 @@ def make_signed_seer_api_request(
         tags={"endpoint": parsed.path, **(metric_tags or {})},
     ):
         return connection_pool.urlopen(
-            "POST",
+            method,
             parsed.path,
             body=body,
             headers={"content-type": "application/json;charset=utf-8", **auth_headers},
@@ -55,16 +69,16 @@ def make_signed_seer_api_request(
 
 def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     auth_headers: dict[str, str] = {}
-    if random() < options.get("seer.api.use-shared-secret"):
-        if settings.SEER_API_SHARED_SECRET:
-            signature = hmac.new(
-                settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-                body,
-                hashlib.sha256,
-            ).hexdigest()
-            auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
-        else:
-            logger.warning(
-                "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
-            )
+    if settings.SEER_API_SHARED_SECRET:
+        signature = hmac.new(
+            settings.SEER_API_SHARED_SECRET.encode("utf-8"),
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+        auth_headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
+    else:
+        # TODO(jstanley): remove this once the shared secret is confirmed to always be set
+        logger.warning(
+            "Seer.api.use-shared-secret is set but secret is not set. Unable to add auth headers for call to Seer."
+        )
     return auth_headers

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -4,7 +4,6 @@ import pytest
 from django.test import override_settings
 
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.testutils.helpers import override_options
 
 REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
@@ -81,15 +80,14 @@ def test_uses_given_retries() -> None:
 
 @pytest.mark.django_db
 def test_uses_shared_secret_missing_secret() -> None:
-    with override_options({"seer.api.use-shared-secret": 1.0}):
-        mock_url_open = run_test_case(shared_secret="")
+    mock_url_open = run_test_case(shared_secret="")
 
-        mock_url_open.assert_called_once_with(
-            "POST",
-            PATH,
-            body=REQUEST_BODY,
-            headers={"content-type": "application/json;charset=utf-8"},
-        )
+    mock_url_open.assert_called_once_with(
+        "POST",
+        PATH,
+        body=REQUEST_BODY,
+        headers={"content-type": "application/json;charset=utf-8"},
+    )
 
 
 @pytest.mark.django_db

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -80,21 +80,6 @@ def test_uses_given_retries() -> None:
 
 
 @pytest.mark.django_db
-def test_uses_shared_secret() -> None:
-    with override_options({"seer.api.use-shared-secret": 1.0}):
-        mock_url_open = run_test_case()
-        mock_url_open.assert_called_once_with(
-            "POST",
-            PATH,
-            body=REQUEST_BODY,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
-            },
-        )
-
-
-@pytest.mark.django_db
 def test_uses_shared_secret_missing_secret() -> None:
     with override_options({"seer.api.use-shared-secret": 1.0}):
         mock_url_open = run_test_case(shared_secret="")

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -42,7 +42,10 @@ def test_simple() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
     )
 
 
@@ -53,7 +56,10 @@ def test_uses_given_timeout() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         timeout=5,
     )
 
@@ -65,7 +71,10 @@ def test_uses_given_retries() -> None:
         "POST",
         PATH,
         body=REQUEST_BODY,
-        headers={"content-type": "application/json;charset=utf-8"},
+        headers={
+            "content-type": "application/json;charset=utf-8",
+            "Authorization": "Rpcsignature rpc0:d2e6070dfab955db6fc9f3bc0518f75f27ca93ae2e393072929e5f6cba26ff07",
+        },
         retries=5,
     )
 


### PR DESCRIPTION
Add optional 'method' parameter to make_signed_seer_api_request() with
"POST" as default for backwards compatibility. 

Update sign_with_seer_secret to consistently apply authentication when
a shared secret is available, removing the previous random sampling.

These changes prepare for migrating from requests library to urllib3
connection pools while maintaining full backwards compatibility.