### PR TITLE
chore(gsAdmin): Remove stale React 18 upgrade TODO comments

### DIFF
--- a/static/gsAdmin/components/editAdminOptionModal.tsx
+++ b/static/gsAdmin/components/editAdminOptionModal.tsx
@@ -73,5 +73,4 @@ function EditOption({option}: {option: SerializedOption}) {
   );
 }
 
-// TODO(TS): Type cast added as part of react 18 upgrade, can remove after?
 export default EditAdminOptionModal;

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -619,7 +619,4 @@ const ErrorAlert = styled(Alert)`
   margin-bottom: ${space(1.5)};
 `;
 
-export default withApi(
-  // TODO(TS): Type cast added as part of react 18 upgrade, can remove after?
-  withSentryRouter(ResultGrid)
-);
+export default withApi(withSentryRouter(ResultGrid));


### PR DESCRIPTION
## Summary
- Remove two stale TODO comments from the React 18 upgrade in `editAdminOptionModal.tsx` and `resultGrid.tsx`
- Sentry is now on React 19; these are no longer relevant

## Test plan
- Pre-commit hooks (eslint, prettier, stylelint) pass
- Comments only, no behavioral change