### PR TITLE
ref(repos): Refactor useOrganizationRepositoriesWithSettings to use apiOptions & useInfiniteQuery

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -5,6 +5,8 @@ import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
+import {encodeSort} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -75,15 +77,17 @@ export function organizationRepositoriesInfiniteOptions({
     integration_id?: string;
     per_page?: number;
     query?: string;
+    sort?: Sort;
     status?: 'active' | 'deleted' | 'unmigratable';
   };
   staleTime?: number;
 }) {
+  const sortQuery = query?.sort ? encodeSort(query.sort) : undefined;
   return apiOptions.asInfinite<RepositoryWithSettings[]>()(
     '/organizations/$organizationIdOrSlug/repos/',
     {
       path: {organizationIdOrSlug: organization.slug},
-      query: {expand: 'settings', per_page: 100, ...query},
+      query: {expand: 'settings', per_page: 100, ...query, sort: sortQuery},
       staleTime: staleTime ?? 0,
     }
   );

--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -70,7 +70,13 @@ export function organizationRepositoriesInfiniteOptions({
   staleTime,
 }: {
   organization: Organization;
-  query?: {per_page: number};
+  query?: {
+    cursor?: string;
+    integration_id?: string;
+    per_page?: number;
+    query?: string;
+    status?: 'active' | 'deleted' | 'unmigratable';
+  };
   staleTime?: number;
 }) {
   return apiOptions.asInfinite<RepositoryWithSettings[]>()(

--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -1,6 +1,8 @@
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 
 import type {Repository, RepositoryWithSettings} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import useFetchSequentialPages from 'sentry/utils/api/useFetchSequentialPages';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
@@ -10,6 +12,9 @@ interface Props {
   query?: Record<string, string>;
 }
 
+/**
+ * @deprecated Use organizationRepositoriesInfiniteOptions instead.
+ */
 export function useOrganizationRepositories<T extends Repository = Repository>(
   {query = {}} = {} as Props
 ) {
@@ -59,9 +64,21 @@ export function useOrganizationRepositories<T extends Repository = Repository>(
   );
 }
 
-// TODO(ryan953): express this in typescript instead of having the extra function
-export function useOrganizationRepositoriesWithSettings() {
-  return useOrganizationRepositories<RepositoryWithSettings>({
-    query: {expand: 'settings'},
-  });
+export function organizationRepositoriesInfiniteOptions({
+  organization,
+  query,
+  staleTime,
+}: {
+  organization: Organization;
+  query?: {per_page: number};
+  staleTime?: number;
+}) {
+  return apiOptions.asInfinite<RepositoryWithSettings[]>()(
+    '/organizations/$organizationIdOrSlug/repos/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {expand: 'settings', per_page: 100, ...query},
+      staleTime: staleTime ?? 0,
+    }
+  );
 }

--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -1,6 +1,7 @@
 import type {QueryFunctionContext} from '@tanstack/react-query';
 
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
+import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 import {parseQueryKey, QUERY_API_CLIENT} from 'sentry/utils/queryClient';
 
 export type ApiResponse<TResponseData = unknown> = {
@@ -13,7 +14,7 @@ export type ApiResponse<TResponseData = unknown> = {
 };
 
 export default async function apiFetch<TQueryFnData = unknown>(
-  context: QueryFunctionContext<ApiQueryKey>
+  context: QueryFunctionContext<ApiQueryKey, never>
 ): Promise<ApiResponse<TQueryFnData>> {
   const {url, options} = parseQueryKey(context.queryKey);
 
@@ -26,13 +27,42 @@ export default async function apiFetch<TQueryFnData = unknown>(
     headers: options?.headers,
   });
 
-  const xhits = response!.getResponseHeader('X-Hits') ?? null;
-  const xmaxhits = response!.getResponseHeader('X-Max-Hits') ?? null;
+  const hits = response!.getResponseHeader('X-Hits') ?? null;
+  const maxHits = response!.getResponseHeader('X-Max-Hits') ?? null;
   return {
     headers: {
       Link: response!.getResponseHeader('Link') ?? undefined,
-      'X-Hits': xhits === null ? undefined : Number(xhits),
-      'X-Max-Hits': xmaxhits === null ? undefined : Number(xmaxhits),
+      'X-Hits': hits === null ? undefined : Number(hits),
+      'X-Max-Hits': maxHits === null ? undefined : Number(maxHits),
+    },
+    json: json as TQueryFnData,
+  };
+}
+
+export async function apiFetchInfinite<TQueryFnData = unknown>(
+  context: QueryFunctionContext<InfiniteApiQueryKey, null | undefined | ParsedHeader>
+): Promise<ApiResponse<TQueryFnData>> {
+  const {url, options} = parseQueryKey(context.queryKey);
+
+  const [json, , response] = await QUERY_API_CLIENT.requestPromise(url, {
+    includeAllArgs: true,
+    host: options?.host,
+    method: options?.method ?? 'GET',
+    data: options?.data,
+    query: {
+      ...options?.query,
+      cursor: context.pageParam?.cursor ?? options?.query?.cursor,
+    },
+    headers: options?.headers,
+  });
+
+  const hits = response!.getResponseHeader('X-Hits') ?? null;
+  const maxHits = response!.getResponseHeader('X-Max-Hits') ?? null;
+  return {
+    headers: {
+      Link: response!.getResponseHeader('Link') ?? undefined,
+      'X-Hits': hits === null ? undefined : Number(hits),
+      'X-Max-Hits': maxHits === null ? undefined : Number(maxHits),
     },
     json: json as TQueryFnData,
   };

--- a/static/app/utils/api/apiFetch.tsx
+++ b/static/app/utils/api/apiFetch.tsx
@@ -27,13 +27,13 @@ export default async function apiFetch<TQueryFnData = unknown>(
     headers: options?.headers,
   });
 
-  const hits = response!.getResponseHeader('X-Hits') ?? null;
-  const maxHits = response!.getResponseHeader('X-Max-Hits') ?? null;
+  const hits = response?.getResponseHeader('X-Hits');
+  const maxHits = response?.getResponseHeader('X-Max-Hits');
   return {
     headers: {
-      Link: response!.getResponseHeader('Link') ?? undefined,
-      'X-Hits': hits === null ? undefined : Number(hits),
-      'X-Max-Hits': maxHits === null ? undefined : Number(maxHits),
+      Link: response?.getResponseHeader('Link') ?? undefined,
+      'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
+      'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
     },
     json: json as TQueryFnData,
   };
@@ -56,13 +56,13 @@ export async function apiFetchInfinite<TQueryFnData = unknown>(
     headers: options?.headers,
   });
 
-  const hits = response!.getResponseHeader('X-Hits') ?? null;
-  const maxHits = response!.getResponseHeader('X-Max-Hits') ?? null;
+  const hits = response?.getResponseHeader('X-Hits');
+  const maxHits = response?.getResponseHeader('X-Max-Hits');
   return {
     headers: {
-      Link: response!.getResponseHeader('Link') ?? undefined,
-      'X-Hits': hits === null ? undefined : Number(hits),
-      'X-Max-Hits': maxHits === null ? undefined : Number(maxHits),
+      Link: response?.getResponseHeader('Link') ?? undefined,
+      'X-Hits': typeof hits === 'string' ? Number(hits) : undefined,
+      'X-Max-Hits': typeof maxHits === 'string' ? Number(maxHits) : undefined,
     },
     json: json as TQueryFnData,
   };

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -5,7 +5,7 @@ import {expectTypeOf} from 'expect-type';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
-import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 
 type Promisable<T> = T | Promise<T>;
 type QueryFunctionResult<T> = Promisable<ApiResponse<T>>;
@@ -99,7 +99,7 @@ describe('apiOptions', () => {
     });
 
     const {result} = renderHookWithProviders(() =>
-      useQuery({...options, select: selectJsonWithHeaders})
+      useQuery({...options, select: _ => _})
     );
 
     await waitFor(() => expect(result.current.isPending).toBe(false));

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -4,12 +4,11 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 import type {ExtractPathParams, OptionalPathParams} from 'sentry/utils/api/getApiUrl';
 import type {KnownGetsentryApiUrls} from 'sentry/utils/api/knownGetsentryApiUrls';
 import type {KnownSentryApiUrls} from 'sentry/utils/api/knownSentryApiUrls.generated';
-import parseLinkHeader, {type ParsedHeader} from 'sentry/utils/parseLinkHeader';
+import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {infiniteQueryOptions, queryOptions, skipToken} from 'sentry/utils/queryClient';
 import type {
   ApiQueryKey,
   InfiniteApiQueryKey,
-  InfiniteData,
   QueryKeyEndpointOptions,
   SkipToken,
 } from 'sentry/utils/queryClient';
@@ -83,9 +82,6 @@ function _apiOptionsInfinite<
     initialPageParam: undefined,
     enabled: pathParams !== skipToken,
     staleTime,
-    select: (
-      data: InfiniteData<ApiResponse<TActualData>, null | undefined | ParsedHeader>
-    ) => data.pages.map(page => page.json),
   });
 }
 

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -1,12 +1,18 @@
-import {queryOptions, skipToken} from '@tanstack/react-query';
-import type {SkipToken} from '@tanstack/react-query';
-
-import apiFetch, {type ApiResponse} from 'sentry/utils/api/apiFetch';
+import apiFetch, {apiFetchInfinite} from 'sentry/utils/api/apiFetch';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import type {ExtractPathParams, OptionalPathParams} from 'sentry/utils/api/getApiUrl';
 import type {KnownGetsentryApiUrls} from 'sentry/utils/api/knownGetsentryApiUrls';
 import type {KnownSentryApiUrls} from 'sentry/utils/api/knownSentryApiUrls.generated';
-import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/queryClient';
+import parseLinkHeader, {type ParsedHeader} from 'sentry/utils/parseLinkHeader';
+import {infiniteQueryOptions, queryOptions, skipToken} from 'sentry/utils/queryClient';
+import type {
+  ApiQueryKey,
+  InfiniteApiQueryKey,
+  InfiniteData,
+  QueryKeyEndpointOptions,
+  SkipToken,
+} from 'sentry/utils/queryClient';
 
 type KnownApiUrls = KnownGetsentryApiUrls | KnownSentryApiUrls;
 
@@ -16,14 +22,6 @@ type PathParamOptions<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never
     ? {path?: never}
     : {path: Record<ExtractPathParams<TApiPath>, string | number> | SkipToken};
-
-/** @public **/
-export const selectJson = <TData>(data: ApiResponse<TData>) => data.json;
-
-/** @public **/
-export const selectJsonWithHeaders = <TData>(
-  data: ApiResponse<TData>
-): ApiResponse<TData> => data;
 
 function _apiOptions<
   TManualData = never,
@@ -38,14 +36,7 @@ function _apiOptions<
     ? [Options & {path?: never}]
     : [Options & PathParamOptions<TApiPath>]
 ) {
-  const url = getApiUrl(
-    path,
-    ...([
-      {
-        path: pathParams,
-      },
-    ] as OptionalPathParams<TApiPath>)
-  );
+  const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
 
   return queryOptions({
     queryKey:
@@ -55,7 +46,46 @@ function _apiOptions<
     queryFn: pathParams === skipToken ? skipToken : apiFetch<TActualData>,
     enabled: pathParams !== skipToken,
     staleTime,
-    select: selectJson,
+    select: data => data.json,
+  });
+}
+
+function parsePageParam<TQueryFnData = unknown>(dir: 'previous' | 'next') {
+  return ({headers}: ApiResponse<TQueryFnData>) => {
+    const parsed = parseLinkHeader(headers.Link ?? null);
+    return parsed[dir]?.results ? parsed[dir] : null;
+  };
+}
+
+function _apiOptionsInfinite<
+  TManualData = never,
+  TApiPath extends KnownApiUrls = KnownApiUrls,
+  // todo: infer the actual data type from the ApiMapping
+  TActualData = TManualData,
+>(
+  path: TApiPath,
+  ...[
+    {staleTime, path: pathParams, ...options},
+  ]: ExtractPathParams<TApiPath> extends never
+    ? [Options & {path?: never}]
+    : [Options & PathParamOptions<TApiPath>]
+) {
+  const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
+
+  return infiniteQueryOptions({
+    queryKey:
+      Object.keys(options).length > 0
+        ? (['infinite', url, options] as InfiniteApiQueryKey)
+        : (['infinite', url] as InfiniteApiQueryKey),
+    queryFn: pathParams === skipToken ? skipToken : apiFetchInfinite<TActualData>,
+    getPreviousPageParam: parsePageParam('previous'),
+    getNextPageParam: parsePageParam('next'),
+    initialPageParam: undefined,
+    enabled: pathParams !== skipToken,
+    staleTime,
+    select: (
+      data: InfiniteData<ApiResponse<TActualData>, null | undefined | ParsedHeader>
+    ) => data.pages.map(page => page.json),
   });
 }
 
@@ -67,4 +97,12 @@ export const apiOptions = {
       options: Options & PathParamOptions<TApiPath>
     ) =>
       _apiOptions<TManualData, TApiPath>(path, options as never),
+
+  asInfinite:
+    <TManualData>() =>
+    <TApiPath extends KnownApiUrls = KnownApiUrls>(
+      path: TApiPath,
+      options: Options & PathParamOptions<TApiPath>
+    ) =>
+      _apiOptionsInfinite<TManualData, TApiPath>(path, options as never),
 };

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -60,7 +60,7 @@ export default function SeerRepoTable() {
         'id'
       )
         .filter(repository => isSupportedAutofixProvider(repository.provider))
-        .toSorted((a, b) => {
+        .sort((a, b) => {
           if (sort.field === 'name') {
             return sort.kind === 'asc'
               ? a.name.localeCompare(b.name)
@@ -82,10 +82,10 @@ export default function SeerRepoTable() {
 
   // Auto-fetch each page, one at a time
   useEffect(() => {
-    if (!isFetchingNextPage && hasNextPage) {
+    if (!isError && !isFetchingNextPage && hasNextPage) {
       fetchNextPage();
     }
-  }, [hasNextPage, fetchNextPage, isFetchingNextPage]);
+  }, [hasNextPage, fetchNextPage, isError, isFetchingNextPage]);
 
   const [mutationData, setMutations] = useState<Record<string, RepositoryWithSettings>>(
     {}
@@ -223,7 +223,6 @@ function RepoTable({
           </InputGroup.LeadingItems>
           <InputGroup.Input
             size="md"
-            disabled={!hasData}
             placeholder={t('Search')}
             value={searchTerm ?? ''}
             onChange={e =>

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -57,9 +57,12 @@ export default function SeerRepoTable() {
     select: ({pages}) =>
       uniqBy(
         pages.flatMap(page => page.json),
-        'id'
+        'externalId'
       )
-        .filter(repository => isSupportedAutofixProvider(repository.provider))
+        .filter(
+          repository =>
+            repository.externalId && isSupportedAutofixProvider(repository.provider)
+        )
         .sort((a, b) => {
           if (sort.field === 'name') {
             return sort.kind === 'asc'

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -1,12 +1,13 @@
-import {useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import uniqBy from 'lodash/uniqBy';
 import {debounce, parseAsString, useQueryState} from 'nuqs';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {InputGroup} from '@sentry/scraps/input';
 import {Grid, Stack} from '@sentry/scraps/layout';
 
-import {useOrganizationRepositoriesWithSettings} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -17,7 +18,7 @@ import {t, tct} from 'sentry/locale';
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
-import {useQueryClient, type ApiQueryKey} from 'sentry/utils/queryClient';
+import {useInfiniteQuery, useQueryClient} from 'sentry/utils/queryClient';
 import parseAsSort from 'sentry/utils/url/parseAsSort';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -29,19 +30,67 @@ import {getRepositoryWithSettingsQueryKey} from 'getsentry/views/seerAutomation/
 export default function SeerRepoTable() {
   const queryClient = useQueryClient();
   const organization = useOrganization();
-  const {
-    data: repositoriesWithSettings,
-    error,
-    isFetching,
-  } = useOrganizationRepositoriesWithSettings();
 
-  const supportedRepositories = useMemo(
-    () =>
-      repositoriesWithSettings.filter(repository =>
-        isSupportedAutofixProvider(repository.provider)
-      ),
-    [repositoriesWithSettings]
+  const [searchTerm, setSearchTerm] = useQueryState(
+    'query',
+    parseAsString.withDefault('')
   );
+
+  const [sort, setSort] = useQueryState(
+    'sort',
+    parseAsSort.withDefault({field: 'name', kind: 'asc'})
+  );
+
+  const lowerCaseSearchTerm = searchTerm?.toLowerCase() ?? '';
+
+  const queryOptions = organizationRepositoriesInfiniteOptions({
+    organization,
+    query: {per_page: 100},
+  });
+  const {
+    data: repositories,
+    hasNextPage,
+    isError,
+    isPending,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    ...queryOptions,
+    select: ({pages}) =>
+      uniqBy(
+        pages.flatMap(page => page.json),
+        'id'
+      )
+        .filter(repository => isSupportedAutofixProvider(repository.provider))
+        .toSorted((a, b) => {
+          if (sort.field === 'name') {
+            return sort.kind === 'asc'
+              ? a.name.localeCompare(b.name)
+              : b.name.localeCompare(a.name);
+          }
+          // TODO: if we can bulk-fetch all the preferences, then it'll be easier to sort by fixes, pr creation, and repos
+          // if (sort.field === 'fixes') {
+          //   return a.slug.localeCompare(b.slug);
+          // }
+          // if (sort.field === 'pr_creation') {
+          //   return a.platform.localeCompare(b.platform);
+          // }
+          // if (sort.field === 'repos') {
+          //   return a.status.localeCompare(b.status);
+          // }
+          return 0;
+        })
+        .filter(repository =>
+          repository.name.toLowerCase().includes(lowerCaseSearchTerm)
+        ),
+  });
+
+  // Auto-fetch each page, one at a time
+  useEffect(() => {
+    if (!isFetchingNextPage && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, fetchNextPage, isFetchingNextPage]);
 
   const [mutationData, setMutations] = useState<Record<string, RepositoryWithSettings>>(
     {}
@@ -66,59 +115,14 @@ export default function SeerRepoTable() {
     },
   });
 
-  const [searchTerm, setSearchTerm] = useQueryState(
-    'query',
-    parseAsString.withDefault('')
-  );
-
-  const [sort, setSort] = useQueryState(
-    'sort',
-    parseAsSort.withDefault({field: 'name', kind: 'asc'})
-  );
-
-  const queryKey: ApiQueryKey = [
-    'seer-repos',
-    {query: {query: searchTerm, sort}},
-  ] as unknown as ApiQueryKey;
-
-  const sortedRepositories = useMemo(() => {
-    return supportedRepositories.toSorted((a, b) => {
-      if (sort.field === 'name') {
-        return sort.kind === 'asc'
-          ? a.name.localeCompare(b.name)
-          : b.name.localeCompare(a.name);
-      }
-
-      // TODO: if we can bulk-fetch all the preferences, then it'll be easier to sort by fixes, pr creation, and repos
-      // if (sort.field === 'fixes') {
-      //   return a.slug.localeCompare(b.slug);
-      // }
-      // if (sort.field === 'pr_creation') {
-      //   return a.platform.localeCompare(b.platform);
-      // }
-      // if (sort.field === 'repos') {
-      //   return a.status.localeCompare(b.status);
-      // }
-      return 0;
-    });
-  }, [supportedRepositories, sort]);
-
-  const filteredRepositories = useMemo(() => {
-    const lowerCase = searchTerm?.toLowerCase() ?? '';
-    if (lowerCase) {
-      return sortedRepositories.filter(repository =>
-        repository.name.toLowerCase().includes(lowerCase)
-      );
-    }
-    return sortedRepositories;
-  }, [sortedRepositories, searchTerm]);
-
-  if (isFetching) {
+  if (isPending) {
     return (
       <RepoTable
         mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
-        repositories={filteredRepositories}
+        isLoading={isPending || isFetchingNextPage}
+        isLoadingMore={false /* prevent redundant spinners */}
+        repositories={[]}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         sort={sort}
@@ -130,12 +134,14 @@ export default function SeerRepoTable() {
     );
   }
 
-  if (error) {
+  if (isError) {
     return (
       <RepoTable
         mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
-        repositories={filteredRepositories}
+        isLoading={isPending || isFetchingNextPage}
+        isLoadingMore={hasNextPage || isFetchingNextPage}
+        repositories={[]}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         sort={sort}
@@ -149,19 +155,21 @@ export default function SeerRepoTable() {
 
   return (
     <ListItemCheckboxProvider
-      hits={filteredRepositories.length}
-      knownIds={filteredRepositories.map(repository => repository.id)}
-      queryKey={queryKey}
+      hits={repositories.length}
+      knownIds={repositories.map(repository => repository.id)}
+      queryKey={queryOptions.queryKey}
     >
       <RepoTable
         mutateRepositorySettings={mutateRepositorySettings}
         onSortClick={setSort}
-        repositories={filteredRepositories}
+        isLoading={isPending || isFetchingNextPage}
+        isLoadingMore={hasNextPage || isFetchingNextPage}
+        repositories={repositories}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
         sort={sort}
       >
-        {filteredRepositories.length === 0 ? (
+        {repositories.length === 0 ? (
           <SimpleTable.Empty>
             {searchTerm
               ? tct('No repositories found matching [searchTerm]', {
@@ -170,7 +178,7 @@ export default function SeerRepoTable() {
               : t('No repositories found')}
           </SimpleTable.Empty>
         ) : (
-          filteredRepositories.map(repository => (
+          repositories.map(repository => (
             <SeerRepoTableRow
               key={repository.id}
               mutateRepositorySettings={mutateRepositorySettings}
@@ -186,6 +194,8 @@ export default function SeerRepoTable() {
 
 function RepoTable({
   children,
+  isLoading,
+  isLoadingMore,
   mutateRepositorySettings,
   onSortClick,
   repositories,
@@ -194,6 +204,8 @@ function RepoTable({
   sort,
 }: {
   children: React.ReactNode;
+  isLoading: boolean;
+  isLoadingMore: boolean;
   mutateRepositorySettings: ReturnType<typeof useBulkUpdateRepositorySettings>['mutate'];
   onSortClick: (sort: Sort) => void;
   repositories: RepositoryWithSettings[];
@@ -202,15 +214,21 @@ function RepoTable({
   sort: Sort;
 }) {
   const organization = useOrganization();
+  const hasData = repositories.length > 0;
   return (
     <Stack gap="lg">
-      <Grid minWidth="0" gap="md" columns="1fr max-content">
+      <Grid
+        minWidth="0"
+        gap="md"
+        columns={hasData ? '1fr max-content' : '1fr max-content max-content'}
+      >
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch />
           </InputGroup.LeadingItems>
           <InputGroup.Input
             size="md"
+            disabled={!hasData}
             placeholder={t('Search')}
             value={searchTerm ?? ''}
             onChange={e =>
@@ -218,6 +236,9 @@ function RepoTable({
             }
           />
         </InputGroup>
+
+        {hasData ? null : <LoadingIndicator mini />}
+
         <LinkButton
           priority="primary"
           icon={<IconAdd />}
@@ -236,10 +257,22 @@ function RepoTable({
         <SeerRepoTableHeader
           mutateRepositorySettings={mutateRepositorySettings}
           onSortClick={onSortClick}
+          disabled={isLoading}
           repositories={repositories}
           sort={sort}
         />
         {children}
+        {isLoadingMore ? (
+          <SimpleTable.Row key="loading-row">
+            <SimpleTable.RowCell
+              align="center"
+              justify="center"
+              style={{gridColumn: '1 / -1'}}
+            >
+              <LoadingIndicator mini />
+            </SimpleTable.RowCell>
+          </SimpleTable.Row>
+        ) : null}
       </SimpleTableWithColumns>
     </Stack>
   );

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -41,11 +41,9 @@ export default function SeerRepoTable() {
     parseAsSort.withDefault({field: 'name', kind: 'asc'})
   );
 
-  const lowerCaseSearchTerm = searchTerm?.toLowerCase() ?? '';
-
   const queryOptions = organizationRepositoriesInfiniteOptions({
     organization,
-    query: {per_page: 100},
+    query: {per_page: 100, query: searchTerm, sort},
   });
   const {
     data: repositories,
@@ -79,10 +77,7 @@ export default function SeerRepoTable() {
           //   return a.status.localeCompare(b.status);
           // }
           return 0;
-        })
-        .filter(repository =>
-          repository.name.toLowerCase().includes(lowerCaseSearchTerm)
-        ),
+        }),
   });
 
   // Auto-fetch each page, one at a time

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -19,6 +19,7 @@ import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCa
 import type {useBulkUpdateRepositorySettings} from 'getsentry/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings';
 
 interface Props {
+  disabled: boolean;
   mutateRepositorySettings: ReturnType<typeof useBulkUpdateRepositorySettings>['mutate'];
   onSortClick: (key: Sort) => void;
   repositories: RepositoryWithSettings[];
@@ -46,10 +47,11 @@ const COLUMNS = [
 ];
 
 export default function SeerRepoTableHeader({
+  disabled,
+  mutateRepositorySettings,
   onSortClick,
   repositories,
   sort,
-  mutateRepositorySettings,
 }: Props) {
   const canWrite = useCanWriteSettings();
   const listItemCheckboxState = useListItemCheckboxContext();
@@ -96,6 +98,7 @@ export default function SeerRepoTableHeader({
           <SelectAllCheckbox
             listItemCheckboxState={listItemCheckboxState}
             repositories={repositories}
+            disabled={disabled}
           />
         </SimpleTable.HeaderCell>
         {COLUMNS.map(({title, key, sortKey}) => (
@@ -128,6 +131,7 @@ export default function SeerRepoTableHeader({
             <SelectAllCheckbox
               listItemCheckboxState={listItemCheckboxState}
               repositories={repositories}
+              disabled={disabled}
             />
           </TableCellFirst>
           <TableCellsRemainingContent align="center" gap="md">
@@ -195,7 +199,9 @@ export default function SeerRepoTableHeader({
 function SelectAllCheckbox({
   listItemCheckboxState: {deselectAll, isAllSelected, selectedIds, selectAll},
   repositories,
+  disabled,
 }: {
+  disabled: boolean;
   listItemCheckboxState: ReturnType<typeof useListItemCheckboxContext>;
   repositories: RepositoryWithSettings[];
 }) {
@@ -203,7 +209,7 @@ function SelectAllCheckbox({
     <Checkbox
       id="repository-table-select-all"
       checked={isAllSelected}
-      disabled={repositories.length === 0}
+      disabled={repositories.length === 0 || disabled}
       onChange={() => {
         if (isAllSelected === true || selectedIds.length === repositories.length) {
           deselectAll();

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -91,6 +91,7 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
 
   const {
     data: repositories,
+    isError: isRepositoriesError,
     isFetching: isRepositoriesFetching,
     hasNextPage: hasNextPageRepositories,
     fetchNextPage: fetchNextPageRepositories,
@@ -103,17 +104,22 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
     select: ({pages}) =>
       uniqBy(
         pages.flatMap(page => page.json),
-        'id'
-      ),
+        'externalId'
+      ).filter(repository => repository.externalId !== null),
   });
   // Auto-fetch each page, one at a time
   useEffect(() => {
-    if (!isFetchingNextPageRepositories && hasNextPageRepositories) {
+    if (
+      !isRepositoriesError &&
+      !isFetchingNextPageRepositories &&
+      hasNextPageRepositories
+    ) {
       fetchNextPageRepositories();
     }
   }, [
-    hasNextPageRepositories,
     fetchNextPageRepositories,
+    hasNextPageRepositories,
+    isRepositoriesError,
     isFetchingNextPageRepositories,
   ]);
 

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -9,13 +9,16 @@ import {
   type RefObject,
 } from 'react';
 import * as Sentry from '@sentry/react';
+import uniqBy from 'lodash/uniqBy';
 
-import {useOrganizationRepositoriesWithSettings} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
   RepositoryWithSettings,
 } from 'sentry/types/integrations';
+import {useInfiniteQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import {useIntegrationInstallation} from './useIntegrationInstallation';
 import {useIntegrationProvider} from './useIntegrationProvider';
@@ -71,6 +74,7 @@ const SeerOnboardingContext = createContext<SeerOnboardingContextProps>({
 });
 
 export function SeerOnboardingProvider({children}: {children: React.ReactNode}) {
+  const organization = useOrganization();
   const [selectedCodeReviewRepositoriesMap, setSelectedCodeReviewRepositoriesMap] =
     useState<Record<string, boolean>>({});
   const [selectedRootCauseAnalysisRepositories, setRootCauseAnalysisRepositories] =
@@ -85,8 +89,34 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
   // Track if we've initialized the map to avoid overwriting user changes
   const hasInitializedCodeReviewMap = useRef(false);
 
-  const {data: repositories, isFetching: isRepositoriesFetching} =
-    useOrganizationRepositoriesWithSettings();
+  const {
+    data: repositories,
+    isFetching: isRepositoriesFetching,
+    hasNextPage: hasNextPageRepositories,
+    fetchNextPage: fetchNextPageRepositories,
+    isFetchingNextPage: isFetchingNextPageRepositories,
+  } = useInfiniteQuery({
+    ...organizationRepositoriesInfiniteOptions({
+      organization,
+      query: {per_page: 100},
+    }),
+    select: ({pages}) =>
+      uniqBy(
+        pages.flatMap(page => page.json),
+        'id'
+      ),
+  });
+  // Auto-fetch each page, one at a time
+  useEffect(() => {
+    if (!isFetchingNextPageRepositories && hasNextPageRepositories) {
+      fetchNextPageRepositories();
+    }
+  }, [
+    hasNextPageRepositories,
+    fetchNextPageRepositories,
+    isFetchingNextPageRepositories,
+  ]);
+
   const {data: installationData, isPending: isInstallationPending} =
     useIntegrationInstallation('github');
   const {provider, isPending: isProviderPending} = useIntegrationProvider('github');


### PR DESCRIPTION
This brings in useInfiniteApiQuery to replace useFetchSequentialPages inside of useOrganizationRepositoriesWithSettings

The idea is that this will be a better foundation to use to continue to iterate on the pages that load up lists of repos (there's a seer wizard step, and also the org settings page).

I believe that the new system is a bit slower to run on orgs that have 1,000's of repos. It's because we're loading and rendering each chunk of data using react to trigger the next chunk. I like it better however because we return a proper `queryResult` object that useQuery knows how to keep track of. The benefit is that we can re-fetch the data instead of it being cached inside the state inside useFetchSequentialPages. Also, I'm following up with virtual rendering which will counteract the re-render penalty.

