### PR TITLE
feat(sdk): Add sampling overrides for high-volume API endpoints

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -92,6 +92,19 @@ SAMPLED_ROUTES = {
     "/api/0/organizations/sentry/ai-conversations/": 1.0,
 }
 
+# High-volume API endpoints sampled at 10% of the backend APM rate.
+# Keys are parameterized transaction names as resolved by the Django URL resolver.
+SAMPLED_API_ENDPOINTS: dict[str, float] = {
+    "/api/0/organizations/{organization_id_or_slug}/chunk-upload/": 0.1
+    * settings.SENTRY_BACKEND_APM_SAMPLING,
+    "/api/0/organizations/{organization_id_or_slug}/artifactbundle/assemble/": 0.1
+    * settings.SENTRY_BACKEND_APM_SAMPLING,
+    "/api/0/organizations/{organization_id_or_slug}/events/": 0.1
+    * settings.SENTRY_BACKEND_APM_SAMPLING,
+    "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/overview/": 0.1
+    * settings.SENTRY_BACKEND_APM_SAMPLING,
+}
+
 if settings.ADDITIONAL_SAMPLED_TASKS:
     SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
 
@@ -184,6 +197,11 @@ def traces_sampler(sampling_context):
     wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
     if wsgi_path and wsgi_path in SAMPLED_ROUTES:
         return SAMPLED_ROUTES[wsgi_path]
+
+    if "transaction_context" in sampling_context:
+        transaction_name = sampling_context["transaction_context"].get("name")
+        if transaction_name and transaction_name in SAMPLED_API_ENDPOINTS:
+            return SAMPLED_API_ENDPOINTS[transaction_name]
 
     # Apply sample_rate from custom_sampling_context
     custom_sample_rate = sampling_context.get("sample_rate")

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -528,6 +528,13 @@ def test_before_send_error_level() -> None:
 
 
 class TracesSamplerTest(TestCase):
+    MOCK_SAMPLED_API_ENDPOINTS = {
+        "/api/0/organizations/{organization_id_or_slug}/chunk-upload/": 0.05,
+        "/api/0/organizations/{organization_id_or_slug}/artifactbundle/assemble/": 0.05,
+        "/api/0/organizations/{organization_id_or_slug}/events/": 0.05,
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/overview/": 0.05,
+    }
+
     def _make_context(self, wsgi_path=None, transaction_name=None, parent_sampled=None):
         ctx: dict[str, object] = {"parent_sampled": parent_sampled}
         if wsgi_path is not None:
@@ -540,37 +547,37 @@ class TracesSamplerTest(TestCase):
         ctx = self._make_context(wsgi_path="/_warmup/")
         assert sdk.traces_sampler(ctx) == 0.0
 
+    @patch.dict(sdk.SAMPLED_API_ENDPOINTS, MOCK_SAMPLED_API_ENDPOINTS, clear=True)
     def test_sampled_api_endpoint_via_transaction_context(self):
         ctx = self._make_context(
             wsgi_path="/api/0/organizations/my-org/chunk-upload/",
             transaction_name="/api/0/organizations/{organization_id_or_slug}/chunk-upload/",
         )
-        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
-        assert sdk.traces_sampler(ctx) == expected
+        assert sdk.traces_sampler(ctx) == 0.05
 
+    @patch.dict(sdk.SAMPLED_API_ENDPOINTS, MOCK_SAMPLED_API_ENDPOINTS, clear=True)
     def test_sampled_api_endpoint_artifactbundle_assemble(self):
         ctx = self._make_context(
             wsgi_path="/api/0/organizations/my-org/artifactbundle/assemble/",
             transaction_name="/api/0/organizations/{organization_id_or_slug}/artifactbundle/assemble/",
         )
-        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
-        assert sdk.traces_sampler(ctx) == expected
+        assert sdk.traces_sampler(ctx) == 0.05
 
+    @patch.dict(sdk.SAMPLED_API_ENDPOINTS, MOCK_SAMPLED_API_ENDPOINTS, clear=True)
     def test_sampled_api_endpoint_events(self):
         ctx = self._make_context(
             wsgi_path="/api/0/organizations/my-org/events/",
             transaction_name="/api/0/organizations/{organization_id_or_slug}/events/",
         )
-        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
-        assert sdk.traces_sampler(ctx) == expected
+        assert sdk.traces_sampler(ctx) == 0.05
 
+    @patch.dict(sdk.SAMPLED_API_ENDPOINTS, MOCK_SAMPLED_API_ENDPOINTS, clear=True)
     def test_sampled_api_endpoint_project_overview(self):
         ctx = self._make_context(
             wsgi_path="/api/0/projects/my-org/my-project/overview/",
             transaction_name="/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/overview/",
         )
-        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
-        assert sdk.traces_sampler(ctx) == expected
+        assert sdk.traces_sampler(ctx) == 0.05
 
     def test_exact_route_takes_priority_over_transaction_context(self):
         ctx = self._make_context(
@@ -579,12 +586,13 @@ class TracesSamplerTest(TestCase):
         )
         assert sdk.traces_sampler(ctx) == 0.0
 
+    @patch.object(settings, "SENTRY_BACKEND_APM_SAMPLING", 0.5)
     def test_unmatched_route_falls_through_to_default(self):
         ctx = self._make_context(
             wsgi_path="/api/0/organizations/my-org/projects/",
             transaction_name="/api/0/organizations/{organization_id_or_slug}/projects/",
         )
-        assert sdk.traces_sampler(ctx) == float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+        assert sdk.traces_sampler(ctx) == 0.5
 
     def test_parent_sampled_used_when_no_route_match(self):
         ctx = self._make_context(

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -525,3 +525,71 @@ def test_before_send_error_level() -> None:
     event_with_before_send = sdk.before_send(event, hint)  # type: ignore[arg-type]
     assert event_with_before_send
     assert event_with_before_send["level"] == "warning"
+
+
+class TracesSamplerTest(TestCase):
+    def _make_context(self, wsgi_path=None, transaction_name=None, parent_sampled=None):
+        ctx: dict[str, object] = {"parent_sampled": parent_sampled}
+        if wsgi_path is not None:
+            ctx["wsgi_environ"] = {"PATH_INFO": wsgi_path}
+        if transaction_name is not None:
+            ctx["transaction_context"] = {"name": transaction_name}
+        return ctx
+
+    def test_sampled_route_exact_match(self):
+        ctx = self._make_context(wsgi_path="/_warmup/")
+        assert sdk.traces_sampler(ctx) == 0.0
+
+    def test_sampled_api_endpoint_via_transaction_context(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/organizations/my-org/chunk-upload/",
+            transaction_name="/api/0/organizations/{organization_id_or_slug}/chunk-upload/",
+        )
+        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
+        assert sdk.traces_sampler(ctx) == expected
+
+    def test_sampled_api_endpoint_artifactbundle_assemble(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/organizations/my-org/artifactbundle/assemble/",
+            transaction_name="/api/0/organizations/{organization_id_or_slug}/artifactbundle/assemble/",
+        )
+        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
+        assert sdk.traces_sampler(ctx) == expected
+
+    def test_sampled_api_endpoint_events(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/organizations/my-org/events/",
+            transaction_name="/api/0/organizations/{organization_id_or_slug}/events/",
+        )
+        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
+        assert sdk.traces_sampler(ctx) == expected
+
+    def test_sampled_api_endpoint_project_overview(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/projects/my-org/my-project/overview/",
+            transaction_name="/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/overview/",
+        )
+        expected = 0.1 * settings.SENTRY_BACKEND_APM_SAMPLING
+        assert sdk.traces_sampler(ctx) == expected
+
+    def test_exact_route_takes_priority_over_transaction_context(self):
+        ctx = self._make_context(
+            wsgi_path="/_warmup/",
+            transaction_name="/api/0/organizations/{organization_id_or_slug}/chunk-upload/",
+        )
+        assert sdk.traces_sampler(ctx) == 0.0
+
+    def test_unmatched_route_falls_through_to_default(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/organizations/my-org/projects/",
+            transaction_name="/api/0/organizations/{organization_id_or_slug}/projects/",
+        )
+        assert sdk.traces_sampler(ctx) == float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+
+    def test_parent_sampled_used_when_no_route_match(self):
+        ctx = self._make_context(
+            wsgi_path="/api/0/some-other-path/",
+            transaction_name="/api/0/some-other-path/",
+            parent_sampled=True,
+        )
+        assert sdk.traces_sampler(ctx) is True


### PR DESCRIPTION
## Summary

Adds a new `SAMPLED_API_ENDPOINTS` dict in `traces_sampler` to reduce trace sampling for high-volume API endpoints to 10% of `SENTRY_BACKEND_APM_SAMPLING`:

- `/api/0/organizations/{org}/chunk-upload/`
- `/api/0/organizations/{org}/artifactbundle/assemble/`
- `/api/0/organizations/{org}/events/`
- `/api/0/projects/{org}/{project}/overview/`

Uses the resolved transaction name from `transaction_context` (set by the Django URL resolver) for matching, avoiding the need for regex against raw paths.