### PR TITLE
perf(tests): Convert tests to pure unit tests

### DIFF
--- a/tests/sentry/api/serializers/rest_framework/test_base.py
+++ b/tests/sentry/api/serializers/rest_framework/test_base.py
@@ -9,7 +9,7 @@ from sentry.api.serializers.rest_framework.base import (
     convert_dict_key_case,
     snake_to_camel_case,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.pytest.fixtures import django_db_all
 
 
 class PersonSerializer(CamelSnakeSerializer):
@@ -46,19 +46,21 @@ class ContentTypeSerializer(CamelSnakeModelSerializer):
         fields = ["app_label", "model"]
 
 
-class CamelSnakeModelSerializerTest(TestCase):
-    def test_simple(self) -> None:
-        serializer = ContentTypeSerializer(data={"appLabel": "hello", "model": "Something"})
-        assert serializer.is_valid()
-        assert serializer.data == {"model": "Something", "app_label": "hello"}
+@django_db_all
+def test_camel_snake_model_serializer_simple() -> None:
+    serializer = ContentTypeSerializer(data={"appLabel": "hello", "model": "Something"})
+    assert serializer.is_valid()
+    assert serializer.data == {"model": "Something", "app_label": "hello"}
 
-    def test_error(self) -> None:
-        serializer = ContentTypeSerializer(data={"appLabel": None})
-        assert not serializer.is_valid()
-        assert serializer.errors == {
-            "appLabel": ["This field may not be null."],
-            "model": ["This field is required."],
-        }
+
+@django_db_all
+def test_camel_snake_model_serializer_error() -> None:
+    serializer = ContentTypeSerializer(data={"appLabel": None})
+    assert not serializer.is_valid()
+    assert serializer.errors == {
+        "appLabel": ["This field may not be null."],
+        "model": ["This field is required."],
+    }
 
 
 def test_convert_dict_key_case() -> None:

--- a/tests/sentry/api/serializers/rest_framework/test_base.py
+++ b/tests/sentry/api/serializers/rest_framework/test_base.py
@@ -17,26 +17,27 @@ class PersonSerializer(CamelSnakeSerializer):
     works_at = serializers.CharField()
 
 
-class CamelSnakeSerializerTest(TestCase):
-    def test_simple(self) -> None:
-        serializer = PersonSerializer(data={"name": "Rick", "worksAt": "Sentry"})
-        assert serializer.is_valid()
-        assert serializer.data == {"name": "Rick", "works_at": "Sentry"}
+def test_camel_snake_serializer_simple() -> None:
+    serializer = PersonSerializer(data={"name": "Rick", "worksAt": "Sentry"})
+    assert serializer.is_valid()
+    assert serializer.data == {"name": "Rick", "works_at": "Sentry"}
 
-    def test_error(self) -> None:
-        serializer = PersonSerializer(data={"worksAt": None})
-        assert not serializer.is_valid()
-        assert serializer.errors == {
-            "worksAt": ["This field may not be null."],
-            "name": ["This field is required."],
-        }
 
-    def test_smuggling(self) -> None:
-        with pytest.raises(
-            serializers.ValidationError,
-            match=r"_name collides with name, please pass only one value",
-        ):
-            PersonSerializer(data={"name": "Rick", "worksAt": "Sentry", "_name": "Chuck"})
+def test_camel_snake_serializer_error() -> None:
+    serializer = PersonSerializer(data={"worksAt": None})
+    assert not serializer.is_valid()
+    assert serializer.errors == {
+        "worksAt": ["This field may not be null."],
+        "name": ["This field is required."],
+    }
+
+
+def test_camel_snake_serializer_smuggling() -> None:
+    with pytest.raises(
+        serializers.ValidationError,
+        match=r"_name collides with name, please pass only one value",
+    ):
+        PersonSerializer(data={"name": "Rick", "worksAt": "Sentry", "_name": "Chuck"})
 
 
 class ContentTypeSerializer(CamelSnakeModelSerializer):

--- a/tests/sentry/api/serializers/rest_framework/test_origin.py
+++ b/tests/sentry/api/serializers/rest_framework/test_origin.py
@@ -1,22 +1,21 @@
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework import OriginField
-from sentry.testutils.cases import TestCase
 
 
 class DummySerializer(serializers.Serializer):
     origin_field = OriginField()
 
 
-class OriginFieldTest(TestCase):
-    def test_valid_origin(self) -> None:
-        urls = ["https://www.foo.com", "*", "*.domain.com", "*:80", "localhost:8080"]
-        for url in urls:
-            serializer = DummySerializer(data={"origin_field": url})
-            assert serializer.is_valid()
+def test_origin_field_valid_origin() -> None:
+    urls = ["https://www.foo.com", "*", "*.domain.com", "*:80", "localhost:8080"]
+    for url in urls:
+        serializer = DummySerializer(data={"origin_field": url})
+        assert serializer.is_valid()
 
-    def test_invalid_origin(self) -> None:
-        urls = ["https://www.foo.com:*", "localhost:*"]
-        for url in urls:
-            serializer = DummySerializer(data={"origin_field": url})
-            assert serializer.is_valid() is False
+
+def test_origin_field_invalid_origin() -> None:
+    urls = ["https://www.foo.com:*", "localhost:*"]
+    for url in urls:
+        serializer = DummySerializer(data={"origin_field": url})
+        assert serializer.is_valid() is False

--- a/tests/sentry/auth/test_password_validation.py
+++ b/tests/sentry/auth/test_password_validation.py
@@ -7,7 +7,6 @@ from pytest import raises
 
 from sentry.auth.password_validation import validate_password
 from sentry.conf.server import AUTH_PASSWORD_VALIDATORS
-from sentry.testutils.cases import TestCase
 from sentry.users.models.user import User
 
 PWNED_PASSWORDS_RESPONSE_MOCK = """4145D488EF49819E75E71019A6E8EA21905:1
@@ -25,77 +24,85 @@ AUTH_PASSWORD_VALIDATORS_TEST: list[dict[str, Any]] = [
 
 
 @override_settings(AUTH_PASSWORD_VALIDATORS=AUTH_PASSWORD_VALIDATORS_TEST)
-class PasswordValidationTestCase(TestCase):
-    def test_user_attribute_similarity(self) -> None:
-        user = User(username="hello@example.com")
-        with raises(ValidationError, match="The password is too similar to the username."):
-            validate_password("hallo@example.com", user=user)
+def test_password_user_attribute_similarity() -> None:
+    user = User(username="hello@example.com")
+    with raises(ValidationError, match="The password is too similar to the username."):
+        validate_password("hallo@example.com", user=user)
 
-    def test_minimum_length(self) -> None:
-        with raises(ValidationError, match="This password is too short."):
-            validate_password("p@sswrd")
 
-    def test_maximum_length(self) -> None:
-        with raises(ValidationError, match="This password is too long."):
-            validate_password("A" * 257)
+@override_settings(AUTH_PASSWORD_VALIDATORS=AUTH_PASSWORD_VALIDATORS_TEST)
+def test_password_minimum_length() -> None:
+    with raises(ValidationError, match="This password is too short."):
+        validate_password("p@sswrd")
 
-    def test_common_password(self) -> None:
-        with raises(ValidationError, match="This password is too common."):
-            validate_password("password")
 
-    def test_numeric_password(self) -> None:
-        with raises(ValidationError, match="This password is entirely numeric."):
-            validate_password("12345670007654321")
+@override_settings(AUTH_PASSWORD_VALIDATORS=AUTH_PASSWORD_VALIDATORS_TEST)
+def test_password_maximum_length() -> None:
+    with raises(ValidationError, match="This password is too long."):
+        validate_password("A" * 257)
 
-    @responses.activate
-    @override_settings(
-        AUTH_PASSWORD_VALIDATORS=[
-            {
-                "NAME": "sentry.auth.password_validation.PwnedPasswordsValidator",
-                "OPTIONS": {"threshold": 34},
-            }
-        ]
+
+@override_settings(AUTH_PASSWORD_VALIDATORS=AUTH_PASSWORD_VALIDATORS_TEST)
+def test_password_common_password() -> None:
+    with raises(ValidationError, match="This password is too common."):
+        validate_password("password")
+
+
+@override_settings(AUTH_PASSWORD_VALIDATORS=AUTH_PASSWORD_VALIDATORS_TEST)
+def test_password_numeric_password() -> None:
+    with raises(ValidationError, match="This password is entirely numeric."):
+        validate_password("12345670007654321")
+
+
+@responses.activate
+@override_settings(
+    AUTH_PASSWORD_VALIDATORS=[
+        {
+            "NAME": "sentry.auth.password_validation.PwnedPasswordsValidator",
+            "OPTIONS": {"threshold": 34},
+        }
+    ]
+)
+def test_pwned_passwords() -> None:
+    # sha1("hiphophouse") == "74BA3..."
+    responses.add(
+        responses.GET,
+        "https://api.pwnedpasswords.com/range/74BA3",
+        body=PWNED_PASSWORDS_RESPONSE_MOCK,
     )
-    def test_pwned_passwords(self) -> None:
-        # sha1("hiphophouse") == "74BA3..."
-        responses.add(
-            responses.GET,
-            "https://api.pwnedpasswords.com/range/74BA3",
-            body=PWNED_PASSWORDS_RESPONSE_MOCK,
-        )
-        with raises(
-            ValidationError,
-            match="This password has previously appeared in data breaches 34 times.",
-        ):
-            validate_password("hiphophouse")
+    with raises(
+        ValidationError,
+        match="This password has previously appeared in data breaches 34 times.",
+    ):
+        validate_password("hiphophouse")
 
-    @responses.activate
-    @override_settings(
-        AUTH_PASSWORD_VALIDATORS=[
-            {
-                "NAME": "sentry.auth.password_validation.PwnedPasswordsValidator",
-                "OPTIONS": {"threshold": 35},
-            }
-        ]
-    )
-    def test_pwned_passwords_low_threshold(self) -> None:
-        responses.add(
-            responses.GET,
-            "https://api.pwnedpasswords.com/range/74BA3",
-            body=PWNED_PASSWORDS_RESPONSE_MOCK,
-        )
-        validate_password("hiphophouse")  # should not raise
 
-    @responses.activate
-    @override_settings(
-        AUTH_PASSWORD_VALIDATORS=[
-            {"NAME": "sentry.auth.password_validation.PwnedPasswordsValidator"}
-        ]
+@responses.activate
+@override_settings(
+    AUTH_PASSWORD_VALIDATORS=[
+        {
+            "NAME": "sentry.auth.password_validation.PwnedPasswordsValidator",
+            "OPTIONS": {"threshold": 35},
+        }
+    ]
+)
+def test_pwned_passwords_low_threshold() -> None:
+    responses.add(
+        responses.GET,
+        "https://api.pwnedpasswords.com/range/74BA3",
+        body=PWNED_PASSWORDS_RESPONSE_MOCK,
     )
-    def test_pwned_passwords_corrupted_content(self) -> None:
-        responses.add(
-            responses.GET,
-            "https://api.pwnedpasswords.com/range/74BA3",
-            body="corrupted_content_with_no_colon",
-        )
-        validate_password("hiphophouse")  # should not raise
+    validate_password("hiphophouse")  # should not raise
+
+
+@responses.activate
+@override_settings(
+    AUTH_PASSWORD_VALIDATORS=[{"NAME": "sentry.auth.password_validation.PwnedPasswordsValidator"}]
+)
+def test_pwned_passwords_corrupted_content() -> None:
+    responses.add(
+        responses.GET,
+        "https://api.pwnedpasswords.com/range/74BA3",
+        body="corrupted_content_with_no_colon",
+    )
+    validate_password("hiphophouse")  # should not raise

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -139,7 +139,8 @@ def test_publish_data_success():
     CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
     CONDUIT_PUBLISH_URL="http://localhost:9093",
 )
-def test_publish_data_retry_on_failure():
+@patch("sentry.utils.retries.time.sleep")
+def test_publish_data_retry_on_failure(mock_sleep):
     """Test that publish_data retries on RequestException."""
     org_id = 123
     channel_id = str(uuid4())
@@ -188,7 +189,8 @@ def test_publish_data_retry_on_failure():
     CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
     CONDUIT_PUBLISH_URL="http://localhost:9093",
 )
-def test_publish_data_max_retries_exceeded():
+@patch("sentry.utils.retries.time.sleep")
+def test_publish_data_max_retries_exceeded(mock_sleep):
     """Test that publish_data raises after max retries."""
     org_id = 123
     channel_id = str(uuid4())

--- a/tests/sentry/conduit/test_tasks.py
+++ b/tests/sentry/conduit/test_tasks.py
@@ -18,290 +18,303 @@ from sentry.conduit.tasks import (
     publish_data,
     stream_demo_data,
 )
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
+# GenerateJWT tests
 
-class GenerateJWTTest(TestCase):
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="test-issuer",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="test-audience",
+
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="test-issuer",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="test-audience",
+)
+def test_generate_jwt_uses_settings():
+    """Test that generate_jwt uses settings when parameters are not provided."""
+    token = generate_jwt(subject="test-subject")
+
+    claims = pyjwt.decode(token, options={"verify_signature": False})
+
+    assert claims["sub"] == "test-subject"
+    assert claims["iss"] == "test-issuer"
+    assert claims["aud"] == "test-audience"
+    assert "exp" in claims
+
+
+def test_generate_jwt_uses_provided_parameters():
+    """Test that generate_jwt uses parameters when provided."""
+    token = generate_jwt(
+        subject="test-subject",
+        issuer="custom-issuer",
+        audience="custom-audience",
+        secret="custom-secret",
     )
-    def test_generate_jwt_uses_settings(self):
-        """Test that generate_jwt uses settings when parameters are not provided."""
-        token = generate_jwt(subject="test-subject")
 
-        claims = pyjwt.decode(token, options={"verify_signature": False})
+    claims = pyjwt.decode(token, options={"verify_signature": False})
 
-        assert claims["sub"] == "test-subject"
-        assert claims["iss"] == "test-issuer"
-        assert claims["aud"] == "test-audience"
-        assert "exp" in claims
-
-    def test_generate_jwt_uses_provided_parameters(self):
-        """Test that generate_jwt uses parameters when provided."""
-        token = generate_jwt(
-            subject="test-subject",
-            issuer="custom-issuer",
-            audience="custom-audience",
-            secret="custom-secret",
-        )
-
-        claims = pyjwt.decode(token, options={"verify_signature": False})
-
-        assert claims["sub"] == "test-subject"
-        assert claims["iss"] == "custom-issuer"
-        assert claims["aud"] == "custom-audience"
-        assert "exp" in claims
-
-    def test_generate_jwt_raises_when_secret_missing(self):
-        """Test that generate_jwt raises ValueError when secret is not configured."""
-        with pytest.raises(ValueError) as context:
-            generate_jwt(subject="test-subject")
-
-        assert "CONDUIT_PUBLISH_SECRET not configured" in str(context.value)
+    assert claims["sub"] == "test-subject"
+    assert claims["iss"] == "custom-issuer"
+    assert claims["aud"] == "custom-audience"
+    assert "exp" in claims
 
 
-class GetTimestampTest(TestCase):
-    @freeze_time("2025-01-01T12:00:00Z")
-    def test_get_timestamp_uses_current_time(self):
-        """Test that get_timestamp generates a valid timestamp."""
-        timestamp = get_timestamp()
+def test_generate_jwt_raises_when_secret_missing():
+    """Test that generate_jwt raises ValueError when secret is not configured."""
+    with pytest.raises(ValueError) as context:
+        generate_jwt(subject="test-subject")
 
-        dt = timestamp.ToDatetime()
-        expected = datetime.datetime(2025, 1, 1, 12, 0, 0)
-        assert dt == expected
-
-    def test_get_timestamp_uses_provided_datetime(self):
-        """Test that get_timestamp uses provided datetime."""
-        custom_dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
-        timestamp = get_timestamp(custom_dt)
-
-        dt = timestamp.ToDatetime()
-        assert dt == custom_dt
+    assert "CONDUIT_PUBLISH_SECRET not configured" in str(context.value)
 
 
-class PublishDataTest(TestCase):
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
+# GetTimestamp tests
+
+
+@freeze_time("2025-01-01T12:00:00Z")
+def test_get_timestamp_uses_current_time():
+    """Test that get_timestamp generates a valid timestamp."""
+    timestamp = get_timestamp()
+
+    dt = timestamp.ToDatetime()
+    expected = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    assert dt == expected
+
+
+def test_get_timestamp_uses_provided_datetime():
+    """Test that get_timestamp uses provided datetime."""
+    custom_dt = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    timestamp = get_timestamp(custom_dt)
+
+    dt = timestamp.ToDatetime()
+    assert dt == custom_dt
+
+
+# PublishData tests
+
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+def test_publish_data_success():
+    """Test successful publish request."""
+    org_id = 123
+    channel_id = str(uuid4())
+    token = generate_jwt(subject="test")
+
+    publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=0,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_START,
     )
-    def test_publish_data_success(self):
-        """Test successful publish request."""
-        org_id = 123
-        channel_id = str(uuid4())
-        token = generate_jwt(subject="test")
 
-        publish_request = PublishRequest(
-            channel_id=channel_id,
-            message_id=str(uuid4()),
-            sequence=0,
-            client_timestamp=get_timestamp(),
-            phase=Phase.PHASE_START,
-        )
-
-        responses.add(
-            responses.POST,
-            f"http://localhost:9093/publish/{org_id}/{channel_id}",
-            status=200,
-        )
-
-        response = publish_data(
-            org_id=org_id,
-            publish_request=publish_request,
-            token=token,
-            publish_url="http://localhost:9093",
-        )
-
-        assert response.status_code == 200
-        assert len(responses.calls) == 1
-
-        request = responses.calls[0].request
-        assert request.headers["Authorization"] == f"Bearer {token}"
-        assert request.headers["Content-Type"] == "application/x-protobuf"
-
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    responses.add(
+        responses.POST,
+        f"http://localhost:9093/publish/{org_id}/{channel_id}",
+        status=200,
     )
-    def test_publish_data_retry_on_failure(self):
-        """Test that publish_data retries on RequestException."""
-        org_id = 123
-        channel_id = str(uuid4())
-        token = generate_jwt(subject="test")
 
-        publish_request = PublishRequest(
-            channel_id=channel_id,
-            message_id=str(uuid4()),
-            sequence=0,
-            client_timestamp=get_timestamp(),
-            phase=Phase.PHASE_START,
-        )
+    response = publish_data(
+        org_id=org_id,
+        publish_request=publish_request,
+        token=token,
+        publish_url="http://localhost:9093",
+    )
 
-        # Fails twice, then succeeds
+    assert response.status_code == 200
+    assert len(responses.calls) == 1
+
+    request = responses.calls[0].request
+    assert request.headers["Authorization"] == f"Bearer {token}"
+    assert request.headers["Content-Type"] == "application/x-protobuf"
+
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+def test_publish_data_retry_on_failure():
+    """Test that publish_data retries on RequestException."""
+    org_id = 123
+    channel_id = str(uuid4())
+    token = generate_jwt(subject="test")
+
+    publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=0,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_START,
+    )
+
+    # Fails twice, then succeeds
+    responses.add(
+        responses.POST,
+        f"http://localhost:9093/publish/{org_id}/{channel_id}",
+        status=500,
+    )
+    responses.add(
+        responses.POST,
+        f"http://localhost:9093/publish/{org_id}/{channel_id}",
+        status=500,
+    )
+    responses.add(
+        responses.POST,
+        f"http://localhost:9093/publish/{org_id}/{channel_id}",
+        status=200,
+    )
+
+    response = publish_data(
+        org_id=org_id,
+        publish_request=publish_request,
+        token=token,
+        publish_url="http://localhost:9093",
+    )
+
+    assert response.status_code == 200
+    assert len(responses.calls) == 3
+
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+def test_publish_data_max_retries_exceeded():
+    """Test that publish_data raises after max retries."""
+    org_id = 123
+    channel_id = str(uuid4())
+    token = generate_jwt(subject="test")
+
+    publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=0,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_START,
+    )
+
+    for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
         responses.add(
             responses.POST,
             f"http://localhost:9093/publish/{org_id}/{channel_id}",
             status=500,
         )
-        responses.add(
-            responses.POST,
-            f"http://localhost:9093/publish/{org_id}/{channel_id}",
-            status=500,
-        )
-        responses.add(
-            responses.POST,
-            f"http://localhost:9093/publish/{org_id}/{channel_id}",
-            status=200,
-        )
 
-        response = publish_data(
+    with pytest.raises(RequestException):
+        publish_data(
             org_id=org_id,
             publish_request=publish_request,
             token=token,
-            publish_url="http://localhost:9093",
         )
 
-        assert response.status_code == 200
-        assert len(responses.calls) == 3
+    assert len(responses.calls) == PUBLISH_REQUEST_MAX_RETRIES
 
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+def test_publish_data_uses_custom_url():
+    """Test that publish_data uses provided publish_url."""
+    org_id = 123
+    channel_id = str(uuid4())
+    token = generate_jwt(subject="test")
+    custom_url = "http://custom.example.com"
+
+    publish_request = PublishRequest(
+        channel_id=channel_id,
+        message_id=str(uuid4()),
+        sequence=0,
+        client_timestamp=get_timestamp(),
+        phase=Phase.PHASE_START,
     )
-    def test_publish_data_max_retries_exceeded(self):
-        """Test that publish_data raises after max retries."""
-        org_id = 123
-        channel_id = str(uuid4())
-        token = generate_jwt(subject="test")
 
-        publish_request = PublishRequest(
-            channel_id=channel_id,
-            message_id=str(uuid4()),
-            sequence=0,
-            client_timestamp=get_timestamp(),
-            phase=Phase.PHASE_START,
-        )
-
-        for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
-            responses.add(
-                responses.POST,
-                f"http://localhost:9093/publish/{org_id}/{channel_id}",
-                status=500,
-            )
-
-        with pytest.raises(RequestException):
-            publish_data(
-                org_id=org_id,
-                publish_request=publish_request,
-                token=token,
-            )
-
-        assert len(responses.calls) == PUBLISH_REQUEST_MAX_RETRIES
-
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    responses.add(
+        responses.POST,
+        f"{custom_url}/publish/{org_id}/{channel_id}",
+        status=200,
     )
-    def test_publish_data_uses_custom_url(self):
-        """Test that publish_data uses provided publish_url."""
-        org_id = 123
-        channel_id = str(uuid4())
-        token = generate_jwt(subject="test")
-        custom_url = "http://custom.example.com"
 
-        publish_request = PublishRequest(
-            channel_id=channel_id,
-            message_id=str(uuid4()),
-            sequence=0,
-            client_timestamp=get_timestamp(),
-            phase=Phase.PHASE_START,
-        )
-
-        responses.add(
-            responses.POST,
-            f"{custom_url}/publish/{org_id}/{channel_id}",
-            status=200,
-        )
-
-        response = publish_data(
-            org_id=org_id,
-            publish_request=publish_request,
-            token=token,
-            publish_url=custom_url,
-        )
-
-        assert response.status_code == 200
-        assert len(responses.calls) == 1
-
-
-class StreamDemoDataTest(TestCase):
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
+    response = publish_data(
+        org_id=org_id,
+        publish_request=publish_request,
+        token=token,
+        publish_url=custom_url,
     )
-    @patch("sentry.conduit.tasks.time.sleep")
-    def test_stream_demo_data_sends_all_phases(self, mock_sleep):
-        """Test that stream_demo_data sends START, DELTA, and END phases."""
-        org_id = 123
-        channel_id = str(uuid4())
 
+    assert response.status_code == 200
+    assert len(responses.calls) == 1
+
+
+# StreamDemoData tests
+
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+@patch("sentry.conduit.tasks.time.sleep")
+def test_stream_demo_data_sends_all_phases(mock_sleep):
+    """Test that stream_demo_data sends START, DELTA, and END phases."""
+    org_id = 123
+    channel_id = str(uuid4())
+
+    responses.add(
+        responses.POST,
+        re.compile(r"http://localhost:9093/publish/\d+/.+"),
+        status=200,
+    )
+
+    stream_demo_data(org_id=org_id, channel_id=channel_id)
+
+    assert len(responses.calls) == NUM_DELTAS + 2
+    assert mock_sleep.call_count == NUM_DELTAS
+
+
+@responses.activate
+@override_settings(
+    CONDUIT_PUBLISH_SECRET="test-secret",
+    CONDUIT_PUBLISH_JWT_ISSUER="sentry",
+    CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
+    CONDUIT_PUBLISH_URL="http://localhost:9093",
+)
+@patch("sentry.conduit.tasks.time.sleep")
+def test_stream_demo_data_stops_on_exhausted_retries(mock_sleep):
+    """Test that stream_demo_data stops streaming when a publish fails after max retries."""
+    org_id = 123
+    channel_id = str(uuid4())
+
+    # Fail after 10 successful requests
+    for _ in range(10):
         responses.add(
             responses.POST,
             re.compile(r"http://localhost:9093/publish/\d+/.+"),
             status=200,
         )
 
+    for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
+        responses.add(
+            responses.POST,
+            re.compile(r"http://localhost:9093/publish/\d+/.+"),
+            status=500,
+        )
+
+    with pytest.raises(RequestException):
         stream_demo_data(org_id=org_id, channel_id=channel_id)
 
-        assert len(responses.calls) == NUM_DELTAS + 2
-        assert mock_sleep.call_count == NUM_DELTAS
-
-    @responses.activate
-    @override_settings(
-        CONDUIT_PUBLISH_SECRET="test-secret",
-        CONDUIT_PUBLISH_JWT_ISSUER="sentry",
-        CONDUIT_PUBLISH_JWT_AUDIENCE="conduit",
-        CONDUIT_PUBLISH_URL="http://localhost:9093",
-    )
-    @patch("sentry.conduit.tasks.time.sleep")
-    def test_stream_demo_data_stops_on_exhausted_retries(self, mock_sleep):
-        """Test that stream_demo_data stops streaming when a publish fails after max retries."""
-        org_id = 123
-        channel_id = str(uuid4())
-
-        # Fail after 10 successful requests
-        for _ in range(10):
-            responses.add(
-                responses.POST,
-                re.compile(r"http://localhost:9093/publish/\d+/.+"),
-                status=200,
-            )
-
-        for _ in range(PUBLISH_REQUEST_MAX_RETRIES):
-            responses.add(
-                responses.POST,
-                re.compile(r"http://localhost:9093/publish/\d+/.+"),
-                status=500,
-            )
-
-        with pytest.raises(RequestException):
-            stream_demo_data(org_id=org_id, channel_id=channel_id)
-
-        assert len(responses.calls) == 10 + PUBLISH_REQUEST_MAX_RETRIES
+    assert len(responses.calls) == 10 + PUBLISH_REQUEST_MAX_RETRIES

--- a/tests/sentry/data_secrecy/test_types.py
+++ b/tests/sentry/data_secrecy/test_types.py
@@ -4,179 +4,190 @@ import pytest
 
 from sentry.data_secrecy.service.model import RpcEffectiveGrantStatus
 from sentry.data_secrecy.types import NEGATIVE_CACHE_TTL, EffectiveGrantStatus, GrantCacheStatus
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 
+# Test fixtures
+CURRENT_TIME = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+ACCESS_START = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+ACCESS_END = datetime(2025, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
+EXPIRED_ACCESS_END = datetime(2025, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
 
-class EffectiveGrantStatusTest(TestCase):
-    def setUp(self) -> None:
-        self.current_time = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        self.access_start = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        self.access_end = datetime(2025, 1, 1, 14, 0, 0, tzinfo=timezone.utc)
-        self.expired_access_end = datetime(2025, 1, 1, 11, 0, 0, tzinfo=timezone.utc)
 
-    def test_from_cache_with_none(self) -> None:
-        """Test from_cache with None returns CACHE_MISS status"""
-        result = EffectiveGrantStatus.from_cache(None)
+def test_from_cache_with_none() -> None:
+    """Test from_cache with None returns CACHE_MISS status"""
+    result = EffectiveGrantStatus.from_cache(None)
 
-        assert result.cache_status == GrantCacheStatus.CACHE_MISS
-        assert result.access_end is None
-        assert result.access_start is None
+    assert result.cache_status == GrantCacheStatus.CACHE_MISS
+    assert result.access_end is None
+    assert result.access_start is None
 
-    def test_from_cache_with_negative_cache_object(self) -> None:
-        """Test from_cache with negative cache object returns the same object"""
-        cached_object = EffectiveGrantStatus(cache_status=GrantCacheStatus.NEGATIVE_CACHE)
-        result = EffectiveGrantStatus.from_cache(cached_object)
 
-        assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
-        assert result.access_end is None
-        assert result.access_start is None
-        assert result is cached_object  # Should return the same object
+def test_from_cache_with_negative_cache_object() -> None:
+    """Test from_cache with negative cache object returns the same object"""
+    cached_object = EffectiveGrantStatus(cache_status=GrantCacheStatus.NEGATIVE_CACHE)
+    result = EffectiveGrantStatus.from_cache(cached_object)
 
-    @freeze_time("2025-01-01 12:00:00")
-    def test_from_cache_with_expired_grant_object(self) -> None:
-        """Test from_cache with expired grant object returns EXPIRED_WINDOW status"""
-        cached_object = EffectiveGrantStatus(
+    assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
+    assert result.access_end is None
+    assert result.access_start is None
+    assert result is cached_object  # Should return the same object
+
+
+@freeze_time("2025-01-01 12:00:00")
+def test_from_cache_with_expired_grant_object() -> None:
+    """Test from_cache with expired grant object returns EXPIRED_WINDOW status"""
+    cached_object = EffectiveGrantStatus(
+        cache_status=GrantCacheStatus.VALID_WINDOW,
+        access_start=ACCESS_START,
+        access_end=EXPIRED_ACCESS_END,  # expired
+    )
+
+    result = EffectiveGrantStatus.from_cache(cached_object)
+
+    assert result.cache_status == GrantCacheStatus.EXPIRED_WINDOW
+    assert result.access_end is None
+    assert result.access_start is None
+
+
+@freeze_time("2025-01-01 12:00:00")
+def test_from_cache_with_valid_grant_object() -> None:
+    """Test from_cache with valid grant object returns the same object"""
+    cached_object = EffectiveGrantStatus(
+        cache_status=GrantCacheStatus.VALID_WINDOW,
+        access_start=ACCESS_START,
+        access_end=ACCESS_END,  # future time
+    )
+
+    result = EffectiveGrantStatus.from_cache(cached_object)
+
+    assert result.cache_status == GrantCacheStatus.VALID_WINDOW
+    assert result.access_end == ACCESS_END
+    assert result.access_start == ACCESS_START
+    assert result is cached_object  # Should return the same object
+
+
+def test_from_rpc_grant_status_with_none() -> None:
+    """Test from_rpc_grant_status with None returns NEGATIVE_CACHE status"""
+    result = EffectiveGrantStatus.from_rpc_grant_status(None, CURRENT_TIME)
+
+    assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
+    assert result.access_end is None
+    assert result.access_start is None
+
+
+def test_from_rpc_grant_status_with_expired_grant() -> None:
+    """Test from_rpc_grant_status with expired grant returns NEGATIVE_CACHE status"""
+    rpc_grant = RpcEffectiveGrantStatus(
+        organization_id=1,
+        access_start=ACCESS_START,
+        access_end=EXPIRED_ACCESS_END,
+    )
+
+    result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, CURRENT_TIME)
+
+    assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
+    assert result.access_end is None
+    assert result.access_start is None
+
+
+def test_from_rpc_grant_status_with_valid_grant() -> None:
+    """Test from_rpc_grant_status with valid grant returns VALID_WINDOW status"""
+    rpc_grant = RpcEffectiveGrantStatus(
+        organization_id=1,
+        access_start=ACCESS_START,
+        access_end=ACCESS_END,
+    )
+
+    result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, CURRENT_TIME)
+
+    assert result.cache_status == GrantCacheStatus.VALID_WINDOW
+    assert result.access_end == ACCESS_END
+    assert result.access_start == ACCESS_START
+
+
+def test_from_rpc_grant_status_with_about_to_expire_grant() -> None:
+    """Test from_rpc_grant_status with grant expiring now returns NEGATIVE_CACHE status"""
+    rpc_grant = RpcEffectiveGrantStatus(
+        organization_id=1,
+        access_start=ACCESS_START,
+        access_end=CURRENT_TIME,  # expires exactly now
+    )
+
+    result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, CURRENT_TIME)
+
+    assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
+
+
+def test_cache_ttl_for_valid_grant() -> None:
+    """Test cache_ttl calculation for valid grant"""
+    grant_status = EffectiveGrantStatus(
+        cache_status=GrantCacheStatus.VALID_WINDOW,
+        access_end=ACCESS_END,
+        access_start=ACCESS_START,
+    )
+
+    ttl = grant_status.cache_ttl(CURRENT_TIME)
+    expected_ttl = int((ACCESS_END - CURRENT_TIME).total_seconds())
+
+    assert ttl == expected_ttl
+    assert ttl == 7200  # 2 hours in seconds
+
+
+def test_cache_ttl_for_negative_cache() -> None:
+    """Test cache_ttl for negative cache returns NEGATIVE_CACHE_TTL"""
+    grant_status = EffectiveGrantStatus(
+        cache_status=GrantCacheStatus.NEGATIVE_CACHE,
+    )
+
+    ttl = grant_status.cache_ttl(CURRENT_TIME)
+
+    assert ttl == NEGATIVE_CACHE_TTL
+    assert ttl == 120  # 2 minutes
+
+
+def test_cache_ttl_for_invalid_status_raises_error() -> None:
+    """Test cache_ttl raises ValueError for invalid cache status"""
+    grant_status = EffectiveGrantStatus(
+        cache_status=GrantCacheStatus.CACHE_MISS,
+    )
+
+    with pytest.raises(ValueError):
+        grant_status.cache_ttl(CURRENT_TIME)
+
+
+def test_post_init_validation_valid_window_without_access_times() -> None:
+    """Test that __post_init__ raises error when VALID_WINDOW lacks access times"""
+    with pytest.raises(ValueError):
+        EffectiveGrantStatus(cache_status=GrantCacheStatus.VALID_WINDOW)
+
+
+def test_post_init_validation_valid_window_without_access_end() -> None:
+    """Test that __post_init__ raises error when VALID_WINDOW lacks access_end"""
+    with pytest.raises(ValueError):
+        EffectiveGrantStatus(
             cache_status=GrantCacheStatus.VALID_WINDOW,
-            access_start=self.access_start,
-            access_end=self.expired_access_end,  # expired
+            access_start=ACCESS_START,
         )
 
-        result = EffectiveGrantStatus.from_cache(cached_object)
 
-        assert result.cache_status == GrantCacheStatus.EXPIRED_WINDOW
-        assert result.access_end is None
-        assert result.access_start is None
-
-    @freeze_time("2025-01-01 12:00:00")
-    def test_from_cache_with_valid_grant_object(self) -> None:
-        """Test from_cache with valid grant object returns the same object"""
-        cached_object = EffectiveGrantStatus(
+def test_post_init_validation_valid_window_without_access_start() -> None:
+    """Test that __post_init__ raises error when VALID_WINDOW lacks access_start"""
+    with pytest.raises(ValueError):
+        EffectiveGrantStatus(
             cache_status=GrantCacheStatus.VALID_WINDOW,
-            access_start=self.access_start,
-            access_end=self.access_end,  # future time
+            access_end=ACCESS_END,
         )
 
-        result = EffectiveGrantStatus.from_cache(cached_object)
 
-        assert result.cache_status == GrantCacheStatus.VALID_WINDOW
-        assert result.access_end == self.access_end
-        assert result.access_start == self.access_start
-        assert result is cached_object  # Should return the same object
-
-    def test_from_rpc_grant_status_with_none(self) -> None:
-        """Test from_rpc_grant_status with None returns NEGATIVE_CACHE status"""
-        result = EffectiveGrantStatus.from_rpc_grant_status(None, self.current_time)
-
-        assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
-        assert result.access_end is None
-        assert result.access_start is None
-
-    def test_from_rpc_grant_status_with_expired_grant(self) -> None:
-        """Test from_rpc_grant_status with expired grant returns NEGATIVE_CACHE status"""
-        rpc_grant = RpcEffectiveGrantStatus(
-            organization_id=1,
-            access_start=self.access_start,
-            access_end=self.expired_access_end,
-        )
-
-        result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, self.current_time)
-
-        assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
-        assert result.access_end is None
-        assert result.access_start is None
-
-    def test_from_rpc_grant_status_with_valid_grant(self) -> None:
-        """Test from_rpc_grant_status with valid grant returns VALID_WINDOW status"""
-        rpc_grant = RpcEffectiveGrantStatus(
-            organization_id=1,
-            access_start=self.access_start,
-            access_end=self.access_end,
-        )
-
-        result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, self.current_time)
-
-        assert result.cache_status == GrantCacheStatus.VALID_WINDOW
-        assert result.access_end == self.access_end
-        assert result.access_start == self.access_start
-
-    def test_from_rpc_grant_status_with_about_to_expire_grant(self) -> None:
-        """Test from_rpc_grant_status with grant expiring now returns NEGATIVE_CACHE status"""
-        rpc_grant = RpcEffectiveGrantStatus(
-            organization_id=1,
-            access_start=self.access_start,
-            access_end=self.current_time,  # expires exactly now
-        )
-
-        result = EffectiveGrantStatus.from_rpc_grant_status(rpc_grant, self.current_time)
-
-        assert result.cache_status == GrantCacheStatus.NEGATIVE_CACHE
-
-    def test_cache_ttl_for_valid_grant(self) -> None:
-        """Test cache_ttl calculation for valid grant"""
-        grant_status = EffectiveGrantStatus(
-            cache_status=GrantCacheStatus.VALID_WINDOW,
-            access_end=self.access_end,
-            access_start=self.access_start,
-        )
-
-        ttl = grant_status.cache_ttl(self.current_time)
-        expected_ttl = int((self.access_end - self.current_time).total_seconds())
-
-        assert ttl == expected_ttl
-        assert ttl == 7200  # 2 hours in seconds
-
-    def test_cache_ttl_for_negative_cache(self) -> None:
-        """Test cache_ttl for negative cache returns NEGATIVE_CACHE_TTL"""
-        grant_status = EffectiveGrantStatus(
-            cache_status=GrantCacheStatus.NEGATIVE_CACHE,
-        )
-
-        ttl = grant_status.cache_ttl(self.current_time)
-
-        assert ttl == NEGATIVE_CACHE_TTL
-        assert ttl == 120  # 2 minutes
-
-    def test_cache_ttl_for_invalid_status_raises_error(self) -> None:
-        """Test cache_ttl raises ValueError for invalid cache status"""
-        grant_status = EffectiveGrantStatus(
-            cache_status=GrantCacheStatus.CACHE_MISS,
-        )
-
-        with pytest.raises(ValueError):
-            grant_status.cache_ttl(self.current_time)
-
-    def test_post_init_validation_valid_window_without_access_times(self) -> None:
-        """Test that __post_init__ raises error when VALID_WINDOW lacks access times"""
-        with pytest.raises(ValueError):
-            EffectiveGrantStatus(cache_status=GrantCacheStatus.VALID_WINDOW)
-
-    def test_post_init_validation_valid_window_without_access_end(self) -> None:
-        """Test that __post_init__ raises error when VALID_WINDOW lacks access_end"""
-        with pytest.raises(ValueError):
-            EffectiveGrantStatus(
-                cache_status=GrantCacheStatus.VALID_WINDOW,
-                access_start=self.access_start,
-            )
-
-    def test_post_init_validation_valid_window_without_access_start(self) -> None:
-        """Test that __post_init__ raises error when VALID_WINDOW lacks access_start"""
-        with pytest.raises(ValueError):
-            EffectiveGrantStatus(
-                cache_status=GrantCacheStatus.VALID_WINDOW,
-                access_end=self.access_end,
-            )
+def test_grant_cache_status_values() -> None:
+    """Test that GrantCacheStatus enum has expected values"""
+    assert GrantCacheStatus.CACHE_MISS == "cache_miss"
+    assert GrantCacheStatus.NEGATIVE_CACHE == "negative_cache"
+    assert GrantCacheStatus.VALID_WINDOW == "valid_window"
+    assert GrantCacheStatus.EXPIRED_WINDOW == "expired_window"
 
 
-class GrantCacheStatusTest(TestCase):
-    def test_grant_cache_status_values(self) -> None:
-        """Test that GrantCacheStatus enum has expected values"""
-        assert GrantCacheStatus.CACHE_MISS == "cache_miss"
-        assert GrantCacheStatus.NEGATIVE_CACHE == "negative_cache"
-        assert GrantCacheStatus.VALID_WINDOW == "valid_window"
-        assert GrantCacheStatus.EXPIRED_WINDOW == "expired_window"
-
-    def test_grant_cache_status_is_string_enum(self) -> None:
-        """Test that GrantCacheStatus values are strings"""
-        for status in GrantCacheStatus:
-            assert isinstance(status.value, str)
+def test_grant_cache_status_is_string_enum() -> None:
+    """Test that GrantCacheStatus values are strings"""
+    for status in GrantCacheStatus:
+        assert isinstance(status.value, str)

--- a/tests/sentry/grouping/test_enhancer_dart_flutter_javascript.py
+++ b/tests/sentry/grouping/test_enhancer_dart_flutter_javascript.py
@@ -8,67 +8,64 @@ from __future__ import annotations
 from typing import Any
 
 from sentry.grouping.enhancer import ENHANCEMENT_BASES
-from sentry.testutils.cases import TestCase
+
+PLATFORM = "javascript"
+ENHANCEMENTS = ENHANCEMENT_BASES["all-platforms:2023-01-11"]
 
 
-class _BaseJavaScriptDartFlutterEnhancerTest(TestCase):
-    PLATFORM = "javascript"
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.enhancements = ENHANCEMENT_BASES["all-platforms:2023-01-11"]
-
-    def apply_rules(self, frame: dict[str, str]) -> dict[str, Any]:
-        frames = [frame]
-        self.enhancements.apply_category_and_updated_in_app_to_frames(frames, self.PLATFORM, {})
-        return frames[0]
+def _apply_rules(frame: dict[str, str]) -> dict[str, Any]:
+    frames = [frame]
+    ENHANCEMENTS.apply_category_and_updated_in_app_to_frames(frames, PLATFORM, {})
+    return frames[0]
 
 
-class TestDartFlutterEnhancerJavaScript(_BaseJavaScriptDartFlutterEnhancerTest):
-    """Tests that are expected to run with platform="javascript" only."""
+# ------------------------------------------------------------------
+# Dart SDK
+# ------------------------------------------------------------------
 
-    # ------------------------------------------------------------------
-    # Dart SDK
-    # ------------------------------------------------------------------
 
-    def test_dart_sdk_not_in_app(self) -> None:
-        """All frames coming from the Dart SDK must be out-of-app."""
-        sdk_paths = [
-            "org-dartlang-sdk:///sdk/lib/core/object.dart",
-            "org-dartlang-sdk:///sdk/lib/async/future.dart",
-            "org-dartlang-sdk:///sdk/lib/collection/list.dart",
-            "org-dartlang-sdk:///flutter/lib/ui/window.dart",
-        ]
-        for path in sdk_paths:
-            frame = {"abs_path": path}
-            result = self.apply_rules(frame)
-            assert result["in_app"] is False
-
-    # ------------------------------------------------------------------
-    # Flutter framework (compiled to JS)
-    # ------------------------------------------------------------------
-
-    def test_flutter_packages_not_in_app(self) -> None:
-        """Flutter framework modules compiled to JS (dart2js) are out-of-app."""
-        frame = {"module": "packages/flutter/src/widgets/framework.dart"}
-        result = self.apply_rules(frame)
+def test_dart_sdk_not_in_app() -> None:
+    """All frames coming from the Dart SDK must be out-of-app."""
+    sdk_paths = [
+        "org-dartlang-sdk:///sdk/lib/core/object.dart",
+        "org-dartlang-sdk:///sdk/lib/async/future.dart",
+        "org-dartlang-sdk:///sdk/lib/collection/list.dart",
+        "org-dartlang-sdk:///flutter/lib/ui/window.dart",
+    ]
+    for path in sdk_paths:
+        frame = {"abs_path": path}
+        result = _apply_rules(frame)
         assert result["in_app"] is False
 
-        # Another example module
-        frame = {"module": "packages/flutter/src/widgets/container.dart"}
-        result = self.apply_rules(frame)
-        assert result["in_app"] is False
 
-    # ------------------------------------------------------------------
-    # Ensure native-specific rules do not leak into JS
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# Flutter framework (compiled to JS)
+# ------------------------------------------------------------------
 
-    def test_android_app_rule_does_not_apply_on_javascript(self) -> None:
-        """The APK rule is native-specific and must not affect JS frames."""
-        frame = {
-            "package": "/data/app/com.example.myapp-1/base.apk",
-            "abs_path": "package:myapp/main.dart",
-        }
-        result = self.apply_rules(frame)
-        # The JS family definitions have no such rule → in_app should be untouched
-        assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"
+
+def test_flutter_packages_not_in_app() -> None:
+    """Flutter framework modules compiled to JS (dart2js) are out-of-app."""
+    frame = {"module": "packages/flutter/src/widgets/framework.dart"}
+    result = _apply_rules(frame)
+    assert result["in_app"] is False
+
+    # Another example module
+    frame = {"module": "packages/flutter/src/widgets/container.dart"}
+    result = _apply_rules(frame)
+    assert result["in_app"] is False
+
+
+# ------------------------------------------------------------------
+# Ensure native-specific rules do not leak into JS
+# ------------------------------------------------------------------
+
+
+def test_android_app_rule_does_not_apply_on_javascript() -> None:
+    """The APK rule is native-specific and must not affect JS frames."""
+    frame = {
+        "package": "/data/app/com.example.myapp-1/base.apk",
+        "abs_path": "package:myapp/main.dart",
+    }
+    result = _apply_rules(frame)
+    # The JS family definitions have no such rule → in_app should be untouched
+    assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"

--- a/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
+++ b/tests/sentry/grouping/test_enhancer_dart_flutter_native.py
@@ -7,169 +7,171 @@ from __future__ import annotations
 from typing import Any
 
 from sentry.grouping.enhancer import ENHANCEMENT_BASES
-from sentry.testutils.cases import TestCase
+
+PLATFORM = "native"
+ENHANCEMENTS = ENHANCEMENT_BASES["all-platforms:2023-01-11"]
 
 
-class _BaseNativeDartFlutterEnhancerTest(TestCase):
-    """Common setup and helpers shared by native-platform tests."""
-
-    PLATFORM = "native"
-
-    def setUp(self) -> None:
-        super().setUp()
-        # Load the default enhancement rules that include Dart/Flutter logic.
-        self.enhancements = ENHANCEMENT_BASES["all-platforms:2023-01-11"]
-
-    def apply_rules(self, frame: dict[str, str]) -> dict[str, Any]:
-        """Apply enhancement rules to a single frame and return the processed frame."""
-        frames = [frame]
-        self.enhancements.apply_category_and_updated_in_app_to_frames(frames, self.PLATFORM, {})
-        return frames[0]
+def _apply_rules(frame: dict[str, str]) -> dict[str, Any]:
+    """Apply enhancement rules to a single frame and return the processed frame."""
+    frames = [frame]
+    ENHANCEMENTS.apply_category_and_updated_in_app_to_frames(frames, PLATFORM, {})
+    return frames[0]
 
 
-class TestDartFlutterEnhancerNative(_BaseNativeDartFlutterEnhancerTest):
-    """Tests that are expected to run with platform="native" only."""
+# ---------------------------------------------------------------------
+# Android application frames
+# ---------------------------------------------------------------------
 
-    # ---------------------------------------------------------------------
-    # Android application frames
-    # ---------------------------------------------------------------------
 
-    def test_dart_android_app_files_are_in_app(self) -> None:
-        """Dart files shipped in an Android APK of the app should be in-app."""
-        frame = {
-            "package": "/data/app/com.example.myapp-1/base.apk",
-            "abs_path": "package:myapp/main.dart",
-        }
-        result = self.apply_rules(frame)
-        assert result["in_app"] is True
+def test_dart_android_app_files_are_in_app() -> None:
+    """Dart files shipped in an Android APK of the app should be in-app."""
+    frame = {
+        "package": "/data/app/com.example.myapp-1/base.apk",
+        "abs_path": "package:myapp/main.dart",
+    }
+    result = _apply_rules(frame)
+    assert result["in_app"] is True
 
-        # Different APK path + deeper Dart file structure
-        frame = {
-            "package": "/data/app/com.example.flutter-2/split_config.arm64_v8a.apk",
-            "abs_path": "package:myapp/src/widgets/home_screen.dart",
-        }
-        result = self.apply_rules(frame)
-        assert result["in_app"] is True
+    # Different APK path + deeper Dart file structure
+    frame = {
+        "package": "/data/app/com.example.flutter-2/split_config.arm64_v8a.apk",
+        "abs_path": "package:myapp/src/widgets/home_screen.dart",
+    }
+    result = _apply_rules(frame)
+    assert result["in_app"] is True
 
-        # Must satisfy both conditions (package path + *.dart)
-        frame = {
-            "package": "/data/app/com.example.myapp-1/base.apk",
-            "abs_path": "some_other_file.txt",
-        }
-        result = self.apply_rules(frame)
-        assert result.get("in_app") is None
+    # Must satisfy both conditions (package path + *.dart)
+    frame = {
+        "package": "/data/app/com.example.myapp-1/base.apk",
+        "abs_path": "some_other_file.txt",
+    }
+    result = _apply_rules(frame)
+    assert result.get("in_app") is None
 
-    # ------------------------------------------------------------------
-    # Flutter framework & engine
-    # ------------------------------------------------------------------
 
-    def test_flutter_packages_not_in_app(self) -> None:
-        """Flutter framework sources should be out-of-app on the native platform."""
-        frame = {"abs_path": "/Users/dev/project/packages/flutter/lib/src/material/app.dart"}
-        result = self.apply_rules(frame)
+# ------------------------------------------------------------------
+# Flutter framework & engine
+# ------------------------------------------------------------------
+
+
+def test_flutter_packages_not_in_app() -> None:
+    """Flutter framework sources should be out-of-app on the native platform."""
+    frame = {"abs_path": "/Users/dev/project/packages/flutter/lib/src/material/app.dart"}
+    result = _apply_rules(frame)
+    assert result["in_app"] is False
+
+    # Flutter engine SDK specific paths
+    for engine_path in ("lib/ui/hooks.dart", "lib/ui/platform_dispatcher.dart"):
+        frame = {"abs_path": engine_path}
+        result = _apply_rules(frame)
         assert result["in_app"] is False
 
-        # Flutter engine SDK specific paths
-        for engine_path in ("lib/ui/hooks.dart", "lib/ui/platform_dispatcher.dart"):
-            frame = {"abs_path": engine_path}
-            result = self.apply_rules(frame)
-            assert result["in_app"] is False
+    # Misc additional flutter-package paths
+    flutter_paths = [
+        "packages/flutter/lib/material.dart",
+        "/home/user/.pub-cache/hosted/pub.dev/flutter-3.0.0/lib/widgets.dart",
+        "file:///Users/dev/packages/flutter/src/foundation/binding.dart",
+    ]
+    for path in flutter_paths:
+        frame = {"abs_path": path}
+        result = _apply_rules(frame)
+        assert result["in_app"] is False, f"Path {path} should be out-of-app"
 
-        # Misc additional flutter-package paths
-        flutter_paths = [
-            "packages/flutter/lib/material.dart",
-            "/home/user/.pub-cache/hosted/pub.dev/flutter-3.0.0/lib/widgets.dart",
-            "file:///Users/dev/packages/flutter/src/foundation/binding.dart",
-        ]
-        for path in flutter_paths:
-            frame = {"abs_path": path}
-            result = self.apply_rules(frame)
-            assert result["in_app"] is False, f"Path {path} should be out-of-app"
 
-    # ------------------------------------------------------------------
-    # Sentry Dart SDK
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# Sentry Dart SDK
+# ------------------------------------------------------------------
 
-    def test_sentry_dart_packages_not_in_app(self) -> None:
-        """All Sentry Dart SDK packages should always be out-of-app."""
-        sentry_packages = [
-            "package:sentry/sentry.dart",
-            "package:sentry/src/hub.dart",
-            "package:sentry_flutter/sentry_flutter.dart",
-            "package:sentry_flutter/src/native_bridge.dart",
-        ]
-        integration_packages = [
-            "package:sentry_logging/sentry_logging.dart",
-            "package:sentry_dio/src/dio_event_processor.dart",
-            "package:sentry_file/sentry_file.dart",
-            "package:sentry_hive/src/sentry_hive_impl.dart",
-            "package:sentry_isar/sentry_isar.dart",
-            "package:sentry_sqflite/src/sentry_database.dart",
-            "package:sentry_drift/sentry_drift.dart",
-            "package:sentry_link/sentry_link.dart",
-            "package:sentry_firebase_remote_config/sentry_firebase_remote_config.dart",
-        ]
-        for path in sentry_packages + integration_packages:
-            frame = {"abs_path": path}
-            result = self.apply_rules(frame)
-            assert result["in_app"] is False, f"Sentry package {path} should be out-of-app"
 
-    # ------------------------------------------------------------------
-    # pub-cache packages
-    # ------------------------------------------------------------------
+def test_sentry_dart_packages_not_in_app() -> None:
+    """All Sentry Dart SDK packages should always be out-of-app."""
+    sentry_packages = [
+        "package:sentry/sentry.dart",
+        "package:sentry/src/hub.dart",
+        "package:sentry_flutter/sentry_flutter.dart",
+        "package:sentry_flutter/src/native_bridge.dart",
+    ]
+    integration_packages = [
+        "package:sentry_logging/sentry_logging.dart",
+        "package:sentry_dio/src/dio_event_processor.dart",
+        "package:sentry_file/sentry_file.dart",
+        "package:sentry_hive/src/sentry_hive_impl.dart",
+        "package:sentry_isar/sentry_isar.dart",
+        "package:sentry_sqflite/src/sentry_database.dart",
+        "package:sentry_drift/sentry_drift.dart",
+        "package:sentry_link/sentry_link.dart",
+        "package:sentry_firebase_remote_config/sentry_firebase_remote_config.dart",
+    ]
+    for path in sentry_packages + integration_packages:
+        frame = {"abs_path": path}
+        result = _apply_rules(frame)
+        assert result["in_app"] is False, f"Sentry package {path} should be out-of-app"
 
-    def test_pub_cache_not_in_app(self) -> None:
-        """Third-party packages coming from the pub-cache are out-of-app."""
-        pub_cache_paths = [
-            "/Users/dev/.pub-cache/hosted/pub.dev/http-0.13.5/lib/http.dart",
-            "/home/user/.pub-cache/git/some_package-abc123/lib/main.dart",
-            "C:\\Users\\Dev\\.pub-cache\\hosted\\pub.dev\\provider-6.0.0\\lib\\provider.dart",
-            "/opt/flutter/.pub-cache/hosted/pub.dartlang.org/dio-4.0.0/lib/dio.dart",
-        ]
-        for path in pub_cache_paths:
-            frame = {"abs_path": path}
-            result = self.apply_rules(frame)
-            assert result["in_app"] is False, f"pub-cache path {path} should be out-of-app"
 
-    # ------------------------------------------------------------------
-    # User code – default behaviour
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# pub-cache packages
+# ------------------------------------------------------------------
 
-    def test_user_dart_files_default_behavior(self) -> None:
-        """User Dart files that do not match any rule should keep their original in_app status."""
-        frames = [
-            {"abs_path": "lib/main.dart"},
-            {"abs_path": "package:myapp/src/utils/helper.dart"},
-            {"abs_path": "file:///home/user/projects/myapp/lib/models/user.dart"},
-        ]
-        for frame in frames:
-            result = self.apply_rules(frame)
-            assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"
 
-    # ------------------------------------------------------------------
-    # Rules specific to *other* platforms should not fire
-    # ------------------------------------------------------------------
+def test_pub_cache_not_in_app() -> None:
+    """Third-party packages coming from the pub-cache are out-of-app."""
+    pub_cache_paths = [
+        "/Users/dev/.pub-cache/hosted/pub.dev/http-0.13.5/lib/http.dart",
+        "/home/user/.pub-cache/git/some_package-abc123/lib/main.dart",
+        "C:\\Users\\Dev\\.pub-cache\\hosted\\pub.dev\\provider-6.0.0\\lib\\provider.dart",
+        "/opt/flutter/.pub-cache/hosted/pub.dartlang.org/dio-4.0.0/lib/dio.dart",
+    ]
+    for path in pub_cache_paths:
+        frame = {"abs_path": path}
+        result = _apply_rules(frame)
+        assert result["in_app"] is False, f"pub-cache path {path} should be out-of-app"
 
-    def test_javascript_specific_rule_does_not_apply_on_native(self) -> None:
-        """Rules that are only defined for the JavaScript family must not affect native frames."""
-        frames = [
-            {"module": "packages/flutter/src/widgets/container.dart"},
-            {"abs_path": "org-dartlang-sdk:///sdk/lib/core/object.dart"},
-        ]
-        for frame in frames:
-            result = self.apply_rules(frame)
-            assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"
 
-    # ------------------------------------------------------------------
-    # Misc / edge-cases
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# User code – default behaviour
+# ------------------------------------------------------------------
 
-    def test_edge_cases(self) -> None:
-        """Cover miscellaneous edge-cases for native frames."""
-        # Android rule – requires *.dart extension
-        frame = {
-            "package": "/data/app/com.example.myapp-1/base.apk",
-            "abs_path": "package:myapp/main",  # Missing .dart
-        }
-        result = self.apply_rules(frame)
-        assert result.get("in_app") is None
+
+def test_user_dart_files_default_behavior() -> None:
+    """User Dart files that do not match any rule should keep their original in_app status."""
+    frames = [
+        {"abs_path": "lib/main.dart"},
+        {"abs_path": "package:myapp/src/utils/helper.dart"},
+        {"abs_path": "file:///home/user/projects/myapp/lib/models/user.dart"},
+    ]
+    for frame in frames:
+        result = _apply_rules(frame)
+        assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"
+
+
+# ------------------------------------------------------------------
+# Rules specific to *other* platforms should not fire
+# ------------------------------------------------------------------
+
+
+def test_javascript_specific_rule_does_not_apply_on_native() -> None:
+    """Rules that are only defined for the JavaScript family must not affect native frames."""
+    frames = [
+        {"module": "packages/flutter/src/widgets/container.dart"},
+        {"abs_path": "org-dartlang-sdk:///sdk/lib/core/object.dart"},
+    ]
+    for frame in frames:
+        result = _apply_rules(frame)
+        assert result.get("in_app") is None, f"{frame['abs_path']} should be untouched"
+
+
+# ------------------------------------------------------------------
+# Misc / edge-cases
+# ------------------------------------------------------------------
+
+
+def test_edge_cases() -> None:
+    """Cover miscellaneous edge-cases for native frames."""
+    # Android rule – requires *.dart extension
+    frame = {
+        "package": "/data/app/com.example.myapp-1/base.apk",
+        "abs_path": "package:myapp/main",  # Missing .dart
+    }
+    result = _apply_rules(frame)
+    assert result.get("in_app") is None

--- a/tests/sentry/integrations/discord/test_utils.py
+++ b/tests/sentry/integrations/discord/test_utils.py
@@ -9,145 +9,132 @@ from sentry.integrations.discord.utils.auth import verify_signature
 from sentry.integrations.discord.utils.channel import ChannelType, validate_channel_id
 from sentry.integrations.discord.utils.channel_from_url import get_channel_id_from_url
 from sentry.shared_integrations.exceptions import ApiError, ApiTimeoutError, IntegrationError
+from sentry.testutils.cases import TestCase
 
 
-def test_verify_signature_valid() -> None:
-    public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
-    signature = "DBC99471F8DD30BA0F488912CF9BA7AC1E938047782BB72FF9A6873D452A1A75DC9F8A07182B8EB7FC67A3771C2271D568DCDC2AB2A5D927A42A4F0FC233C506"
-    timestamp = "1688960024"
-    body = '{"type":1}'
+class AuthTest(TestCase):
+    def test_verify_signature_valid(self) -> None:
+        public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
+        signature = "DBC99471F8DD30BA0F488912CF9BA7AC1E938047782BB72FF9A6873D452A1A75DC9F8A07182B8EB7FC67A3771C2271D568DCDC2AB2A5D927A42A4F0FC233C506"
+        timestamp = "1688960024"
+        body = '{"type":1}'
 
-    verify_signature(public_key_string, signature, timestamp, body)
-
-
-def test_verify_signature_invalid() -> None:
-    public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
-    signature = "0123456789abcdef"
-    timestamp = "1688960024"
-    body = '{"type":1}'
-
-    with raises(InvalidSignature):
         verify_signature(public_key_string, signature, timestamp, body)
 
+    def test_verify_signature_invalid(self) -> None:
+        public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
+        signature = "0123456789abcdef"
+        timestamp = "1688960024"
+        body = '{"type":1}'
 
-# ValidateChannel tests
-GUILD_ID = "guild-id"
-CHANNEL_ID = "channel-id"
-CHANNEL_TYPE = 0  # text
-GUILD_NAME = "server name"
-
-
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_happy_path(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.return_value = {"guild_id": GUILD_ID, "type": CHANNEL_TYPE}
-    validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+        with raises(InvalidSignature):
+            verify_signature(public_key_string, signature, timestamp, body)
 
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_404(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.side_effect = ApiError(code=404, text="")
-    with raises(ValidationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+class ValidateChannelTest(TestCase):
+    guild_id = "guild-id"
+    channel_id = "channel-id"
+    channel_type = 0  # text
+    integration_id = 1234
+    guild_name = "server name"
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_happy_path(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.return_value = {"guild_id": self.guild_id, "type": self.channel_type}
+        validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_404(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.side_effect = ApiError(code=404, text="")
+        with raises(ValidationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_403(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.side_effect = ApiError(code=403, text="")
+        with raises(ValidationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_400(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.side_effect = ApiError(code=400, text="")
+        with raises(ValidationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_api_error(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.side_effect = ApiError(code=401, text="")
+        with raises(IntegrationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_bad_response(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.return_value = ""
+        with raises(IntegrationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_not_guild_member(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.return_value = {"guild_id": "not-my-guild", "type": self.channel_type}
+        with raises(ValidationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_timeout(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.side_effect = Timeout("foo")
+        with raises(ApiTimeoutError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+
+    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+    def test_not_supported_type(self, mock_get_channel: mock.MagicMock) -> None:
+        mock_get_channel.return_value = {"guild_id": self.guild_id, "type": ChannelType.DM.value}
+        with raises(ValidationError):
+            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
 
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_403(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.side_effect = ApiError(code=403, text="")
-    with raises(ValidationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+class GetChannelIdFromUrl(TestCase):
+    channel_id = "12345678910"
 
+    def test_happy_path(self) -> None:
+        channel = get_channel_id_from_url(
+            f"https://discord.com/channels/guild-id/{self.channel_id}"
+        )
+        assert channel == self.channel_id
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_400(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.side_effect = ApiError(code=400, text="")
-    with raises(ValidationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+    def test_happy_path_with_extra_slash(self) -> None:
+        channel = get_channel_id_from_url(
+            f"https://discord.com/channels/guild-id/{self.channel_id}"
+        )
+        assert channel == self.channel_id
 
+    def test_missing_channel_id_with_slash(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("https://discord.com/channels/guild-id/")
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_api_error(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.side_effect = ApiError(code=401, text="")
-    with raises(IntegrationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+    def test_missing_channel_id_no_slash(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("https://discord.com/channels/guild-id")
 
+    def test_missing_guild_and_channel_with_slash(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("https://discord.com/channels/")
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_bad_response(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.return_value = ""
-    with raises(IntegrationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+    def test_missing_guild_and_channel_no_slash(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("https://discord.com/channels")
 
+    def test_different_link(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("https://different.com")
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_not_guild_member(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.return_value = {"guild_id": "not-my-guild", "type": CHANNEL_TYPE}
-    with raises(ValidationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+    def test_just_channel_id(self) -> None:
+        channel = get_channel_id_from_url(self.channel_id)
+        assert channel == self.channel_id
 
+    def test_no_channel_at_all(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("")
 
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_timeout(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.side_effect = Timeout("foo")
-    with raises(ApiTimeoutError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
-
-
-@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-def test_validate_channel_not_supported_type(mock_get_channel: mock.MagicMock) -> None:
-    mock_get_channel.return_value = {"guild_id": GUILD_ID, "type": ChannelType.DM.value}
-    with raises(ValidationError):
-        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
-
-
-# GetChannelIdFromUrl tests
-TEST_CHANNEL_ID = "12345678910"
-
-
-def test_get_channel_id_from_url_happy_path() -> None:
-    channel = get_channel_id_from_url(f"https://discord.com/channels/guild-id/{TEST_CHANNEL_ID}")
-    assert channel == TEST_CHANNEL_ID
-
-
-def test_get_channel_id_from_url_with_extra_slash() -> None:
-    channel = get_channel_id_from_url(f"https://discord.com/channels/guild-id/{TEST_CHANNEL_ID}")
-    assert channel == TEST_CHANNEL_ID
-
-
-def test_get_channel_id_from_url_missing_channel_id_with_slash() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("https://discord.com/channels/guild-id/")
-
-
-def test_get_channel_id_from_url_missing_channel_id_no_slash() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("https://discord.com/channels/guild-id")
-
-
-def test_get_channel_id_from_url_missing_guild_and_channel_with_slash() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("https://discord.com/channels/")
-
-
-def test_get_channel_id_from_url_missing_guild_and_channel_no_slash() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("https://discord.com/channels")
-
-
-def test_get_channel_id_from_url_different_link() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("https://different.com")
-
-
-def test_get_channel_id_from_url_just_channel_id() -> None:
-    channel = get_channel_id_from_url(TEST_CHANNEL_ID)
-    assert channel == TEST_CHANNEL_ID
-
-
-def test_get_channel_id_from_url_no_channel_at_all() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("")
-
-
-def test_get_channel_id_from_url_non_integer_channel() -> None:
-    with raises(ValidationError):
-        get_channel_id_from_url("channel-id")
+    def test_non_integer_channel(self) -> None:
+        with raises(ValidationError):
+            get_channel_id_from_url("channel-id")

--- a/tests/sentry/integrations/discord/test_utils.py
+++ b/tests/sentry/integrations/discord/test_utils.py
@@ -9,132 +9,145 @@ from sentry.integrations.discord.utils.auth import verify_signature
 from sentry.integrations.discord.utils.channel import ChannelType, validate_channel_id
 from sentry.integrations.discord.utils.channel_from_url import get_channel_id_from_url
 from sentry.shared_integrations.exceptions import ApiError, ApiTimeoutError, IntegrationError
-from sentry.testutils.cases import TestCase
 
 
-class AuthTest(TestCase):
-    def test_verify_signature_valid(self) -> None:
-        public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
-        signature = "DBC99471F8DD30BA0F488912CF9BA7AC1E938047782BB72FF9A6873D452A1A75DC9F8A07182B8EB7FC67A3771C2271D568DCDC2AB2A5D927A42A4F0FC233C506"
-        timestamp = "1688960024"
-        body = '{"type":1}'
+def test_verify_signature_valid() -> None:
+    public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
+    signature = "DBC99471F8DD30BA0F488912CF9BA7AC1E938047782BB72FF9A6873D452A1A75DC9F8A07182B8EB7FC67A3771C2271D568DCDC2AB2A5D927A42A4F0FC233C506"
+    timestamp = "1688960024"
+    body = '{"type":1}'
 
+    verify_signature(public_key_string, signature, timestamp, body)
+
+
+def test_verify_signature_invalid() -> None:
+    public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
+    signature = "0123456789abcdef"
+    timestamp = "1688960024"
+    body = '{"type":1}'
+
+    with raises(InvalidSignature):
         verify_signature(public_key_string, signature, timestamp, body)
 
-    def test_verify_signature_invalid(self) -> None:
-        public_key_string = "3AC1A3E56E967E1C61E3D17B37FA1865CB20CD6C54418631F4E8AE4D1E83EE0E"
-        signature = "0123456789abcdef"
-        timestamp = "1688960024"
-        body = '{"type":1}'
 
-        with raises(InvalidSignature):
-            verify_signature(public_key_string, signature, timestamp, body)
+# ValidateChannel tests
+GUILD_ID = "guild-id"
+CHANNEL_ID = "channel-id"
+CHANNEL_TYPE = 0  # text
+GUILD_NAME = "server name"
 
 
-class ValidateChannelTest(TestCase):
-    guild_id = "guild-id"
-    channel_id = "channel-id"
-    channel_type = 0  # text
-    integration_id = 1234
-    guild_name = "server name"
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_happy_path(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.return_value = {"guild_id": self.guild_id, "type": self.channel_type}
-        validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_404(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.side_effect = ApiError(code=404, text="")
-        with raises(ValidationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_403(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.side_effect = ApiError(code=403, text="")
-        with raises(ValidationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_400(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.side_effect = ApiError(code=400, text="")
-        with raises(ValidationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_api_error(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.side_effect = ApiError(code=401, text="")
-        with raises(IntegrationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_bad_response(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.return_value = ""
-        with raises(IntegrationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_not_guild_member(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.return_value = {"guild_id": "not-my-guild", "type": self.channel_type}
-        with raises(ValidationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_timeout(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.side_effect = Timeout("foo")
-        with raises(ApiTimeoutError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
-
-    @mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
-    def test_not_supported_type(self, mock_get_channel: mock.MagicMock) -> None:
-        mock_get_channel.return_value = {"guild_id": self.guild_id, "type": ChannelType.DM.value}
-        with raises(ValidationError):
-            validate_channel_id(self.channel_id, self.guild_id, self.guild_name)
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_happy_path(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.return_value = {"guild_id": GUILD_ID, "type": CHANNEL_TYPE}
+    validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
 
-class GetChannelIdFromUrl(TestCase):
-    channel_id = "12345678910"
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_404(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.side_effect = ApiError(code=404, text="")
+    with raises(ValidationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
-    def test_happy_path(self) -> None:
-        channel = get_channel_id_from_url(
-            f"https://discord.com/channels/guild-id/{self.channel_id}"
-        )
-        assert channel == self.channel_id
 
-    def test_happy_path_with_extra_slash(self) -> None:
-        channel = get_channel_id_from_url(
-            f"https://discord.com/channels/guild-id/{self.channel_id}"
-        )
-        assert channel == self.channel_id
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_403(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.side_effect = ApiError(code=403, text="")
+    with raises(ValidationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
-    def test_missing_channel_id_with_slash(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("https://discord.com/channels/guild-id/")
 
-    def test_missing_channel_id_no_slash(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("https://discord.com/channels/guild-id")
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_400(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.side_effect = ApiError(code=400, text="")
+    with raises(ValidationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
-    def test_missing_guild_and_channel_with_slash(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("https://discord.com/channels/")
 
-    def test_missing_guild_and_channel_no_slash(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("https://discord.com/channels")
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_api_error(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.side_effect = ApiError(code=401, text="")
+    with raises(IntegrationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
-    def test_different_link(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("https://different.com")
 
-    def test_just_channel_id(self) -> None:
-        channel = get_channel_id_from_url(self.channel_id)
-        assert channel == self.channel_id
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_bad_response(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.return_value = ""
+    with raises(IntegrationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
 
-    def test_no_channel_at_all(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("")
 
-    def test_non_integer_channel(self) -> None:
-        with raises(ValidationError):
-            get_channel_id_from_url("channel-id")
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_not_guild_member(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.return_value = {"guild_id": "not-my-guild", "type": CHANNEL_TYPE}
+    with raises(ValidationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+
+
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_timeout(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.side_effect = Timeout("foo")
+    with raises(ApiTimeoutError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+
+
+@mock.patch("sentry.integrations.discord.utils.channel.DiscordClient.get_channel")
+def test_validate_channel_not_supported_type(mock_get_channel: mock.MagicMock) -> None:
+    mock_get_channel.return_value = {"guild_id": GUILD_ID, "type": ChannelType.DM.value}
+    with raises(ValidationError):
+        validate_channel_id(CHANNEL_ID, GUILD_ID, GUILD_NAME)
+
+
+# GetChannelIdFromUrl tests
+TEST_CHANNEL_ID = "12345678910"
+
+
+def test_get_channel_id_from_url_happy_path() -> None:
+    channel = get_channel_id_from_url(f"https://discord.com/channels/guild-id/{TEST_CHANNEL_ID}")
+    assert channel == TEST_CHANNEL_ID
+
+
+def test_get_channel_id_from_url_with_extra_slash() -> None:
+    channel = get_channel_id_from_url(f"https://discord.com/channels/guild-id/{TEST_CHANNEL_ID}")
+    assert channel == TEST_CHANNEL_ID
+
+
+def test_get_channel_id_from_url_missing_channel_id_with_slash() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("https://discord.com/channels/guild-id/")
+
+
+def test_get_channel_id_from_url_missing_channel_id_no_slash() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("https://discord.com/channels/guild-id")
+
+
+def test_get_channel_id_from_url_missing_guild_and_channel_with_slash() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("https://discord.com/channels/")
+
+
+def test_get_channel_id_from_url_missing_guild_and_channel_no_slash() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("https://discord.com/channels")
+
+
+def test_get_channel_id_from_url_different_link() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("https://different.com")
+
+
+def test_get_channel_id_from_url_just_channel_id() -> None:
+    channel = get_channel_id_from_url(TEST_CHANNEL_ID)
+    assert channel == TEST_CHANNEL_ID
+
+
+def test_get_channel_id_from_url_no_channel_at_all() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("")
+
+
+def test_get_channel_id_from_url_non_integer_channel() -> None:
+    with raises(ValidationError):
+        get_channel_id_from_url("channel-id")

--- a/tests/sentry/middleware/test_ai_agent.py
+++ b/tests/sentry/middleware/test_ai_agent.py
@@ -4,121 +4,146 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
 from sentry.middleware.ai_agent import AIAgentMiddleware, _accepts_markdown
-from sentry.testutils.cases import TestCase
 
 
-class AcceptsMarkdownTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.factory = RequestFactory()
-
-    def test_accepts_text_markdown(self):
-        request = self.factory.get("/", HTTP_ACCEPT="text/markdown")
-        assert _accepts_markdown(request) is True
-
-    def test_accepts_text_x_markdown(self):
-        request = self.factory.get("/", HTTP_ACCEPT="text/x-markdown")
-        assert _accepts_markdown(request) is True
-
-    def test_rejects_other_types(self):
-        request = self.factory.get("/", HTTP_ACCEPT="text/plain")
-        assert _accepts_markdown(request) is False
-
-    def test_case_insensitive(self):
-        request = self.factory.get("/", HTTP_ACCEPT="TEXT/MARKDOWN")
-        assert _accepts_markdown(request) is True
-
-    def test_case_insensitive_mixed(self):
-        request = self.factory.get("/", HTTP_ACCEPT="Text/Markdown")
-        assert _accepts_markdown(request) is True
+def test_accepts_text_markdown():
+    factory = RequestFactory()
+    request = factory.get("/", HTTP_ACCEPT="text/markdown")
+    assert _accepts_markdown(request) is True
 
 
-class AIAgentMiddlewareTest(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.factory = RequestFactory()
-        self.middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+def test_accepts_text_x_markdown():
+    factory = RequestFactory()
+    request = factory.get("/", HTTP_ACCEPT="text/x-markdown")
+    assert _accepts_markdown(request) is True
 
-    def make_anonymous_request(self, path: str, **kwargs):
-        request = self.factory.get(path, **kwargs)
-        request.user = AnonymousUser()
-        request.auth = None
-        return request
 
-    def test_returns_guidance_for_anonymous_markdown_request(self):
-        request = self.make_anonymous_request(
-            "/organizations/test-org/issues/", HTTP_ACCEPT="text/markdown"
-        )
+def test_rejects_other_types():
+    factory = RequestFactory()
+    request = factory.get("/", HTTP_ACCEPT="text/plain")
+    assert _accepts_markdown(request) is False
 
-        response = self.middleware(request)
 
-        assert response.status_code == 200
-        assert response["Content-Type"] == "text/markdown"
-        content = response.content.decode()
-        assert "# This Is the Web UI" in content
-        assert "https://mcp.sentry.dev/mcp/test-org" in content
+def test_case_insensitive():
+    factory = RequestFactory()
+    request = factory.get("/", HTTP_ACCEPT="TEXT/MARKDOWN")
+    assert _accepts_markdown(request) is True
 
-    def test_includes_project_in_mcp_url(self):
-        request = self.make_anonymous_request(
-            "/organizations/my-org/projects/my-project/", HTTP_ACCEPT="text/markdown"
-        )
 
-        response = self.middleware(request)
+def test_case_insensitive_mixed():
+    factory = RequestFactory()
+    request = factory.get("/", HTTP_ACCEPT="Text/Markdown")
+    assert _accepts_markdown(request) is True
 
-        assert response.status_code == 200
-        assert "https://mcp.sentry.dev/mcp/my-org/my-project" in response.content.decode()
 
-    def test_base_mcp_url_without_org_context(self):
-        request = self.make_anonymous_request("/settings/", HTTP_ACCEPT="text/markdown")
+def _make_anonymous_request(factory: RequestFactory, path: str, **kwargs):
+    request = factory.get(path, **kwargs)
+    request.user = AnonymousUser()
+    request.auth = None
+    return request
 
-        response = self.middleware(request)
 
-        assert response.status_code == 200
-        assert "https://mcp.sentry.dev/mcp" in response.content.decode()
+def test_returns_guidance_for_anonymous_markdown_request():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(
+        factory, "/organizations/test-org/issues/", HTTP_ACCEPT="text/markdown"
+    )
 
-    def test_authenticated_user_passes_through(self):
-        request = self.factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
-        request.user = self.create_user()
-        request.auth = None
+    response = middleware(request)
 
-        assert self.middleware(request).status_code == 401
+    assert response.status_code == 200
+    assert response["Content-Type"] == "text/markdown"
+    content = response.content.decode()
+    assert "# This Is the Web UI" in content
+    assert "https://mcp.sentry.dev/mcp/test-org" in content
 
-    def test_auth_token_passes_through(self):
-        request = self.factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
-        request.user = AnonymousUser()
-        request.auth = MagicMock()
 
-        assert self.middleware(request).status_code == 401
+def test_includes_project_in_mcp_url():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(
+        factory, "/organizations/my-org/projects/my-project/", HTTP_ACCEPT="text/markdown"
+    )
 
-    def test_non_markdown_accept_passes_through(self):
-        request = self.make_anonymous_request("/organizations/test-org/", HTTP_ACCEPT="text/html")
+    response = middleware(request)
 
-        assert self.middleware(request).status_code == 401
+    assert response.status_code == 200
+    assert "https://mcp.sentry.dev/mcp/my-org/my-project" in response.content.decode()
 
-    def test_api_path_passes_through(self):
-        request = self.make_anonymous_request("/api/0/projects/", HTTP_ACCEPT="text/markdown")
 
-        assert self.middleware(request).status_code == 401
+def test_base_mcp_url_without_org_context():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(factory, "/settings/", HTTP_ACCEPT="text/markdown")
 
-    def test_oauth_path_passes_through(self):
-        request = self.make_anonymous_request("/oauth/token/", HTTP_ACCEPT="text/markdown")
+    response = middleware(request)
 
-        assert self.middleware(request).status_code == 401
+    assert response.status_code == 200
+    assert "https://mcp.sentry.dev/mcp" in response.content.decode()
 
-    @patch("sentry.middleware.ai_agent.logger.info")
-    def test_logs_request(self, mock_logger: MagicMock):
-        request = self.make_anonymous_request(
-            "/organizations/test-org/",
-            HTTP_ACCEPT="text/markdown",
-            HTTP_USER_AGENT="Claude-Code/1.0",
-        )
 
-        self.middleware(request)
+def test_authenticated_user_passes_through():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
+    request.user = MagicMock(is_authenticated=True)
+    request.auth = None
 
-        mock_logger.assert_called_once_with(
-            "ai_agent.guidance_served",
-            extra={
-                "path": "/organizations/test-org/",
-                "user_agent": "Claude-Code/1.0",
-            },
-        )
+    assert middleware(request).status_code == 401
+
+
+def test_auth_token_passes_through():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = factory.get("/organizations/test-org/", HTTP_ACCEPT="text/markdown")
+    request.user = AnonymousUser()
+    request.auth = MagicMock()
+
+    assert middleware(request).status_code == 401
+
+
+def test_non_markdown_accept_passes_through():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(factory, "/organizations/test-org/", HTTP_ACCEPT="text/html")
+
+    assert middleware(request).status_code == 401
+
+
+def test_api_path_passes_through():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(factory, "/api/0/projects/", HTTP_ACCEPT="text/markdown")
+
+    assert middleware(request).status_code == 401
+
+
+def test_oauth_path_passes_through():
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(factory, "/oauth/token/", HTTP_ACCEPT="text/markdown")
+
+    assert middleware(request).status_code == 401
+
+
+@patch("sentry.middleware.ai_agent.logger.info")
+def test_logs_request(mock_logger: MagicMock):
+    factory = RequestFactory()
+    middleware = AIAgentMiddleware(get_response=lambda r: MagicMock(status_code=401))
+    request = _make_anonymous_request(
+        factory,
+        "/organizations/test-org/",
+        HTTP_ACCEPT="text/markdown",
+        HTTP_USER_AGENT="Claude-Code/1.0",
+    )
+
+    middleware(request)
+
+    mock_logger.assert_called_once_with(
+        "ai_agent.guidance_served",
+        extra={
+            "path": "/organizations/test-org/",
+            "user_agent": "Claude-Code/1.0",
+        },
+    )

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -1,38 +1,38 @@
 from __future__ import annotations
 
-from functools import cached_property
-
 from django.http import HttpRequest
 
 from sentry.middleware.proxy import SetRemoteAddrFromForwardedFor
 from sentry.models.team import Team
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.region import Region, RegionCategory
 from sentry.utils import json
 
 
-class SetRemoteAddrFromForwardedForTestCase(TestCase):
-    middleware = cached_property(SetRemoteAddrFromForwardedFor)
+def test_set_remote_addr_ipv4() -> None:
+    middleware = SetRemoteAddrFromForwardedFor(get_response=lambda r: r)
+    request = HttpRequest()
+    request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8:80,8.8.4.4"
+    middleware.process_request(request)
+    assert request.META["REMOTE_ADDR"] == "8.8.8.8"
 
-    def test_ipv4(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8:80,8.8.4.4"
-        self.middleware.process_request(request)
-        assert request.META["REMOTE_ADDR"] == "8.8.8.8"
 
-    def test_ipv4_whitespace(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8:80 "
-        self.middleware.process_request(request)
-        assert request.META["REMOTE_ADDR"] == "8.8.8.8"
+def test_set_remote_addr_ipv4_whitespace() -> None:
+    middleware = SetRemoteAddrFromForwardedFor(get_response=lambda r: r)
+    request = HttpRequest()
+    request.META["HTTP_X_FORWARDED_FOR"] = "8.8.8.8:80 "
+    middleware.process_request(request)
+    assert request.META["REMOTE_ADDR"] == "8.8.8.8"
 
-    def test_ipv6(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_X_FORWARDED_FOR"] = "2001:4860:4860::8888,2001:4860:4860::8844"
-        self.middleware.process_request(request)
-        assert request.META["REMOTE_ADDR"] == "2001:4860:4860::8888"
+
+def test_set_remote_addr_ipv6() -> None:
+    middleware = SetRemoteAddrFromForwardedFor(get_response=lambda r: r)
+    request = HttpRequest()
+    request.META["HTTP_X_FORWARDED_FOR"] = "2001:4860:4860::8888,2001:4860:4860::8844"
+    middleware.process_request(request)
+    assert request.META["REMOTE_ADDR"] == "2001:4860:4860::8888"
 
 
 test_region = Region(

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 from unittest.mock import MagicMock, Mock, patch, sentinel
 
 from django.test import RequestFactory, override_settings
@@ -9,7 +8,6 @@ from sentry.api.base import Endpoint
 from sentry.middleware.ratelimit import RatelimitMiddleware
 from sentry.middleware.stats import RequestTimingMiddleware
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.testutils.cases import TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -25,82 +23,86 @@ class RateLimitedEndpoint(Endpoint):
         raise NotImplementedError
 
 
-class RequestTimingMiddlewareTest(TestCase):
-    middleware = cached_property(RequestTimingMiddleware)
+@patch("sentry.utils.metrics.incr")
+def test_records_default_api_metrics(incr: MagicMock) -> None:
+    factory = RequestFactory()
+    middleware = RequestTimingMiddleware(lambda r: r)
 
-    @cached_property
-    def factory(self):
-        return RequestFactory()
+    request = factory.get("/")
+    request._view_path = "/"
+    request.resolver_match = resolve("/")
+    response = Mock(status_code=200)
 
-    @patch("sentry.utils.metrics.incr")
-    def test_records_default_api_metrics(self, incr: MagicMock) -> None:
-        request = self.factory.get("/")
-        request._view_path = "/"
-        request.resolver_match = resolve("/")
-        response = Mock(status_code=200)
+    middleware.process_response(request, response)
 
-        self.middleware.process_response(request, response)
+    incr.assert_called_with(
+        "view.response",
+        instance=request._view_path,
+        tags={
+            "method": "GET",
+            "status_code": 200,
+            "ui_request": False,
+            "rate_limit_type": None,
+            "url_name": "sentry",
+        },
+        skip_internal=False,
+    )
 
-        incr.assert_called_with(
-            "view.response",
-            instance=request._view_path,
-            tags={
-                "method": "GET",
-                "status_code": 200,
-                "ui_request": False,
-                "rate_limit_type": None,
-                "url_name": "sentry",
-            },
-            skip_internal=False,
-        )
 
-    @patch("sentry.utils.metrics.incr")
-    @override_settings(SENTRY_SELF_HOSTED=False)
-    def test_records_default_api_metrics_with_rate_limit_type(self, incr: MagicMock) -> None:
-        rate_limit_middleware = RatelimitMiddleware(sentinel.callback)
-        test_endpoint = RateLimitedEndpoint.as_view()
-        request = self.factory.get("/")
-        request._view_path = "/"
-        request.resolver_match = resolve("/")
-        response = Mock(status_code=429)
+@patch("sentry.utils.metrics.incr")
+@override_settings(SENTRY_SELF_HOSTED=False)
+def test_records_default_api_metrics_with_rate_limit_type(incr: MagicMock) -> None:
+    factory = RequestFactory()
+    middleware = RequestTimingMiddleware(lambda r: r)
 
-        rate_limit_middleware.process_view(request, test_endpoint, [], {})
-        self.middleware.process_response(request, response)
+    rate_limit_middleware = RatelimitMiddleware(sentinel.callback)
+    test_endpoint = RateLimitedEndpoint.as_view()
+    request = factory.get("/")
+    request._view_path = "/"
+    request.resolver_match = resolve("/")
+    response = Mock(status_code=429)
 
-        incr.assert_called_with(
-            "view.response",
-            instance=request._view_path,
-            tags={
-                "method": "GET",
-                "status_code": 429,
-                "ui_request": False,
-                "rate_limit_type": "fixed_window",
-                "url_name": "sentry",
-            },
-            skip_internal=False,
-        )
+    rate_limit_middleware.process_view(request, test_endpoint, [], {})
+    middleware.process_response(request, response)
 
-    @patch("sentry.utils.metrics.incr")
-    def test_records_ui_request(self, incr: MagicMock) -> None:
-        request = self.factory.get("/")
-        request._view_path = "/"
-        # mypy says this is nullable so we test that path here too
-        # request.resolver_match = resolve("/")
-        response = Mock(status_code=200)
-        request.COOKIES = {"foo": "bar"}
-        request.auth = None
+    incr.assert_called_with(
+        "view.response",
+        instance=request._view_path,
+        tags={
+            "method": "GET",
+            "status_code": 429,
+            "ui_request": False,
+            "rate_limit_type": "fixed_window",
+            "url_name": "sentry",
+        },
+        skip_internal=False,
+    )
 
-        self.middleware.process_response(request, response)
 
-        incr.assert_called_with(
-            "view.response",
-            instance=request._view_path,
-            tags={
-                "method": "GET",
-                "status_code": 200,
-                "ui_request": True,
-                "rate_limit_type": None,
-                "url_name": "unreachable-unknown",
-            },
-            skip_internal=False,
-        )
+@patch("sentry.utils.metrics.incr")
+def test_records_ui_request(incr: MagicMock) -> None:
+    factory = RequestFactory()
+    middleware = RequestTimingMiddleware(lambda r: r)
+
+    request = factory.get("/")
+    request._view_path = "/"
+    # mypy says this is nullable so we test that path here too
+    # request.resolver_match = resolve("/")
+    response = Mock(status_code=200)
+    request.COOKIES = {"foo": "bar"}
+    request.auth = None
+
+    middleware.process_response(request, response)
+
+    incr.assert_called_with(
+        "view.response",
+        instance=request._view_path,
+        tags={
+            "method": "GET",
+            "status_code": 200,
+            "ui_request": True,
+            "rate_limit_type": None,
+            "url_name": "unreachable-unknown",
+        },
+        skip_internal=False,
+    )

--- a/tests/sentry/monitors/test_types.py
+++ b/tests/sentry/monitors/test_types.py
@@ -1,13 +1,11 @@
 from sentry.monitors.testutils import build_checkin_item
 from sentry.monitors.types import CheckinItem
-from sentry.testutils.cases import TestCase
 
 
-class CheckinItemTest(TestCase):
-    def test(self) -> None:
-        checkin_item = build_checkin_item()
-        recreated_checkin_item = CheckinItem.from_dict(checkin_item.to_dict())
-        assert checkin_item.ts == recreated_checkin_item.ts
-        assert checkin_item.partition == recreated_checkin_item.partition
-        assert checkin_item.message == recreated_checkin_item.message
-        assert checkin_item.payload == recreated_checkin_item.payload
+def test_checkin_item_round_trip() -> None:
+    checkin_item = build_checkin_item()
+    recreated_checkin_item = CheckinItem.from_dict(checkin_item.to_dict())
+    assert checkin_item.ts == recreated_checkin_item.ts
+    assert checkin_item.partition == recreated_checkin_item.partition
+    assert checkin_item.message == recreated_checkin_item.message
+    assert checkin_item.payload == recreated_checkin_item.payload

--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -3,41 +3,42 @@ from unittest.mock import MagicMock, patch
 from django.test import override_settings
 
 from sentry.net.socket import ensure_fqdn, is_ipaddress_allowed, is_safe_hostname
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import override_blocklist
 
 
-class SocketTest(TestCase):
-    @override_blocklist("10.0.0.0/8", "127.0.0.1")
-    def test_is_ipaddress_allowed(self) -> None:
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("127.0.0.1") is False
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("10.0.1.1") is False
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("1.1.1.1") is True
+@override_blocklist("10.0.0.0/8", "127.0.0.1")
+def test_is_ipaddress_allowed() -> None:
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("127.0.0.1") is False
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("10.0.1.1") is False
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("1.1.1.1") is True
 
-    @override_blocklist("::ffff:10.0.0.0/104", "::1/128")
-    def test_is_ipaddress_allowed_ipv6(self) -> None:
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("::1") is False
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("::ffff:10.0.1.2") is False
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("::ffff:1.1.1.1") is True
-        is_ipaddress_allowed.cache_clear()
-        assert is_ipaddress_allowed("2001:db8:a::123") is True
 
-    @override_blocklist("10.0.0.0/8", "127.0.0.1")
-    @patch("socket.getaddrinfo")
-    def test_is_safe_hostname(self, mock_getaddrinfo: MagicMock) -> None:
-        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("81.0.0.1", 0))]
-        assert is_safe_hostname("example.com") is True
-        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 0))]
-        assert is_safe_hostname("example.com") is False
+@override_blocklist("::ffff:10.0.0.0/104", "::1/128")
+def test_is_ipaddress_allowed_ipv6() -> None:
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("::1") is False
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("::ffff:10.0.1.2") is False
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("::ffff:1.1.1.1") is True
+    is_ipaddress_allowed.cache_clear()
+    assert is_ipaddress_allowed("2001:db8:a::123") is True
 
-    @override_settings(SENTRY_ENSURE_FQDN=True)
-    def test_ensure_fqdn(self) -> None:
-        assert ensure_fqdn("example.com") == "example.com."
-        assert ensure_fqdn("127.0.0.1") == "127.0.0.1"
-        assert ensure_fqdn("example.com.") == "example.com."
+
+@override_blocklist("10.0.0.0/8", "127.0.0.1")
+@patch("socket.getaddrinfo")
+def test_is_safe_hostname(mock_getaddrinfo: MagicMock) -> None:
+    mock_getaddrinfo.return_value = [(2, 1, 6, "", ("81.0.0.1", 0))]
+    assert is_safe_hostname("example.com") is True
+    mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 0))]
+    assert is_safe_hostname("example.com") is False
+
+
+@override_settings(SENTRY_ENSURE_FQDN=True)
+def test_ensure_fqdn() -> None:
+    assert ensure_fqdn("example.com") == "example.com."
+    assert ensure_fqdn("127.0.0.1") == "127.0.0.1"
+    assert ensure_fqdn("example.com.") == "example.com."

--- a/tests/sentry/plugins/test_helpers.py
+++ b/tests/sentry/plugins/test_helpers.py
@@ -1,28 +1,28 @@
 from unittest import mock
 
 from sentry.plugins.helpers import get_option, set_option, unset_option
-from sentry.testutils.cases import TestCase
 
 
-class SentryPluginTest(TestCase):
-    def test_set_option_with_project(self) -> None:
-        with mock.patch("sentry.models.ProjectOption.objects.set_value") as set_value:
-            project = mock.Mock()
-            set_option("key", "value", project)
+def test_set_option_with_project() -> None:
+    with mock.patch("sentry.models.ProjectOption.objects.set_value") as set_value:
+        project = mock.Mock()
+        set_option("key", "value", project)
 
-            set_value.assert_called_once_with(project, "key", "value")
+        set_value.assert_called_once_with(project, "key", "value")
 
-    def test_get_option_with_project(self) -> None:
-        with mock.patch("sentry.models.ProjectOption.objects.get_value") as get_value:
-            project = mock.Mock()
-            result = get_option("key", project)
-            self.assertEqual(result, get_value.return_value)
 
-            get_value.assert_called_once_with(project, "key", None)
+def test_get_option_with_project() -> None:
+    with mock.patch("sentry.models.ProjectOption.objects.get_value") as get_value:
+        project = mock.Mock()
+        result = get_option("key", project)
+        assert result == get_value.return_value
 
-    def test_unset_option_with_project(self) -> None:
-        with mock.patch("sentry.models.ProjectOption.objects.unset_value") as unset_value:
-            project = mock.Mock()
-            unset_option("key", project)
+        get_value.assert_called_once_with(project, "key", None)
 
-            unset_value.assert_called_once_with(project, "key")
+
+def test_unset_option_with_project() -> None:
+    with mock.patch("sentry.models.ProjectOption.objects.unset_value") as unset_value:
+        project = mock.Mock()
+        unset_option("key", project)
+
+        unset_value.assert_called_once_with(project, "key")

--- a/tests/sentry/preprod/size_analysis/test_comparison_utils.py
+++ b/tests/sentry/preprod/size_analysis/test_comparison_utils.py
@@ -1,348 +1,356 @@
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 from sentry.preprod.size_analysis.utils import ComparisonValidationResult, can_compare_size_metrics
-from sentry.testutils.cases import TestCase
 
 
-class CanCompareSizeMetricsTest(TestCase):
-    def test_can_compare_when_metrics_match(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
-
-        result = can_compare_size_metrics(head_metrics, base_metrics)
-
-        assert result.can_compare is True
-        assert result.error_message is None
-        assert result.error_type is None
-
-    def test_cannot_compare_empty_lists(self):
-        result = can_compare_size_metrics([], [])
-
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
-        assert result.error_message is not None
-        assert "no completed size metrics" in result.error_message
-
-    def test_cannot_compare_empty_head(self):
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
-
-        result = can_compare_size_metrics([], base_metrics)
-
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
-        assert result.error_message is not None
-
-    def test_cannot_compare_empty_base(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-
-        result = can_compare_size_metrics(head_metrics, [])
-
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
-        assert result.error_message is not None
-
-    def test_different_length_error_type(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            ),
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
-                identifier="com.example.watch",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=200,
-                max_download_size=100,
-            ),
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
-
-        result = can_compare_size_metrics(head_metrics, base_metrics)
-
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
-        assert result.error_message is not None
-        assert "Head has 2 metric(s), base has 1 metric(s)" in result.error_message
-
-    def test_different_app_ids_error_type(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app.debug",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
-
-        result = can_compare_size_metrics(head_metrics, base_metrics)
-
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_APP_IDS
-        assert result.error_message is not None
-        assert "mismatched metrics" in result.error_message
-        assert "com.example.app" in result.error_message
-        assert "com.example.app.debug" in result.error_message
-
-    def test_different_build_configurations_error_type(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=200,
-                max_download_size=100,
-            )
-        ]
-
-        result = can_compare_size_metrics(head_metrics, base_metrics)
-
-        assert result.can_compare is False
-        assert (
-            result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_BUILD_CONFIGURATIONS
+def test_can_compare_when_metrics_match() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
         )
-        assert result.error_message is not None
-        assert "mismatched metrics" in result.error_message
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
 
-    def test_cannot_compare_when_metrics_not_completed(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
+    result = can_compare_size_metrics(head_metrics, base_metrics)
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
+    assert result.can_compare is True
+    assert result.error_message is None
+    assert result.error_type is None
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
-        assert result.error_message is not None
-        assert "not completed" in result.error_message
 
-    def test_cannot_compare_when_all_metrics_pending(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
+def test_cannot_compare_empty_lists() -> None:
+    result = can_compare_size_metrics([], [])
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+    assert result.error_message is not None
+    assert "no completed size metrics" in result.error_message
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
-        assert result.error_message is not None
-        assert "2 metric(s)" in result.error_message
 
-    def test_cannot_compare_when_metric_failed(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
+def test_cannot_compare_empty_head() -> None:
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
+    result = can_compare_size_metrics([], base_metrics)
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
-        assert result.error_message is not None
-        assert "failed" in result.error_message
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+    assert result.error_message is not None
 
-    def test_cannot_compare_when_metric_not_ran(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
+def test_cannot_compare_empty_base() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
-        assert result.error_message is not None
-        assert "failed" in result.error_message
+    result = can_compare_size_metrics(head_metrics, [])
 
-    def test_failed_takes_priority_over_pending(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
-                max_install_size=900,
-                max_download_size=450,
-            )
-        ]
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+    assert result.error_message is not None
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+def test_different_length_error_type() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        ),
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.watch",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=200,
+            max_download_size=100,
+        ),
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
 
-    def test_different_metrics_error_type(self):
-        head_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=1,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
-                identifier="com.example.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=1000,
-                max_download_size=500,
-            )
-        ]
-        base_metrics = [
-            PreprodArtifactSizeMetrics(
-                preprod_artifact_id=2,
-                metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
-                identifier="com.different.app",
-                state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
-                max_install_size=200,
-                max_download_size=100,
-            )
-        ]
+    result = can_compare_size_metrics(head_metrics, base_metrics)
 
-        result = can_compare_size_metrics(head_metrics, base_metrics)
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_LENGTH
+    assert result.error_message is not None
+    assert "Head has 2 metric(s), base has 1 metric(s)" in result.error_message
 
-        assert result.can_compare is False
-        assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_METRICS
-        assert result.error_message is not None
-        assert "mismatched metrics" in result.error_message
+
+def test_different_app_ids_error_type() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app.debug",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_APP_IDS
+    assert result.error_message is not None
+    assert "mismatched metrics" in result.error_message
+    assert "com.example.app" in result.error_message
+    assert "com.example.app.debug" in result.error_message
+
+
+def test_different_build_configurations_error_type() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=200,
+            max_download_size=100,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_BUILD_CONFIGURATIONS
+    assert result.error_message is not None
+    assert "mismatched metrics" in result.error_message
+
+
+def test_cannot_compare_when_metrics_not_completed() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+    assert result.error_message is not None
+    assert "not completed" in result.error_message
+
+
+def test_cannot_compare_when_all_metrics_pending() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.NOT_ALL_COMPLETED
+    assert result.error_message is not None
+    assert "2 metric(s)" in result.error_message
+
+
+def test_cannot_compare_when_metric_failed() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+    assert result.error_message is not None
+    assert "failed" in result.error_message
+
+
+def test_cannot_compare_when_metric_not_ran() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+    assert result.error_message is not None
+    assert "failed" in result.error_message
+
+
+def test_failed_takes_priority_over_pending() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            max_install_size=900,
+            max_download_size=450,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.METRICS_FAILED
+
+
+def test_different_metrics_error_type() -> None:
+    head_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=1,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            identifier="com.example.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=1000,
+            max_download_size=500,
+        )
+    ]
+    base_metrics = [
+        PreprodArtifactSizeMetrics(
+            preprod_artifact_id=2,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.WATCH_ARTIFACT,
+            identifier="com.different.app",
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            max_install_size=200,
+            max_download_size=100,
+        )
+    ]
+
+    result = can_compare_size_metrics(head_metrics, base_metrics)
+
+    assert result.can_compare is False
+    assert result.error_type == ComparisonValidationResult.ErrorType.DIFFERENT_METRICS
+    assert result.error_message is not None
+    assert "mismatched metrics" in result.error_message

--- a/tests/sentry/roles/test_manager.py
+++ b/tests/sentry/roles/test_manager.py
@@ -2,182 +2,189 @@ from unittest import mock
 
 from sentry.roles import default_manager
 from sentry.roles.manager import RoleManager
-from sentry.testutils.cases import TestCase
 
 
-class RoleManagerTest(TestCase):
-    @staticmethod
-    def _assert_minimum_team_role_is(manager: RoleManager, org_role: str, team_role: str) -> None:
-        assert manager.get_minimum_team_role(org_role).id == team_role
+def _assert_minimum_team_role_is(manager: RoleManager, org_role: str, team_role: str) -> None:
+    assert manager.get_minimum_team_role(org_role).id == team_role
 
-    def test_default_manager(self) -> None:
-        assert default_manager.get_all()
-        assert len(default_manager.get_choices()) == len(default_manager.get_all())
-        assert default_manager.get_top_dog().id == "owner"
 
-        assert default_manager.can_manage("owner", "manager")
-        assert default_manager.can_manage("owner", "member")
-        assert default_manager.can_manage("manager", "member")
+TEST_ORG_ROLES = [
+    {"id": "peasant", "name": "Peasant", "desc": "Poor farmer"},
+    {"id": "baron", "name": "Baron", "desc": "Lowest of nobility"},
+    {"id": "earl", "name": "Earl", "desc": "Middle of nobility"},
+    {"id": "duke", "name": "Duke", "desc": "Highest of nobility"},
+    {"id": "monarch", "name": "Monarch", "desc": "Ruler of all"},
+]
 
-        self._assert_minimum_team_role_is(default_manager, "member", "contributor")
-        self._assert_minimum_team_role_is(default_manager, "admin", "admin")
-        self._assert_minimum_team_role_is(default_manager, "manager", "admin")
-        self._assert_minimum_team_role_is(default_manager, "owner", "admin")
+TEST_TEAM_ROLES = [
+    {
+        "id": "private",
+        "name": "Private",
+        "is_minimum_role_for": "peasant",
+        "desc": "Lowest rank in the army",
+    },
+    {
+        "id": "sergeant",
+        "name": "Sergeant",
+        "is_minimum_role_for": "earl",
+        "desc": "Low officer class",
+    },
+    {"id": "lieutenant", "name": "Lieutenant", "desc": "Leads platoons and companies"},
+    {
+        "id": "captain",
+        "name": "Captain",
+        "is_minimum_role_for": "monarch",
+        "desc": "Commands big groups",
+    },
+]
 
-    TEST_ORG_ROLES = [
-        {"id": "peasant", "name": "Peasant", "desc": "Poor farmer"},
-        {"id": "baron", "name": "Baron", "desc": "Lowest of nobility"},
-        {"id": "earl", "name": "Earl", "desc": "Middle of nobility"},
-        {"id": "duke", "name": "Duke", "desc": "Highest of nobility"},
-        {"id": "monarch", "name": "Monarch", "desc": "Ruler of all"},
+
+def test_default_manager() -> None:
+    assert default_manager.get_all()
+    assert len(default_manager.get_choices()) == len(default_manager.get_all())
+    assert default_manager.get_top_dog().id == "owner"
+
+    assert default_manager.can_manage("owner", "manager")
+    assert default_manager.can_manage("owner", "member")
+    assert default_manager.can_manage("manager", "member")
+
+    _assert_minimum_team_role_is(default_manager, "member", "contributor")
+    _assert_minimum_team_role_is(default_manager, "admin", "admin")
+    _assert_minimum_team_role_is(default_manager, "manager", "admin")
+    _assert_minimum_team_role_is(default_manager, "owner", "admin")
+
+
+def test_priority() -> None:
+    manager = RoleManager(TEST_ORG_ROLES, TEST_TEAM_ROLES)
+
+    assert len(manager.get_all()) == len(TEST_ORG_ROLES)
+    assert manager.can_manage("duke", "baron")
+    assert manager.get_default().id == "peasant"
+    assert manager.get_top_dog().id == "monarch"
+
+    assert len(manager.get_all()) == 5
+    assert manager.can_manage("duke", "baron")
+    assert manager.get_default().id == "peasant"
+    assert manager.get_top_dog().id == "monarch"
+
+
+def test_mapping() -> None:
+    manager = RoleManager(TEST_ORG_ROLES, TEST_TEAM_ROLES)
+
+    _assert_minimum_team_role_is(manager, "monarch", "captain")
+    _assert_minimum_team_role_is(manager, "duke", "sergeant")
+    _assert_minimum_team_role_is(manager, "earl", "sergeant")
+    _assert_minimum_team_role_is(manager, "baron", "private")
+    _assert_minimum_team_role_is(manager, "peasant", "private")
+
+
+def test_choices() -> None:
+    manager = RoleManager(TEST_ORG_ROLES, TEST_TEAM_ROLES)
+
+    assert manager.get_choices() == manager.organization_roles.get_choices()
+    assert manager.team_roles.get_choices() == tuple(
+        (role["id"], role["name"]) for role in TEST_TEAM_ROLES
+    )
+
+
+def test_descriptions() -> None:
+    manager = RoleManager(TEST_ORG_ROLES, TEST_TEAM_ROLES)
+
+    assert manager.team_roles.get_descriptions() == tuple(
+        (role["id"], role["desc"]) for role in TEST_TEAM_ROLES
+    )
+
+
+def test_team_default_mapping() -> None:
+    # Check that RoleManager provides sensible defaults in case the team roles
+    # don't specify any mappings
+
+    team_roles = [
+        {k: v for (k, v) in role.items() if k != "is_minimum_role_for"} for role in TEST_TEAM_ROLES
     ]
+    manager = RoleManager(TEST_ORG_ROLES, team_roles)
 
-    TEST_TEAM_ROLES = [
+    _assert_minimum_team_role_is(manager, "monarch", "captain")
+    _assert_minimum_team_role_is(manager, "duke", "private")
+    _assert_minimum_team_role_is(manager, "earl", "private")
+    _assert_minimum_team_role_is(manager, "baron", "private")
+    _assert_minimum_team_role_is(manager, "peasant", "private")
+
+
+def test_top_dog_accesses_all_team_roles() -> None:
+    # Check that the org's top dog role has access to the top team role even if
+    # it's explicitly mapped to a lower role
+
+    team_roles = [
+        {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+        {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
         {
-            "id": "private",
-            "name": "Private",
-            "is_minimum_role_for": "peasant",
-            "desc": "Lowest rank in the army",
-        },
-        {
-            "id": "sergeant",
-            "name": "Sergeant",
-            "is_minimum_role_for": "earl",
-            "desc": "Low officer class",
-        },
-        {"id": "lieutenant", "name": "Lieutenant", "desc": "Leads platoons and companies"},
-        {
-            "id": "captain",
-            "name": "Captain",
+            "id": "lieutenant",
+            "name": "Lieutenant",
             "is_minimum_role_for": "monarch",
-            "desc": "Commands big groups",
+            "desc": "fo",
         },
+        {"id": "captain", "name": "Captain", "desc": "fum"},
     ]
+    manager = RoleManager(TEST_ORG_ROLES, team_roles)
 
-    def test_priority(self) -> None:
-        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+    _assert_minimum_team_role_is(manager, "monarch", "captain")
+    _assert_minimum_team_role_is(manager, "duke", "sergeant")
+    _assert_minimum_team_role_is(manager, "earl", "sergeant")
+    _assert_minimum_team_role_is(manager, "baron", "private")
+    _assert_minimum_team_role_is(manager, "peasant", "private")
 
-        assert len(manager.get_all()) == len(self.TEST_ORG_ROLES)
-        assert manager.can_manage("duke", "baron")
-        assert manager.get_default().id == "peasant"
-        assert manager.get_top_dog().id == "monarch"
 
-        assert len(manager.get_all()) == 5
-        assert manager.can_manage("duke", "baron")
-        assert manager.get_default().id == "peasant"
-        assert manager.get_top_dog().id == "monarch"
+def test_if_team_top_dog_is_not_org_top_dog() -> None:
+    team_roles = [
+        {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+        {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
+        {"id": "lieutenant", "name": "Lieutenant", "desc": "fo"},
+        {"id": "captain", "name": "Captain", "is_minimum_role_for": "duke", "desc": "fum"},
+    ]
+    manager = RoleManager(TEST_ORG_ROLES, team_roles)
 
-    def test_mapping(self) -> None:
-        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+    _assert_minimum_team_role_is(manager, "monarch", "captain")
+    _assert_minimum_team_role_is(manager, "duke", "captain")
+    _assert_minimum_team_role_is(manager, "earl", "sergeant")
+    _assert_minimum_team_role_is(manager, "baron", "private")
+    _assert_minimum_team_role_is(manager, "peasant", "private")
 
-        self._assert_minimum_team_role_is(manager, "monarch", "captain")
-        self._assert_minimum_team_role_is(manager, "duke", "sergeant")
-        self._assert_minimum_team_role_is(manager, "earl", "sergeant")
-        self._assert_minimum_team_role_is(manager, "baron", "private")
-        self._assert_minimum_team_role_is(manager, "peasant", "private")
 
-    def test_choices(self) -> None:
-        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+def test_handles_non_injective_mapping() -> None:
+    # Check that RoleManager tolerates multiple team roles pointing at the same
+    # org role and maps to the highest one
 
-        assert manager.get_choices() == manager.organization_roles.get_choices()
-        assert manager.team_roles.get_choices() == tuple(
-            (role["id"], role["name"]) for role in self.TEST_TEAM_ROLES
-        )
+    team_roles = [
+        {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
+        {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
+        {"id": "lieutenant", "name": "Lieutenant", "is_minimum_role_for": "earl", "desc": "fo"},
+        {"id": "captain", "name": "Captain", "is_minimum_role_for": "monarch", "desc": "fum"},
+    ]
+    manager = RoleManager(TEST_ORG_ROLES, team_roles)
 
-    def test_descriptions(self) -> None:
-        manager = RoleManager(self.TEST_ORG_ROLES, self.TEST_TEAM_ROLES)
+    _assert_minimum_team_role_is(manager, "monarch", "captain")
+    _assert_minimum_team_role_is(manager, "duke", "lieutenant")
+    _assert_minimum_team_role_is(manager, "earl", "lieutenant")
+    _assert_minimum_team_role_is(manager, "baron", "private")
+    _assert_minimum_team_role_is(manager, "peasant", "private")
 
-        assert manager.team_roles.get_descriptions() == tuple(
-            (role["id"], role["desc"]) for role in self.TEST_TEAM_ROLES
-        )
 
-    def test_team_default_mapping(self) -> None:
-        # Check that RoleManager provides sensible defaults in case the team roles
-        # don't specify any mappings
+@mock.patch("sentry.roles.manager.warnings")
+def test_team_mapping_to_legacy_roles(mock_warnings: mock.MagicMock) -> None:
+    # Check that RoleManager provides sensible defaults in case the default org
+    # roles have been overridden by unfamiliar values, leaving behind default
+    # team roles with mapping keys that point to nothing
 
-        team_roles = [
-            {k: v for (k, v) in role.items() if k != "is_minimum_role_for"}
-            for role in self.TEST_TEAM_ROLES
-        ]
-        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
+    legacy_roles = [
+        {"id": "legionary", "name": "Legionary", "desc": "Member of a legion"},
+        {"id": "centurion", "name": "Centurion", "desc": "Commander of a military unit"},
+        {"id": "legate", "name": "Legate", "desc": "Commander of a legion"},
+    ]
+    manager = RoleManager(legacy_roles, TEST_TEAM_ROLES)
 
-        self._assert_minimum_team_role_is(manager, "monarch", "captain")
-        self._assert_minimum_team_role_is(manager, "duke", "private")
-        self._assert_minimum_team_role_is(manager, "earl", "private")
-        self._assert_minimum_team_role_is(manager, "baron", "private")
-        self._assert_minimum_team_role_is(manager, "peasant", "private")
+    assert mock_warnings.warn.called
 
-    def test_top_dog_accesses_all_team_roles(self) -> None:
-        # Check that the org's top dog role has access to the top team role even if
-        # it's explicitly mapped to a lower role
-
-        team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
-            {
-                "id": "lieutenant",
-                "name": "Lieutenant",
-                "is_minimum_role_for": "monarch",
-                "desc": "fo",
-            },
-            {"id": "captain", "name": "Captain", "desc": "fum"},
-        ]
-        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
-
-        self._assert_minimum_team_role_is(manager, "monarch", "captain")
-        self._assert_minimum_team_role_is(manager, "duke", "sergeant")
-        self._assert_minimum_team_role_is(manager, "earl", "sergeant")
-        self._assert_minimum_team_role_is(manager, "baron", "private")
-        self._assert_minimum_team_role_is(manager, "peasant", "private")
-
-    def test_if_team_top_dog_is_not_org_top_dog(self) -> None:
-        team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
-            {"id": "lieutenant", "name": "Lieutenant", "desc": "fo"},
-            {"id": "captain", "name": "Captain", "is_minimum_role_for": "duke", "desc": "fum"},
-        ]
-        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
-
-        self._assert_minimum_team_role_is(manager, "monarch", "captain")
-        self._assert_minimum_team_role_is(manager, "duke", "captain")
-        self._assert_minimum_team_role_is(manager, "earl", "sergeant")
-        self._assert_minimum_team_role_is(manager, "baron", "private")
-        self._assert_minimum_team_role_is(manager, "peasant", "private")
-
-    def test_handles_non_injective_mapping(self) -> None:
-        # Check that RoleManager tolerates multiple team roles pointing at the same
-        # org role and maps to the highest one
-
-        team_roles = [
-            {"id": "private", "name": "Private", "is_minimum_role_for": "peasant", "desc": "fee"},
-            {"id": "sergeant", "name": "Sergeant", "is_minimum_role_for": "earl", "desc": "fi"},
-            {"id": "lieutenant", "name": "Lieutenant", "is_minimum_role_for": "earl", "desc": "fo"},
-            {"id": "captain", "name": "Captain", "is_minimum_role_for": "monarch", "desc": "fum"},
-        ]
-        manager = RoleManager(self.TEST_ORG_ROLES, team_roles)
-
-        self._assert_minimum_team_role_is(manager, "monarch", "captain")
-        self._assert_minimum_team_role_is(manager, "duke", "lieutenant")
-        self._assert_minimum_team_role_is(manager, "earl", "lieutenant")
-        self._assert_minimum_team_role_is(manager, "baron", "private")
-        self._assert_minimum_team_role_is(manager, "peasant", "private")
-
-    @mock.patch("sentry.roles.manager.warnings")
-    def test_team_mapping_to_legacy_roles(self, mock_warnings: mock.MagicMock) -> None:
-        # Check that RoleManager provides sensible defaults in case the default org
-        # roles have been overridden by unfamiliar values, leaving behind default
-        # team roles with mapping keys that point to nothing
-
-        legacy_roles = [
-            {"id": "legionary", "name": "Legionary", "desc": "Member of a legion"},
-            {"id": "centurion", "name": "Centurion", "desc": "Commander of a military unit"},
-            {"id": "legate", "name": "Legate", "desc": "Commander of a legion"},
-        ]
-        manager = RoleManager(legacy_roles, self.TEST_TEAM_ROLES)
-
-        assert mock_warnings.warn.called
-
-        self._assert_minimum_team_role_is(manager, "legate", "captain")
-        self._assert_minimum_team_role_is(manager, "centurion", "private")
-        self._assert_minimum_team_role_is(manager, "legionary", "private")
+    _assert_minimum_team_role_is(manager, "legate", "captain")
+    _assert_minimum_team_role_is(manager, "centurion", "private")
+    _assert_minimum_team_role_is(manager, "legionary", "private")

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -1,84 +1,92 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 import responses
-from pytest import raises
 from requests import PreparedRequest, Request
 
 from sentry.exceptions import RestrictedIPAddress
 from sentry.net.http import Session
 from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.shared_integrations.exceptions import ApiHostError
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.socket import override_blocklist
 
 
-class BaseApiClientTest(TestCase):
+class Client(BaseApiClient):
+    """Test client for BaseApiClient tests."""
+
+    integration_type = "integration"
+    integration_name = "base"
+
+
+@responses.activate
+@patch.object(BaseApiClient, "finalize_request", side_effect=lambda req: req)
+def test_finalize_request(mock_finalize_request) -> None:
     """
     The BaseApiClient was created after ApiClient, so many tests can be found
     there instead (tests/sentry/integrations/test_client.py)
     """
+    api_client = Client()
 
-    def setUp(self) -> None:
-        class Client(BaseApiClient):
-            integration_type = "integration"
-            integration_name = "base"
+    # Ensure finalize_request is called before all requests
+    get_response = responses.add(responses.GET, "https://example.com/get", json={})
+    assert not mock_finalize_request.called
+    assert get_response.call_count == 0
+    api_client.get("https://example.com/get")
+    assert mock_finalize_request.called
+    assert get_response.call_count == 1
 
-        self.api_client = Client()
+    # Ensure finalize_request can modify the request prior to sending
+    put_response = responses.add(responses.PUT, "https://example.com/put", json={})
+    assert put_response.call_count == 0
 
-    @responses.activate
-    @patch.object(BaseApiClient, "finalize_request", side_effect=lambda req: req)
-    def test_finalize_request(self, mock_finalize_request) -> None:
-        # Ensure finalize_request is called before all requests
-        get_response = responses.add(responses.GET, "https://example.com/get", json={})
-        assert not mock_finalize_request.called
-        assert get_response.call_count == 0
-        self.api_client.get("https://example.com/get")
-        assert mock_finalize_request.called
-        assert get_response.call_count == 1
+    class TestClient(BaseApiClient):
+        integration_type = "integration"
+        integration_name = "test"
 
-        # Ensure finalize_request can modify the request prior to sending
-        put_response = responses.add(responses.PUT, "https://example.com/put", json={})
-        assert put_response.call_count == 0
+        def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
+            prepared_request.method = "PUT"
+            prepared_request.url = "https://example.com/put"
+            return prepared_request
 
-        class TestClient(BaseApiClient):
-            integration_type = "integration"
-            integration_name = "test"
+    # Method and url are overridden in TestClient.finalize_request
+    TestClient().get("https://example.com/get")
+    assert get_response.call_count == 1
+    assert put_response.call_count == 1
 
-            def finalize_request(self, prepared_request: PreparedRequest) -> PreparedRequest:
-                prepared_request.method = "PUT"
-                prepared_request.url = "https://example.com/put"
-                return prepared_request
 
-        # Method and url are overridden in TestClient.finalize_request
-        TestClient().get("https://example.com/get")
-        assert get_response.call_count == 1
-        assert put_response.call_count == 1
+@responses.activate
+def test__request_prepared_request() -> None:
+    api_client = Client()
 
-    @responses.activate
-    def test__request_prepared_request(self) -> None:
-        put_response = responses.add(responses.PUT, "https://example.com/put", json={})
-        prepared_request = Request(method="PUT", url="https://example.com/put").prepare()
-        # Client should use prepared request instead of using other params
-        assert put_response.call_count == 0
-        self.api_client.get("https://example.com/get", prepared_request=prepared_request)
-        assert put_response.call_count == 1
+    put_response = responses.add(responses.PUT, "https://example.com/put", json={})
+    prepared_request = Request(method="PUT", url="https://example.com/put").prepare()
+    # Client should use prepared request instead of using other params
+    assert put_response.call_count == 0
+    api_client.get("https://example.com/get", prepared_request=prepared_request)
+    assert put_response.call_count == 1
 
-    @responses.activate
-    @patch.object(BaseApiClient, "finalize_request", side_effect=lambda req: req)
-    @patch.object(Session, "send", side_effect=RestrictedIPAddress())
-    @override_blocklist("172.16.0.0/12")
-    def test_restricted_ip_address(self, mock_finalize_request, mock_session_send) -> None:
-        assert not mock_finalize_request.called
-        with raises(ApiHostError):
-            self.api_client.get("https://172.31.255.255")
-        assert mock_finalize_request.called
 
-    @patch.object(Session, "send")
-    def test_default_timeout(self, mock_session_send) -> None:
-        response = MagicMock()
-        response.status_code = 204
-        mock_session_send.return_value = response
+@responses.activate
+@patch.object(BaseApiClient, "finalize_request", side_effect=lambda req: req)
+@patch.object(Session, "send", side_effect=RestrictedIPAddress())
+@override_blocklist("172.16.0.0/12")
+def test_restricted_ip_address(mock_session_send, mock_finalize_request) -> None:
+    api_client = Client()
 
-        self.api_client.get("https://172.31.255.255")
-        assert mock_session_send.call_count == 1
-        assert mock_session_send.mock_calls[0].kwargs["timeout"] == 30
+    assert not mock_finalize_request.called
+    with pytest.raises(ApiHostError):
+        api_client.get("https://172.31.255.255")
+    assert mock_finalize_request.called
+
+
+@patch.object(Session, "send")
+def test_default_timeout(mock_session_send) -> None:
+    api_client = Client()
+
+    response = MagicMock()
+    response.status_code = 204
+    mock_session_send.return_value = response
+
+    api_client.get("https://172.31.255.255")
+    assert mock_session_send.call_count == 1
+    assert mock_session_send.mock_calls[0].kwargs["timeout"] == 30

--- a/tests/sentry/silo/test_base.py
+++ b/tests/sentry/silo/test_base.py
@@ -3,66 +3,63 @@ import django.urls
 from django.views.generic import RedirectView, TemplateView, View
 
 from sentry.api.base import Endpoint
-from sentry.testutils.cases import TestCase
 
 
-class SiloLimitCoverageTest(TestCase):
+def test_all_models_have_silo_limit_decorator() -> None:
     """Check that all subclasses have expected SiloLimit decorators."""
+    undecorated_model_classes = []
 
-    def test_all_models_have_silo_limit_decorator(self) -> None:
-        undecorated_model_classes = []
+    for model_class in django.apps.apps.get_models():
+        if model_class._meta.app_label == "sentry" and not hasattr(model_class._meta, "silo_limit"):
+            undecorated_model_classes.append(model_class)
 
-        for model_class in django.apps.apps.get_models():
-            if model_class._meta.app_label == "sentry" and not hasattr(
-                model_class._meta, "silo_limit"
-            ):
-                undecorated_model_classes.append(model_class)
+    assert len(undecorated_model_classes) == 0, (
+        "Model classes missing ModelSiloLimit: "
+        f"{', '.join(m.__name__ for m in undecorated_model_classes)}"
+    )
 
-        assert len(undecorated_model_classes) == 0, (
-            "Model classes missing ModelSiloLimit: "
-            f"{', '.join(m.__name__ for m in undecorated_model_classes)}"
-        )
 
-    def test_all_endpoints_have_silo_mode_decorator(self) -> None:
-        undecorated_endpoint_classes = []
-        undecorated_view_classes = []
-        undecorated_view_functions = []
+def test_all_endpoints_have_silo_mode_decorator() -> None:
+    """Check that all subclasses have expected SiloLimit decorators."""
+    undecorated_endpoint_classes = []
+    undecorated_view_classes = []
+    undecorated_view_functions = []
 
-        url_mappings = django.urls.get_resolver().reverse_dict.items()
-        for view_function, bindings in url_mappings:
-            view_class = getattr(view_function, "view_class", None)
-            if (
-                view_class
-                and issubclass(view_class, Endpoint)
-                and not hasattr(view_class, "silo_limit")
-            ):
-                undecorated_endpoint_classes.append(view_class)
-            elif (
-                view_class
-                and issubclass(view_class, View)
-                and view_class != RedirectView
-                and view_class != TemplateView
-                and not hasattr(view_class, "silo_limit")
-            ):
-                undecorated_view_classes.append(view_class)
-            elif (
-                view_class is None
-                and callable(view_function)
-                and not hasattr(view_function, "silo_limit")
-                # Django's internal media views/static
-                and "django.views.static" not in view_function.__module__
-            ):
-                undecorated_view_functions.append(view_function)
+    url_mappings = django.urls.get_resolver().reverse_dict.items()
+    for view_function, bindings in url_mappings:
+        view_class = getattr(view_function, "view_class", None)
+        if (
+            view_class
+            and issubclass(view_class, Endpoint)
+            and not hasattr(view_class, "silo_limit")
+        ):
+            undecorated_endpoint_classes.append(view_class)
+        elif (
+            view_class
+            and issubclass(view_class, View)
+            and view_class != RedirectView
+            and view_class != TemplateView
+            and not hasattr(view_class, "silo_limit")
+        ):
+            undecorated_view_classes.append(view_class)
+        elif (
+            view_class is None
+            and callable(view_function)
+            and not hasattr(view_function, "silo_limit")
+            # Django's internal media views/static
+            and "django.views.static" not in view_function.__module__
+        ):
+            undecorated_view_functions.append(view_function)
 
-        assert len(undecorated_endpoint_classes) == 0, (
-            "Endpoint classes missing EndpointSiloLimit: "
-            f"{', '.join(f'{m.__module__}.{m.__name__}' for m in undecorated_endpoint_classes)}"
-        )
-        assert len(undecorated_view_classes) == 0, (
-            "View classes missing ViewSiloLimit: "
-            f"{', '.join(f'{m.__module__}.{m.__name__}' for m in undecorated_view_classes)}"
-        )
-        assert len(undecorated_view_functions) == 0, (
-            "View functions missing ViewSiloLimit: "
-            f"{', '.join(f'{m.__module__}.{m}' for m in undecorated_view_functions)}"
-        )
+    assert len(undecorated_endpoint_classes) == 0, (
+        "Endpoint classes missing EndpointSiloLimit: "
+        f"{', '.join(f'{m.__module__}.{m.__name__}' for m in undecorated_endpoint_classes)}"
+    )
+    assert len(undecorated_view_classes) == 0, (
+        "View classes missing ViewSiloLimit: "
+        f"{', '.join(f'{m.__module__}.{m.__name__}' for m in undecorated_view_classes)}"
+    )
+    assert len(undecorated_view_functions) == 0, (
+        "View functions missing ViewSiloLimit: "
+        f"{', '.join(f'{m.__module__}.{m}' for m in undecorated_view_functions)}"
+    )

--- a/tests/sentry/stacktraces/test_in_app_normalization.py
+++ b/tests/sentry/stacktraces/test_in_app_normalization.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
-from sentry.testutils.cases import TestCase
 
 
 def make_stacktrace(frame_0_in_app="not set", frame_1_in_app="not set") -> dict[str, Any]:
@@ -34,332 +33,316 @@ def make_event(stacktraces: list[Any]) -> dict[str, Any]:
     return {"exception": {"values": [{"stacktrace": stacktrace} for stacktrace in stacktraces]}}
 
 
-class NormalizeStacktracesFroGroupingTest(TestCase):
-    def test_sets_client_in_app(self) -> None:
-        event_data_with_client_values = make_event(
-            [
-                make_stacktrace(
-                    frame_0_in_app=True,
-                    frame_1_in_app=False,
-                )
-            ]
+def test_sets_client_in_app() -> None:
+    event_data_with_client_values = make_event(
+        [
+            make_stacktrace(
+                frame_0_in_app=True,
+                frame_1_in_app=False,
+            )
+        ]
+    )
+
+    normalize_stacktraces_for_grouping(event_data_with_client_values)
+
+    frames = event_data_with_client_values["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["data"]["client_in_app"] is True
+    assert frames[1]["data"]["client_in_app"] is False
+
+    event_data_no_client_values = make_event([make_stacktrace()])
+
+    normalize_stacktraces_for_grouping(event_data_no_client_values)
+
+    frames = event_data_no_client_values["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["data"].get("client_in_app") is None
+    assert frames[1]["data"].get("client_in_app") is None
+
+
+def test_changes_in_app_None_into_in_app_False() -> None:
+    event_data = make_event(
+        [
+            make_stacktrace(
+                frame_0_in_app=True,
+                frame_1_in_app=None,
+            )
+        ]
+    )
+
+    normalize_stacktraces_for_grouping(event_data)
+
+    frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["in_app"] is True
+    assert frames[1]["in_app"] is False
+
+
+def test_changes_in_app_not_set_into_in_app_False() -> None:
+    event_data = make_event(
+        [
+            make_stacktrace(
+                frame_0_in_app=True,
+                # `frame_1_in_app` not set
+            )
+        ]
+    )
+
+    normalize_stacktraces_for_grouping(event_data)
+
+    frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["in_app"] is True
+    assert frames[1]["in_app"] is False
+
+
+def test_skips_None_frames() -> None:
+    # No arguments passed to `make_stacktrace` means neither example frame will have an `in_app` value
+    stacktrace = make_stacktrace()
+    stacktrace["frames"].insert(0, None)
+    event_data = make_event([stacktrace])
+
+    normalize_stacktraces_for_grouping(event_data)
+
+    frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
+    # The values here weren't set before we called `normalize_stacktraces_for_grouping`,
+    # so the fact that they now are shows that it didn't bail when it hit the `None` frame
+    assert frames[1]["in_app"] is False
+    assert frames[2]["in_app"] is False
+
+
+def test_detects_frame_mix_correctly_with_single_stacktrace() -> None:
+    # Each case is `(frame1_in_app, frame2_in_app, expected_result)`
+    cases = [
+        (True, True, "in-app-only"),
+        (True, False, "mixed"),
+        (False, False, "system-only"),
+    ]
+
+    for frame_0_in_app, frame_1_in_app, expected_frame_mix in cases:
+        event_data = make_event([make_stacktrace(frame_0_in_app, frame_1_in_app)])
+
+        normalize_stacktraces_for_grouping(event_data)
+
+        computed_frame_mix = event_data["metadata"]["in_app_frame_mix"]
+        assert computed_frame_mix == expected_frame_mix, (
+            f"Expected {expected_frame_mix}, got {computed_frame_mix} with `in_app` values {frame_0_in_app}, {frame_1_in_app}"
         )
 
-        normalize_stacktraces_for_grouping(event_data_with_client_values)
 
-        frames = event_data_with_client_values["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["data"]["client_in_app"] is True
-        assert frames[1]["data"]["client_in_app"] is False
+def test_detects_frame_mix_correctly_with_multiple_stacktraces() -> None:
+    # Each case is `(stacktrace1_in_app_values, stacktrace2_in_app_values, expected_result)`
+    cases = [
+        # Two in-app-only stacktrces
+        ((True, True), (True, True), "in-app-only"),
+        # One in-app-only stacktrace and one system-only stacktrace
+        ((True, True), (False, False), "mixed"),
+        # One mixed stacktrace and one in-app-only stacktrace
+        ((True, False), (True, True), "mixed"),
+        # One mixed stacktrace and one system-only stacktrace
+        ((True, False), (False, False), "mixed"),
+        # Two mixed stacktraces
+        ((True, False), (True, False), "mixed"),
+        # Two system-only stacktraces
+        ((False, False), (False, False), "system-only"),
+    ]
 
-        event_data_no_client_values = make_event([make_stacktrace()])
-
-        normalize_stacktraces_for_grouping(event_data_no_client_values)
-
-        frames = event_data_no_client_values["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["data"].get("client_in_app") is None
-        assert frames[1]["data"].get("client_in_app") is None
-
-
-class NormalizeInApptest(TestCase):
-    def test_changes_in_app_None_into_in_app_False(self) -> None:
+    for stacktrace_0_mix, stacktrace_1_mix, expected_frame_mix in cases:
         event_data = make_event(
             [
-                make_stacktrace(
-                    frame_0_in_app=True,
-                    frame_1_in_app=None,
-                )
+                make_stacktrace(*stacktrace_0_mix),
+                make_stacktrace(*stacktrace_1_mix),
             ]
         )
 
         normalize_stacktraces_for_grouping(event_data)
 
-        frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["in_app"] is True
-        assert frames[1]["in_app"] is False
+        frame_mix = event_data["metadata"]["in_app_frame_mix"]
+        assert frame_mix == expected_frame_mix, (
+            f"Expected {expected_frame_mix}, got {frame_mix} with stacktrace `in-app` values {stacktrace_0_mix}, {stacktrace_1_mix}"
+        )
 
-    def test_changes_in_app_not_set_into_in_app_False(self) -> None:
-        event_data = make_event(
-            [
-                make_stacktrace(
-                    frame_0_in_app=True,
-                    # `frame_1_in_app` not set
-                )
+
+def test_macos_package_in_app_detection() -> None:
+    data: dict[str, Any] = {
+        "platform": "cocoa",
+        "debug_meta": {"images": []},  # omitted
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "-[CRLCrashAsyncSafeThread crash]",
+                                "package": "/Users/haza/Library/Developer/Xcode/Archives/2017-06-19/CrashProbe 19-06-2017, 08.53.xcarchive/Products/Applications/CrashProbe.app/Contents/Frameworks/CrashLib.framework/Versions/A/CrashLib",
+                                "instruction_addr": 4295098388,
+                            },
+                            {
+                                "function": "[KSCrash ]",
+                                "package": "/usr/lib/system/libdyld.dylib",
+                                "instruction_addr": 4295098388,
+                            },
+                        ]
+                    },
+                    "type": "NSRangeException",
+                }
             ]
-        )
+        },
+        "contexts": {"os": {"version": "10.12.5", "type": "os", "name": "macOS"}},
+    }
 
-        normalize_stacktraces_for_grouping(event_data)
+    config = load_grouping_config(get_default_grouping_config_dict())
+    normalize_stacktraces_for_grouping(data, grouping_config=config)
 
-        frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["in_app"] is True
-        assert frames[1]["in_app"] is False
-
-    def test_skips_None_frames(self) -> None:
-        # No arguments passed to `make_stacktrace` means neither example frame will have an `in_app` value
-        stacktrace = make_stacktrace()
-        stacktrace["frames"].insert(0, None)
-        event_data = make_event([stacktrace])
-
-        normalize_stacktraces_for_grouping(event_data)
-
-        frames = event_data["exception"]["values"][0]["stacktrace"]["frames"]
-        # The values here weren't set before we called `normalize_stacktraces_for_grouping`,
-        # so the fact that they now are shows that it didn't bail when it hit the `None` frame
-        assert frames[1]["in_app"] is False
-        assert frames[2]["in_app"] is False
-
-    def test_detects_frame_mix_correctly_with_single_stacktrace(self) -> None:
-        # Each case is `(frame1_in_app, frame2_in_app, expected_result)`
-        cases = [
-            (True, True, "in-app-only"),
-            (True, False, "mixed"),
-            (False, False, "system-only"),
-        ]
-
-        for frame_0_in_app, frame_1_in_app, expected_frame_mix in cases:
-            event_data = make_event([make_stacktrace(frame_0_in_app, frame_1_in_app)])
-
-            normalize_stacktraces_for_grouping(event_data)
-
-            computed_frame_mix = event_data["metadata"]["in_app_frame_mix"]
-            assert computed_frame_mix == expected_frame_mix, (
-                f"Expected {expected_frame_mix}, got {computed_frame_mix} with `in_app` values {frame_0_in_app}, {frame_1_in_app}"
-            )
-
-    def test_detects_frame_mix_correctly_with_multiple_stacktraces(self) -> None:
-        # Each case is `(stacktrace1_in_app_values, stacktrace2_in_app_values, expected_result)`
-        cases = [
-            # Two in-app-only stacktrces
-            ((True, True), (True, True), "in-app-only"),
-            # One in-app-only stacktrace and one system-only stacktrace
-            ((True, True), (False, False), "mixed"),
-            # One mixed stacktrace and one in-app-only stacktrace
-            ((True, False), (True, True), "mixed"),
-            # One mixed stacktrace and one system-only stacktrace
-            ((True, False), (False, False), "mixed"),
-            # Two mixed stacktraces
-            ((True, False), (True, False), "mixed"),
-            # Two system-only stacktraces
-            ((False, False), (False, False), "system-only"),
-        ]
-
-        for stacktrace_0_mix, stacktrace_1_mix, expected_frame_mix in cases:
-            event_data = make_event(
-                [
-                    make_stacktrace(*stacktrace_0_mix),
-                    make_stacktrace(*stacktrace_1_mix),
-                ]
-            )
-
-            normalize_stacktraces_for_grouping(event_data)
-
-            frame_mix = event_data["metadata"]["in_app_frame_mix"]
-            assert frame_mix == expected_frame_mix, (
-                f"Expected {expected_frame_mix}, got {frame_mix} with stacktrace `in-app` values {stacktrace_0_mix}, {stacktrace_1_mix}"
-            )
+    frames = data["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["in_app"] is True
+    assert frames[1]["in_app"] is False
 
 
-class MacOSInAppDetectionTest(TestCase):
-    def test_macos_package_in_app_detection(self) -> None:
-        data: dict[str, Any] = {
-            "platform": "cocoa",
-            "debug_meta": {"images": []},  # omitted
-            "exception": {
-                "values": [
-                    {
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": "-[CRLCrashAsyncSafeThread crash]",
-                                    "package": "/Users/haza/Library/Developer/Xcode/Archives/2017-06-19/CrashProbe 19-06-2017, 08.53.xcarchive/Products/Applications/CrashProbe.app/Contents/Frameworks/CrashLib.framework/Versions/A/CrashLib",
-                                    "instruction_addr": 4295098388,
-                                },
-                                {
-                                    "function": "[KSCrash ]",
-                                    "package": "/usr/lib/system/libdyld.dylib",
-                                    "instruction_addr": 4295098388,
-                                },
-                            ]
-                        },
-                        "type": "NSRangeException",
-                    }
-                ]
-            },
-            "contexts": {"os": {"version": "10.12.5", "type": "os", "name": "macOS"}},
-        }
-
-        config = load_grouping_config(get_default_grouping_config_dict())
-        normalize_stacktraces_for_grouping(data, grouping_config=config)
-
-        frames = data["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["in_app"] is True
-        assert frames[1]["in_app"] is False
-
-
-class iOSInAppDetectionTest(TestCase):
-    def assert_correct_in_app_value(self, function, is_in_app: bool):
-        data: dict[str, Any] = {
-            "platform": "cocoa",
-            "debug_meta": {"images": []},  # omitted
-            "exception": {
-                "values": [
-                    {
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": function,
-                                    "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
-                                    "instruction_addr": 4295098388,
-                                },
-                                # We need two frames otherwise all frames are inApp
-                                {
-                                    "function": "[KSCrash ]",
-                                    "package": "/usr/lib/system/libdyld.dylib",
-                                    "instruction_addr": 4295098388,
-                                },
-                            ]
-                        },
-                        "type": "NSRangeException",
-                    }
-                ]
-            },
-            "contexts": {"os": {"version": "9.3.2", "type": "os", "name": "iOS"}},
-        }
-
-        config = load_grouping_config(get_default_grouping_config_dict())
-        normalize_stacktraces_for_grouping(data, grouping_config=config)
-
-        frames = data["exception"]["values"][0]["stacktrace"]["frames"]
-        assert frames[0]["in_app"] is is_in_app, (
-            "For function: " + function + " expected:" + str(is_in_app)
-        )
-
-    def test_ios_function_name_in_app_detection(self) -> None:
-        self.assert_correct_in_app_value(
-            function="sentrycrash__hook_dispatch_async", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="sentrycrash__hook_dispatch_after_f", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="sentrycrash__async_backtrace_capture", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="__sentrycrash__hook_dispatch_async_block_invoke", is_in_app=False
-        )
-
-        self.assert_correct_in_app_value(function="kscm_f", is_in_app=False)
-        self.assert_correct_in_app_value(function="kscm_", is_in_app=False)
-        self.assert_correct_in_app_value(function=" kscm_", is_in_app=False)
-        self.assert_correct_in_app_value(function="kscm", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="sentrycrashcm_f", is_in_app=False)
-        self.assert_correct_in_app_value(function="sentrycrashcm_", is_in_app=False)
-        self.assert_correct_in_app_value(function=" sentrycrashcm_", is_in_app=False)
-        self.assert_correct_in_app_value(function="sentrycrashcm", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="kscrash_f", is_in_app=False)
-        self.assert_correct_in_app_value(function="kscrash_", is_in_app=False)
-        self.assert_correct_in_app_value(function=" kscrash_", is_in_app=False)
-        self.assert_correct_in_app_value(function="kscrash", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="sentrycrash_f", is_in_app=False)
-        self.assert_correct_in_app_value(function="sentrycrash_", is_in_app=False)
-        self.assert_correct_in_app_value(function=" sentrycrash_", is_in_app=False)
-        self.assert_correct_in_app_value(function="sentrycrash", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="+[KSCrash ]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[KSCrash]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[KSCrashy]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[MyKSCrashy ", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="+[RNSentry ]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[RNSentry]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[RNSentry]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[MRNSentry ]", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="+[Sentry ]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[Sentry]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[Sentry]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[MSentry capture]", is_in_app=True)
-
-        self.assert_correct_in_app_value(function="-[SentryHub captureMessage]", is_in_app=False)
-        self.assert_correct_in_app_value(function="-[SentryClient captureMessage]", is_in_app=False)
-        self.assert_correct_in_app_value(function="+[SentrySDK captureMessage]", is_in_app=False)
-        self.assert_correct_in_app_value(
-            function="-[SentryStacktraceBuilder buildStacktraceForCurrentThread]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryThreadInspector getCurrentThreads]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryClient captureMessage:withScope:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryFrameInAppLogic isInApp:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryFrameRemover removeNonSdkFrames:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryDebugMetaBuilder buildDebugMeta:withScope:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryCrashAdapter crashedLastLaunch]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryCrashAdapter isRateLimitActive:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryTransport sendEvent:attachments:]", is_in_app=False
-        )
-        self.assert_correct_in_app_value(
-            function="-[SentryHttpTransport sendEvent:attachments:]", is_in_app=False
-        )
-
-    def test_swizzling_in_app_detection(self) -> None:
-        self.assert_correct_in_app_value(
-            function="__42-[SentryCoreDataSwizzling swizzleCoreData]_block_invoke_2.24",
-            is_in_app=False,
-        )
-        self.assert_correct_in_app_value(
-            function="__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
-            is_in_app=False,
-        )
-        self.assert_correct_in_app_value(
-            function="__49+[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
-            is_in_app=False,
-        )
-
-    def test_ios_package_in_app_detection(self) -> None:
-        data: dict[str, Any] = {
-            "platform": "native",
-            "stacktrace": {
-                "frames": [
-                    {
-                        "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
-                        "instruction_addr": "0x1000",
+def _assert_ios_in_app_value(function: str, is_in_app: bool) -> None:
+    """Helper for iOS function name in-app detection tests."""
+    data: dict[str, Any] = {
+        "platform": "cocoa",
+        "debug_meta": {"images": []},  # omitted
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": function,
+                                "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
+                                "instruction_addr": 4295098388,
+                            },
+                            # We need two frames otherwise all frames are inApp
+                            {
+                                "function": "[KSCrash ]",
+                                "package": "/usr/lib/system/libdyld.dylib",
+                                "instruction_addr": 4295098388,
+                            },
+                        ]
                     },
-                    {
-                        "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/Frameworks/foo.dylib",
-                        "instruction_addr": "0x2000",
-                    },
-                    {
-                        "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/Frameworks/libswiftCore.dylib",
-                        "instruction_addr": "0x3000",
-                    },
-                    {"package": "/usr/lib/whatever.dylib", "instruction_addr": "0x4000"},
-                ]
-            },
-        }
+                    "type": "NSRangeException",
+                }
+            ]
+        },
+        "contexts": {"os": {"version": "9.3.2", "type": "os", "name": "iOS"}},
+    }
 
-        config = load_grouping_config(get_default_grouping_config_dict())
-        normalize_stacktraces_for_grouping(data, grouping_config=config)
+    config = load_grouping_config(get_default_grouping_config_dict())
+    normalize_stacktraces_for_grouping(data, grouping_config=config)
 
-        # App object should be in_app
-        assert data["stacktrace"]["frames"][0]["in_app"] is True
-        # Framework should be in app (but optional)
-        assert data["stacktrace"]["frames"][1]["in_app"] is True
-        # libswift should not be system
-        assert data["stacktrace"]["frames"][2]["in_app"] is False
-        # Unknown object should default to not in_app
-        assert data["stacktrace"]["frames"][3]["in_app"] is False
+    frames = data["exception"]["values"][0]["stacktrace"]["frames"]
+    assert frames[0]["in_app"] is is_in_app, (
+        "For function: " + function + " expected:" + str(is_in_app)
+    )
+
+
+def test_ios_function_name_in_app_detection() -> None:
+    _assert_ios_in_app_value(function="sentrycrash__hook_dispatch_async", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrash__hook_dispatch_after_f", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrash__async_backtrace_capture", is_in_app=False)
+    _assert_ios_in_app_value(
+        function="__sentrycrash__hook_dispatch_async_block_invoke", is_in_app=False
+    )
+
+    _assert_ios_in_app_value(function="kscm_f", is_in_app=False)
+    _assert_ios_in_app_value(function="kscm_", is_in_app=False)
+    _assert_ios_in_app_value(function=" kscm_", is_in_app=False)
+    _assert_ios_in_app_value(function="kscm", is_in_app=True)
+
+    _assert_ios_in_app_value(function="sentrycrashcm_f", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrashcm_", is_in_app=False)
+    _assert_ios_in_app_value(function=" sentrycrashcm_", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrashcm", is_in_app=True)
+
+    _assert_ios_in_app_value(function="kscrash_f", is_in_app=False)
+    _assert_ios_in_app_value(function="kscrash_", is_in_app=False)
+    _assert_ios_in_app_value(function=" kscrash_", is_in_app=False)
+    _assert_ios_in_app_value(function="kscrash", is_in_app=True)
+
+    _assert_ios_in_app_value(function="sentrycrash_f", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrash_", is_in_app=False)
+    _assert_ios_in_app_value(function=" sentrycrash_", is_in_app=False)
+    _assert_ios_in_app_value(function="sentrycrash", is_in_app=True)
+
+    _assert_ios_in_app_value(function="+[KSCrash ]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[KSCrash]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[KSCrashy]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[MyKSCrashy ", is_in_app=True)
+
+    _assert_ios_in_app_value(function="+[RNSentry ]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[RNSentry]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[RNSentry]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[MRNSentry ]", is_in_app=True)
+
+    _assert_ios_in_app_value(function="+[Sentry ]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[Sentry]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[Sentry]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[MSentry capture]", is_in_app=True)
+
+    _assert_ios_in_app_value(function="-[SentryHub captureMessage]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryClient captureMessage]", is_in_app=False)
+    _assert_ios_in_app_value(function="+[SentrySDK captureMessage]", is_in_app=False)
+    _assert_ios_in_app_value(
+        function="-[SentryStacktraceBuilder buildStacktraceForCurrentThread]", is_in_app=False
+    )
+    _assert_ios_in_app_value(function="-[SentryThreadInspector getCurrentThreads]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryClient captureMessage:withScope:]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryFrameInAppLogic isInApp:]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryFrameRemover removeNonSdkFrames:]", is_in_app=False)
+    _assert_ios_in_app_value(
+        function="-[SentryDebugMetaBuilder buildDebugMeta:withScope:]", is_in_app=False
+    )
+    _assert_ios_in_app_value(function="-[SentryCrashAdapter crashedLastLaunch]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryCrashAdapter isRateLimitActive:]", is_in_app=False)
+    _assert_ios_in_app_value(function="-[SentryTransport sendEvent:attachments:]", is_in_app=False)
+    _assert_ios_in_app_value(
+        function="-[SentryHttpTransport sendEvent:attachments:]", is_in_app=False
+    )
+
+
+def test_swizzling_in_app_detection() -> None:
+    _assert_ios_in_app_value(
+        function="__42-[SentryCoreDataSwizzling swizzleCoreData]_block_invoke_2.24",
+        is_in_app=False,
+    )
+    _assert_ios_in_app_value(
+        function="__49-[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+        is_in_app=False,
+    )
+    _assert_ios_in_app_value(
+        function="__49+[SentrySwizzleWrapper swizzleSendAction:forKey:]_block_invoke_2",
+        is_in_app=False,
+    )
+
+
+def test_ios_package_in_app_detection() -> None:
+    data: dict[str, Any] = {
+        "platform": "native",
+        "stacktrace": {
+            "frames": [
+                {
+                    "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
+                    "instruction_addr": "0x1000",
+                },
+                {
+                    "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/Frameworks/foo.dylib",
+                    "instruction_addr": "0x2000",
+                },
+                {
+                    "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/Frameworks/libswiftCore.dylib",
+                    "instruction_addr": "0x3000",
+                },
+                {"package": "/usr/lib/whatever.dylib", "instruction_addr": "0x4000"},
+            ]
+        },
+    }
+
+    config = load_grouping_config(get_default_grouping_config_dict())
+    normalize_stacktraces_for_grouping(data, grouping_config=config)
+
+    # App object should be in_app
+    assert data["stacktrace"]["frames"][0]["in_app"] is True
+    # Framework should be in app (but optional)
+    assert data["stacktrace"]["frames"][1]["in_app"] is True
+    # libswift should not be system
+    assert data["stacktrace"]["frames"][2]["in_app"] is False
+    # Unknown object should default to not in_app
+    assert data["stacktrace"]["frames"][3]["in_app"] is False

--- a/tests/sentry/utils/email/test_signer.py
+++ b/tests/sentry/utils/email/test_signer.py
@@ -1,13 +1,13 @@
-from sentry.testutils.cases import TestCase
+from django.test import override_settings
+
 from sentry.utils.email.signer import _CaseInsensitiveSigner
 
 
-class CaseInsensitiveSignerTests(TestCase):
-    def test_it_works(self) -> None:
-        with self.settings(SECRET_KEY="a"):
-            # the default salt is the module path
-            # the class was moved at some point so this sets a constant salt
-            signer = _CaseInsensitiveSigner(salt="sentry.utils.email._CaseInsensitiveSigner")
-            assert signer.unsign(signer.sign("foo")) == "foo"
-            assert signer.sign("foo") == "foo:wkpxg5djz3d4m0zktktfl9hdzw4"
-            assert signer.unsign("foo:WKPXG5DJZ3D4M0ZKTKTFL9HDZW4") == "foo"
+@override_settings(SECRET_KEY="a")
+def test_case_insensitive_signer() -> None:
+    # the default salt is the module path
+    # the class was moved at some point so this sets a constant salt
+    signer = _CaseInsensitiveSigner(salt="sentry.utils.email._CaseInsensitiveSigner")
+    assert signer.unsign(signer.sign("foo")) == "foo"
+    assert signer.sign("foo") == "foo:wkpxg5djz3d4m0zktktfl9hdzw4"
+    assert signer.unsign("foo:WKPXG5DJZ3D4M0ZKTKTFL9HDZW4") == "foo"

--- a/tests/sentry/utils/test_circuit_breaker.py
+++ b/tests/sentry/utils/test_circuit_breaker.py
@@ -3,39 +3,41 @@ from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 
-from sentry.testutils.cases import TestCase
 from sentry.utils.circuit_breaker import (
     ERROR_COUNT_CACHE_KEY,
     CircuitBreakerPassthrough,
     circuit_breaker_activated,
 )
 
+KEY = "test"
+ERROR_LIMIT = 5
 
-class TestCircuitBreaker(TestCase):
-    def setUp(self) -> None:
-        self.key = "test"
-        self.error_limit = 5
-        self.passthrough_data = CircuitBreakerPassthrough(limit=2, window=1)
-        cache.set(ERROR_COUNT_CACHE_KEY(self.key), self.error_limit)
 
-    def test_not_activated(self) -> None:
-        assert not circuit_breaker_activated(self.key, self.error_limit + 1)
+def test_circuit_breaker_not_activated() -> None:
+    cache.set(ERROR_COUNT_CACHE_KEY(KEY), ERROR_LIMIT)
+    assert not circuit_breaker_activated(KEY, ERROR_LIMIT + 1)
 
-    def test_activated_at_error_limit(self) -> None:
-        assert circuit_breaker_activated(key=self.key, error_limit=self.error_limit)
 
-    @patch("sentry.utils.circuit_breaker.metrics.incr")
-    def test_passthrough(self, mock_metrics: MagicMock) -> None:
-        assert not circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
-        mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+def test_circuit_breaker_activated_at_error_limit() -> None:
+    cache.set(ERROR_COUNT_CACHE_KEY(KEY), ERROR_LIMIT)
+    assert circuit_breaker_activated(key=KEY, error_limit=ERROR_LIMIT)
 
-        assert not circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
-        mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
 
-        assert circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
-        mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.throttled")
+@patch("sentry.utils.circuit_breaker.metrics.incr")
+def test_circuit_breaker_passthrough(mock_metrics: MagicMock) -> None:
+    cache.set(ERROR_COUNT_CACHE_KEY(KEY), ERROR_LIMIT)
+    passthrough_data = CircuitBreakerPassthrough(limit=2, window=1)
 
-        # Wait for the passthrough window to expire and try again
-        time.sleep(1)
-        assert not circuit_breaker_activated(self.key, self.error_limit, self.passthrough_data)
-        mock_metrics.assert_called_with(f"circuit_breaker.{self.key}.bypassed")
+    assert not circuit_breaker_activated(KEY, ERROR_LIMIT, passthrough_data)
+    mock_metrics.assert_called_with(f"circuit_breaker.{KEY}.bypassed")
+
+    assert not circuit_breaker_activated(KEY, ERROR_LIMIT, passthrough_data)
+    mock_metrics.assert_called_with(f"circuit_breaker.{KEY}.bypassed")
+
+    assert circuit_breaker_activated(KEY, ERROR_LIMIT, passthrough_data)
+    mock_metrics.assert_called_with(f"circuit_breaker.{KEY}.throttled")
+
+    # Wait for the passthrough window to expire and try again
+    time.sleep(1)
+    assert not circuit_breaker_activated(KEY, ERROR_LIMIT, passthrough_data)
+    mock_metrics.assert_called_with(f"circuit_breaker.{KEY}.bypassed")

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -356,99 +356,102 @@ class CocoaFilenameMungingTestCase(unittest.TestCase):
         )
 
 
-class ReactNativeFilenameMungingTestCase(TestCase):
-    def test_not_munged(self) -> None:
-        frames = [
-            {
-                "function": "callFunctionReturnFlushedQueue",
-                "module": "react-native/Libraries/BatchedBridge/MessageQueue",
-                "filename": "node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
-                "abs_path": "app:///node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
-                "lineno": 115,
-                "colno": 5,
-                "in_app": False,
-                "data": {"sourcemap": "app:///main.jsbundle.map"},
-            },
-            {"function": "apply", "filename": "native", "abs_path": "native", "in_app": True},
-            {
-                "function": "onPress",
-                "module": "src/screens/EndToEndTestsScreen",
-                "filename": "src/screens/EndToEndTestsScreen.tsx",
-                "abs_path": "app:///src/screens/EndToEndTestsScreen.tsx",
-                "lineno": 57,
-                "colno": 11,
-                "in_app": True,
-                "data": {"sourcemap": "app:///main.jsbundle.map"},
-            },
-        ]
+def test_react_native_not_munged() -> None:
+    frames = [
+        {
+            "function": "callFunctionReturnFlushedQueue",
+            "module": "react-native/Libraries/BatchedBridge/MessageQueue",
+            "filename": "node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+            "abs_path": "app:///node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js",
+            "lineno": 115,
+            "colno": 5,
+            "in_app": False,
+            "data": {"sourcemap": "app:///main.jsbundle.map"},
+        },
+        {"function": "apply", "filename": "native", "abs_path": "native", "in_app": True},
+        {
+            "function": "onPress",
+            "module": "src/screens/EndToEndTestsScreen",
+            "filename": "src/screens/EndToEndTestsScreen.tsx",
+            "abs_path": "app:///src/screens/EndToEndTestsScreen.tsx",
+            "lineno": 57,
+            "colno": 11,
+            "in_app": True,
+            "data": {"sourcemap": "app:///main.jsbundle.map"},
+        },
+    ]
 
-        munged_frames = munged_filename_and_frames(
-            "javascript", frames, "munged_filename", "sentry.javascript.react-native"
+    munged_frames = munged_filename_and_frames(
+        "javascript", frames, "munged_filename", "sentry.javascript.react-native"
+    )
+    assert not munged_frames
+
+
+def test_flutter_not_munged() -> None:
+    frames = [
+        {
+            "package": "my_package",
+            "filename": "service.dart",
+            "abs_path": "package:my_package/a/b/service.dart",
+            "in_app": True,
+        }
+    ]
+    munged_frames = munged_filename_and_frames("other", frames, "doesnt_matter", "sentry.sdk")
+    assert not munged_frames
+
+
+def test_flutter_munger_supported() -> None:
+    frames = [
+        {
+            "function": "tryCatchModule",
+            "package": "sentry_flutter_example",
+            "filename": "test.dart",
+            "abs_path": "package:sentry_flutter_example/a/b/test.dart",
+            "lineno": 8,
+            "colno": 5,
+            "in_app": True,
+        }
+    ]
+    munged_frames = munged_filename_and_frames(
+        "other", frames, "munged_filename", "sentry.dart.flutter"
+    )
+    assert munged_frames is not None
+    munged_first_frame = munged_frames[1][0]
+    assert munged_first_frame.items() > frames[0].items()
+    assert munged_first_frame["munged_filename"] == "a/b/test.dart"
+
+
+def test_flutter_dart_prefix_not_munged() -> None:
+    assert not flutter_frame_munger(
+        EventFrame(abs_path="dart:ui/a/b/test.dart"),
+    )
+
+
+def test_flutter_abs_path_not_present_not_munged() -> None:
+    assert not flutter_frame_munger(
+        EventFrame(
+            function="tryCatchModule",
+            package="sentry_flutter_example",
+            filename="test.dart",
         )
-        assert not munged_frames
+    )
 
 
-class FlutterFilenameMungingTestCase(TestCase):
-    def test_not_munged(self) -> None:
-        frames = [
-            {
-                "package": "my_package",
-                "filename": "service.dart",
-                "abs_path": "package:my_package/a/b/service.dart",
-                "in_app": True,
-            }
-        ]
-        munged_frames = munged_filename_and_frames("other", frames, "doesnt_matter", "sentry.sdk")
-        assert not munged_frames
-
-    def test_flutter_munger_supported(self) -> None:
-        frames = [
-            {
-                "function": "tryCatchModule",
-                "package": "sentry_flutter_example",
-                "filename": "test.dart",
-                "abs_path": "package:sentry_flutter_example/a/b/test.dart",
-                "lineno": 8,
-                "colno": 5,
-                "in_app": True,
-            }
-        ]
-        munged_frames = munged_filename_and_frames(
-            "other", frames, "munged_filename", "sentry.dart.flutter"
+def test_flutter_different_package_not_munged() -> None:
+    assert not flutter_frame_munger(
+        EventFrame(
+            package="sentry_flutter_example",
+            abs_path="package:different_package/a/b/test.dart",
         )
-        assert munged_frames is not None
-        munged_first_frame = munged_frames[1][0]
-        assert munged_first_frame.items() > frames[0].items()
-        assert munged_first_frame["munged_filename"] == "a/b/test.dart"
+    )
 
-    def test_dart_prefix_not_munged(self) -> None:
-        assert not flutter_frame_munger(
-            EventFrame(abs_path="dart:ui/a/b/test.dart"),
-        )
 
-    def test_abs_path_not_present_not_munged(self) -> None:
-        assert not flutter_frame_munger(
-            EventFrame(
-                function="tryCatchModule",
-                package="sentry_flutter_example",
-                filename="test.dart",
-            )
+def test_flutter_no_package_not_munged() -> None:
+    assert not flutter_frame_munger(
+        EventFrame(
+            abs_path="package:different_package/a/b/test.dart",
         )
-
-    def test_different_package_not_munged(self) -> None:
-        assert not flutter_frame_munger(
-            EventFrame(
-                package="sentry_flutter_example",
-                abs_path="package:different_package/a/b/test.dart",
-            )
-        )
-
-    def test_no_package_not_munged(self) -> None:
-        assert not flutter_frame_munger(
-            EventFrame(
-                abs_path="package:different_package/a/b/test.dart",
-            )
-        )
+    )
 
 
 class CocoaWaterFallTestCase(TestCase):

--- a/tests/sentry/utils/test_event_frames.py
+++ b/tests/sentry/utils/test_event_frames.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sentry.testutils.cases import TestCase
 from sentry.utils.event_frames import (
     EventFrame,
     cocoa_frame_munger,
@@ -14,33 +13,27 @@ from sentry.utils.event_frames import (
 from sentry.utils.safe import get_path
 
 
-class SdkNameTestCase(TestCase):
-    def test_sdk_data_pathing(self) -> None:
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "Foo bar",
-                "sdk": {"name": "sentry.javascript.react-native", "version": "1.2.3"},
-            },
-            project_id=self.project.id,
-        )
+def test_sdk_data_pathing() -> None:
+    event_data = {
+        "event_id": "a" * 32,
+        "message": "Foo bar",
+        "sdk": {"name": "sentry.javascript.react-native", "version": "1.2.3"},
+    }
 
-        assert not get_sdk_name(None)
-        assert event.data["sdk"]["name"] == "sentry.javascript.react-native"
-        assert get_sdk_name(event.data) == "sentry.javascript.react-native"
-        assert str(get_path(event.data, "sdk", "version", filter=True)) == "1.2.3"
-        assert not get_path(event.data, "sdk", "does_not_exist", filter=True)
+    assert not get_sdk_name(None)
+    assert event_data["sdk"]["name"] == "sentry.javascript.react-native"
+    assert get_sdk_name(event_data) == "sentry.javascript.react-native"
+    assert str(get_path(event_data, "sdk", "version", filter=True)) == "1.2.3"
+    assert not get_path(event_data, "sdk", "does_not_exist", filter=True)
 
-    def test_sdk_data_not_exist(self) -> None:
-        event = self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "Foo bar",
-            },
-            project_id=self.project.id,
-        )
 
-        assert not get_sdk_name(event.data)
+def test_sdk_data_not_exist() -> None:
+    event_data = {
+        "event_id": "a" * 32,
+        "message": "Foo bar",
+    }
+
+    assert not get_sdk_name(event_data)
 
 
 class CrashingThreadTestCase(unittest.TestCase):
@@ -454,462 +447,508 @@ def test_flutter_no_package_not_munged() -> None:
     )
 
 
-class CocoaWaterFallTestCase(TestCase):
-    def test_crashing_event_with_exception_interface_but_no_frame_should_waterfall_to_thread_frames(
-        self,
-    ) -> None:
-        event = self.store_event(
-            data={
-                "platform": "cocoa",
-                "exception": {
-                    "values": [
-                        {
-                            "type": "C++ Exception",
-                            "value": "NSt3__112system_errorE",
-                            "thread_id": 9,
-                            "mechanism": {
-                                "type": "cpp_exception",
-                                "handled": False,
-                                "meta": {
-                                    "signal": {"number": 6, "code": 0, "name": "SIGABRT"},
-                                    "mach_exception": {
-                                        "exception": 10,
-                                        "code": 0,
-                                        "subcode": 0,
-                                        "name": "EXC_CRASH",
-                                    },
+def test_cocoa_crashing_event_with_exception_interface_but_no_frame_should_waterfall_to_thread_frames() -> (
+    None
+):
+    event_data = {
+        "platform": "cocoa",
+        "exception": {
+            "values": [
+                {
+                    "type": "C++ Exception",
+                    "value": "NSt3__112system_errorE",
+                    "thread_id": 9,
+                    "mechanism": {
+                        "type": "cpp_exception",
+                        "handled": False,
+                        "meta": {
+                            "signal": {"number": 6, "code": 0, "name": "SIGABRT"},
+                            "mach_exception": {
+                                "exception": 10,
+                                "code": 0,
+                                "subcode": 0,
+                                "name": "EXC_CRASH",
+                            },
+                        },
+                    },
+                }
+            ]
+        },
+        "threads": {
+            "values": [
+                {
+                    "id": 0,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "<redacted>",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "unknown_image"},
+                                "image_addr": "0x0",
+                                "instruction_addr": "0x1028d5aa4",
+                                "symbol_addr": "0x0",
+                            },
+                            {
+                                "function": "main",
+                                "symbol": "main",
+                                "package": "Runner",
+                                "filename": "AppDelegate.swift",
+                                "abs_path": "/Users/denis/Repos/sentry/sentry-mobile/ios/Runner/AppDelegate.swift",
+                                "lineno": 5,
+                                "in_app": True,
+                                "data": {"symbolicator_status": "symbolicated"},
+                                "image_addr": "0x102684000",
+                                "instruction_addr": "0x10268ab9c",
+                                "symbol_addr": "0x102684000",
+                            },
+                            {
+                                "function": "UIApplicationMain",
+                                "symbol": "UIApplicationMain",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "threadbase",
+                                    "symbolicator_status": "symbolicated",
                                 },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x184203954",
+                                "symbol_addr": "0x18420312c",
                             },
-                        }
-                    ]
+                            {
+                                "function": "-[UIApplication _run]",
+                                "symbol": "-[UIApplication _run]",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "ui",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x184485084",
+                                "symbol_addr": "0x184484c3c",
+                            },
+                            {
+                                "function": "GSEventRunModal",
+                                "symbol": "GSEventRunModal",
+                                "package": "GraphicsServices",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x19d66d000",
+                                "instruction_addr": "0x19d66e388",
+                                "symbol_addr": "0x19d66e2e8",
+                            },
+                            {
+                                "function": "CFRunLoopRunSpecific",
+                                "symbol": "CFRunLoopRunSpecific",
+                                "package": "CoreFoundation",
+                                "in_app": False,
+                                "data": {
+                                    "category": "indirection",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x181ac4000",
+                                "instruction_addr": "0x181ae3464",
+                                "symbol_addr": "0x181ae3210",
+                            },
+                            {
+                                "function": "__CFRunLoopRun",
+                                "symbol": "__CFRunLoopRun",
+                                "package": "CoreFoundation",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x181ac4000",
+                                "instruction_addr": "0x181acf8a0",
+                                "symbol_addr": "0x181acf570",
+                            },
+                            {
+                                "function": "__CFRunLoopDoSources0",
+                                "symbol": "__CFRunLoopDoSources0",
+                                "package": "CoreFoundation",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x181ac4000",
+                                "instruction_addr": "0x181aca094",
+                                "symbol_addr": "0x181ac9f8c",
+                            },
+                            {
+                                "function": "__CFRunLoopDoSource0",
+                                "symbol": "__CFRunLoopDoSource0",
+                                "package": "CoreFoundation",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x181ac4000",
+                                "instruction_addr": "0x181b8fd8c",
+                                "symbol_addr": "0x181b8fcc0",
+                            },
+                            {
+                                "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
+                                "symbol": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
+                                "package": "CoreFoundation",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x181ac4000",
+                                "instruction_addr": "0x181b7f0cc",
+                                "symbol_addr": "0x181b7f0b4",
+                            },
+                            {
+                                "function": "-[FBSSerialQueue _performNextFromRunLoopSource]",
+                                "symbol": "-[FBSSerialQueue _performNextFromRunLoopSource]",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "symbolicated"},
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x19379b410",
+                                "symbol_addr": "0x19379b3f8",
+                            },
+                            {
+                                "function": "-[FBSSerialQueue _targetQueue_performNextIfPossible]",
+                                "symbol": "-[FBSSerialQueue _targetQueue_performNextIfPossible]",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "symbolicated"},
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x193796d88",
+                                "symbol_addr": "0x193796cb0",
+                            },
+                            {
+                                "function": "__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__",
+                                "symbol": "__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "symbolicated"},
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x1937979c0",
+                                "symbol_addr": "0x193797994",
+                            },
+                            {
+                                "function": "_dispatch_block_invoke_direct",
+                                "symbol": "_dispatch_block_invoke_direct",
+                                "package": "libdispatch.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x1817cb000",
+                                "instruction_addr": "0x1817d3124",
+                                "symbol_addr": "0x1817d3020",
+                            },
+                            {
+                                "function": "_dispatch_client_callout",
+                                "symbol": "_dispatch_client_callout",
+                                "package": "libdispatch.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "threadbase",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x1817cb000",
+                                "instruction_addr": "0x1817cf66c",
+                                "symbol_addr": "0x1817cf65c",
+                            },
+                            {
+                                "function": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke",
+                                "symbol": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x1937db714",
+                                "symbol_addr": "0x1937db694",
+                            },
+                            {
+                                "function": "-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:]",
+                                "symbol": "-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:]",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "symbolicated"},
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x193796068",
+                                "symbol_addr": "0x193795f7c",
+                            },
+                            {
+                                "function": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke_2",
+                                "symbol": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke_2",
+                                "package": "FrontBoardServices",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x19378c000",
+                                "instruction_addr": "0x1937db77c",
+                                "symbol_addr": "0x1937db730",
+                            },
+                            {
+                                "function": "-[UIApplication workspaceShouldExit:withTransitionContext:]",
+                                "symbol": "-[UIApplication workspaceShouldExit:withTransitionContext:]",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x184ebc298",
+                                "symbol_addr": "0x184ebc1c8",
+                            },
+                            {
+                                "function": "-[_UISceneLifecycleMultiplexer forceExitWithTransitionContext:scene:]",
+                                "symbol": "-[_UISceneLifecycleMultiplexer forceExitWithTransitionContext:scene:]",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x18479ca7c",
+                                "symbol_addr": "0x18479c9a0",
+                            },
+                            {
+                                "function": "-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]",
+                                "symbol": "-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x1845a7b34",
+                                "symbol_addr": "0x1845a7ab8",
+                            },
+                            {
+                                "function": "-[UIApplication _terminateWithStatus:]",
+                                "symbol": "-[UIApplication _terminateWithStatus:]",
+                                "package": "UIKitCore",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x183f6b000",
+                                "instruction_addr": "0x184ebf71c",
+                                "symbol_addr": "0x184ebf528",
+                            },
+                            {
+                                "function": "exit",
+                                "symbol": "exit",
+                                "package": "libsystem_c.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "shutdown",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x18ca01000",
+                                "instruction_addr": "0x18ca1c224",
+                                "symbol_addr": "0x18ca1c208",
+                            },
+                            {
+                                "function": "__cxa_finalize_ranges",
+                                "symbol": "__cxa_finalize_ranges",
+                                "package": "libsystem_c.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x18ca01000",
+                                "instruction_addr": "0x18ca218c0",
+                                "symbol_addr": "0x18ca216f8",
+                            },
+                            {
+                                "function": "__cxa_finalize_ranges",
+                                "symbol": "__cxa_finalize_ranges",
+                                "package": "libsystem_c.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x18ca01000",
+                                "instruction_addr": "0x18ca218c0",
+                                "symbol_addr": "0x18ca216f8",
+                            },
+                            {
+                                "function": "<redacted>",
+                                "package": "MetalPerformanceShadersGraph",
+                                "in_app": False,
+                                "data": {"symbolicator_status": "missing_symbol"},
+                                "image_addr": "0x1bec7a000",
+                                "instruction_addr": "0x1bf179c98",
+                                "symbol_addr": "0x0",
+                            },
+                        ]
+                    },
+                    "crashed": False,
+                    "current": False,
                 },
-                "threads": {
-                    "values": [
-                        {
-                            "id": 0,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "<redacted>",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "unknown_image"},
-                                        "image_addr": "0x0",
-                                        "instruction_addr": "0x1028d5aa4",
-                                        "symbol_addr": "0x0",
-                                    },
-                                    {
-                                        "function": "main",
-                                        "symbol": "main",
-                                        "package": "Runner",
-                                        "filename": "AppDelegate.swift",
-                                        "abs_path": "/Users/denis/Repos/sentry/sentry-mobile/ios/Runner/AppDelegate.swift",
-                                        "lineno": 5,
-                                        "in_app": True,
-                                        "data": {"symbolicator_status": "symbolicated"},
-                                        "image_addr": "0x102684000",
-                                        "instruction_addr": "0x10268ab9c",
-                                        "symbol_addr": "0x102684000",
-                                    },
-                                    {
-                                        "function": "UIApplicationMain",
-                                        "symbol": "UIApplicationMain",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "threadbase",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x184203954",
-                                        "symbol_addr": "0x18420312c",
-                                    },
-                                    {
-                                        "function": "-[UIApplication _run]",
-                                        "symbol": "-[UIApplication _run]",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "ui",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x184485084",
-                                        "symbol_addr": "0x184484c3c",
-                                    },
-                                    {
-                                        "function": "GSEventRunModal",
-                                        "symbol": "GSEventRunModal",
-                                        "package": "GraphicsServices",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x19d66d000",
-                                        "instruction_addr": "0x19d66e388",
-                                        "symbol_addr": "0x19d66e2e8",
-                                    },
-                                    {
-                                        "function": "CFRunLoopRunSpecific",
-                                        "symbol": "CFRunLoopRunSpecific",
-                                        "package": "CoreFoundation",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "indirection",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x181ac4000",
-                                        "instruction_addr": "0x181ae3464",
-                                        "symbol_addr": "0x181ae3210",
-                                    },
-                                    {
-                                        "function": "__CFRunLoopRun",
-                                        "symbol": "__CFRunLoopRun",
-                                        "package": "CoreFoundation",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x181ac4000",
-                                        "instruction_addr": "0x181acf8a0",
-                                        "symbol_addr": "0x181acf570",
-                                    },
-                                    {
-                                        "function": "__CFRunLoopDoSources0",
-                                        "symbol": "__CFRunLoopDoSources0",
-                                        "package": "CoreFoundation",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x181ac4000",
-                                        "instruction_addr": "0x181aca094",
-                                        "symbol_addr": "0x181ac9f8c",
-                                    },
-                                    {
-                                        "function": "__CFRunLoopDoSource0",
-                                        "symbol": "__CFRunLoopDoSource0",
-                                        "package": "CoreFoundation",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x181ac4000",
-                                        "instruction_addr": "0x181b8fd8c",
-                                        "symbol_addr": "0x181b8fcc0",
-                                    },
-                                    {
-                                        "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
-                                        "symbol": "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__",
-                                        "package": "CoreFoundation",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x181ac4000",
-                                        "instruction_addr": "0x181b7f0cc",
-                                        "symbol_addr": "0x181b7f0b4",
-                                    },
-                                    {
-                                        "function": "-[FBSSerialQueue _performNextFromRunLoopSource]",
-                                        "symbol": "-[FBSSerialQueue _performNextFromRunLoopSource]",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "symbolicated"},
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x19379b410",
-                                        "symbol_addr": "0x19379b3f8",
-                                    },
-                                    {
-                                        "function": "-[FBSSerialQueue _targetQueue_performNextIfPossible]",
-                                        "symbol": "-[FBSSerialQueue _targetQueue_performNextIfPossible]",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "symbolicated"},
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x193796d88",
-                                        "symbol_addr": "0x193796cb0",
-                                    },
-                                    {
-                                        "function": "__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__",
-                                        "symbol": "__FBSSERIALQUEUE_IS_CALLING_OUT_TO_A_BLOCK__",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "symbolicated"},
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x1937979c0",
-                                        "symbol_addr": "0x193797994",
-                                    },
-                                    {
-                                        "function": "_dispatch_block_invoke_direct",
-                                        "symbol": "_dispatch_block_invoke_direct",
-                                        "package": "libdispatch.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x1817cb000",
-                                        "instruction_addr": "0x1817d3124",
-                                        "symbol_addr": "0x1817d3020",
-                                    },
-                                    {
-                                        "function": "_dispatch_client_callout",
-                                        "symbol": "_dispatch_client_callout",
-                                        "package": "libdispatch.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "threadbase",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x1817cb000",
-                                        "instruction_addr": "0x1817cf66c",
-                                        "symbol_addr": "0x1817cf65c",
-                                    },
-                                    {
-                                        "function": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke",
-                                        "symbol": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x1937db714",
-                                        "symbol_addr": "0x1937db694",
-                                    },
-                                    {
-                                        "function": "-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:]",
-                                        "symbol": "-[FBSWorkspace _calloutQueue_executeCalloutFromSource:withBlock:]",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "symbolicated"},
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x193796068",
-                                        "symbol_addr": "0x193795f7c",
-                                    },
-                                    {
-                                        "function": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke_2",
-                                        "symbol": "__63-[FBSWorkspaceScenesClient willTerminateWithTransitionContext:]_block_invoke_2",
-                                        "package": "FrontBoardServices",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x19378c000",
-                                        "instruction_addr": "0x1937db77c",
-                                        "symbol_addr": "0x1937db730",
-                                    },
-                                    {
-                                        "function": "-[UIApplication workspaceShouldExit:withTransitionContext:]",
-                                        "symbol": "-[UIApplication workspaceShouldExit:withTransitionContext:]",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x184ebc298",
-                                        "symbol_addr": "0x184ebc1c8",
-                                    },
-                                    {
-                                        "function": "-[_UISceneLifecycleMultiplexer forceExitWithTransitionContext:scene:]",
-                                        "symbol": "-[_UISceneLifecycleMultiplexer forceExitWithTransitionContext:scene:]",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x18479ca7c",
-                                        "symbol_addr": "0x18479c9a0",
-                                    },
-                                    {
-                                        "function": "-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]",
-                                        "symbol": "-[_UISceneLifecycleMultiplexer _evalTransitionToSettings:fromSettings:forceExit:withTransitionStore:]",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x1845a7b34",
-                                        "symbol_addr": "0x1845a7ab8",
-                                    },
-                                    {
-                                        "function": "-[UIApplication _terminateWithStatus:]",
-                                        "symbol": "-[UIApplication _terminateWithStatus:]",
-                                        "package": "UIKitCore",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x183f6b000",
-                                        "instruction_addr": "0x184ebf71c",
-                                        "symbol_addr": "0x184ebf528",
-                                    },
-                                    {
-                                        "function": "exit",
-                                        "symbol": "exit",
-                                        "package": "libsystem_c.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "shutdown",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x18ca01000",
-                                        "instruction_addr": "0x18ca1c224",
-                                        "symbol_addr": "0x18ca1c208",
-                                    },
-                                    {
-                                        "function": "__cxa_finalize_ranges",
-                                        "symbol": "__cxa_finalize_ranges",
-                                        "package": "libsystem_c.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x18ca01000",
-                                        "instruction_addr": "0x18ca218c0",
-                                        "symbol_addr": "0x18ca216f8",
-                                    },
-                                    {
-                                        "function": "__cxa_finalize_ranges",
-                                        "symbol": "__cxa_finalize_ranges",
-                                        "package": "libsystem_c.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x18ca01000",
-                                        "instruction_addr": "0x18ca218c0",
-                                        "symbol_addr": "0x18ca216f8",
-                                    },
-                                    {
-                                        "function": "<redacted>",
-                                        "package": "MetalPerformanceShadersGraph",
-                                        "in_app": False,
-                                        "data": {"symbolicator_status": "missing_symbol"},
-                                        "image_addr": "0x1bec7a000",
-                                        "instruction_addr": "0x1bf179c98",
-                                        "symbol_addr": "0x0",
-                                    },
-                                ]
+                {
+                    "id": 1,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "_pthread_wqthread",
+                                "symbol": "_pthread_wqthread",
+                                "package": "libsystem_pthread.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "threadbase",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x1f2532000",
+                                "instruction_addr": "0x1f253313c",
+                                "symbol_addr": "0x1f2532fd4",
                             },
-                            "crashed": False,
-                            "current": False,
-                        },
-                        {
-                            "id": 1,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "_pthread_wqthread",
-                                        "symbol": "_pthread_wqthread",
-                                        "package": "libsystem_pthread.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "threadbase",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x1f2532000",
-                                        "instruction_addr": "0x1f253313c",
-                                        "symbol_addr": "0x1f2532fd4",
-                                    },
-                                    {
-                                        "function": "__workq_kernreturn",
-                                        "symbol": "__workq_kernreturn",
-                                        "package": "libsystem_kernel.dylib",
-                                        "in_app": False,
-                                        "data": {
-                                            "category": "internals",
-                                            "symbolicator_status": "symbolicated",
-                                        },
-                                        "image_addr": "0x1b9090000",
-                                        "instruction_addr": "0x1b9091b2c",
-                                        "symbol_addr": "0x1b9091b24",
-                                    },
-                                ]
+                            {
+                                "function": "__workq_kernreturn",
+                                "symbol": "__workq_kernreturn",
+                                "package": "libsystem_kernel.dylib",
+                                "in_app": False,
+                                "data": {
+                                    "category": "internals",
+                                    "symbolicator_status": "symbolicated",
+                                },
+                                "image_addr": "0x1b9090000",
+                                "instruction_addr": "0x1b9091b2c",
+                                "symbol_addr": "0x1b9091b24",
                             },
-                            "crashed": False,
-                            "current": False,
-                        },
-                    ]
+                        ]
+                    },
+                    "crashed": False,
+                    "current": False,
                 },
-            },
-            project_id=self.project.id,
-        )
+            ]
+        },
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 0  # exception has no frames, no threads that are crashed, or current
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 0  # exception has no frames, no threads that are crashed, or current
 
 
-class WaterFallTestCase(TestCase):
-    def test_only_exception_interface_with_no_stacktrace(self) -> None:
-        event = self.store_event(
-            data={
-                "exception": {
-                    "values": [
-                        {
-                            "type": "EXC_BAD_ACCESS",
-                            "value": "Attempted to dereference a null pointer",
-                        }
-                    ]
+def test_waterfall_only_exception_interface_with_no_stacktrace() -> None:
+    event_data = {
+        "exception": {
+            "values": [
+                {
+                    "type": "EXC_BAD_ACCESS",
+                    "value": "Attempted to dereference a null pointer",
                 }
-            },
-            project_id=self.project.id,
-        )
+            ]
+        }
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 0
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 0
 
-    def test_only_exception_interface_single_stacktrace(self) -> None:
-        event = self.store_event(
-            data={
-                "exception": {
-                    "values": [
-                        {
-                            "type": "EXC_BAD_ACCESS",
-                            "value": "Attempted to dereference a null pointer",
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "invoke0",
-                                        "abs_path": "NativeMethodAccessorImpl.java",
-                                        "in_app": False,
-                                        "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                                        "filename": "NativeMethodAccessorImpl.java",
-                                    }
-                                ],
-                                "registers": {},
-                            },
-                        }
-                    ]
+
+def test_waterfall_only_exception_interface_single_stacktrace() -> None:
+    event_data = {
+        "exception": {
+            "values": [
+                {
+                    "type": "EXC_BAD_ACCESS",
+                    "value": "Attempted to dereference a null pointer",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "invoke0",
+                                "abs_path": "NativeMethodAccessorImpl.java",
+                                "in_app": False,
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ],
+                        "registers": {},
+                    },
                 }
-            },
-            project_id=self.project.id,
-        )
+            ]
+        }
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert frames[0]["function"] == "invoke0"
-        assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert frames[0]["function"] == "invoke0"
+    assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
 
-    def test_only_stacktrace_interface(self) -> None:
-        event = self.store_event(
-            data={
+
+def test_waterfall_only_stacktrace_interface() -> None:
+    event_data = {
+        "stacktrace": {
+            "frames": [
+                {
+                    "function": "invoke0",
+                    "abs_path": "NativeMethodAccessorImpl.java",
+                    "in_app": False,
+                    "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                    "filename": "NativeMethodAccessorImpl.java",
+                }
+            ],
+            "registers": {},
+        },
+    }
+
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert frames[0]["function"] == "invoke0"
+    assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+
+
+def test_waterfall_only_thread_interface() -> None:
+    event_data = {
+        "threads": {
+            "values": [
+                {
+                    "id": 0,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "function": "invoke0",
+                                "abs_path": "NativeMethodAccessorImpl.java",
+                                "in_app": False,
+                                "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+                                "filename": "NativeMethodAccessorImpl.java",
+                            }
+                        ],
+                        "registers": {},
+                    },
+                    "crashed": False,
+                    "current": False,
+                }
+            ]
+        }
+    }
+
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert frames[0]["function"] == "invoke0"
+    assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+
+
+def test_waterfall_only_thread_interface_flattened() -> None:
+    event_data = {
+        "threads": [
+            {
+                "id": 0,
                 "stacktrace": {
                     "frames": [
                         {
@@ -922,150 +961,85 @@ class WaterFallTestCase(TestCase):
                     ],
                     "registers": {},
                 },
-            },
-            project_id=self.project.id,
-        )
+                "crashed": False,
+                "current": False,
+            }
+        ]
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert frames[0]["function"] == "invoke0"
-        assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert frames[0]["function"] == "invoke0"
+    assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
 
-    def test_only_thread_interface(self) -> None:
-        event = self.store_event(
-            data={
-                "threads": {
-                    "values": [
-                        {
-                            "id": 0,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "invoke0",
-                                        "abs_path": "NativeMethodAccessorImpl.java",
-                                        "in_app": False,
-                                        "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                                        "filename": "NativeMethodAccessorImpl.java",
-                                    }
-                                ],
-                                "registers": {},
-                            },
-                            "crashed": False,
-                            "current": False,
-                        }
-                    ]
+
+def test_waterfall_exception_and_stacktrace_interfaces() -> None:
+    exception_frame = {
+        "function": "invoke0",
+        "abs_path": "NativeMethodAccessorImpl.java",
+        "in_app": False,
+        "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
+        "filename": "NativeMethodAccessorImpl.java",
+    }
+
+    # When both exception and stacktrace interfaces are present,
+    # find_stack_frames prioritizes exception interface frames
+    event_data = {
+        "exception": {
+            "values": [
+                {
+                    "type": "EXC_BAD_ACCESS",
+                    "value": "Attempted to dereference a null pointer",
+                    "stacktrace": {
+                        "frames": [exception_frame],
+                        "registers": {},
+                    },
                 }
-            },
-            project_id=self.project.id,
-        )
+            ]
+        },
+        "stacktrace": {
+            "frames": [{"different": "frame"}],
+            "registers": {},
+        },
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert frames[0]["function"] == "invoke0"
-        assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert exception_frame.items() <= frames[0].items()
 
-    def test_only_thread_interface_flattened(self) -> None:
-        event = self.store_event(
-            data={
-                "threads": [
-                    {
-                        "id": 0,
-                        "stacktrace": {
-                            "frames": [
-                                {
-                                    "function": "invoke0",
-                                    "abs_path": "NativeMethodAccessorImpl.java",
-                                    "in_app": False,
-                                    "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-                                    "filename": "NativeMethodAccessorImpl.java",
-                                }
-                            ],
-                            "registers": {},
-                        },
-                        "crashed": False,
-                        "current": False,
-                    }
-                ]
-            },
-            project_id=self.project.id,
-        )
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert frames[0]["function"] == "invoke0"
-        assert frames[0]["filename"] == "NativeMethodAccessorImpl.java"
-
-    def test_exception_and_stacktrace_interfaces(self) -> None:
-        exception_frame = {
-            "function": "invoke0",
-            "abs_path": "NativeMethodAccessorImpl.java",
-            "in_app": False,
-            "module": "jdk.internal.reflect.NativeMethodAccessorImpl",
-            "filename": "NativeMethodAccessorImpl.java",
-        }
-
-        # event.stacktrace will get re-processed and moved over to event.exception.values[0].stacktrace
-        event = self.store_event(
-            data={
-                "exception": {
-                    "values": [
-                        {
-                            "type": "EXC_BAD_ACCESS",
-                            "value": "Attempted to dereference a null pointer",
-                            "stacktrace": {
-                                "frames": [{"doesn't": "matter"}],
-                                "registers": {},
+def test_waterfall_exception_and_stacktrace_and_thread_interfaces() -> None:
+    # no stacktrace frame in exception interface, so we waterfall to the threads interface
+    event_data = {
+        "exception": {
+            "values": [
+                {
+                    "type": "EXC_BAD_ACCESS",
+                    "value": "Attempted to dereference a null pointer",
+                }
+            ]
+        },
+        "threads": {
+            "values": [
+                {
+                    "id": 0,
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "module": "io.sentry.example.Application",
+                                "filename": "Application.java",
                             },
-                        }
-                    ]
-                },
-                "stacktrace": {
-                    "frames": [exception_frame],
-                    "registers": {},
-                },
-            },
-            project_id=self.project.id,
-        )
+                        ],
+                        "registers": {},
+                    },
+                    "crashed": False,
+                    "current": False,
+                }
+            ]
+        },
+    }
 
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert exception_frame.items() <= frames[0].items()
-
-    def test_exception_and_stacktrace_and_thread_interfaces(self) -> None:
-        # no stacktrace frame in exception interface, so we waterfall to the threads interface
-        event = self.store_event(
-            data={
-                "exception": {
-                    "values": [
-                        {
-                            "type": "EXC_BAD_ACCESS",
-                            "value": "Attempted to dereference a null pointer",
-                        }
-                    ]
-                },
-                "threads": {
-                    "values": [
-                        {
-                            "id": 0,
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "module": "io.sentry.example.Application",
-                                        "filename": "Application.java",
-                                    },
-                                ],
-                                "registers": {},
-                            },
-                            "crashed": False,
-                            "current": False,
-                        }
-                    ]
-                },
-            },
-            project_id=self.project.id,
-        )
-
-        frames = find_stack_frames(event.data)
-        assert len(frames) == 1
-        assert frames[0]["module"] == "io.sentry.example.Application"
-        assert frames[0]["filename"] == "Application.java"
+    frames = find_stack_frames(event_data)
+    assert len(frames) == 1
+    assert frames[0]["module"] == "io.sentry.example.Application"
+    assert frames[0]["filename"] == "Application.java"

--- a/tests/sentry/utils/test_geo.py
+++ b/tests/sentry/utils/test_geo.py
@@ -1,24 +1,22 @@
+import importlib
+
 from django.test.utils import override_settings
 
-from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import get_fixture_path
 
 
 @override_settings(GEOIP_PATH_MMDB=get_fixture_path("test.mmdb"))
-class TestGeo(TestCase):
-    def test_geo_by_addr(self) -> None:
-        import importlib
+def test_geo_by_addr() -> None:
+    import sentry.utils.geo
 
-        import sentry.utils.geo
+    importlib.reload(sentry.utils.geo)
 
-        importlib.reload(sentry.utils.geo)
+    from sentry.utils.geo import geo_by_addr
 
-        from sentry.utils.geo import geo_by_addr
-
-        assert geo_by_addr("8.8.8.8") == {
-            "country_code": "US",
-            "region": "CA",
-            "city": "Beverly Hills",
-            "latitude": 34.09109878540039,
-            "longitude": -118.41169738769531,
-        }
+    assert geo_by_addr("8.8.8.8") == {
+        "country_code": "US",
+        "region": "CA",
+        "city": "Beverly Hills",
+        "latitude": 34.09109878540039,
+        "longitude": -118.41169738769531,
+    }

--- a/tests/sentry/utils/test_hashlib.py
+++ b/tests/sentry/utils/test_hashlib.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 import pytest
 
 from sentry.utils.hashlib import fnv1a_32, hash_values, md5_text, sha1_text
@@ -26,14 +24,14 @@ def test_hash_values(seed: str, value: object, hash: str) -> None:
     assert hash_values([value], seed=seed) == hash
 
 
-class HashlibTest(TestCase):
-    def test_simple(self) -> None:
-        assert md5_text("x").hexdigest() == "9dd4e461268c8034f5c8564e155c67a6"
-        assert sha1_text("x").hexdigest() == "11f6ad8ec52a2984abaafd7c3b516503785c2072"
+def test_md5_sha1_simple() -> None:
+    assert md5_text("x").hexdigest() == "9dd4e461268c8034f5c8564e155c67a6"
+    assert sha1_text("x").hexdigest() == "11f6ad8ec52a2984abaafd7c3b516503785c2072"
 
-    def test_unicode(self) -> None:
-        assert md5_text("ü").hexdigest() == "c03410a5204b21cd8229ff754688d743"
-        assert sha1_text("ü").hexdigest() == "94a759fd37735430753c7b6b80684306d80ea16e"
+
+def test_md5_sha1_unicode() -> None:
+    assert md5_text("ü").hexdigest() == "c03410a5204b21cd8229ff754688d743"
+    assert sha1_text("ü").hexdigest() == "94a759fd37735430753c7b6b80684306d80ea16e"
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/utils/test_http.py
+++ b/tests/sentry/utils/test_http.py
@@ -217,26 +217,28 @@ class IsValidOriginTestCase(unittest.TestCase):
         assert result is True
 
 
-class OriginFromRequestTestCase(TestCase):
-    def test_nothing(self) -> None:
-        request = HttpRequest()
-        assert origin_from_request(request) is None
+def test_origin_from_request_nothing() -> None:
+    request = HttpRequest()
+    assert origin_from_request(request) is None
 
-    def test_origin(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_ORIGIN"] = "http://example.com"
-        request.META["HTTP_REFERER"] = "nope"
-        assert origin_from_request(request) == "http://example.com"
 
-    def test_referer(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_REFERER"] = "http://example.com/foo/bar"
-        assert origin_from_request(request) == "http://example.com"
+def test_origin_from_request_origin() -> None:
+    request = HttpRequest()
+    request.META["HTTP_ORIGIN"] = "http://example.com"
+    request.META["HTTP_REFERER"] = "nope"
+    assert origin_from_request(request) == "http://example.com"
 
-    def test_null_origin(self) -> None:
-        request = HttpRequest()
-        request.META["HTTP_ORIGIN"] = "null"
-        assert origin_from_request(request) is None
 
-        request.META["HTTP_REFERER"] = "http://example.com"
-        assert origin_from_request(request) == "http://example.com"
+def test_origin_from_request_referer() -> None:
+    request = HttpRequest()
+    request.META["HTTP_REFERER"] = "http://example.com/foo/bar"
+    assert origin_from_request(request) == "http://example.com"
+
+
+def test_origin_from_request_null_origin() -> None:
+    request = HttpRequest()
+    request.META["HTTP_ORIGIN"] = "null"
+    assert origin_from_request(request) is None
+
+    request.META["HTTP_REFERER"] = "http://example.com"
+    assert origin_from_request(request) == "http://example.com"

--- a/tests/sentry/utils/test_json.py
+++ b/tests/sentry/utils/test_json.py
@@ -1,86 +1,81 @@
 import datetime
 import uuid
 from enum import Enum
-from unittest import TestCase
 
 from django.utils.translation import gettext_lazy as _
 
 from sentry.utils import json
 
 
-class JSONSerializationTest(TestCase):
-    def test_uuid(self) -> None:
-        res = uuid.uuid4()
-        self.assertEqual(json.dumps(res), '"%s"' % res.hex)
-
-    def test_datetime(self) -> None:
-        res = datetime.datetime(day=1, month=1, year=2011, hour=1, minute=1, second=1)
-        self.assertEqual(json.dumps(res), '"2011-01-01T01:01:01.000000Z"')
-
-    def test_set(self) -> None:
-        res = {"foo"}
-        self.assertEqual(json.dumps(res), '["foo"]')
-
-    def test_frozenset(self) -> None:
-        res = frozenset(["foo"])
-        self.assertEqual(json.dumps(res), '["foo"]')
-
-    def test_escape(self) -> None:
-        res = "<script>alert('&');</script>"
-        assert json.dumps(res) == "\"<script>alert('&');</script>\""
-        assert (
-            json.dumps(res, escape=True).encode("utf-8")
-            == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
-        )
-        assert (
-            json.dumps_htmlsafe(res).encode("utf-8")
-            == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
-        )
-
-    def test_inf(self) -> None:
-        res = float("inf")
-        self.assertEqual(json.dumps(res), "null")
-
-    def test_enum(self) -> None:
-        EnumFoo = Enum("EnumFoo", "a b c")
-        res = EnumFoo.a
-        self.assertEqual(json.dumps(res), "1")
-
-    def test_translation(self) -> None:
-        self.assertEqual(json.dumps(_("word")), '"word"')
-
-    def test_sort_keys(self) -> None:
-        res = {"z": 1, "a": 2, "m": 3}
-        self.assertEqual(json.dumps(res, sort_keys=True), '{"a":2,"m":3,"z":1}')
+def test_uuid() -> None:
+    res = uuid.uuid4()
+    assert json.dumps(res) == '"%s"' % res.hex
 
 
-class JSONHelpersTest(TestCase):
-    def test_prune_empty_keys_simple(self) -> None:
-        assert json.prune_empty_keys(
-            {
-                "dogs_are_great": True,
-                "good_dogs": "all",
-                "bad_dogs": None,
-            }
-        ) == {
+def test_datetime() -> None:
+    res = datetime.datetime(day=1, month=1, year=2011, hour=1, minute=1, second=1)
+    assert json.dumps(res) == '"2011-01-01T01:01:01.000000Z"'
+
+
+def test_set() -> None:
+    res = {"foo"}
+    assert json.dumps(res) == '["foo"]'
+
+
+def test_frozenset() -> None:
+    res = frozenset(["foo"])
+    assert json.dumps(res) == '["foo"]'
+
+
+def test_escape() -> None:
+    res = "<script>alert('&');</script>"
+    assert json.dumps(res) == "\"<script>alert('&');</script>\""
+    assert (
+        json.dumps(res, escape=True).encode("utf-8")
+        == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
+    )
+    assert (
+        json.dumps_htmlsafe(res).encode("utf-8")
+        == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
+    )
+
+
+def test_inf() -> None:
+    res = float("inf")
+    assert json.dumps(res) == "null"
+
+
+def test_enum() -> None:
+    EnumFoo = Enum("EnumFoo", "a b c")
+    res = EnumFoo.a
+    assert json.dumps(res) == "1"
+
+
+def test_translation() -> None:
+    assert json.dumps(_("word")) == '"word"'
+
+
+def test_sort_keys() -> None:
+    res = {"z": 1, "a": 2, "m": 3}
+    assert json.dumps(res, sort_keys=True) == '{"a":2,"m":3,"z":1}'
+
+
+def test_prune_empty_keys_simple() -> None:
+    assert json.prune_empty_keys(
+        {
             "dogs_are_great": True,
             "good_dogs": "all",
+            "bad_dogs": None,
         }
+    ) == {
+        "dogs_are_great": True,
+        "good_dogs": "all",
+    }
 
-    def test_prune_empty_keys_keeps_falsy_values(self) -> None:
-        assert json.prune_empty_keys(
-            {
-                "empty_string": "",
-                "empty_list": [],
-                "empty_dict": {},
-                "empty_set": set(),
-                "empty_tuple": tuple(),
-                "false": False,
-                "zero": 0,
-                "zero_point_zero": 0.0,
-                "none": None,
-            }
-        ) == {
+
+def test_prune_empty_keys_keeps_falsy_values() -> None:
+    assert json.prune_empty_keys(
+        {
             "empty_string": "",
             "empty_list": [],
             "empty_dict": {},
@@ -89,7 +84,19 @@ class JSONHelpersTest(TestCase):
             "false": False,
             "zero": 0,
             "zero_point_zero": 0.0,
+            "none": None,
         }
+    ) == {
+        "empty_string": "",
+        "empty_list": [],
+        "empty_dict": {},
+        "empty_set": set(),
+        "empty_tuple": tuple(),
+        "false": False,
+        "zero": 0,
+        "zero_point_zero": 0.0,
+    }
 
-    def test_prune_empty_keys_none_input(self) -> None:
-        assert json.prune_empty_keys(None) is None
+
+def test_prune_empty_keys_none_input() -> None:
+    assert json.prune_empty_keys(None) is None

--- a/tests/sentry/utils/test_not_set.py
+++ b/tests/sentry/utils/test_not_set.py
@@ -1,8 +1,6 @@
-from sentry.testutils.cases import TestCase
 from sentry.utils.not_set import NOT_SET, default_if_not_set
 
 
-class ClearFlagTest(TestCase):
-    def test(self) -> None:
-        assert default_if_not_set(1, NOT_SET) == 1
-        assert default_if_not_set(1, 2) == 2
+def test_default_if_not_set() -> None:
+    assert default_if_not_set(1, NOT_SET) == 1
+    assert default_if_not_set(1, 2) == 2

--- a/tests/sentry/utils/test_registry.py
+++ b/tests/sentry/utils/test_registry.py
@@ -2,54 +2,53 @@ from collections.abc import Callable
 
 import pytest
 
-from sentry.testutils.cases import TestCase
 from sentry.utils.registry import AlreadyRegisteredError, NoRegistrationExistsError, Registry
 
 
-class RegistryTest(TestCase):
-    def test(self) -> None:
-        test_registry = Registry[Callable]()
+def test_registry() -> None:
+    test_registry = Registry[Callable]()
 
-        @test_registry.register("something")
-        def registered_func():
-            raise NotImplementedError
+    @test_registry.register("something")
+    def registered_func():
+        raise NotImplementedError
 
-        def unregistered_func():
-            raise NotImplementedError
+    def unregistered_func():
+        raise NotImplementedError
 
-        assert test_registry.get("something") == registered_func
-        with pytest.raises(NoRegistrationExistsError):
-            test_registry.get("something else")
+    assert test_registry.get("something") == registered_func
+    with pytest.raises(NoRegistrationExistsError):
+        test_registry.get("something else")
 
-        assert test_registry.get_key(registered_func) == "something"
-        with pytest.raises(NoRegistrationExistsError):
-            test_registry.get_key(unregistered_func)
+    assert test_registry.get_key(registered_func) == "something"
+    with pytest.raises(NoRegistrationExistsError):
+        test_registry.get_key(unregistered_func)
 
-        with pytest.raises(AlreadyRegisteredError):
-            test_registry.register("something")(unregistered_func)
+    with pytest.raises(AlreadyRegisteredError):
+        test_registry.register("something")(unregistered_func)
 
-        with pytest.raises(AlreadyRegisteredError):
-            test_registry.register("new_key")(registered_func)
+    with pytest.raises(AlreadyRegisteredError):
+        test_registry.register("new_key")(registered_func)
 
-        test_registry.register("something else")(unregistered_func)
-        assert test_registry.get("something else") == unregistered_func
+    test_registry.register("something else")(unregistered_func)
+    assert test_registry.get("something else") == unregistered_func
 
-    def test_allow_duplicate_values(self) -> None:
-        test_registry = Registry[Callable[[], None]](enable_reverse_lookup=False)
 
-        @test_registry.register("something")
-        @test_registry.register("something 2")
-        def registered_func():
-            raise NotImplementedError
+def test_registry_allow_duplicate_values() -> None:
+    test_registry = Registry[Callable[[], None]](enable_reverse_lookup=False)
 
-        assert test_registry.get("something") == registered_func
-        assert test_registry.get("something 2") == registered_func
+    @test_registry.register("something")
+    @test_registry.register("something 2")
+    def registered_func():
+        raise NotImplementedError
 
-        with pytest.raises(NoRegistrationExistsError):
-            test_registry.get("something else")
+    assert test_registry.get("something") == registered_func
+    assert test_registry.get("something 2") == registered_func
 
-        with pytest.raises(NotImplementedError):
-            test_registry.get_key(registered_func)
+    with pytest.raises(NoRegistrationExistsError):
+        test_registry.get("something else")
 
-        test_registry.register("something else")(registered_func)
-        assert test_registry.get("something else") == registered_func
+    with pytest.raises(NotImplementedError):
+        test_registry.get_key(registered_func)
+
+    test_registry.register("something else")(registered_func)
+    assert test_registry.get("something else") == registered_func

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import unittest
 from collections.abc import MutableMapping
 from functools import partial
 from typing import Any
 
 import pytest
 
-from sentry.testutils.cases import TestCase
 from sentry.utils.safe import (
     get_path,
     safe_execute,
@@ -20,184 +18,204 @@ from sentry.utils.safe import (
 a_very_long_string = "a" * 1024
 
 
-class TrimTest(unittest.TestCase):
-    def test_simple_string(self) -> None:
-        assert trim(a_very_long_string) == a_very_long_string[:509] + "..."
-
-    def test_list_of_strings(self) -> None:
-        assert trim([a_very_long_string, a_very_long_string]) == [a_very_long_string[:507] + "..."]
-
-    def test_nonascii(self) -> None:
-        assert trim({"x": "\xc3\xbc"}) == {"x": "\xc3\xbc"}
-        assert trim(["x", "\xc3\xbc"]) == ["x", "\xc3\xbc"]
-
-    def test_idempotent(self) -> None:
-        trm = partial(trim, max_depth=2)
-        a = {"a": {"b": {"c": {"d": 1}}}}
-        assert trm(a) == {"a": {"b": {"c": '{"d":1}'}}}
-        assert trm(trm(trm(trm(a)))) == trm(a)
-
-    def test_sorted_trim(self) -> None:
-        # Trim should always trim the keys in alpha order
-        # regardless of the original order.
-        alpha = {"a": "12345", "z": "12345"}
-        reverse = {"z": "12345", "a": "12345"}
-        trm = partial(trim, max_size=12)
-        expected = {"a": "12345", "z": "1..."}
-
-        assert trm(alpha) == expected
-        assert trm(reverse) == expected
-
-    def test_max_depth(self) -> None:
-        trm = partial(trim, max_depth=2)
-        a: dict[str, Any] = {"a": {"b": {"c": "d"}}}
-        assert trm(a) == a
-
-        a = {"a": {"b": {"c": "d"}}}
-        assert trm(a) == {"a": {"b": {"c": "d"}}}
-
-        a = {"a": {"b": {"c": {"d": "e"}}}}
-        assert trm(a) == {"a": {"b": {"c": '{"d":"e"}'}}}
-
-        a = {"a": {"b": {"c": []}}}
-        assert trm(a) == {"a": {"b": {"c": "[]"}}}
+# Trim tests
+def test_trim_simple_string() -> None:
+    assert trim(a_very_long_string) == a_very_long_string[:509] + "..."
 
 
-class SafeExecuteTest(TestCase):
-    def test_with_nameless_function(self) -> None:
-        assert safe_execute(lambda a: a, 1) == 1
-        assert safe_execute(lambda: eval("a")) is None
+def test_trim_list_of_strings() -> None:
+    assert trim([a_very_long_string, a_very_long_string]) == [a_very_long_string[:507] + "..."]
 
-    def test_with_simple_function(self) -> None:
-        def simple(a):
+
+def test_trim_nonascii() -> None:
+    assert trim({"x": "\xc3\xbc"}) == {"x": "\xc3\xbc"}
+    assert trim(["x", "\xc3\xbc"]) == ["x", "\xc3\xbc"]
+
+
+def test_trim_idempotent() -> None:
+    trm = partial(trim, max_depth=2)
+    a = {"a": {"b": {"c": {"d": 1}}}}
+    assert trm(a) == {"a": {"b": {"c": '{"d":1}'}}}
+    assert trm(trm(trm(trm(a)))) == trm(a)
+
+
+def test_trim_sorted() -> None:
+    # Trim should always trim the keys in alpha order
+    # regardless of the original order.
+    alpha = {"a": "12345", "z": "12345"}
+    reverse = {"z": "12345", "a": "12345"}
+    trm = partial(trim, max_size=12)
+    expected = {"a": "12345", "z": "1..."}
+
+    assert trm(alpha) == expected
+    assert trm(reverse) == expected
+
+
+def test_trim_max_depth() -> None:
+    trm = partial(trim, max_depth=2)
+    a: dict[str, Any] = {"a": {"b": {"c": "d"}}}
+    assert trm(a) == a
+
+    a = {"a": {"b": {"c": "d"}}}
+    assert trm(a) == {"a": {"b": {"c": "d"}}}
+
+    a = {"a": {"b": {"c": {"d": "e"}}}}
+    assert trm(a) == {"a": {"b": {"c": '{"d":"e"}'}}}
+
+    a = {"a": {"b": {"c": []}}}
+    assert trm(a) == {"a": {"b": {"c": "[]"}}}
+
+
+# SafeExecute tests
+def test_safe_execute_with_nameless_function() -> None:
+    assert safe_execute(lambda a: a, 1) == 1
+    assert safe_execute(lambda: eval("a")) is None
+
+
+def test_safe_execute_with_simple_function() -> None:
+    def simple(a):
+        return a
+
+    assert safe_execute(simple, 1) == 1
+
+
+def test_safe_execute_with_simple_function_raising_exception() -> None:
+    def simple(a):
+        raise Exception()
+
+    assert safe_execute(simple, 1) is None
+
+
+def test_safe_execute_with_instance_method() -> None:
+    class Foo:
+        def simple(self, a):
             return a
 
-        assert safe_execute(simple, 1) == 1
+    assert safe_execute(Foo().simple, 1) == 1
 
-    def test_with_simple_function_raising_exception(self) -> None:
-        def simple(a):
+
+def test_safe_execute_with_instance_method_raising_exception() -> None:
+    class Foo:
+        def simple(self, a):
             raise Exception()
 
-        assert safe_execute(simple, 1) is None
-
-    def test_with_instance_method(self) -> None:
-        class Foo:
-            def simple(self, a):
-                return a
-
-        assert safe_execute(Foo().simple, 1) == 1
-
-    def test_with_instance_method_raising_exception(self) -> None:
-        class Foo:
-            def simple(self, a):
-                raise Exception()
-
-        assert safe_execute(Foo().simple, 1) is None
+    assert safe_execute(Foo().simple, 1) is None
 
 
-class GetPathTest(unittest.TestCase):
-    def test_get_none(self) -> None:
-        assert get_path(None, "foo") is None
-        assert get_path("foo", "foo") is None
-        assert get_path(42, "foo") is None  # type: ignore[arg-type]
-        assert get_path(ValueError(), "foo") is None  # type: ignore[arg-type]
-        assert get_path(True, "foo") is None  # type: ignore[arg-type]
-
-    def test_get_path_dict(self) -> None:
-        assert get_path({}, "a") is None
-        assert get_path({"a": 2}, "a") == 2
-        assert get_path({"a": 2}, "b") is None
-        assert get_path({"a": {"b": []}}, "a", "b") == []
-        assert get_path({"a": []}, "a", "b") is None
-
-    def test_get_default(self) -> None:
-        assert get_path({"a": 2}, "b", default=1) == 1
-        assert get_path({"a": 2}, "a", default=1) == 2
-        assert get_path({"a": None}, "a", default=1) == 1
-
-    def test_get_path_list(self) -> None:
-        arr = [1, 2]
-        assert get_path(arr, 1) == 2
-        assert get_path(arr, -1) == 2
-        assert get_path(arr, 2) is None
-        assert get_path(arr, "1") is None
-        assert get_path([], 1) is None
-        assert get_path({"items": [2]}, "items", 0) == 2
-
-    def test_filter_list(self) -> None:
-        data = {"a": [False, 1, None]}
-        assert get_path(data, "a", filter=True) == [False, 1]
-        assert get_path(data, "a", filter=lambda x: x) == [1]
-
-    def test_filter_tuple(self) -> None:
-        data = {"a": (False, 1, None)}
-        assert get_path(data, "a", filter=True) == [False, 1]
-        assert get_path(data, "a", filter=lambda x: x) == [1]
-
-    def test_filter_other(self) -> None:
-        assert get_path({"a": 42}, "a", filter=True) == 42
-        assert get_path({"a": True}, "a", filter=True) is True
-        assert get_path({"a": {"b": 42}}, "a", filter=True) == {"b": 42}
-        assert get_path({"a": 42}, "b", filter=True) is None
-
-        # We use get_path to process Event's Http's query_strings to remove Nones
-        # (which can occur as a result of normalization and datascrubbing).
-        assert get_path([["foo", "bar"], None], filter=True) == [["foo", "bar"]]
-
-    def test_kwargs(self) -> None:
-        with pytest.raises(TypeError):
-            get_path({}, "foo", unknown=True)
+# GetPath tests
+def test_get_path_none() -> None:
+    assert get_path(None, "foo") is None
+    assert get_path("foo", "foo") is None
+    assert get_path(42, "foo") is None  # type: ignore[arg-type]
+    assert get_path(ValueError(), "foo") is None  # type: ignore[arg-type]
+    assert get_path(True, "foo") is None  # type: ignore[arg-type]
 
 
-class SetPathTest(unittest.TestCase):
-    def test_set_none(self) -> None:
-        assert not set_path(None, "foo", value=42)
-        assert not set_path("foo", "foo", value=42)
-        assert not set_path(42, "foo", value=42)
-        assert not set_path(ValueError(), "foo", value=42)
-        assert not set_path(True, "foo", value=42)
-
-    def test_set_dict(self) -> None:
-        data: MutableMapping[str, Any] = {}
-        assert set_path(data, "a", value=42)
-        assert data == {"a": 42}
-
-        data = {"a": 2}
-        assert set_path(data, "a", value=42)
-        assert data == {"a": 42}
-
-        data = {}
-        assert set_path(data, "a", "b", value=42)
-        assert data == {"a": {"b": 42}}
-
-    def test_set_default(self) -> None:
-        data = {"a": {"b": 2}}
-        assert not setdefault_path(data, "a", "b", value=42)
-        assert data == {"a": {"b": 2}}
-
-        data = {}
-        assert setdefault_path(data, "a", "b", value=42)
-        assert data == {"a": {"b": 42}}
-
-    def test_kwargs(self) -> None:
-        with pytest.raises(TypeError):
-            set_path({}, "foo")
-
-        with pytest.raises(TypeError):
-            set_path({}, "foo", value=1, unknown=True)
+def test_get_path_dict() -> None:
+    assert get_path({}, "a") is None
+    assert get_path({"a": 2}, "a") == 2
+    assert get_path({"a": 2}, "b") is None
+    assert get_path({"a": {"b": []}}, "a", "b") == []
+    assert get_path({"a": []}, "a", "b") is None
 
 
-class SafeUrlencodeTest(unittest.TestCase):
-    def test_dict(self) -> None:
-        d = {"1": None, "3": "4"}
-        assert safe_urlencode(d) == "1=&3=4"
-        assert d == {"1": None, "3": "4"}
-        d = {"1": "2", "3": "4"}
-        assert safe_urlencode(d) == "1=2&3=4"
+def test_get_path_default() -> None:
+    assert get_path({"a": 2}, "b", default=1) == 1
+    assert get_path({"a": 2}, "a", default=1) == 2
+    assert get_path({"a": None}, "a", default=1) == 1
 
-    def test_pair_sequence(self) -> None:
-        d = [["1", None], ["3", "4"]]
-        assert safe_urlencode(d) == "1=&3=4"
-        assert d == [["1", None], ["3", "4"]]
-        d = [["1", "2"], ["3", "4"]]
-        assert safe_urlencode(d) == "1=2&3=4"
+
+def test_get_path_list() -> None:
+    arr = [1, 2]
+    assert get_path(arr, 1) == 2
+    assert get_path(arr, -1) == 2
+    assert get_path(arr, 2) is None
+    assert get_path(arr, "1") is None
+    assert get_path([], 1) is None
+    assert get_path({"items": [2]}, "items", 0) == 2
+
+
+def test_get_path_filter_list() -> None:
+    data = {"a": [False, 1, None]}
+    assert get_path(data, "a", filter=True) == [False, 1]
+    assert get_path(data, "a", filter=lambda x: x) == [1]
+
+
+def test_get_path_filter_tuple() -> None:
+    data = {"a": (False, 1, None)}
+    assert get_path(data, "a", filter=True) == [False, 1]
+    assert get_path(data, "a", filter=lambda x: x) == [1]
+
+
+def test_get_path_filter_other() -> None:
+    assert get_path({"a": 42}, "a", filter=True) == 42
+    assert get_path({"a": True}, "a", filter=True) is True
+    assert get_path({"a": {"b": 42}}, "a", filter=True) == {"b": 42}
+    assert get_path({"a": 42}, "b", filter=True) is None
+
+    # We use get_path to process Event's Http's query_strings to remove Nones
+    # (which can occur as a result of normalization and datascrubbing).
+    assert get_path([["foo", "bar"], None], filter=True) == [["foo", "bar"]]
+
+
+def test_get_path_kwargs() -> None:
+    with pytest.raises(TypeError):
+        get_path({}, "foo", unknown=True)
+
+
+# SetPath tests
+def test_set_path_none() -> None:
+    assert not set_path(None, "foo", value=42)
+    assert not set_path("foo", "foo", value=42)
+    assert not set_path(42, "foo", value=42)
+    assert not set_path(ValueError(), "foo", value=42)
+    assert not set_path(True, "foo", value=42)
+
+
+def test_set_path_dict() -> None:
+    data: MutableMapping[str, Any] = {}
+    assert set_path(data, "a", value=42)
+    assert data == {"a": 42}
+
+    data = {"a": 2}
+    assert set_path(data, "a", value=42)
+    assert data == {"a": 42}
+
+    data = {}
+    assert set_path(data, "a", "b", value=42)
+    assert data == {"a": {"b": 42}}
+
+
+def test_set_path_default() -> None:
+    data = {"a": {"b": 2}}
+    assert not setdefault_path(data, "a", "b", value=42)
+    assert data == {"a": {"b": 2}}
+
+    data = {}
+    assert setdefault_path(data, "a", "b", value=42)
+    assert data == {"a": {"b": 42}}
+
+
+def test_set_path_kwargs() -> None:
+    with pytest.raises(TypeError):
+        set_path({}, "foo")
+
+    with pytest.raises(TypeError):
+        set_path({}, "foo", value=1, unknown=True)
+
+
+# SafeUrlencode tests
+def test_safe_urlencode_dict() -> None:
+    d = {"1": None, "3": "4"}
+    assert safe_urlencode(d) == "1=&3=4"
+    assert d == {"1": None, "3": "4"}
+    d = {"1": "2", "3": "4"}
+    assert safe_urlencode(d) == "1=2&3=4"
+
+
+def test_safe_urlencode_pair_sequence() -> None:
+    d = [["1", None], ["3", "4"]]
+    assert safe_urlencode(d) == "1=&3=4"
+    assert d == [["1", None], ["3", "4"]]
+    d = [["1", "2"], ["3", "4"]]
+    assert safe_urlencode(d) == "1=2&3=4"

--- a/tests/sentry/utils/test_signing.py
+++ b/tests/sentry/utils/test_signing.py
@@ -1,19 +1,18 @@
 import pytest
 from django.core.signing import BadSignature
+from django.test import override_settings
 
-from sentry.testutils.cases import TestCase
 from sentry.utils.signing import sign, unsign
 
 
-class SigningTestCase(TestCase):
-    def test_sign(self) -> None:
-        with self.settings(SECRET_KEY="a"):
-            # standard case
-            assert unsign(sign(foo="bar")) == {"foo": "bar"}
+@override_settings(SECRET_KEY="a")
+def test_sign() -> None:
+    # standard case
+    assert unsign(sign(foo="bar")) == {"foo": "bar"}
 
-            # sign with aaa, unsign with aaa
-            assert unsign(sign(foo="bar", salt="aaa"), salt="aaa") == {"foo": "bar"}
+    # sign with aaa, unsign with aaa
+    assert unsign(sign(foo="bar", salt="aaa"), salt="aaa") == {"foo": "bar"}
 
-            # sign with aaa, unsign with bbb
-            with pytest.raises(BadSignature):
-                unsign(sign(foo="bar", salt="aaa"), salt="bbb")
+    # sign with aaa, unsign with bbb
+    with pytest.raises(BadSignature):
+        unsign(sign(foo="bar", salt="aaa"), salt="bbb")

--- a/tests/sentry/utils/test_snowflake.py
+++ b/tests/sentry/utils/test_snowflake.py
@@ -8,7 +8,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.team import Team
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.region import override_regions
 from sentry.types.region import Region, RegionCategory
@@ -24,78 +23,81 @@ from sentry.utils.snowflake import (
     uses_snowflake_id,
 )
 
+CURRENT_TIME = datetime(2022, 7, 21, 6, 0)
 
-class SnowflakeUtilsTest(TestCase):
-    CURRENT_TIME = datetime(2022, 7, 21, 6, 0)
 
-    def test_uses_snowflake_id(self) -> None:
-        assert uses_snowflake_id(Organization)
-        assert uses_snowflake_id(Project)
-        assert uses_snowflake_id(Team)
-        assert not uses_snowflake_id(User)
+def test_uses_snowflake_id() -> None:
+    assert uses_snowflake_id(Organization)
+    assert uses_snowflake_id(Project)
+    assert uses_snowflake_id(Team)
+    assert not uses_snowflake_id(User)
 
-    @freeze_time(CURRENT_TIME)
-    def test_generate_correct_ids(self) -> None:
-        snowflake_id = generate_snowflake_id("test_redis_key")
-        expected_value = (16 << 48) + (
-            int(self.CURRENT_TIME.timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START) << 16
-        )
 
-        assert snowflake_id == expected_value
+@freeze_time(CURRENT_TIME)
+def test_generate_correct_ids() -> None:
+    snowflake_id = generate_snowflake_id("test_redis_key")
+    expected_value = (16 << 48) + (
+        int(CURRENT_TIME.timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START) << 16
+    )
 
-    @freeze_time(CURRENT_TIME)
-    def test_generate_correct_ids_with_region_sequence(self) -> None:
-        # next id in the same timestamp, should be 1 greater than last id up to 16 timestamps
-        # the 17th will be at the previous timestamp
-        snowflake_id = generate_snowflake_id("test_redis_key")
+    assert snowflake_id == expected_value
 
-        for _ in range(MAX_AVAILABLE_REGION_SEQUENCES - 1):
-            new_snowflake_id = generate_snowflake_id("test_redis_key")
 
-            assert new_snowflake_id - snowflake_id == 1
-            snowflake_id = new_snowflake_id
+@freeze_time(CURRENT_TIME)
+def test_generate_correct_ids_with_region_sequence() -> None:
+    # next id in the same timestamp, should be 1 greater than last id up to 16 timestamps
+    # the 17th will be at the previous timestamp
+    snowflake_id = generate_snowflake_id("test_redis_key")
 
-        snowflake_id = generate_snowflake_id("test_redis_key")
+    for _ in range(MAX_AVAILABLE_REGION_SEQUENCES - 1):
+        new_snowflake_id = generate_snowflake_id("test_redis_key")
 
-        expected_value = (16 << 48) + (
-            (int(self.CURRENT_TIME.timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START) - 1) << 16
-        )
+        assert new_snowflake_id - snowflake_id == 1
+        snowflake_id = new_snowflake_id
 
-        assert snowflake_id == expected_value
+    snowflake_id = generate_snowflake_id("test_redis_key")
 
-    @freeze_time(CURRENT_TIME)
-    def test_out_of_region_sequences(self) -> None:
-        cluster = get_redis_cluster()
-        current_timestamp = int(datetime.now().timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START)
-        redis_key = "test_redis_key"
+    expected_value = (16 << 48) + (
+        (int(CURRENT_TIME.timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START) - 1) << 16
+    )
 
-        for i in range(int(_TTL.total_seconds())):
-            timestamp = current_timestamp - i
-            cluster.set(get_timestamp_redis_key(redis_key, timestamp), 16)
+    assert snowflake_id == expected_value
 
-        with pytest.raises(Exception) as context:
-            generate_snowflake_id(redis_key)
 
-        assert str(context.value) == "No available ID"
+@freeze_time(CURRENT_TIME)
+def test_out_of_region_sequences() -> None:
+    cluster = get_redis_cluster()
+    current_timestamp = int(datetime.now().timestamp() - settings.SENTRY_SNOWFLAKE_EPOCH_START)
+    redis_key = "test_redis_key"
 
-    @freeze_time(CURRENT_TIME)
-    def test_generate_correct_ids_with_region_id(self) -> None:
-        regions = [
-            r1 := Region("test-region-1", 1, "localhost:8001", RegionCategory.MULTI_TENANT),
-            r2 := Region("test-region-2", 2, "localhost:8002", RegionCategory.MULTI_TENANT),
-        ]
-        with override_settings(SILO_MODE=SiloMode.REGION):
-            with override_regions(regions, r1):
-                snowflake1 = generate_snowflake_id("test_redis_key")
-            with override_regions(regions, r2):
-                snowflake2 = generate_snowflake_id("test_redis_key")
+    for i in range(int(_TTL.total_seconds())):
+        timestamp = current_timestamp - i
+        cluster.set(get_timestamp_redis_key(redis_key, timestamp), 16)
 
-            def recover_segment_value(segment: SnowflakeBitSegment, value: int) -> int:
-                for s in reversed(snowflake.BIT_SEGMENT_SCHEMA):
-                    if s == segment:
-                        return value & ((1 << s.length) - 1)
-                    value >>= s.length
-                raise AssertionError("unreachable")
+    with pytest.raises(Exception) as context:
+        generate_snowflake_id(redis_key)
+
+    assert str(context.value) == "No available ID"
+
+
+@freeze_time(CURRENT_TIME)
+def test_generate_correct_ids_with_region_id() -> None:
+    regions = [
+        r1 := Region("test-region-1", 1, "localhost:8001", RegionCategory.MULTI_TENANT),
+        r2 := Region("test-region-2", 2, "localhost:8002", RegionCategory.MULTI_TENANT),
+    ]
+    with override_settings(SILO_MODE=SiloMode.REGION):
+        with override_regions(regions, r1):
+            snowflake1 = generate_snowflake_id("test_redis_key")
+        with override_regions(regions, r2):
+            snowflake2 = generate_snowflake_id("test_redis_key")
+
+        def recover_segment_value(segment: SnowflakeBitSegment, value: int) -> int:
+            for s in reversed(snowflake.BIT_SEGMENT_SCHEMA):
+                if s == segment:
+                    return value & ((1 << s.length) - 1)
+                value >>= s.length
+            raise AssertionError("unreachable")
 
             assert recover_segment_value(snowflake.REGION_ID, snowflake1) == r1.snowflake_id
             assert recover_segment_value(snowflake.REGION_ID, snowflake2) == r2.snowflake_id

--- a/tests/sentry/workflow_engine/utils/test_log_context.py
+++ b/tests/sentry/workflow_engine/utils/test_log_context.py
@@ -2,125 +2,128 @@ import logging
 from typing import Any
 from unittest.mock import patch
 
-from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.utils import log_context
 
 
-class LogContextTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.logger: log_context._Adapter = log_context.get_logger(__name__)  # type: ignore[assignment]
+def test_get_logger() -> None:
+    logger: Any = log_context.get_logger("test")
+    assert isinstance(logger, log_context._Adapter)
 
-    def test_get_logger(self) -> None:
-        logger: Any = log_context.get_logger("test")
-        assert isinstance(logger, log_context._Adapter)
 
-    def test_root_decorator(self) -> None:
-        @log_context.root()
-        def test_func() -> None:
-            context = log_context._log_context_state.get()
-            assert "context_id" in context.extra
-            assert isinstance(context.extra["context_id"], str)
+def test_root_decorator() -> None:
+    @log_context.root()
+    def test_func() -> None:
+        context = log_context._log_context_state.get()
+        assert "context_id" in context.extra
+        assert isinstance(context.extra["context_id"], str)
 
-        test_func()
+    test_func()
 
-    def test_set_verbose(self) -> None:
-        """Test that set_verbose promotes DEBUG logs to INFO."""
 
-        @log_context.root(add_context_id=False)
-        def test_func() -> None:
-            with (
-                log_context.new_context(verbose=True),
-                patch.object(self.logger.logger, "log") as mock_log,
-            ):
-                self.logger.debug("test message")
-                mock_log.assert_called_once_with(logging.INFO, "test message")
+def test_set_verbose() -> None:
+    """Test that set_verbose promotes DEBUG logs to INFO."""
+    logger: log_context._Adapter = log_context.get_logger(__name__)  # type: ignore[assignment]
 
-            with (
-                log_context.new_context(verbose=False),
-                patch.object(self.logger.logger, "log") as mock_log,
-            ):
-                self.logger.debug("test message")
-                mock_log.assert_not_called()
+    @log_context.root(add_context_id=False)
+    def test_func() -> None:
+        with (
+            log_context.new_context(verbose=True),
+            patch.object(logger.logger, "log") as mock_log,
+        ):
+            logger.debug("test message")
+            mock_log.assert_called_once_with(logging.INFO, "test message")
 
-        test_func()
+        with (
+            log_context.new_context(verbose=False),
+            patch.object(logger.logger, "log") as mock_log,
+        ):
+            logger.debug("test message")
+            mock_log.assert_not_called()
 
-    def test_add_extras(self) -> None:
-        """Test that add_extras adds data to the log context."""
+    test_func()
 
-        @log_context.root()
-        def test_func() -> None:
-            log_context.add_extras(workflow_id=123, rule_id=456)
+
+def test_add_extras() -> None:
+    """Test that add_extras adds data to the log context."""
+
+    @log_context.root()
+    def test_func() -> None:
+        log_context.add_extras(workflow_id=123, rule_id=456)
+        context = log_context._log_context_state.get()
+        assert context.extra["workflow_id"] == 123
+        assert context.extra["rule_id"] == 456
+
+        with log_context.new_context():
             context = log_context._log_context_state.get()
             assert context.extra["workflow_id"] == 123
             assert context.extra["rule_id"] == 456
 
-            with log_context.new_context():
-                context = log_context._log_context_state.get()
-                assert context.extra["workflow_id"] == 123
-                assert context.extra["rule_id"] == 456
+    test_func()
 
-        test_func()
 
-    def test_logged_extras_override_context(self) -> None:
-        """Test that extras passed to log calls override context extras."""
+def test_logged_extras_override_context() -> None:
+    """Test that extras passed to log calls override context extras."""
+    logger: log_context._Adapter = log_context.get_logger(__name__)  # type: ignore[assignment]
 
-        @log_context.root(add_context_id=False)
-        def test_func() -> None:
-            log_context.add_extras(workflow_id=123, rule_id=456)
-            with patch.object(self.logger.logger, "log") as mock_log:
-                self.logger.info("test message", extra={"workflow_id": 789})
-                mock_log.assert_called_once_with(
-                    logging.INFO,
-                    "test message",
-                    extra={"workflow_id": 789, "rule_id": 456},
-                )
+    @log_context.root(add_context_id=False)
+    def test_func() -> None:
+        log_context.add_extras(workflow_id=123, rule_id=456)
+        with patch.object(logger.logger, "log") as mock_log:
+            logger.info("test message", extra={"workflow_id": 789})
+            mock_log.assert_called_once_with(
+                logging.INFO,
+                "test message",
+                extra={"workflow_id": 789, "rule_id": 456},
+            )
 
-        test_func()
+    test_func()
 
-    def test_new_context(self) -> None:
-        """Test that new_context creates a sub-context with inherited and new data."""
 
-        @log_context.root()
-        def test_func() -> None:
-            log_context.add_extras(workflow_id=123)
-            with log_context.new_context(rule_id=456):
-                context = log_context._log_context_state.get()
-                assert context.extra["workflow_id"] == 123
-                assert context.extra["rule_id"] == 456
+def test_new_context() -> None:
+    """Test that new_context creates a sub-context with inherited and new data."""
 
-        test_func()
-
-    def test_new_context_verbose_inheritance(self) -> None:
-        """Test that new_context inherits verbose setting unless specified."""
-
-        @log_context.root()
-        def test_func() -> None:
-            log_context.set_verbose(True)
-            with log_context.new_context():
-                context = log_context._log_context_state.get()
-                assert context.verbose is True
-
-            with log_context.new_context(verbose=False):
-                context = log_context._log_context_state.get()
-                assert context.verbose is False
-
-        test_func()
-
-    def test_context_isolation(self) -> None:
-        """Test that contexts are isolated between different root contexts."""
-        context_ids = set()
-
-        @log_context.root()
-        def first_context() -> None:
+    @log_context.root()
+    def test_func() -> None:
+        log_context.add_extras(workflow_id=123)
+        with log_context.new_context(rule_id=456):
             context = log_context._log_context_state.get()
-            context_ids.add(context.extra["context_id"])
+            assert context.extra["workflow_id"] == 123
+            assert context.extra["rule_id"] == 456
 
-        @log_context.root()
-        def second_context() -> None:
+    test_func()
+
+
+def test_new_context_verbose_inheritance() -> None:
+    """Test that new_context inherits verbose setting unless specified."""
+
+    @log_context.root()
+    def test_func() -> None:
+        log_context.set_verbose(True)
+        with log_context.new_context():
             context = log_context._log_context_state.get()
-            context_ids.add(context.extra["context_id"])
+            assert context.verbose is True
 
-        first_context()
-        second_context()
-        assert len(context_ids) == 2
+        with log_context.new_context(verbose=False):
+            context = log_context._log_context_state.get()
+            assert context.verbose is False
+
+    test_func()
+
+
+def test_context_isolation() -> None:
+    """Test that contexts are isolated between different root contexts."""
+    context_ids = set()
+
+    @log_context.root()
+    def first_context() -> None:
+        context = log_context._log_context_state.get()
+        context_ids.add(context.extra["context_id"])
+
+    @log_context.root()
+    def second_context() -> None:
+        context = log_context._log_context_state.get()
+        context_ids.add(context.extra["context_id"])
+
+    first_context()
+    second_context()
+    assert len(context_ids) == 2


### PR DESCRIPTION
Convert tests from TestCase-based to plain pytest functions for faster execution. These tests don't require database access.

Single run of the modified tests, note that some in these files are still hitting the DB:
```
┌───────────────────────────────┬────────┬────────────┐
│            Branch             │  Time  │   Tests    │
├───────────────────────────────┼────────┼────────────┤
│ master (before)               │ 24.75s │ 269 passed │
├───────────────────────────────┼────────┼────────────┤
│ mrduncan/faster-tests (after) │ 14.40s │ 269 passed │
└───────────────────────────────┴────────┴────────────┘
  Speedup: 10.35 seconds (42% faster)
```

<details>
<summary>Timing test command</summary>

```
pytest -q --reuse-db \
    tests/sentry/api/serializers/rest_framework/test_base.py \
    tests/sentry/api/serializers/rest_framework/test_origin.py \
    tests/sentry/auth/test_password_validation.py \
    tests/sentry/conduit/test_tasks.py \
    tests/sentry/data_secrecy/test_types.py \
    tests/sentry/grouping/test_enhancer_dart_flutter_javascript.py \
    tests/sentry/grouping/test_enhancer_dart_flutter_native.py \
    tests/sentry/middleware/test_ai_agent.py \
    tests/sentry/middleware/test_proxy.py \
    tests/sentry/middleware/test_stats.py \
    tests/sentry/monitors/test_types.py \
    tests/sentry/net/test_socket.py \
    tests/sentry/plugins/test_helpers.py \
    tests/sentry/preprod/size_analysis/test_comparison_utils.py \
    tests/sentry/roles/test_manager.py \
    tests/sentry/shared_integrations/client/test_base.py \
    tests/sentry/silo/test_base.py \
    tests/sentry/stacktraces/test_in_app_normalization.py \
    tests/sentry/utils/email/test_signer.py \
    tests/sentry/utils/test_circuit_breaker.py \
    tests/sentry/utils/test_event_frames.py \
    tests/sentry/utils/test_geo.py \
    tests/sentry/utils/test_hashlib.py \
    tests/sentry/utils/test_http.py \
    tests/sentry/utils/test_json.py \
    tests/sentry/utils/test_not_set.py \
    tests/sentry/utils/test_registry.py \
    tests/sentry/utils/test_safe.py \
    tests/sentry/utils/test_signing.py \
    tests/sentry/utils/test_snowflake.py \
    tests/sentry/workflow_engine/utils/test_log_context.py
```
</details>