### PR TITLE
chore(issue-details): Remove obsolete plugin.title fallback

### DIFF
--- a/static/app/views/issueDetails/groupSidebar.tsx
+++ b/static/app/views/issueDetails/groupSidebar.tsx
@@ -115,11 +115,10 @@ export default function GroupSidebar({
     const issues: React.ReactNode[] = [];
     (group.pluginIssues || []).forEach(plugin => {
       const issue = plugin.issue;
-      // # TODO(dcramer): remove plugin.title check in Sentry 8.22+
       if (issue) {
         issues.push(
           <Fragment key={plugin.slug}>
-            <span>{`${plugin.shortName || plugin.name || plugin.title}: `}</span>
+            <span>{`${plugin.shortName || plugin.name}: `}</span>
             <a href={issue.url}>
               {typeof issue.label === 'object' ? issue.label.id : issue.label}
             </a>


### PR DESCRIPTION
## Summary
- Remove the `plugin.title` fallback and associated TODO comment from the group sidebar
- This TODO dates back to Sentry 8.22; all plugins now provide `shortName` or `name`

## Test plan
- Pre-commit hooks (eslint, prettier, stylelint) pass
- `plugin.title` was only used as a last-resort fallback after `shortName` and `name`