### PR TITLE
feat(dashboards): Add chart-legend-component feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -76,6 +76,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:code-review-experiments-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Prevent Test Analytics
     manager.add("organizations:prevent-test-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable new React chart legend component
+    manager.add("organizations:chart-legend-component", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the improved command menu (Cmd+K)
     manager.add("organizations:command-menu-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable continuous profiling


### PR DESCRIPTION
Adds `organizations:chart-legend-component` feature flag to gate the new React-rendered chart legend component behind a controlled rollout, see [Linear](https://linear.app/getsentry/project/improved-chart-legend-e0d2083d7197/overview)

## Related
- Automator PR (flag definition): https://github.com/getsentry/sentry-options-automator/pull/6495