### PR TITLE
ref(github): Centralize GitHub API Accept header into shared constant

### DIFF
--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -2,6 +2,7 @@ from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
+from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.types import IntegrationProviderSlug
 
 
@@ -9,10 +10,7 @@ def get_user_info(access_token):
     with http.build_session() as session:
         resp = session.get(
             "https://api.github.com/user",
-            headers={
-                "Accept": "application/vnd.github.machine-man-preview+json",
-                "Authorization": f"token {access_token}",
-            },
+            headers={"Accept": GITHUB_API_ACCEPT_HEADER, "Authorization": f"token {access_token}"},
         )
         resp.raise_for_status()
     return resp.json()

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -2,11 +2,12 @@ from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
-from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.types import IntegrationProviderSlug
 
 
 def get_user_info(access_token):
+    from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
+
     with http.build_session() as session:
         resp = session.get(
             "https://api.github.com/user",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -17,6 +17,7 @@ from sentry.integrations.github.blame import (
     generate_file_path_mapping,
     is_graphql_response,
 )
+from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.utils import get_jwt, get_next_link
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
@@ -102,7 +103,7 @@ class GithubSetupApiClient(IntegrationProxyClient):
             token = self.jwt
 
         prepared_request.headers["Authorization"] = f"Bearer {token}"
-        prepared_request.headers["Accept"] = "application/vnd.github+json"
+        prepared_request.headers["Accept"] = GITHUB_API_ACCEPT_HEADER
         return prepared_request
 
     def get_installation_info(self, installation_id: int | str) -> dict[str, Any]:
@@ -294,7 +295,7 @@ class GithubProxyClient(IntegrationProxyClient):
             return prepared_request
 
         prepared_request.headers["Authorization"] = f"Bearer {token}"
-        prepared_request.headers["Accept"] = "application/vnd.github+json"
+        prepared_request.headers["Accept"] = GITHUB_API_ACCEPT_HEADER
         if prepared_request.headers.get("Content-Type") == "application/raw; charset=utf-8":
             prepared_request.headers["Accept"] = "application/vnd.github.raw"
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -17,7 +17,7 @@ from sentry.integrations.github.blame import (
     generate_file_path_mapping,
     is_graphql_response,
 )
-from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
+from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.utils import get_jwt, get_next_link
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration

--- a/src/sentry/integrations/github/constants.py
+++ b/src/sentry/integrations/github/constants.py
@@ -1,3 +1,5 @@
+GITHUB_API_ACCEPT_HEADER = "application/vnd.github+json"
+
 ISSUE_LOCKED_ERROR_MESSAGE = "Unable to create comment because issue is locked."
 
 RATE_LIMITED_MESSAGE = "API rate limit exceeded"

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -172,6 +172,8 @@ ERR_INTEGRATION_MISSING_ORGANIZATION = _(
     "You must be logged into an organization to access this feature."
 )
 
+GITHUB_API_ACCEPT_HEADER = "application/vnd.github+json"
+
 
 class GithubInstallationInfo(TypedDict):
     installation_id: str

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -172,8 +172,6 @@ ERR_INTEGRATION_MISSING_ORGANIZATION = _(
     "You must be logged into an organization to access this feature."
 )
 
-GITHUB_API_ACCEPT_HEADER = "application/vnd.github+json"
-
 
 class GithubInstallationInfo(TypedDict):
     installation_id: str

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -19,7 +19,11 @@ from sentry.integrations.base import (
     IntegrationMetadata,
 )
 from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
-from sentry.integrations.github.integration import GitHubIntegrationProvider, build_repository_query
+from sentry.integrations.github.integration import (
+    GITHUB_API_ACCEPT_HEADER,
+    GitHubIntegrationProvider,
+    build_repository_query,
+)
 from sentry.integrations.github.issue_sync import GitHubIssueSyncSpec
 from sentry.integrations.github.issues import GitHubIssuesSpec
 from sentry.integrations.github.types import GitHubIssueStatus
@@ -51,10 +55,7 @@ def get_user_info(url, access_token):
     with http.build_session() as session:
         resp = session.get(
             f"https://{url}/api/v3/user",
-            headers={
-                "Accept": "application/vnd.github.machine-man-preview+json",
-                "Authorization": f"token {access_token}",
-            },
+            headers={"Accept": GITHUB_API_ACCEPT_HEADER, "Authorization": f"token {access_token}"},
             verify=False,
         )
         resp.raise_for_status()
@@ -671,10 +672,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         pass
 
     def _get_ghe_installation_info(self, installation_data, access_token, installation_id):
-        headers = {
-            # TODO(jess): remove this whenever it's out of preview
-            "Accept": "application/vnd.github.machine-man-preview+json",
-        }
+        headers = {"Accept": GITHUB_API_ACCEPT_HEADER}
         headers.update(
             jwt.authorization_header(
                 get_jwt(
@@ -695,7 +693,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             resp = session.get(
                 f"https://{installation_data['url']}/api/v3/user/installations",
                 headers={
-                    "Accept": "application/vnd.github.machine-man-preview+json",
+                    "Accept": GITHUB_API_ACCEPT_HEADER,
                     "Authorization": f"token {access_token}",
                 },
                 verify=installation_data["verify_ssl"],

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -18,9 +18,12 @@ from sentry.integrations.base import (
     IntegrationFeatures,
     IntegrationMetadata,
 )
-from sentry.integrations.github.constants import ISSUE_LOCKED_ERROR_MESSAGE, RATE_LIMITED_MESSAGE
-from sentry.integrations.github.integration import (
+from sentry.integrations.github.constants import (
     GITHUB_API_ACCEPT_HEADER,
+    ISSUE_LOCKED_ERROR_MESSAGE,
+    RATE_LIMITED_MESSAGE,
+)
+from sentry.integrations.github.integration import (
     GitHubIntegrationProvider,
     build_repository_query,
 )

--- a/src/sentry/utils/github.py
+++ b/src/sentry/utils/github.py
@@ -10,7 +10,7 @@ from requests.exceptions import HTTPError
 
 from sentry import options
 from sentry.http import build_session
-from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
+from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.shared_integrations.exceptions import ApiError
 
 

--- a/src/sentry/utils/github.py
+++ b/src/sentry/utils/github.py
@@ -10,6 +10,7 @@ from requests.exceptions import HTTPError
 
 from sentry import options
 from sentry.http import build_session
+from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
 from sentry.shared_integrations.exceptions import ApiError
 
 
@@ -23,7 +24,7 @@ class _GitHubClient:
             try:
                 resp = session.get(
                     f"https://api.github.com{url}",
-                    headers={"Accept": "application/vnd.github.valkyrie-preview+json"},
+                    headers={"Accept": GITHUB_API_ACCEPT_HEADER},
                     auth=(self._client_id, self._client_secret),
                     allow_redirects=True,
                 )

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -3,7 +3,7 @@ import datetime
 import time
 
 from sentry import options
-from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
+from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.utils import jwt
 from sentry_plugins.client import ApiClient, AuthApiClient

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -3,6 +3,7 @@ import datetime
 import time
 
 from sentry import options
+from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.utils import jwt
 from sentry_plugins.client import ApiClient, AuthApiClient
@@ -66,8 +67,7 @@ class GithubPluginClient(GithubPluginClientMixin, AuthApiClient):
         return self.delete(f"/repos/{repo}/hooks/{id}")
 
     def get_installations(self):
-        # TODO(jess): remove this whenever it's out of preview
-        headers = {"Accept": "application/vnd.github.machine-man-preview+json"}
+        headers = {"Accept": GITHUB_API_ACCEPT_HEADER}
 
         return self._request("GET", "/user/installations", headers=headers)
 
@@ -108,16 +108,12 @@ class GithubPluginAppsClient(GithubPluginClientMixin, ApiClient):
         if headers is None:
             headers = {
                 "Authorization": "token %s" % self.get_token(),
-                # TODO(jess): remove this whenever it's out of preview
-                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Accept": GITHUB_API_ACCEPT_HEADER,
             }
         return self._request(method, path, headers=headers, data=data, params=params)
 
     def create_token(self):
-        headers = {
-            # TODO(jess): remove this whenever it's out of preview
-            "Accept": "application/vnd.github.machine-man-preview+json",
-        }
+        headers = {"Accept": GITHUB_API_ACCEPT_HEADER}
         headers.update(jwt.authorization_header(self.get_jwt()))
         return self.post(
             f"/app/installations/{self.integration.external_id}/access_tokens",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -14,7 +14,7 @@ from responses import matchers
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
 from sentry.integrations.github.client import GitHubApiClient, GitHubReaction
-from sentry.integrations.github.integration import GitHubIntegration
+from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER, GitHubIntegration
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
@@ -701,7 +701,7 @@ class GithubProxyClientTest(TestCase):
         # First request should refresh the token and add headers
         self.gh_client.authorize_request(prepared_request=access_token_request)
         assert mock_jwt.called
-        assert access_token_request.headers["Accept"] == "application/vnd.github+json"
+        assert access_token_request.headers["Accept"] == GITHUB_API_ACCEPT_HEADER
         assert self.access_token in access_token_request.headers["Authorization"]
 
         mock_jwt.reset_mock()
@@ -710,13 +710,13 @@ class GithubProxyClientTest(TestCase):
         # Following requests should just add headers
         self.gh_client.authorize_request(prepared_request=access_token_request)
         assert not mock_jwt.called
-        assert access_token_request.headers["Accept"] == "application/vnd.github+json"
+        assert access_token_request.headers["Accept"] == GITHUB_API_ACCEPT_HEADER
         assert self.access_token in access_token_request.headers["Authorization"]
 
         # JWT-authorized requests should be identified by request path
         self.gh_client.authorize_request(prepared_request=jwt_request)
         assert mock_jwt.called
-        assert jwt_request.headers["Accept"] == "application/vnd.github+json"
+        assert jwt_request.headers["Accept"] == GITHUB_API_ACCEPT_HEADER
         assert jwt_request.headers["Authorization"] == f"Bearer {self.jwt}"
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -14,7 +14,8 @@ from responses import matchers
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
 from sentry.integrations.github.client import GitHubApiClient, GitHubReaction
-from sentry.integrations.github.integration import GITHUB_API_ACCEPT_HEADER, GitHubIntegration
+from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
+from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,


### PR DESCRIPTION
Replace hardcoded GitHub API `Accept` header strings with a shared `GITHUB_API_ACCEPT_HEADER` constant. Also updates deprecated preview media types (`machine-man-preview`, `valkyrie-preview`) to the stable `application/vnd.github+json` format.
- machine-man was removed [here](https://developer.github.com/changes/2020-08-20-graduate-machine-man-and-sailor-v-previews/)
- valkyrie was removed [here](https://developer.github.com/changes/2018-05-22-marketplace-api/)
- the only other custom gh accept header is `application/vnd.github.raw` which is set when `application/raw`is the content type, probably for repo contents or something.