### PR TITLE
chore(dynamic-sampling): fix arrow direction in _admin table

### DIFF
--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -415,7 +415,11 @@ function DynamicSamplingRulesTable({
                   row.impact > 0 ? 'increases' : 'decreases'
                 } sample rate of matching events`}
               >
-                <ImpactIndicatorIcon impact={row.impact} size="xs" />
+                <ImpactIndicatorIcon
+                  direction={row.impact > 0 ? 'up' : 'down'}
+                  impact={row.impact}
+                  size="xs"
+                />
               </Tooltip>
             </Flex>
             <div>{row.target}</div>
@@ -429,7 +433,6 @@ function DynamicSamplingRulesTable({
 const ImpactIndicatorIcon = styled(IconArrow)<{impact: number}>`
   display: ${p => (p.impact === 0 ? 'none' : 'inline-block')};
   color: ${p => (p.impact > 0 ? p.theme.colors.green400 : p.theme.colors.red400)};
-  transform: ${p => (p.impact > 0 ? 'rotate(45deg)' : 'rotate(135deg)')};
 `;
 
 const PanelHeaderRight = styled('div')`


### PR DESCRIPTION
Before: 
<img width="244" height="184" alt="image" src="https://github.com/user-attachments/assets/4f7a1d7d-b175-4e75-9713-5c351ed06036" />


After:
<img width="268" height="297" alt="image" src="https://github.com/user-attachments/assets/b70d3287-6545-4e50-93ac-7dbd5dcd10c9" />
