### PR TITLE
Reapply "feat(integrations): Add integration_id tag to SLO lifecycle metrics"

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -237,6 +237,10 @@ class GitHubIntegration(
 ):
     integration_name = IntegrationProviderSlug.GITHUB
 
+    @property
+    def integration_id(self) -> int:
+        return self.model.id
+
     # IssueSyncIntegration configuration keys
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -177,6 +177,10 @@ class GitHubEnterpriseIntegration(
     def integration_name(self) -> str:
         return IntegrationProviderSlug.GITHUB_ENTERPRISE.value
 
+    @property
+    def integration_id(self) -> int:
+        return self.model.id
+
     def get_client(self):
         if not self.org_integration:
             raise IntegrationError("Organization Integration does not exist")

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -123,6 +123,10 @@ class GitlabIntegration(
     def integration_name(self) -> str:
         return IntegrationProviderSlug.GITLAB
 
+    @property
+    def integration_id(self) -> int:
+        return self.model.id
+
     def get_client(self) -> GitLabApiClient:
         try:
             # eagerly populate this just for the error message

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -172,6 +172,10 @@ class PerforceIntegration(RepositoryIntegration, CommitContextIntegration):
 
     integration_name = "perforce"
 
+    @property
+    def integration_id(self) -> int:
+        return self.model.id
+
     def __init__(
         self,
         model: Integration,

--- a/src/sentry/integrations/project_management/metrics.py
+++ b/src/sentry/integrations/project_management/metrics.py
@@ -45,3 +45,6 @@ class ProjectManagementEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.action_type)
+
+    def get_integration_id(self) -> int | None:
+        return self.integration.id

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -130,6 +130,11 @@ class CommitContextIntegration(ABC):
     def integration_name(self) -> str:
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def integration_id(self) -> int:
+        raise NotImplementedError
+
     @abstractmethod
     def get_client(self) -> CommitContextClient:
         raise NotImplementedError
@@ -145,6 +150,7 @@ class CommitContextIntegration(ABC):
         with CommitContextIntegrationInteractionEvent(
             interaction_type=SCMIntegrationInteractionType.GET_BLAME_FOR_FILES,
             provider_key=self.integration_name,
+            integration_id=self.integration_id,
         ).capture() as lifecycle:
             try:
                 client = self.get_client()
@@ -224,6 +230,7 @@ class CommitContextIntegration(ABC):
         with CommitContextIntegrationInteractionEvent(
             interaction_type=SCMIntegrationInteractionType.QUEUE_COMMENT_TASK,
             provider_key=self.integration_name,
+            integration_id=self.integration_id,
             organization_id=project.organization_id,
             project=project,
             commit=commit,
@@ -334,6 +341,7 @@ class CommitContextIntegration(ABC):
         with CommitContextIntegrationInteractionEvent(
             interaction_type=interaction_type,
             provider_key=self.integration_name,
+            integration_id=self.integration_id,
             repository=repo,
             pull_request_id=pr.id,
         ).capture():

--- a/src/sentry/integrations/source_code_management/metrics.py
+++ b/src/sentry/integrations/source_code_management/metrics.py
@@ -52,6 +52,9 @@ class SCMIntegrationInteractionType(StrEnum):
     # Status Checks
     CREATE_STATUS_CHECK = "create_status_check"
 
+    # Rate Limiting
+    GET_RATE_LIMIT = "get_rate_limit"
+
 
 @dataclass
 class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
@@ -72,6 +75,9 @@ class SCMIntegrationInteractionEvent(IntegrationEventLifecycleMetric):
 
     def get_interaction_type(self) -> str:
         return str(self.interaction_type)
+
+    def get_integration_id(self) -> int | None:
+        return self.integration_id
 
     def get_extras(self) -> Mapping[str, Any]:
         return {

--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -9,6 +9,7 @@ from typing import Any, Self
 
 import sentry_sdk
 
+from sentry import options
 from sentry.exceptions import RestrictedIPAddress
 from sentry.integrations.base import IntegrationDomain
 from sentry.integrations.types import EventLifecycleOutcome
@@ -86,12 +87,23 @@ class IntegrationEventLifecycleMetric(EventLifecycleMetric, ABC):
         tokens = ("integrations", self.get_metrics_domain(), str(outcome))
         return ".".join(tokens)
 
+    def get_integration_id(self) -> int | None:
+        """Return the integration ID if available. Override in subclasses."""
+        return None
+
     def get_metric_tags(self) -> Mapping[str, str]:
-        return {
+        tags: dict[str, str] = {
             "integration_domain": str(self.get_integration_domain()),
             "integration_name": self.get_integration_name(),
             "interaction_type": self.get_interaction_type(),
         }
+        # TODO(telkins): Remove killswitch once we no longer need integration_id on SLO metrics
+        integration_id = self.get_integration_id()
+        if integration_id is not None and options.get(
+            "integrations.slo.integration-id-tag-enabled"
+        ):
+            tags["integration_id"] = str(integration_id)
+        return tags
 
     def capture(
         self, assume_success: bool = True, sample_log_rate: float = 1.0

--- a/src/sentry/metrics/middleware.py
+++ b/src/sentry/metrics/middleware.py
@@ -21,6 +21,11 @@ _METRICS_THAT_CAN_HAVE_BAD_TAGS = frozenset(
         "batching_consumer.batch.size",
         "batching_consumer.batch.flush",
         "batching_consumer.batch.flush.normalized",
+        # TODO(telkins): Remove once we figure out interaction_type org breakdown
+        "integrations.slo.started",
+        "integrations.slo.success",
+        "integrations.slo.halted",
+        "integrations.slo.failure",
     ]
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4012,3 +4012,11 @@ register(
     type=Bool,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# TODO(telkins): Remove once we no longer need integration_id on SLO metrics
+register(
+    "integrations.slo.integration-id-tag-enabled",
+    default=False,
+    type=Bool,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -22,6 +22,7 @@ class MockCommitContextIntegration(CommitContextIntegration):
     """Mock implementation for testing"""
 
     integration_name = "mock_integration"
+    integration_id = 1
 
     def __init__(self) -> None:
         self.client = Mock()

--- a/tests/sentry/integrations/utils/test_lifecycle_metrics.py
+++ b/tests/sentry/integrations/utils/test_lifecycle_metrics.py
@@ -24,6 +24,14 @@ class IntegrationEventLifecycleMetricTest(TestCase):
         def get_interaction_type(self) -> str:
             return "my_interaction"
 
+        def get_integration_id(self) -> int | None:
+            return 123
+
+    def setUp(self) -> None:
+        patcher = mock.patch("sentry.integrations.utils.metrics.options.get", return_value=True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_key_and_tag_assignment(self) -> None:
         metric_obj = self.TestLifecycleMetric()
 
@@ -33,6 +41,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
             "integration_domain": "messaging",
             "integration_name": "my_integration",
             "interaction_type": "my_interaction",
+            "integration_id": "123",
         }
 
     @staticmethod
@@ -44,6 +53,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                     "integration_domain": "messaging",
                     "integration_name": "my_integration",
                     "interaction_type": "my_interaction",
+                    "integration_id": "123",
                 },
                 sample_rate=1.0,
             ),
@@ -53,6 +63,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                     "integration_domain": "messaging",
                     "integration_name": "my_integration",
                     "interaction_type": "my_interaction",
+                    "integration_id": "123",
                 },
                 sample_rate=1.0,
             ),
@@ -85,6 +96,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
             },
         )
 
@@ -107,6 +119,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
                 "exception_summary": repr(ExampleException("")),
             },
         )
@@ -131,6 +144,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
             },
         )
 
@@ -160,6 +174,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
                 "exception_summary": repr(ExampleException()),
                 "slo_event_id": "test-event-id",
             },
@@ -191,6 +206,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
                 "exception_summary": repr(ExampleException()),
                 "slo_event_id": "test-event-id",
             },
@@ -216,6 +232,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
             },
         )
 
@@ -244,6 +261,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
                 "exception_summary": repr(ExampleException("test")),
                 "slo_event_id": "test-event-id",
             },
@@ -270,6 +288,7 @@ class IntegrationEventLifecycleMetricTest(TestCase):
                 "integration_domain": "messaging",
                 "integration_name": "my_integration",
                 "interaction_type": "my_interaction",
+                "integration_id": "123",
                 "exception_summary": repr(ExampleException("test")),
             },
         )


### PR DESCRIPTION
## Summary
- Reverts the revert (378f650d4b1) to re-apply the original PR #108137
- The Sentry issue (SENTRY-5JQ3) that triggered the revert was a pre-existing error (SENTRY-5HAA, 19k occurrences, archived) — transient 500s from the integration proxy on GitHub's `/rate_limit` endpoint
- The new SLO wrapper on `get_rate_limit` simply created a new issue group for the same underlying error that was already being tracked under `get_blame_for_files`

## Original PR
https://github.com/getsentry/sentry/pull/108137

## Test plan
- [x] Verified SENTRY-5JQ3 is the same root cause as pre-existing SENTRY-5HAA
- [ ] Monitor after merge for any unexpected issues