### PR TITLE
ref(pagefilters) align checkbox

### DIFF
--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -120,6 +120,7 @@ const StyledContentWrap = styled('div')<{
   display: flex;
   gap: ${p => p.theme.space.md};
   justify-content: space-between;
+  align-items: center;
   padding: 0;
 `;
 

--- a/static/app/components/pageFilters/hybridFilter.tsx
+++ b/static/app/components/pageFilters/hybridFilter.tsx
@@ -204,6 +204,7 @@ export function HybridFilter<Value extends SelectKey>({
             gap="md"
             align="center"
             flow="column"
+            height="100%"
             onKeyDown={e => e.stopPropagation()}
             onPointerDown={e => e.stopPropagation()}
             onClick={e => e.stopPropagation()}
@@ -222,6 +223,7 @@ export function HybridFilter<Value extends SelectKey>({
             gap="md"
             align="center"
             flow="column"
+            height="100%"
             onKeyDown={e => e.stopPropagation()}
             onPointerDown={e => e.stopPropagation()}
             onClick={e => e.stopPropagation()}

--- a/static/app/components/pageFilters/project/projectPageFilter.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.tsx
@@ -252,25 +252,29 @@ export function ProjectPageFilter({
         value: parseInt(project.id, 10),
         textValue: project.slug,
         leadingItems: ({isSelected}) => (
-          <Checkbox
-            size="sm"
-            checked={isSelected}
-            onChange={() =>
-              hybridFilterRef.current?.toggleOption?.(parseInt(project.id, 10))
-            }
-            aria-label={t('Select %s', project.slug)}
-            tabIndex={-1}
-          />
+          <Flex align="center" gap="sm" flex="1 1 100%">
+            <Checkbox
+              size="sm"
+              checked={isSelected}
+              onChange={() =>
+                hybridFilterRef.current?.toggleOption?.(parseInt(project.id, 10))
+              }
+              aria-label={t('Select %s', project.slug)}
+              tabIndex={-1}
+            />
+          </Flex>
         ),
         label: (
-          <Flex align="center" gap="sm">
+          <Flex align="center" gap="sm" flex="1 1 100%">
             <ProjectBadge project={project} avatarSize={16} hideName disableLink />
             <Text ellipsis>{project.slug}</Text>
           </Flex>
         ),
         trailingItems: (props: {isFocused: boolean}) => {
           return (
-            <Flex align="center">
+            // This is nasty, but because CompactSelect's menuListItem has a padding around the entire item and a height
+            // that is smaller than the height of an xs button, they end up being misaligned and we need to manually adjust them.
+            <Flex align="center" style={{marginTop: '-4px'}}>
               {props.isFocused ? (
                 <Fragment>
                   <LinkButton


### PR DESCRIPTION
Best effort to align pagefilters checkbox. Most visible on the env page filter

before
<img width="484" height="104" alt="CleanShot 2026-02-17 at 04 01 50@2x" src="https://github.com/user-attachments/assets/7a6aa062-d8c2-4444-bb6f-8135d6ccf7a3" />
after
<img width="640" height="86" alt="CleanShot 2026-02-17 at 04 01 59@2x" src="https://github.com/user-attachments/assets/d15968a6-08a4-47f1-881f-32d9cc39942a" />

