### PR TITLE
fix(teams): Prevent contributors from downgrading org admins' team roles

### DIFF
--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -412,7 +412,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
                 old_role = team_roles.get(omt.role) if omt.role else None
             except KeyError:
                 old_role = None
-            can_set_old_role = can_set_team_role(request, team, old_role) if old_role else True
+            if old_role is None:
+                old_role = roles.get_minimum_team_role(member.role)
+            can_set_old_role = can_set_team_role(request, team, old_role)
 
             # Verify that the request is allowed to set both the old and new role to prevent role downgrades by low-privilege users
             if not (can_set_new_role and can_set_old_role):

--- a/tests/sentry/core/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_team_details.py
@@ -1126,3 +1126,22 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
 
         assert resp.status_code == 400
         assert resp.data["detail"] == ERR_INSUFFICIENT_ROLE
+
+    @with_feature("organizations:team-roles")
+    def test_member_cannot_downgrade_org_admin_without_explicit_team_role(self) -> None:
+        """VULN-734: A contributor must not be able to downgrade an org admin
+        who has no explicit team role (their effective role comes from their
+        org role's minimum team role mapping)."""
+        # Access cached_property to create the user attribute
+        _ = self.member_on_team
+        self.login_as(self.member_on_team_user)
+
+        resp = self.get_response(
+            self.org.slug,
+            self.admin_on_team.id,
+            self.team.slug,
+            teamRole="contributor",
+        )
+
+        assert resp.status_code == 400
+        assert resp.data["detail"] == ERR_INSUFFICIENT_ROLE


### PR DESCRIPTION
VULN-734: When a team member had no explicit team role (inheriting from their org role), the permission check defaulted to allowing the change. Use the target member's minimum team role from their org role instead of defaulting to True.

<!-- Describe your PR here. -->