### PR TITLE
ref(seer): Add summarization connection pool

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from typing import Any
 
 import orjson
-import requests
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -27,6 +26,7 @@ from sentry.seer.autofix.constants import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    autofix_connection_pool,
     get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
@@ -35,7 +35,10 @@ from sentry.seer.autofix.utils import (
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
-from sentry.seer.signed_seer_api import make_signed_seer_api_request, sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_summarization_default_connection_pool,
+)
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.base import instrumented_task
@@ -93,16 +96,15 @@ def _fetch_user_preference(project_id: int) -> str | None:
         path = "/v1/project-preference"
         body = orjson.dumps({"project_id": project_id})
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
             timeout=5,
         )
-        response.raise_for_status()
+
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         result = response.json()
         preference = result.get("preference")
@@ -262,16 +264,15 @@ def _call_seer(
     )
 
     # Route to summarization URL
-    response = requests.post(
-        f"{settings.SEER_SUMMARIZATION_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        path,
+        body,
         timeout=30,
     )
-    response.raise_for_status()
+
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
     return SummarizeIssueResponse.validate(response.json())
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -8,9 +8,15 @@ import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
+from sentry.net.http import connection_from_url
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
+
+
+seer_summarization_default_connection_pool = connection_from_url(
+    settings.SEER_SUMMARIZATION_URL,
+)
 
 
 @sentry_sdk.tracing.trace

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1026,13 +1026,11 @@ class TestTriggerAutofixWithHideAiFeatures(APITestCase, SnubaTestCase):
 
 class TestCallAutofix(TestCase):
     @patch("sentry.seer.autofix.autofix._get_github_username_for_user")
-    @patch("sentry.seer.autofix.autofix.requests.post")
-    @patch("sentry.seer.autofix.autofix.sign_with_seer_secret")
-    def test_call_autofix(self, mock_sign, mock_post, mock_get_username) -> None:
+    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    def test_call_autofix(self, mock_request, mock_get_username) -> None:
         """Tests the _call_autofix function makes the correct API call."""
         # Setup mocks
-        mock_sign.return_value = {"Authorization": "Bearer test"}
-        mock_post.return_value.json.return_value = {"run_id": "test-run-id"}
+        mock_request.return_value.json.return_value = {"run_id": "test-run-id"}
         mock_get_username.return_value = None  # No GitHub username
 
         # Mock objects
@@ -1078,12 +1076,12 @@ class TestCallAutofix(TestCase):
         assert run_id == "test-run-id"
 
         # Verify the API call
-        mock_post.assert_called_once()
-        url = mock_post.call_args[0][0]
+        mock_request.assert_called_once()
+        url = mock_request.call_args[0][0]
         assert "/v1/automation/autofix/start" in url
 
         # Verify the request body
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_request.call_args[1]["data"])
         assert body["organization_id"] == 456
         assert body["project_id"] == 789
         assert body["repos"] == repos
@@ -1108,7 +1106,7 @@ class TestCallAutofix(TestCase):
         assert body["options"]["disable_coding_step"] is False
 
         # Verify headers
-        headers = mock_post.call_args[1]["headers"]
+        headers = mock_request.call_args[1]["headers"]
         assert headers["content-type"] == "application/json;charset=utf-8"
         assert headers["Authorization"] == "Bearer test"
 
@@ -1475,13 +1473,12 @@ class UpdateAutofixTest(TestCase):
         self.run_id = 123
         self.payload: AutofixSelectRootCausePayload = {"type": "select_root_cause", "cause_id": 1}
 
-    @patch("sentry.seer.autofix.autofix.requests.post")
-    def test_update_autofix_http_error(self, mock_post):
+    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    def test_update_autofix_http_error(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 
         mock_response = Mock()
-        mock_response.raise_for_status.side_effect = Exception("bad request, fix something")
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = update_autofix(
             organization_id=self.organization.id, run_id=self.run_id, payload=self.payload
@@ -1490,14 +1487,14 @@ class UpdateAutofixTest(TestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Failed to update autofix run"
 
-    @patch("sentry.seer.autofix.autofix.requests.post")
-    def test_update_autofix_json_decode_error(self, mock_post):
+    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    def test_update_autofix_json_decode_error(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 
         mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
+        mock_response.status = 200
         mock_response.json.side_effect = Exception("Invalid JSON")
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = update_autofix(
             organization_id=self.organization.id, run_id=self.run_id, payload=self.payload
@@ -1506,14 +1503,14 @@ class UpdateAutofixTest(TestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Seer returned an invalid response"
 
-    @patch("sentry.seer.autofix.autofix.requests.post")
-    def test_update_autofix_success(self, mock_post):
+    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    def test_update_autofix_success(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 
         mock_response = Mock()
-        mock_response.raise_for_status.return_value = None
+        mock_response.status = 200
         mock_response.json.return_value = {"run_id": self.run_id, "status": "updated"}
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = update_autofix(
             organization_id=self.organization.id, run_id=self.run_id, payload=self.payload

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1030,7 +1030,10 @@ class TestCallAutofix(TestCase):
     def test_call_autofix(self, mock_request, mock_get_username) -> None:
         """Tests the _call_autofix function makes the correct API call."""
         # Setup mocks
-        mock_request.return_value.json.return_value = {"run_id": "test-run-id"}
+        mock_response = Mock()
+        mock_response.status = 200
+        mock_response.json.return_value = {"run_id": "test-run-id"}
+        mock_request.return_value = mock_response
         mock_get_username.return_value = None  # No GitHub username
 
         # Mock objects
@@ -1077,11 +1080,12 @@ class TestCallAutofix(TestCase):
 
         # Verify the API call
         mock_request.assert_called_once()
-        url = mock_request.call_args[0][0]
-        assert "/v1/automation/autofix/start" in url
+        # Verify path (second positional argument)
+        path = mock_request.call_args[0][1]
+        assert path == "/v1/automation/autofix/start"
 
-        # Verify the request body
-        body = orjson.loads(mock_request.call_args[1]["data"])
+        # Verify the request body (third positional argument)
+        body = orjson.loads(mock_request.call_args[0][2])
         assert body["organization_id"] == 456
         assert body["project_id"] == 789
         assert body["repos"] == repos
@@ -1104,11 +1108,6 @@ class TestCallAutofix(TestCase):
             == "https://github.com/getsentry/sentry/pull/123"
         )
         assert body["options"]["disable_coding_step"] is False
-
-        # Verify headers
-        headers = mock_request.call_args[1]["headers"]
-        assert headers["content-type"] == "application/json;charset=utf-8"
-        assert headers["Authorization"] == "Bearer test"
 
 
 class TestGetGithubUsernameForUser(TestCase):
@@ -1478,6 +1477,7 @@ class UpdateAutofixTest(TestCase):
         from sentry.seer.autofix.autofix import update_autofix
 
         mock_response = Mock()
+        mock_response.status = 500
         mock_request.return_value = mock_response
 
         response = update_autofix(

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -128,9 +128,11 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         cached_summary = cache.get(f"ai-group-summary-v2:{self.group.id}")
         assert cached_summary == expected_response_summary
 
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
     @patch("sentry.seer.autofix.issue_summary._get_event")
-    def test_call_seer_integration(self, mock_get_event: MagicMock, mock_post: MagicMock) -> None:
+    def test_call_seer_integration(
+        self, mock_get_event: MagicMock, mock_request: MagicMock
+    ) -> None:
         event = Mock(
             event_id="test_event_id",
             data="test_event_data",
@@ -140,6 +142,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         serialized_event = {"event_id": "test_event_id", "data": "test_event_data"}
         mock_get_event.return_value = [serialized_event, event]
         mock_response = Mock()
+        mock_response.status = 200
         mock_response.json.return_value = {
             "group_id": str(self.group.id),
             "whats_wrong": "Test whats wrong",
@@ -154,7 +157,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
                 "fixability_score_version": 1,
             },
         }
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         expected_response_summary = mock_response.json.return_value
         expected_response_summary["event_id"] = event.event_id
@@ -163,8 +166,8 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
 
         assert status_code == 200
         assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)
-        mock_post.assert_called_once()
-        payload = orjson.loads(mock_post.call_args_list[0].kwargs["data"])
+        mock_request.assert_called_once()
+        payload = orjson.loads(mock_request.call_args_list[0].kwargs["data"])
         assert payload["trace_tree"] is None
 
         assert cache.get(f"ai-group-summary-v2:{self.group.id}") == expected_response_summary
@@ -306,8 +309,7 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         # Ensure generation was called directly
         mock_generate_summary.assert_called_once()
 
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
     def test_call_seer_routes_to_summarization_url(self, post: MagicMock, _sign: MagicMock) -> None:
         resp = Mock()
         resp.json.return_value = {
@@ -334,7 +336,6 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert payload["trace_tree"] == {"trace": "tree"}
         resp.raise_for_status.assert_called_once()
 
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
     @patch(
         "sentry.seer.autofix.issue_summary.requests.post", side_effect=Exception("primary error")
     )
@@ -806,50 +807,45 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
 
 
 class TestFetchUserPreference:
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
-    def test_fetch_user_preference_success(self, mock_post, mock_sign):
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
+    def test_fetch_user_preference_success(self, mock_request):
         mock_response = Mock()
+        mock_response.status = 200
         mock_response.json.return_value = {
             "preference": {"automated_run_stopping_point": "solution"}
         }
-        mock_response.raise_for_status = Mock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         result = _fetch_user_preference(project_id=123)
 
         assert result == "solution"
-        mock_post.assert_called_once()
-        mock_response.raise_for_status.assert_called_once()
+        mock_request.assert_called_once()
 
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
-    def test_fetch_user_preference_no_preference(self, mock_post, mock_sign):
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
+    def test_fetch_user_preference_no_preference(self, mock_request):
         mock_response = Mock()
+        mock_response.status = 200
         mock_response.json.return_value = {"preference": None}
-        mock_response.raise_for_status = Mock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         result = _fetch_user_preference(project_id=123)
 
         assert result is None
 
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
-    def test_fetch_user_preference_empty_preference(self, mock_post, mock_sign):
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
+    def test_fetch_user_preference_empty_preference(self, mock_request):
         mock_response = Mock()
+        mock_response.status = 200
         mock_response.json.return_value = {"preference": {"automated_run_stopping_point": None}}
-        mock_response.raise_for_status = Mock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         result = _fetch_user_preference(project_id=123)
 
         assert result is None
 
-    @patch("sentry.seer.autofix.issue_summary.sign_with_seer_secret", return_value={})
-    @patch("sentry.seer.autofix.issue_summary.requests.post")
-    def test_fetch_user_preference_api_error(self, mock_post, mock_sign):
-        mock_post.side_effect = Exception("API error")
+    @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
+    def test_fetch_user_preference_api_error(self, mock_request):
+        mock_request.side_effect = Exception("API error")
 
         result = _fetch_user_preference(project_id=123)
 

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 import orjson
 import pytest
-from django.conf import settings
 
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.issues.grouptype import WebVitalsGroup
@@ -167,7 +166,8 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert status_code == 200
         assert summary_data == convert_dict_key_case(expected_response_summary, snake_to_camel_case)
         mock_request.assert_called_once()
-        payload = orjson.loads(mock_request.call_args_list[0].kwargs["data"])
+        # Body is the third positional argument
+        payload = orjson.loads(mock_request.call_args_list[0][0][2])
         assert payload["trace_tree"] is None
 
         assert cache.get(f"ai-group-summary-v2:{self.group.id}") == expected_response_summary
@@ -310,8 +310,9 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_generate_summary.assert_called_once()
 
     @patch("sentry.seer.autofix.issue_summary.make_signed_seer_api_request")
-    def test_call_seer_routes_to_summarization_url(self, post: MagicMock, _sign: MagicMock) -> None:
+    def test_call_seer_routes_to_summarization_url(self, mock_request: MagicMock) -> None:
         resp = Mock()
+        resp.status = 200
         resp.json.return_value = {
             "group_id": str(self.group.id),
             "whats_wrong": "w",
@@ -320,28 +321,24 @@ class IssueSummaryTest(APITestCase, SnubaTestCase, OccurrenceTestMixin):
             "headline": "h",
             "scores": {},
         }
-        resp.raise_for_status = Mock()
-        post.return_value = resp
+        mock_request.return_value = resp
 
         result = _call_seer(self.group, {"event_id": "e1"}, {"trace": "tree"})
 
         assert result.group_id == str(self.group.id)
-        assert post.call_count == 1
-        assert (
-            post.call_args_list[0]
-            .args[0]
-            .startswith(f"{settings.SEER_SUMMARIZATION_URL}/v1/automation/summarize/issue")
-        )
-        payload = orjson.loads(post.call_args_list[0].kwargs["data"])
+        assert mock_request.call_count == 1
+        # Verify path argument (second argument)
+        call_path = mock_request.call_args_list[0][0][1]
+        assert call_path == "/v1/automation/summarize/issue"
+        # Verify body payload (third argument)
+        payload = orjson.loads(mock_request.call_args_list[0][0][2])
         assert payload["trace_tree"] == {"trace": "tree"}
-        resp.raise_for_status.assert_called_once()
 
     @patch(
-        "sentry.seer.autofix.issue_summary.requests.post", side_effect=Exception("primary error")
+        "sentry.seer.autofix.issue_summary.make_signed_seer_api_request",
+        side_effect=Exception("primary error"),
     )
-    def test_call_seer_raises_exception_when_endpoint_fails(
-        self, post: MagicMock, sign: MagicMock
-    ) -> None:
+    def test_call_seer_raises_exception_when_endpoint_fails(self, mock_request: MagicMock) -> None:
         with pytest.raises(Exception):
             _call_seer(self.group, {"event_id": "e1"}, None)
 


### PR DESCRIPTION
Add missing seer_summarization_default_connection_pool that was referenced
in the cherry-picked autofix migration commit but not defined.

Also updates test mocks to match the make_signed_seer_api_request signature
(add status attributes, fix positional argument access).

Follows up on #108246 which added the method parameter to the signed API.