### PR TITLE
chore(integrations): Remove dead CUSTOM external provider constant

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -35,7 +35,6 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.MSTEAMS,
     ExternalProviders.JIRA_SERVER,
     ExternalProviders.PERFORCE,
-    ExternalProviders.CUSTOM,
 }
 
 STRICT_NAME_PROVIDERS = {

--- a/src/sentry/integrations/models/external_actor.py
+++ b/src/sentry/integrations/models/external_actor.py
@@ -42,12 +42,10 @@ class ExternalActor(ReplicatedRegionModel):
             (ExternalProviders.GITLAB, IntegrationProviderSlug.GITLAB.value),
             (ExternalProviders.JIRA_SERVER, IntegrationProviderSlug.JIRA_SERVER.value),
             (ExternalProviders.PERFORCE, IntegrationProviderSlug.PERFORCE.value),
-            # TODO: do migration to delete this from database
-            (ExternalProviders.CUSTOM, "custom_scm"),
         ),
     )
     # The display name i.e. username, team name, channel name.
-    # if provider__in = [GITHUB, GITHUB_ENTERPRISE, GITLAB, CUSTOM], external_name starts with "@"
+    # if provider__in = [GITHUB, GITHUB_ENTERPRISE, GITLAB], external_name starts with "@"
     external_name = models.TextField()
     # The unique identifier i.e user ID, channel ID.
     external_id = models.TextField(null=True)

--- a/src/sentry/integrations/types.py
+++ b/src/sentry/integrations/types.py
@@ -21,9 +21,6 @@ class ExternalProviders(ValueEqualityEnum):
     JIRA_SERVER = 300
     PERFORCE = 400
 
-    # TODO: do migration to delete this from database
-    CUSTOM = 700
-
     @property
     def name(self) -> str:
         return EXTERNAL_PROVIDERS.get(ExternalProviders(self.value), "")
@@ -54,7 +51,6 @@ class DataForwarderProviderSlug(StrEnum):
 
 class ExternalProviderEnum(StrEnum):
     EMAIL = "email"
-    CUSTOM = "custom_scm"
     SLACK = IntegrationProviderSlug.SLACK
     MSTEAMS = IntegrationProviderSlug.MSTEAMS
     PAGERDUTY = IntegrationProviderSlug.PAGERDUTY
@@ -78,7 +74,6 @@ EXTERNAL_PROVIDERS_REVERSE = {
     ExternalProviderEnum.GITHUB_ENTERPRISE: ExternalProviders.GITHUB_ENTERPRISE,
     ExternalProviderEnum.GITLAB: ExternalProviders.GITLAB,
     ExternalProviderEnum.PERFORCE: ExternalProviders.PERFORCE,
-    ExternalProviderEnum.CUSTOM: ExternalProviders.CUSTOM,
 }
 
 EXTERNAL_PROVIDERS_REVERSE_VALUES = {k.value: v for k, v in EXTERNAL_PROVIDERS_REVERSE.items()}
@@ -95,7 +90,6 @@ EXTERNAL_PROVIDERS = {
     ExternalProviders.GITLAB: ExternalProviderEnum.GITLAB.value,
     ExternalProviders.JIRA_SERVER: ExternalProviderEnum.JIRA_SERVER.value,
     ExternalProviders.PERFORCE: ExternalProviderEnum.PERFORCE.value,
-    ExternalProviders.CUSTOM: ExternalProviderEnum.CUSTOM.value,
 }
 
 PERSONAL_NOTIFICATION_PROVIDERS = [


### PR DESCRIPTION
## Summary
- Remove `ExternalProviders.CUSTOM` (value 700) and `ExternalProviderEnum.CUSTOM` ("custom_scm")
- Remove all references from provider mappings, model choices, and `AVAILABLE_PROVIDERS`
- These had a TODO to run a database migration to clean up; the constant itself is dead code

## Test plan
- Verified no remaining code references to `ExternalProviders.CUSTOM` or `ExternalProviderEnum.CUSTOM`
- Pre-commit hooks pass