### PR TITLE
feat(gsAdmin): Add product trial extension support

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.spec.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.spec.tsx
@@ -596,26 +596,38 @@ describe('CustomerOverview', () => {
           name: 'Stop Trial',
         });
         expect(stopTrialButton).toBeInTheDocument();
+        const extendTrialButton = within(definition).getByRole('button', {
+          name: 'Extend Trial',
+        });
+        expect(extendTrialButton).toBeInTheDocument();
 
         if (category === DataCategory.REPLAYS) {
           expect(allowTrialButton).toBeDisabled();
           expect(startTrialButton).toBeDisabled();
           expect(stopTrialButton).toBeEnabled();
-          expect(within(definition).getByText('Active')).toBeInTheDocument();
+          expect(extendTrialButton).toBeEnabled();
+          expect(
+            within(definition).getByText(/Active \(until .* UTC\)/)
+          ).toBeInTheDocument();
         } else if (category === DataCategory.SPANS) {
           expect(allowTrialButton).toBeDisabled();
           expect(startTrialButton).toBeDisabled();
           expect(stopTrialButton).toBeDisabled();
-          expect(within(definition).getByText(/Active \(/)).toBeInTheDocument();
+          expect(extendTrialButton).toBeEnabled();
+          expect(
+            within(definition).getByText(/Active \(until .* UTC\)/)
+          ).toBeInTheDocument();
         } else if (category === AddOnCategory.LEGACY_SEER) {
           expect(allowTrialButton).toBeEnabled();
           expect(startTrialButton).toBeDisabled();
           expect(stopTrialButton).toBeDisabled();
+          expect(extendTrialButton).toBeDisabled();
           expect(within(definition).getByText('Used')).toBeInTheDocument();
         } else {
           expect(allowTrialButton).toBeDisabled();
           expect(startTrialButton).toBeEnabled();
           expect(stopTrialButton).toBeDisabled();
+          expect(extendTrialButton).toBeDisabled();
           expect(within(definition).getByText('Available')).toBeInTheDocument();
         }
       } else {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -17,6 +17,7 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {toTitleCase} from 'sentry/utils/string/toTitleCase';
 
+import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
 import ChangeARRAction from 'admin/components/changeARRAction';
 import ChangeContractEndDateAction from 'admin/components/changeContractEndDateAction';
 import CustomerContact from 'admin/components/customerContact';
@@ -24,6 +25,7 @@ import CustomerStatus from 'admin/components/customerStatus';
 import DetailLabel from 'admin/components/detailLabel';
 import DetailList from 'admin/components/detailList';
 import DetailsContainer from 'admin/components/detailsContainer';
+import ExtendProductTrialAction from 'admin/components/extendProductTrialAction';
 import {getLogQuery} from 'admin/utils';
 import {BILLED_DATA_CATEGORY_INFO, UNLIMITED} from 'getsentry/constants';
 import type {
@@ -536,6 +538,26 @@ function CustomerOverview({customer, onAction, organization}: Props) {
       moment(activeProductTrial?.endDate).add(1, 'day').diff(moment(), 'days') < 1;
     const hasUsedProductTrial =
       hasActiveProductTrial || categoryHasUsedProductTrial(category);
+
+    const handleExtendTrial = () => {
+      if (!activeProductTrial) {
+        return;
+      }
+      openAdminConfirmModal({
+        header: <h4>Extend {formattedTrialName} Trial</h4>,
+        confirmText: 'Extend Trial',
+        renderModalSpecificContent: deps => (
+          <ExtendProductTrialAction
+            activeProductTrial={activeProductTrial}
+            apiName={apiName}
+            trialName={formattedTrialName}
+            {...deps}
+          />
+        ),
+        onConfirm: onAction,
+      });
+    };
+
     return (
       <DetailLabel key={apiName} title={formattedTrialName}>
         <Stack gap="md">
@@ -551,7 +573,7 @@ function CustomerOverview({customer, onAction, organization}: Props) {
             }
           >
             {hasActiveProductTrial
-              ? `Active${lessThanOneDayLeft ? ` (${moment(activeProductTrial.endDate).add(1, 'day').fromNow(true)} left)` : ''}`
+              ? `Active (until ${moment.utc(activeProductTrial.endDate).format('MMM D, YYYY')} UTC)`
               : hasUsedProductTrial
                 ? 'Used'
                 : 'Available'}
@@ -600,6 +622,18 @@ function CustomerOverview({customer, onAction, organization}: Props) {
               }}
             >
               Stop Trial
+            </Button>
+            <Button
+              size="xs"
+              onClick={handleExtendTrial}
+              disabled={!hasActiveProductTrial}
+              tooltipProps={{
+                title: hasActiveProductTrial
+                  ? `Extend the current ${formattedTrialName} product trial`
+                  : `No active product trial to extend for ${formattedTrialName}`,
+              }}
+            >
+              Extend Trial
             </Button>
           </Flex>
         </Stack>

--- a/static/gsAdmin/components/extendProductTrialAction.spec.tsx
+++ b/static/gsAdmin/components/extendProductTrialAction.spec.tsx
@@ -1,0 +1,157 @@
+import moment from 'moment-timezone';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {DataCategory} from 'sentry/types/core';
+
+import ExtendProductTrialAction from 'admin/components/extendProductTrialAction';
+
+describe('ExtendProductTrialAction', () => {
+  const activeProductTrial = {
+    category: DataCategory.REPLAYS,
+    isStarted: true,
+    reasonCode: 1001,
+    startDate: moment().utc().subtract(10, 'days').format(),
+    endDate: moment().utc().add(4, 'days').format(),
+  };
+
+  const defaultProps = {
+    activeProductTrial,
+    apiName: 'replays',
+    trialName: 'Replays',
+    confirm: jest.fn(),
+    close: jest.fn(),
+    disableConfirmButton: jest.fn(),
+    setConfirmCallback: jest.fn(),
+    onConfirm: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with default 14 days', () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    expect(screen.getByText(/Extend the/)).toBeInTheDocument();
+    expect(screen.getByText('Replays')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('14')).toBeInTheDocument();
+  });
+
+  it('displays current trial end date in UTC', () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    const expectedCurrentDate = moment
+      .utc(activeProductTrial.endDate)
+      .format('MMMM Do YYYY');
+    expect(screen.getByText(/Current trial ends:/)).toBeInTheDocument();
+    expect(screen.getByText(`${expectedCurrentDate} UTC`)).toBeInTheDocument();
+  });
+
+  it('calculates new end date correctly', () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    // New end date should be current + 14 days (default)
+    const expectedNewDate = moment
+      .utc(activeProductTrial.endDate)
+      .add(14, 'days')
+      .format('MMMM Do YYYY');
+    expect(screen.getByText(`${expectedNewDate} UTC`)).toBeInTheDocument();
+  });
+
+  it('updates new end date when days change', async () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('14');
+    await userEvent.clear(input);
+    await userEvent.type(input, '30');
+
+    const expectedNewDate = moment
+      .utc(activeProductTrial.endDate)
+      .add(30, 'days')
+      .format('MMMM Do YYYY');
+    expect(screen.getByText(`${expectedNewDate} UTC`)).toBeInTheDocument();
+  });
+
+  it('disables confirm button for values less than 1', async () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('14');
+    await userEvent.clear(input);
+    await userEvent.type(input, '0');
+
+    expect(defaultProps.disableConfirmButton).toHaveBeenCalledWith(true);
+  });
+
+  it('disables confirm button for values greater than 90', async () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('14');
+    await userEvent.clear(input);
+    await userEvent.type(input, '91');
+
+    expect(defaultProps.disableConfirmButton).toHaveBeenCalledWith(true);
+  });
+
+  it('enables confirm button for valid values', async () => {
+    render(<ExtendProductTrialAction {...defaultProps} />);
+
+    const input = screen.getByDisplayValue('14');
+    await userEvent.clear(input);
+    await userEvent.type(input, '30');
+
+    expect(defaultProps.disableConfirmButton).toHaveBeenLastCalledWith(false);
+  });
+
+  it('calls onConfirm with correct data', () => {
+    let confirmCallback: ((params: Record<string, unknown>) => void) | undefined;
+    const setConfirmCallback = jest.fn(
+      (cb: (params: Record<string, unknown>) => void) => {
+        confirmCallback = cb;
+      }
+    );
+
+    render(
+      <ExtendProductTrialAction
+        {...defaultProps}
+        setConfirmCallback={setConfirmCallback}
+      />
+    );
+
+    expect(setConfirmCallback).toHaveBeenCalled();
+
+    // Trigger the confirm callback
+    confirmCallback?.({notes: 'test notes'});
+
+    expect(defaultProps.onConfirm).toHaveBeenCalledWith({
+      extendTrialReplays: true,
+      extendTrialDays: 14,
+      notes: 'test notes',
+    });
+  });
+
+  it('formats API name correctly for multi-word categories', () => {
+    let confirmCallback: ((params: Record<string, unknown>) => void) | undefined;
+    const setConfirmCallback = jest.fn(
+      (cb: (params: Record<string, unknown>) => void) => {
+        confirmCallback = cb;
+      }
+    );
+
+    render(
+      <ExtendProductTrialAction
+        {...defaultProps}
+        apiName="profileDuration"
+        trialName="Continuous Profiling"
+        setConfirmCallback={setConfirmCallback}
+      />
+    );
+
+    confirmCallback?.({});
+
+    expect(defaultProps.onConfirm).toHaveBeenCalledWith({
+      extendTrialProfileDuration: true,
+      extendTrialDays: 14,
+    });
+  });
+});

--- a/static/gsAdmin/components/extendProductTrialAction.tsx
+++ b/static/gsAdmin/components/extendProductTrialAction.tsx
@@ -1,0 +1,87 @@
+import {Fragment, useEffect, useRef, useState} from 'react';
+import upperFirst from 'lodash/upperFirst';
+import moment from 'moment-timezone';
+
+import NumberField from 'sentry/components/forms/fields/numberField';
+
+import type {
+  AdminConfirmParams,
+  AdminConfirmRenderProps,
+} from 'admin/components/adminConfirmationModal';
+import type {ProductTrial} from 'getsentry/types';
+
+type Props = AdminConfirmRenderProps & {
+  activeProductTrial: ProductTrial;
+  apiName: string;
+  trialName: string;
+};
+
+/**
+ * Rendered as part of an openAdminConfirmModal call for extending product trials
+ */
+function ExtendProductTrialAction({
+  activeProductTrial,
+  apiName,
+  trialName,
+  onConfirm,
+  setConfirmCallback,
+  disableConfirmButton,
+}: Props) {
+  const [extendDays, setExtendDays] = useState(14);
+
+  // Use a ref to access the latest extendDays value in the callback
+  // without causing re-renders when the callback is set
+  const extendDaysRef = useRef(extendDays);
+  extendDaysRef.current = extendDays;
+
+  useEffect(() => {
+    setConfirmCallback((params: AdminConfirmParams) => {
+      const formattedApiName = upperFirst(apiName);
+      onConfirm?.({
+        [`extendTrial${formattedApiName}`]: true,
+        extendTrialDays: extendDaysRef.current,
+        ...params,
+      });
+    });
+    // Only set up the callback once on mount, using ref for latest value
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleDaysChange = (value: string) => {
+    const days = parseInt(value, 10) || 0;
+    setExtendDays(days);
+    disableConfirmButton(days < 1 || days > 90);
+  };
+
+  const currentEndDate = moment.utc(activeProductTrial.endDate);
+  const newEndDate = currentEndDate.clone().add(extendDays, 'days');
+
+  return (
+    <Fragment>
+      <p>
+        Extend the <strong>{trialName}</strong> product trial.
+      </p>
+      <p>
+        Current trial ends: <strong>{currentEndDate.format('MMMM Do YYYY')} UTC</strong>
+      </p>
+      <NumberField
+        inline={false}
+        stacked
+        flexibleControlStateSize
+        label="Number of Days to Extend"
+        help={
+          <Fragment>
+            New trial end date: <strong>{newEndDate.format('MMMM Do YYYY')} UTC</strong>
+          </Fragment>
+        }
+        name="extendDays"
+        min={1}
+        max={90}
+        value={extendDays}
+        onChange={handleDaysChange}
+      />
+    </Fragment>
+  );
+}
+
+export default ExtendProductTrialAction;


### PR DESCRIPTION
Add UI for extending product trials in the customer overview.

Extend Trial button in Product Trials section and add trial end date in UTC for active trials:
<img width="533" height="94" alt="Screenshot 2026-02-15 at 4 10 15 PM" src="https://github.com/user-attachments/assets/7d9ac013-ead4-45f7-ac17-385e81f66fec" />

New ExtendProductTrialAction modal component with days input (1-90):
<img width="621" height="521" alt="Screenshot 2026-02-15 at 4 10 28 PM" src="https://github.com/user-attachments/assets/34e27664-9539-4a06-8f8e-76fbdb195f8a" />

Verified in-product handles these longer durations:
<img width="859" height="83" alt="Screenshot 2026-02-15 at 4 42 19 PM" src="https://github.com/user-attachments/assets/8dcb9385-25c4-4790-8321-6d67b811597a" />

See: https://github.com/getsentry/getsentry/pull/19376