### PR TITLE
fix(tests): Clean up auth.allow-registration in system options tests

### DIFF
--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -70,15 +70,15 @@ class SystemOptionsTest(APITestCase):
         with override_settings(SENTRY_SELF_HOSTED=True):
             self.login_as(user=self.user, superuser=True)
             response = self.client.put(self.url, {"auth.allow-registration": 1})
-            assert response.status_code == 200
             options.delete("auth.allow-registration")
+            assert response.status_code == 200
 
     def test_put_int_for_boolean(self) -> None:
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
-        assert response.status_code == 200
         options.delete("auth.allow-registration")
+        assert response.status_code == 200
 
     def test_put_unknown_option(self) -> None:
         self.login_as(user=self.user, superuser=True)
@@ -114,9 +114,9 @@ class SystemOptionsTest(APITestCase):
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
-        assert response.status_code == 200
         assert (
             options.get_last_update_channel("auth.allow-registration")
             == options.UpdateChannel.APPLICATION
         )
         options.delete("auth.allow-registration")
+        assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -71,12 +71,14 @@ class SystemOptionsTest(APITestCase):
             self.login_as(user=self.user, superuser=True)
             response = self.client.put(self.url, {"auth.allow-registration": 1})
             assert response.status_code == 200
+            options.delete("auth.allow-registration")
 
     def test_put_int_for_boolean(self) -> None:
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
         assert response.status_code == 200
+        options.delete("auth.allow-registration")
 
     def test_put_unknown_option(self) -> None:
         self.login_as(user=self.user, superuser=True)
@@ -117,3 +119,4 @@ class SystemOptionsTest(APITestCase):
             options.get_last_update_channel("auth.allow-registration")
             == options.UpdateChannel.APPLICATION
         )
+        options.delete("auth.allow-registration")


### PR DESCRIPTION
found in this shuffle-tests-across-shards run https://github.com/getsentry/sentry/actions/runs/22010195505/job/63602406261

this consistently fails:
```
pytest tests/sentry/api/endpoints/test_system_options.py::SystemOptionsTest::test_put_self_hosted_superuser_access_allowed tests/sentry/web/frontend/test_oauth_authorize.py::OAuthAuthorizeCustomSchemeTest::test_code_flow_unauthenticated_custom_scheme
```

and was bisected here https://github.com/getsentry/sentry/actions/runs/22013373357/job/63611146322

---

- Fix test pollution where `SystemOptionsTest` tests set `auth.allow-registration` to `1` via the API without cleaning up afterward
- The leaked option caused `has_user_registration()` to return `True` in subsequent tests, breaking login redirect behavior (returning 200 instead of 302) in `OAuthAuthorizeCustomSchemeTest::test_code_flow_unauthenticated_custom_scheme`
- Added `options.delete("auth.allow-registration")` cleanup in three tests: `test_put_self_hosted_superuser_access_allowed`, `test_put_int_for_boolean`, and `test_update_channel`