### PR TITLE
fix(trace-waterfall): span name panel was not taking into account scroll wheel

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -210,4 +210,231 @@ describe('VirtualizedViewManger', () => {
       expect(Math.round(manager.transformXFromTimestamp(100))).toBe(-500);
     });
   });
+
+  describe('horizontal scrolling', () => {
+    describe('onWheel (timeline/span durations)', () => {
+      it('scrolls horizontally with shift + vertical wheel', () => {
+        const scheduler = new TraceScheduler();
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          scheduler,
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        const initialX = manager.view.trace_view.x;
+
+        // Simulate shift + vertical mouse wheel scroll (browser converts to horizontal)
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 50, // Browser converts shift+vertical to horizontal
+          deltaY: 0,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        let dispatchedView: {width?: number, x?: number;} | null = null;
+        scheduler.on('set trace view', view => {
+          dispatchedView = view;
+        });
+
+        manager.onWheel(wheelEvent);
+
+        expect(dispatchedView).not.toBeNull();
+        expect(dispatchedView?.x).toBeGreaterThan(initialX);
+      });
+
+      it('scrolls horizontally with trackpad horizontal swipe', () => {
+        const scheduler = new TraceScheduler();
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          scheduler,
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        const initialX = manager.view.trace_view.x;
+
+        // Simulate trackpad horizontal swipe
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 50,
+          deltaY: 0,
+          shiftKey: false,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        let dispatchedView: {width?: number, x?: number;} | null = null;
+        scheduler.on('set trace view', view => {
+          dispatchedView = view;
+        });
+
+        manager.onWheel(wheelEvent);
+
+        expect(dispatchedView).not.toBeNull();
+        expect(dispatchedView?.x).toBeGreaterThan(initialX);
+      });
+
+      it('does not scroll horizontally with vertical wheel (no shift)', () => {
+        const scheduler = new TraceScheduler();
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          scheduler,
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        // Simulate vertical mouse wheel scroll without shift
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 0,
+          deltaY: 50,
+          shiftKey: false,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        let dispatchedView: {width?: number, x?: number;} = null;
+        scheduler.on('set trace view', view => {
+          dispatchedView = view;
+        });
+
+        manager.onWheel(wheelEvent);
+
+        expect(dispatchedView).not.toBeNull();
+        expect(dispatchedView?.x).toBe(0);
+      });
+    });
+
+    describe('onSyncedScrollbarScroll (span names list)', () => {
+      it('scrolls horizontally with shift + vertical wheel', () => {
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          new TraceScheduler(),
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        // Set up scrollable content (span names wider than container)
+        manager.row_measurer.cache.set({id: 'test-node'} as any, {
+          width: 800,
+          height: 24,
+        });
+        manager.row_measurer.max = 800;
+
+        const initialTranslate = manager.columns.list.translate[0];
+
+        // Simulate shift + vertical mouse wheel scroll (browser converts to horizontal)
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 50, // Browser converts shift+vertical to horizontal
+          deltaY: 0,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        manager.onSyncedScrollbarScroll(wheelEvent);
+
+        // Should update the translate value to scroll left
+        expect(manager.columns.list.translate[0]).toBeLessThan(initialTranslate);
+      });
+
+      it('scrolls horizontally with trackpad horizontal swipe', () => {
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          new TraceScheduler(),
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        // Set up scrollable content
+        manager.row_measurer.cache.set({id: 'test-node'} as any, {
+          width: 800,
+          height: 24,
+        });
+        manager.row_measurer.max = 800;
+
+        const initialTranslate = manager.columns.list.translate[0];
+
+        // Simulate trackpad horizontal swipe
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 50,
+          deltaY: 0,
+          shiftKey: false,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        manager.onSyncedScrollbarScroll(wheelEvent);
+
+        expect(manager.columns.list.translate[0]).toBeLessThan(initialTranslate);
+      });
+
+      it('does not scroll when content fits within container', () => {
+        const manager = new VirtualizedViewManager(
+          {
+            list: {width: 0.5},
+            span_list: {width: 0.5},
+          },
+          new TraceScheduler(),
+          new TraceView(),
+          ThemeFixture()
+        );
+
+        manager.view.setTraceSpace([0, 0, 1000, 1]);
+        manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
+
+        // Content fits within container (no overflow)
+        manager.row_measurer.cache.set({id: 'test-node'} as any, {
+          width: 200,
+          height: 24,
+        });
+        manager.row_measurer.max = 200;
+
+        const initialTranslate = manager.columns.list.translate[0];
+
+        const wheelEvent = new WheelEvent('wheel', {
+          deltaX: 50,
+          deltaY: 0,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        });
+
+        manager.onSyncedScrollbarScroll(wheelEvent);
+
+        // Should not scroll when there's no overflow
+        expect(manager.columns.list.translate[0]).toBe(initialTranslate);
+      });
+    });
+  });
 });

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.spec.tsx
@@ -239,15 +239,15 @@ describe('VirtualizedViewManger', () => {
           cancelable: true,
         });
 
-        let dispatchedView: {width?: number, x?: number;} | null = null;
-        scheduler.on('set trace view', view => {
+        let dispatchedView: {width?: number; x?: number} | null = null;
+        scheduler.on('set trace view', (view: {width?: number; x?: number}) => {
           dispatchedView = view;
         });
 
         manager.onWheel(wheelEvent);
 
         expect(dispatchedView).not.toBeNull();
-        expect(dispatchedView?.x).toBeGreaterThan(initialX);
+        expect(dispatchedView!.x).toBeGreaterThan(initialX);
       });
 
       it('scrolls horizontally with trackpad horizontal swipe', () => {
@@ -276,15 +276,15 @@ describe('VirtualizedViewManger', () => {
           cancelable: true,
         });
 
-        let dispatchedView: {width?: number, x?: number;} | null = null;
-        scheduler.on('set trace view', view => {
+        let dispatchedView: {width?: number; x?: number} | null = null;
+        scheduler.on('set trace view', (view: {width?: number; x?: number}) => {
           dispatchedView = view;
         });
 
         manager.onWheel(wheelEvent);
 
         expect(dispatchedView).not.toBeNull();
-        expect(dispatchedView?.x).toBeGreaterThan(initialX);
+        expect(dispatchedView!.x).toBeGreaterThan(initialX);
       });
 
       it('does not scroll horizontally with vertical wheel (no shift)', () => {
@@ -311,15 +311,16 @@ describe('VirtualizedViewManger', () => {
           cancelable: true,
         });
 
-        let dispatchedView: {width?: number, x?: number;} = null;
-        scheduler.on('set trace view', view => {
+        let dispatchedView: {width?: number; x?: number} | null = null;
+        scheduler.on('set trace view', (view: {width?: number; x?: number}) => {
           dispatchedView = view;
         });
 
         manager.onWheel(wheelEvent);
 
+        // Should not dispatch for vertical-only scroll without shift
         expect(dispatchedView).not.toBeNull();
-        expect(dispatchedView?.x).toBe(0);
+        expect(dispatchedView!.x).toBe(0);
       });
     });
 
@@ -339,10 +340,7 @@ describe('VirtualizedViewManger', () => {
         manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
 
         // Set up scrollable content (span names wider than container)
-        manager.row_measurer.cache.set({id: 'test-node'} as any, {
-          width: 800,
-          height: 24,
-        });
+        manager.row_measurer.cache.set({id: 'test-node'} as any, 800);
         manager.row_measurer.max = 800;
 
         const initialTranslate = manager.columns.list.translate[0];
@@ -377,10 +375,7 @@ describe('VirtualizedViewManger', () => {
         manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
 
         // Set up scrollable content
-        manager.row_measurer.cache.set({id: 'test-node'} as any, {
-          width: 800,
-          height: 24,
-        });
+        manager.row_measurer.cache.set({id: 'test-node'} as any, 800);
         manager.row_measurer.max = 800;
 
         const initialTranslate = manager.columns.list.translate[0];
@@ -414,10 +409,7 @@ describe('VirtualizedViewManger', () => {
         manager.view.setTracePhysicalSpace([0, 0, 1000, 1], [0, 0, 500, 1]);
 
         // Content fits within container (no overflow)
-        manager.row_measurer.cache.set({id: 'test-node'} as any, {
-          width: 200,
-          height: 24,
-        });
+        manager.row_measurer.cache.set({id: 'test-node'} as any, 200);
         manager.row_measurer.max = 200;
 
         const initialTranslate = manager.columns.list.translate[0];

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -808,7 +808,10 @@ export class VirtualizedViewManager {
       ? getHorizontalDelta(event.deltaX, event.deltaY)
       : event.deltaX;
 
-    if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+    if (
+      event.shiftKey ||
+      (!event.shiftKey && Math.abs(event.deltaX) > Math.abs(event.deltaY))
+    ) {
       // Prevents firing back/forward navigation
       event.preventDefault();
     } else {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -804,7 +804,9 @@ export class VirtualizedViewManager {
     }
 
     // Holding shift key allows for horizontal scrolling
-    const distance = event.shiftKey ? event.deltaY : event.deltaX;
+    const distance = event.shiftKey
+      ? getHorizontalDelta(event.deltaX, event.deltaY)
+      : event.deltaX;
 
     if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
       // Prevents firing back/forward navigation


### PR DESCRIPTION
Prior to this fix with a mouse scroll wheel you could click shift and scroll left / right in the span timeline, but you could not scroll left and right in the span name list (when a long span name overflowed).