### PR TITLE
feat(onboarding): Add global sentry exception middlewares to tanstack start onboarding

### DIFF
--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -325,7 +325,9 @@ export const startInstance = createStart(() => {
           ],
         },
         {
-          type: 'text',
+          type: 'alert',
+          alertType: 'info',
+          showIcon: false,
           text: t(
             'The Sentry middleware should be the first middleware in the arrays to ensure all errors are captured. SSR rendering exceptions are not captured by the middleware. Use captureException to manually capture those errors.'
           ),

--- a/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-tanstackstart-react/onboarding.tsx
@@ -298,8 +298,36 @@ export default defineConfig({
         {
           type: 'text',
           text: tct(
-            'Sentry automatically captures unhandled client-side errors. On the server side of TanStack Start, automatic error monitoring is not yet supported. Use [code:captureException] to manually capture errors in your server-side code.',
+            "To capture server-side errors from HTTP requests and server function invocations, add Sentry's global middlewares to [code:createStart()] in your [code:src/start.ts] file:",
             {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'TypeScript',
+              language: 'typescript',
+              filename: 'src/start.ts',
+              code: `import {
+  sentryGlobalFunctionMiddleware,
+  sentryGlobalRequestMiddleware,
+} from "@sentry/tanstackstart-react";
+import { createStart } from "@tanstack/react-start";
+
+export const startInstance = createStart(() => {
+  return {
+    requestMiddleware: [sentryGlobalRequestMiddleware],
+    functionMiddleware: [sentryGlobalFunctionMiddleware],
+  };
+});`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: t(
+            'The Sentry middleware should be the first middleware in the arrays to ensure all errors are captured. SSR rendering exceptions are not captured by the middleware. Use captureException to manually capture those errors.'
           ),
         },
         {


### PR DESCRIPTION
We added global sentry middlewares to capture server-side errors in the Tanstack Start SDK. [PR](https://github.com/getsentry/sentry-javascript/pull/19330) [Docs PR](https://github.com/getsentry/sentry-docs/pull/16411)

This will ship with the `10.40.0` release of the javascript SDKs. Updating the onboarding accordingly.
