### PR TITLE
ref(performance): Rename segment spans referrers

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -316,12 +316,12 @@ class Referrer(StrEnum):
     API_INSIGHTS_MOBILE_SPAN_TABLE = "api.insights.mobile-span-table"
     API_INSIGHTS_MOBILE_LANDING_TABLE = "api.insights.mobile.landing-table"
 
-    # Service Entry Spans
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE = "api.insights.service-entry-spans-table"
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_WITH_CATEGORY = (
-        "api.insights.service-entry-spans-table-with-category"
+    # Segment Spans
+    API_INSIGHTS_SEGMENT_SPANS_TABLE = "api.insights.segment-spans-table"
+    API_INSIGHTS_SEGMENT_SPANS_TABLE_WITH_CATEGORY = (
+        "api.insights.segment-spans-table-with-category"
     )
-    API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_COUNT = "api.insights.service-entry-spans-table-count"
+    API_INSIGHTS_SEGMENT_SPANS_TABLE_COUNT = "api.insights.segment-spans-table-count"
 
     # Trace Panel
     API_INSIGHTS_TRACE_PANEL_LEFT_TRACE_LINK = "api.insights.trace-panel-left-trace-link"


### PR DESCRIPTION
## Summary

Renames Snuba referrer constants from "service entry spans" to "segment spans" to align with updated product terminology.

This is a backend-only change that updates the referrer constant names used in Snuba queries. The frontend changes are in a separate PR.

## Changes

- `API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE` → `API_INSIGHTS_SEGMENT_SPANS_TABLE`
- `API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_WITH_CATEGORY` → `API_INSIGHTS_SEGMENT_SPANS_TABLE_WITH_CATEGORY`
- `API_INSIGHTS_SERVICE_ENTRY_SPANS_TABLE_COUNT` → `API_INSIGHTS_SEGMENT_SPANS_TABLE_COUNT`

## Related

Frontend changes: #108355