### PR TITLE
feat(dashboards): Add chart threshold support to dashboard widgets

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/constants.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/constants.tsx
@@ -1,0 +1,2 @@
+export const NEGATIVE_POLARITY_COLOR_ORDER = ['green400', 'yellow400', 'red400'] as const;
+export const POSITIVE_POLARITY_COLOR_ORDER = ['red400', 'yellow400', 'green400'] as const;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -101,6 +102,7 @@ export function Thresholds({
   preferredPolarity = '-',
   onPolarityChange,
 }: ThresholdsStepProps) {
+  const theme = useTheme();
   const maxOneValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_1] ?? '';
   const maxTwoValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_2] ?? '';
   const unit = thresholdsConfig?.unit ?? dataUnit;
@@ -113,6 +115,10 @@ export function Thresholds({
   const rowColors = isHigherBetter
     ? POSITIVE_POLARITY_COLOR_ORDER
     : NEGATIVE_POLARITY_COLOR_ORDER;
+
+  const bottomColor = theme.colors[rowColors[0]];
+  const middleColor = theme.colors[rowColors[1]];
+  const topColor = theme.colors[rowColors[2]];
 
   const thresholdRowProps: ThresholdRowProp[] = [
     {
@@ -128,7 +134,7 @@ export function Thresholds({
         'aria-label': 'First Maximum',
         error: errors?.max1,
       },
-      color: rowColors[0],
+      color: bottomColor,
       unitOptions,
       unitSelectProps: {
         name: 'First unit select',
@@ -148,7 +154,7 @@ export function Thresholds({
         'aria-label': 'Second Maximum',
         error: errors?.max2,
       },
-      color: rowColors[1],
+      color: middleColor,
       unitOptions,
       unitSelectProps: {
         name: 'Second unit select',
@@ -168,7 +174,7 @@ export function Thresholds({
         placeholder: t('No max'),
         'aria-label': 'Third Maximum',
       },
-      color: rowColors[2],
+      color: topColor,
       unitOptions,
       unitSelectProps: {
         name: 'Third unit select',

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -110,8 +110,6 @@ export function Thresholds({
 
   const isHigherBetter = preferredPolarity === '+';
 
-  // Row colors: for '-' (lower is better): green, yellow , red top-to-bottom
-  // For '+' (higher is better): red, yellow, green top-to-bottom
   const rowColors = isHigherBetter
     ? POSITIVE_POLARITY_COLOR_ORDER
     : NEGATIVE_POLARITY_COLOR_ORDER;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -2,9 +2,9 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
-import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import CircleIndicator from 'sentry/components/circleIndicator';
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
 import type {NumberFieldProps} from 'sentry/components/forms/fields/numberField';
 import NumberField from 'sentry/components/forms/fields/numberField';
@@ -180,14 +180,16 @@ export function Thresholds({
 
   return (
     <ThresholdsContainer>
-      <SegmentedControl
+      <RadioGroup
+        label={t('Preferred polarity')}
         value={preferredPolarity || '-'}
         onChange={value => onPolarityChange?.(value as Polarity)}
-        size="sm"
-      >
-        <SegmentedControl.Item key="-">{t('Lower is better')}</SegmentedControl.Item>
-        <SegmentedControl.Item key="+">{t('Higher is better')}</SegmentedControl.Item>
-      </SegmentedControl>
+        orientInline
+        choices={[
+          ['-', t('Lower is better')],
+          ['+', t('Higher is better')],
+        ]}
+      />
       {thresholdRowProps.map((props, index) => (
         <ThresholdRow
           {...props}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -1,4 +1,3 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -14,6 +13,10 @@ import type {Polarity} from 'sentry/components/percentChange';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getThresholdUnitSelectOptions} from 'sentry/views/dashboards/utils';
+import {
+  NEGATIVE_POLARITY_COLOR_ORDER,
+  POSITIVE_POLARITY_COLOR_ORDER,
+} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/constants';
 
 type ThresholdErrors = Partial<Record<ThresholdMaxKeys, string>>;
 
@@ -98,7 +101,6 @@ export function Thresholds({
   preferredPolarity = '-',
   onPolarityChange,
 }: ThresholdsStepProps) {
-  const theme = useTheme();
   const maxOneValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_1] ?? '';
   const maxTwoValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_2] ?? '';
   const unit = thresholdsConfig?.unit ?? dataUnit;
@@ -108,11 +110,11 @@ export function Thresholds({
 
   const isHigherBetter = preferredPolarity === '+';
 
-  // Row colors: for '-' (lower is better): green, yellow, red top-to-bottom
+  // Row colors: for '-' (lower is better): green, yellow , red top-to-bottom
   // For '+' (higher is better): red, yellow, green top-to-bottom
   const rowColors = isHigherBetter
-    ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
-    : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
+    ? POSITIVE_POLARITY_COLOR_ORDER
+    : NEGATIVE_POLARITY_COLOR_ORDER;
 
   const thresholdRowProps: ThresholdRowProp[] = [
     {
@@ -128,7 +130,7 @@ export function Thresholds({
         'aria-label': 'First Maximum',
         error: errors?.max1,
       },
-      color: rowColors[0]!,
+      color: rowColors[0],
       unitOptions,
       unitSelectProps: {
         name: 'First unit select',
@@ -148,7 +150,7 @@ export function Thresholds({
         'aria-label': 'Second Maximum',
         error: errors?.max2,
       },
-      color: rowColors[1]!,
+      color: rowColors[1],
       unitOptions,
       unitSelectProps: {
         name: 'Second unit select',
@@ -168,7 +170,7 @@ export function Thresholds({
         placeholder: t('No max'),
         'aria-label': 'Third Maximum',
       },
-      color: rowColors[2]!,
+      color: rowColors[2],
       unitOptions,
       unitSelectProps: {
         name: 'Third unit select',
@@ -183,7 +185,7 @@ export function Thresholds({
       <RadioGroup
         label={t('Preferred polarity')}
         value={preferredPolarity || '-'}
-        onChange={value => onPolarityChange?.(value as Polarity)}
+        onChange={value => onPolarityChange?.(value)}
         orientInline
         choices={[
           ['-', t('Lower is better')],

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import CircleIndicator from 'sentry/components/circleIndicator';
 import {FieldWrapper} from 'sentry/components/forms/fieldGroup/fieldWrapper';
@@ -23,6 +24,8 @@ type ThresholdsStepProps = {
   dataType?: string;
   dataUnit?: string;
   errors?: ThresholdErrors;
+  onPolarityChange?: (polarity: Polarity) => void;
+  preferredPolarity?: Polarity;
 };
 
 type ThresholdRowProp = {
@@ -92,6 +95,8 @@ export function Thresholds({
   errors,
   dataType = '',
   dataUnit = '',
+  preferredPolarity = '-',
+  onPolarityChange,
 }: ThresholdsStepProps) {
   const theme = useTheme();
   const maxOneValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_1] ?? '';
@@ -100,6 +105,15 @@ export function Thresholds({
   const unitOptions = ['duration', 'rate'].includes(dataType)
     ? getThresholdUnitSelectOptions(dataType)
     : [];
+
+  const isHigherBetter = preferredPolarity === '+';
+
+  // Row colors: for '-' (lower is better): green, yellow, red top-to-bottom
+  // For '+' (higher is better): red, yellow, green top-to-bottom
+  const rowColors = isHigherBetter
+    ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
+    : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
+
   const thresholdRowProps: ThresholdRowProp[] = [
     {
       maxKey: ThresholdMaxKeys.MAX_1,
@@ -114,7 +128,7 @@ export function Thresholds({
         'aria-label': 'First Maximum',
         error: errors?.max1,
       },
-      color: theme.colors.green400,
+      color: rowColors[0]!,
       unitOptions,
       unitSelectProps: {
         name: 'First unit select',
@@ -134,7 +148,7 @@ export function Thresholds({
         'aria-label': 'Second Maximum',
         error: errors?.max2,
       },
-      color: theme.colors.yellow400,
+      color: rowColors[1]!,
       unitOptions,
       unitSelectProps: {
         name: 'Second unit select',
@@ -154,7 +168,7 @@ export function Thresholds({
         placeholder: t('No max'),
         'aria-label': 'Third Maximum',
       },
-      color: theme.colors.red400,
+      color: rowColors[2]!,
       unitOptions,
       unitSelectProps: {
         name: 'Third unit select',
@@ -166,6 +180,14 @@ export function Thresholds({
 
   return (
     <ThresholdsContainer>
+      <SegmentedControl
+        value={preferredPolarity || '-'}
+        onChange={value => onPolarityChange?.(value as Polarity)}
+        size="sm"
+      >
+        <SegmentedControl.Item key="-">{t('Lower is better')}</SegmentedControl.Item>
+        <SegmentedControl.Item key="+">{t('Higher is better')}</SegmentedControl.Item>
+      </SegmentedControl>
       {thresholdRowProps.map((props, index) => (
         <ThresholdRow
           {...props}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholdsHoverWrapper.tsx
@@ -8,6 +8,10 @@ import CircleIndicator from 'sentry/components/circleIndicator';
 import {Hovercard} from 'sentry/components/hovercard';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {
+  NEGATIVE_POLARITY_COLOR_ORDER,
+  POSITIVE_POLARITY_COLOR_ORDER,
+} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/constants';
 
 import type {ThresholdsConfig} from './thresholds';
 
@@ -16,9 +20,6 @@ type Props = {
   thresholds: ThresholdsConfig;
   type?: string;
 };
-
-const NEGATIVE_POLARITY_COLOR_ORDER = ['green400', 'yellow400', 'red400'] as const;
-const POSITIVE_POLARITY_COLOR_ORDER = ['red400', 'yellow400', 'green400'] as const;
 
 export function ThresholdsHoverWrapper({children, thresholds, type}: Props) {
   const {

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -3,7 +3,6 @@ import {closestCorners, DndContext, useDraggable, useDroppable} from '@dnd-kit/c
 import {css, Global, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion, type MotionNodeAnimationOptions} from 'framer-motion';
-import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -12,7 +11,6 @@ import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
-import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -46,6 +44,7 @@ import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {DashboardsMEPProvider} from 'sentry/views/dashboards/widgetCard/dashboardsMEPContext';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {isLogsEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
@@ -155,21 +154,23 @@ function WidgetBuilderV2({
     }));
   };
 
-  const handleWidgetDataFetched = useCallback(
-    (tableData: TableDataWithTitle[]) => {
-      const tableMeta = {...tableData[0]!.meta};
+  const handleWidgetDataFetched = useCallback((results: OnDataFetchedParams) => {
+    let dataType: string | undefined;
+    let dataUnit: string | undefined;
+
+    if (results.tableResults?.length) {
+      const tableMeta = {...results.tableResults[0]!.meta};
       const keys = Object.keys(tableMeta);
       const field = keys[0]!;
-      const dataType = tableMeta[field];
-      const dataUnit = tableMeta.units?.[field];
+      dataType = tableMeta[field];
+      dataUnit = tableMeta.units?.[field];
+    } else if (results.timeseriesResultsTypes) {
+      const keys = Object.keys(results.timeseriesResultsTypes);
+      dataType = results.timeseriesResultsTypes[keys[0]!];
+    }
 
-      const newState = cloneDeep(thresholdMetaState);
-      newState.dataType = dataType;
-      newState.dataUnit = dataUnit;
-      setThresholdMetaState(newState);
-    },
-    [thresholdMetaState]
-  );
+    setThresholdMetaState({dataType, dataUnit});
+  }, []);
 
   // reset the drag position when the draggable preview is not visible
   useEffect(() => {
@@ -275,7 +276,7 @@ export function WidgetPreviewContainer({
   isWidgetInvalid: boolean;
   dragPosition?: WidgetDragPositioning;
   isDraggable?: boolean;
-  onDataFetched?: (tableData: TableDataWithTitle[]) => void;
+  onDataFetched?: (results: OnDataFetchedParams) => void;
   openWidgetTemplates?: boolean;
 }) {
   const {state} = useWidgetBuilderContext();

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -91,6 +91,7 @@ function ThresholdsSection({
             payload: {
               max_values: state.thresholds?.max_values ?? {},
               unit,
+              preferredPolarity: state.thresholds?.preferredPolarity,
             },
           });
         }}

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -42,6 +42,17 @@ function ThresholdsSection({
       />
       <Thresholds
         thresholdsConfig={state.thresholds ?? null}
+        preferredPolarity={state.thresholds?.preferredPolarity ?? '-'}
+        onPolarityChange={polarity => {
+          dispatch({
+            type: BuilderStateAction.SET_THRESHOLDS,
+            payload: {
+              max_values: state.thresholds?.max_values ?? {},
+              unit: state.thresholds?.unit ?? null,
+              preferredPolarity: polarity,
+            },
+          });
+        }}
         onThresholdChange={(maxKey, value) => {
           let newThresholds = cloneDeep(state.thresholds);
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -429,17 +429,17 @@ function WidgetBuilderSlideout({
                         />
                       </Section>
                     )}
-                    {state.displayType === DisplayType.BIG_NUMBER ||
-                      (usesTimeSeriesData(state.displayType) && (
-                        <Section>
-                          <ThresholdsSection
-                            dataType={thresholdMetaState?.dataType}
-                            dataUnit={thresholdMetaState?.dataUnit}
-                            error={error}
-                            setError={setError}
-                          />
-                        </Section>
-                      ))}
+                    {(state.displayType === DisplayType.BIG_NUMBER ||
+                      usesTimeSeriesData(state.displayType)) && (
+                      <Section>
+                        <ThresholdsSection
+                          dataType={thresholdMetaState?.dataType}
+                          dataUnit={thresholdMetaState?.dataUnit}
+                          error={error}
+                          setError={setError}
+                        />
+                      </Section>
+                    )}
                     {showGroupBySelector && (
                       <Section>
                         <WidgetBuilderGroupBySelector

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -429,7 +429,9 @@ function WidgetBuilderSlideout({
                         />
                       </Section>
                     )}
-                    {state.displayType === DisplayType.BIG_NUMBER && (
+                    {(state.displayType === DisplayType.BIG_NUMBER ||
+                      (usesTimeSeriesData(state.displayType) &&
+                        (state.query?.length ?? 1) <= 1)) && (
                       <Section>
                         <ThresholdsSection
                           dataType={thresholdMetaState?.dataType}

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -24,7 +24,6 @@ import {IconClose} from 'sentry/icons';
 import {t, tctCode} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
-import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -62,6 +61,7 @@ import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useI
 import {useSegmentSpanWidgetState} from 'sentry/views/dashboards/widgetBuilder/hooks/useSegmentSpanWidgetState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
 import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import {getTopNConvertedDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 
 type WidgetBuilderSlideoutProps = {
@@ -74,7 +74,7 @@ type WidgetBuilderSlideoutProps = {
   openWidgetTemplates: boolean;
   setIsPreviewDraggable: (draggable: boolean) => void;
   setOpenWidgetTemplates: (openWidgetTemplates: boolean) => void;
-  onDataFetched?: (tableData: TableDataWithTitle[]) => void;
+  onDataFetched?: (results: OnDataFetchedParams) => void;
   thresholdMetaState?: ThresholdMetaState;
 };
 

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -429,18 +429,17 @@ function WidgetBuilderSlideout({
                         />
                       </Section>
                     )}
-                    {(state.displayType === DisplayType.BIG_NUMBER ||
-                      (usesTimeSeriesData(state.displayType) &&
-                        (state.query?.length ?? 1) <= 1)) && (
-                      <Section>
-                        <ThresholdsSection
-                          dataType={thresholdMetaState?.dataType}
-                          dataUnit={thresholdMetaState?.dataUnit}
-                          error={error}
-                          setError={setError}
-                        />
-                      </Section>
-                    )}
+                    {state.displayType === DisplayType.BIG_NUMBER ||
+                      (usesTimeSeriesData(state.displayType) && (
+                        <Section>
+                          <ThresholdsSection
+                            dataType={thresholdMetaState?.dataType}
+                            dataUnit={thresholdMetaState?.dataUnit}
+                            error={error}
+                            setError={setError}
+                          />
+                        </Section>
+                      ))}
                     {showGroupBySelector && (
                       <Section>
                         <WidgetBuilderGroupBySelector

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -3,7 +3,6 @@ import {useState} from 'react';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import PanelAlert from 'sentry/components/panels/panelAlert';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
-import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -19,6 +18,7 @@ import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
+import type {OnDataFetchedParams} from 'sentry/views/dashboards/widgetCard';
 import WidgetCard from 'sentry/views/dashboards/widgetCard';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
@@ -28,7 +28,7 @@ interface WidgetPreviewProps {
   dashboard: DashboardDetails;
   dashboardFilters: DashboardFilters;
   isWidgetInvalid?: boolean;
-  onDataFetched?: (tableData: TableDataWithTitle[]) => void;
+  onDataFetched?: (results: OnDataFetchedParams) => void;
   shouldForceDescriptionTooltip?: boolean;
 }
 

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -526,6 +526,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                                       preferredPolarity:
                                         widget.thresholds?.preferredPolarity ?? '-',
                                     },
+                                    dataType: outputType,
                                   }).toSeries({theme})
                                 : []),
                             ],

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -90,6 +90,7 @@ import {
   convertTableDataToTabularData,
   decodeColumnAliases,
 } from 'sentry/views/dashboards/widgets/tableWidget/utils';
+import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
@@ -516,6 +517,16 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                               // only add release series if there is series data
                               ...(series?.length > 0
                                 ? (modifiedReleaseSeriesResults ?? [])
+                                : []),
+                              ...(defined(widget.thresholds?.max_values.max1) &&
+                              defined(widget.thresholds?.max_values.max2)
+                                ? new ThresholdsPlottable({
+                                    thresholds: {
+                                      ...widget.thresholds,
+                                      preferredPolarity:
+                                        widget.thresholds?.preferredPolarity ?? '-',
+                                    },
+                                  }).toSeries({theme})
                                 : []),
                             ],
                             onLegendSelectChanged: handleLegendSelectChange,

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -518,7 +518,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                               ...(series?.length > 0
                                 ? (modifiedReleaseSeriesResults ?? [])
                                 : []),
-                              ...(defined(widget.thresholds?.max_values.max1) &&
+                              ...(defined(widget.thresholds?.max_values.max1) ||
                               defined(widget.thresholds?.max_values.max2)
                                 ? new ThresholdsPlottable({
                                     thresholds: {

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -142,6 +142,12 @@ function WidgetCard(props: Props) {
     const {...rest} = newData;
     if (props.onDataFetched && rest.tableResults) {
       props.onDataFetched(rest.tableResults);
+    } else if (props.onDataFetched && rest.timeseriesResultsTypes) {
+      // For time series data, construct synthetic table results with meta
+      // so the threshold section can determine the data type
+      props.onDataFetched([
+        {title: '', data: [], meta: {...rest.timeseriesResultsTypes}},
+      ]);
     }
 
     setData(prevData => ({...prevData, ...rest}));

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -60,6 +60,11 @@ import {
 } from './widgetCardContextMenu';
 import {WidgetFrame} from './widgetFrame';
 
+export type OnDataFetchedParams = {
+  tableResults?: TableDataWithTitle[];
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+};
+
 const DAYS_TO_MS = 24 * 60 * 60 * 1000;
 
 const SESSION_DURATION_INGESTION_STOP_DATE = new Date('2023-01-12');
@@ -98,7 +103,7 @@ type Props = WithRouterProps & {
   isWidgetInvalid?: boolean;
   legendOptions?: LegendComponentOption;
   minTableColumnWidth?: number;
-  onDataFetched?: (results: TableDataWithTitle[]) => void;
+  onDataFetched?: (results: OnDataFetchedParams) => void;
   onDelete?: () => void;
   onDuplicate?: () => void;
   onEdit?: () => void;
@@ -139,18 +144,14 @@ function WidgetCard(props: Props) {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const onDataFetched = (newData: Data) => {
-    const {...rest} = newData;
-    if (props.onDataFetched && rest.tableResults) {
-      props.onDataFetched(rest.tableResults);
-    } else if (props.onDataFetched && rest.timeseriesResultsTypes) {
-      // For time series data, construct synthetic table results with meta
-      // so the threshold section can determine the data type
-      props.onDataFetched([
-        {title: '', data: [], meta: {...rest.timeseriesResultsTypes}},
-      ]);
+    if (props.onDataFetched) {
+      props.onDataFetched({
+        tableResults: newData.tableResults,
+        timeseriesResultsTypes: newData.timeseriesResultsTypes,
+      });
     }
 
-    setData(prevData => ({...prevData, ...rest}));
+    setData(prevData => ({...prevData, ...newData}));
 
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -356,7 +356,7 @@ function VisualizationWidgetContent({
   );
 
   if (
-    defined(widget.thresholds?.max_values.max1) &&
+    defined(widget.thresholds?.max_values.max1) ||
     defined(widget.thresholds?.max_values.max2)
   ) {
     plottables.push(

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -41,6 +41,7 @@ import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesW
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
 import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
 import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
+import {Thresholds} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
@@ -350,7 +351,23 @@ function VisualizationWidgetContent({
     paddingBottom: 'lg',
   };
 
-  const plottables = timeSeriesWithPlottable.map(([, plottable]) => plottable);
+  const plottables: Plottable[] = timeSeriesWithPlottable.map(
+    ([, plottable]) => plottable
+  );
+
+  if (
+    defined(widget.thresholds?.max_values.max1) &&
+    defined(widget.thresholds?.max_values.max2)
+  ) {
+    plottables.push(
+      new Thresholds({
+        thresholds: {
+          ...widget.thresholds,
+          preferredPolarity: '-',
+        },
+      })
+    );
+  }
 
   // Check for empty plottables before rendering the visualization
   // This prevents TimeSeriesWidgetVisualization from throwing an error

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -365,6 +365,7 @@ function VisualizationWidgetContent({
           ...widget.thresholds,
           preferredPolarity: widget.thresholds?.preferredPolarity ?? '-',
         },
+        dataType: timeSeriesWithPlottable[0]?.[0]?.meta?.valueType,
       })
     );
   }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -361,7 +361,7 @@ function VisualizationWidgetContent({
   ) {
     plottables.push(
       new Thresholds({
-        thresholds: {...widget.thresholds},
+        thresholds: widget.thresholds,
         dataType: timeSeriesWithPlottable[0]?.[0]?.meta?.valueType,
       })
     );

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -363,7 +363,7 @@ function VisualizationWidgetContent({
       new Thresholds({
         thresholds: {
           ...widget.thresholds,
-          preferredPolarity: '-',
+          preferredPolarity: widget.thresholds?.preferredPolarity ?? '-',
         },
       })
     );

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -361,10 +361,7 @@ function VisualizationWidgetContent({
   ) {
     plottables.push(
       new Thresholds({
-        thresholds: {
-          ...widget.thresholds,
-          preferredPolarity: widget.thresholds?.preferredPolarity ?? '-',
-        },
+        thresholds: {...widget.thresholds},
         dataType: timeSeriesWithPlottable[0]?.[0]?.meta?.valueType,
       })
     );

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -9,6 +9,10 @@ import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {Theme} from 'sentry/utils/theme';
 import {normalizeUnit} from 'sentry/views/dashboards/utils';
+import {
+  NEGATIVE_POLARITY_COLOR_ORDER,
+  POSITIVE_POLARITY_COLOR_ORDER,
+} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/constants';
 import type {
   Thresholds as ThresholdsConfig,
   TimeSeriesValueUnit,
@@ -85,9 +89,13 @@ export class Thresholds implements Plottable {
 
     // For '-' (lower is better): green, yellow, red bottom-to-top
     // For '+' (higher is better): red, yellow, green bottom-to-top
-    const [bottomColor, middleColor, topColor] = isHigherBetter
-      ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
-      : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
+    const colorOrder = isHigherBetter
+      ? POSITIVE_POLARITY_COLOR_ORDER
+      : NEGATIVE_POLARITY_COLOR_ORDER;
+
+    const bottomColor = theme.colors[colorOrder[0]];
+    const middleColor = theme.colors[colorOrder[1]];
+    const topColor = theme.colors[colorOrder[2]];
 
     const markAreas = [
       this.toMarkArea([0, max1 ?? Infinity], {
@@ -144,9 +152,14 @@ export class Thresholds implements Plottable {
 
     // For '-' (lower is better): Good (green), Meh (yellow), Poor (red) bottom-to-top
     // For '+' (higher is better): Poor (red), Meh (yellow), Good (green) bottom-to-top
-    const [bottomColor, middleColor, topColor] = isHigherBetter
-      ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
-      : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
+    const colorOrder = isHigherBetter
+      ? POSITIVE_POLARITY_COLOR_ORDER
+      : NEGATIVE_POLARITY_COLOR_ORDER;
+
+    const bottomColor = theme.colors[colorOrder[0]];
+    const middleColor = theme.colors[colorOrder[1]];
+    const topColor = theme.colors[colorOrder[2]];
+
     const [bottomLabel, middleLabel, topLabel] = isHigherBetter
       ? [t('Poor'), t('Meh'), t('Good')]
       : [t('Good'), t('Meh'), t('Poor')];

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -56,10 +56,17 @@ export class Thresholds implements Plottable {
 
   toMarkAreas(theme: Theme) {
     const {max1, max2} = this.thresholds.max_values;
+    const isHigherBetter = this.thresholds.preferredPolarity === '+';
+
+    // For '-' (lower is better): green, yellow, red bottom-to-top
+    // For '+' (higher is better): red, yellow, green bottom-to-top
+    const [bottomColor, middleColor, topColor] = isHigherBetter
+      ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
+      : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
 
     const markAreas = [
       this.toMarkArea([0, max1 ?? Infinity], {
-        color: theme.colors.green400,
+        color: bottomColor,
         opacity: 0.1,
       }),
     ];
@@ -67,7 +74,7 @@ export class Thresholds implements Plottable {
     if (max1) {
       markAreas.push(
         this.toMarkArea([max1, max2 ?? Infinity], {
-          color: theme.colors.yellow400,
+          color: middleColor,
           opacity: 0.1,
         })
       );
@@ -76,7 +83,7 @@ export class Thresholds implements Plottable {
     if (max2) {
       markAreas.push(
         this.toMarkArea([max2, Infinity], {
-          color: theme.colors.red400,
+          color: topColor,
           opacity: 0.1,
         })
       );
@@ -108,25 +115,35 @@ export class Thresholds implements Plottable {
 
   toMarkLines(theme: Theme) {
     const {max1, max2} = this.thresholds.max_values;
+    const isHigherBetter = this.thresholds.preferredPolarity === '+';
+
+    // For '-' (lower is better): Good (green), Meh (yellow), Poor (red) bottom-to-top
+    // For '+' (higher is better): Poor (red), Meh (yellow), Good (green) bottom-to-top
+    const [bottomColor, middleColor, topColor] = isHigherBetter
+      ? [theme.colors.red400, theme.colors.yellow400, theme.colors.green400]
+      : [theme.colors.green400, theme.colors.yellow400, theme.colors.red400];
+    const [bottomLabel, middleLabel, topLabel] = isHigherBetter
+      ? [t('Poor'), t('Meh'), t('Good')]
+      : [t('Good'), t('Meh'), t('Poor')];
 
     const markLines = [
-      this.toMarkLine(max1 ?? Infinity, t('Good'), {
-        color: theme.colors.green400,
+      this.toMarkLine(max1 ?? Infinity, bottomLabel, {
+        color: bottomColor,
       }),
     ];
 
     if (max1) {
       markLines.push(
-        this.toMarkLine(max2 ?? Infinity, t('Meh'), {
-          color: theme.colors.yellow400,
+        this.toMarkLine(max2 ?? Infinity, middleLabel, {
+          color: middleColor,
         })
       );
     }
 
     if (max2) {
       markLines.push(
-        this.toMarkLine(Infinity, t('Poor'), {
-          color: theme.colors.red400,
+        this.toMarkLine(Infinity, topLabel, {
+          color: topColor,
         })
       );
     }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -8,6 +8,7 @@ import MarkArea from 'sentry/components/charts/components/markArea';
 import MarkLine from 'sentry/components/charts/components/markLine';
 import {t} from 'sentry/locale';
 import type {Theme} from 'sentry/utils/theme';
+import {normalizeUnit} from 'sentry/views/dashboards/utils';
 import type {
   Thresholds as ThresholdsConfig,
   TimeSeriesValueUnit,
@@ -19,6 +20,7 @@ import type {
 
 type ThresholdPlottableOptions = {
   thresholds: ThresholdsConfig;
+  dataType?: string;
   showLabels?: boolean;
 };
 
@@ -41,7 +43,27 @@ export class Thresholds implements Plottable {
   end: number | null = null;
 
   constructor(options: ThresholdPlottableOptions) {
-    this.thresholds = options.thresholds;
+    const {thresholds, dataType} = options;
+    const thresholdUnit = thresholds.unit;
+
+    // Normalize threshold values to the base unit (e.g., milliseconds for duration)
+    // so they align with the chart's y-axis values
+    if (thresholdUnit && dataType) {
+      this.thresholds = {
+        ...thresholds,
+        max_values: {
+          max1: thresholds.max_values.max1
+            ? normalizeUnit(thresholds.max_values.max1, thresholdUnit, dataType)
+            : thresholds.max_values.max1,
+          max2: thresholds.max_values.max2
+            ? normalizeUnit(thresholds.max_values.max2, thresholdUnit, dataType)
+            : thresholds.max_values.max2,
+        },
+      };
+    } else {
+      this.thresholds = thresholds;
+    }
+
     this.showLabels = options.showLabels ?? false;
     this.isEmpty = !this.thresholds.max_values.max1 && !this.thresholds.max_values.max2;
   }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -87,8 +87,6 @@ export class Thresholds implements Plottable {
     const {max1, max2} = this.thresholds.max_values;
     const isHigherBetter = this.thresholds.preferredPolarity === '+';
 
-    // For '-' (lower is better): green, yellow, red bottom-to-top
-    // For '+' (higher is better): red, yellow, green bottom-to-top
     const colorOrder = isHigherBetter
       ? POSITIVE_POLARITY_COLOR_ORDER
       : NEGATIVE_POLARITY_COLOR_ORDER;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -19,6 +19,7 @@ import type {
 
 type ThresholdPlottableOptions = {
   thresholds: ThresholdsConfig;
+  showLabels?: boolean;
 };
 
 type ThresholdPlottablePlottingOptions = {
@@ -28,6 +29,7 @@ type ThresholdPlottablePlottingOptions = {
 export class Thresholds implements Plottable {
   maxOffset = 5; // The offset from the top of the chart (in pixels), of the max threshold
   thresholds: ThresholdsConfig;
+  showLabels: boolean;
 
   /** State variables required for Plottable interface */
   dataType: PlottableTimeSeriesValueType = 'duration';
@@ -40,6 +42,7 @@ export class Thresholds implements Plottable {
 
   constructor(options: ThresholdPlottableOptions) {
     this.thresholds = options.thresholds;
+    this.showLabels = options.showLabels ?? false;
     this.isEmpty = !this.thresholds.max_values.max1 && !this.thresholds.max_values.max2;
   }
 
@@ -127,14 +130,14 @@ export class Thresholds implements Plottable {
       : [t('Good'), t('Meh'), t('Poor')];
 
     const markLines = [
-      this.toMarkLine(max1 ?? Infinity, bottomLabel, {
+      this.toMarkLine(max1 ?? Infinity, this.showLabels ? bottomLabel : '', {
         color: bottomColor,
       }),
     ];
 
     if (max1) {
       markLines.push(
-        this.toMarkLine(max2 ?? Infinity, middleLabel, {
+        this.toMarkLine(max2 ?? Infinity, this.showLabels ? middleLabel : '', {
           color: middleColor,
         })
       );
@@ -142,7 +145,7 @@ export class Thresholds implements Plottable {
 
     if (max2) {
       markLines.push(
-        this.toMarkLine(Infinity, topLabel, {
+        this.toMarkLine(Infinity, this.showLabels ? topLabel : '', {
           color: topColor,
         })
       );

--- a/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
+++ b/static/app/views/insights/browser/webVitals/components/charts/webVitalStatusLineChart.tsx
@@ -84,6 +84,7 @@ export function WebVitalStatusLineChart({
       },
       unit: 'ms',
     },
+    showLabels: true,
   });
 
   const extraPlottables: Plottable[] = isTimeseriesLoading ? [] : [thresholdsPlottable];


### PR DESCRIPTION
## Summary

- Adds chart threshold support to time series widgets (line, area, bar) in addition to the existing big number widget support
- Adds a preferred polarity toggle ("Lower is better" / "Higher is better") that controls threshold color ordering
- Shows threshold reference lines and colored regions in full screen mode, with labels hidden by default
- Fixes threshold percentage conversion for time series widgets by forwarding `timeseriesResultsTypes` through `onDataFetched` so the threshold section can correctly identify the data type

<img width="1369" height="556" alt="image" src="https://github.com/user-attachments/assets/10c37a54-7c1d-4880-9906-d74e2e18707e" />

## Changes

- **Threshold rendering** (`plottables/thresholds.tsx`): Added `preferredPolarity` support to reverse color ordering (green/yellow/red vs red/yellow/green) and a `showLabels` option to control label visibility
- **Widget builder** (`widgetBuilderSlideout.tsx`): Expanded threshold section visibility to time series widgets with single queries
- **Polarity toggle** (`buildSteps/thresholdsStep/thresholds.tsx`, `components/thresholds.tsx`): Added segmented control for polarity selection
- **Chart integration** (`chart.tsx`, `visualizationWidget.tsx`): Added `ThresholdsPlottable` to both legacy and new chart rendering paths
- **Data type fix** (`widgetCard/index.tsx`): Forward `timeseriesResultsTypes` as synthetic table meta so percentage thresholds convert correctly (users can type `0.5` for `0.5%` instead of `0.005`)