### PR TITLE
chore(models): Remove deprecated Group.checksum property

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1057,11 +1057,6 @@ class Group(Model):
         except KeyError:
             return None
 
-    @property
-    def checksum(self):
-        warnings.warn("Group.checksum is no longer used", DeprecationWarning)
-        return ""
-
     def get_email_subject(self) -> str:
         return f"{self.qualified_short_id} - {self.title}"
 


### PR DESCRIPTION
## Summary
- Remove the deprecated `Group.checksum` property which only emitted a `DeprecationWarning` and returned an empty string
- No callers remain in the codebase

## Test plan
- Verified no references to `Group.checksum` exist in the codebase via grep
- Pre-commit hooks pass (ruff, flake8, formatting)