### PR TITLE
feat(explore): multi-aggregate overlays for traces visualize toolbar

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -35,12 +35,16 @@ export function ToolbarVisualizeHeader() {
 
 interface ToolbarVisualizeDropdownProps {
   aggregateOptions: Array<SelectOption<SelectKey>>;
+  aggregateValue: string | string[];
   canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;
-  onChangeAggregate: (option: SelectOption<SelectKey>) => void;
+  onChangeAggregate: (
+    option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>
+  ) => void;
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   onDelete: () => void;
   parsedFunction: ParsedFunction | null;
+  aggregateMultiple?: boolean;
   label?: ReactNode;
   loading?: boolean;
   onClose?: () => void;
@@ -48,7 +52,9 @@ interface ToolbarVisualizeDropdownProps {
 }
 
 export function ToolbarVisualizeDropdown({
+  aggregateMultiple = false,
   aggregateOptions,
+  aggregateValue,
   canDelete,
   fieldOptions,
   onChangeAggregate,
@@ -65,15 +71,34 @@ export function ToolbarVisualizeDropdown({
     ? getFieldDefinition(aggregateFunc, 'span')
     : undefined;
 
+  const singleAggregateValue = Array.isArray(aggregateValue)
+    ? (aggregateValue[0] ?? '')
+    : aggregateValue;
+  const multiAggregateValue = Array.isArray(aggregateValue)
+    ? aggregateValue
+    : aggregateValue
+      ? [aggregateValue]
+      : [];
+
   return (
     <ToolbarRow>
       {label}
-      <AggregateCompactSelect
-        searchable
-        options={aggregateOptions}
-        value={parsedFunction?.name ?? ''}
-        onChange={onChangeAggregate}
-      />
+      {aggregateMultiple ? (
+        <AggregateCompactSelect
+          multiple
+          searchable
+          options={aggregateOptions}
+          value={multiAggregateValue}
+          onChange={options => onChangeAggregate(options)}
+        />
+      ) : (
+        <AggregateCompactSelect
+          searchable
+          options={aggregateOptions}
+          value={singleAggregateValue}
+          onChange={option => onChangeAggregate(option)}
+        />
+      )}
       {aggregateDefinition?.parameters?.map((param, index) => {
         return (
           <FieldCompactSelect

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -2,7 +2,11 @@ import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
+import type {
+  SelectKey,
+  SelectOption,
+  SelectOptionOrSection,
+} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -34,7 +38,7 @@ export function ToolbarVisualizeHeader() {
 }
 
 interface ToolbarVisualizeDropdownProps {
-  aggregateOptions: Array<SelectOption<SelectKey>>;
+  aggregateOptions: Array<SelectOptionOrSection<SelectKey>>;
   aggregateValue: string | string[];
   canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -384,7 +384,11 @@ describe('SpanQueryParamsProvider', () => {
         {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
-          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+          yAxes: ['min(span.self_time)'],
+        },
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['max(span.duration)'],
         },
       ],
     });
@@ -400,7 +404,10 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
+          new VisualizeFunction(['min(span.self_time)'], {
+            chartType: ChartType.AREA,
+          }),
+          new VisualizeFunction(['max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -415,7 +422,11 @@ describe('SpanQueryParamsProvider', () => {
         {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
-          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+          yAxes: ['min(span.self_time)'],
+        },
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['max(span.duration)'],
         },
       ],
     });
@@ -431,7 +442,10 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
+          new VisualizeFunction(['min(span.self_time)'], {
+            chartType: ChartType.AREA,
+          }),
+          new VisualizeFunction(['max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -532,7 +546,11 @@ describe('SpanQueryParamsProvider', () => {
         },
         {
           chartType: ChartType.LINE,
-          yAxes: ['avg(span.duration)', 'avg(span.self_time)'],
+          yAxes: ['avg(span.duration)'],
+        },
+        {
+          chartType: ChartType.LINE,
+          yAxes: ['avg(span.self_time)'],
         },
       ])
     );
@@ -549,7 +567,10 @@ describe('SpanQueryParamsProvider', () => {
           new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new VisualizeFunction(['avg(span.duration)', 'avg(span.self_time)'], {
+          new VisualizeFunction(['avg(span.duration)'], {
+            chartType: ChartType.LINE,
+          }),
+          new VisualizeFunction(['avg(span.self_time)'], {
             chartType: ChartType.LINE,
           }),
         ],

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -400,10 +400,7 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction('min(span.self_time)', {
-            chartType: ChartType.AREA,
-          }),
-          new VisualizeFunction('max(span.duration)', {
+          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -434,10 +431,7 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction('min(span.self_time)', {
-            chartType: ChartType.AREA,
-          }),
-          new VisualizeFunction('max(span.duration)', {
+          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -555,10 +549,7 @@ describe('SpanQueryParamsProvider', () => {
           new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new VisualizeFunction('avg(span.duration)', {
-            chartType: ChartType.LINE,
-          }),
-          new VisualizeFunction('avg(span.self_time)', {
+          new VisualizeFunction(['avg(span.duration)', 'avg(span.self_time)'], {
             chartType: ChartType.LINE,
           }),
         ],

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -453,6 +453,68 @@ describe('SpanQueryParamsProvider', () => {
     );
   });
 
+  it('correctly updates sort bys in aggregates mode with known y axis from a multi-yAxes visualize', () => {
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      aggregateFields: [
+        {groupBy: 'span.op'},
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+
+    act(() => setAggregateSortBys([{field: 'max(span.duration)', kind: 'desc'}]));
+
+    expect(queryParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
+  });
+
+  it('correctly falls back aggregate sort by in aggregates mode with unknown y axis for a multi-yAxes visualize', () => {
+    renderTestComponent({
+      mode: Mode.AGGREGATE,
+      aggregateFields: [
+        {groupBy: 'span.op'},
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+        },
+      ],
+    });
+
+    act(() => setAggregateSortBys([{field: 'avg(span.duration)', kind: 'desc'}]));
+
+    expect(queryParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
+        mode: Mode.AGGREGATE,
+        query: '',
+        sortBys: [{field: 'timestamp', kind: 'asc'}],
+        aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new VisualizeFunction(['min(span.self_time)', 'max(span.duration)'], {
+            chartType: ChartType.AREA,
+          }),
+        ],
+      })
+    );
+  });
+
   it('correctly updates sort bys in aggregates mode with known group by', () => {
     renderTestComponent({
       mode: Mode.AGGREGATE,
@@ -611,6 +673,52 @@ describe('SpanQueryParamsProvider', () => {
     expect(queryParams).toEqual(
       expect.objectContaining({
         fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
+      })
+    );
+  });
+
+  it('manages inserting and deleting columns when a single visualize has multiple yAxes', () => {
+    renderTestComponent();
+
+    act(() =>
+      setVisualizes([
+        {
+          chartType: ChartType.LINE,
+          yAxes: ['avg(span.duration)', 'p95(span.self_time)'],
+        },
+      ])
+    );
+
+    expect(queryParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time', 'span.duration'],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new VisualizeFunction(['avg(span.duration)', 'p95(span.self_time)'], {
+            chartType: ChartType.LINE,
+          }),
+        ],
+      })
+    );
+
+    act(() =>
+      setVisualizes([
+        {
+          chartType: ChartType.LINE,
+          yAxes: ['p95(span.self_time)'],
+        },
+      ])
+    );
+
+    expect(queryParams).toEqual(
+      expect.objectContaining({
+        fields: ['id', 'timestamp', 'span.op', 'span.self_time'],
+        aggregateFields: [
+          {groupBy: 'span.op'},
+          new VisualizeFunction(['p95(span.self_time)'], {
+            chartType: ChartType.LINE,
+          }),
+        ],
       })
     );
   });

--- a/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
@@ -223,7 +223,7 @@ describe('AddToDashboardButton', () => {
     );
   });
 
-  it('takes the first 3 yAxes', async () => {
+  it('passes all yAxes from a multi-aggregate visualize', async () => {
     render(
       <Wrapper>
         <TestPage visualizeIndex={0} />
@@ -260,8 +260,10 @@ describe('AddToDashboardButton', () => {
             queries: [
               {
                 aggregates: [
-                  // because the visualizes get flattend, we only take the first y axis
                   'avg(span.duration)',
+                  'max(span.duration)',
+                  'min(span.duration)',
+                  'p90(span.duration)',
                 ],
                 columns: [],
                 fields: [],

--- a/static/app/views/explore/hooks/useAddToDashboard.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.tsx
@@ -49,14 +49,14 @@ export function useAddToDashboard() {
 
   const getEventView = useCallback(
     (visualizeIndex: number) => {
-      const yAxis = visualizes[visualizeIndex]!.yAxis;
+      const yAxes = visualizes[visualizeIndex]!.yAxes;
 
       let fields: any;
       if (mode === Mode.SAMPLES) {
         fields = [];
       } else {
         fields = [
-          ...new Set([...groupBys, yAxis, ...sortBys.map(sort => sort.field)]),
+          ...new Set([...groupBys, ...yAxes, ...sortBys.map(sort => sort.field)]),
         ].filter(Boolean);
       }
 
@@ -69,7 +69,7 @@ export function useAddToDashboard() {
         query: search.formatString(),
         version: 2,
         dataset,
-        yAxis: [yAxis],
+        yAxis: [...yAxes],
       };
 
       const newEventView = EventView.fromNewQueryWithPageFilters(

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -125,7 +125,7 @@ function useTrackAnalytics({
       : 'given';
 
     const dataScanned = aggregatesTableResult.result.meta?.dataScanned ?? '';
-    const yAxes = visualizes.map(visualize => visualize.yAxis);
+    const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
 
     trackAnalytics('trace.explorer.metadata', {
       organization,
@@ -218,7 +218,7 @@ function useTrackAnalytics({
       : 'given';
 
     const dataScanned = spansTableResult.result.meta?.dataScanned ?? '';
-    const yAxes = visualizes.map(visualize => visualize.yAxis);
+    const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
 
     trackAnalytics('trace.explorer.metadata', {
       organization,
@@ -307,7 +307,7 @@ function useTrackAnalytics({
       ? 'gen_ai_features_disabled'
       : 'given';
 
-    const yAxes = visualizes.map(visualize => visualize.yAxis);
+    const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
 
     trackAnalytics('trace.explorer.metadata', {
       organization,
@@ -407,7 +407,7 @@ function useTrackAnalytics({
       ? 'gen_ai_features_disabled'
       : 'given';
 
-    const yAxes = visualizes.map(visualize => visualize.yAxis);
+    const yAxes = visualizes.flatMap(visualize => visualize.yAxes);
 
     trackAnalytics('trace.explorer.metadata', {
       organization,

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -141,4 +141,132 @@ describe('useExploreTimeseries', () => {
       })
     );
   });
+
+  it('requests all yAxes when a visualize has multiple aggregates', async () => {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            ...TimeSeriesFixture(),
+            yAxis: 'avg(span.duration)',
+            meta: {
+              ...TimeSeriesFixture().meta,
+              dataScanned: 'full',
+            },
+          },
+        ],
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return (
+            Array.isArray(options.query.yAxis) &&
+            options.query.yAxis.includes('avg(span.duration)') &&
+            options.query.yAxis.includes('p95(span.duration)') &&
+            options.query.yAxis.includes('count(span.duration)')
+          );
+        },
+      ],
+    });
+
+    renderHookWithProviders(
+      () =>
+        useExploreTimeseries({
+          query: 'test value',
+          enabled: true,
+        }),
+      {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
+            },
+          },
+        },
+      }
+    );
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
+  });
+
+  it('triggers high accuracy for multi-yAxis visualizes with no data and partial scan', async () => {
+    const mockTimeSeries = TimeSeriesFixture();
+    const mockNormalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            ...mockTimeSeries,
+            yAxis: 'avg(span.duration)',
+            values: [
+              {
+                ...mockTimeSeries.values[0]!,
+                value: 0,
+              },
+            ],
+            meta: {
+              ...mockTimeSeries.meta,
+              dataScanned: 'partial',
+            },
+          },
+          {
+            ...mockTimeSeries,
+            yAxis: 'p95(span.duration)',
+            values: [
+              {
+                ...mockTimeSeries.values[0]!,
+                value: 0,
+              },
+            ],
+            meta: {
+              ...mockTimeSeries.meta,
+              dataScanned: 'partial',
+            },
+          },
+        ],
+      },
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === SAMPLING_MODE.NORMAL;
+        },
+      ],
+    });
+    const mockHighAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      method: 'GET',
+      match: [
+        function (_url: string, options: Record<string, any>) {
+          return options.query.sampling === SAMPLING_MODE.HIGH_ACCURACY;
+        },
+      ],
+    });
+
+    renderHookWithProviders(
+      () =>
+        useExploreTimeseries({
+          query: 'test value',
+          enabled: true,
+        }),
+      {
+        additionalWrapper: Wrapper,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/explore/traces/',
+            query: {
+              visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
+            },
+          },
+        },
+      }
+    );
+
+    expect(mockNormalRequest).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockHighAccuracyRequest).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -170,24 +170,21 @@ describe('useExploreTimeseries', () => {
       ],
     });
 
-    renderHookWithProviders(
-      () =>
-        useExploreTimeseries({
-          query: 'test value',
-          enabled: true,
-        }),
-      {
-        additionalWrapper: Wrapper,
-        initialRouterConfig: {
-          location: {
-            pathname: '/organizations/org-slug/explore/traces/',
-            query: {
-              visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
-            },
+    renderHookWithProviders(useExploreTimeseries, {
+      additionalWrapper: Wrapper,
+      initialProps: {
+        query: 'test value',
+        enabled: true,
+      },
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
           },
         },
-      }
-    );
+      },
+    });
 
     await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(1));
   });
@@ -201,30 +198,14 @@ describe('useExploreTimeseries', () => {
           {
             ...mockTimeSeries,
             yAxis: 'avg(span.duration)',
-            values: [
-              {
-                ...mockTimeSeries.values[0]!,
-                value: 0,
-              },
-            ],
-            meta: {
-              ...mockTimeSeries.meta,
-              dataScanned: 'partial',
-            },
+            values: [{...mockTimeSeries.values[0]!, value: 0}],
+            meta: {...mockTimeSeries.meta, dataScanned: 'partial'},
           },
           {
             ...mockTimeSeries,
             yAxis: 'p95(span.duration)',
-            values: [
-              {
-                ...mockTimeSeries.values[0]!,
-                value: 0,
-              },
-            ],
-            meta: {
-              ...mockTimeSeries.meta,
-              dataScanned: 'partial',
-            },
+            values: [{...mockTimeSeries.values[0]!, value: 0}],
+            meta: {...mockTimeSeries.meta, dataScanned: 'partial'},
           },
         ],
       },
@@ -245,24 +226,21 @@ describe('useExploreTimeseries', () => {
       ],
     });
 
-    renderHookWithProviders(
-      () =>
-        useExploreTimeseries({
-          query: 'test value',
-          enabled: true,
-        }),
-      {
-        additionalWrapper: Wrapper,
-        initialRouterConfig: {
-          location: {
-            pathname: '/organizations/org-slug/explore/traces/',
-            query: {
-              visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
-            },
+    renderHookWithProviders(useExploreTimeseries, {
+      additionalWrapper: Wrapper,
+      initialProps: {
+        query: 'test value',
+        enabled: true,
+      },
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["avg(span.duration)","p95(span.duration)"]}',
           },
         },
-      }
-    );
+      },
+    });
 
     expect(mockNormalRequest).toHaveBeenCalledTimes(1);
     await waitFor(() => {

--- a/static/app/views/explore/hooks/useExploreTimeseries.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.tsx
@@ -73,7 +73,7 @@ function useExploreTimeseriesImpl({
   const topEvents = useTopEvents();
 
   const validYAxes = useMemo(() => {
-    return visualizes.map(visualize => visualize.yAxis);
+    return visualizes.flatMap(visualize => visualize.yAxes);
   }, [visualizes]);
 
   const fields: string[] = useMemo(() => {
@@ -130,7 +130,7 @@ export function shouldTriggerHighAccuracy(
   isTopN: boolean
 ) {
   const hasData = computeVisualizeSampleTotals(
-    visualizes.map(visualize => visualize.yAxis),
+    visualizes.flatMap(visualize => visualize.yAxes),
     data,
     isTopN
   ).some(total => total > 0);
@@ -143,7 +143,7 @@ function _checkCanQueryForMoreData(
   isTopN: boolean
 ) {
   return visualizes.some(visualize => {
-    const dedupedYAxes = [visualize.yAxis];
+    const dedupedYAxes = dedupeArray([...visualize.yAxes]);
     const series = dedupedYAxes.flatMap(yAxis => data[yAxis]).filter(defined);
     const {dataScanned} = determineSeriesSampleCountAndIsSampled(series, isTopN);
     return dataScanned === 'partial';

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -218,8 +218,7 @@ describe('getReadableQueryParamsFromLocation', () => {
           aggregateFields: [
             new VisualizeFunction('count(message)', {chartType: ChartType.AREA}),
             {groupBy: 'message.template'},
-            new VisualizeFunction('p50(foo)'),
-            new VisualizeFunction('p75(bar)'),
+            new VisualizeFunction(['p50(foo)', 'p75(bar)']),
           ],
         })
       )

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -208,7 +208,8 @@ describe('getReadableQueryParamsFromLocation', () => {
       aggregateField: [
         {yAxes: ['count(message)'], chartType: ChartType.AREA},
         {groupBy: 'message.template'},
-        {yAxes: ['p50(foo)', 'p75(bar)']},
+        {yAxes: ['p50(foo)']},
+        {yAxes: ['p75(bar)']},
       ].map(aggregateField => JSON.stringify(aggregateField)),
     });
     const queryParams = getReadableQueryParamsFromLocation(location);
@@ -218,7 +219,32 @@ describe('getReadableQueryParamsFromLocation', () => {
           aggregateFields: [
             new VisualizeFunction('count(message)', {chartType: ChartType.AREA}),
             {groupBy: 'message.template'},
-            new VisualizeFunction(['p50(foo)', 'p75(bar)']),
+            new VisualizeFunction(['p50(foo)']),
+            new VisualizeFunction(['p75(bar)']),
+          ],
+        })
+      )
+    );
+  });
+
+  it('decodes aggregate fields with multiple yAxes into one visualize', () => {
+    const location = locationFixture({
+      aggregateField: [
+        {yAxes: ['count(message)'], chartType: ChartType.AREA},
+        {groupBy: 'message.template'},
+        {yAxes: ['p50(foo)', 'p75(bar)'], chartType: ChartType.LINE},
+      ].map(aggregateField => JSON.stringify(aggregateField)),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            new VisualizeFunction('count(message)', {chartType: ChartType.AREA}),
+            {groupBy: 'message.template'},
+            new VisualizeFunction(['p50(foo)', 'p75(bar)'], {
+              chartType: ChartType.LINE,
+            }),
           ],
         })
       )
@@ -261,6 +287,50 @@ describe('getReadableQueryParamsFromLocation', () => {
             {groupBy: 'message.template'},
             new VisualizeFunction('count(message)'),
           ],
+        })
+      )
+    );
+  });
+
+  it('decodes custom aggregate sort bys with a secondary yAxis from a multi-yAxes visualize', () => {
+    const location = locationFixture({
+      logsAggregateSortBys: '-p75(bar)',
+      aggregateField: [
+        {groupBy: 'message.template'},
+        {yAxes: ['p50(foo)', 'p75(bar)']},
+      ].map(aggregateField => JSON.stringify(aggregateField)),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: 'message.template'},
+            new VisualizeFunction(['p50(foo)', 'p75(bar)']),
+          ],
+          aggregateSortBys: [{field: 'p75(bar)', kind: 'desc'}],
+        })
+      )
+    );
+  });
+
+  it('falls back aggregate sort by for invalid sort field with a multi-yAxes visualize', () => {
+    const location = locationFixture({
+      logsAggregateSortBys: '-avg(baz)',
+      aggregateField: [
+        {groupBy: 'message.template'},
+        {yAxes: ['p50(foo)', 'p75(bar)']},
+      ].map(aggregateField => JSON.stringify(aggregateField)),
+    });
+    const queryParams = getReadableQueryParamsFromLocation(location);
+    expect(queryParams).toEqual(
+      new ReadableQueryParams(
+        readableQueryParamOptions({
+          aggregateFields: [
+            {groupBy: 'message.template'},
+            new VisualizeFunction(['p50(foo)', 'p75(bar)']),
+          ],
+          aggregateSortBys: [{field: 'p50(foo)', kind: 'desc'}],
         })
       )
     );

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -364,10 +364,14 @@ function VisualizeDropdown({
   }, [aggregateFunction, sortedBooleanKeys, sortedNumberKeys, sortedStringKeys]);
 
   const onChangeAggregate = useCallback(
-    (option: SelectOption<SelectKey>) => {
-      if (typeof option.value === 'string') {
+    (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
+      const selected = Array.isArray(option) ? option[0] : option;
+      if (!selected) {
+        return;
+      }
+      if (typeof selected.value === 'string') {
         const yAxis = updateVisualizeAggregate({
-          newAggregate: option.value,
+          newAggregate: selected.value,
           oldAggregate: aggregateFunction,
           oldArgument: aggregateParam,
           firstNumberKey: sortedNumberKeys[0] || null,
@@ -390,6 +394,7 @@ function VisualizeDropdown({
 
   return (
     <ToolbarVisualizeDropdown
+      aggregateValue={visualize.parsedFunction?.name ?? ''}
       aggregateOptions={aggregateOptions}
       fieldOptions={fieldOptions}
       canDelete={canDelete}

--- a/static/app/views/explore/queryParams/aggregateSortBy.ts
+++ b/static/app/views/explore/queryParams/aggregateSortBy.ts
@@ -32,7 +32,7 @@ export function validateAggregateSort(
     }
 
     if (isVisualize(aggregateField)) {
-      return aggregateField.yAxis === sort.field;
+      return aggregateField.yAxes.includes(sort.field);
     }
 
     throw new Error('Unknown aggregate field');

--- a/static/app/views/explore/queryParams/managedFields.tsx
+++ b/static/app/views/explore/queryParams/managedFields.tsx
@@ -173,8 +173,10 @@ function findAllFieldRefs(
 
 function getVisualizeFields(visualize: Visualize): string[] {
   if (isVisualizeFunction(visualize)) {
-    const field = parseFunction(visualize.yAxis)?.arguments?.[0];
-    return defined(field) ? [field] : [];
+    return visualize.yAxes.flatMap(yAxis => {
+      const field = parseFunction(yAxis)?.arguments?.[0];
+      return defined(field) ? [field] : [];
+    });
   }
 
   return []; // TODO: unsupported

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -1,4 +1,8 @@
-import {Visualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  Visualize,
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 describe('VisualizeFunction', () => {
@@ -49,6 +53,20 @@ describe('VisualizeFunction', () => {
     expect(vis2).toEqual(
       new VisualizeFunction('avg(span.duration)', {chartType: ChartType.AREA})
     );
+    expect(vis2.yAxes).toEqual(['avg(span.duration)']);
+  });
+
+  it('replaces multiple yAxes', () => {
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
+    const vis2 = vis1.replace({yAxes: ['avg(span.duration)', 'p95(span.duration)']});
+    expect(vis2).toEqual(
+      new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+        chartType: ChartType.AREA,
+      })
+    );
+    expect(vis2.yAxis).toBe('avg(span.duration)');
   });
 
   it('replaces chart type', () => {
@@ -101,6 +119,62 @@ describe('VisualizeFunction', () => {
     });
     expect(visualize).toEqual([
       new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
+    ]);
+  });
+
+  it('converts multiple yAxes from JSON into one visualize', () => {
+    const visualize = Visualize.fromJSON({
+      yAxes: ['avg(span.duration)', 'p95(span.duration)'],
+      chartType: ChartType.LINE,
+    });
+    expect(visualize).toEqual([
+      new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+        chartType: ChartType.LINE,
+      }),
+    ]);
+    expect(visualize[0]!.yAxis).toBe('avg(span.duration)');
+    expect(visualize[0]!.yAxes).toEqual(['avg(span.duration)', 'p95(span.duration)']);
+  });
+
+  it('serializes all yAxes', () => {
+    const visualize = new VisualizeFunction(
+      ['avg(span.duration)', 'p95(span.duration)'],
+      {
+        chartType: ChartType.LINE,
+        visible: false,
+      }
+    );
+    expect(visualize.serialize()).toEqual({
+      yAxes: ['avg(span.duration)', 'p95(span.duration)'],
+      chartType: ChartType.LINE,
+      visible: false,
+    });
+  });
+
+  it('exposes parsedFunctions and parsedFunction', () => {
+    const visualize = new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)']);
+    expect(visualize.parsedFunction?.name).toBe('avg');
+    expect(visualize.parsedFunctions.map(func => func?.name)).toEqual(['avg', 'p95']);
+  });
+
+  it('clones multiple yAxes', () => {
+    const vis1 = new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+      chartType: ChartType.LINE,
+      visible: false,
+    });
+    const vis2 = vis1.clone();
+    expect(vis1).toEqual(vis2);
+    expect(vis2.yAxes).toEqual(['avg(span.duration)', 'p95(span.duration)']);
+  });
+
+  it('splits equation and function visualizes from JSON', () => {
+    const visualize = Visualize.fromJSON({
+      yAxes: ['equation|a+b', 'avg(span.duration)'],
+      chartType: ChartType.LINE,
+    });
+    expect(visualize).toEqual([
+      new VisualizeEquation('equation|a+b', {chartType: ChartType.LINE}),
+      new VisualizeFunction('avg(span.duration)', {chartType: ChartType.LINE}),
     ]);
   });
 });

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -19,18 +19,29 @@ interface VisualizeOptions {
   visible?: boolean;
 }
 
+function normalizeYAxes(yAxis: string | readonly string[]): readonly string[] {
+  if (typeof yAxis === 'string') {
+    return [yAxis];
+  }
+  return [...yAxis];
+}
+
 export abstract class Visualize {
-  readonly yAxis: string;
+  readonly yAxes: readonly string[];
   readonly chartType: ChartType;
   readonly visible: boolean;
   protected readonly selectedChartType?: ChartType;
   abstract readonly kind: 'function' | 'equation';
 
-  constructor(yAxis: string, options?: VisualizeOptions) {
-    this.yAxis = yAxis;
+  constructor(yAxis: string | readonly string[], options?: VisualizeOptions) {
+    this.yAxes = normalizeYAxes(yAxis);
     this.selectedChartType = options?.chartType;
-    this.chartType = this.selectedChartType ?? determineDefaultChartType([yAxis]);
+    this.chartType = this.selectedChartType ?? determineDefaultChartType(this.yAxes);
     this.visible = options?.visible ?? true;
+  }
+
+  get yAxis(): string {
+    return this.yAxes[0] ?? '';
   }
 
   abstract clone(): Visualize;
@@ -38,15 +49,17 @@ export abstract class Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): Visualize;
 
   serialize(): BaseVisualize {
     const json: BaseVisualize = {
-      yAxes: [this.yAxis],
+      yAxes: this.yAxes,
     };
 
     if (defined(this.selectedChartType)) {
@@ -61,32 +74,49 @@ export abstract class Visualize {
   }
 
   static fromJSON(json: BaseVisualize): Visualize[] {
-    return json.yAxes.map(yAxis => {
-      if (isEquation(yAxis)) {
-        return new VisualizeEquation(yAxis, {
+    if (!json.yAxes.length) {
+      return [];
+    }
+
+    if (json.yAxes.some(isEquation)) {
+      return json.yAxes.map(yAxis => {
+        if (isEquation(yAxis)) {
+          return new VisualizeEquation(yAxis, {
+            chartType: json.chartType,
+            visible: json.visible,
+          });
+        }
+        return new VisualizeFunction(yAxis, {
           chartType: json.chartType,
           visible: json.visible,
         });
-      }
-      return new VisualizeFunction(yAxis, {
+      });
+    }
+
+    return [
+      new VisualizeFunction(json.yAxes, {
         chartType: json.chartType,
         visible: json.visible,
-      });
-    });
+      }),
+    ];
   }
 }
 
 export class VisualizeFunction extends Visualize {
   readonly kind = 'function';
-  readonly parsedFunction: ParsedFunction | null;
+  readonly parsedFunctions: ReadonlyArray<ParsedFunction | null>;
 
-  constructor(yAxis: string, options?: VisualizeOptions) {
+  constructor(yAxis: string | readonly string[], options?: VisualizeOptions) {
     super(yAxis, options);
-    this.parsedFunction = parseFunction(yAxis);
+    this.parsedFunctions = this.yAxes.map(axis => parseFunction(axis));
+  }
+
+  get parsedFunction(): ParsedFunction | null {
+    return this.parsedFunctions[0] ?? null;
   }
 
   clone(): VisualizeFunction {
-    return new VisualizeFunction(this.yAxis, {
+    return new VisualizeFunction(this.yAxes, {
       chartType: this.selectedChartType,
       visible: this.visible,
     });
@@ -96,12 +126,14 @@ export class VisualizeFunction extends Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): VisualizeFunction {
-    return new VisualizeFunction(yAxis ?? this.yAxis, {
+    return new VisualizeFunction(yAxes ?? yAxis ?? this.yAxes, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,
     });
@@ -127,12 +159,14 @@ export class VisualizeEquation extends Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): Visualize {
-    return new VisualizeEquation(yAxis ?? this.yAxis, {
+    return new VisualizeEquation(yAxes?.[0] ?? yAxis ?? this.yAxis, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,
     });

--- a/static/app/views/explore/spans/charts/index.spec.tsx
+++ b/static/app/views/explore/spans/charts/index.spec.tsx
@@ -4,6 +4,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ChartSelectionProvider} from 'sentry/views/explore/components/attributeBreakdowns/chartSelectionContext';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {ExploreCharts} from 'sentry/views/explore/spans/charts';
 import {defaultVisualizes} from 'sentry/views/explore/spans/spansQueryParams';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
@@ -45,6 +46,51 @@ describe('ExploreCharts', () => {
       await screen.findByText(
         "Hey, we're scanning all the data we can to answer your query, so please wait a bit longer"
       )
+    ).toBeInTheDocument();
+  });
+
+  it('renders one chart with combined series for multi-yAxis visualize', async () => {
+    const mockTimeseriesResult = {
+      data: {
+        'avg(span.duration)': [],
+        'p95(span.duration)': [],
+      },
+      isLoading: false,
+      isPending: false,
+      isFetching: false,
+    } as any;
+
+    render(
+      <SpansQueryParamsProvider>
+        <ChartSelectionProvider>
+          <ExploreCharts
+            extrapolate
+            setTab={() => {}}
+            confidences={[]}
+            query=""
+            timeseriesResult={mockTimeseriesResult}
+            visualizes={[
+              new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)']),
+            ]}
+            setVisualizes={() => {}}
+            rawSpanCounts={{
+              highAccuracy: {count: 0, isLoading: false},
+              normal: {count: 0, isLoading: false},
+            }}
+          />
+        </ChartSelectionProvider>
+      </SpansQueryParamsProvider>,
+      {
+        organization: OrganizationFixture(),
+      }
+    );
+
+    expect(
+      await screen.findByText(content => {
+        return (
+          content.includes('avg(') && content.includes('p95(') && content.includes(',')
+        );
+      })
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/spans/charts/index.spec.tsx
+++ b/static/app/views/explore/spans/charts/index.spec.tsx
@@ -1,3 +1,4 @@
+import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -9,6 +10,14 @@ import {ExploreCharts} from 'sentry/views/explore/spans/charts';
 import {defaultVisualizes} from 'sentry/views/explore/spans/spansQueryParams';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
+function Wrapper({children}: {children: ReactNode}) {
+  return (
+    <SpansQueryParamsProvider>
+      <ChartSelectionProvider>{children}</ChartSelectionProvider>
+    </SpansQueryParamsProvider>
+  );
+}
+
 describe('ExploreCharts', () => {
   it('renders the high accuracy message when the widget is loading more data', async () => {
     const mockTimeseriesResult = {
@@ -19,26 +28,23 @@ describe('ExploreCharts', () => {
     } as any;
 
     render(
-      <SpansQueryParamsProvider>
-        <ChartSelectionProvider>
-          <ExploreCharts
-            extrapolate
-            setTab={() => {}}
-            confidences={[]}
-            query=""
-            timeseriesResult={mockTimeseriesResult}
-            visualizes={defaultVisualizes()}
-            setVisualizes={() => {}}
-            samplingMode={SAMPLING_MODE.HIGH_ACCURACY}
-            rawSpanCounts={{
-              highAccuracy: {count: 0, isLoading: true},
-              normal: {count: 0, isLoading: true},
-            }}
-          />
-        </ChartSelectionProvider>
-      </SpansQueryParamsProvider>,
+      <ExploreCharts
+        extrapolate
+        setTab={() => {}}
+        confidences={[]}
+        query=""
+        timeseriesResult={mockTimeseriesResult}
+        visualizes={defaultVisualizes()}
+        setVisualizes={() => {}}
+        samplingMode={SAMPLING_MODE.HIGH_ACCURACY}
+        rawSpanCounts={{
+          highAccuracy: {count: 0, isLoading: true},
+          normal: {count: 0, isLoading: true},
+        }}
+      />,
       {
         organization: OrganizationFixture(),
+        additionalWrapper: Wrapper,
       }
     );
 
@@ -51,37 +57,29 @@ describe('ExploreCharts', () => {
 
   it('renders one chart with combined series for multi-yAxis visualize', async () => {
     const mockTimeseriesResult = {
-      data: {
-        'avg(span.duration)': [],
-        'p95(span.duration)': [],
-      },
+      data: {'avg(span.duration)': [], 'p95(span.duration)': []},
       isLoading: false,
       isPending: false,
       isFetching: false,
     } as any;
 
     render(
-      <SpansQueryParamsProvider>
-        <ChartSelectionProvider>
-          <ExploreCharts
-            extrapolate
-            setTab={() => {}}
-            confidences={[]}
-            query=""
-            timeseriesResult={mockTimeseriesResult}
-            visualizes={[
-              new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)']),
-            ]}
-            setVisualizes={() => {}}
-            rawSpanCounts={{
-              highAccuracy: {count: 0, isLoading: false},
-              normal: {count: 0, isLoading: false},
-            }}
-          />
-        </ChartSelectionProvider>
-      </SpansQueryParamsProvider>,
+      <ExploreCharts
+        extrapolate
+        setTab={() => {}}
+        confidences={[]}
+        query=""
+        timeseriesResult={mockTimeseriesResult}
+        visualizes={[new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'])]}
+        setVisualizes={() => {}}
+        rawSpanCounts={{
+          highAccuracy: {count: 0, isLoading: false},
+          normal: {count: 0, isLoading: false},
+        }}
+      />,
       {
         organization: OrganizationFixture(),
+        additionalWrapper: Wrapper,
       }
     );
 

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -187,7 +187,7 @@ function Chart({
 
   const chartInfo: ChartInfo = useMemo(() => {
     const isTopN = defined(topEvents) && topEvents > 0;
-    const series = timeseriesResult.data[visualize.yAxis] ?? [];
+    const series = visualize.yAxes.flatMap(yAxis => timeseriesResult.data[yAxis] ?? []);
 
     let confidenceSeries = series;
 
@@ -214,11 +214,22 @@ function Chart({
     };
   }, [chartType, timeseriesResult, visualize, samplingMode, topEvents]);
 
+  const chartTitle = useMemo(
+    () => visualize.yAxes.map(yAxis => prettifyAggregation(yAxis) ?? yAxis).join(', '),
+    [visualize.yAxes]
+  );
+
+  const visualizeYAxes = useMemo(() => {
+    if (visualize.yAxes.length <= 1) {
+      return [visualize];
+    }
+
+    return visualize.yAxes.map(yAxis => visualize.replace({yAxis}));
+  }, [visualize]);
+
   const Title = (
     <Flex>
-      <Widget.WidgetTitle
-        title={prettifyAggregation(visualize.yAxis) ?? visualize.yAxis}
-      />
+      <Widget.WidgetTitle title={chartTitle} />
     </Flex>
   );
 
@@ -260,7 +271,7 @@ function Chart({
       </Tooltip>
       <ChartContextMenu
         key="context"
-        visualizeYAxes={[visualize]}
+        visualizeYAxes={visualizeYAxes}
         query={query}
         interval={interval}
         visualizeIndex={index}

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -218,21 +218,17 @@ describe('getReadableQueryParamsFromLocation', () => {
       visualize: JSON.stringify({yAxes: ['count(span.duration)', 'avg(span.self_time)']}),
     });
     const queryParams = getReadableQueryParamsFromLocation(location);
-    expect(queryParams.aggregateFields).toHaveLength(3);
+    expect(queryParams.aggregateFields).toHaveLength(2);
     expect(queryParams.aggregateFields[0]).toEqual({groupBy: ''});
     expect(queryParams.aggregateFields[1]).toEqual(
-      new VisualizeFunction('count(span.duration)')
-    );
-    expect(queryParams.aggregateFields[2]).toEqual(
-      new VisualizeFunction('avg(span.self_time)')
+      new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)'])
     );
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new VisualizeFunction('count(span.duration)'),
-            new VisualizeFunction('avg(span.self_time)'),
+            new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)']),
           ],
         })
       )
@@ -252,8 +248,9 @@ describe('getReadableQueryParamsFromLocation', () => {
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new VisualizeFunction('count(span.duration)', {chartType: ChartType.LINE}),
-            new VisualizeFunction('avg(span.self_time)', {chartType: ChartType.LINE}),
+            new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)'], {
+              chartType: ChartType.LINE,
+            }),
           ],
         })
       )
@@ -275,8 +272,7 @@ describe('getReadableQueryParamsFromLocation', () => {
           aggregateFields: [
             new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
             {groupBy: 'span.op'},
-            new VisualizeFunction('p50(span.duration)'),
-            new VisualizeFunction('p75(span.duration)'),
+            new VisualizeFunction(['p50(span.duration)', 'p75(span.duration)']),
           ],
         })
       )

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -21,6 +21,7 @@ import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -265,7 +266,7 @@ function SpanTabContentSection({
   const confidences = useMemo(
     () =>
       visualizes.map(visualize => {
-        const dedupedYAxes = [visualize.yAxis];
+        const dedupedYAxes = dedupeArray([...visualize.yAxes]);
         const series = dedupedYAxes
           .flatMap(yAxis => timeseriesResult.data[yAxis])
           .filter(defined);

--- a/static/app/views/explore/toolbar/constants.tsx
+++ b/static/app/views/explore/toolbar/constants.tsx
@@ -1,0 +1,55 @@
+import type {SelectSection} from '@sentry/scraps/compactSelect';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {AggregationKey} from 'sentry/utils/fields';
+
+const toOption = (aggregate: AggregationKey, showDefault = false) => {
+  return {
+    label: aggregate,
+    value: aggregate,
+    textValue: aggregate,
+    trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
+  };
+};
+
+export const SPAN_AGGREGATE_OPTIONS: Array<SelectSection<string>> = [
+  {
+    key: 'count',
+    label: t('Count'),
+    options: [
+      toOption(AggregationKey.COUNT, true),
+      toOption(AggregationKey.COUNT_UNIQUE),
+      toOption(AggregationKey.SUM),
+    ],
+  },
+  {
+    key: 'percentiles',
+    label: t('Percentiles'),
+    options: [
+      AggregationKey.AVG,
+      AggregationKey.P50,
+      AggregationKey.P75,
+      AggregationKey.P90,
+      AggregationKey.P95,
+      AggregationKey.P99,
+      AggregationKey.P100,
+      AggregationKey.MIN,
+      AggregationKey.MAX,
+    ].map(aggregate => toOption(aggregate)),
+  },
+  {
+    key: 'rate',
+    label: t('Rate'),
+    options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
+      toOption(aggregate)
+    ),
+  },
+  {
+    key: 'error',
+    label: t('Error'),
+    options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(aggregate =>
+      toOption(aggregate)
+    ),
+  },
+];

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -311,7 +311,7 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
-  it('supports multi-aggregate overlays in a single visualize when feature is enabled', async () => {
+  it('supports multi-aggregate overlays within the same group when feature is enabled', async () => {
     let visualizes: any;
     function Component() {
       visualizes = useQueryParamsVisualizes();
@@ -329,23 +329,67 @@ describe('ExploreToolbar', () => {
     expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
-    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
-    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
-
-    expect(visualizes).toHaveLength(1);
-    expect(visualizes[0]!.yAxes).toEqual(['avg(span.duration)']);
-
+    await userEvent.click(within(section).getByRole('option', {name: 'p50'}));
     await userEvent.click(within(section).getByRole('option', {name: 'p95'}));
+
     expect(visualizes).toHaveLength(1);
     expect(visualizes[0]!.yAxes).toEqual(
-      expect.arrayContaining(['avg(span.duration)', 'p95(span.duration)'])
+      expect.arrayContaining(['p50(span.duration)', 'p95(span.duration)'])
     );
 
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
     expect(visualizes[0]!.yAxes).toEqual(
-      expect.arrayContaining(['avg(span.self_time)', 'p95(span.self_time)'])
+      expect.arrayContaining(['p50(span.self_time)', 'p95(span.self_time)'])
     );
+  });
+
+  it('clears selected aggregates from other groups in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['count(span.duration)', 'count_unique(span.op)'])
+    );
+
+    await userEvent.click(within(section).getByRole('option', {name: 'p50'}));
+    expect(visualizes[0]!.yAxes).toEqual(['p50(span.duration)']);
+  });
+
+  it('shows count as the default aggregate option', async () => {
+    function Component() {
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    expect(screen.getByText('Default')).toBeInTheDocument();
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    expect(screen.queryByText('Default')).not.toBeInTheDocument();
   });
 
   it('resets to default visualize when all aggregates are deselected in multi-select mode', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -371,6 +371,40 @@ describe('ExploreToolbar', () => {
     expect(visualizes[0]!.yAxes).toEqual(['p50(span.duration)']);
   });
 
+  it('does not apply invalid field choices to every aggregate in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'sum'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
+
+    expect(visualizes[0]!.yAxes).toEqual(['count_unique(span.op)', 'sum(span.duration)']);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'span.op'}));
+    await userEvent.click(
+      within(section).getByRole('option', {name: 'span.description'})
+    );
+
+    expect(visualizes[0]!.yAxes).toEqual([
+      'count_unique(span.description)',
+      'sum(span.duration)',
+    ]);
+  });
+
   it('shows count as the default aggregate option', async () => {
     function Component() {
       return <ExploreToolbar />;

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -406,11 +406,7 @@ describe('ExploreToolbar', () => {
   });
 
   it('shows count as the default aggregate option', async () => {
-    function Component() {
-      return <ExploreToolbar />;
-    }
-
-    render(<Component />, {
+    render(<ExploreToolbar />, {
       additionalWrapper: Wrapper,
       organization: OrganizationFixture({
         features: ['dashboards-edit', 'traces-overlay-charts-ui'],

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -405,6 +405,40 @@ describe('ExploreToolbar', () => {
     ]);
   });
 
+  it('preserves remaining aggregate arguments when deselecting count_unique in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["count_unique(span.self_time)","sum(span.self_time)"]}',
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes[0]!.yAxes).toEqual([
+      'count_unique(span.self_time)',
+      'sum(span.self_time)',
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: /count_unique/i}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(visualizes[0]!.yAxes).toEqual(['sum(span.self_time)']);
+  });
+
   it('shows count as the default aggregate option', async () => {
     render(<ExploreToolbar />, {
       additionalWrapper: Wrapper,

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -311,6 +311,73 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
+  it('supports multi-aggregate overlays in a single visualize when feature is enabled', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
+
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(['avg(span.duration)']);
+
+    await userEvent.click(within(section).getByRole('option', {name: 'p95'}));
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['avg(span.duration)', 'p95(span.duration)'])
+    );
+
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['avg(span.self_time)', 'p95(span.self_time)'])
+    );
+  });
+
+  it('resets to default visualize when all aggregates are deselected in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["avg(span.duration)"]}',
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(['count(span.duration)']);
+  });
+
   it('allows changing group bys', async () => {
     let groupBys: any;
 

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -68,7 +68,7 @@ export function ToolbarSaveAs() {
   const mode = useQueryParamsMode();
   const id = useQueryParamsId();
   const visualizeYAxes = useMemo(
-    () => dedupeArray(visualizes.filter(isVisualizeFunction).map(v => v.yAxis)),
+    () => dedupeArray(visualizes.filter(isVisualizeFunction).flatMap(v => v.yAxes)),
     [visualizes]
   );
   const [caseInsensitive] = useCaseInsensitivity();

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -170,10 +170,9 @@ export function ToolbarSaveAs() {
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
 
   const chartOptions = useMemo(() => {
-    return visualizeYAxes.map((yAxis, index) => {
-      const dedupedYAxes = [yAxis];
-      const formattedYAxes = dedupedYAxes.map(yaxis => {
-        const func = parseFunction(yaxis);
+    return visualizes.filter(isVisualizeFunction).map((visualize, index) => {
+      const formattedYAxes = visualize.yAxes.map(yAxis => {
+        const func = parseFunction(yAxis);
         return func ? prettifyParsedFunction(func) : undefined;
       });
 
@@ -194,7 +193,7 @@ export function ToolbarSaveAs() {
         },
       };
     });
-  }, [addToDashboard, disableAddToDashboard, organization, visualizeYAxes]);
+  }, [addToDashboard, disableAddToDashboard, organization, visualizes]);
 
   items.push({
     key: 'add-to-dashboard',

--- a/static/app/views/explore/toolbar/toolbarSortBy.tsx
+++ b/static/app/views/explore/toolbar/toolbarSortBy.tsx
@@ -49,7 +49,7 @@ export function ToolbarSortBy() {
 
   const fieldOptions = useSortByFields({
     fields,
-    yAxes: visualizes.map(v => v.yAxis),
+    yAxes: visualizes.flatMap(v => v.yAxes),
     groupBys,
     mode,
   });

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -3,13 +3,11 @@ import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import type {SelectKey, SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
-import {Text} from '@sentry/scraps/text';
+import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 
 import {IconHide} from 'sentry/icons/iconHide';
-import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {AggregationKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -39,6 +37,7 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {SPAN_AGGREGATE_OPTIONS} from 'sentry/views/explore/toolbar/constants';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ToolbarVisualizeProps {
@@ -207,58 +206,6 @@ function VisualizeDropdown({
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
   const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
-  const aggregateOptions: Array<SelectSection<string>> = useMemo(() => {
-    const toOption = (aggregate: AggregationKey, showDefault = false) => {
-      return {
-        label: aggregate,
-        value: aggregate,
-        textValue: aggregate,
-        trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
-      };
-    };
-
-    return [
-      {
-        key: 'count',
-        label: t('Count'),
-        options: [
-          toOption(AggregationKey.COUNT, true),
-          toOption(AggregationKey.COUNT_UNIQUE),
-          toOption(AggregationKey.SUM),
-        ],
-      },
-      {
-        key: 'percentiles',
-        label: t('Percentiles'),
-        options: [
-          AggregationKey.AVG,
-          AggregationKey.P50,
-          AggregationKey.P75,
-          AggregationKey.P90,
-          AggregationKey.P95,
-          AggregationKey.P99,
-          AggregationKey.P100,
-          AggregationKey.MIN,
-          AggregationKey.MAX,
-        ].map(aggregate => toOption(aggregate)),
-      },
-      {
-        key: 'rate',
-        label: t('Rate'),
-        options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
-          toOption(aggregate)
-        ),
-      },
-      {
-        key: 'error',
-        label: t('Error'),
-        options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(
-          aggregate => toOption(aggregate)
-        ),
-      },
-    ];
-  }, []);
-
   const parsedFunctions = useMemo(
     () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
     [visualize.yAxes]
@@ -289,7 +236,7 @@ function VisualizeDropdown({
           aggregate => !previousAggregates.has(aggregate)
         );
         if (newlyAdded) {
-          const targetGroup = aggregateOptions.find(section =>
+          const targetGroup = SPAN_AGGREGATE_OPTIONS.find(section =>
             section.options.some(opt => opt.value === newlyAdded)
           );
           if (targetGroup) {
@@ -329,7 +276,13 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
+    [
+      onReplace,
+      parsedAggregates,
+      parsedFunction?.arguments,
+      parsedFunction?.name,
+      visualize,
+    ]
   );
 
   const getFieldValueType = useCallback(
@@ -433,7 +386,7 @@ function VisualizeDropdown({
   return (
     <ToolbarVisualizeDropdown
       aggregateMultiple={hasMultiSelect}
-      aggregateOptions={aggregateOptions}
+      aggregateOptions={SPAN_AGGREGATE_OPTIONS}
       aggregateValue={aggregateValue}
       fieldOptions={fieldOptions}
       canDelete={canDelete}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -231,6 +231,24 @@ function VisualizeDropdown({
           return typeof selected.value === 'string' ? [selected.value] : [];
         });
 
+        const previousAxesByAggregate = new Map(
+          parsedFunctions.flatMap((func, index) => {
+            if (!func) {
+              return [];
+            }
+            return [[func.name, visualize.yAxes[index] ?? ''] as const];
+          })
+        );
+
+        const previousFunctionsByAggregate = new Map(
+          parsedFunctions.flatMap(func => {
+            if (!func) {
+              return [];
+            }
+            return [[func.name, func] as const];
+          })
+        );
+
         const previousAggregates = new Set(parsedAggregates);
         const newlyAdded = selectedAggregates.find(
           aggregate => !previousAggregates.has(aggregate)
@@ -256,12 +274,19 @@ function VisualizeDropdown({
           return;
         }
 
-        const yAxes = selectedAggregates.map(aggregate =>
-          updateVisualizeAggregate({
-            newAggregate: aggregate,
-            oldAggregate: parsedFunction?.name,
-            oldArguments: parsedFunction?.arguments,
-          })
+        const baselineFunction =
+          selectedAggregates
+            .map(aggregate => previousFunctionsByAggregate.get(aggregate))
+            .find(Boolean) ?? parsedFunction;
+
+        const yAxes = selectedAggregates.map(
+          aggregate =>
+            previousAxesByAggregate.get(aggregate) ??
+            updateVisualizeAggregate({
+              newAggregate: aggregate,
+              oldAggregate: baselineFunction?.name,
+              oldArguments: baselineFunction?.arguments,
+            })
         );
         onReplace(visualize.replace({yAxes}));
         return;
@@ -276,13 +301,7 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [
-      onReplace,
-      parsedAggregates,
-      parsedFunction?.arguments,
-      parsedFunction?.name,
-      visualize,
-    ]
+    [onReplace, parsedAggregates, parsedFunction, parsedFunctions, visualize]
   );
 
   const getFieldValueType = useCallback(

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -3,11 +3,13 @@ import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
+import type {SelectKey, SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
+import {Text} from '@sentry/scraps/text';
 
 import {IconHide} from 'sentry/icons/iconHide';
+import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -205,23 +207,67 @@ function VisualizeDropdown({
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
   const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
-  const aggregateOptions = useMemo(
-    () =>
-      ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.map(aggregate => {
-        return {
-          label: aggregate,
-          value: aggregate,
-          textValue: aggregate,
-        };
-      }),
-    []
-  );
+  const aggregateOptions: Array<SelectSection<string>> = useMemo(() => {
+    const toOption = (aggregate: AggregationKey, showDefault = false) => {
+      return {
+        label: aggregate,
+        value: aggregate,
+        textValue: aggregate,
+        trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
+      };
+    };
+
+    return [
+      {
+        key: 'count',
+        label: t('Count'),
+        options: [
+          toOption(AggregationKey.COUNT, true),
+          toOption(AggregationKey.COUNT_UNIQUE),
+          toOption(AggregationKey.SUM),
+        ],
+      },
+      {
+        key: 'percentiles',
+        label: t('Percentiles'),
+        options: [
+          AggregationKey.AVG,
+          AggregationKey.P50,
+          AggregationKey.P75,
+          AggregationKey.P90,
+          AggregationKey.P95,
+          AggregationKey.P99,
+          AggregationKey.P100,
+          AggregationKey.MIN,
+          AggregationKey.MAX,
+        ].map(aggregate => toOption(aggregate)),
+      },
+      {
+        key: 'rate',
+        label: t('Rate'),
+        options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
+          toOption(aggregate)
+        ),
+      },
+      {
+        key: 'error',
+        label: t('Error'),
+        options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(
+          aggregate => toOption(aggregate)
+        ),
+      },
+    ];
+  }, []);
 
   const parsedFunctions = useMemo(
     () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
     [visualize.yAxes]
   );
   const parsedFunction = parsedFunctions[0] ?? null;
+  const parsedAggregates = useMemo(
+    () => parsedFunctions.flatMap(func => (func?.name ? [func.name] : [])),
+    [parsedFunctions]
+  );
 
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
@@ -234,9 +280,29 @@ function VisualizeDropdown({
   const onChangeAggregate = useCallback(
     (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
       if (Array.isArray(option)) {
-        const selectedAggregates = option.flatMap(selected => {
+        let selectedAggregates = option.flatMap(selected => {
           return typeof selected.value === 'string' ? [selected.value] : [];
         });
+
+        const previousAggregates = new Set(parsedAggregates);
+        const newlyAdded = selectedAggregates.find(
+          aggregate => !previousAggregates.has(aggregate)
+        );
+        if (newlyAdded) {
+          const targetGroup = aggregateOptions.find(section =>
+            section.options.some(opt => opt.value === newlyAdded)
+          );
+          if (targetGroup) {
+            const groupValues = new Set(
+              targetGroup.options.flatMap(opt =>
+                typeof opt.value === 'string' ? [opt.value] : []
+              )
+            );
+            selectedAggregates = selectedAggregates.filter(aggregate =>
+              groupValues.has(aggregate)
+            );
+          }
+        }
 
         if (selectedAggregates.length === 0) {
           onReplace(visualize.replace({yAxis: DEFAULT_VISUALIZATION}));
@@ -263,7 +329,7 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [onReplace, parsedFunction, visualize]
+    [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
   );
 
   const onChangeArgument = useCallback(
@@ -300,9 +366,7 @@ function VisualizeDropdown({
     [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
   );
 
-  const aggregateValue = hasMultiSelect
-    ? parsedFunctions.flatMap(func => (func?.name ? [func.name] : []))
-    : (parsedFunction?.name ?? '');
+  const aggregateValue = hasMultiSelect ? parsedAggregates : (parsedFunction?.name ?? '');
 
   return (
     <ToolbarVisualizeDropdown

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -9,6 +9,7 @@ import {IconHide} from 'sentry/icons/iconHide';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -198,9 +199,11 @@ function VisualizeDropdown({
   onSearch,
   onClose,
 }: VisualizeDropdownProps & {onClose: () => void; onSearch: (search: string) => void}) {
+  const organization = useOrganization();
   const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
   const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
+  const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
   const aggregateOptions = useMemo(
     () =>
@@ -214,7 +217,11 @@ function VisualizeDropdown({
     []
   );
 
-  const parsedFunction = useMemo(() => parseFunction(visualize.yAxis), [visualize.yAxis]);
+  const parsedFunctions = useMemo(
+    () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
+    [visualize.yAxes]
+  );
+  const parsedFunction = parsedFunctions[0] ?? null;
 
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
@@ -225,7 +232,28 @@ function VisualizeDropdown({
   });
 
   const onChangeAggregate = useCallback(
-    (option: SelectOption<SelectKey>) => {
+    (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
+      if (Array.isArray(option)) {
+        const selectedAggregates = option.flatMap(selected => {
+          return typeof selected.value === 'string' ? [selected.value] : [];
+        });
+
+        if (selectedAggregates.length === 0) {
+          onReplace(visualize.replace({yAxis: DEFAULT_VISUALIZATION}));
+          return;
+        }
+
+        const yAxes = selectedAggregates.map(aggregate =>
+          updateVisualizeAggregate({
+            newAggregate: aggregate,
+            oldAggregate: parsedFunction?.name,
+            oldArguments: parsedFunction?.arguments,
+          })
+        );
+        onReplace(visualize.replace({yAxes}));
+        return;
+      }
+
       if (typeof option.value === 'string') {
         const yAxis = updateVisualizeAggregate({
           newAggregate: option.value,
@@ -241,22 +269,46 @@ function VisualizeDropdown({
   const onChangeArgument = useCallback(
     (index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
+        const nextArgument = option.value;
+        if (hasMultiSelect && visualize.yAxes.length > 1) {
+          const yAxes = parsedFunctions.flatMap(func => {
+            if (!func) {
+              return [];
+            }
+            let args = cloneDeep(func.arguments);
+            if (args) {
+              args[index] = nextArgument;
+            } else {
+              args = [nextArgument];
+            }
+            return [`${func.name}(${args.join(',')})`];
+          });
+          onReplace(visualize.replace({yAxes}));
+          return;
+        }
+
         let args = cloneDeep(parsedFunction?.arguments);
         if (args) {
-          args[index] = option.value;
+          args[index] = nextArgument;
         } else {
-          args = [option.value];
+          args = [nextArgument];
         }
         const yAxis = `${parsedFunction?.name}(${args.join(',')})`;
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [onReplace, parsedFunction, visualize]
+    [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
   );
+
+  const aggregateValue = hasMultiSelect
+    ? parsedFunctions.flatMap(func => (func?.name ? [func.name] : []))
+    : (parsedFunction?.name ?? '');
 
   return (
     <ToolbarVisualizeDropdown
+      aggregateMultiple={hasMultiSelect}
       aggregateOptions={aggregateOptions}
+      aggregateValue={aggregateValue}
       fieldOptions={fieldOptions}
       canDelete={canDelete}
       onChangeAggregate={onChangeAggregate}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -9,7 +9,7 @@ import {Text} from '@sentry/scraps/text';
 import {IconHide} from 'sentry/icons/iconHide';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {AggregationKey} from 'sentry/utils/fields';
+import {AggregationKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -332,6 +332,50 @@ function VisualizeDropdown({
     [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
   );
 
+  const getFieldValueType = useCallback(
+    (field: string): FieldValueType => {
+      const tag = numberTags[field] ?? stringTags[field] ?? booleanTags[field];
+      const fieldDefinition = tag
+        ? getFieldDefinition(field, 'span', tag.kind)
+        : getFieldDefinition(field, 'span');
+
+      if (fieldDefinition?.valueType) {
+        return fieldDefinition.valueType;
+      }
+
+      if (Object.hasOwn(numberTags, field)) {
+        return FieldValueType.NUMBER;
+      }
+      if (Object.hasOwn(booleanTags, field)) {
+        return FieldValueType.BOOLEAN;
+      }
+      return FieldValueType.STRING;
+    },
+    [booleanTags, numberTags, stringTags]
+  );
+
+  const canApplyArgumentToAggregate = useCallback(
+    (aggregate: string, index: number, nextArgument: string): boolean => {
+      const aggregateDefinition = getFieldDefinition(aggregate, 'span');
+      const parameter = aggregateDefinition?.parameters?.[index];
+
+      if (!parameter || parameter.kind !== 'column') {
+        return false;
+      }
+
+      const valueType = getFieldValueType(nextArgument);
+      if (typeof parameter.columnTypes === 'function') {
+        return parameter.columnTypes({
+          key: nextArgument,
+          valueType,
+        });
+      }
+
+      return parameter.columnTypes.includes(valueType);
+    },
+    [getFieldValueType]
+  );
+
   const onChangeArgument = useCallback(
     (index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
@@ -341,6 +385,17 @@ function VisualizeDropdown({
             if (!func) {
               return [];
             }
+
+            if (!canApplyArgumentToAggregate(func.name, index, nextArgument)) {
+              return [
+                updateVisualizeAggregate({
+                  newAggregate: func.name,
+                  oldAggregate: func.name,
+                  oldArguments: func.arguments,
+                }),
+              ];
+            }
+
             let args = cloneDeep(func.arguments);
             if (args) {
               args[index] = nextArgument;
@@ -363,7 +418,14 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
+    [
+      canApplyArgumentToAggregate,
+      hasMultiSelect,
+      onReplace,
+      parsedFunction,
+      parsedFunctions,
+      visualize,
+    ]
   );
 
   const aggregateValue = hasMultiSelect ? parsedAggregates : (parsedFunction?.name ?? '');

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -408,7 +408,7 @@ export function viewSamplesTarget({
     search,
     row,
     sorts,
-    yAxes: visualizes.map(visualize => visualize.yAxis),
+    yAxes: visualizes.flatMap(visualize => visualize.yAxes),
   });
 
   return getTargetWithReadableQueryParams(location, {


### PR DESCRIPTION
## Summary
- add multi-yAxis support for trace visualize models and overlay charts
- propagate multi-aggregate handling through explore consumers (charts, save-as, query param management)
- group traces visualize aggregate options by similarity and add behavior/tests for same-group multi-select and cross-group clearing

## Test plan
- [x] `CI=true pnpm test static/app/views/explore/toolbar/index.spec.tsx`
- [ ] smoke test traces Explore visualize toolbar in UI
- [ ] verify grouped aggregate dropdown sections and default badge
- [ ] verify cross-group selection clears prior group selections

Made with [Cursor](https://cursor.com)