### PR TITLE
chore(grouping): Clean up grouphash caching

### DIFF
--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from django.core.cache import cache
 
@@ -21,13 +21,6 @@ def get_grouphash_object_cache_key(hash_value: str, project_id: int) -> str:
     return f"grouphash_with_assigned_group:{project_id}:{hash_value}"
 
 
-# TODO: Once we settle on a good expiry time for both caches, this can go
-def get_grouphash_cache_version(cache_type: Literal["existence", "object"]) -> int:
-    option_name = f"grouping.ingest_grouphash_{cache_type}_cache_expiry.trial_values"
-    possible_cache_expiries = options.get(option_name)
-    return abs(hash(tuple(possible_cache_expiries)))
-
-
 def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> None:
     # TODO: `GroupHash.project` is nullable for some reason, even though it's never ever null. If we
     # fix that, we can remove this check.
@@ -42,8 +35,7 @@ def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> No
         return
 
     cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
-    # TODO: We can remove the version once we've settled on a good retention period
-    cache.delete(cache_key, version=get_grouphash_cache_version("object"))
+    cache.delete(cache_key)
 
 
 def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) -> None:
@@ -58,8 +50,4 @@ def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) ->
     object_cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
     existence_cache_key = get_grouphash_existence_cache_key(instance.hash, instance.project.id)
 
-    # TODO: This can go back to being just
-    #     cache.delete_many([object_cache_key, existence_cache_key])
-    # once we've settled on a good retention period
-    cache.delete(object_cache_key, version=get_grouphash_cache_version("object"))
-    cache.delete(existence_cache_key, version=get_grouphash_cache_version("existence"))
+    cache.delete_many([object_cache_key, existence_cache_key])

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -217,9 +217,6 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
 
     If `use_caching` is True, cache the boolean result. Cache retention is controlled by the
     `grouping.ingest_grouphash_existence_cache_expiry` option.
-
-    TODO: That last sentence is temporarily untrue. While we're experimenting with retention
-    periods, cache retention is actually controlled by the helper `_get_cache_expiry`.
     """
     with metrics.timer(
         "grouping.get_or_create_grouphashes.check_secondary_hash_existence"
@@ -257,9 +254,6 @@ def _get_or_create_single_grouphash(
     `GroupHash` object. (Grouphashes without a group aren't cached because their data is about to
     change when a group is assigned.) Cache retention is controlled by the
     `grouping.ingest_grouphash_object_cache_expiry` option.
-
-    TODO: That last sentence is temporarily untrue. While we're experimenting with retention
-    periods, cache retention is actually controlled by the helper `_get_cache_expiry`.
     """
     with metrics.timer(
         "grouping.get_or_create_grouphashes.get_or_create_grouphash"

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from collections.abc import Iterable, Sequence
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import sentry_sdk
 from django.core.cache import cache
@@ -211,21 +211,6 @@ def find_grouphash_with_group(
     return winning_grouphash
 
 
-# TODO: This can go once we've settled on an expiry time for each cache
-def _get_cache_expiry(
-    cache_key: str, cache_type: Literal["existence", "object"]
-) -> tuple[int, int]:
-    option_name = f"grouping.ingest_grouphash_{cache_type}_cache_expiry.trial_values"
-    possible_cache_expiries = options.get(option_name)
-    expiry_for_cache_key = possible_cache_expiries[hash(cache_key) % len(possible_cache_expiries)]
-
-    # Calculate a option version value so that when the option value changes, we invalidate the
-    # cache entries stored under the old value of the option
-    option_version = abs(hash(tuple(possible_cache_expiries)))
-
-    return (expiry_for_cache_key, option_version)
-
-
 def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_caching: bool) -> bool:
     """
     Check whether a given hash value has a corresponding `GroupHash` record in the database.
@@ -241,10 +226,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
-            # TODO: This can go back to being just
-            #     cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
-            # once we've settled on a good retention period
-            cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="existence")
+            cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
             # TODO: We can remove the version once we've settled on a good retention period
             grouphash_exists = cache.get(cache_key, version=option_version)
@@ -288,10 +270,7 @@ def _get_or_create_single_grouphash(
     ) as metrics_tags:
         if use_caching:
             cache_key = get_grouphash_object_cache_key(hash_value, project.id)
-            # TODO: This can go back to being just
-            #     cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
-            # once we've settled on a good retention period
-            cache_expiry, option_version = _get_cache_expiry(cache_key, cache_type="object")
+            cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
 
             # TODO: We can remove the version once we've settled on a good retention period
             grouphash = cache.get(cache_key, version=option_version)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -233,6 +233,8 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
                 metrics_tags["grouphash_exists"] = grouphash_exists
                 return grouphash_exists
 
+        # Get an answer from the database if we didn't find what we needed in the cache (or if
+        # caching is turned off)
         grouphash_exists = GroupHash.objects.filter(project=project, hash=hash_value).exists()
 
         if use_caching:

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -231,8 +231,6 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
-            # TODO: Temporary tag to let us compare hit rates across different retention periods
-            metrics_tags["expiry_seconds"] = cache_expiry
 
             if got_cache_hit:
                 metrics_tags["grouphash_exists"] = grouphash_exists
@@ -273,8 +271,6 @@ def _get_or_create_single_grouphash(
             grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
-            # TODO: Temporary tag to let us compare hit rates across different retention periods
-            metrics_tags["expiry_seconds"] = cache_expiry
 
             if got_cache_hit:
                 return (grouphash, False)

--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -228,8 +228,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
             cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
-            # TODO: We can remove the version once we've settled on a good retention period
-            grouphash_exists = cache.get(cache_key, version=option_version)
+            grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
             # TODO: Temporary tag to let us compare hit rates across different retention periods
@@ -245,8 +244,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             metrics_tags["grouphash_exists"] = grouphash_exists
             metrics_tags["cache_set"] = True
 
-            # TODO: We can remove the version once we've settled on a good retention period
-            cache.set(cache_key, grouphash_exists, cache_expiry, version=option_version)
+            cache.set(cache_key, grouphash_exists, cache_expiry)
 
         return grouphash_exists
 
@@ -272,8 +270,7 @@ def _get_or_create_single_grouphash(
             cache_key = get_grouphash_object_cache_key(hash_value, project.id)
             cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
 
-            # TODO: We can remove the version once we've settled on a good retention period
-            grouphash = cache.get(cache_key, version=option_version)
+            grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
             # TODO: Temporary tag to let us compare hit rates across different retention periods
@@ -290,8 +287,7 @@ def _get_or_create_single_grouphash(
         if use_caching and grouphash.group_id is not None:
             metrics_tags["cache_set"] = True
 
-            # TODO: We can remove the version once we've settled on a good retention period
-            cache.set(cache_key, grouphash, cache_expiry, version=option_version)
+            cache.set(cache_key, grouphash, cache_expiry)
 
         return (grouphash, created)
 

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -20,7 +20,6 @@ from sentry.db.models.base import sane_repr
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.grouping.ingest.caching import (
-    get_grouphash_cache_version,
     get_grouphash_object_cache_key,
     invalidate_grouphash_cache_on_save,
     invalidate_grouphash_caches_on_delete,
@@ -52,8 +51,7 @@ class GroupHashQuerySet(BaseQuerySet):
             )
         ]
 
-        # TODO: We can remove the version once we've settled on a good retention period
-        cache.delete_many(cache_keys, version=get_grouphash_cache_version("object"))
+        cache.delete_many(cache_keys)
 
         return len(cache_keys)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3054,22 +3054,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# TODO: Temporary options to let us play around with expiry times and see what hit rates they give
-# us. Once we've decided, we can stick our values into the two expiry options above and get rid of
-# these two options.
-register(
-    "grouping.ingest_grouphash_existence_cache_expiry.trial_values",
-    type=Sequence,
-    default=[60, 120, 600],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "grouping.ingest_grouphash_object_cache_expiry.trial_values",
-    type=Sequence,
-    default=[60, 120, 600],
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 
 # Sample rate for double writing to experimental dsn
 register(

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -457,26 +457,19 @@ class GroupHashCachingTest(TestCase):
             # testing grouphash object handling)
             cache_get_spy, cache_set_spy, database_fn_spy = spies
             cache_get_args = [cache_key]
-            cache_get_kwargs = {"version": expiry_option_version}
             cache_set_args = [cache_key, cached_value, cache_expiry]
-            cache_set_kwargs = {"version": expiry_option_version}
             database_fn_kwargs = {"project": self.project, "hash": hash_value}
 
-            # TODO: this (and the check below) can be simplified to use in/not in once version is gone
-            assert not cache.has_key(cache_key, version=expiry_option_version)
+            assert cache_key not in cache
 
             # ######### First call for grouphashes, with a hash we've never seen before ######### #
 
             get_or_create_grouphashes(event1, self.project, {}, [hash_value], grouping_config_id)
 
-            assert cache.has_key(cache_key, version=expiry_option_version) == cache_use_expected
+            assert (cache_key in cache) == cache_use_expected
 
-            cache_get_call_count = count_matching_calls(
-                cache_get_spy, *cache_get_args, **cache_get_kwargs
-            )
-            cache_set_call_count = count_matching_calls(
-                cache_set_spy, *cache_set_args, **cache_set_kwargs
-            )
+            cache_get_call_count = count_matching_calls(cache_get_spy, *cache_get_args)
+            cache_set_call_count = count_matching_calls(cache_set_spy, *cache_set_args)
             database_fn_call_count = count_matching_calls(database_fn_spy, **database_fn_kwargs)
 
             assert cache_get_call_count == (1 if cache_check_expected else 0)
@@ -488,12 +481,8 @@ class GroupHashCachingTest(TestCase):
 
             get_or_create_grouphashes(event2, self.project, {}, [hash_value], grouping_config_id)
 
-            cache_get_call_count = count_matching_calls(
-                cache_get_spy, *cache_get_args, **cache_get_kwargs
-            )
-            cache_set_call_count = count_matching_calls(
-                cache_set_spy, *cache_set_args, **cache_set_kwargs
-            )
+            cache_get_call_count = count_matching_calls(cache_get_spy, *cache_get_args)
+            cache_set_call_count = count_matching_calls(cache_set_spy, *cache_set_args)
             database_fn_call_count = count_matching_calls(database_fn_spy, **database_fn_kwargs)
 
             # With caching, call count increases by 1

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -11,7 +11,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from django.core.cache import cache
 
-from sentry import audit_log
+from sentry import audit_log, options
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG, SENTRY_GROUPING_CONFIG_TRANSITION_DURATION
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
@@ -23,7 +23,6 @@ from sentry.grouping.ingest.caching import (
 )
 from sentry.grouping.ingest.config import update_or_set_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
-    _get_cache_expiry,
     find_grouphash_with_group,
     get_or_create_grouphashes,
 )
@@ -441,19 +440,13 @@ class GroupHashCachingTest(TestCase):
             grouping_config_id = "old_config"
             grouping_config_option = "sentry:secondary_grouping_config"
             cache_key = get_grouphash_existence_cache_key(hash_value, self.project.id)
-            # TODO: This can go back to being `options.get("grouping.ingest_grouphash_existence_cache_expiry")`
-            # once we've settled on a retention period
-            cache_expiry, expiry_option_version = _get_cache_expiry(
-                cache_key, cache_type="existence"
-            )
+            cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
             cached_value: Any = grouphash_exists
         else:
             grouping_config_id = "new_config"
             grouping_config_option = "sentry:grouping_config"
             cache_key = get_grouphash_object_cache_key(hash_value, self.project.id)
-            # TODO: This can go back to being `options.get("grouping.ingest_grouphash_object_cache_expiry")`
-            # once we've settled on a retention period
-            cache_expiry, expiry_option_version = _get_cache_expiry(cache_key, cache_type="object")
+            cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
             cached_value = grouphash
 
         self.project.update_option(grouping_config_option, grouping_config_id)

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -4,7 +4,6 @@ from django.core.cache import cache
 
 from sentry import options
 from sentry.grouping.ingest.caching import (
-    get_grouphash_cache_version,
     get_grouphash_existence_cache_key,
     get_grouphash_object_cache_key,
     invalidate_grouphash_cache_on_save,
@@ -124,7 +123,6 @@ class CacheInvalidationTest(TestCase):
     def test_removes_from_cache_on_queryset_update(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        expiry_option_version = get_grouphash_cache_version("object")
         cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
@@ -138,27 +136,25 @@ class CacheInvalidationTest(TestCase):
         grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
         grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
 
-        cache.set(maisey_key, grouphash1, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(charlie_key, grouphash2, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(dogs_key, grouphash3, cache_expiry_seconds, version=expiry_option_version)
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
 
-        # TODO: These (and the checks below) can be simplified to use in/not in once version is gone
-        assert cache.has_key(maisey_key, version=expiry_option_version)
-        assert cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
 
         GroupHash.objects.filter(hash__in=["maisey", "charlie"]).update(group=group2)
 
         # The updated grouphashes have been removed from the cache, but the one we didn't update is
         # still there
-        assert not cache.has_key(maisey_key, version=expiry_option_version)
-        assert not cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
 
     def test_removes_from_cache_on_model_update(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        expiry_option_version = get_grouphash_cache_version("object")
         cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
@@ -172,28 +168,26 @@ class CacheInvalidationTest(TestCase):
         grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
         grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
 
-        cache.set(maisey_key, grouphash1, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(charlie_key, grouphash2, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(dogs_key, grouphash3, cache_expiry_seconds, version=expiry_option_version)
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
 
-        # TODO: These (and the checks below) can be simplified to use in/not in once version is gone
-        assert cache.has_key(maisey_key, version=expiry_option_version)
-        assert cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
 
         grouphash1.update(group=group2)
         grouphash2.update(group=group2)
 
         # The updated grouphashes have been removed from the cache, but the one we didn't update is
         # still there
-        assert not cache.has_key(maisey_key, version=expiry_option_version)
-        assert not cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
 
     def test_removes_from_cache_on_model_save(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        expiry_option_version = get_grouphash_cache_version("object")
         cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
@@ -207,14 +201,13 @@ class CacheInvalidationTest(TestCase):
         grouphash2 = GroupHash.objects.create(project=project, group=group1, hash="charlie")
         grouphash3 = GroupHash.objects.create(project=project, group=group1, hash="dogs_are_great")
 
-        cache.set(maisey_key, grouphash1, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(charlie_key, grouphash2, cache_expiry_seconds, version=expiry_option_version)
-        cache.set(dogs_key, grouphash3, cache_expiry_seconds, version=expiry_option_version)
+        cache.set(maisey_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_key, grouphash3, cache_expiry_seconds)
 
-        # TODO: These (and the checks below) can be simplified to use in/not in once version is gone
-        assert cache.has_key(maisey_key, version=expiry_option_version)
-        assert cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key in cache
+        assert charlie_key in cache
+        assert dogs_key in cache
 
         grouphash1.group = group2
         grouphash1.save()
@@ -223,16 +216,14 @@ class CacheInvalidationTest(TestCase):
 
         # The grouphashes on which we called `save` have been removed from the cache, but the one we
         # didn't update is still there
-        assert not cache.has_key(maisey_key, version=expiry_option_version)
-        assert not cache.has_key(charlie_key, version=expiry_option_version)
-        assert cache.has_key(dogs_key, version=expiry_option_version)
+        assert maisey_key not in cache
+        assert charlie_key not in cache
+        assert dogs_key in cache
 
     def test_removes_from_cache_on_queryset_delete(self) -> None:
         project = self.project
         get_object_cache_key = get_grouphash_object_cache_key
         get_existence_cache_key = get_grouphash_existence_cache_key
-        object_expiry_option_version = get_grouphash_cache_version("object")
-        existence_expiry_option_version = get_grouphash_cache_version("existence")
         cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
@@ -250,62 +241,35 @@ class CacheInvalidationTest(TestCase):
         grouphash2 = GroupHash.objects.create(project=project, group=group, hash="charlie")
         grouphash3 = GroupHash.objects.create(project=project, group=group, hash="dogs_are_great")
 
-        cache.set(
-            maisey_object_key,
-            grouphash1,
-            cache_expiry_seconds,
-            version=object_expiry_option_version,
-        )
-        cache.set(
-            charlie_object_key,
-            grouphash2,
-            cache_expiry_seconds,
-            version=object_expiry_option_version,
-        )
-        cache.set(
-            dogs_object_key, grouphash3, cache_expiry_seconds, version=object_expiry_option_version
-        )
-        cache.set(
-            maisey_existence_key,
-            True,
-            cache_expiry_seconds,
-            version=existence_expiry_option_version,
-        )
-        cache.set(
-            charlie_existence_key,
-            True,
-            cache_expiry_seconds,
-            version=existence_expiry_option_version,
-        )
-        cache.set(
-            dogs_existence_key, True, cache_expiry_seconds, version=existence_expiry_option_version
-        )
+        cache.set(maisey_object_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_object_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_object_key, grouphash3, cache_expiry_seconds)
+        cache.set(maisey_existence_key, True, cache_expiry_seconds)
+        cache.set(charlie_existence_key, True, cache_expiry_seconds)
+        cache.set(dogs_existence_key, True, cache_expiry_seconds)
 
-        # TODO: These (and the checks below) can be simplified to use in/not in once version is gone
-        assert cache.has_key(maisey_object_key, version=object_expiry_option_version)
-        assert cache.has_key(charlie_object_key, version=object_expiry_option_version)
-        assert cache.has_key(dogs_object_key, version=object_expiry_option_version)
-        assert cache.has_key(maisey_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(charlie_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(dogs_existence_key, version=existence_expiry_option_version)
+        assert maisey_object_key in cache
+        assert charlie_object_key in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key in cache
+        assert charlie_existence_key in cache
+        assert dogs_existence_key in cache
 
         GroupHash.objects.filter(hash__in=["maisey", "charlie"]).delete()
 
         # The deleted grouphashes have been removed from the cache, but the one we didn't delete is
         # still there
-        assert not cache.has_key(maisey_object_key, version=object_expiry_option_version)
-        assert not cache.has_key(charlie_object_key, version=object_expiry_option_version)
-        assert cache.has_key(dogs_object_key, version=object_expiry_option_version)
-        assert not cache.has_key(maisey_existence_key, version=existence_expiry_option_version)
-        assert not cache.has_key(charlie_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(dogs_existence_key, version=existence_expiry_option_version)
+        assert maisey_object_key not in cache
+        assert charlie_object_key not in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key not in cache
+        assert charlie_existence_key not in cache
+        assert dogs_existence_key in cache
 
     def test_removes_from_cache_on_model_delete(self) -> None:
         project = self.project
         get_object_cache_key = get_grouphash_object_cache_key
         get_existence_cache_key = get_grouphash_existence_cache_key
-        object_expiry_option_version = get_grouphash_cache_version("object")
-        existence_expiry_option_version = get_grouphash_cache_version("existence")
         cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
@@ -323,62 +287,36 @@ class CacheInvalidationTest(TestCase):
         grouphash2 = GroupHash.objects.create(project=project, group=group, hash="charlie")
         grouphash3 = GroupHash.objects.create(project=project, group=group, hash="dogs_are_great")
 
-        cache.set(
-            maisey_object_key,
-            grouphash1,
-            cache_expiry_seconds,
-            version=object_expiry_option_version,
-        )
-        cache.set(
-            charlie_object_key,
-            grouphash2,
-            cache_expiry_seconds,
-            version=object_expiry_option_version,
-        )
-        cache.set(
-            dogs_object_key, grouphash3, cache_expiry_seconds, version=object_expiry_option_version
-        )
-        cache.set(
-            maisey_existence_key,
-            True,
-            cache_expiry_seconds,
-            version=existence_expiry_option_version,
-        )
-        cache.set(
-            charlie_existence_key,
-            True,
-            cache_expiry_seconds,
-            version=existence_expiry_option_version,
-        )
-        cache.set(
-            dogs_existence_key, True, cache_expiry_seconds, version=existence_expiry_option_version
-        )
+        cache.set(maisey_object_key, grouphash1, cache_expiry_seconds)
+        cache.set(charlie_object_key, grouphash2, cache_expiry_seconds)
+        cache.set(dogs_object_key, grouphash3, cache_expiry_seconds)
+        cache.set(maisey_existence_key, True, cache_expiry_seconds)
+        cache.set(charlie_existence_key, True, cache_expiry_seconds)
+        cache.set(dogs_existence_key, True, cache_expiry_seconds)
 
-        # TODO: These (and the checks below) can be simplified to use in/not in once version is gone
-        assert cache.has_key(maisey_object_key, version=object_expiry_option_version)
-        assert cache.has_key(charlie_object_key, version=object_expiry_option_version)
-        assert cache.has_key(dogs_object_key, version=object_expiry_option_version)
-        assert cache.has_key(maisey_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(charlie_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(dogs_existence_key, version=existence_expiry_option_version)
+        assert maisey_object_key in cache
+        assert charlie_object_key in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key in cache
+        assert charlie_existence_key in cache
+        assert dogs_existence_key in cache
 
         grouphash1.delete()
         grouphash2.delete()
 
         # The deleted grouphashes have been removed from the cache, but the one we didn't delete is
         # still there
-        assert not cache.has_key(maisey_object_key, version=object_expiry_option_version)
-        assert not cache.has_key(charlie_object_key, version=object_expiry_option_version)
-        assert cache.has_key(dogs_object_key, version=object_expiry_option_version)
-        assert not cache.has_key(maisey_existence_key, version=existence_expiry_option_version)
-        assert not cache.has_key(charlie_existence_key, version=existence_expiry_option_version)
-        assert cache.has_key(dogs_existence_key, version=existence_expiry_option_version)
+        assert maisey_object_key not in cache
+        assert charlie_object_key not in cache
+        assert dogs_object_key in cache
+        assert maisey_existence_key not in cache
+        assert charlie_existence_key not in cache
+        assert dogs_existence_key in cache
 
     @patch("sentry.grouping.ingest.caching.cache.delete")
     def test_no_ops_on_grouphash_creation(self, cache_delete_mock: MagicMock) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        expiry_option_version = get_grouphash_cache_version("object")
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
 
         group1 = self.create_group(project)
@@ -389,16 +327,12 @@ class CacheInvalidationTest(TestCase):
         # We listen to the `pre_save` signal, which gets triggered by both `create` and `save`
         # calls, but there's only something to invalidate in the latter case, so we bail early
         # during grouphash creation.
-        assert (
-            count_matching_calls(cache_delete_mock, maisey_key, version=expiry_option_version) == 0
-        )
+        assert count_matching_calls(cache_delete_mock, maisey_key) == 0
 
         grouphash.group = group2
         grouphash.save()
 
-        assert (
-            count_matching_calls(cache_delete_mock, maisey_key, version=expiry_option_version) == 1
-        )
+        assert count_matching_calls(cache_delete_mock, maisey_key) == 1
 
     @patch("sentry.grouping.ingest.caching.cache.delete")
     @patch("sentry.grouping.ingest.caching.cache.delete_many")
@@ -409,8 +343,6 @@ class CacheInvalidationTest(TestCase):
         get_object_cache_key = get_grouphash_object_cache_key
         get_existence_cache_key = get_grouphash_existence_cache_key
 
-        object_expiry_option_version = get_grouphash_cache_version("object")
-        existence_expiry_option_version = get_grouphash_cache_version("existence")
         object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
         existence_key = get_existence_cache_key(hash_value="maisey", project_id=project.id)
 
@@ -422,40 +354,12 @@ class CacheInvalidationTest(TestCase):
             invalidate_grouphash_cache_on_save(grouphash)
             invalidate_grouphash_caches_on_delete(grouphash)
 
-            # TODO: These two can go back to being
-            #    assert count_matching_calls(cache_delete_mock, object_key) == 0
-            #    assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 0
-            # once version is gone
-            assert (
-                count_matching_calls(
-                    cache_delete_mock, object_key, version=object_expiry_option_version
-                )
-                == 0
-            )
-            assert (
-                count_matching_calls(
-                    cache_delete_mock, existence_key, version=existence_expiry_option_version
-                )
-                == 0
-            )
+            assert count_matching_calls(cache_delete_mock, object_key) == 0
+            assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 0
 
         with override_options({"grouping.use_ingest_grouphash_caching": True}):
             invalidate_grouphash_cache_on_save(grouphash)
             invalidate_grouphash_caches_on_delete(grouphash)
 
-            # TODO: These two can go back to being
-            #    assert count_matching_calls(cache_delete_mock, object_key) == 1
-            #    assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 1
-            # once version is gone
-            assert (
-                count_matching_calls(
-                    cache_delete_mock, object_key, version=object_expiry_option_version
-                )
-                == 2
-            )
-            assert (
-                count_matching_calls(
-                    cache_delete_mock, existence_key, version=existence_expiry_option_version
-                )
-                == 1
-            )
+            assert count_matching_calls(cache_delete_mock, object_key) == 1
+            assert count_matching_calls(cache_delete_many_mock, [object_key, existence_key]) == 1


### PR DESCRIPTION
This undoes the changes made in https://github.com/getsentry/sentry/issues/104460 and https://github.com/getsentry/sentry/issues/104537, which enabled us to experiment with expiry times for the caches we use for grouphashes during ingest. I'd hoped that leaving stuff in the cache longer would increase the hit rate, but as we can see from the graph below, it didn't really make any difference - all 3 expiry times (1, 2, and 5 minutes) had essentially identical hit rates. 

<img width="584" height="329" alt="image" src="https://github.com/user-attachments/assets/eb0f06ec-6a81-4fd8-9e10-0ebb7c364236" />

At the same time, leaving things in the cache longer did (unsurprisingly) mean that we used more cache space by having more entries in the cache at any one time:

<img width="583" height="335" alt="image" src="https://github.com/user-attachments/assets/60240c1b-d8ba-4fa0-b6b2-cded4de62d3e" />

Clearly, using all of that space in the cache isn't worth it, so this PR removes the code letting expiry time be variable and switches to just using the smallest expiry time of 1 minute. It also removes the versioning of our cache values, because it only existed to allow us to switch from one set of experimental values to another. Finally, it removes the `expiry_seconds` tag from our metrics, since the value will no longer vary.