### PR TITLE
fix(reprocessing): Add select_for_update() to Group queries in finish_reprocessing

### DIFF
--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -231,7 +231,7 @@ def finish_reprocessing(project_id: int, group_id: int) -> None:
     from sentry.models.groupredirect import GroupRedirect
 
     with transaction.atomic(router.db_for_write(Group)):
-        group = Group.objects.get(id=group_id)
+        group = Group.objects.select_for_update().get(id=group_id)
 
         # While we migrated all associated models at the beginning of
         # reprocessing, there is still the "reprocessing" activity that we need
@@ -243,7 +243,7 @@ def finish_reprocessing(project_id: int, group_id: int) -> None:
         new_group_id = activity.group_id = activity.data["newGroupId"]
         activity.save()
 
-        new_group = Group.objects.get(id=new_group_id)
+        new_group = Group.objects.select_for_update().get(id=new_group_id)
 
         # Remove the marker that indicates that the new group is currently being reprocessed to.
         # Thus making it re-processable.


### PR DESCRIPTION
Add `select_for_update()` to both `Group.objects.get()` calls inside the
`transaction.atomic()` block in `finish_reprocessing`.

`group` is fetched and deleted, while `new_group` is fetched, has its `data`
dict mutated, and is saved — both without row-level locks. Without
`select_for_update()`, concurrent writes to either row (e.g. a user assigning
the group, or event count updates) could be silently overwritten by the
subsequent `save()` / `delete()`.