### PR TITLE
ref(tests): Add instasnapshot types to event manager interface tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -788,6 +788,7 @@ module = [
     "tests.sentry.demo_mode.*",
     "tests.sentry.digests.*",
     "tests.sentry.discover.translation.*",
+    "tests.sentry.event_manager.interfaces.*",
     "tests.sentry.event_manager.test_event_manager",
     "tests.sentry.eventstream.*",
     "tests.sentry.eventtypes.*",

--- a/tests/sentry/event_manager/interfaces/__init__.py
+++ b/tests/sentry/event_manager/interfaces/__init__.py
@@ -1,0 +1,6 @@
+from collections.abc import Callable
+from typing import TypeVar
+
+SnapshotInput = TypeVar("SnapshotInput")
+
+CustomSnapshotter = Callable[[SnapshotInput], None]

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_ctx_snapshot(insta_snapshot):
-    def inner(data):
+def make_ctx_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"contexts": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -24,47 +31,47 @@ def make_ctx_snapshot(insta_snapshot):
     return inner
 
 
-def test_os(make_ctx_snapshot) -> None:
+def test_os(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"os": {"os": "Windows 95", "name": "Windows", "version": "95", "rooted": True}}
     )
 
 
-def test_null_values(make_ctx_snapshot) -> None:
+def test_null_values(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot({"os": None})
 
 
-def test_null_values2(make_ctx_snapshot) -> None:
+def test_null_values2(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot({"os": {}})
 
 
-def test_null_values3(make_ctx_snapshot) -> None:
+def test_null_values3(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot({"os": {"name": None}})
 
 
-def test_os_normalization(make_ctx_snapshot) -> None:
+def test_os_normalization(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot({"os": {"raw_description": "Microsoft Windows 6.1.7601 S"}})
 
 
-def test_runtime(make_ctx_snapshot) -> None:
+def test_runtime(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"runtime": {"runtime": "Java 1.2.3", "name": "Java", "version": "1.2.3", "build": "BLAH"}}
     )
 
 
-def test_runtime_normalization(make_ctx_snapshot) -> None:
+def test_runtime_normalization(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"runtime": {"raw_description": ".NET Framework 4.0.30319.42000", "build": "461808"}}
     )
 
 
-def test_browser(make_ctx_snapshot) -> None:
+def test_browser(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"browser": {"browser": "Chrome 132.0.6834.0", "name": "Chrome", "version": "132.0.6834.0"}}
     )
 
 
-def test_device(make_ctx_snapshot) -> None:
+def test_device(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {
             "device": {
@@ -79,7 +86,7 @@ def test_device(make_ctx_snapshot) -> None:
     )
 
 
-def test_device_with_alias(make_ctx_snapshot) -> None:
+def test_device_with_alias(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {
             "my_device": {
@@ -95,17 +102,17 @@ def test_device_with_alias(make_ctx_snapshot) -> None:
     )
 
 
-def test_default(make_ctx_snapshot) -> None:
+def test_default(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"whatever": {"foo": "bar", "blub": "blah", "biz": [1, 2, 3], "baz": {"foo": "bar"}}}
     )
 
 
-def test_app(make_ctx_snapshot) -> None:
+def test_app(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot({"app": {"app_id": "1234", "device_app_hash": "5678"}})
 
 
-def test_gpu(make_ctx_snapshot) -> None:
+def test_gpu(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {"gpu": {"name": "AMD Radeon Pro 560", "vendor_name": "Apple", "version": "Metal"}}
     )
@@ -186,7 +193,7 @@ def test_large_nested_numbers() -> None:
     assert ctx_data == expected_data
 
 
-def test_unity(make_ctx_snapshot) -> None:
+def test_unity(make_ctx_snapshot: CustomSnapshotter) -> None:
     make_ctx_snapshot(
         {
             "unity": {

--- a/tests/sentry/event_manager/interfaces/test_csp.py
+++ b/tests/sentry/event_manager/interfaces/test_csp.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_csp_snapshot(insta_snapshot):
-    def inner(data):
+def make_csp_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(
             data={"csp": data, "logentry": {"message": "XXX CSP MESSAGE NOT THROUGH RELAY XXX"}}
         )
@@ -30,7 +37,7 @@ def make_csp_snapshot(insta_snapshot):
     return inner
 
 
-def test_basic(make_csp_snapshot) -> None:
+def test_basic(make_csp_snapshot: CustomSnapshotter) -> None:
     make_csp_snapshot(
         dict(
             document_uri="http://example.com",
@@ -41,7 +48,7 @@ def test_basic(make_csp_snapshot) -> None:
     )
 
 
-def test_coerce_blocked_uri_if_missing(make_csp_snapshot) -> None:
+def test_coerce_blocked_uri_if_missing(make_csp_snapshot: CustomSnapshotter) -> None:
     make_csp_snapshot(dict(document_uri="http://example.com", effective_directive="script-src"))
 
 
@@ -96,5 +103,5 @@ def test_coerce_blocked_uri_if_missing(make_csp_snapshot) -> None:
         ),
     ],
 )
-def test_get_message(make_csp_snapshot, input) -> None:
+def test_get_message(make_csp_snapshot: CustomSnapshotter, input: SnapshotInput) -> None:
     make_csp_snapshot(input)

--- a/tests/sentry/event_manager/interfaces/test_csp.py
+++ b/tests/sentry/event_manager/interfaces/test_csp.py
@@ -11,11 +11,11 @@ def make_csp_snapshot(insta_snapshot):
             data={"csp": data, "logentry": {"message": "XXX CSP MESSAGE NOT THROUGH RELAY XXX"}}
         )
         mgr.normalize()
-        data = mgr.get_data()
-        event_type = get_event_type(data)
-        event_metadata = event_type.get_metadata(data)
-        data.update(materialize_metadata(data, event_type, event_metadata))
-        evt = eventstore.backend.create_event(project_id=1, data=data)
+        event_data = mgr.get_data()
+        event_type = get_event_type(event_data)
+        event_metadata = event_type.get_metadata(event_data)
+        event_data.update(materialize_metadata(event_data, event_type, event_metadata))
+        evt = eventstore.backend.create_event(project_id=1, data=event_data)
         interface = evt.interfaces.get("csp")
 
         insta_snapshot(

--- a/tests/sentry/event_manager/interfaces/test_debug_meta.py
+++ b/tests/sentry/event_manager/interfaces/test_debug_meta.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_debug_meta_snapshot(insta_snapshot):
-    def inner(data):
+def make_debug_meta_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"debug_meta": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -27,11 +34,11 @@ def make_debug_meta_snapshot(insta_snapshot):
         {"images": [None]},
     ],
 )
-def test_null_values(make_debug_meta_snapshot, input) -> None:
+def test_null_values(make_debug_meta_snapshot: CustomSnapshotter, input: SnapshotInput) -> None:
     make_debug_meta_snapshot(input)
 
 
-def test_apple_behavior(make_debug_meta_snapshot) -> None:
+def test_apple_behavior(make_debug_meta_snapshot: CustomSnapshotter) -> None:
     image_name = (
         "/var/containers/Bundle/Application/"
         "B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest"
@@ -60,7 +67,7 @@ def test_apple_behavior(make_debug_meta_snapshot) -> None:
     )
 
 
-def test_apple_behavior_with_arch(make_debug_meta_snapshot) -> None:
+def test_apple_behavior_with_arch(make_debug_meta_snapshot: CustomSnapshotter) -> None:
     image_name = (
         "/var/containers/Bundle/Application/"
         "B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest"
@@ -90,7 +97,7 @@ def test_apple_behavior_with_arch(make_debug_meta_snapshot) -> None:
     )
 
 
-def test_symbolic_behavior(make_debug_meta_snapshot) -> None:
+def test_symbolic_behavior(make_debug_meta_snapshot: CustomSnapshotter) -> None:
     make_debug_meta_snapshot(
         {
             "images": [
@@ -112,7 +119,7 @@ def test_symbolic_behavior(make_debug_meta_snapshot) -> None:
     )
 
 
-def test_symbolic_behavior_with_arch(make_debug_meta_snapshot) -> None:
+def test_symbolic_behavior_with_arch(make_debug_meta_snapshot: CustomSnapshotter) -> None:
     make_debug_meta_snapshot(
         {
             "images": [
@@ -135,7 +142,7 @@ def test_symbolic_behavior_with_arch(make_debug_meta_snapshot) -> None:
     )
 
 
-def test_proguard_behavior(make_debug_meta_snapshot) -> None:
+def test_proguard_behavior(make_debug_meta_snapshot: CustomSnapshotter) -> None:
     make_debug_meta_snapshot(
         {"images": [{"type": "proguard", "uuid": "C05B4DDD-69A7-3840-A649-32180D341587"}]}
     )

--- a/tests/sentry/event_manager/interfaces/test_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_exception.py
@@ -1,14 +1,21 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.interfaces.exception import Exception
 from sentry.services import eventstore
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_exception_snapshot(insta_snapshot):
-    def inner(data):
+def make_exception_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"exception": data}, remove_other=False)
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -32,7 +39,7 @@ def make_exception_snapshot(insta_snapshot):
     return inner
 
 
-def test_basic(make_exception_snapshot) -> None:
+def test_basic(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -57,21 +64,21 @@ def test_basic(make_exception_snapshot) -> None:
     )
 
 
-def test_args_as_keyword_args(make_exception_snapshot) -> None:
+def test_args_as_keyword_args(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(values=[{"type": "ValueError", "value": "hello world", "module": "foo.bar"}])
     )
 
 
-def test_args_as_old_style(make_exception_snapshot) -> None:
+def test_args_as_old_style(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot({"type": "ValueError", "value": "hello world", "module": "foo.bar"})
 
 
-def test_non_string_value_with_no_type(make_exception_snapshot) -> None:
+def test_non_string_value_with_no_type(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot({"value": {"foo": "bar"}})
 
 
-def test_context_with_mixed_frames(make_exception_snapshot) -> None:
+def test_context_with_mixed_frames(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -96,7 +103,7 @@ def test_context_with_mixed_frames(make_exception_snapshot) -> None:
     )
 
 
-def test_context_with_symbols(make_exception_snapshot) -> None:
+def test_context_with_symbols(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -121,7 +128,7 @@ def test_context_with_symbols(make_exception_snapshot) -> None:
     )
 
 
-def test_context_with_only_system_frames(make_exception_snapshot) -> None:
+def test_context_with_only_system_frames(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -146,7 +153,7 @@ def test_context_with_only_system_frames(make_exception_snapshot) -> None:
     )
 
 
-def test_context_with_only_app_frames(make_exception_snapshot) -> None:
+def test_context_with_only_app_frames(make_exception_snapshot: CustomSnapshotter) -> None:
     values = [
         {
             "type": "ValueError",
@@ -166,7 +173,7 @@ def test_context_with_only_app_frames(make_exception_snapshot) -> None:
     make_exception_snapshot(exc)
 
 
-def test_context_with_raw_values(make_exception_snapshot) -> None:
+def test_context_with_raw_values(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -203,7 +210,7 @@ def test_context_with_raw_values(make_exception_snapshot) -> None:
     )
 
 
-def test_context_with_mechanism(make_exception_snapshot) -> None:
+def test_context_with_mechanism(make_exception_snapshot: CustomSnapshotter) -> None:
     make_exception_snapshot(
         dict(
             values=[
@@ -225,7 +232,9 @@ def test_context_with_mechanism(make_exception_snapshot) -> None:
     )
 
 
-def test_context_with_two_exceptions_having_mechanism(make_exception_snapshot) -> None:
+def test_context_with_two_exceptions_having_mechanism(
+    make_exception_snapshot: CustomSnapshotter,
+) -> None:
     make_exception_snapshot(
         dict(
             values=[

--- a/tests/sentry/event_manager/interfaces/test_expectct.py
+++ b/tests/sentry/event_manager/interfaces/test_expectct.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_expectct_snapshot(insta_snapshot):
-    def inner(data):
+def make_expectct_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(
             data={
                 "expectct": data,
@@ -45,5 +52,5 @@ interface_json = {
 }
 
 
-def test_basic(make_expectct_snapshot) -> None:
+def test_basic(make_expectct_snapshot: CustomSnapshotter) -> None:
     make_expectct_snapshot(interface_json)

--- a/tests/sentry/event_manager/interfaces/test_expectct.py
+++ b/tests/sentry/event_manager/interfaces/test_expectct.py
@@ -14,11 +14,11 @@ def make_expectct_snapshot(insta_snapshot):
             }
         )
         mgr.normalize()
-        data = mgr.get_data()
-        event_type = get_event_type(data)
-        event_metadata = event_type.get_metadata(data)
-        data.update(materialize_metadata(data, event_type, event_metadata))
-        evt = eventstore.backend.create_event(project_id=1, data=data)
+        event_data = mgr.get_data()
+        event_type = get_event_type(event_data)
+        event_metadata = event_type.get_metadata(event_data)
+        event_data.update(materialize_metadata(event_data, event_type, event_metadata))
+        evt = eventstore.backend.create_event(project_id=1, data=event_data)
 
         interface = evt.interfaces.get("expectct")
 

--- a/tests/sentry/event_manager/interfaces/test_expectstaple.py
+++ b/tests/sentry/event_manager/interfaces/test_expectstaple.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager, get_event_type, materialize_metadata
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_csp_snapshot(insta_snapshot):
-    def inner(data):
+def make_csp_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(
             data={
                 "expectstaple": data,
@@ -45,5 +52,5 @@ interface_json = {
 }
 
 
-def test_basic(make_csp_snapshot) -> None:
+def test_basic(make_csp_snapshot: CustomSnapshotter) -> None:
     make_csp_snapshot(interface_json)

--- a/tests/sentry/event_manager/interfaces/test_expectstaple.py
+++ b/tests/sentry/event_manager/interfaces/test_expectstaple.py
@@ -14,11 +14,11 @@ def make_csp_snapshot(insta_snapshot):
             }
         )
         mgr.normalize()
-        data = mgr.get_data()
-        event_type = get_event_type(data)
-        event_metadata = event_type.get_metadata(data)
-        data.update(materialize_metadata(data, event_type, event_metadata))
-        evt = eventstore.backend.create_event(project_id=1, data=data)
+        event_data = mgr.get_data()
+        event_type = get_event_type(event_data)
+        event_metadata = event_type.get_metadata(event_data)
+        event_data.update(materialize_metadata(event_data, event_type, event_metadata))
+        evt = eventstore.backend.create_event(project_id=1, data=event_data)
         expectstaple_interface = evt.interfaces.get("expectstaple")
         assert expectstaple_interface is not None
         insta_snapshot(

--- a/tests/sentry/event_manager/interfaces/test_geo.py
+++ b/tests/sentry/event_manager/interfaces/test_geo.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_geo_snapshot(insta_snapshot):
-    def inner(data):
+def make_geo_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"user": {"id": "123", "geo": data}})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -19,10 +26,10 @@ def make_geo_snapshot(insta_snapshot):
     return inner
 
 
-def test_serialize_behavior(make_geo_snapshot) -> None:
+def test_serialize_behavior(make_geo_snapshot: CustomSnapshotter) -> None:
     make_geo_snapshot({"country_code": "US", "city": "San Francisco", "region": "CA"})
 
 
 @pytest.mark.parametrize("input", [{}, {"country_code": None}, {"city": None}, {"region": None}])
-def test_null_values(make_geo_snapshot, input) -> None:
+def test_null_values(make_geo_snapshot: CustomSnapshotter, input: SnapshotInput) -> None:
     make_geo_snapshot(input)

--- a/tests/sentry/event_manager/interfaces/test_mechanism.py
+++ b/tests/sentry/event_manager/interfaces/test_mechanism.py
@@ -1,13 +1,20 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.interfaces.exception import upgrade_legacy_mechanism
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_mechanism_snapshot(insta_snapshot):
-    def inner(data):
+def make_mechanism_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(
             data={"exception": {"values": [{"type": "FooError", "mechanism": data}]}}
         )
@@ -26,34 +33,34 @@ def make_mechanism_snapshot(insta_snapshot):
     return inner
 
 
-def test_empty_mechanism(make_mechanism_snapshot) -> None:
+def test_empty_mechanism(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic"}
     make_mechanism_snapshot(data)
 
 
-def test_tag(make_mechanism_snapshot) -> None:
+def test_tag(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic"}
     make_mechanism_snapshot(data)
 
 
-def test_tag_with_handled(make_mechanism_snapshot) -> None:
+def test_tag_with_handled(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "handled": False}
 
     make_mechanism_snapshot(data)
 
 
-def test_data(make_mechanism_snapshot) -> None:
+def test_data(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "data": {"relevant_address": "0x1"}}
     make_mechanism_snapshot(data)
 
 
-def test_empty_data(make_mechanism_snapshot) -> None:
+def test_empty_data(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "data": {}}
 
     make_mechanism_snapshot(data)
 
 
-def test_min_mach_meta(make_mechanism_snapshot) -> None:
+def test_min_mach_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     input = {
         "type": "generic",
         "meta": {"mach_exception": {"exception": 10, "code": 0, "subcode": 0}},
@@ -61,7 +68,7 @@ def test_min_mach_meta(make_mechanism_snapshot) -> None:
     make_mechanism_snapshot(input)
 
 
-def test_full_mach_meta(make_mechanism_snapshot) -> None:
+def test_full_mach_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {
         "type": "generic",
         "meta": {"mach_exception": {"exception": 10, "code": 0, "subcode": 0, "name": "EXC_CRASH"}},
@@ -69,12 +76,12 @@ def test_full_mach_meta(make_mechanism_snapshot) -> None:
     make_mechanism_snapshot(data)
 
 
-def test_min_signal_meta(make_mechanism_snapshot) -> None:
+def test_min_signal_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "meta": {"signal": {"number": 10, "code": 0}}}
     make_mechanism_snapshot(data)
 
 
-def test_full_signal_meta(make_mechanism_snapshot) -> None:
+def test_full_signal_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {
         "type": "generic",
         "meta": {"signal": {"number": 10, "code": 0, "name": "SIGBUS", "code_name": "BUS_NOOP"}},
@@ -82,12 +89,12 @@ def test_full_signal_meta(make_mechanism_snapshot) -> None:
     make_mechanism_snapshot(data)
 
 
-def test_min_errno_meta(make_mechanism_snapshot) -> None:
+def test_min_errno_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "meta": {"errno": {"number": 2}}}
     make_mechanism_snapshot(data)
 
 
-def test_full_errno_meta(make_mechanism_snapshot) -> None:
+def test_full_errno_meta(make_mechanism_snapshot: CustomSnapshotter) -> None:
     data = {"type": "generic", "meta": {"errno": {"number": 2, "name": "ENOENT"}}}
     make_mechanism_snapshot(data)
 

--- a/tests/sentry/event_manager/interfaces/test_sdk.py
+++ b/tests/sentry/event_manager/interfaces/test_sdk.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_sdk_snapshot(insta_snapshot):
-    def inner(data):
+def make_sdk_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"sdk": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -17,7 +24,7 @@ def make_sdk_snapshot(insta_snapshot):
     return inner
 
 
-def test_serialize_behavior(make_sdk_snapshot) -> None:
+def test_serialize_behavior(make_sdk_snapshot: CustomSnapshotter) -> None:
     make_sdk_snapshot(
         {
             "name": "sentry-java",
@@ -28,9 +35,9 @@ def test_serialize_behavior(make_sdk_snapshot) -> None:
     )
 
 
-def test_missing_name(make_sdk_snapshot) -> None:
+def test_missing_name(make_sdk_snapshot: CustomSnapshotter) -> None:
     make_sdk_snapshot({"version": "1.0"})
 
 
-def test_missing_version(make_sdk_snapshot) -> None:
+def test_missing_version(make_sdk_snapshot: CustomSnapshotter) -> None:
     make_sdk_snapshot({"name": "sentry-unity"})

--- a/tests/sentry/event_manager/interfaces/test_single_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_single_exception.py
@@ -1,13 +1,21 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_single_exception_snapshot(insta_snapshot):
-    def inner(data):
+def make_single_exception_snapshot(
+    insta_snapshot: InstaSnapshotter,
+) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"exception": {"values": [data]}})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -24,35 +32,45 @@ def make_single_exception_snapshot(insta_snapshot):
 
 
 @django_db_all
-def test_basic(make_single_exception_snapshot) -> None:
+def test_basic(make_single_exception_snapshot: CustomSnapshotter) -> None:
     make_single_exception_snapshot(dict(type="ValueError", value="hello world", module="foo.bar"))
 
 
-def test_requires_only_type_or_value(make_single_exception_snapshot) -> None:
+def test_requires_only_type_or_value(
+    make_single_exception_snapshot: CustomSnapshotter,
+) -> None:
     make_single_exception_snapshot(dict(type="ValueError"))
 
 
-def test_requires_only_type_or_value2(make_single_exception_snapshot) -> None:
+def test_requires_only_type_or_value2(
+    make_single_exception_snapshot: CustomSnapshotter,
+) -> None:
     make_single_exception_snapshot(dict(value="ValueError"))
 
 
-def test_coerces_object_value_to_string(make_single_exception_snapshot) -> None:
+def test_coerces_object_value_to_string(
+    make_single_exception_snapshot: CustomSnapshotter,
+) -> None:
     make_single_exception_snapshot({"type": "ValueError", "value": {"unauthorized": True}})
 
 
 @django_db_all
-def test_handles_type_in_value(make_single_exception_snapshot) -> None:
+def test_handles_type_in_value(make_single_exception_snapshot: CustomSnapshotter) -> None:
     make_single_exception_snapshot(dict(value="ValueError: unauthorized"))
 
 
-def test_handles_type_in_value2(make_single_exception_snapshot) -> None:
+def test_handles_type_in_value2(make_single_exception_snapshot: CustomSnapshotter) -> None:
     make_single_exception_snapshot(dict(value="ValueError:unauthorized"))
 
 
-def test_value_serialization_idempotent(make_single_exception_snapshot) -> None:
+def test_value_serialization_idempotent(
+    make_single_exception_snapshot: CustomSnapshotter,
+) -> None:
     make_single_exception_snapshot({"type": None, "value": {"unauthorized": True}})
 
 
-def test_value_serialization_idempotent2(make_single_exception_snapshot) -> None:
+def test_value_serialization_idempotent2(
+    make_single_exception_snapshot: CustomSnapshotter,
+) -> None:
     # Don't re-split a json-serialized value on the colon
     make_single_exception_snapshot({"type": None, "value": '{"unauthorized":true}'})

--- a/tests/sentry/event_manager/interfaces/test_spans.py
+++ b/tests/sentry/event_manager/interfaces/test_spans.py
@@ -1,15 +1,22 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
 
 START_TIME = 1562873192.624
 END_TIME = 1562873194.624
 
+SnapshotInput = list[dict[str, Any]]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
+
 
 @pytest.fixture
-def make_spans_snapshot(insta_snapshot):
-    def inner(data):
+def make_spans_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"spans": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -21,11 +28,11 @@ def make_spans_snapshot(insta_snapshot):
     return inner
 
 
-def test_empty(make_spans_snapshot) -> None:
+def test_empty(make_spans_snapshot: CustomSnapshotter) -> None:
     make_spans_snapshot([])
 
 
-def test_single_invalid(make_spans_snapshot) -> None:
+def test_single_invalid(make_spans_snapshot: CustomSnapshotter) -> None:
     make_spans_snapshot(
         [
             {
@@ -38,7 +45,7 @@ def test_single_invalid(make_spans_snapshot) -> None:
     )
 
 
-def test_single_incomplete(make_spans_snapshot) -> None:
+def test_single_incomplete(make_spans_snapshot: CustomSnapshotter) -> None:
     make_spans_snapshot(
         [
             {
@@ -51,7 +58,7 @@ def test_single_incomplete(make_spans_snapshot) -> None:
     )
 
 
-def test_single_full(make_spans_snapshot) -> None:
+def test_single_full(make_spans_snapshot: CustomSnapshotter) -> None:
     make_spans_snapshot(
         [
             {
@@ -68,7 +75,7 @@ def test_single_full(make_spans_snapshot) -> None:
     )
 
 
-def test_multiple_full(make_spans_snapshot) -> None:
+def test_multiple_full(make_spans_snapshot: CustomSnapshotter) -> None:
     make_spans_snapshot(
         [
             {

--- a/tests/sentry/event_manager/interfaces/test_template.py
+++ b/tests/sentry/event_manager/interfaces/test_template.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_template_snapshot(insta_snapshot):
-    def inner(data):
+def make_template_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"template": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -24,7 +31,7 @@ def make_template_snapshot(insta_snapshot):
     return inner
 
 
-def test_basic(make_template_snapshot) -> None:
+def test_basic(make_template_snapshot: CustomSnapshotter) -> None:
     make_template_snapshot(dict(filename="foo.html", context_line="hello world", lineno=1))
 
 
@@ -38,5 +45,7 @@ def test_basic(make_template_snapshot) -> None:
         {"lineno": 1, "context_line": 42},
     ],
 )
-def test_required_attributes(make_template_snapshot, input) -> None:
+def test_required_attributes(
+    make_template_snapshot: CustomSnapshotter, input: SnapshotInput
+) -> None:
     make_template_snapshot(input)

--- a/tests/sentry/event_manager/interfaces/test_threads.py
+++ b/tests/sentry/event_manager/interfaces/test_threads.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_threads_snapshot(insta_snapshot):
-    def inner(data):
+def make_threads_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"threads": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -55,7 +62,7 @@ basic_payload = dict(
 )
 
 
-def test_basics(make_threads_snapshot) -> None:
+def test_basics(make_threads_snapshot: CustomSnapshotter) -> None:
     make_threads_snapshot(basic_payload)
 
 
@@ -70,5 +77,5 @@ def test_basics(make_threads_snapshot) -> None:
         {"values": [{"held_locks": None}]},
     ],
 )
-def test_null_values(make_threads_snapshot, input) -> None:
+def test_null_values(make_threads_snapshot: CustomSnapshotter, input: SnapshotInput) -> None:
     make_threads_snapshot(input)

--- a/tests/sentry/event_manager/interfaces/test_user.py
+++ b/tests/sentry/event_manager/interfaces/test_user.py
@@ -1,12 +1,19 @@
+from typing import Any
+
 import pytest
 
 from sentry.event_manager import EventManager
 from sentry.services import eventstore
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
+from tests.sentry.event_manager.interfaces import CustomSnapshotter as CustomSnapshotterBase
+
+SnapshotInput = dict[str, Any]
+CustomSnapshotter = CustomSnapshotterBase[SnapshotInput]
 
 
 @pytest.fixture
-def make_user_snapshot(insta_snapshot):
-    def inner(data):
+def make_user_snapshot(insta_snapshot: InstaSnapshotter) -> CustomSnapshotter:
+    def inner(data: SnapshotInput) -> None:
         mgr = EventManager(data={"user": data})
         mgr.normalize()
         evt = eventstore.backend.create_event(project_id=1, data=mgr.get_data())
@@ -20,22 +27,22 @@ def make_user_snapshot(insta_snapshot):
     return inner
 
 
-def test_null_values(make_user_snapshot) -> None:
+def test_null_values(make_user_snapshot: CustomSnapshotter) -> None:
     make_user_snapshot({})
 
 
-def test_serialize_behavior(make_user_snapshot) -> None:
+def test_serialize_behavior(make_user_snapshot: CustomSnapshotter) -> None:
     make_user_snapshot(dict(id=1, email="lol@example.com", favorite_color="brown"))
 
 
-def test_invalid_ip_address(make_user_snapshot) -> None:
+def test_invalid_ip_address(make_user_snapshot: CustomSnapshotter) -> None:
     make_user_snapshot(dict(ip_address="abc"))
 
 
 @pytest.mark.parametrize("email", [1, "foo"])
-def test_invalid_email_address(make_user_snapshot, email) -> None:
+def test_invalid_email_address(make_user_snapshot: CustomSnapshotter, email: int | str) -> None:
     make_user_snapshot(dict(email=email))
 
 
-def test_extra_keys(make_user_snapshot) -> None:
+def test_extra_keys(make_user_snapshot: CustomSnapshotter) -> None:
     make_user_snapshot({"extra1": "foo", "data": {"extra2": "bar"}})


### PR DESCRIPTION
This adds types to everywhere we use the instasnapshotter in event manager interface tests. In a few cases, this meant fixing spots where we were replacing a variable's value with a value of a different type. (In such cases there are now two separate variables.)

With these changes, the interface tests now qualify for stricter typing, so they've been opted in in `pyproject.toml`.