### PR TITLE
feat(preprod): Add artifact-type filtering controls to status rule UI

### DIFF
--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -17,6 +17,7 @@ import type {ArtifactType, StatusCheckRule} from './types';
 import {
   ARTIFACT_TYPE_OPTIONS,
   bytesToMB,
+  DEFAULT_ARTIFACT_TYPE,
   getDisplayUnit,
   getMeasurementLabel,
   getMetricLabel,
@@ -40,7 +41,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
   const [displayValue, setDisplayValue] = useState(initialDisplayValue);
   const [filterQuery, setFilterQuery] = useState(rule.filterQuery ?? '');
   const [artifactType, setArtifactType] = useState<ArtifactType>(
-    rule.artifactType ?? 'main_artifact'
+    rule.artifactType ?? DEFAULT_ARTIFACT_TYPE
   );
 
   const currentValueInBytes =
@@ -50,7 +51,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
     measurement !== rule.measurement ||
     currentValueInBytes !== rule.value ||
     filterQuery !== (rule.filterQuery ?? '') ||
-    artifactType !== (rule.artifactType ?? 'main_artifact');
+    artifactType !== (rule.artifactType ?? DEFAULT_ARTIFACT_TYPE);
 
   const handleSave = () => {
     onSave({

--- a/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleForm.tsx
@@ -13,8 +13,9 @@ import {t} from 'sentry/locale';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {SectionLabel} from './statusCheckSharedComponents';
-import type {StatusCheckRule} from './types';
+import type {ArtifactType, StatusCheckRule} from './types';
 import {
+  ARTIFACT_TYPE_OPTIONS,
   bytesToMB,
   getDisplayUnit,
   getMeasurementLabel,
@@ -38,6 +39,9 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
   const initialDisplayValue = displayUnit === '%' ? rule.value : bytesToMB(rule.value);
   const [displayValue, setDisplayValue] = useState(initialDisplayValue);
   const [filterQuery, setFilterQuery] = useState(rule.filterQuery ?? '');
+  const [artifactType, setArtifactType] = useState<ArtifactType>(
+    rule.artifactType ?? 'main_artifact'
+  );
 
   const currentValueInBytes =
     displayUnit === '%' ? displayValue : mbToBytes(displayValue);
@@ -45,7 +49,8 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
     metric !== rule.metric ||
     measurement !== rule.measurement ||
     currentValueInBytes !== rule.value ||
-    filterQuery !== (rule.filterQuery ?? '');
+    filterQuery !== (rule.filterQuery ?? '') ||
+    artifactType !== (rule.artifactType ?? 'main_artifact');
 
   const handleSave = () => {
     onSave({
@@ -54,6 +59,7 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
       measurement,
       metric,
       value: currentValueInBytes,
+      artifactType,
     });
   };
 
@@ -111,6 +117,15 @@ export function StatusCheckRuleForm({rule, onSave, onDelete}: Props) {
           <Text variant="muted">{displayUnit}</Text>
         </Flex>
       </Flex>
+
+      <Stack gap="sm">
+        <SectionLabel>{t('Artifact Type')}</SectionLabel>
+        <CompactSelect
+          value={artifactType}
+          options={ARTIFACT_TYPE_OPTIONS}
+          onChange={opt => setArtifactType(opt.value)}
+        />
+      </Stack>
 
       <Stack gap="sm">
         <SectionLabel>{t('For')}</SectionLabel>

--- a/static/app/views/settings/project/preprod/statusCheckRuleItem.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRuleItem.tsx
@@ -14,7 +14,13 @@ import {space} from 'sentry/styles/space';
 
 import {StatusCheckRuleForm} from './statusCheckRuleForm';
 import type {StatusCheckFilter, StatusCheckRule} from './types';
-import {bytesToMB, getDisplayUnit, getMeasurementLabel, getMetricLabel} from './types';
+import {
+  bytesToMB,
+  getArtifactTypeLabel,
+  getDisplayUnit,
+  getMeasurementLabel,
+  getMetricLabel,
+} from './types';
 
 interface Props {
   isExpanded: boolean;
@@ -66,7 +72,7 @@ export function StatusCheckRuleItem({
   const displayUnit = getDisplayUnit(rule.measurement);
   const displayValue = displayUnit === '%' ? rule.value : bytesToMB(rule.value);
   const valueWithUnit = `${displayValue} ${displayUnit}`;
-  const title = `${getMetricLabel(rule.metric)} • ${getMeasurementLabel(rule.measurement)} • ${valueWithUnit}`;
+  const title = `${getMetricLabel(rule.metric)} • ${getMeasurementLabel(rule.measurement)} • ${getArtifactTypeLabel(rule.artifactType)} • ${valueWithUnit}`;
 
   return (
     <ItemContainer>

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -1,4 +1,6 @@
-type MetricType = 'install_size' | 'download_size';
+export const ALL_METRIC_TYPES = ['install_size', 'download_size'] as const;
+
+type MetricType = (typeof ALL_METRIC_TYPES)[number];
 
 export const ALL_MEASUREMENT_TYPES = [
   'absolute',
@@ -35,10 +37,18 @@ export interface StatusCheckRule {
   filterQuery?: string;
 }
 
-export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> = [
-  {label: 'Install/Uncompressed Size', value: 'install_size'},
-  {label: 'Download Size', value: 'download_size'},
-];
+export const DEFAULT_METRIC_TYPE: MetricType = 'install_size';
+
+export const METRIC_LABELS: Record<MetricType, string> = {
+  install_size: 'Install/Uncompressed Size',
+  download_size: 'Download Size',
+};
+
+export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> =
+  ALL_METRIC_TYPES.map(value => ({
+    label: METRIC_LABELS[value],
+    value,
+  }));
 
 export const DEFAULT_MEASUREMENT_TYPE: MeasurementType = 'absolute';
 
@@ -68,7 +78,7 @@ export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> 
   }));
 
 export function getMetricLabel(metric: MetricType): string {
-  return METRIC_OPTIONS.find(o => o.value === metric)?.label ?? metric;
+  return METRIC_LABELS[toMetricType(metric)];
 }
 
 export function getMeasurementLabel(measurement: MeasurementType): string {
@@ -81,6 +91,13 @@ export function getSafeValue<T>(
   fallback: T
 ): T {
   return validOptions.includes(value as T) ? (value as T) : fallback;
+}
+
+export function toMetricType(
+  value: unknown,
+  fallback: MetricType = DEFAULT_METRIC_TYPE
+): MetricType {
+  return getSafeValue(value, ALL_METRIC_TYPES, fallback);
 }
 
 export function toMeasurementType(

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -2,11 +2,17 @@ type MetricType = 'install_size' | 'download_size';
 
 type MeasurementType = 'absolute' | 'absolute_diff' | 'relative_diff';
 
-export type ArtifactType =
-  | 'main_artifact'
-  | 'watch_artifact'
-  | 'android_dynamic_feature_artifact'
-  | 'all_artifacts';
+export const ALL_ARTIFACT_TYPES = [
+  'all_artifacts',
+  'main_artifact',
+  'watch_artifact',
+  'android_dynamic_feature_artifact',
+] as const;
+
+export type ArtifactType = (typeof ALL_ARTIFACT_TYPES)[number];
+
+export const DEFAULT_ARTIFACT_TYPE: ArtifactType = 'main_artifact';
+export const ALL_ARTIFACTS_ARTIFACT_TYPE: ArtifactType = 'all_artifacts';
 
 export interface StatusCheckFilter {
   key: string;
@@ -34,12 +40,18 @@ export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}>
   {label: 'Relative Diff', value: 'relative_diff'},
 ];
 
-export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> = [
-  {label: 'All Artifact Types', value: 'all_artifacts'},
-  {label: 'Main App', value: 'main_artifact'},
-  {label: 'Watch App', value: 'watch_artifact'},
-  {label: 'Android Dynamic Feature', value: 'android_dynamic_feature_artifact'},
-];
+export const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
+  all_artifacts: 'All Artifact Types',
+  main_artifact: 'Main App',
+  watch_artifact: 'Watch App',
+  android_dynamic_feature_artifact: 'Android Dynamic Feature',
+};
+
+export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> =
+  ALL_ARTIFACT_TYPES.map(value => ({
+    label: ARTIFACT_TYPE_LABELS[value],
+    value,
+  }));
 
 export function getMetricLabel(metric: MetricType): string {
   return METRIC_OPTIONS.find(o => o.value === metric)?.label ?? metric;
@@ -49,11 +61,23 @@ export function getMeasurementLabel(measurement: MeasurementType): string {
   return MEASUREMENT_OPTIONS.find(o => o.value === measurement)?.label ?? measurement;
 }
 
+export function getSafeValue<T>(
+  value: unknown,
+  validOptions: readonly T[],
+  fallback: T
+): T {
+  return validOptions.includes(value as T) ? (value as T) : fallback;
+}
+
+export function toArtifactType(
+  value: unknown,
+  fallback: ArtifactType = DEFAULT_ARTIFACT_TYPE
+): ArtifactType {
+  return getSafeValue(value, ALL_ARTIFACT_TYPES, fallback);
+}
+
 export function getArtifactTypeLabel(artifactType: ArtifactType | undefined): string {
-  return (
-    ARTIFACT_TYPE_OPTIONS.find(option => option.value === artifactType)?.label ??
-    'Main App'
-  );
+  return ARTIFACT_TYPE_LABELS[toArtifactType(artifactType)];
 }
 
 export function getDisplayUnit(measurement: MeasurementType): string {

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -78,11 +78,11 @@ export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> 
   }));
 
 export function getMetricLabel(metric: MetricType): string {
-  return METRIC_LABELS[toMetricType(metric)];
+  return METRIC_LABELS[metric];
 }
 
 export function getMeasurementLabel(measurement: MeasurementType): string {
-  return MEASUREMENT_LABELS[toMeasurementType(measurement)];
+  return MEASUREMENT_LABELS[measurement];
 }
 
 export function getSafeValue<T>(
@@ -115,7 +115,7 @@ export function toArtifactType(
 }
 
 export function getArtifactTypeLabel(artifactType: ArtifactType | undefined): string {
-  return ARTIFACT_TYPE_LABELS[toArtifactType(artifactType)];
+  return ARTIFACT_TYPE_LABELS[artifactType ?? DEFAULT_ARTIFACT_TYPE];
 }
 
 export function getDisplayUnit(measurement: MeasurementType): string {

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -1,6 +1,12 @@
 type MetricType = 'install_size' | 'download_size';
 
-type MeasurementType = 'absolute' | 'absolute_diff' | 'relative_diff';
+export const ALL_MEASUREMENT_TYPES = [
+  'absolute',
+  'absolute_diff',
+  'relative_diff',
+] as const;
+
+type MeasurementType = (typeof ALL_MEASUREMENT_TYPES)[number];
 
 export const ALL_ARTIFACT_TYPES = [
   'all_artifacts',
@@ -34,11 +40,19 @@ export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> = [
   {label: 'Download Size', value: 'download_size'},
 ];
 
-export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}> = [
-  {label: 'Absolute Size', value: 'absolute'},
-  {label: 'Absolute Diff', value: 'absolute_diff'},
-  {label: 'Relative Diff', value: 'relative_diff'},
-];
+export const DEFAULT_MEASUREMENT_TYPE: MeasurementType = 'absolute';
+
+export const MEASUREMENT_LABELS: Record<MeasurementType, string> = {
+  absolute: 'Absolute Size',
+  absolute_diff: 'Absolute Diff',
+  relative_diff: 'Relative Diff',
+};
+
+export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}> =
+  ALL_MEASUREMENT_TYPES.map(value => ({
+    label: MEASUREMENT_LABELS[value],
+    value,
+  }));
 
 export const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
   all_artifacts: 'All Artifact Types',
@@ -58,7 +72,7 @@ export function getMetricLabel(metric: MetricType): string {
 }
 
 export function getMeasurementLabel(measurement: MeasurementType): string {
-  return MEASUREMENT_OPTIONS.find(o => o.value === measurement)?.label ?? measurement;
+  return MEASUREMENT_LABELS[toMeasurementType(measurement)];
 }
 
 export function getSafeValue<T>(
@@ -67,6 +81,13 @@ export function getSafeValue<T>(
   fallback: T
 ): T {
   return validOptions.includes(value as T) ? (value as T) : fallback;
+}
+
+export function toMeasurementType(
+  value: unknown,
+  fallback: MeasurementType = DEFAULT_MEASUREMENT_TYPE
+): MeasurementType {
+  return getSafeValue(value, ALL_MEASUREMENT_TYPES, fallback);
 }
 
 export function toArtifactType(

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -2,6 +2,12 @@ type MetricType = 'install_size' | 'download_size';
 
 type MeasurementType = 'absolute' | 'absolute_diff' | 'relative_diff';
 
+export type ArtifactType =
+  | 'main_artifact'
+  | 'watch_artifact'
+  | 'android_dynamic_feature_artifact'
+  | 'all_artifacts';
+
 export interface StatusCheckFilter {
   key: string;
   value: string;
@@ -13,6 +19,7 @@ export interface StatusCheckRule {
   measurement: MeasurementType;
   metric: MetricType;
   value: number;
+  artifactType?: ArtifactType;
   filterQuery?: string;
 }
 
@@ -27,12 +34,26 @@ export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}>
   {label: 'Relative Diff', value: 'relative_diff'},
 ];
 
+export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> = [
+  {label: 'All Artifact Types', value: 'all_artifacts'},
+  {label: 'Main App', value: 'main_artifact'},
+  {label: 'Watch App', value: 'watch_artifact'},
+  {label: 'Android Dynamic Feature', value: 'android_dynamic_feature_artifact'},
+];
+
 export function getMetricLabel(metric: MetricType): string {
   return METRIC_OPTIONS.find(o => o.value === metric)?.label ?? metric;
 }
 
 export function getMeasurementLabel(measurement: MeasurementType): string {
   return MEASUREMENT_OPTIONS.find(o => o.value === measurement)?.label ?? measurement;
+}
+
+export function getArtifactTypeLabel(artifactType: ArtifactType | undefined): string {
+  return (
+    ARTIFACT_TYPE_OPTIONS.find(option => option.value === artifactType)?.label ??
+    'Main App'
+  );
 }
 
 export function getDisplayUnit(measurement: MeasurementType): string {

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -1,12 +1,8 @@
-export const ALL_METRIC_TYPES = ['install_size', 'download_size'] as const;
+const ALL_METRIC_TYPES = ['install_size', 'download_size'] as const;
 
 type MetricType = (typeof ALL_METRIC_TYPES)[number];
 
-export const ALL_MEASUREMENT_TYPES = [
-  'absolute',
-  'absolute_diff',
-  'relative_diff',
-] as const;
+const ALL_MEASUREMENT_TYPES = ['absolute', 'absolute_diff', 'relative_diff'] as const;
 
 type MeasurementType = (typeof ALL_MEASUREMENT_TYPES)[number];
 
@@ -39,7 +35,7 @@ export interface StatusCheckRule {
 
 export const DEFAULT_METRIC_TYPE: MetricType = 'install_size';
 
-export const METRIC_LABELS: Record<MetricType, string> = {
+const METRIC_LABELS: Record<MetricType, string> = {
   install_size: 'Install/Uncompressed Size',
   download_size: 'Download Size',
 };
@@ -52,7 +48,7 @@ export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> =
 
 export const DEFAULT_MEASUREMENT_TYPE: MeasurementType = 'absolute';
 
-export const MEASUREMENT_LABELS: Record<MeasurementType, string> = {
+const MEASUREMENT_LABELS: Record<MeasurementType, string> = {
   absolute: 'Absolute Size',
   absolute_diff: 'Absolute Diff',
   relative_diff: 'Relative Diff',
@@ -64,7 +60,7 @@ export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}>
     value,
   }));
 
-export const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
+const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
   all_artifacts: 'All Artifact Types',
   main_artifact: 'Main App',
   watch_artifact: 'Watch App',
@@ -85,11 +81,7 @@ export function getMeasurementLabel(measurement: MeasurementType): string {
   return MEASUREMENT_LABELS[measurement];
 }
 
-export function getSafeValue<T>(
-  value: unknown,
-  validOptions: readonly T[],
-  fallback: T
-): T {
+function getSafeValue<T>(value: unknown, validOptions: readonly T[], fallback: T): T {
   return validOptions.includes(value as T) ? (value as T) : fallback;
 }
 

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -13,20 +13,18 @@ import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {
   ALL_ARTIFACTS_ARTIFACT_TYPE,
   DEFAULT_MEASUREMENT_TYPE,
-  getSafeValue,
-  METRIC_OPTIONS,
+  DEFAULT_METRIC_TYPE,
   toArtifactType,
   toMeasurementType,
+  toMetricType,
   type StatusCheckRule,
 } from './types';
 
 const ENABLED_KEY = 'sentry:preprod_size_status_checks_enabled';
 const RULES_KEY = 'sentry:preprod_size_status_checks_rules';
 
-const DEFAULT_METRIC = METRIC_OPTIONS[0]!.value;
+const DEFAULT_METRIC = DEFAULT_METRIC_TYPE;
 const DEFAULT_MEASUREMENT = DEFAULT_MEASUREMENT_TYPE;
-
-const VALID_METRICS: Array<StatusCheckRule['metric']> = METRIC_OPTIONS.map(o => o.value);
 
 function parseRules(raw: unknown): StatusCheckRule[] {
   if (!Array.isArray(raw)) {
@@ -35,7 +33,7 @@ function parseRules(raw: unknown): StatusCheckRule[] {
   return raw
     .filter((r): r is Record<string, unknown> => !!r && typeof r.id === 'string')
     .map(r => {
-      const metric = getSafeValue(r.metric, VALID_METRICS, DEFAULT_METRIC);
+      const metric = toMetricType(r.metric, DEFAULT_METRIC);
       const measurement = toMeasurementType(r.measurement, DEFAULT_MEASUREMENT);
       const artifactType = toArtifactType(r.artifactType);
       return {

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -10,7 +10,13 @@ import type {Project} from 'sentry/types/project';
 import {uniqueId} from 'sentry/utils/guid';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
-import {MEASUREMENT_OPTIONS, METRIC_OPTIONS, type StatusCheckRule} from './types';
+import {
+  ARTIFACT_TYPE_OPTIONS,
+  MEASUREMENT_OPTIONS,
+  METRIC_OPTIONS,
+  type ArtifactType,
+  type StatusCheckRule,
+} from './types';
 
 const ENABLED_KEY = 'sentry:preprod_size_status_checks_enabled';
 const RULES_KEY = 'sentry:preprod_size_status_checks_rules';
@@ -20,6 +26,7 @@ const DEFAULT_MEASUREMENT = MEASUREMENT_OPTIONS[0]!.value;
 
 const VALID_METRICS: string[] = METRIC_OPTIONS.map(o => o.value);
 const VALID_MEASUREMENTS: string[] = MEASUREMENT_OPTIONS.map(o => o.value);
+const VALID_ARTIFACT_TYPES: string[] = ARTIFACT_TYPE_OPTIONS.map(o => o.value);
 
 function parseRules(raw: unknown): StatusCheckRule[] {
   if (!Array.isArray(raw)) {
@@ -34,12 +41,16 @@ function parseRules(raw: unknown): StatusCheckRule[] {
       const measurement = VALID_MEASUREMENTS.includes(r.measurement as string)
         ? (r.measurement as StatusCheckRule['measurement'])
         : DEFAULT_MEASUREMENT;
+      const artifactType = VALID_ARTIFACT_TYPES.includes(r.artifactType as string)
+        ? (r.artifactType as ArtifactType)
+        : 'main_artifact';
       return {
         id: r.id as string,
         metric,
         measurement,
         value: typeof r.value === 'number' ? r.value : 0,
         filterQuery: typeof r.filterQuery === 'string' ? r.filterQuery : '',
+        artifactType,
       };
     });
 }
@@ -138,6 +149,7 @@ export function useStatusCheckRules(project: Project) {
       measurement: DEFAULT_MEASUREMENT,
       value: 0,
       filterQuery: '',
+      artifactType: 'all_artifacts',
     };
   }, []);
 

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -12,10 +12,11 @@ import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
 import {
   ALL_ARTIFACTS_ARTIFACT_TYPE,
+  DEFAULT_MEASUREMENT_TYPE,
   getSafeValue,
-  MEASUREMENT_OPTIONS,
   METRIC_OPTIONS,
   toArtifactType,
+  toMeasurementType,
   type StatusCheckRule,
 } from './types';
 
@@ -23,12 +24,9 @@ const ENABLED_KEY = 'sentry:preprod_size_status_checks_enabled';
 const RULES_KEY = 'sentry:preprod_size_status_checks_rules';
 
 const DEFAULT_METRIC = METRIC_OPTIONS[0]!.value;
-const DEFAULT_MEASUREMENT = MEASUREMENT_OPTIONS[0]!.value;
+const DEFAULT_MEASUREMENT = DEFAULT_MEASUREMENT_TYPE;
 
 const VALID_METRICS: Array<StatusCheckRule['metric']> = METRIC_OPTIONS.map(o => o.value);
-const VALID_MEASUREMENTS: Array<StatusCheckRule['measurement']> = MEASUREMENT_OPTIONS.map(
-  o => o.value
-);
 
 function parseRules(raw: unknown): StatusCheckRule[] {
   if (!Array.isArray(raw)) {
@@ -38,11 +36,7 @@ function parseRules(raw: unknown): StatusCheckRule[] {
     .filter((r): r is Record<string, unknown> => !!r && typeof r.id === 'string')
     .map(r => {
       const metric = getSafeValue(r.metric, VALID_METRICS, DEFAULT_METRIC);
-      const measurement = getSafeValue(
-        r.measurement,
-        VALID_MEASUREMENTS,
-        DEFAULT_MEASUREMENT
-      );
+      const measurement = toMeasurementType(r.measurement, DEFAULT_MEASUREMENT);
       const artifactType = toArtifactType(r.artifactType);
       return {
         id: r.id as string,

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -11,10 +11,11 @@ import {uniqueId} from 'sentry/utils/guid';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
 import {
-  ARTIFACT_TYPE_OPTIONS,
+  ALL_ARTIFACTS_ARTIFACT_TYPE,
+  getSafeValue,
   MEASUREMENT_OPTIONS,
   METRIC_OPTIONS,
-  type ArtifactType,
+  toArtifactType,
   type StatusCheckRule,
 } from './types';
 
@@ -24,9 +25,10 @@ const RULES_KEY = 'sentry:preprod_size_status_checks_rules';
 const DEFAULT_METRIC = METRIC_OPTIONS[0]!.value;
 const DEFAULT_MEASUREMENT = MEASUREMENT_OPTIONS[0]!.value;
 
-const VALID_METRICS: string[] = METRIC_OPTIONS.map(o => o.value);
-const VALID_MEASUREMENTS: string[] = MEASUREMENT_OPTIONS.map(o => o.value);
-const VALID_ARTIFACT_TYPES: string[] = ARTIFACT_TYPE_OPTIONS.map(o => o.value);
+const VALID_METRICS: Array<StatusCheckRule['metric']> = METRIC_OPTIONS.map(o => o.value);
+const VALID_MEASUREMENTS: Array<StatusCheckRule['measurement']> = MEASUREMENT_OPTIONS.map(
+  o => o.value
+);
 
 function parseRules(raw: unknown): StatusCheckRule[] {
   if (!Array.isArray(raw)) {
@@ -35,15 +37,13 @@ function parseRules(raw: unknown): StatusCheckRule[] {
   return raw
     .filter((r): r is Record<string, unknown> => !!r && typeof r.id === 'string')
     .map(r => {
-      const metric = VALID_METRICS.includes(r.metric as string)
-        ? (r.metric as StatusCheckRule['metric'])
-        : DEFAULT_METRIC;
-      const measurement = VALID_MEASUREMENTS.includes(r.measurement as string)
-        ? (r.measurement as StatusCheckRule['measurement'])
-        : DEFAULT_MEASUREMENT;
-      const artifactType = VALID_ARTIFACT_TYPES.includes(r.artifactType as string)
-        ? (r.artifactType as ArtifactType)
-        : 'main_artifact';
+      const metric = getSafeValue(r.metric, VALID_METRICS, DEFAULT_METRIC);
+      const measurement = getSafeValue(
+        r.measurement,
+        VALID_MEASUREMENTS,
+        DEFAULT_MEASUREMENT
+      );
+      const artifactType = toArtifactType(r.artifactType);
       return {
         id: r.id as string,
         metric,
@@ -149,7 +149,7 @@ export function useStatusCheckRules(project: Project) {
       measurement: DEFAULT_MEASUREMENT,
       value: 0,
       filterQuery: '',
-      artifactType: 'all_artifacts',
+      artifactType: ALL_ARTIFACTS_ARTIFACT_TYPE,
     };
   }, []);
 


### PR DESCRIPTION
Add frontend support for artifact-type filtering in mobile build size status check rules.

This PR adds the UI and client-side rule handling needed to configure artifact targeting for status checks and aligns frontend behavior with backend rule evaluation in #108311.

Key changes:
- Add artifact type options to the rule editor (All, Main App, Watch App, Dynamic Feature).
- Move the artifact type dropdown below the Artifact Type label for consistent layout.
- Order the dropdown with All at the top.
- Default new rules to All artifacts.
- Preserve existing saved rules by reading missing artifact type as Main App.
- Update rule typing and persistence logic so `artifactType` is round-tripped correctly.

This PR remains stacked on #108311 so backend and frontend can be deployed independently.

<img width="765" height="655" alt="Screenshot 2026-02-16 at 16 18 39" src="https://github.com/user-attachments/assets/8792ab33-4bd3-4cc4-81ac-a65e2a592672" />

Refs EME-808