### PR TITLE
ref(explorer): clamp rec event algo to 14d and fallback on error or timeout

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -793,20 +793,20 @@ def _get_recommended_event(
     Time range defaults to the group's first and last seen times.
     If multiple events are valid, return the one with highest RECOMMENDED ordering.
     If no events are valid, return the highest recommended event.
+
+    Also falls back to the regular recommended event in case of query failures or custom timeout.
     """
     start_time = time.time()
 
     # Config
-    max_date_range = timedelta(days=14)
+    max_date_range = timedelta(days=14)  # Clamp date range as the query loop can be very expensive.
     timeout = 55  # Sentry API timeout is 60s - 5s buffer.
     event_query_limit = 50  # Events/trace IDs to query in each window.
     w_size = timedelta(days=3)
 
     start, end = get_group_date_range(group, organization, start, end)
-    # Clamp date range as these queries can be very expensive.
     start = max(start, end - max_date_range)
     retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
-
     w_start = max(end - w_size, start)
     w_end = end
     # Fallback to first event we find (most recommended in most recent window).

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -802,14 +802,14 @@ def _get_recommended_event(
     max_date_range = timedelta(days=14)  # Clamp date range as the query loop can be very expensive.
     timeout = 50  # Sentry API timeout is 60s - 10s buffer.
     event_query_limit = 50  # Events/trace IDs to query in each window.
-    w_size = timedelta(days=3)
+    window_size = timedelta(days=3)
 
     start, end = get_group_date_range(group, organization, start, end)
     unclamped_start = start
     start = max(start, end - max_date_range)
     retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
-    w_start = max(end - w_size, start)
-    w_end = end
+    window_start = max(end - window_size, start)
+    window_end = end
     # Fallback to first event we find (most recommended in most recent window).
     fallback_event: GroupEvent | None = None
 
@@ -818,23 +818,9 @@ def _get_recommended_event(
     else:
         dataset = Dataset.IssuePlatform
 
-    def get_default_event() -> GroupEvent | None:
+    def get_latest_event() -> GroupEvent | None:
         """If no events are found in the clamped range, use this query to return most recent event in the full range."""
-        events = eventstore.backend.get_events(
-            filter=eventstore.Filter(
-                start=unclamped_start,
-                end=end,
-                project_ids=[group.project.id],
-                group_ids=[group.id],
-            ),
-            limit=1,
-            referrer=Referrer.SEER_EXPLORER_TOOLS,
-            dataset=dataset,
-            tenant_ids={"organization_id": group.project.organization_id},
-        )
-        if events:
-            return events[0].for_group(group)
-        return None
+        return group.get_latest_event(start=unclamped_start, end=end)
 
     logger.info(
         "_get_recommended_event: starting query loop",
@@ -849,7 +835,7 @@ def _get_recommended_event(
         },
     )
 
-    while w_start >= start:
+    while window_start >= start:
         if time.time() - start_time > timeout:
             logger.warning(
                 "_get_recommended_event: timeout reached",
@@ -864,7 +850,7 @@ def _get_recommended_event(
                     "timeout": timeout,
                 },
             )
-            return fallback_event or get_default_event()
+            return fallback_event or get_latest_event()
 
         # Get candidate events with the standard recommended ordering.
         # This is an expensive orderby, hence the inner limit and sliding window.
@@ -872,8 +858,8 @@ def _get_recommended_event(
             events: list[Event] = eventstore.backend.get_events_snql(
                 organization_id=organization.id,
                 group_id=group.id,
-                start=w_start,
-                end=w_end,
+                start=window_start,
+                end=window_end,
                 conditions=[
                     Condition(Column("project_id"), Op.IN, [group.project.id]),
                     Condition(Column("group_id"), Op.IN, [group.id]),
@@ -895,7 +881,7 @@ def _get_recommended_event(
                     "dataset": dataset.value,
                 },
             )
-            return fallback_event or get_default_event()
+            return fallback_event or get_latest_event()
 
         if events and not fallback_event:
             fallback_event = events[0].for_group(group)
@@ -906,8 +892,8 @@ def _get_recommended_event(
             # Query EAP to get the span count of each trace.
             # Extend the time range by +-1 day to account for min/max trace start/end times.
             # Clamp spans_start to retention boundary to avoid QueryOutsideRetentionError.
-            spans_start = max(w_start - timedelta(days=1), retention_boundary)
-            spans_end = w_end + timedelta(days=1)
+            spans_start = max(window_start - timedelta(days=1), retention_boundary)
+            spans_end = window_end + timedelta(days=1)
             count_field = "count(span.duration)"
 
             try:
@@ -930,7 +916,7 @@ def _get_recommended_event(
                         "num_trace_ids": len(trace_ids),
                     },
                 )
-                return fallback_event or get_default_event()
+                return fallback_event or get_latest_event()
 
             if result and result.get("data"):
                 # Return the first event with a span count greater than 0.
@@ -944,11 +930,11 @@ def _get_recommended_event(
                     if e.trace_id in traces_with_spans:
                         return e.for_group(group)
 
-        if w_start == start:
+        if window_start == start:
             break
 
-        w_end = w_start
-        w_start = max(w_start - w_size, start)
+        window_end = window_start
+        window_start = max(window_start - window_size, start)
 
     logger.warning(
         "_get_recommended_event: no event with a span found",
@@ -963,7 +949,7 @@ def _get_recommended_event(
             "has_fallback_event": bool(fallback_event),
         },
     )
-    return fallback_event or get_default_event()
+    return fallback_event or get_latest_event()
 
 
 # Activity types to include in issue details for Seer Explorer (manual actions only)

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -800,11 +800,12 @@ def _get_recommended_event(
 
     # Config
     max_date_range = timedelta(days=14)  # Clamp date range as the query loop can be very expensive.
-    timeout = 55  # Sentry API timeout is 60s - 5s buffer.
+    timeout = 50  # Sentry API timeout is 60s - 10s buffer.
     event_query_limit = 50  # Events/trace IDs to query in each window.
     w_size = timedelta(days=3)
 
     start, end = get_group_date_range(group, organization, start, end)
+    unclamped_start = start
     start = max(start, end - max_date_range)
     retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
     w_start = max(end - w_size, start)
@@ -816,6 +817,24 @@ def _get_recommended_event(
         dataset = Dataset.Events
     else:
         dataset = Dataset.IssuePlatform
+
+    def get_default_event() -> GroupEvent | None:
+        """If no events are found in the clamped range, use this query to return most recent event in the full range."""
+        events = eventstore.backend.get_events(
+            filter=eventstore.Filter(
+                start=unclamped_start,
+                end=end,
+                project_ids=[group.project.id],
+                group_ids=[group.id],
+            ),
+            limit=1,
+            referrer=Referrer.SEER_EXPLORER_TOOLS,
+            dataset=dataset,
+            tenant_ids={"organization_id": group.project.organization_id},
+        )
+        if events:
+            return events[0].for_group(group)
+        return None
 
     logger.info(
         "_get_recommended_event: starting query loop",
@@ -845,7 +864,7 @@ def _get_recommended_event(
                     "timeout": timeout,
                 },
             )
-            return fallback_event
+            return fallback_event or get_default_event()
 
         # Get candidate events with the standard recommended ordering.
         # This is an expensive orderby, hence the inner limit and sliding window.
@@ -876,7 +895,7 @@ def _get_recommended_event(
                     "dataset": dataset.value,
                 },
             )
-            return fallback_event
+            return fallback_event or get_default_event()
 
         if events and not fallback_event:
             fallback_event = events[0].for_group(group)
@@ -911,7 +930,7 @@ def _get_recommended_event(
                         "num_trace_ids": len(trace_ids),
                     },
                 )
-                return fallback_event
+                return fallback_event or get_default_event()
 
             if result and result.get("data"):
                 # Return the first event with a span count greater than 0.
@@ -944,7 +963,7 @@ def _get_recommended_event(
             "has_fallback_event": bool(fallback_event),
         },
     )
-    return fallback_event
+    return fallback_event or get_default_event()
 
 
 # Activity types to include in issue details for Seer Explorer (manual actions only)

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -787,8 +787,6 @@ def _get_recommended_event(
     organization: Organization,
     start: datetime | None = None,
     end: datetime | None = None,
-    max_date_range: timedelta = timedelta(days=14),
-    timeout: int = 55,  # Sentry API timeout is 60s
 ) -> GroupEvent | None:
     """
     Our own implementation of Group.get_recommended_event. Requires the return event to fall in the time range and have a non-empty trace.
@@ -797,17 +795,21 @@ def _get_recommended_event(
     If no events are valid, return the highest recommended event.
     """
     start_time = time.time()
+
+    # Config
+    max_date_range = timedelta(days=14)
+    timeout = 55  # Sentry API timeout is 60s - 5s buffer.
+    event_query_limit = 50  # Events/trace IDs to query in each window.
+    w_size = timedelta(days=3)
+
     start, end = get_group_date_range(group, organization, start, end)
     # Clamp date range as these queries can be very expensive.
     start = max(start, end - max_date_range)
     retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
 
-    # Config
-    event_query_limit = 50  # Events/trace IDs to query in each window.
-    w_size = timedelta(days=3)
     w_start = max(end - w_size, start)
     w_end = end
-    # First event we find (most recommended in most recent window).
+    # Fallback to first event we find (most recommended in most recent window).
     fallback_event: GroupEvent | None = None
 
     if group.issue_category == GroupCategory.ERROR:

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import uuid
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, cast
@@ -786,6 +787,8 @@ def _get_recommended_event(
     organization: Organization,
     start: datetime | None = None,
     end: datetime | None = None,
+    max_date_range: timedelta = timedelta(days=14),
+    timeout: int = 55,  # Sentry API timeout is 60s
 ) -> GroupEvent | None:
     """
     Our own implementation of Group.get_recommended_event. Requires the return event to fall in the time range and have a non-empty trace.
@@ -793,51 +796,85 @@ def _get_recommended_event(
     If multiple events are valid, return the one with highest RECOMMENDED ordering.
     If no events are valid, return the highest recommended event.
     """
+    start_time = time.time()
     start, end = get_group_date_range(group, organization, start, end)
+    # Clamp date range as these queries can be very expensive.
+    start = max(start, end - max_date_range)
     retention_boundary = get_retention_boundary(organization, bool(start.tzinfo))
+
+    # Config
+    event_query_limit = 50  # Events/trace IDs to query in each window.
+    w_size = timedelta(days=3)
+    w_start = max(end - w_size, start)
+    w_end = end
+    # First event we find (most recommended in most recent window).
+    fallback_event: GroupEvent | None = None
 
     if group.issue_category == GroupCategory.ERROR:
         dataset = Dataset.Events
     else:
         dataset = Dataset.IssuePlatform
 
-    w_size = timedelta(days=3)
-    w_start = max(end - w_size, start)
-    w_end = end
-    event_query_limit = 100
-    fallback_event: GroupEvent | None = None  # Highest recommended in most recent window
-
     logger.info(
-        "get_issue_and_event_details_v2: Querying for recommended event with sliding window",
+        "_get_recommended_event: starting query loop",
         extra={
             "organization_id": organization.id,
+            "project_id": group.project.id,
             "issue_id": group.id,
             "timedelta": end - start,
             "start": start,
             "end": end,
-            "window_size": w_size,
+            "dataset": dataset.value,
         },
     )
 
     while w_start >= start:
+        if time.time() - start_time > timeout:
+            logger.warning(
+                "_get_recommended_event: timeout reached",
+                extra={
+                    "organization_id": organization.id,
+                    "project_id": group.project.id,
+                    "issue_id": group.id,
+                    "timedelta": end - start,
+                    "start": start,
+                    "end": end,
+                    "dataset": dataset.value,
+                    "timeout": timeout,
+                },
+            )
+            return fallback_event
+
         # Get candidate events with the standard recommended ordering.
         # This is an expensive orderby, hence the inner limit and sliding window.
-        events: list[Event] = eventstore.backend.get_events_snql(
-            organization_id=organization.id,
-            group_id=group.id,
-            start=w_start,
-            end=w_end,
-            conditions=[
-                Condition(Column("project_id"), Op.IN, [group.project.id]),
-                Condition(Column("group_id"), Op.IN, [group.id]),
-            ],
-            limit=event_query_limit,
-            orderby=EventOrdering.RECOMMENDED.value,
-            referrer=Referrer.SEER_EXPLORER_TOOLS,
-            dataset=dataset,
-            tenant_ids={"organization_id": group.project.organization_id},
-            inner_limit=1000,
-        )
+        try:
+            events: list[Event] = eventstore.backend.get_events_snql(
+                organization_id=organization.id,
+                group_id=group.id,
+                start=w_start,
+                end=w_end,
+                conditions=[
+                    Condition(Column("project_id"), Op.IN, [group.project.id]),
+                    Condition(Column("group_id"), Op.IN, [group.id]),
+                ],
+                limit=event_query_limit,
+                orderby=EventOrdering.RECOMMENDED.value,
+                referrer=Referrer.SEER_EXPLORER_TOOLS,
+                dataset=dataset,
+                tenant_ids={"organization_id": group.project.organization_id},
+                inner_limit=1000,
+            )
+        except Exception:
+            logger.exception(
+                "_get_recommended_event: eventstore query failed",
+                extra={
+                    "organization_id": organization.id,
+                    "project_id": group.project.id,
+                    "issue_id": group.id,
+                    "dataset": dataset.value,
+                },
+            )
+            return fallback_event
 
         if events and not fallback_event:
             fallback_event = events[0].for_group(group)
@@ -850,17 +887,29 @@ def _get_recommended_event(
             # Clamp spans_start to retention boundary to avoid QueryOutsideRetentionError.
             spans_start = max(w_start - timedelta(days=1), retention_boundary)
             spans_end = w_end + timedelta(days=1)
-
             count_field = "count(span.duration)"
-            result = execute_table_query(
-                org_id=organization.id,
-                dataset="spans",
-                per_page=len(trace_ids),
-                fields=["trace", count_field],
-                query=f"trace:[{','.join(trace_ids)}]",
-                start=spans_start.isoformat(),
-                end=spans_end.isoformat(),
-            )
+
+            try:
+                result = execute_table_query(
+                    org_id=organization.id,
+                    dataset="spans",
+                    per_page=len(trace_ids),
+                    fields=["trace", count_field],
+                    query=f"trace:[{','.join(trace_ids)}]",
+                    start=spans_start.isoformat(),
+                    end=spans_end.isoformat(),
+                )
+            except Exception:
+                logger.exception(
+                    "_get_recommended_event: spans query failed",
+                    extra={
+                        "organization_id": organization.id,
+                        "project_id": group.project.id,
+                        "issue_id": group.id,
+                        "num_trace_ids": len(trace_ids),
+                    },
+                )
+                return fallback_event
 
             if result and result.get("data"):
                 # Return the first event with a span count greater than 0.
@@ -881,12 +930,16 @@ def _get_recommended_event(
         w_start = max(w_start - w_size, start)
 
     logger.warning(
-        "_get_recommended_event: No event with a span found",
+        "_get_recommended_event: no event with a span found",
         extra={
-            "group_id": group.id,
+            "issue_id": group.id,
             "organization_id": organization.id,
+            "project_id": group.project.id,
             "start": start,
             "end": end,
+            "timedelta": end - start,
+            "dataset": dataset.value,
+            "has_fallback_event": bool(fallback_event),
         },
     )
     return fallback_event


### PR DESCRIPTION
Clamp time range to 14d max before falling back.
2 new fallback conditions:
- one of the queries fails - could be snuba timeout, rate limit, etc (still logs exception)
- custom timeout of 50s (sentry API/RPC raises 504 after 60s)

Fallback event: either the most recommended event in the clamped range, or most recent event in the whole range

Reduce event chunks to 50 so less trace ids are in the span query.

**Impact**
Overall, clamps algo runtime and clickhouse queries to be more reasonable. For each window, we're summing spans for every trace in the event chunk. The fallbacks also improve the tool's reliability. This can have a big impact on explorer performance when calling issue details tool, reducing runtime and failure rate

[AIML-2367: issues tool timing out for long time ranges](https://linear.app/getsentry/issue/AIML-2367/issues-tool-timing-out-for-long-time-ranges)