### PR TITLE
feat(issues): Track AI title usage in issue view creation analytics

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -215,6 +215,8 @@ export type IssueEventParameters = {
   'issue_views.save.clicked': Record<string, unknown>;
   'issue_views.save_as.clicked': Record<string, unknown>;
   'issue_views.save_as.created': {
+    ai_title_shown: boolean;
+    ai_title_used: boolean;
     starred: boolean;
     surface: 'issue-view-details' | 'issues-feed' | 'issue-views-list';
   };

--- a/static/app/views/issueList/issueViews/createIssueViewModal.tsx
+++ b/static/app/views/issueList/issueViews/createIssueViewModal.tsx
@@ -76,7 +76,7 @@ function useGeneratedIssueViewName({
     cancelFormTypingAnimation();
   }, [cancelFormTypingAnimation]);
 
-  return {isGeneratingTitle, handleNameChange};
+  return {isGeneratingTitle, handleNameChange, generatedTitle: data?.title};
 }
 
 export function CreateIssueViewModal({
@@ -96,11 +96,13 @@ export function CreateIssueViewModal({
   const initialQuery = incomingQuery ?? 'is:unresolved';
   const organization = useOrganization();
   const navigate = useNavigate();
-  const {isGeneratingTitle, handleNameChange} = useGeneratedIssueViewName({
-    formModel,
-    query: initialQuery,
-    enabled: !initialName.trim(),
-  });
+  const {isGeneratingTitle, handleNameChange, generatedTitle} = useGeneratedIssueViewName(
+    {
+      formModel,
+      query: initialQuery,
+      enabled: !initialName.trim(),
+    }
+  );
 
   const {
     mutate: createIssueView,
@@ -119,6 +121,8 @@ export function CreateIssueViewModal({
         organization,
         surface: analyticsSurface,
         starred: variables.starred ?? false,
+        ai_title_shown: !!generatedTitle,
+        ai_title_used: !!generatedTitle && variables.name === generatedTitle,
       });
       closeModal();
     },


### PR DESCRIPTION
Add ai_title_shown and ai_title_used properties to the issue_views.save_as.created analytics event to measure adoption of AI-generated issue view titles.
