### PR TITLE
fix(explore): Require query field on saved query creation and handle malformed queries in frontend

### DIFF
--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -177,7 +177,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
     interval = serializers.CharField(
         required=False, allow_null=True, help_text="Resolution of the time series."
     )
-    query = ListField(child=QuerySerializer(), required=False, allow_null=True)
+    query = ListField(child=QuerySerializer(), required=True, min_length=1)
 
     def validate_projects(self, projects):
         from sentry.api.validators import validate_project_ids

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -249,13 +249,11 @@ export function useGetSavedQuery(id?: string) {
       enabled: defined(id),
     }
   );
-  const savedQuery = useMemo(
-    () =>
-      defined(data) && Array.isArray(data.query) && data.query.length > 0
-        ? new SavedQuery(data)
-        : data,
-    [data]
-  );
+  const savedQuery = useMemo(() => {
+    return Array.isArray(data?.query) && data.query.length > 0
+      ? new SavedQuery(data)
+      : data;
+  }, [data]);
   return {data: savedQuery, isLoading, ...rest};
 }
 

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -250,9 +250,12 @@ export function useGetSavedQuery(id?: string) {
     }
   );
   const savedQuery = useMemo(() => {
-    return Array.isArray(data?.query) && data.query.length > 0
+    if (!defined(data)) {
+      return undefined;
+    }
+    return Array.isArray(data.query) && data.query.length > 0
       ? new SavedQuery(data)
-      : data;
+      : undefined;
   }, [data]);
   return {data: savedQuery, isLoading, ...rest};
 }

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -211,7 +211,13 @@ export function useGetSavedQueries({
 
   const pageLinks = getResponseHeader?.('Link');
 
-  const savedQueries = useMemo(() => data?.map(q => new SavedQuery(q)), [data]);
+  const savedQueries = useMemo(
+    () =>
+      data
+        ?.filter(q => Array.isArray(q.query) && q.query.length > 0)
+        .map(q => new SavedQuery(q)),
+    [data]
+  );
   return {data: savedQueries, isLoading, pageLinks, ...rest};
 }
 
@@ -243,7 +249,13 @@ export function useGetSavedQuery(id?: string) {
       enabled: defined(id),
     }
   );
-  const savedQuery = useMemo(() => (defined(data) ? new SavedQuery(data) : data), [data]);
+  const savedQuery = useMemo(
+    () =>
+      defined(data) && Array.isArray(data.query) && data.query.length > 0
+        ? new SavedQuery(data)
+        : data,
+    [data]
+  );
   return {data: savedQuery, isLoading, ...rest};
 }
 

--- a/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.spec.tsx
@@ -390,6 +390,59 @@ describe('SavedQueriesTable', () => {
     );
   });
 
+  it('should not crash when a saved query has no query field', async () => {
+    getQueriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [
+        {
+          id: 1,
+          name: 'Malformed Query',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {name: 'Attacker'},
+        },
+        {
+          id: 2,
+          name: 'Valid Query',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {name: 'Test User'},
+          query: [{visualize: [], groupby: []}],
+        },
+      ],
+    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
+    expect(await screen.findByText('Valid Query')).toBeInTheDocument();
+    expect(screen.queryByText('Malformed Query')).not.toBeInTheDocument();
+  });
+
+  it('should not crash when a saved query has an empty query array', async () => {
+    getQueriesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [
+        {
+          id: 1,
+          name: 'Empty Query',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {name: 'Attacker'},
+          query: [],
+        },
+        {
+          id: 2,
+          name: 'Valid Query',
+          projects: [1],
+          environment: ['production'],
+          createdBy: {name: 'Test User'},
+          query: [{visualize: [], groupby: []}],
+        },
+      ],
+    });
+    render(<SavedQueriesTable mode="owned" title="title" />);
+    expect(await screen.findByText('Valid Query')).toBeInTheDocument();
+    expect(screen.queryByText('Empty Query')).not.toBeInTheDocument();
+  });
+
   it('should duplicate a query', async () => {
     render(<SavedQueriesTable mode="owned" title="title" />);
     await screen.findByText('Query Name');

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1285,6 +1285,12 @@ class ExploreSavedQueriesTest(APITestCase):
                     "dataset": "spans",
                     "start": "2025-11-12T23:00:00.000Z",
                     "end": "2025-11-20T22:59:59.000Z",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
                 },
             )
         assert response.status_code == 201, response.content
@@ -1335,3 +1341,53 @@ class ExploreSavedQueriesTest(APITestCase):
         data = response.data
         assert data["query"][0]["query"] == "user.email:*@sentry.io"
         assert data["query"][0]["mode"] == "samples"
+
+    def test_malformed_query_missing_query_field_in_get(self) -> None:
+        """VULN-950: A saved query with no 'query' content returns a response
+        missing the 'query' key, which crashes the frontend All Queries page."""
+        malformed = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="malformed",
+            query={"range": "24h"},
+        )
+        malformed.set_projects(self.project_ids)
+
+        with self.feature(self.features):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail",
+                args=[self.org.slug, malformed.id],
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 200
+        # The response is missing the 'query' key entirely — this is what
+        # crashes the frontend, which expects it to be an array.
+        assert "query" not in response.data
+
+    def test_post_without_query_is_rejected(self) -> None:
+        """VULN-950: POST with no query field should be rejected."""
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "crash",
+                    "projects": self.project_ids,
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 400
+
+    def test_post_with_empty_query_is_rejected(self) -> None:
+        """VULN-950: POST with empty query list should also be rejected."""
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "crash",
+                    "projects": self.project_ids,
+                    "query": [],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 400

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -222,7 +222,13 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
             )
 
             response = self.client.put(
-                url, {"name": "New query", "projects": [], "range": "24h", "mode": "samples"}
+                url,
+                {
+                    "name": "New query",
+                    "projects": [],
+                    "range": "24h",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
+                },
             )
 
             assert response.status_code == 200
@@ -283,6 +289,7 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
                     "projects": self.project_ids,
                     "range": "24h",
                     "dataset": "spans",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
                 },
             )
             assert response.status_code == 200


### PR DESCRIPTION
VULN-950: A member could POST to the explore saved queries endpoint with no query content, creating a malformed saved query that crashes the All Queries page for all org members.

Backend: Make the query field required with at least one entry in the serializer.
Frontend: Filter out malformed saved queries (missing or empty query array) before constructing SavedQuery objects, so existing bad data doesn't crash the page.
