### PR TITLE
ref(tests): Add instasnapshot types to various tests

### DIFF
--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -53,6 +53,7 @@ from sentry.silo.base import SiloMode
 from sentry.tempest.models import TempestCredentials
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
 from sentry.testutils.silo import assume_test_silo_mode
 
 # XXX(dcramer): this is a compatibility layer to transition to pytest-based fixtures
@@ -1182,5 +1183,5 @@ class Fixtures:
         return head_artifact, head_size_metrics, base_artifact, base_size_metrics
 
     @pytest.fixture(autouse=True)
-    def _init_insta_snapshot(self, insta_snapshot):
+    def _init_insta_snapshot(self, insta_snapshot: InstaSnapshotter) -> None:
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -7,7 +7,7 @@ from sentry_relay.processing import normalize_global_config
 
 from sentry.relay.globalconfig import get_global_config
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 
 
 @pytest.fixture
@@ -126,6 +126,6 @@ def test_global_config_valid_with_generic_filters() -> None:
 
 
 @django_db_all
-def test_global_config_histogram_outliers(insta_snapshot) -> None:
+def test_global_config_histogram_outliers(insta_snapshot: InstaSnapshotter) -> None:
     config = get_global_config()
     insta_snapshot(config["metricExtraction"])

--- a/tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
+++ b/tests/sentry/dynamic_sampling/rules/biases/test_custom_rule_bias.py
@@ -7,11 +7,14 @@ from sentry.dynamic_sampling.rules.biases.custom_rule_bias import CustomRuleBias
 from sentry.models.dynamicsampling import CustomDynamicSamplingRule
 from sentry.models.project import Project
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
 
 
 @freeze_time("2023-09-19 10:00:00")
 @mock.patch("sentry.models.CustomDynamicSamplingRule.get_project_rules")
-def test_custom_rule_bias(custom_dynamic_sampling_rule_mock, insta_snapshot) -> None:
+def test_custom_rule_bias(
+    custom_dynamic_sampling_rule_mock: mock.MagicMock, insta_snapshot: InstaSnapshotter
+) -> None:
     """
     Test that the custom rule bias transforms the rules from the model into the expected format.
     """
@@ -46,7 +49,7 @@ def test_custom_rule_bias(custom_dynamic_sampling_rule_mock, insta_snapshot) -> 
 @freeze_time("2023-09-19 10:00:00")
 @mock.patch("sentry.models.CustomDynamicSamplingRule.get_project_rules")
 def test_custom_rule_bias_with_invalid_condition(
-    custom_dynamic_sampling_rule_mock, insta_snapshot
+    custom_dynamic_sampling_rule_mock: mock.MagicMock, insta_snapshot: InstaSnapshotter
 ) -> None:
     """
     Test that the custom rule bias throws an error if the condition is invalid.

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -17,6 +17,7 @@ from sentry.dynamic_sampling import (
     get_redis_client_for_ds,
 )
 from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
+from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.transaction_threshold import TransactionMetric
@@ -26,7 +27,7 @@ from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.pytest.fixtures import InstaSnapshotter, django_db_all
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.safe import get_path
 
@@ -107,7 +108,7 @@ def test_get_project_config_non_visible(default_project) -> None:
 
 @django_db_all
 @region_silo_test
-def test_get_project_config(default_project, insta_snapshot) -> None:
+def test_get_project_config(default_project: Project, insta_snapshot: InstaSnapshotter) -> None:
     # We could use the default_project fixture here, but we would like to avoid 1) hitting the db 2) creating a mock
     default_project.update_option("sentry:relay_pii_config", PII_CONFIG)
     default_project.organization.update_option("sentry:relay_pii_config", PII_CONFIG)
@@ -523,7 +524,7 @@ def test_project_config_with_trace_health_checks_enabled(
 @pytest.mark.parametrize("transaction_metrics", ("with_metrics", "without_metrics"))
 @region_silo_test
 def test_project_config_with_breakdown(
-    default_project, insta_snapshot, transaction_metrics
+    default_project: Project, insta_snapshot: InstaSnapshotter, transaction_metrics: str
 ) -> None:
     with Feature(
         {
@@ -568,11 +569,11 @@ def test_project_config_with_organizations_metrics_extraction(
 @pytest.mark.parametrize("has_project_transaction_threshold_overrides", (False, True))
 @region_silo_test
 def test_project_config_satisfaction_thresholds(
-    default_project,
-    insta_snapshot,
-    has_project_transaction_threshold_overrides,
-    has_project_transaction_threshold,
-):
+    default_project: Project,
+    insta_snapshot: InstaSnapshotter,
+    has_project_transaction_threshold_overrides: bool,
+    has_project_transaction_threshold: bool,
+) -> None:
     if has_project_transaction_threshold:
         default_project.projecttransactionthreshold_set.create(
             organization=default_project.organization,
@@ -1354,7 +1355,9 @@ def test_mobile_performance_calculate_score(default_project) -> None:
 @django_db_all
 @region_silo_test
 @pytest.mark.parametrize("passive", [False, True])
-def test_project_config_cardinality_limits(default_project, insta_snapshot, passive) -> None:
+def test_project_config_cardinality_limits(
+    default_project: Project, insta_snapshot: InstaSnapshotter, passive: bool
+) -> None:
     options: dict[Any, Any] = {
         "relay.cardinality-limiter.mode": "enabled",
         "sentry-metrics.cardinality-limiter.limits.transactions.per-org": [

--- a/tests/symbolicator/__init__.py
+++ b/tests/symbolicator/__init__.py
@@ -1,5 +1,8 @@
 import re
+from typing import Any
 
+from sentry.db.models.fields.node import NodeData
+from sentry.testutils.pytest.fixtures import InstaSnapshotter
 from sentry.utils.safe import get_path
 
 
@@ -59,7 +62,7 @@ def strip_stacktrace_container(container):
     return container
 
 
-def insta_snapshot_native_stacktrace_data(self, event, **kwargs):
+def insta_snapshot_native_stacktrace_data(self, event: NodeData, **kwargs: Any):
     # limit amount of data going into a snapshot so that they don't break all
     # the time due to unrelated changes.
     self.insta_snapshot(
@@ -88,7 +91,9 @@ def insta_snapshot_native_stacktrace_data(self, event, **kwargs):
     )
 
 
-def insta_snapshot_javascript_stacktrace_data(insta_snapshot, event):
+def insta_snapshot_javascript_stacktrace_data(
+    insta_snapshot: InstaSnapshotter, event: NodeData
+) -> None:
     # limit amount of data going into a snapshot so that they don't break all
     # the time due to unrelated changes.
     insta_snapshot(


### PR DESCRIPTION
This adds types to functions in tests where we're using the instasnapshotter. It's not meant as comprehensive typing for those files; rather, it came up while I was cleaning up snapshots in the wake of https://github.com/getsentry/sentry/pull/103243 (which simplified snapshot headers in an effort to avoid merge conflicts).