### PR TITLE
ref(performance): Replace service entry span terminology with segment span and transaction

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -316,12 +316,12 @@ class Referrer(StrEnum):
     API_INSIGHTS_MOBILE_SPAN_TABLE = "api.insights.mobile-span-table"
     API_INSIGHTS_MOBILE_LANDING_TABLE = "api.insights.mobile.landing-table"
 
-    # Service Entry Spans
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE = "api.insights.service-entry-spans-table"
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_WITH_CATEGORY = (
-        "api.insights.service-entry-spans-table-with-category"
+    # Segment Spans
+    API_INSIGHTS_SEGMENT_SPANS_TABLE = "api.insights.segment-spans-table"
+    API_INSIGHTS_SEGMENT_SPANS_TABLE_WITH_CATEGORY = (
+        "api.insights.segment-spans-table-with-category"
     )
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_COUNT = "api.insights.service-entry-spans-table-count"
+    API_INSIGHTS_SEGMENT_SPANS_TABLE_COUNT = "api.insights.segment-spans-table-count"
 
     # Trace Panel
     API_INSIGHTS_TRACE_PANEL_LEFT_TRACE_LINK = "api.insights.trace-panel-left-trace-link"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -316,12 +316,12 @@ class Referrer(StrEnum):
     API_INSIGHTS_MOBILE_SPAN_TABLE = "api.insights.mobile-span-table"
     API_INSIGHTS_MOBILE_LANDING_TABLE = "api.insights.mobile.landing-table"
 
-    # Segment Spans
-    API_INSIGHTS_SEGMENT_SPANS_TABLE = "api.insights.segment-spans-table"
-    API_INSIGHTS_SEGMENT_SPANS_TABLE_WITH_CATEGORY = (
-        "api.insights.segment-spans-table-with-category"
+    # Service Entry Spans
+    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE = "api.insights.service-entry-spans-table"
+    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_WITH_CATEGORY = (
+        "api.insights.service-entry-spans-table-with-category"
     )
-    API_INSIGHTS_SEGMENT_SPANS_TABLE_COUNT = "api.insights.segment-spans-table-count"
+    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_COUNT = "api.insights.service-entry-spans-table-count"
 
     # Trace Panel
     API_INSIGHTS_TRACE_PANEL_LEFT_TRACE_LINK = "api.insights.trace-panel-left-trace-link"

--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -58,12 +58,10 @@ export const getTabCrumbs = ({
   eventSlug,
   traceSlug,
   view,
-  shouldUseOTelFriendlyUI,
 }: {
   location: Location;
   organization: Organization;
   eventSlug?: string;
-  shouldUseOTelFriendlyUI?: boolean;
   spanSlug?: SpanSlug;
   traceSlug?: string;
   transaction?: {
@@ -86,17 +84,11 @@ export const getTabCrumbs = ({
     view,
   };
 
-  shouldUseOTelFriendlyUI
-    ? crumbs.push({
-        to: transactionSummaryRouteWithQuery(routeQuery),
-        label: t('Service Entry Span Summary'),
-        preservePageFilters: true,
-      })
-    : crumbs.push({
-        to: transactionSummaryRouteWithQuery(routeQuery),
-        label: t('Transaction Summary'),
-        preservePageFilters: true,
-      });
+  crumbs.push({
+    to: transactionSummaryRouteWithQuery(routeQuery),
+    label: t('Transaction Summary'),
+    preservePageFilters: true,
+  });
 
   if (spanSlug) {
     crumbs.push({

--- a/static/app/views/performance/otlp/overviewSpansTable.tsx
+++ b/static/app/views/performance/otlp/overviewSpansTable.tsx
@@ -25,12 +25,12 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {ModuleName} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
-  SERVICE_ENTRY_SPANS_COLUMN_ORDER,
-  type ServiceEntrySpansColumn,
-  type ServiceEntrySpansRow,
+  SEGMENT_SPANS_COLUMN_ORDER,
+  type SegmentSpansColumn,
+  type SegmentSpansRow,
 } from 'sentry/views/performance/otlp/types';
-import {useServiceEntrySpansQuery} from 'sentry/views/performance/otlp/useServiceEntrySpansQuery';
-import {SERVICE_ENTRY_SPANS_CURSOR} from 'sentry/views/performance/otlp/utils';
+import {useSegmentSpansQuery} from 'sentry/views/performance/otlp/useSegmentSpansQuery';
+import {SEGMENT_SPANS_CURSOR} from 'sentry/views/performance/otlp/utils';
 
 const LIMIT = 50;
 
@@ -65,7 +65,7 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
       fields: ['count()'],
       pageFilters: selection,
     },
-    'api.insights.service-entry-spans-table-count'
+    'api.insights.segment-spans-table-count'
   );
 
   const pageEventsCount = Math.min(numEvents[0]?.['count()'] ?? 0, LIMIT);
@@ -84,7 +84,7 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
     pageLinks,
     meta,
     error,
-  } = useServiceEntrySpansQuery({
+  } = useSegmentSpansQuery({
     query: defaultQuery.formatString(),
     sort: {
       field: 'span.duration',
@@ -107,7 +107,7 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
   const handleCursor: CursorHandler = (_cursor, pathname, query) => {
     navigate({
       pathname,
-      query: {...query, [SERVICE_ENTRY_SPANS_CURSOR]: _cursor},
+      query: {...query, [SEGMENT_SPANS_CURSOR]: _cursor},
     });
   };
 
@@ -117,7 +117,7 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
         isLoading={isLoading}
         error={error}
         data={consolidatedData}
-        columnOrder={SERVICE_ENTRY_SPANS_COLUMN_ORDER}
+        columnOrder={SEGMENT_SPANS_COLUMN_ORDER}
         columnSortBy={[]}
         grid={{
           renderHeadCell: column =>
@@ -139,8 +139,8 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
 }
 
 function renderBodyCell(
-  column: ServiceEntrySpansColumn,
-  row: ServiceEntrySpansRow,
+  column: SegmentSpansColumn,
+  row: SegmentSpansRow,
   meta: EventsMetaType | undefined,
   projectSlug: string | undefined,
   location: Location,

--- a/static/app/views/performance/otlp/segmentSpansTable.tsx
+++ b/static/app/views/performance/otlp/segmentSpansTable.tsx
@@ -28,14 +28,14 @@ import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spa
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {
-  SERVICE_ENTRY_SPANS_COLUMN_ORDER,
-  type ServiceEntrySpansColumn,
-  type ServiceEntrySpansRow,
+  SEGMENT_SPANS_COLUMN_ORDER,
+  type SegmentSpansColumn,
+  type SegmentSpansRow,
 } from 'sentry/views/performance/otlp/types';
-import {useServiceEntrySpansQuery} from 'sentry/views/performance/otlp/useServiceEntrySpansQuery';
+import {useSegmentSpansQuery} from 'sentry/views/performance/otlp/useSegmentSpansQuery';
 import {
   getOTelTransactionsListSort,
-  SERVICE_ENTRY_SPANS_CURSOR,
+  SEGMENT_SPANS_CURSOR,
 } from 'sentry/views/performance/otlp/utils';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -50,7 +50,7 @@ type Props = {
   showViewSampledEventsButton?: boolean;
 };
 
-export function ServiceEntrySpansTable({
+export function SegmentSpansTable({
   eventView,
   handleDropdownChange,
   totalValues,
@@ -79,7 +79,7 @@ export function ServiceEntrySpansTable({
     pageLinks,
     meta,
     error,
-  } = useServiceEntrySpansQuery({
+  } = useSegmentSpansQuery({
     query: eventViewQuery.formatString(),
     sort: selected.sort,
     transactionName,
@@ -99,7 +99,7 @@ export function ServiceEntrySpansTable({
   const handleCursor: CursorHandler = (_cursor, pathname, query) => {
     navigate({
       pathname,
-      query: {...query, [SERVICE_ENTRY_SPANS_CURSOR]: _cursor},
+      query: {...query, [SEGMENT_SPANS_CURSOR]: _cursor},
     });
   };
 
@@ -151,7 +151,7 @@ export function ServiceEntrySpansTable({
         isLoading={isLoading}
         error={error}
         data={consolidatedData}
-        columnOrder={SERVICE_ENTRY_SPANS_COLUMN_ORDER}
+        columnOrder={SEGMENT_SPANS_COLUMN_ORDER}
         columnSortBy={[]}
         grid={{
           renderHeadCell: column =>
@@ -167,8 +167,8 @@ export function ServiceEntrySpansTable({
 }
 
 function renderBodyCell(
-  column: ServiceEntrySpansColumn,
-  row: ServiceEntrySpansRow,
+  column: SegmentSpansColumn,
+  row: SegmentSpansRow,
   meta: EventsMetaType | undefined,
   projectSlug: string | undefined,
   location: Location,

--- a/static/app/views/performance/otlp/types.tsx
+++ b/static/app/views/performance/otlp/types.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
 // TODO: When supported, also add span operation breakdown as a field
-export type ServiceEntrySpansRow = Pick<
+export type SegmentSpansRow = Pick<
   SpanResponse,
   | 'span_id'
   | 'user.id'
@@ -24,11 +24,11 @@ export type ServiceEntrySpansRow = Pick<
   | 'precise.finish_ts'
 >;
 
-export type ServiceEntrySpansColumn = GridColumnHeader<
+export type SegmentSpansColumn = GridColumnHeader<
   'span_id' | 'span.duration' | 'trace' | 'timestamp' | 'replayId' | 'profile.id'
 >;
 
-export const SERVICE_ENTRY_SPANS_COLUMN_ORDER: ServiceEntrySpansColumn[] = [
+export const SEGMENT_SPANS_COLUMN_ORDER: SegmentSpansColumn[] = [
   {
     key: 'trace',
     name: t('Trace ID'),

--- a/static/app/views/performance/otlp/useSegmentSpansQuery.tsx
+++ b/static/app/views/performance/otlp/useSegmentSpansQuery.tsx
@@ -5,7 +5,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanFields, type SpanProperty} from 'sentry/views/insights/types';
-import {SERVICE_ENTRY_SPANS_CURSOR_NAME} from 'sentry/views/performance/transactionSummary/transactionOverview/content';
+import {SEGMENT_SPANS_CURSOR_NAME} from 'sentry/views/performance/transactionSummary/transactionOverview/content';
 import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
 type Options = {
@@ -35,7 +35,7 @@ const FIELDS: SpanProperty[] = [
   'precise.finish_ts',
 ];
 
-export function useServiceEntrySpansQuery({
+export function useSegmentSpansQuery({
   query,
   transactionName,
   sort,
@@ -111,7 +111,7 @@ type UseSingleQueryOptions = {
 // Hook for executing the default query to fetch table data for spans when no category is selected
 function useSingleQuery(options: UseSingleQueryOptions) {
   const location = useLocation();
-  const cursor = decodeScalar(location.query?.[SERVICE_ENTRY_SPANS_CURSOR_NAME]);
+  const cursor = decodeScalar(location.query?.[SEGMENT_SPANS_CURSOR_NAME]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
   const {query, sort, p95, enabled, limit} = options;
@@ -135,7 +135,7 @@ function useSingleQuery(options: UseSingleQueryOptions) {
       pageFilters: selection,
       enabled,
     },
-    'api.insights.service-entry-spans-table'
+    'api.insights.segment-spans-table'
   );
 
   return {
@@ -158,7 +158,7 @@ type UseMultipleQueriesOptions = {
 function useMultipleQueries(options: UseMultipleQueriesOptions) {
   const {transactionName, sort, p95, enabled, limit} = options;
   const location = useLocation();
-  const cursor = decodeScalar(location.query?.[SERVICE_ENTRY_SPANS_CURSOR_NAME]);
+  const cursor = decodeScalar(location.query?.[SEGMENT_SPANS_CURSOR_NAME]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
@@ -191,7 +191,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
       pageFilters: selection,
       enabled,
     },
-    'api.insights.service-entry-spans-table'
+    'api.insights.segment-spans-table'
   );
 
   const specificSpansQuery = new MutableSearch('');
@@ -218,7 +218,7 @@ function useMultipleQueries(options: UseMultipleQueriesOptions) {
       limit,
       enabled: !!categorizedSpanIds && categorizedSpanIds.length > 0,
     },
-    'api.insights.service-entry-spans-table-with-category'
+    'api.insights.segment-spans-table-with-category'
   );
 
   return {

--- a/static/app/views/performance/otlp/utils.tsx
+++ b/static/app/views/performance/otlp/utils.tsx
@@ -27,30 +27,30 @@ function getOTelFilterOptions(spanCategory?: string): DropdownOption[] {
       sort: {kind: 'asc', field: 'span.duration'},
       value: TransactionFilterOptions.FASTEST,
       label: spanCategory
-        ? t('Fastest %s Service Entry Spans', spanCategory)
-        : t('Fastest Service Entry Spans'),
+        ? t('Fastest %s Transactions', spanCategory)
+        : t('Fastest Transactions'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.SLOW,
       label: spanCategory
-        ? t('Slow %s Service Entry Spans (p95)', spanCategory)
-        : t('Slow Service Entry Spans (p95)'),
+        ? t('Slow %s Transactions (p95)', spanCategory)
+        : t('Slow Transactions (p95)'),
     },
     {
       sort: {kind: 'desc', field: 'span.duration'},
       value: TransactionFilterOptions.OUTLIER,
       label: spanCategory
-        ? t('Outlier %s Service Entry Spans (p100)', spanCategory)
-        : t('Outlier Service Entry Spans (p100)'),
+        ? t('Outlier %s Transactions (p100)', spanCategory)
+        : t('Outlier Transactions (p100)'),
     },
     {
       sort: {kind: 'desc', field: 'timestamp'},
       value: TransactionFilterOptions.RECENT,
       // The category does not apply to this option
-      label: t('Recent Service Entry Spans'),
+      label: t('Recent Transactions'),
     },
   ];
 }
 
-export const SERVICE_ENTRY_SPANS_CURSOR = 'serviceEntrySpansCursor';
+export const SEGMENT_SPANS_CURSOR = 'segmentSpansCursor';

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -33,7 +33,6 @@ import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader'
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import Breadcrumb, {getTabCrumbs} from 'sentry/views/performance/breadcrumb';
-import {useTransactionSummaryEAP} from 'sentry/views/performance/otlp/useTransactionSummaryEAP';
 import {TAB_ANALYTICS} from 'sentry/views/performance/transactionSummary/pageLayout';
 import {eventsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionEvents/utils';
 import {profilesRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionProfiles/utils';
@@ -169,8 +168,6 @@ function TransactionHeader({
     </TabList>
   );
 
-  const shouldUseOTelFriendlyUI = useTransactionSummaryEAP();
-
   if (isInDomainView) {
     const headerProps = {
       headerTitle: (
@@ -202,7 +199,6 @@ function TransactionHeader({
           project: projectId,
         },
         view,
-        shouldUseOTelFriendlyUI,
       }),
       headerActions: (
         <Fragment>

--- a/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
+++ b/static/app/views/performance/transactionSummary/spanCategoryFilter.tsx
@@ -20,7 +20,7 @@ import {useCompactSelectOptionsCache} from 'sentry/views/insights/common/utils/u
 import {SpanFields} from 'sentry/views/insights/types';
 
 type Props = {
-  serviceEntrySpanName: string;
+  segmentSpanName: string;
 };
 
 const LIMIT = 10;
@@ -29,7 +29,7 @@ const LIMIT = 10;
 // for now, it will only allow categories that match the hardcoded list of span ops that were supported in the previous iteration
 const ALLOWED_CATEGORIES = ['http', 'db', 'browser', 'resource', 'ui'];
 
-export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
+export function SpanCategoryFilter({segmentSpanName}: Props) {
   const location = useLocation();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
@@ -42,7 +42,7 @@ export function SpanCategoryFilter({serviceEntrySpanName}: Props) {
   const theme = useTheme();
 
   const query = new MutableSearch('');
-  query.addFilterValue('transaction', serviceEntrySpanName);
+  query.addFilterValue('transaction', segmentSpanName);
 
   const {data, isError} = useSpans(
     {

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -257,7 +257,7 @@ function Search(props: Props) {
   return (
     <FilterActions>
       {shouldUseOTelFriendlyUI ? (
-        <SpanCategoryFilter serviceEntrySpanName={transactionName} />
+        <SpanCategoryFilter segmentSpanName={transactionName} />
       ) : (
         <Filter
           organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -45,7 +45,7 @@ import {updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {SpanFields} from 'sentry/views/insights/types';
-import {ServiceEntrySpansTable} from 'sentry/views/performance/otlp/serviceEntrySpansTable';
+import {SegmentSpansTable} from 'sentry/views/performance/otlp/segmentSpansTable';
 import Filter, {
   decodeFilterFromLocation,
   filterToField,
@@ -96,7 +96,7 @@ type Props = {
   transactionName: string;
 };
 
-export const SERVICE_ENTRY_SPANS_CURSOR_NAME = 'serviceEntrySpansCursor';
+export const SEGMENT_SPANS_CURSOR_NAME = 'segmentSpansCursor';
 
 function OTelSummaryContentInner({
   eventView,
@@ -137,7 +137,7 @@ function OTelSummaryContentInner({
       query: {
         ...location.query,
         showTransactions: value,
-        [SERVICE_ENTRY_SPANS_CURSOR_NAME]: undefined,
+        [SEGMENT_SPANS_CURSOR_NAME]: undefined,
       },
     };
 
@@ -253,7 +253,7 @@ function OTelSummaryContentInner({
     <Fragment>
       <Layout.Main>
         <FilterActions>
-          <SpanCategoryFilter serviceEntrySpanName={transactionName} />
+          <SpanCategoryFilter segmentSpanName={transactionName} />
           <PageFilterBar condensed>
             <EnvironmentPageFilter />
             <DatePageFilter {...datePageFilterProps} />
@@ -265,7 +265,7 @@ function OTelSummaryContentInner({
         </EAPChartsWidgetContainer>
 
         <PerformanceAtScaleContextProvider>
-          <ServiceEntrySpansTable
+          <SegmentSpansTable
             eventView={transactionsListEventView}
             handleDropdownChange={handleTransactionsListSortChange}
             totalValues={totalValues}

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -19,7 +19,6 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useTransactionSummaryEAP} from 'sentry/views/performance/otlp/useTransactionSummaryEAP';
 import {removeTracingKeysFromSearch} from 'sentry/views/performance/utils';
 
 type Props = {
@@ -39,8 +38,6 @@ function RelatedIssues({
   end,
   statsPeriod,
 }: Props) {
-  const shouldUseOTelFriendlyUI = useTransactionSummaryEAP();
-
   const getIssuesEndpointQueryParams = () => {
     const queryParams = {
       start,
@@ -82,10 +79,7 @@ function RelatedIssues({
         <PanelBody>
           <EmptyStateWarning>
             <p>
-              {tct('No new issues for this [identifier] for the [timePeriod].', {
-                identifier: shouldUseOTelFriendlyUI
-                  ? 'service entry span'
-                  : 'transaction',
+              {tct('No new issues for this transaction for the [timePeriod].', {
                 timePeriod: displayedPeriod,
               })}
             </p>

--- a/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/useWidgetChartVisualization.tsx
@@ -87,7 +87,7 @@ function useDurationBreakdownVisualization({
   newQuery.addFilterValue('transaction', transactionName);
   newQuery.addFilterValue('is_transaction', '1');
 
-  // If a span category is selected, the chart will focus on that span category rather than just the service entry span
+  // If a span category is selected, the chart will focus on that span category rather than just the segment span
   if (spanCategoryUrlParam) {
     newQuery.addFilterValue('span.category', spanCategoryUrlParam);
     newQuery.removeFilterValue('is_transaction', '1');


### PR DESCRIPTION
## Summary

This PR refactors terminology across the performance monitoring UI, replacing "service entry span" with "segment span" in code and "transaction" in user-facing strings.

The UI might also eventually start calling these things segments or segment spans too, but that will be a global change if done and not just in this new EAP version of the transaction summary.

## Changes

**Terminology Updates:**
- Code identifiers: `ServiceEntrySpans` → `SegmentSpans`
- TypeScript types: `ServiceEntrySpansRow` → `SegmentSpansRow`
- User-facing UI: "Service Entry Spans" → "Transactions"

**File Renames:**
- `serviceEntrySpansTable.tsx` → `segmentSpansTable.tsx`
- `useServiceEntrySpansQuery.tsx` → `useSegmentSpansQuery.tsx`

**Simplifications:**
- Removed `shouldUseOTelFriendlyUI` parameter and conditional logic
- Simplified breadcrumb and empty state messages to always use "transaction"
- Cleaned up unused imports and parameters

## Related

Backend referrer changes: #108358