### PR TITLE
chore(signals): Remove deprecated event_received

### DIFF
--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -97,8 +97,7 @@ org_setup_complete = BetterSignal()  # ["organization", "user"]
 # transactions through post processing
 transaction_processed = BetterSignal()  # ["project", "event"]
 
-# DEPRECATED
-event_received = BetterSignal()  # ["ip", "project"]
+# Used in getsentry/getsentry to power live.sentry.io
 event_accepted = BetterSignal()  # ["ip", "data", "project"]
 
 # Organization Onboarding Signals


### PR DESCRIPTION
## Summary
- Remove the `event_received` signal which was marked `DEPRECATED` with no receivers or senders
- Have to keep the `event_accepted` signal which is used by getsentry/getsentry to power live.sentry.io