### PR TITLE
chore: Stop using /subscriptions and use /customers instead

### DIFF
--- a/fixtures/events/issue_detection/n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream.json
+++ b/fixtures/events/issue_detection/n-plus-one-api-calls/n-plus-one-api-calls-in-issue-stream.json
@@ -91,14 +91,14 @@
       "timestamp": 1667330086.5295,
       "start_timestamp": 1667330086.3058,
       "exclusive_time": 223.700046,
-      "description": "GET /api/0/subscriptions/sentry/",
+      "description": "GET /api/0/customers/sentry/",
       "op": "http.client",
       "span_id": "8252b556def01d1c",
       "parent_span_id": "a0c39078d1570b00",
       "trace_id": "0102834d0bf74d388ce0b1e15329f731",
       "status": "ok",
       "tags": {"http.status_code": "200"},
-      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/subscriptions/sentry/"},
+      "data": {"http.method": "GET", "type": "fetch", "url": "/api/0/customers/sentry/"},
       "hash": "51a97bb49057facc"
     },
     {

--- a/fixtures/events/issue_detection/n-plus-one-api-calls/not-n-plus-one-api-calls.json
+++ b/fixtures/events/issue_detection/n-plus-one-api-calls/not-n-plus-one-api-calls.json
@@ -138,7 +138,7 @@
       "timestamp": 1668493710.303,
       "start_timestamp": 1668493709.905,
       "exclusive_time": 398.000002,
-      "description": "GET /api/0/subscriptions/sentry/",
+      "description": "GET /api/0/customers/sentry/",
       "op": "http.client",
       "span_id": "902e507b27ba76ef",
       "parent_span_id": "9e4e36110481b5b5",
@@ -148,7 +148,7 @@
       "data": {
         "http.method": "GET",
         "type": "fetch",
-        "url": "/api/0/subscriptions/sentry/"
+        "url": "/api/0/customers/sentry/"
       },
       "hash": "d09dea4693554039"
     },

--- a/static/app/components/events/interfaces/performance/anrRootCause.spec.tsx
+++ b/static/app/components/events/interfaces/performance/anrRootCause.spec.tsx
@@ -176,7 +176,7 @@ describe('anrRootCause', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/subscriptions/org-slug/',
+      url: '/customers/org-slug/',
       method: 'GET',
       body: {},
     });

--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -42,7 +42,7 @@ describe('EventTraceView', () => {
   it('renders a trace', async () => {
     const size = 20;
     MockApiClient.addMockResponse({
-      url: '/subscriptions/org-slug/',
+      url: '/customers/org-slug/',
       method: 'GET',
       body: {},
     });
@@ -117,7 +117,7 @@ describe('EventTraceView', () => {
 
   it('does not render the trace preview if it has no transactions', async () => {
     MockApiClient.addMockResponse({
-      url: '/subscriptions/org-slug/',
+      url: '/customers/org-slug/',
       method: 'GET',
       body: {},
     });

--- a/static/app/gettingStartedDocs/react-native/logs.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/logs.spec.tsx
@@ -21,7 +21,7 @@ function renderMockRequests({
     body: [ProjectKeysFixture()[0]],
   });
   MockApiClient.addMockResponse({
-    url: `/subscriptions/${organization.slug}/`,
+    url: `/customers/${organization.slug}/`,
     method: 'GET',
     body: {},
   });

--- a/static/app/utils/requestError/sanitizePath.spec.tsx
+++ b/static/app/utils/requestError/sanitizePath.spec.tsx
@@ -113,12 +113,6 @@ describe('sanitizePath', () => {
         '/customers/{orgSlug}/',
       ],
 
-      [
-        // CustomerDetailsEndpoint
-        '/subscriptions/sentry/',
-        '/subscriptions/{orgSlug}/',
-      ],
-
       // replays endpionts
       [
         // ProjectReplayDetailsEndpoint

--- a/static/app/views/explore/logs/content.spec.tsx
+++ b/static/app/views/explore/logs/content.spec.tsx
@@ -70,7 +70,7 @@ describe('LogsPage', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/app/views/explore/logs/logsTab.spec.tsx
+++ b/static/app/views/explore/logs/logsTab.spec.tsx
@@ -153,7 +153,7 @@ describe('LogsTabContent', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -128,7 +128,7 @@ describe('MetricsTabContent', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });
@@ -462,7 +462,7 @@ describe('MetricsTabContent', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -103,7 +103,7 @@ describe('MultiQueryModeContent', () => {
       method: 'POST',
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: [],
     });

--- a/static/app/views/explore/spans/content.spec.tsx
+++ b/static/app/views/explore/spans/content.spec.tsx
@@ -20,7 +20,7 @@ describe('ExploreContent', () => {
     PageFiltersStore.init();
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -78,7 +78,7 @@ describe('SpansTabContent', () => {
       datetime: {period: '7d', start: null, end: null, utc: null},
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -347,7 +347,7 @@ const mockGroupApis = (
   });
 
   MockApiClient.addMockResponse({
-    url: '/subscriptions/org-slug/',
+    url: '/customers/org-slug/',
     method: 'GET',
     body: {},
   });

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -85,7 +85,7 @@ function mockTraceResponse(resp?: Partial<ResponseType>) {
 
 function mockPerformanceSubscriptionDetailsResponse(resp?: Partial<ResponseType>) {
   MockApiClient.addMockResponse({
-    url: '/subscriptions/org-slug/',
+    url: '/customers/org-slug/',
     method: 'GET',
     asyncDelay: 1,
     ...(resp ?? {body: {}}),

--- a/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTypeWarnings/usePerformanceSubscriptionDetails.tsx
@@ -45,7 +45,7 @@ export function usePerformanceSubscriptionDetails({
   const organization = useOrganization();
 
   const {data: subscription, ...rest} = useApiQuery<Subscription>(
-    [`/subscriptions/${organization.slug}/`],
+    [`/customers/${organization.slug}/`],
     {
       staleTime: Infinity,
     }

--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -91,7 +91,7 @@ describe('ChangePlanAction', () => {
 
     // Set up default subscription response
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${mockOrg.slug}/`,
+      url: `/customers/${mockOrg.slug}/`,
       body: subscription,
     });
 
@@ -184,7 +184,7 @@ describe('ChangePlanAction', () => {
     });
     SubscriptionStore.set(mockOrg.slug, ntSubscription);
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${mockOrg.slug}/`,
+      url: `/customers/${mockOrg.slug}/`,
       body: ntSubscription,
     });
 
@@ -413,7 +413,7 @@ describe('ChangePlanAction', () => {
 
       // Set up default subscription response
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${mockOrg.slug}/`,
+        url: `/customers/${mockOrg.slug}/`,
         body: subscription,
       });
 
@@ -475,7 +475,7 @@ describe('ChangePlanAction', () => {
 
       SubscriptionStore.set(mockOrg.slug, subscriptionWithSeer);
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${mockOrg.slug}/`,
+        url: `/customers/${mockOrg.slug}/`,
         body: subscriptionWithSeer,
       });
 

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -2227,10 +2227,6 @@ describe('Customer Details', () => {
         method: 'PUT',
         body: Subscription,
       });
-      MockApiClient.addMockResponse({
-        url: `/customers/${sub.slug}/`,
-        body: sub,
-      });
 
       render(<CustomerDetails />, {
         initialRouterConfig: {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -2228,7 +2228,7 @@ describe('Customer Details', () => {
         body: Subscription,
       });
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${sub.slug}/`,
+        url: `/customers/${sub.slug}/`,
         body: sub,
       });
 
@@ -2276,7 +2276,7 @@ describe('Customer Details', () => {
       });
 
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${sub.slug}/`,
+        url: `/customers/${sub.slug}/`,
         body: sub,
       });
 

--- a/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
+++ b/static/gsApp/components/features/insightsDateRangeQueryLimitFooter.spec.tsx
@@ -23,7 +23,7 @@ describe('InsightsUpsellPage', () => {
       body: BillingConfigFixture(PlanTier.AM3),
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/org-slug/`,
+      url: `/customers/org-slug/`,
       body: {},
     });
 

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -52,7 +52,7 @@ function setUpTests() {
     body: [],
   });
   MockApiClient.addMockResponse({
-    url: `/subscriptions/org-slug/`,
+    url: `/customers/org-slug/`,
     body: {},
   });
   MockApiClient.addMockResponse({

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -296,7 +296,7 @@ describe('PrimaryNavigationQuotaExceeded', () => {
     );
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       body: freeSub,
     });
 

--- a/static/gsApp/components/productSelectionAvailability.spec.tsx
+++ b/static/gsApp/components/productSelectionAvailability.spec.tsx
@@ -42,7 +42,7 @@ function renderMockRequests({
   act(() => SubscriptionStore.set(organization.slug, subscription));
 
   MockApiClient.addMockResponse({
-    url: `/subscriptions/org-slug/`,
+    url: `/customers/org-slug/`,
     body: {
       planTier,
       canSelfServe,

--- a/static/gsApp/components/productTrial/productTrialAlert.spec.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.spec.tsx
@@ -22,7 +22,7 @@ describe('ProductTrialAlert', () => {
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/components/productUnavailableCTA.spec.tsx
+++ b/static/gsApp/components/productUnavailableCTA.spec.tsx
@@ -41,7 +41,7 @@ function renderMockRequests({
   act(() => SubscriptionStore.set(organization.slug, subscription));
 
   MockApiClient.addMockResponse({
-    url: `/subscriptions/${organization.slug}/`,
+    url: `/customers/${organization.slug}/`,
     body: {
       planTier,
     },

--- a/static/gsApp/components/startTrialButton.spec.tsx
+++ b/static/gsApp/components/startTrialButton.spec.tsx
@@ -12,7 +12,7 @@ describe('StartTrialButton', () => {
 
     org = OrganizationFixture();
     endpoint = MockApiClient.addMockResponse({
-      url: `/subscriptions/${org.slug}/`,
+      url: `/customers/${org.slug}/`,
       method: 'GET',
       body: SubscriptionFixture({organization: org}),
     });

--- a/static/gsApp/components/trialStarter.spec.tsx
+++ b/static/gsApp/components/trialStarter.spec.tsx
@@ -53,7 +53,7 @@ describe('TrialStarter', () => {
     });
 
     const reloadSubsMock = MockApiClient.addMockResponse({
-      url: `/subscriptions/${org.slug}/`,
+      url: `/customers/${org.slug}/`,
       method: 'GET',
       body: sub,
     });

--- a/static/gsApp/components/upsellModal/details.spec.tsx
+++ b/static/gsApp/components/upsellModal/details.spec.tsx
@@ -15,7 +15,7 @@ describe('Upsell Modal Details', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/components/upsellModal/footer.spec.tsx
+++ b/static/gsApp/components/upsellModal/footer.spec.tsx
@@ -14,7 +14,7 @@ describe('Business Landing Footer', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/components/upsellProvider.spec.tsx
+++ b/static/gsApp/components/upsellProvider.spec.tsx
@@ -56,7 +56,7 @@ describe('UpsellProvider', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${org.slug}/`,
+      url: `/customers/${org.slug}/`,
       body: sub,
     });
 

--- a/static/gsApp/hooks/disabledMemberView.spec.tsx
+++ b/static/gsApp/hooks/disabledMemberView.spec.tsx
@@ -15,7 +15,7 @@ describe('DisabledMemberView', () => {
     SubscriptionStore.set(organization.slug, sub);
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/org-slug/`,
+      url: `/customers/org-slug/`,
       body: sub,
     });
 

--- a/static/gsApp/hooks/githubInstallationSelectInstall.spec.tsx
+++ b/static/gsApp/hooks/githubInstallationSelectInstall.spec.tsx
@@ -39,7 +39,7 @@ describe('GithubInstallationSelectInstallButton', () => {
 
   it('renders Install button when installationID is -1', async () => {
     MockApiClient.addMockResponse({
-      url: '/subscriptions/org-slug/',
+      url: '/customers/org-slug/',
       method: 'GET',
       body: subscription,
     });
@@ -78,7 +78,7 @@ describe('GithubInstallationSelectInstallButton', () => {
 
   it('opens upsell modal and tracks analytics when Upgrade button is clicked', async () => {
     MockApiClient.addMockResponse({
-      url: '/subscriptions/org-slug/',
+      url: '/customers/org-slug/',
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/stores/subscriptionStore.spec.tsx
+++ b/static/gsApp/stores/subscriptionStore.spec.tsx
@@ -22,7 +22,7 @@ describe('SubscriptionStore', () => {
 
   it('should load data', async () => {
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       body: subscription,
     });
 
@@ -35,7 +35,7 @@ describe('SubscriptionStore', () => {
 
   it('should mark trial started and clear trial', async () => {
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       body: subscription,
     });
 

--- a/static/gsApp/stores/subscriptionStore.tsx
+++ b/static/gsApp/stores/subscriptionStore.tsx
@@ -107,7 +107,7 @@ const subscriptionStoreConfig: SubscriptionStoreDefintion = {
     }
     this.loadingData[orgSlug] = true;
 
-    const data = await this.api.requestPromise(`/subscriptions/${orgSlug}/`);
+    const data = await this.api.requestPromise(`/customers/${orgSlug}/`);
     if (markStartedTrial) {
       data.isTrialStarted = true;
     }

--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -68,7 +68,7 @@ describe('Cart', () => {
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/index.spec.tsx
+++ b/static/gsApp/views/amCheckout/index.spec.tsx
@@ -53,7 +53,7 @@ describe('Legacy Tier Checkout', () => {
     MockApiClient.clearMockResponses();
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });
@@ -187,7 +187,7 @@ describe('Default Tier Checkout', () => {
       body: BillingConfigFixture(PlanTier.AM3),
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/steps/addBillingInfo.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/addBillingInfo.spec.tsx
@@ -22,7 +22,7 @@ describe('AddBillingInformation', () => {
     SubscriptionStore.set(organization.slug, subscription);
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/steps/buildYourPlan.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/buildYourPlan.spec.tsx
@@ -21,7 +21,7 @@ describe('BuildYourPlan', () => {
     SubscriptionStore.set(organization.slug, subscription);
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.spec.tsx
@@ -28,7 +28,7 @@ describe('ChooseYourBillingCycle', () => {
     SubscriptionStore.set(organization.slug, subscription);
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/productSelect.spec.tsx
@@ -26,7 +26,7 @@ describe('ProductSelect', () => {
     SubscriptionStore.set(organization.slug, subscription);
 
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -105,7 +105,7 @@ describe('ReserveAdditionalVolume', () => {
         body: {},
       });
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${organization.slug}/`,
+        url: `/customers/${organization.slug}/`,
         method: 'GET',
         body: {},
       });
@@ -240,7 +240,7 @@ describe('ReserveAdditionalVolume', () => {
         body: {},
       });
       MockApiClient.addMockResponse({
-        url: `/subscriptions/${organization.slug}/`,
+        url: `/customers/${organization.slug}/`,
         method: 'GET',
         body: {},
       });

--- a/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/setSpendLimit.spec.tsx
@@ -24,7 +24,7 @@ describe('SetSpendLimit', () => {
     api = new MockApiClient();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: {},
     });

--- a/static/gsApp/views/cancelSubscription.spec.tsx
+++ b/static/gsApp/views/cancelSubscription.spec.tsx
@@ -22,11 +22,6 @@ describe('CancelSubscription', () => {
       method: 'GET',
       body: subscription,
     });
-    MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/`,
-      method: 'GET',
-      body: subscription,
-    });
   });
 
   it('renders', async () => {

--- a/static/gsApp/views/cancelSubscription.spec.tsx
+++ b/static/gsApp/views/cancelSubscription.spec.tsx
@@ -23,7 +23,7 @@ describe('CancelSubscription', () => {
       body: subscription,
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/views/legalAndCompliance/termsAndConditions.spec.tsx
+++ b/static/gsApp/views/legalAndCompliance/termsAndConditions.spec.tsx
@@ -22,7 +22,7 @@ describe('TermsAndConditions', () => {
       method: 'GET',
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
@@ -36,7 +36,7 @@ describe('Subscription > BillingInformation', () => {
       body: BillingConfigFixture(PlanTier.AM1),
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
     });
     MockApiClient.addMockResponse({
@@ -44,7 +44,7 @@ describe('Subscription > BillingInformation', () => {
       method: 'GET',
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: subscription,
     });

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.spec.tsx
@@ -134,7 +134,7 @@ describe('PaygCard', () => {
 
   it('can update using inline input', async () => {
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
     });
     const mockApiCall = MockApiClient.addMockResponse({

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.spec.tsx
@@ -26,7 +26,7 @@ describe('SubscriptionHeader', () => {
       method: 'GET',
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/org-slug/`,
+      url: `/customers/org-slug/`,
       method: 'GET',
       body: [],
     });

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.spec.tsx
@@ -21,7 +21,7 @@ describe('SubscriptionUpsellBanner', () => {
       body: {},
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/org-slug/`,
+      url: `/customers/org-slug/`,
       body: {},
     });
     MockApiClient.addMockResponse({

--- a/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.spec.tsx
@@ -23,7 +23,7 @@ describe('Subscription Usage Log', () => {
       body: BillingConfigFixture(PlanTier.AM1),
     });
     MockApiClient.addMockResponse({
-      url: `/subscriptions/${organization.slug}/`,
+      url: `/customers/${organization.slug}/`,
       method: 'GET',
       body: sub,
     });


### PR DESCRIPTION
We have the same endpoint mounted to two URLs. We're trying to minimize the number of endpoints that require cell routing and this is the only remaining `/subcriptions/` endpoint.

Refs INFRENG-232