### PR TITLE
feat(agent): Try to fix invalid json

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -21,8 +21,8 @@ import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
+  parseJsonWithFix,
   tryParseJson,
-  tryParseJsonWithInvalidJsonFix,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
 import type {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
@@ -136,8 +136,7 @@ function transformInputMessages(inputMessages: string): {
   result: string | undefined;
 } {
   try {
-    const {parsed: json, fixedInvalidJson} =
-      tryParseJsonWithInvalidJsonFix(inputMessages);
+    const {parsed: json, fixedInvalidJson} = parseJsonWithFix(inputMessages);
     const result = [];
     const {system, prompt} = json;
     if (system) {
@@ -176,7 +175,7 @@ function transformPrompt(prompt: string): {
   result: string | undefined;
 } {
   try {
-    const {parsed: json, fixedInvalidJson} = tryParseJsonWithInvalidJsonFix(prompt);
+    const {parsed: json, fixedInvalidJson} = parseJsonWithFix(prompt);
     const result = [];
     const {system, messages} = json;
     if (system) {
@@ -215,7 +214,7 @@ function transformPartsMessages(messages: string): {
   result: string | undefined;
 } {
   try {
-    const {parsed, fixedInvalidJson} = tryParseJsonWithInvalidJsonFix(messages);
+    const {parsed, fixedInvalidJson} = parseJsonWithFix(messages);
 
     if (!Array.isArray(parsed)) {
       return {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -20,7 +20,10 @@ import {
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {FoldSection} from 'sentry/views/issueDetails/streamline/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
-import {tryParseJson} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
+import {
+  tryParseJson,
+  tryParseJsonWithInvalidJsonFix,
+} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {EapSpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/eapSpanNode';
 import type {SpanNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/spanNode';
 import type {TransactionNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode';
@@ -128,9 +131,13 @@ function parseAIMessages(messages: string): AIMessage[] | string {
   }
 }
 
-function transformInputMessages(inputMessages: string) {
+function transformInputMessages(inputMessages: string): {
+  fixedInvalidJson: boolean;
+  result: string | undefined;
+} {
   try {
-    const json = JSON.parse(inputMessages);
+    const {parsed: json, fixedInvalidJson} =
+      tryParseJsonWithInvalidJsonFix(inputMessages);
     const result = [];
     const {system, prompt} = json;
     if (system) {
@@ -145,7 +152,10 @@ function transformInputMessages(inputMessages: string) {
         content: [{type: 'text', text: prompt}],
       });
     }
-    return JSON.stringify(result);
+    return {
+      result: JSON.stringify(result),
+      fixedInvalidJson,
+    };
   } catch (error) {
     try {
       Sentry.captureException(
@@ -154,13 +164,19 @@ function transformInputMessages(inputMessages: string) {
     } catch {
       // ignore errors with browsers that don't support `cause`
     }
-    return undefined;
+    return {
+      result: undefined,
+      fixedInvalidJson: false,
+    };
   }
 }
 
-function transformPrompt(prompt: string) {
+function transformPrompt(prompt: string): {
+  fixedInvalidJson: boolean;
+  result: string | undefined;
+} {
   try {
-    const json = JSON.parse(prompt);
+    const {parsed: json, fixedInvalidJson} = tryParseJsonWithInvalidJsonFix(prompt);
     const result = [];
     const {system, messages} = json;
     if (system) {
@@ -173,14 +189,20 @@ function transformPrompt(prompt: string) {
     if (parsedMessages) {
       result.push(...parsedMessages);
     }
-    return JSON.stringify(result);
+    return {
+      result: JSON.stringify(result),
+      fixedInvalidJson,
+    };
   } catch (error) {
     try {
       Sentry.captureException(new Error('Error parsing ai.prompt', {cause: error}));
     } catch {
       // ignore errors with browsers that don't support `cause`
     }
-    return undefined;
+    return {
+      result: undefined,
+      fixedInvalidJson: false,
+    };
   }
 }
 
@@ -188,11 +210,18 @@ function transformPrompt(prompt: string) {
  * Transforms messages from the new parts-based format to the standard content format.
  * The new format uses a `parts` array with typed objects instead of a `content` field.
  */
-function transformPartsMessages(messages: string): string | undefined {
+function transformPartsMessages(messages: string): {
+  fixedInvalidJson: boolean;
+  result: string | undefined;
+} {
   try {
-    const parsed = JSON.parse(messages);
+    const {parsed, fixedInvalidJson} = tryParseJsonWithInvalidJsonFix(messages);
+
     if (!Array.isArray(parsed)) {
-      return undefined;
+      return {
+        result: undefined,
+        fixedInvalidJson,
+      };
     }
 
     const transformed = parsed.map((msg: any) => {
@@ -226,9 +255,22 @@ function transformPartsMessages(messages: string): string | undefined {
       return {role: msg.role, content};
     });
 
-    return JSON.stringify(transformed);
-  } catch {
-    return undefined;
+    return {
+      result: JSON.stringify(transformed),
+      fixedInvalidJson,
+    };
+  } catch (error) {
+    try {
+      Sentry.captureException(
+        new Error('Error parsing gen_ai messages with parts format', {cause: error})
+      );
+    } catch {
+      // ignore errors with browsers that don't support `cause`
+    }
+    return {
+      result: undefined,
+      fixedInvalidJson: false,
+    };
   }
 }
 
@@ -241,7 +283,7 @@ function getAIInputMessages(
   node: EapSpanNode | SpanNode | TransactionNode,
   attributes?: TraceItemResponseAttribute[],
   event?: EventTransaction
-): string | null {
+): {fixedInvalidJson: boolean; messages: string | null} {
   const systemInstructions = getTraceNodeAttribute(
     'gen_ai.system_instructions',
     node,
@@ -256,9 +298,16 @@ function getAIInputMessages(
     attributes
   );
   if (inputMessages) {
-    const transformed =
-      transformPartsMessages(inputMessages.toString()) ?? inputMessages.toString();
-    return prependSystemInstructions(transformed, systemInstructions?.toString());
+    const {result: transformed, fixedInvalidJson} = transformPartsMessages(
+      inputMessages.toString()
+    );
+    return {
+      messages: prependSystemInstructions(
+        transformed ?? inputMessages.toString(),
+        systemInstructions?.toString()
+      ),
+      fixedInvalidJson,
+    };
   }
 
   const requestMessages = getTraceNodeAttribute(
@@ -267,11 +316,18 @@ function getAIInputMessages(
     event,
     attributes
   );
+
   if (requestMessages) {
-    return prependSystemInstructions(
-      requestMessages.toString(),
-      systemInstructions?.toString()
+    const {result: transformed, fixedInvalidJson} = transformPartsMessages(
+      requestMessages.toString()
     );
+    return {
+      messages: prependSystemInstructions(
+        transformed ?? requestMessages.toString(),
+        systemInstructions?.toString()
+      ),
+      fixedInvalidJson,
+    };
   }
 
   const legacyInputMessages = getTraceNodeAttribute(
@@ -281,25 +337,38 @@ function getAIInputMessages(
     attributes
   );
   if (legacyInputMessages) {
-    const transformed = transformInputMessages(legacyInputMessages.toString());
+    const {result: transformed, fixedInvalidJson} = transformInputMessages(
+      legacyInputMessages.toString()
+    );
     if (transformed) {
-      return prependSystemInstructions(transformed, systemInstructions?.toString());
+      return {
+        messages: prependSystemInstructions(transformed, systemInstructions?.toString()),
+        fixedInvalidJson,
+      };
     }
   }
 
   const prompt = getTraceNodeAttribute('ai.prompt', node, event, attributes);
   if (prompt) {
-    const transformed = transformPrompt(prompt.toString());
+    const {result: transformed, fixedInvalidJson} = transformPrompt(prompt.toString());
     if (transformed) {
-      return prependSystemInstructions(transformed, systemInstructions?.toString());
+      return {
+        messages: prependSystemInstructions(transformed, systemInstructions?.toString()),
+        fixedInvalidJson,
+      };
     }
   }
 
   if (systemInstructions) {
-    return JSON.stringify([{role: 'system', content: systemInstructions.toString()}]);
+    return {
+      messages: JSON.stringify([
+        {role: 'system', content: systemInstructions.toString()},
+      ]),
+      fixedInvalidJson: false,
+    };
   }
 
-  return null;
+  return {messages: null, fixedInvalidJson: false};
 }
 
 /**
@@ -408,11 +477,11 @@ export function AIInputSection({
     attributes
   );
 
-  const promptMessages = shouldRender
+  const {messages: promptMessages, fixedInvalidJson} = shouldRender
     ? getAIInputMessages(node, attributes, event)
-    : null;
+    : {messages: null, fixedInvalidJson: false};
 
-  const messages = defined(promptMessages) && parseAIMessages(promptMessages.toString());
+  const messages = defined(promptMessages) && parseAIMessages(promptMessages);
 
   const toolArgs = getAIToolInput(node, attributes, event);
   const embeddingsInput = getTraceNodeAttribute(
@@ -449,6 +518,7 @@ export function AIInputSection({
           originalLength={
             defined(originalMessagesLength) ? Number(originalMessagesLength) : undefined
           }
+          fixedInvalidJson={fixedInvalidJson}
         />
       ) : null}
       {toolArgs ? (
@@ -471,6 +541,36 @@ const MAX_MESSAGES_AT_START = 2;
 const MAX_MESSAGES_AT_END = 1;
 const MAX_MESSAGES_TO_SHOW = MAX_MESSAGES_AT_START + MAX_MESSAGES_AT_END;
 
+function TruncationAlert({
+  areOldMessagesTruncated,
+  fixedInvalidJson,
+}: {
+  areOldMessagesTruncated: boolean;
+  fixedInvalidJson: boolean;
+}) {
+  if (!areOldMessagesTruncated && !fixedInvalidJson) {
+    return null;
+  }
+
+  const link = (
+    <ExternalLink href="https://develop.sentry.dev/sdk/expected-features/data-handling/#variable-size" />
+  );
+
+  return (
+    <Container paddingBottom="lg">
+      <Alert variant="muted">
+        {areOldMessagesTruncated
+          ? tct(
+              'Due to [link:size limitations], the oldest messages got dropped from the history.',
+              {link}
+            )
+          : tct('Due to [link:size limitations], the content was truncated.', {link})}
+        {fixedInvalidJson ? t(' Truncated parts are marked with `~~`.') : null}
+      </Alert>
+    </Container>
+  );
+}
+
 /**
  * As the whole message history takes up too much space we only show the first two (as those often contain the system and initial user prompt)
  * and the last messages with the option to expand
@@ -478,7 +578,9 @@ const MAX_MESSAGES_TO_SHOW = MAX_MESSAGES_AT_START + MAX_MESSAGES_AT_END;
 function MessagesArrayRenderer({
   messages,
   originalLength,
+  fixedInvalidJson,
 }: {
+  fixedInvalidJson: boolean;
   messages: AIMessage[];
   originalLength?: number;
 }) {
@@ -493,21 +595,6 @@ function MessagesArrayRenderer({
       setIsExpanded(messages.length <= MAX_MESSAGES_TO_SHOW);
     }
   }, [messages.length, previousMessagesLength]);
-
-  const truncationAlert = isTruncated ? (
-    <Container paddingBottom="lg">
-      <Alert variant="muted">
-        {tct(
-          'Due to [link:size limitations], the oldest messages got dropped from the history.',
-          {
-            link: (
-              <ExternalLink href="https://develop.sentry.dev/sdk/expected-features/data-handling/#variable-size" />
-            ),
-          }
-        )}
-      </Alert>
-    </Container>
-  ) : null;
 
   const renderMessage = (message: AIMessage, index: number) => {
     return (
@@ -530,7 +617,10 @@ function MessagesArrayRenderer({
   if (isExpanded) {
     return (
       <Fragment>
-        {truncationAlert}
+        <TruncationAlert
+          areOldMessagesTruncated={isTruncated}
+          fixedInvalidJson={fixedInvalidJson}
+        />
         {messages.map(renderMessage)}
       </Fragment>
     );
@@ -538,7 +628,10 @@ function MessagesArrayRenderer({
 
   return (
     <Fragment>
-      {truncationAlert}
+      <TruncationAlert
+        areOldMessagesTruncated={isTruncated}
+        fixedInvalidJson={fixedInvalidJson}
+      />
       {messages.slice(0, MAX_MESSAGES_AT_START).map(renderMessage)}
       <ButtonDivider>
         <Button onClick={() => setIsExpanded(true)} size="xs">

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
@@ -564,7 +564,7 @@ function TruncationAlert({
               {link}
             )
           : tct('Due to [link:size limitations], the content was truncated.', {link})}
-        {fixedInvalidJson ? t(' Truncated parts are marked with `~~`.') : null}
+        {fixedInvalidJson ? ` ${t('Truncated parts are marked with (~~).')}` : null}
       </Alert>
     </Container>
   );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -265,7 +265,7 @@ export function tryParseJson(value: unknown): unknown {
  * Attempts to parse a JSON string, with fallback to fix invalid JSON.
  * Returns the parsed result and whether the JSON needed fixing.
  */
-export function tryParseJsonWithInvalidJsonFix(value: string): {
+export function parseJsonWithFix(value: string): {
   fixedInvalidJson: boolean;
   parsed: any;
 } {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -15,6 +15,7 @@ import {
   SENTRY_SEARCHABLE_SPAN_STRING_TAGS,
 } from 'sentry/views/explore/constants';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import {fixJson} from 'sentry/views/replays/detail/network/truncateJson/fixJson';
 import {makeTracesPathname} from 'sentry/views/traces/pathnames';
 
 export function getProfileMeta(event: EventTransaction | null) {
@@ -257,5 +258,23 @@ export function tryParseJson(value: unknown): unknown {
     return parsedValue.map((item: unknown): unknown => tryParseJson(item));
   } catch {
     return value;
+  }
+}
+
+/**
+ * Attempts to parse a JSON string, with fallback to fix invalid JSON.
+ * Returns the parsed result and whether the JSON needed fixing.
+ */
+export function tryParseJsonWithInvalidJsonFix(value: string): {
+  fixedInvalidJson: boolean;
+  parsed: any;
+} {
+  try {
+    const parsed = JSON.parse(value);
+    return {parsed, fixedInvalidJson: false};
+  } catch {
+    const fixed = fixJson(value);
+    const parsed = JSON.parse(fixed);
+    return {parsed, fixedInvalidJson: true};
   }
 }


### PR DESCRIPTION
**Problem**
We frequently fail to parse AI input data due to:

- Data scrubbing (e.g., "[Filtered]")
- Truncation from [size limits](https://develop.sentry.dev/sdk/expected-features/data-handling/#variable-size)

When parsing fails, we currently send a `Sentry.captureException` and skip rendering the Input section entirely, leaving users with no visibility into the AI input data.

**Solution**
This PR introduces the `parseJsonWithFix` function, which attempts to parse JSON with a graceful fallback:

1. First, tries to parse the JSON as-is
2. If that fails, uses the existing `parseJsonWithFix` function (from Replays) to repair truncated JSON by beautifying it and adding ~~ markers where content was cut off
3. Attempts to parse the repaired JSON
4. If successful, renders the repaired data with an alert explaining that content was truncated and what the ~~ markers indicate

closes https://linear.app/getsentry/issue/TET-1962/show-incomplete-json-beautifuly