### PR TITLE
chore(utils): Remove deprecated domId utility

### DIFF
--- a/static/app/components/timeRangeSelector/dateRange.tsx
+++ b/static/app/components/timeRangeSelector/dateRange.tsx
@@ -20,7 +20,6 @@ import {
   isValidTime,
   setDateToTime,
 } from 'sentry/utils/dates';
-import {domId} from 'sentry/utils/domId';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 // eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
@@ -98,7 +97,8 @@ class BaseDateRange extends Component<Props, State> {
     hasEndErrors: false,
   };
 
-  private readonly utcInputId = domId('utc-picker-');
+  private readonly utcInputId =
+    'utc-picker-' + Math.random().toString(36).substring(2, 12);
 
   handleSelectDateRange = (range: Range) => {
     const {onChange} = this.props;

--- a/static/app/utils/domId.tsx
+++ b/static/app/utils/domId.tsx
@@ -1,7 +1,0 @@
-/**
- * @deprecated
- * prefer `useId` from `React` instead
- */
-export function domId(prefix: string): string {
-  return prefix + Math.random().toString(36).substring(2, 12);
-}

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -4,7 +4,6 @@ import memoize from 'lodash/memoize';
 import {duration, type Duration} from 'moment-timezone';
 
 import {defined} from 'sentry/utils';
-import {domId} from 'sentry/utils/domId';
 import type {FeedbackEvent} from 'sentry/utils/feedback/types';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import clamp from 'sentry/utils/number/clamp';
@@ -214,7 +213,7 @@ export default class ReplayReader {
     clipWindow,
     eventTimestampMs,
   }: RequiredNotNull<ReplayReaderParams>) {
-    this._cacheKey = domId('replayReader-');
+    this._cacheKey = 'replayReader-' + Math.random().toString(36).substring(2, 12);
     this._fetching = fetching;
 
     if (replayRecord.is_archived) {


### PR DESCRIPTION
## Summary
- Remove the deprecated `domId` utility (`static/app/utils/domId.tsx`)
- Inline the random ID generation at the two call sites:
  - `replayReader.tsx` (cache key)
  - `dateRange.tsx` (checkbox/label association)
- Both callers are classes where `React.useId` cannot be used, so the logic is inlined

## Test plan
- Pre-commit hooks (eslint, prettier, stylelint) pass
- No other references to `domId` exist in the codebase