### PR TITLE
feat(preprod): Group failed checks by bundle ID and build configuration

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -781,6 +781,11 @@ def _compute_overall_status(
                                     platform=artifact.get_platform_label(),
                                     metrics_artifact_type=candidate_metric.metrics_artifact_type,
                                     identifier=candidate_metric.identifier,
+                                    build_configuration_name=(
+                                        artifact.build_configuration.name
+                                        if artifact.build_configuration
+                                        else None
+                                    ),
                                 )
                             )
 

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -337,10 +337,10 @@ def _format_failed_checks_details(
     if not triggered_rules:
         return ""
 
-    # Group rules by app_id
-    rules_by_app: dict[str, list[TriggeredRule]] = {}
+    # Group rules by (app_id, build_configuration_name)
+    rules_by_app: dict[tuple[str, str | None], list[TriggeredRule]] = {}
     for tr in triggered_rules:
-        app_key = tr.app_id or "Unknown"
+        app_key = (tr.app_id or "Unknown", tr.build_configuration_name)
         if app_key not in rules_by_app:
             rules_by_app[app_key] = []
         rules_by_app[app_key].append(tr)
@@ -353,10 +353,11 @@ def _format_failed_checks_details(
     ) % {"count": total_failed}
 
     details_content = []
-    for app_id, app_rules in rules_by_app.items():
+    for (app_id, config_name), app_rules in rules_by_app.items():
         platform = app_rules[0].platform if app_rules else None
         platform_text = f" ({platform})" if platform else ""
-        details_content.append(f"`{app_id}`{platform_text}")
+        config_text = f" | {config_name}" if config_name else ""
+        details_content.append(f"`{app_id}`{config_text}{platform_text}")
 
         for tr in app_rules:
             metric_display = _get_metric_display_name(tr.rule.metric)

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -337,10 +337,10 @@ def _format_failed_checks_details(
     if not triggered_rules:
         return ""
 
-    # Group rules by (app_id, build_configuration_name)
-    rules_by_app: dict[tuple[str, str | None], list[TriggeredRule]] = {}
+    # Group rules by (app_id, build_configuration_name, platform)
+    rules_by_app: dict[tuple[str, str | None, str | None], list[TriggeredRule]] = {}
     for tr in triggered_rules:
-        app_key = (tr.app_id or "Unknown", tr.build_configuration_name)
+        app_key = (tr.app_id or "Unknown", tr.build_configuration_name, tr.platform)
         if app_key not in rules_by_app:
             rules_by_app[app_key] = []
         rules_by_app[app_key].append(tr)
@@ -353,8 +353,7 @@ def _format_failed_checks_details(
     ) % {"count": total_failed}
 
     details_content = []
-    for (app_id, config_name), app_rules in rules_by_app.items():
-        platform = app_rules[0].platform if app_rules else None
+    for (app_id, config_name, platform), app_rules in rules_by_app.items():
         platform_text = f" ({platform})" if platform else ""
         config_text = f" | {config_name}" if config_name else ""
         details_content.append(f"`{app_id}`{config_text}{platform_text}")

--- a/src/sentry/preprod/vcs/status_checks/size/types.py
+++ b/src/sentry/preprod/vcs/status_checks/size/types.py
@@ -86,3 +86,4 @@ class TriggeredRule:
     platform: str | None
     metrics_artifact_type: int | None = None
     identifier: str | None = None
+    build_configuration_name: str | None = None

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -1298,6 +1298,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             artifact_id=artifact.id,
             app_id="com.example.app",
             platform="Android",
+            build_configuration_name=None,
         )
 
         title, subtitle, summary = format_status_check_messages(
@@ -1419,6 +1420,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=artifact.id,
                 app_id="com.example.app",
                 platform="Android",
+                build_configuration_name=None,
             ),
             TriggeredRule(
                 rule=StatusCheckRule(
@@ -1430,6 +1432,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=artifact.id,
                 app_id="com.example.app",
                 platform="Android",
+                build_configuration_name=None,
             ),
             TriggeredRule(
                 rule=StatusCheckRule(
@@ -1441,6 +1444,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=artifact.id,
                 app_id="com.example.app",
                 platform="Android",
+                build_configuration_name=None,
             ),
         ]
 
@@ -1536,6 +1540,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=artifact1.id,
                 app_id="com.example.app1",
                 platform="iOS",
+                build_configuration_name=None,
             ),
             TriggeredRule(
                 rule=StatusCheckRule(
@@ -1547,6 +1552,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=artifact2.id,
                 app_id="com.example.app2",
                 platform="Android",
+                build_configuration_name=None,
             ),
         ]
 
@@ -1650,6 +1656,7 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
                 artifact_id=failed_artifact.id,
                 app_id="com.example.failed",
                 platform="Android",
+                build_configuration_name=None,
             ),
         ]
 

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -1704,3 +1704,187 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
         assert title == "Size Analysis"
         assert subtitle == ""
         assert summary == expected
+
+    def test_single_triggered_rule_with_build_configuration(self):
+        """Test that a triggered rule with build_configuration shows config in header."""
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+
+        size_metrics = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=100 * 1024 * 1024,
+            max_download_size=100 * 1024 * 1024,
+            min_install_size=200 * 1024 * 1024,
+            max_install_size=200 * 1024 * 1024,
+        )
+
+        size_metrics_map = {artifact.id: [size_metrics]}
+
+        triggered_rule = TriggeredRule(
+            rule=StatusCheckRule(
+                id="rule-1",
+                metric="install_size",
+                measurement="absolute",
+                value=50 * 1024 * 1024,
+            ),
+            artifact_id=artifact.id,
+            app_id="com.example.app",
+            platform="iOS",
+            build_configuration_name="Release",
+        )
+
+        title, subtitle, summary = format_status_check_messages(
+            [artifact],
+            size_metrics_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+            {},
+            triggered_rules=[triggered_rule],
+        )
+
+        assert "`com.example.app` | Release (iOS)" in summary
+        assert "<summary>1 Failed Check</summary>" in summary
+
+    def test_same_app_different_configurations_grouped_separately(self):
+        """Test that same app with different build configs shows separate groups."""
+        artifact1 = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.emergetools.hackernews",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+        artifact2 = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.emergetools.hackernews",
+            build_version="1.0.0",
+            build_number=2,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        )
+
+        metrics1 = self.create_preprod_artifact_size_metrics(
+            artifact1,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=2 * 1024 * 1024,
+            max_download_size=2 * 1024 * 1024,
+            min_install_size=3 * 1024 * 1024,
+            max_install_size=3 * 1024 * 1024,
+        )
+        metrics2 = self.create_preprod_artifact_size_metrics(
+            artifact2,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=2 * 1024 * 1024,
+            max_download_size=2 * 1024 * 1024,
+            min_install_size=3 * 1024 * 1024,
+            max_install_size=3 * 1024 * 1024,
+        )
+
+        size_metrics_map = {
+            artifact1.id: [metrics1],
+            artifact2.id: [metrics2],
+        }
+
+        triggered_rules = [
+            TriggeredRule(
+                rule=StatusCheckRule(
+                    id="rule-1",
+                    metric="install_size",
+                    measurement="absolute",
+                    value=1.5 * 1024 * 1024,
+                ),
+                artifact_id=artifact1.id,
+                app_id="com.emergetools.hackernews",
+                platform="iOS",
+                build_configuration_name="Release",
+            ),
+            TriggeredRule(
+                rule=StatusCheckRule(
+                    id="rule-1",
+                    metric="install_size",
+                    measurement="absolute",
+                    value=1.5 * 1024 * 1024,
+                ),
+                artifact_id=artifact2.id,
+                app_id="com.emergetools.hackernews",
+                platform="iOS",
+                build_configuration_name="AdHoc",
+            ),
+        ]
+
+        title, subtitle, summary = format_status_check_messages(
+            [artifact1, artifact2],
+            size_metrics_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+            {},
+            triggered_rules=triggered_rules,
+        )
+
+        # Two separate groups for the same app, different configurations
+        assert "`com.emergetools.hackernews` | Release (iOS)" in summary
+        assert "`com.emergetools.hackernews` | AdHoc (iOS)" in summary
+        assert "<summary>2 Failed Checks</summary>" in summary
+
+    def test_triggered_rule_without_build_configuration_unchanged(self):
+        """Test that None build_configuration renders header same as before."""
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        size_metrics = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+            min_download_size=100 * 1024 * 1024,
+            max_download_size=100 * 1024 * 1024,
+            min_install_size=200 * 1024 * 1024,
+            max_install_size=200 * 1024 * 1024,
+        )
+
+        size_metrics_map = {artifact.id: [size_metrics]}
+
+        triggered_rule = TriggeredRule(
+            rule=StatusCheckRule(
+                id="rule-1",
+                metric="download_size",
+                measurement="absolute",
+                value=50 * 1024 * 1024,
+            ),
+            artifact_id=artifact.id,
+            app_id="com.example.app",
+            platform="Android",
+            build_configuration_name=None,
+        )
+
+        title, subtitle, summary = format_status_check_messages(
+            [artifact],
+            size_metrics_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+            {},
+            triggered_rules=[triggered_rule],
+        )
+
+        # No pipe or config name — same format as before
+        assert "`com.example.app` (Android)" in summary
+        assert " | " not in summary.split("<details>")[1]


### PR DESCRIPTION
## What problems was I solving

Failed checks in GitHub status check summaries were grouped only by bundle ID (`app_id`). When multiple build configurations (Release, AdHoc, etc.) failed the same rule for the same app, users saw duplicate bullet points under a single group with no way to tell which configuration triggered which failure. For example, HackerNews PR #721 showed two identical "Install Size" failures under `com.emergetools.hackernews (iOS)` with no disambiguation.

## What user-facing changes did I ship

The failed checks `<details>` block in GitHub check run summaries now groups by both bundle ID and build configuration. When a build configuration is present, the header includes it after a pipe separator:

**Before:**
```
▼ 2 Failed Checks
com.emergetools.hackernews (iOS)
- Install Size - Total Size ≥ 1.5 MB
- Install Size - Total Size ≥ 1.5 MB
```

**After:**
```
▼ 2 Failed Checks
com.emergetools.hackernews | Release (iOS)
- Install Size - Total Size ≥ 1.5 MB

com.emergetools.hackernews | AdHoc (iOS)
- Install Size - Total Size ≥ 1.5 MB
```

When `build_configuration_name` is `None` (e.g. Android builds), the format is unchanged.

## How to verify it

### Automated Tests
```bash
pytest -svv --reuse-db tests/sentry/preprod/vcs/status_checks/size/test_templates.py -k TriggeredRulesFormattingTest
```

### Manual Testing
- [ ] Verify existing tests pass with `build_configuration_name=None` (backward compatibility)
- [ ] Verify `test_single_triggered_rule_with_build_configuration` — header shows `` `com.example.app` | Release (iOS) ``
- [ ] Verify `test_same_app_different_configurations_grouped_separately` — two separate groups for same app with different configs
- [ ] Verify `test_triggered_rule_without_build_configuration_unchanged` — no pipe in header when config is None

## Description for the changelog

Group failed size check results by bundle ID and build configuration so users can distinguish which configuration (Release, AdHoc, etc.) triggered each failure.
