### PR TITLE
chore(search): Treat currencies as numbers

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -3350,6 +3350,91 @@ describe('SearchQueryBuilder', () => {
       });
     });
 
+    describe('currency', () => {
+      const currencyFilterKeys: TagCollection = {
+        cost: {
+          key: 'cost',
+          name: 'cost',
+        },
+      };
+
+      const fieldDefinitionGetter: FieldDefinitionGetter = () => ({
+        valueType: FieldValueType.CURRENCY,
+        kind: FieldKind.FIELD,
+      });
+
+      const currencyProps: SearchQueryBuilderProps = {
+        ...defaultProps,
+        filterKeys: currencyFilterKeys,
+        filterKeySections: [],
+        fieldDefinitionGetter,
+      };
+
+      it('new currency filters start with greater than operator and default value', async () => {
+        render(<SearchQueryBuilder {...currencyProps} />);
+        await userEvent.click(getLastInput());
+        await userEvent.click(screen.getByRole('option', {name: 'cost'}));
+
+        // Should start with the > operator and a value of 100
+        expect(await screen.findByRole('row', {name: 'cost:>100'})).toBeInTheDocument();
+      });
+
+      it('pre-fills input with current value when editing', async () => {
+        render(<SearchQueryBuilder {...currencyProps} initialQuery="cost:>42" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: cost'})
+        );
+
+        const input = await screen.findByRole('combobox', {name: 'Edit filter value'});
+        expect(input).toHaveValue('42');
+      });
+
+      it('currency filters have the correct operator options', async () => {
+        render(<SearchQueryBuilder {...currencyProps} initialQuery="cost:>100" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: cost'})
+        );
+
+        expect(await screen.findByRole('option', {name: 'is'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: 'is not'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '>'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '<'})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '>='})).toBeInTheDocument();
+        expect(screen.getByRole('option', {name: '<='})).toBeInTheDocument();
+      });
+
+      it('currency filters can change operator', async () => {
+        render(<SearchQueryBuilder {...currencyProps} initialQuery="cost:>100" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit operator for filter: cost'})
+        );
+
+        await userEvent.click(await screen.findByRole('option', {name: '<='}));
+
+        expect(await screen.findByRole('row', {name: 'cost:<=100'})).toBeInTheDocument();
+      });
+
+      it('currency filters do not allow invalid values', async () => {
+        render(<SearchQueryBuilder {...currencyProps} initialQuery="cost:>100" />);
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: cost'})
+        );
+
+        const combobox = await screen.findByRole('combobox', {name: 'Edit filter value'});
+        await userEvent.clear(combobox);
+        await userEvent.keyboard('a{Enter}');
+
+        // Should have the same value because "a" is not a numeric value
+        expect(screen.getByRole('row', {name: 'cost:>100'})).toBeInTheDocument();
+
+        await userEvent.clear(combobox);
+        await userEvent.keyboard('7k{Enter}');
+
+        // Should accept "7k" as a valid value
+        expect(await screen.findByRole('row', {name: 'cost:>7k'})).toBeInTheDocument();
+      });
+    });
+
     describe('date', () => {
       // Transpile the lazy-loaded datepicker up front so tests don't flake
       beforeAll(async () => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/utils.tsx
@@ -26,6 +26,7 @@ export function getValueSuggestions({
 }): SuggestionSection[] | null {
   switch (valueType) {
     case FieldValueType.NUMBER:
+    case FieldValueType.CURRENCY:
     case FieldValueType.INTEGER:
       return getNumericSuggestions(filterValue);
     case FieldValueType.DURATION:
@@ -62,6 +63,7 @@ export function cleanFilterValue({
 
   switch (valueType) {
     case FieldValueType.NUMBER:
+    case FieldValueType.CURRENCY:
       if (FILTER_VALUE_NUMERIC.test(value)) {
         return value;
       }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -54,6 +54,7 @@ export function getDefaultValueForValueType(valueType: FieldValueType | null): s
       return 'true';
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
+    case FieldValueType.CURRENCY:
       return '100';
     case FieldValueType.DATE:
       return '-24h';
@@ -128,6 +129,7 @@ export function getInitialFilterText(
   switch (valueType) {
     case FieldValueType.INTEGER:
     case FieldValueType.NUMBER:
+    case FieldValueType.CURRENCY:
     case FieldValueType.DURATION:
     case FieldValueType.SIZE:
     case FieldValueType.PERCENTAGE:

--- a/static/app/components/searchQueryBuilder/utils.tsx
+++ b/static/app/components/searchQueryBuilder/utils.tsx
@@ -46,6 +46,7 @@ function getSearchConfigFromKeys(
       case FieldValueType.NUMBER:
       case FieldValueType.INTEGER:
       case FieldValueType.PERCENTAGE:
+      case FieldValueType.CURRENCY:
         config.numericKeys.add(key);
         break;
       case FieldValueType.DATE:


### PR DESCRIPTION
This PR updates the search query experience for currency field types to treat them as numerics, given them access to comparison operators.

Requires: #108224
Ticket: EXP-787

