### PR TITLE
Uptime monitor resolution notifications

### DIFF
--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -31,6 +31,7 @@ import {
 } from 'sentry/views/automations/components/automationFormData';
 import DataConditionNodeList from 'sentry/views/automations/components/dataConditionNodeList';
 import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
+import {UptimeResolutionNotificationToggle} from 'sentry/views/automations/components/uptimeResolutionNotificationToggle';
 import {useSendTestNotification} from 'sentry/views/automations/hooks';
 import {findConflictingConditions} from 'sentry/views/automations/hooks/utils';
 
@@ -111,6 +112,7 @@ export default function AutomationBuilder() {
             {(mutationErrors as any).actionFilters.all}
           </StyledAlert>
         )}
+        <UptimeResolutionNotificationToggle />
         {state.actionFilters.map(actionFilter => (
           <ActionFilterBlock
             key={`actionFilters.${actionFilter.id}`}

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
@@ -1,6 +1,10 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
+import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {AutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {UptimeResolutionNotificationToggle} from 'sentry/views/automations/components/uptimeResolutionNotificationToggle';
 
@@ -28,16 +32,19 @@ describe('UptimeResolutionNotificationToggle', () => {
     updateIfLogicType: jest.fn(),
   };
 
-  const mockState = {
+  const mockState: AutomationBuilderState = {
     triggers: {
       id: 'when',
-      logicType: 'any' as const,
+      logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
       conditions: [],
     },
     actionFilters: [],
   };
 
-  const renderComponent = (state = mockState, detectors: any[] = []) => {
+  const renderComponent = (
+    state: AutomationBuilderState = mockState,
+    detectors: any[] = []
+  ) => {
     mockUseConnectedDetectors.mockReturnValue({
       connectedDetectors: detectors,
       isLoading: false,
@@ -73,26 +80,23 @@ describe('UptimeResolutionNotificationToggle', () => {
   });
 
   it('renders guidance message when uptime detector is connected but no resolution filter exists', () => {
-    renderComponent(mockState, [{id: '1', type: 'uptime', name: 'Uptime Monitor'}]);
+    renderComponent(mockState, [
+      {id: '1', type: 'uptime_domain_failure', name: 'Uptime Monitor'},
+    ]);
 
     expect(
       screen.getByText('Want to be notified when uptime monitor outages are resolved?')
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /Add an If\/Then block with the/,
-        {exact: false}
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Add an If\/Then block with the/, {exact: false})).toBeInTheDocument();
   });
 
   it('renders success message when resolution filter is configured', () => {
-    const stateWithResolution = {
+    const stateWithResolution: AutomationBuilderState = {
       ...mockState,
       actionFilters: [
         {
           id: 'filter-1',
-          logicType: 'any' as const,
+          logicType: DataConditionGroupLogicType.ANY_SHORT_CIRCUIT,
           conditions: [
             {
               id: 'cond-1',
@@ -106,7 +110,7 @@ describe('UptimeResolutionNotificationToggle', () => {
     };
 
     renderComponent(stateWithResolution, [
-      {id: '1', type: 'uptime', name: 'Uptime Monitor'},
+      {id: '1', type: 'uptime_domain_failure', name: 'Uptime Monitor'},
     ]);
 
     expect(
@@ -122,7 +126,7 @@ describe('UptimeResolutionNotificationToggle', () => {
   it('renders for mixed detector types when at least one is uptime', () => {
     renderComponent(mockState, [
       {id: '1', type: 'metric_issue', name: 'Metric Detector'},
-      {id: '2', type: 'uptime', name: 'Uptime Monitor'},
+      {id: '2', type: 'uptime_domain_failure', name: 'Uptime Monitor'},
       {id: '3', type: 'error', name: 'Error Detector'},
     ]);
 

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
@@ -87,7 +87,9 @@ describe('UptimeResolutionNotificationToggle', () => {
     expect(
       screen.getByText('Want to be notified when uptime monitor outages are resolved?')
     ).toBeInTheDocument();
-    expect(screen.getByText(/Add an If\/Then block with the/, {exact: false})).toBeInTheDocument();
+    expect(
+      screen.getByText(/Add an If\/Then block with the/, {exact: false})
+    ).toBeInTheDocument();
   });
 
   it('renders success message when resolution filter is configured', () => {

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
@@ -1,0 +1,133 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {AutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
+import {UptimeResolutionNotificationToggle} from 'sentry/views/automations/components/uptimeResolutionNotificationToggle';
+
+jest.mock('sentry/views/automations/hooks/useConnectedDetectors', () => ({
+  useConnectedDetectors: jest.fn(),
+}));
+
+const mockUseConnectedDetectors = require('sentry/views/automations/hooks/useConnectedDetectors')
+  .useConnectedDetectors as jest.Mock;
+
+describe('UptimeResolutionNotificationToggle', () => {
+  const mockActions = {
+    addWhenCondition: jest.fn(),
+    removeWhenCondition: jest.fn(),
+    updateWhenCondition: jest.fn(),
+    updateWhenLogicType: jest.fn(),
+    addIf: jest.fn(),
+    removeIf: jest.fn(),
+    addIfCondition: jest.fn(),
+    removeIfCondition: jest.fn(),
+    updateIfCondition: jest.fn(),
+    addIfAction: jest.fn(),
+    removeIfAction: jest.fn(),
+    updateIfAction: jest.fn(),
+    updateIfLogicType: jest.fn(),
+  };
+
+  const mockState = {
+    triggers: {
+      id: 'when',
+      logicType: 'any' as const,
+      conditions: [],
+    },
+    actionFilters: [],
+  };
+
+  const renderComponent = (state = mockState, detectors: any[] = []) => {
+    mockUseConnectedDetectors.mockReturnValue({
+      connectedDetectors: detectors,
+      isLoading: false,
+    });
+
+    return render(
+      <AutomationBuilderContext.Provider
+        value={{
+          state,
+          actions: mockActions,
+          showTriggerLogicTypeSelector: false,
+        }}
+      >
+        <UptimeResolutionNotificationToggle />
+      </AutomationBuilderContext.Provider>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render when no uptime detectors are connected', () => {
+    const {container} = renderComponent(mockState, []);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when only non-uptime detectors are connected', () => {
+    const {container} = renderComponent(mockState, [
+      {id: '1', type: 'metric_issue', name: 'Metric Detector'},
+    ]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders guidance message when uptime detector is connected but no resolution filter exists', () => {
+    renderComponent(mockState, [{id: '1', type: 'uptime', name: 'Uptime Monitor'}]);
+
+    expect(
+      screen.getByText('Want to be notified when uptime monitor outages are resolved?')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Add an If\/Then block with the/,
+        {exact: false}
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders success message when resolution filter is configured', () => {
+    const stateWithResolution = {
+      ...mockState,
+      actionFilters: [
+        {
+          id: 'filter-1',
+          logicType: 'any' as const,
+          conditions: [
+            {
+              id: 'cond-1',
+              type: DataConditionType.ISSUE_PRIORITY_DEESCALATING,
+              comparison: 75,
+            },
+          ],
+          actions: [],
+        },
+      ],
+    };
+
+    renderComponent(stateWithResolution, [
+      {id: '1', type: 'uptime', name: 'Uptime Monitor'},
+    ]);
+
+    expect(
+      screen.getByText('Resolution notifications are configured')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This automation will send notifications when uptime monitor outages are resolved.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders for mixed detector types when at least one is uptime', () => {
+    renderComponent(mockState, [
+      {id: '1', type: 'metric_issue', name: 'Metric Detector'},
+      {id: '2', type: 'uptime', name: 'Uptime Monitor'},
+      {id: '3', type: 'error', name: 'Error Detector'},
+    ]);
+
+    expect(
+      screen.getByText('Want to be notified when uptime monitor outages are resolved?')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.spec.tsx
@@ -87,9 +87,7 @@ describe('UptimeResolutionNotificationToggle', () => {
     expect(
       screen.getByText('Want to be notified when uptime monitor outages are resolved?')
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Add an If\/Then block with the/, {exact: false})
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Add an If\/Then block with the/, {exact: false})).toBeInTheDocument();
   });
 
   it('renders success message when resolution filter is configured', () => {

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -61,9 +61,7 @@ export function UptimeResolutionNotificationToggle() {
                 'Add an If/Then block with the [condition] filter to receive notifications when your uptime monitors come back online. [link:Learn more]',
                 {
                   condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
-                  link: (
-                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />
-                  ),
+                  link: <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />,
                 }
               )}
             </Text>

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -60,9 +60,7 @@ export function UptimeResolutionNotificationToggle() {
               {tct(
                 'Add an If/Then block with the [condition] filter to receive notifications when your uptime monitors come back online. [link:Learn more]',
                 {
-                  condition: (
-                    <strong>{t('"The issue priority de-escalates"')}</strong>
-                  ),
+                  condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />
                   ),

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -58,7 +58,7 @@ export function UptimeResolutionNotificationToggle() {
             </Text>
             <Text size="sm">
               {tct(
-                'Add an If/Then block with [condition] to send notifications when monitors recover. [link:Learn more]',
+                'Add an If/Then block with [condition] to be notified on recovery. [link:Learn more]',
                 {
                   condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
                   link: <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />,

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -58,7 +58,7 @@ export function UptimeResolutionNotificationToggle() {
             </Text>
             <Text size="sm">
               {tct(
-                'Add an If/Then block with the [condition] filter to receive notifications when your uptime monitors come back online. [link:Learn more]',
+                'Add an If/Then block with [condition] to get notified when monitors come back online. [link:Learn more]',
                 {
                   condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
                   link: <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />,

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -22,7 +22,9 @@ export function UptimeResolutionNotificationToggle() {
   const {state} = useAutomationBuilderContext();
 
   // Only show this if connected to at least one uptime detector
-  const hasUptimeDetectors = connectedDetectors.some(d => d.type === 'uptime');
+  const hasUptimeDetectors = connectedDetectors.some(
+    d => d.type === 'uptime_domain_failure'
+  );
 
   // Check if resolution notifications are currently configured
   const hasResolutionFilter = state.actionFilters.some(filter =>
@@ -38,11 +40,9 @@ export function UptimeResolutionNotificationToggle() {
   return (
     <UptimeResolutionContainer>
       {hasResolutionFilter ? (
-        <Alert type="success" icon={<IconCheckmark />}>
+        <Alert variant="success" icon={<IconCheckmark />}>
           <Flex direction="column" gap="xs">
-            <Text weight="bold">
-              {t('Resolution notifications are configured')}
-            </Text>
+            <Text bold>{t('Resolution notifications are configured')}</Text>
             <Text size="sm">
               {t(
                 'This automation will send notifications when uptime monitor outages are resolved.'
@@ -51,9 +51,9 @@ export function UptimeResolutionNotificationToggle() {
           </Flex>
         </Alert>
       ) : (
-        <Alert type="info" icon={<IconInfo />}>
+        <Alert variant="info" icon={<IconInfo />}>
           <Flex direction="column" gap="xs">
-            <Text weight="bold">
+            <Text bold>
               {t('Want to be notified when uptime monitor outages are resolved?')}
             </Text>
             <Text size="sm">

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -60,7 +60,9 @@ export function UptimeResolutionNotificationToggle() {
               {tct(
                 'Add an If/Then block with the [condition] filter to receive notifications when your uptime monitors come back online. [link:Learn more]',
                 {
-                  condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
+                  condition: (
+                    <strong>{t('"The issue priority de-escalates"')}</strong>
+                  ),
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />
                   ),

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconCheckmark, IconInfo} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
+import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
+import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
+
+/**
+ * Component that provides guidance for configuring resolution notifications
+ * for uptime monitors. Shows users how to use the ISSUE_PRIORITY_DEESCALATING
+ * condition to get notified when uptime monitors are resolved.
+ */
+export function UptimeResolutionNotificationToggle() {
+  const {connectedDetectors} = useConnectedDetectors();
+  const {state} = useAutomationBuilderContext();
+
+  // Only show this if connected to at least one uptime detector
+  const hasUptimeDetectors = connectedDetectors.some(d => d.type === 'uptime');
+
+  // Check if resolution notifications are currently configured
+  const hasResolutionFilter = state.actionFilters.some(filter =>
+    filter.conditions.some(
+      cond => cond.type === DataConditionType.ISSUE_PRIORITY_DEESCALATING
+    )
+  );
+
+  if (!hasUptimeDetectors) {
+    return null;
+  }
+
+  return (
+    <UptimeResolutionContainer>
+      {hasResolutionFilter ? (
+        <Alert type="success" icon={<IconCheckmark />}>
+          <Flex direction="column" gap="xs">
+            <Text weight="bold">
+              {t('Resolution notifications are configured')}
+            </Text>
+            <Text size="sm">
+              {t(
+                'This automation will send notifications when uptime monitor outages are resolved.'
+              )}
+            </Text>
+          </Flex>
+        </Alert>
+      ) : (
+        <Alert type="info" icon={<IconInfo />}>
+          <Flex direction="column" gap="xs">
+            <Text weight="bold">
+              {t('Want to be notified when uptime monitor outages are resolved?')}
+            </Text>
+            <Text size="sm">
+              {tct(
+                'Add an If/Then block with the [condition] filter to receive notifications when your uptime monitors come back online. [link:Learn more]',
+                {
+                  condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
+                  link: (
+                    <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />
+                  ),
+                }
+              )}
+            </Text>
+          </Flex>
+        </Alert>
+      )}
+    </UptimeResolutionContainer>
+  );
+}
+
+const UptimeResolutionContainer = styled('div')`
+  margin-top: ${space(2)};
+  margin-bottom: ${space(2)};
+`;

--- a/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
+++ b/static/app/views/automations/components/uptimeResolutionNotificationToggle.tsx
@@ -58,7 +58,7 @@ export function UptimeResolutionNotificationToggle() {
             </Text>
             <Text size="sm">
               {tct(
-                'Add an If/Then block with [condition] to get notified when monitors come back online. [link:Learn more]',
+                'Add an If/Then block with [condition] to send notifications when monitors recover. [link:Learn more]',
                 {
                   condition: <strong>{t('"The issue priority de-escalates"')}</strong>,
                   link: <ExternalLink href="https://docs.sentry.io/product/alerts/uptime-monitoring/" />,


### PR DESCRIPTION
<!-- Describe your PR here. -->
This PR introduces a new UI component in the automation builder to guide users on configuring resolution notifications for uptime monitors (NEW-742). It leverages the existing `ISSUE_PRIORITY_DEESCALATING` condition, making this functionality discoverable and easier to set up without any backend changes.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
Linear Issue: [NEW-742](https://linear.app/getsentry/issue/NEW-742/notification-for-uptime-monitor-after-resolution)

<p><a href="https://cursor.com/background-agent?bcId=bc-a07a2af3-5602-4438-8806-6c9b69e4c609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a07a2af3-5602-4438-8806-6c9b69e4c609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

