### PR TITLE
chore(buffer): Remove legacy pickle deserialization from Redis buffer

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -512,11 +512,7 @@ class RedisBuffer(Buffer):
 
             model = import_string(force_str(values.pop("m")))
 
-            if values["f"].startswith(b"{" if not self.is_redis_cluster else "{"):
-                filters = self._load_values(json.loads(force_str(values.pop("f"))))
-            else:
-                # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
-                filters = pickle.loads(force_bytes(values.pop("f")))
+            filters = self._load_values(json.loads(force_str(values.pop("f"))))
 
             incr_values = {}
             extra_values = {}
@@ -525,11 +521,7 @@ class RedisBuffer(Buffer):
                 if k.startswith("i+"):
                     incr_values[k[2:]] = int(v)
                 elif k.startswith("e+"):
-                    if v.startswith(b"[" if not self.is_redis_cluster else "["):
-                        extra_values[k[2:]] = self._load_value(json.loads(force_str(v)))
-                    else:
-                        # TODO(dcramer): legacy pickle support - remove in Sentry 9.1
-                        extra_values[k[2:]] = pickle.loads(force_bytes(v))
+                    extra_values[k[2:]] = self._load_value(json.loads(force_str(v)))
                 elif k == "s":
                     signal_only = bool(int(v))  # Should be 1 if set
 


### PR DESCRIPTION
## Summary
- Remove two dead `else` branches in `RedisBuffer.process` that deserialized pickle-encoded data
- These were marked for removal in Sentry 9.1; Sentry is now at 24+
- The write path already uses JSON; this removes the obsolete read-side fallbacks

## Test plan
- Verified `pickle.loads` no longer appears in the file (`pickle.dumps` still used for writes)
- All imports remain used
- Pre-commit hooks pass