### PR TITLE
fix(security): Only include emails in user serialization for the requesting user

### DIFF
--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -44,8 +44,6 @@ class OrganizationMemberSerializer(Serializer):
         users_by_id: MutableMapping[str, Any] = {}
         email_map: MutableMapping[str, str] = {}
         for u in user_service.serialize_many(filter={"user_ids": users_set}):
-            # Filter out the emails from the user data
-            u.pop("emails", None)
             users_by_id[u["id"]] = u
             email_map[u["id"]] = u["email"]
 

--- a/src/sentry/api/serializers/models/organization_member/expand/roles.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/roles.py
@@ -57,10 +57,6 @@ class OrganizationMemberWithRolesSerializer(OrganizationMemberWithTeamsSerialize
             )
         }
 
-        # Filter out emails from the serialized user data
-        for user_data in users_by_id.values():
-            user_data.pop("emails", None)
-
         for item in item_list:
             result.setdefault(item, {})["serializedUser"] = users_by_id.get(str(item.user_id), {})
         return result

--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -177,16 +177,17 @@ class UserSerializer(Serializer):
             "lastActive": obj.last_active,
             "isSuperuser": obj.is_superuser,
             "isStaff": obj.is_staff,
-            "emails": [
-                {"id": str(e.id), "email": e.email, "is_verified": e.is_verified}
-                for e in attrs["emails"]
-            ],
+            "emails": [],
             # TODO(epurkhiser): This can be removed once we confirm the
             # frontend does not use it
             "experiments": {},
         }
 
         if self._user_is_requester(obj, user):
+            d["emails"] = [
+                {"id": str(e.id), "email": e.email, "is_verified": e.is_verified}
+                for e in attrs["emails"]
+            ]
             d = cast(UserSerializerResponseSelf, d)
             options = {
                 o.key: o.value

--- a/tests/sentry/core/endpoints/test_organization_member_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_details.py
@@ -155,8 +155,7 @@ class GetOrganizationMemberTest(OrganizationMemberTestBase):
 
         # Check that only primary email is present and no other email addresses are exposed
         assert response.data["email"] == "primary@example.com"
-        assert "emails" not in response.data["user"]
-        assert "emails" not in response.data.get("serializedUser", {})
+        assert response.data["user"]["emails"] == []
 
     def test_does_not_serialize_placeholder_member(self) -> None:
         invite = self.create_member_invite(organization=self.organization)

--- a/tests/sentry/core/endpoints/test_organization_member_index.py
+++ b/tests/sentry/core/endpoints/test_organization_member_index.py
@@ -562,7 +562,7 @@ class OrganizationMemberListTest(OrganizationMemberListTestBase, HybridCloudTest
 
         # Check that only primary email is present and no other email addresses are exposed
         assert member_data["email"] == "primary@example.com"
-        assert "emails" not in member_data["user"]
+        assert member_data["user"]["emails"] == []
         assert all("email" not in team for team in member_data.get("teams", []))
         assert all("email" not in role for role in member_data.get("teamRoles", []))
 

--- a/tests/sentry/users/api/serializers/test_user.py
+++ b/tests/sentry/users/api/serializers/test_user.py
@@ -24,7 +24,7 @@ class UserSerializerTest(TestCase):
             type=available_authenticators(ignore_backup=True)[0].type, user=user, config={}
         )
 
-        result = serialize(user)
+        result = serialize(user, user)
         assert result["id"] == str(user.id)
         assert result["has2fa"] is True
         assert len(result["emails"]) == 1


### PR DESCRIPTION
VULN-720: The UserSerializer included all secondary email addresses for every serialized user, regardless of who was requesting. This leaked secondary emails to other org members via endpoints like /api/0/organizations/{org}/users/{id}/.

Move email population behind the existing _user_is_requester check in UserSerializer.serialize(), returning an empty list for non-self users. This fixes the leak at the source rather than requiring each endpoint to pop emails defensively.

Remove the three .pop("emails", None) calls added by PR #83556 in organization_user_details, organization_member/base, and organization_member/expand/roles — these are no longer needed since the serializer itself no longer exposes emails to non-self requests.

<!-- Describe your PR here. -->