### PR TITLE
OrganizationCodeMappingsEndpoint GET to respect open team membership

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings.py
@@ -176,8 +176,13 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, OrganizationIntegra
 
         integration_id = request.GET.get("integrationId")
 
-        # Always filter by projects the user can access
-        projects = self.get_projects(request, organization)
+        # When no explicit project IDs are in the request, include all projects the user can
+        # access so open team membership is respected. When explicit IDs are present, get_projects
+        # already uses has_project_access and validates the requested projects.
+        has_explicit_projects = bool(request.GET.getlist("project"))
+        projects = self.get_projects(
+            request, organization, include_all_accessible=not has_explicit_projects
+        )
         queryset = RepositoryProjectPathConfig.objects.filter(project__in=projects).select_related(
             "project", "repository"
         )


### PR DESCRIPTION
A fix resulting from https://github.com/getsentry/sentry/pull/105607, code mappings weren't being properly returned when Open Team Membership is enabled.

get_projects() now passes include_all_accessible=True when no explicit ?project= param is present, so open team membership is respected. It's conditional to preserve 403 validation when specific project IDs are requested and added some additional tests for the various behaviour. Should do it.