### PR TITLE
feat(integrations): Log response headers in integration API client

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -104,6 +104,15 @@ class BaseApiClient:
         if self.integration_type:
             log_params[self.integration_type] = self.name
 
+        # Capture useful response headers for debugging
+        if resp is not None and resp.headers:
+            if github_request_id := resp.headers.get("X-GitHub-Request-Id"):
+                log_params["github_request_id"] = github_request_id
+            if rate_limit_remaining := resp.headers.get("X-RateLimit-Remaining"):
+                log_params["rate_limit_remaining"] = rate_limit_remaining
+            if retry_after := resp.headers.get("Retry-After"):
+                log_params["retry_after"] = retry_after
+
         log_params.update(getattr(self, "logging_context", None) or {})
         self.logger.info("%s.http_response", self.integration_type, extra=log_params)
 


### PR DESCRIPTION
## Summary
- Captures `X-GitHub-Request-Id`, `X-RateLimit-Remaining`, and `Retry-After` headers from integration API responses in `track_response_data` logging
- Improves debuggability of 403 errors and rate limit issues, particularly useful when collaborating with GitHub support (they require the request ID)

## Test plan
- Added 6 unit tests covering:
  - [x] Individual header logging (GitHub request ID, rate limit remaining, retry-after)
  - [x] All headers logged simultaneously
  - [x] Missing headers are omitted from logs
  - [x] Headers are logged on error responses (e.g. 403)

Inspired by #108267