### PR TITLE
fix(tests): Fix test pollution in CheckScopeTransactionTest

### DIFF
--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -239,9 +239,11 @@ class CheckScopeTransactionTest(TestCase):
 
     @patch("sentry.utils.sdk.LEGACY_RESOLVER.resolve", return_value="/dogs/{name}/")
     def test_custom_transaction_name(self, mock_resolve: MagicMock) -> None:
-        with patch_isolation_scope() as mock_scope:
-            mock_scope._transaction = "/tricks/{trick_name}/"
-            mock_scope._transaction_info["source"] = "custom"
+        mock_scope = Scope()
+        mock_scope._transaction = "/tricks/{trick_name}/"
+        mock_scope._transaction_info["source"] = "custom"
+
+        with patch("sentry.utils.sdk.sentry_sdk.get_current_scope", return_value=mock_scope):
             mismatch = check_current_scope_transaction(Request(HttpRequest()))
             # custom transaction names shouldn't be flagged even if they don't match
             assert mismatch is None


### PR DESCRIPTION
seen in this run of shuffle-tests: https://github.com/getsentry/sentry/actions/runs/21654747518/job/62427093320

i'm working on some tools to use detect-test-pollution to automatically bisect test sets from shuffle-test runs here: https://github.com/getsentry/sentry/pull/108281

https://github.com/getsentry/sentry/actions/runs/22007196153/job/63593472299

that identified that running these two tests in this order:

```
pytest tests/sentry/integrations/github/test_installation.py::InstallationEndpointTest::test_installation_endpoint tests/sentry/utils/test_sdk.py::CheckScopeTransactionTest::test_custom_transaction_name
```

fails consistently without this fix

---

- `test_custom_transaction_name` was mocking the wrong scope — it used `patch_isolation_scope()` (which patches `Scope.get_isolation_scope()`), but `check_current_scope_transaction()` reads from `sentry_sdk.get_current_scope()`. The test passed in isolation only because the current scope had `_transaction=None`, short-circuiting the check without ever validating the `source="custom"` logic.
- When preceded by a test like `test_installation_endpoint` that sets a real transaction on the current scope, the leaked state caused the assertion to fail.
- Fixed by mocking `sentry_sdk.get_current_scope` instead, consistent with the other two tests in the same class.