### PR TITLE
fix(explore): Use hasOwn to avoid checking constructor

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3465,12 +3465,6 @@ function _getFieldFromMappings(
       if (Object.hasOwn(SPAN_FIELD_DEFINITIONS, key)) {
         return SPAN_FIELD_DEFINITIONS[key];
       }
-      if (Object.hasOwn(PREPROD_FIELD_DEFINITIONS, key)) {
-        return PREPROD_FIELD_DEFINITIONS[key];
-      }
-      if (Object.hasOwn(SPAN_FIELD_DEFINITIONS, key)) {
-        return SPAN_FIELD_DEFINITIONS[key];
-      }
 
       if (kind === FieldKind.MEASUREMENT) {
         return {kind: FieldKind.FIELD, valueType: FieldValueType.NUMBER};

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3413,8 +3413,7 @@ const FEEDBACK_FIELD_DEFINITIONS: Record<FeedbackFieldKey, FieldDefinition> = {
   },
 };
 
-export const getFieldDefinition = (
-  key: string,
+function _getFieldFromMappings(
   type:
     | 'event'
     | 'replay'
@@ -3425,40 +3424,51 @@ export const getFieldDefinition = (
     | 'log'
     | 'uptime'
     | 'tracemetric' = 'event',
+  key: string,
   kind?: FieldKind
-): FieldDefinition | null => {
+): FieldDefinition | undefined | null {
   switch (type) {
     case 'replay':
-      if (REPLAY_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+      if (Object.hasOwn(REPLAY_FIELD_DEFINITIONS, key)) {
         return REPLAY_FIELD_DEFINITIONS[key as keyof typeof REPLAY_FIELD_DEFINITIONS];
       }
-      if (REPLAY_CLICK_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+      if (Object.hasOwn(REPLAY_CLICK_FIELD_DEFINITIONS, key)) {
         return REPLAY_CLICK_FIELD_DEFINITIONS[
           key as keyof typeof REPLAY_CLICK_FIELD_DEFINITIONS
         ];
       }
-      if (REPLAY_TAP_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+      if (Object.hasOwn(REPLAY_TAP_FIELD_DEFINITIONS, key)) {
         return REPLAY_TAP_FIELD_DEFINITIONS[
           key as keyof typeof REPLAY_TAP_FIELD_DEFINITIONS
         ];
       }
       if (REPLAY_FIELDS.includes(key as FieldKey)) {
-        return EVENT_FIELD_DEFINITIONS[key as FieldKey];
+        if (Object.hasOwn(EVENT_FIELD_DEFINITIONS, key)) {
+          return EVENT_FIELD_DEFINITIONS[key as FieldKey];
+        }
       }
       return null;
     case 'feedback':
-      if (FEEDBACK_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+      if (Object.hasOwn(FEEDBACK_FIELD_DEFINITIONS, key)) {
         return FEEDBACK_FIELD_DEFINITIONS[key as keyof typeof FEEDBACK_FIELD_DEFINITIONS];
       }
       if (FEEDBACK_FIELDS.includes(key as FieldKey)) {
-        return EVENT_FIELD_DEFINITIONS[key as FieldKey];
+        if (Object.hasOwn(EVENT_FIELD_DEFINITIONS, key)) {
+          return EVENT_FIELD_DEFINITIONS[key as FieldKey];
+        }
       }
       return null;
     case 'preprod':
-      if (PREPROD_FIELD_DEFINITIONS[key]) {
+      if (Object.hasOwn(PREPROD_FIELD_DEFINITIONS, key)) {
         return PREPROD_FIELD_DEFINITIONS[key];
       }
-      if (SPAN_FIELD_DEFINITIONS[key]) {
+      if (Object.hasOwn(SPAN_FIELD_DEFINITIONS, key)) {
+        return SPAN_FIELD_DEFINITIONS[key];
+      }
+      if (Object.hasOwn(PREPROD_FIELD_DEFINITIONS, key)) {
+        return PREPROD_FIELD_DEFINITIONS[key];
+      }
+      if (Object.hasOwn(SPAN_FIELD_DEFINITIONS, key)) {
         return SPAN_FIELD_DEFINITIONS[key];
       }
 
@@ -3477,8 +3487,8 @@ export const getFieldDefinition = (
       return null;
 
     case 'span':
-      if (SPAN_FIELD_DEFINITIONS[key]) {
-        return SPAN_FIELD_DEFINITIONS[key];
+      if (Object.hasOwn(SPAN_FIELD_DEFINITIONS, key)) {
+        return SPAN_FIELD_DEFINITIONS[key] ?? null;
       }
 
       // In EAP we have numeric tags that can be passed as parameters to
@@ -3499,8 +3509,7 @@ export const getFieldDefinition = (
       return null;
 
     case 'log':
-      if (LOG_FIELD_DEFINITIONS.hasOwnProperty(key)) {
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      if (Object.hasOwn(LOG_FIELD_DEFINITIONS, key)) {
         return LOG_FIELD_DEFINITIONS[key];
       }
 
@@ -3522,8 +3531,7 @@ export const getFieldDefinition = (
       return null;
 
     case 'tracemetric':
-      if (TRACEMETRIC_FIELD_DEFINITIONS.hasOwnProperty(key)) {
-        // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+      if (Object.hasOwn(TRACEMETRIC_FIELD_DEFINITIONS, key)) {
         return TRACEMETRIC_FIELD_DEFINITIONS[key];
       }
 
@@ -3546,12 +3554,29 @@ export const getFieldDefinition = (
 
     case 'event':
     default:
-      if (EVENT_FIELD_DEFINITIONS.hasOwnProperty(key)) {
+      if (Object.hasOwn(EVENT_FIELD_DEFINITIONS, key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         return EVENT_FIELD_DEFINITIONS[key];
       }
       return null;
   }
+}
+
+export const getFieldDefinition = (
+  key: string,
+  type:
+    | 'event'
+    | 'replay'
+    | 'replay_click'
+    | 'feedback'
+    | 'preprod'
+    | 'span'
+    | 'log'
+    | 'uptime'
+    | 'tracemetric' = 'event',
+  kind?: FieldKind
+): FieldDefinition | null => {
+  return _getFieldFromMappings(type, key, kind) ?? null;
 };
 
 export function makeTagCollection(fieldKeys: FieldKey[]): TagCollection {


### PR DESCRIPTION
Having a tag called `constructor` will accidentally pass on these because the constructor is accessible through `hasOwnProperty` from the prototype. So this returns the constructor function instead of a value from the object mapping. `hasOwn` is a safer recommended method for this because it avoids prototype values.

There are still issues _using_ the constructor tag in other places like filters but this unblocks users UI when it occurs, especially if `constructor` is not what they're querying for at the moment