### PR TITLE
fix(seer): SeerOperator fixes for explorer-autofix compatibility

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -120,7 +120,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
                 SectionBlock(text=data.error_title),
                 SectionBlock(text=MarkdownTextObject(text=f">{data.error_message}")),
             ],
-            text=f"Seer encountered an error: {data.error_title}",
+            text=f"Seer stumbled: {data.error_title}",
         )
 
     @classmethod
@@ -175,7 +175,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         if action_elements:
             blocks.append(ActionsBlock(elements=action_elements))
 
-        return SlackRenderable(blocks=blocks, text="Seer has an update on fixing the issue")
+        return SlackRenderable(blocks=blocks, text="Seer has emerged with news from its voyage")
 
     @classmethod
     def _render_link_button(

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -49,26 +49,26 @@ AUTOFIX_CONFIG: dict[AutofixStoppingPoint, AutofixStageConfig] = {
     AutofixStoppingPoint.ROOT_CAUSE: AutofixStageConfig(
         heading=":mag:  *Root Cause Analysis*",
         label="Fix with Seer",
-        working_text="Seer is analyzing the root cause...",
-        completed_text="Seer has already analyzed the root cause.",
+        working_text="Seer is peering into the void...",
+        completed_text="Seer's eye has seen the root cause",
     ),
     AutofixStoppingPoint.SOLUTION: AutofixStageConfig(
         heading=":test_tube:  *Proposed Solution*",
         label="Plan a Solution",
-        working_text="Seer is working on the solution...",
-        completed_text="Seer has already proposed a solution.",
+        working_text="Seer is conjuring a solution...",
+        completed_text="Seer has materialized a plan",
     ),
     AutofixStoppingPoint.CODE_CHANGES: AutofixStageConfig(
         heading=":pencil2:  *Code Change Suggestions*",
         label="Write Code Changes",
-        working_text="Seer is writing the code...",
-        completed_text="Seer has already written the code changes.",
+        working_text="Seer's many hands are typing...",
+        completed_text="Seer has synthesized the changes",
     ),
     AutofixStoppingPoint.OPEN_PR: AutofixStageConfig(
         heading=":link:  *Pull Request*",
         label="Draft a PR",
-        working_text="Seer is drafting a pull request...",
-        completed_text="Seer has already drafted a pull request.",
+        working_text="Seer is manifesting a PR...",
+        completed_text="Seer has summoned your pull request",
     ),
 }
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.models.organization import Organization
@@ -66,6 +67,13 @@ class SeerOperator[CachePayloadT]:
         If an entrypoint_key is provided, ensures the organization has access to that entrypoint.
         """
         if not has_seer_access(organization):
+            return False
+
+        # Currently, this feature is built around legacy autofix
+        # The explorer autofix pipeline and history is entirely separate, so the runs we trigger
+        # at the moment, won't be visible in-app to users with this flag.
+        # This check can only be removed once this feature migrates to explorer-based autofix.
+        if features.has("organizations:autofix-on-explorer", organization):
             return False
 
         if entrypoint_key:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -382,4 +382,4 @@ def get_latest_cause_id(autofix_state: AutofixState | None) -> int:
         return AUTOFIX_FALLBACK_CAUSE_ID
 
     # The most recent cause is at the end of the list
-    return root_causes[-1].get("cause_id", AUTOFIX_FALLBACK_CAUSE_ID)
+    return root_causes[-1].get("id", AUTOFIX_FALLBACK_CAUSE_ID)

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 # entrypoint's ability to receive updates from those triggers. So 12 is plenty, even accounting for
 # incidents, since a run should not take nearly that long to complete.
 PROCESS_AUTOFIX_TIMEOUT_SECONDS = 60 * 5  # 5 minutes
+AUTOFIX_FALLBACK_CAUSE_ID = 0
 
 
 class SeerOperator[CachePayloadT]:
@@ -176,9 +177,9 @@ class SeerOperator[CachePayloadT]:
                     | None
                 ) = None
                 if stopping_point == AutofixStoppingPoint.SOLUTION:
-                    # TODO(Leander): We need to figure out a way to get the real cause_id for this.
-                    # Probably need to add it to the root cause webhook from seer's side.
-                    payload = AutofixSelectRootCausePayload(type="select_root_cause", cause_id=0)
+                    payload = AutofixSelectRootCausePayload(
+                        type="select_root_cause", cause_id=get_latest_cause_id(existing_state)
+                    )
                 elif stopping_point == AutofixStoppingPoint.CODE_CHANGES:
                     payload = AutofixSelectSolutionPayload(type="select_solution")
                 elif stopping_point == AutofixStoppingPoint.OPEN_PR:
@@ -198,9 +199,6 @@ class SeerOperator[CachePayloadT]:
                     organization_id=group.organization.id, run_id=run_id, payload=payload
                 )
 
-            # Type-safety...
-            assert raw_response is not None
-
             error_message = raw_response.data.get("detail")
 
             # Let the entrypoint signal to the external service that no run was started :/
@@ -214,7 +212,6 @@ class SeerOperator[CachePayloadT]:
                 return
 
             run_id = raw_response.data.get("run_id") if not run_id else run_id
-            # Shouldn't ever happen, but if it we have no run_id, we can't listen for updates
             if not run_id:
                 lifecycle.record_failure(failure_reason="no_run_id")
                 with SeerOperatorEventLifecycleMetric(
@@ -352,3 +349,27 @@ def get_stopping_point_status(
                 None,
             )
     return step
+
+
+def get_latest_cause_id(autofix_state: AutofixState | None) -> int:
+    """
+    Gets the latest cause_id from a given autofix state.
+    """
+    if not autofix_state:
+        return AUTOFIX_FALLBACK_CAUSE_ID
+    root_cause_step = next(
+        (
+            step
+            for step in reversed(autofix_state.steps)
+            if step.get("key") == "root_cause_analysis"
+        ),
+        None,
+    )
+    if not root_cause_step:
+        return AUTOFIX_FALLBACK_CAUSE_ID
+
+    root_causes = root_cause_step.get("causes", [])[-1]
+    if not root_causes:
+        return AUTOFIX_FALLBACK_CAUSE_ID
+
+    return root_causes[-1].get("cause_id", AUTOFIX_FALLBACK_CAUSE_ID)

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -368,6 +368,7 @@ def get_latest_cause_id(autofix_state: AutofixState | None) -> int:
     root_cause_step = next(
         (
             step
+            # If there are multiple RCA steps, we want the latest, so we reverse the list
             for step in reversed(autofix_state.steps)
             if step.get("key") == "root_cause_analysis"
         ),
@@ -376,8 +377,9 @@ def get_latest_cause_id(autofix_state: AutofixState | None) -> int:
     if not root_cause_step:
         return AUTOFIX_FALLBACK_CAUSE_ID
 
-    root_causes = root_cause_step.get("causes", [])[-1]
+    root_causes = root_cause_step.get("causes", [])
     if not root_causes:
         return AUTOFIX_FALLBACK_CAUSE_ID
 
+    # The most recent cause is at the end of the list
     return root_causes[-1].get("cause_id", AUTOFIX_FALLBACK_CAUSE_ID)

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -9,7 +9,11 @@ from fixtures.seer.webhooks import MOCK_RUN_ID
 from sentry.models.organization import Organization
 from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint
-from sentry.seer.entrypoints.operator import SeerOperator, process_autofix_updates
+from sentry.seer.entrypoints.operator import (
+    AUTOFIX_FALLBACK_CAUSE_ID,
+    SeerOperator,
+    process_autofix_updates,
+)
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -329,7 +333,7 @@ class SeerOperatorTest(TestCase):
         assert call_kwargs["organization_id"] == self.group.organization.id
         payload = call_kwargs["payload"]
         assert payload["type"] == "select_root_cause"
-        assert payload["cause_id"] == 0
+        assert payload["cause_id"] == AUTOFIX_FALLBACK_CAUSE_ID
 
     def test_can_trigger_autofix_returns_false_without_seer_access(self):
         assert SeerOperator.can_trigger_autofix(group=self.group) is False

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -360,7 +360,7 @@ class SeerOperatorTest(TestCase):
                 {
                     "key": "root_cause_analysis",
                     "status": AutofixStatus.COMPLETED,
-                    "causes": [{"cause_id": 12}, {"cause_id": 34}],
+                    "causes": [{"id": 12}, {"id": 34}],
                 },
             ],
         )

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -360,12 +360,7 @@ class SeerOperatorTest(TestCase):
                 {
                     "key": "root_cause_analysis",
                     "status": AutofixStatus.COMPLETED,
-                    "causes": [[{"cause_id": 12}]],
-                },
-                {
-                    "key": "root_cause_analysis",
-                    "status": AutofixStatus.COMPLETED,
-                    "causes": [[{"cause_id": 34}]],
+                    "causes": [{"cause_id": 12}, {"cause_id": 34}],
                 },
             ],
         )

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -335,6 +335,55 @@ class SeerOperatorTest(TestCase):
         assert payload["type"] == "select_root_cause"
         assert payload["cause_id"] == AUTOFIX_FALLBACK_CAUSE_ID
 
+    @patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True)
+    def test_has_access_returns_false_with_autofix_on_explorer(self, _mock_has_seer_access):
+        with self.feature({"organizations:autofix-on-explorer": True}):
+            assert not SeerOperator.has_access(organization=self.group.project.organization)
+
+    @patch("sentry.seer.entrypoints.operator.update_autofix")
+    @patch("sentry.seer.entrypoints.operator.get_autofix_state")
+    def test_solution_stopping_point_uses_cause_id_from_state(
+        self, mock_get_autofix_state, mock_update_autofix
+    ):
+        mock_update_autofix.return_value = Response({"run_id": MOCK_RUN_ID}, status=202)
+        existing_state = AutofixState(
+            run_id=MOCK_RUN_ID,
+            request={
+                "organization_id": self.organization.id,
+                "project_id": self.project.id,
+                "issue": {"id": self.group.id, "title": "test"},
+                "repos": [],
+            },
+            updated_at=datetime.now(),
+            status=AutofixStatus.PROCESSING,
+            steps=[
+                {
+                    "key": "root_cause_analysis",
+                    "status": AutofixStatus.COMPLETED,
+                    "causes": [[{"cause_id": 12}]],
+                },
+                {
+                    "key": "root_cause_analysis",
+                    "status": AutofixStatus.COMPLETED,
+                    "causes": [[{"cause_id": 34}]],
+                },
+            ],
+        )
+        mock_get_autofix_state.return_value = existing_state
+
+        self.operator.trigger_autofix(
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.SOLUTION,
+            run_id=MOCK_RUN_ID,
+        )
+
+        mock_update_autofix.assert_called_once()
+        call_kwargs = mock_update_autofix.call_args.kwargs
+        payload = call_kwargs["payload"]
+        assert payload["type"] == "select_root_cause"
+        assert payload["cause_id"] == 34
+
     def test_can_trigger_autofix_returns_false_without_seer_access(self):
         assert SeerOperator.can_trigger_autofix(group=self.group) is False
 


### PR DESCRIPTION
- block SeerOperator for orgs with `autofix-on-explorer` since legacy runs won't be visible in-app
- use `SeerOperator.has_access` in slack notification path instead of raw feature flag check
- extract real `cause_id` from autofix state instead of hardcoding `0`
- remove stale comments and unnecessary assert
- more interesting copy