### PR TITLE
fix(explore): Use unique IDs in drag-and-drop column editors

### DIFF
--- a/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
@@ -2,7 +2,9 @@ import {useState} from 'react';
 
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
-import {useDragNDropColumns} from './useDragNDropColumns';
+import {isUUID} from 'sentry/utils/string/isUUID';
+
+import {useDragNDropColumns, type Column} from './useDragNDropColumns';
 
 describe('useDragNDropColumns', () => {
   const initialColumns = ['span.op', 'span_id', 'timestamp'];
@@ -84,5 +86,71 @@ describe('useDragNDropColumns', () => {
     );
 
     expect(columns).toEqual(['span_id', 'timestamp', 'span.op']);
+  });
+
+  it('should generate unique UUIDs for editable columns', () => {
+    let columns!: string[];
+    let setColumns: (columns: string[]) => void;
+    let editableColumns!: Array<Column<string>>;
+
+    function TestPage() {
+      [columns, setColumns] = useState(initialColumns);
+      ({editableColumns} = useDragNDropColumns({columns, setColumns}));
+      return null;
+    }
+
+    render(<TestPage />);
+
+    expect(editableColumns).toHaveLength(initialColumns.length);
+    expect(editableColumns.map(column => column.column)).toEqual(initialColumns);
+    expect(editableColumns.every(column => isUUID(column.uniqueId))).toBe(true);
+    expect(new Set(editableColumns.map(column => column.uniqueId)).size).toBe(
+      editableColumns.length
+    );
+  });
+
+  it('should generate unique UUIDs when column values are duplicated', () => {
+    const duplicateColumns = ['span.op', 'span.op', 'span.op'];
+    let columns!: string[];
+    let setColumns: (columns: string[]) => void;
+    let editableColumns!: Array<Column<string>>;
+
+    function TestPage() {
+      [columns, setColumns] = useState(duplicateColumns);
+      ({editableColumns} = useDragNDropColumns({columns, setColumns}));
+      return null;
+    }
+
+    render(<TestPage />);
+
+    expect(editableColumns.map(column => column.column)).toEqual(duplicateColumns);
+    expect(new Set(editableColumns.map(column => column.uniqueId)).size).toBe(
+      duplicateColumns.length
+    );
+  });
+
+  it('should preserve unique IDs when updating a column value', () => {
+    let columns!: string[];
+    let setColumns: (columns: string[]) => void;
+    let editableColumns!: Array<Column<string>>;
+    let updateColumnAtIndex: (i: number, column: string) => void;
+
+    function TestPage() {
+      [columns, setColumns] = useState(initialColumns);
+      ({editableColumns, updateColumnAtIndex} = useDragNDropColumns({
+        columns,
+        setColumns,
+      }));
+      return null;
+    }
+
+    render(<TestPage />);
+
+    const uniqueIdsBefore = editableColumns.map(column => column.uniqueId);
+
+    act(() => updateColumnAtIndex(1, 'span.description'));
+
+    const uniqueIdsAfter = editableColumns.map(column => column.uniqueId);
+    expect(uniqueIdsAfter).toEqual(uniqueIdsBefore);
   });
 });

--- a/static/app/views/explore/hooks/useDragNDropColumns.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.tsx
@@ -1,10 +1,13 @@
-import {useMemo} from 'react';
+import {useRef} from 'react';
 import type {DragEndEvent} from '@dnd-kit/core';
 import {arrayMove} from '@dnd-kit/sortable';
+
+import {uniqueId} from 'sentry/utils/guid';
 
 export type Column<T> = {
   column: T;
   id: number;
+  uniqueId: string;
 };
 
 interface UseDragAndDropColumnsProps<T> {
@@ -16,11 +19,22 @@ export function useDragNDropColumns<T>({
   columns,
   setColumns,
 }: UseDragAndDropColumnsProps<T>) {
-  const editableColumns = useMemo(() => {
-    return columns.map((column, i) => ({id: i + 1, column}));
-  }, [columns]);
+  const uniqueIdsRef = useRef<string[]>([]);
+
+  const nextUniqueIds = uniqueIdsRef.current.slice(0, columns.length);
+  while (nextUniqueIds.length < columns.length) {
+    nextUniqueIds.push(uniqueId());
+  }
+  uniqueIdsRef.current = nextUniqueIds;
+
+  const editableColumns = columns.map((column, i) => ({
+    id: i + 1,
+    uniqueId: uniqueIdsRef.current[i]!,
+    column,
+  }));
 
   function insertColumn(column: T) {
+    uniqueIdsRef.current = [...uniqueIdsRef.current, uniqueId()];
     setColumns([...columns, column], 'insert');
   }
 
@@ -32,6 +46,7 @@ export function useDragNDropColumns<T>({
   }
 
   function deleteColumnAtIndex(i: number) {
+    uniqueIdsRef.current = uniqueIdsRef.current.filter((_, j) => i !== j);
     setColumns(
       columns.filter((_: T, j: number) => i !== j),
       'delete'
@@ -44,6 +59,10 @@ export function useDragNDropColumns<T>({
     if (active.id !== over?.id) {
       const oldIndex = editableColumns.findIndex(({id}) => id === active.id);
       const newIndex = editableColumns.findIndex(({id}) => id === over?.id);
+      if (oldIndex < 0 || newIndex < 0) {
+        return;
+      }
+      uniqueIdsRef.current = arrayMove(uniqueIdsRef.current, oldIndex, newIndex);
       setColumns(arrayMove(columns, oldIndex, newIndex), 'reorder');
     }
   }

--- a/static/app/views/explore/hooks/useDragNDropColumns.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.tsx
@@ -21,11 +21,10 @@ export function useDragNDropColumns<T>({
 }: UseDragAndDropColumnsProps<T>) {
   const uniqueIdsRef = useRef<string[]>([]);
 
-  const nextUniqueIds = uniqueIdsRef.current.slice(0, columns.length);
-  while (nextUniqueIds.length < columns.length) {
-    nextUniqueIds.push(uniqueId());
+  uniqueIdsRef.current.length = Math.min(uniqueIdsRef.current.length, columns.length);
+  while (uniqueIdsRef.current.length < columns.length) {
+    uniqueIdsRef.current.push(uniqueId());
   }
-  uniqueIdsRef.current = nextUniqueIds;
 
   const editableColumns = columns.map((column, i) => ({
     id: i + 1,

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -166,6 +166,53 @@ describe('AggregateColumnEditorModal', () => {
     ]);
   });
 
+  it('handles duplicate visualize columns without collapsing rows', async () => {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <AggregateColumnEditorModal
+            {...modalProps}
+            columns={[
+              {groupBy: 'geo.country'},
+              new VisualizeFunction('count(span.duration)'),
+              new VisualizeFunction('count(span.duration)'),
+            ]}
+            onColumnsChange={onColumnsChange}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={booleanTags}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    let rows = await screen.findAllByTestId('editor-row');
+    expectRows(rows).toHaveAggregateFields([
+      {groupBy: 'geo.country'},
+      new VisualizeFunction('count(span.duration)'),
+      new VisualizeFunction('count(span.duration)'),
+    ]);
+
+    await userEvent.click(screen.getAllByLabelText('Remove Column')[2]!);
+
+    rows = await screen.findAllByTestId('editor-row');
+    expectRows(rows).toHaveAggregateFields([
+      {groupBy: 'geo.country'},
+      new VisualizeFunction('count(span.duration)'),
+    ]);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith([
+      {groupBy: 'geo.country'},
+      {yAxes: ['count(span.duration)']},
+    ]);
+  });
+
   it('allows adding a column', async () => {
     const onColumnsChange = jest.fn();
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -123,7 +123,7 @@ export function AggregateColumnEditorModal({
             {editableColumns.map((column, i) => {
               return (
                 <ColumnEditorRow
-                  key={column.id}
+                  key={column.uniqueId}
                   organization={organization}
                   canDelete={
                     isGroupBy(column.column) ? canDeleteGroupBy : canDeleteVisualize

--- a/static/app/views/explore/tables/columnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.spec.tsx
@@ -117,6 +117,44 @@ describe('ColumnEditorModal', () => {
     expect(onColumnsChange).toHaveBeenCalledWith(['project']);
   });
 
+  it('handles duplicate columns without collapsing rows', async () => {
+    const onColumnsChange = jest.fn();
+
+    renderGlobalModal();
+
+    act(() => {
+      openModal(
+        modalProps => (
+          <ColumnEditorModal
+            {...modalProps}
+            columns={['id', 'id', 'project']}
+            onColumnsChange={onColumnsChange}
+            stringTags={stringTags}
+            numberTags={numberTags}
+            booleanTags={{}}
+          />
+        ),
+        {onClose: jest.fn()}
+      );
+    });
+
+    let columns = screen.getAllByTestId('editor-column');
+    expect(columns).toHaveLength(3);
+    expect(columns[0]).toHaveTextContent('id');
+    expect(columns[1]).toHaveTextContent('id');
+    expect(columns[2]).toHaveTextContent('project');
+
+    await userEvent.click(screen.getAllByLabelText('Remove Column')[1]!);
+
+    columns = screen.getAllByTestId('editor-column');
+    expect(columns).toHaveLength(2);
+    expect(columns[0]).toHaveTextContent('id');
+    expect(columns[1]).toHaveTextContent('project');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Apply'}));
+    expect(onColumnsChange).toHaveBeenCalledWith(['id', 'project']);
+  });
+
   it('allows adding a column', async () => {
     const onColumnsChange = jest.fn();
 

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -170,7 +170,7 @@ export function ColumnEditorModal({
             {editableColumns.map((column, i) => {
               return (
                 <ColumnEditorRow
-                  key={`${column.column}-${column.id}`}
+                  key={column.uniqueId}
                   canDelete={editableColumns.length > 1}
                   required={requiredTags?.includes(column.column)}
                   column={column}


### PR DESCRIPTION
## Summary
- Updates `useDragNDropColumns` to generate stable UUIDs for each column, replacing index-based keys
- Uses `uniqueId` as the React `key` in both `columnEditorModal` and `aggregateColumnEditorModal`
- Fixes an issue where duplicate column values (e.g. two `count(span.duration)` visualizes) would cause rows to collapse because React keys were not unique

## Test plan
- Added tests verifying unique UUIDs are generated for editable columns
- Added tests verifying duplicate columns get distinct UUIDs
- Added tests verifying unique IDs are preserved when updating a column value
- Added integration tests for both `columnEditorModal` and `aggregateColumnEditorModal` confirming duplicate rows are not collapsed on deletion