### PR TITLE
fix(ACI): Update tests to use 'any-short' logic type for trigger conditions

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -733,7 +733,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             **self.valid_workflow,
             "actionFilters": [
                 {
-                    "logicType": "any",
+                    "logicType": "any-short",
                     "conditions": [
                         {
                             "conditionGroupId": other_dcg.id,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1023,7 +1023,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
         data = {
             **self.valid_workflow,
             "triggers": {
-                "logicType": "any",
+                "logicType": "any-short",
                 "conditions": [
                     {
                         "conditionGroupId": other_dcg.id,
@@ -1063,7 +1063,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             **self.valid_workflow,
             "actionFilters": [
                 {
-                    "logicType": "any",
+                    "logicType": "any-short",
                     "conditions": [
                         {
                             "conditionGroupId": other_dcg.id,


### PR DESCRIPTION
Three tests were missed in fe7b9ff (#107548) which added validation requiring
trigger conditions to use `any-short` logic type. The `_validate_logic_type`
check in `BaseDataConditionGroupValidator.create()` fires for all DCGs
(triggers and action filters) when conditions contain trigger condition types
like `first_seen_event`.

Failing tests:
- `test_create_trigger_condition_from_different_organization` — trigger with `logicType: "any"`
- `test_create_action_filter_condition_from_different_organization` — action filter with `logicType: "any"` and `first_seen_event` condition
- `test_update_action_filter_condition_from_different_organization` — same as above in update path

Fix: change `logicType` from `"any"` to `"any-short"` in all three test payloads.