### PR TITLE
feat(preprod): Add artifact-type filtering to size status checks

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/types.py
+++ b/src/sentry/preprod/vcs/status_checks/size/types.py
@@ -1,6 +1,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
+
+
+class RuleArtifactType(StrEnum):
+    MAIN_ARTIFACT = "main_artifact"
+    WATCH_ARTIFACT = "watch_artifact"
+    ANDROID_DYNAMIC_FEATURE_ARTIFACT = "android_dynamic_feature_artifact"
+    ALL_ARTIFACTS = "all_artifacts"
+
+    @classmethod
+    def from_raw(cls, raw: object) -> RuleArtifactType | None:
+        if isinstance(raw, cls):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return cls(raw)
+            except ValueError:
+                return None
+        return None
 
 
 @dataclass
@@ -46,6 +65,10 @@ class StatusCheckRule:
     measurement: str
     value: float
     filter_query: str = ""
+    artifact_type: RuleArtifactType | None = None
+
+    def __post_init__(self) -> None:
+        self.artifact_type = RuleArtifactType.from_raw(self.artifact_type)
 
 
 @dataclass
@@ -60,3 +83,5 @@ class TriggeredRule:
     artifact_id: int
     app_id: str | None
     platform: str | None
+    metrics_artifact_type: int | None = None
+    identifier: str | None = None

--- a/tests/sentry/preprod/vcs/status_checks/size/test_metric_selection_helpers.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_metric_selection_helpers.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    _get_candidate_metrics_for_rule,
+    _get_matching_base_metric,
+)
+from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class StatusCheckMetricSelectionHelpersTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(teams=[self.team], organization=self.organization)
+
+        self.artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+        )
+
+    def _create_metric(
+        self,
+        metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType,
+        identifier: str | None = None,
+    ) -> PreprodArtifactSizeMetrics:
+        return PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=self.artifact,
+            metrics_artifact_type=metrics_artifact_type,
+            identifier=identifier,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=100,
+            max_download_size=200,
+            min_install_size=300,
+            max_install_size=400,
+        )
+
+    def test_get_candidate_metrics_for_rule_main_artifact(self) -> None:
+        main_metric = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        )
+        self._create_metric(PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT)
+        self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE,
+            identifier="feature.alpha",
+        )
+
+        rule = StatusCheckRule(
+            id="rule-main",
+            metric="install_size",
+            measurement="absolute",
+            value=1000,
+            artifact_type=RuleArtifactType.MAIN_ARTIFACT,
+        )
+
+        candidates = _get_candidate_metrics_for_rule(
+            rule, list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=self.artifact))
+        )
+
+        assert candidates == [main_metric]
+
+    def test_get_candidate_metrics_for_rule_all_artifacts_sorted(self) -> None:
+        watch_b = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch.b",
+        )
+        dynamic_a = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE,
+            identifier="dynamic.a",
+        )
+        main = self._create_metric(PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT)
+        watch_a = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="watch.a",
+        )
+
+        rule = StatusCheckRule(
+            id="rule-all",
+            metric="install_size",
+            measurement="absolute",
+            value=1000,
+            artifact_type=RuleArtifactType.ALL_ARTIFACTS,
+        )
+
+        candidates = _get_candidate_metrics_for_rule(rule, [watch_b, dynamic_a, main, watch_a])
+
+        assert candidates == [main, watch_a, watch_b, dynamic_a]
+
+    def test_get_matching_base_metric_matches_type_and_identifier(self) -> None:
+        base_main = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
+        )
+        base_watch = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watch",
+        )
+        candidate = PreprodArtifactSizeMetrics(
+            preprod_artifact=self.artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=0,
+            max_download_size=0,
+            min_install_size=0,
+            max_install_size=0,
+        )
+
+        matched = _get_matching_base_metric([base_main, base_watch], candidate)
+
+        assert matched == base_watch
+
+    def test_get_matching_base_metric_returns_none_when_identifier_differs(self) -> None:
+        base_watch = self._create_metric(
+            PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watch",
+        )
+        candidate = PreprodArtifactSizeMetrics(
+            preprod_artifact=self.artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watch.v2",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=0,
+            max_download_size=0,
+            min_install_size=0,
+            max_install_size=0,
+        )
+
+        matched = _get_matching_base_metric([base_watch], candidate)
+
+        assert matched is None

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -331,7 +331,8 @@ class StatusCheckFiltersTest(TestCase):
         self.project.update_option(
             "sentry:preprod_size_status_checks_rules",
             '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", '
-            '"value": 100, "filterQuery": "build_configuration_name:Debug"}]',
+            '"value": 100, "filterQuery": "build_configuration_name:Debug", '
+            '"artifactType": "watch_artifact"}]',
         )
 
         rules = _get_status_check_rules(self.project)
@@ -342,6 +343,19 @@ class StatusCheckFiltersTest(TestCase):
         assert rules[0].measurement == "absolute"
         assert rules[0].value == 100
         assert rules[0].filter_query == "build_configuration_name:Debug"
+        assert rules[0].artifact_type == "watch_artifact"
+
+    def test_parse_rules_defaults_missing_artifact_type_to_main(self):
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_rules",
+            '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", '
+            '"value": 100}]',
+        )
+
+        rules = _get_status_check_rules(self.project)
+
+        assert len(rules) == 1
+        assert rules[0].artifact_type == "main_artifact"
 
     def test_evaluate_absolute_diff_threshold_exceeds(self):
         head_artifact = self.create_preprod_artifact(
@@ -789,6 +803,181 @@ class StatusCheckFiltersTest(TestCase):
         )
         assert status == StatusCheckStatus.SUCCESS
         assert triggered_rules == []
+
+    def test_rules_evaluate_watch_artifact_when_explicitly_selected(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=150 * 1024 * 1024,
+            identifier="com.example.app.watchapp",
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="",
+            artifact_type="watch_artifact",
+        )
+
+        status, triggered_rules = _compute_overall_status(
+            [artifact], size_metrics_map, rules=[rule]
+        )
+        assert status == StatusCheckStatus.FAILURE
+        assert len(triggered_rules) == 1
+        assert (
+            triggered_rules[0].metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT
+        )
+
+    def test_rules_with_missing_targeted_artifact_type_do_not_fail(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=150 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="",
+            artifact_type="watch_artifact",
+        )
+
+        status, triggered_rules = _compute_overall_status(
+            [artifact], size_metrics_map, rules=[rule]
+        )
+        assert status == StatusCheckStatus.SUCCESS
+        assert triggered_rules == []
+
+    def test_rules_evaluate_all_artifacts_when_all_selected(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            commit_comparison=self.commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=50 * 1024 * 1024,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=150 * 1024 * 1024,
+            identifier="com.example.app.watchapp",
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="",
+            artifact_type="all_artifacts",
+        )
+
+        status, triggered_rules = _compute_overall_status(
+            [artifact], size_metrics_map, rules=[rule]
+        )
+        assert status == StatusCheckStatus.FAILURE
+        assert len(triggered_rules) == 1
+        assert (
+            triggered_rules[0].metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT
+        )
+
+    def test_rules_evaluate_dynamic_feature_by_identifier(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+            commit_comparison=self.commit_comparison,
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=90 * 1024 * 1024,
+            identifier="feature.a",
+        )
+
+        PreprodArtifactSizeMetrics.objects.create(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=140 * 1024 * 1024,
+            identifier="feature.b",
+        )
+
+        size_metrics_map = {
+            artifact.id: list(PreprodArtifactSizeMetrics.objects.filter(preprod_artifact=artifact))
+        }
+
+        rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="",
+            artifact_type="android_dynamic_feature_artifact",
+        )
+
+        status, triggered_rules = _compute_overall_status(
+            [artifact], size_metrics_map, rules=[rule]
+        )
+
+        assert status == StatusCheckStatus.FAILURE
+        assert len(triggered_rules) == 1
+        assert (
+            triggered_rules[0].metrics_artifact_type
+            == PreprodArtifactSizeMetrics.MetricsArtifactType.ANDROID_DYNAMIC_FEATURE
+        )
+        assert triggered_rules[0].identifier == "feature.b"
 
     def test_filters_on_missing_fields_do_not_match(self):
         artifact_no_build_config = PreprodArtifact.objects.create(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -348,8 +348,7 @@ class StatusCheckFiltersTest(TestCase):
     def test_parse_rules_defaults_missing_artifact_type_to_main(self):
         self.project.update_option(
             "sentry:preprod_size_status_checks_rules",
-            '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", '
-            '"value": 100}]',
+            '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100}]',
         )
 
         rules = _get_status_check_rules(self.project)

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -15,7 +15,7 @@ from sentry.preprod.vcs.status_checks.size.tasks import (
     _get_status_check_rules,
     _rule_matches_artifact,
 )
-from sentry.preprod.vcs.status_checks.size.types import StatusCheckRule
+from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -836,7 +836,7 @@ class StatusCheckFiltersTest(TestCase):
             measurement="absolute",
             value=100 * 1024 * 1024,
             filter_query="",
-            artifact_type="watch_artifact",
+            artifact_type=RuleArtifactType.WATCH_ARTIFACT,
         )
 
         status, triggered_rules = _compute_overall_status(
@@ -874,7 +874,7 @@ class StatusCheckFiltersTest(TestCase):
             measurement="absolute",
             value=100 * 1024 * 1024,
             filter_query="",
-            artifact_type="watch_artifact",
+            artifact_type=RuleArtifactType.WATCH_ARTIFACT,
         )
 
         status, triggered_rules = _compute_overall_status(
@@ -916,7 +916,7 @@ class StatusCheckFiltersTest(TestCase):
             measurement="absolute",
             value=100 * 1024 * 1024,
             filter_query="",
-            artifact_type="all_artifacts",
+            artifact_type=RuleArtifactType.ALL_ARTIFACTS,
         )
 
         status, triggered_rules = _compute_overall_status(
@@ -963,7 +963,7 @@ class StatusCheckFiltersTest(TestCase):
             measurement="absolute",
             value=100 * 1024 * 1024,
             filter_query="",
-            artifact_type="android_dynamic_feature_artifact",
+            artifact_type=RuleArtifactType.ANDROID_DYNAMIC_FEATURE_ARTIFACT,
         )
 
         status, triggered_rules = _compute_overall_status(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -1292,6 +1292,55 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert subtitle == ""
         assert summary == expected
 
+    def test_triggered_rule_includes_artifact_type_details(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+
+        watch_metrics = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watchapp",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=100 * 1024 * 1024,
+            max_download_size=100 * 1024 * 1024,
+            min_install_size=200 * 1024 * 1024,
+            max_install_size=200 * 1024 * 1024,
+        )
+
+        size_metrics_map = {artifact.id: [watch_metrics]}
+
+        triggered_rule = TriggeredRule(
+            rule=StatusCheckRule(
+                id="rule-1",
+                metric="download_size",
+                measurement="absolute",
+                value=50 * 1024 * 1024,
+            ),
+            artifact_id=artifact.id,
+            app_id="com.example.app",
+            platform="iOS",
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app.watchapp",
+        )
+
+        _, _, summary = format_status_check_messages(
+            [artifact],
+            size_metrics_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+            {},
+            triggered_rules=[triggered_rule],
+        )
+
+        assert "— Watch App" in summary
+
     def test_multiple_triggered_rules_url_formatting(self):
         """Test that multiple triggered rules format the URL correctly with expanded params."""
         artifact = self.create_preprod_artifact(
@@ -1365,7 +1414,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-download-absolute&expanded=rule-install-diff&expanded=rule-download-percent"
 
         expected = f"""\
-## ❌ 1 Failed Size Check
+## ❌ 3 Failed Size Checks
 
 ### Android Builds
 


### PR DESCRIPTION
Add artifact-type filtering support to preprod size status checks.

Previously rules were effectively evaluated only against main-app metrics. This change introduces explicit rule artifact types and applies them during status check evaluation, so rules can target Main App, Watch App, Android Dynamic Feature, or All artifacts.

Key changes:
- Parse and normalize rule artifact type via a typed enum.
- Preserve legacy behavior by defaulting missing artifact type to Main App.
- Select candidate compare metrics per rule artifact type.
- Match base metrics using both metric artifact type and identifier.
- Include triggered artifact type details in status check output.
- Count failed checks from triggered rules and dedupe expanded rule links.
- Add and expand tests for rule parsing, artifact-targeted evaluation, helper selection logic, and templates.

Refs EME-808