### PR TITLE
fix(relocation) Remove fixup passes on relocation processing

### DIFF
--- a/fixtures/backup/fresh-install.json
+++ b/fixtures/backup/fresh-install.json
@@ -16,7 +16,7 @@
     "key": "sentry:last_worker_version",
     "last_updated": "2023-06-27T21:40:01.312Z",
     "last_updated_by": "unknown",
-    "value": "\"23.7.0.dev0\""
+    "value": "23.7.0.dev0"
   }
 },
 {
@@ -26,7 +26,7 @@
     "key": "sentry:install-id",
     "last_updated": "2023-06-23T00:03:42.785Z",
     "last_updated_by": "unknown",
-    "value": "\"1bc81f9440424e908a73ca377581cb52682db68a\""
+    "value": "1bc81f9440424e908a73ca377581cb52682db68a"
   }
 },
 {
@@ -36,7 +36,7 @@
     "key": "sentry:latest_version",
     "last_updated": "2023-06-27T21:25:02.602Z",
     "last_updated_by": "unknown",
-    "value": "\"23.6.1\""
+    "value": "23.6.1"
   }
 },
 {
@@ -181,7 +181,7 @@
     "created_at": "2023-06-22T22:59:55.602Z",
     "last_used_at": null,
     "type": 1,
-    "config": "\"\""
+    "config": ""
   }
 },
 {
@@ -192,7 +192,7 @@
     "created_at": "2023-06-22T22:59:56.602Z",
     "last_used_at": null,
     "type": 1,
-    "config": "\"\""
+    "config": ""
   }
 },
 {
@@ -235,7 +235,7 @@
     "date_updated": "2023-06-22T23:00:00.123Z",
     "date_added": "2023-06-22T22:54:27.960Z",
     "name": "Super Admin",
-    "permissions": "['broadcasts.admin', 'users.admin', 'options.admin']"
+    "permissions": ["broadcasts.admin", "users.admin", "options.admin"]
   }
 },
 {
@@ -375,7 +375,7 @@
     "project": 1,
     "environment_id": null,
     "label": "Send a notification for new issues",
-    "data": "{\"match\":\"all\",\"conditions\":[{\"id\":\"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition\"}],\"actions\":[{\"id\":\"sentry.mail.actions.NotifyEmailAction\",\"targetType\":\"IssueOwners\",\"targetIdentifier\":null,\"fallthroughType\":\"ActiveMembers\"}]}",
+    "data": {"match":"all","conditions":[{"id":"sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],"actions":[{"id":"sentry.mail.actions.NotifyEmailAction","targetType":"IssueOwners","targetIdentifier":null,"fallthroughType":"ActiveMembers"}]},
     "status": 0,
     "source": 0,
     "owner": null,
@@ -425,7 +425,7 @@
   "fields": {
     "project": 1,
     "key": "sentry:origins",
-    "value": "[\"*\"]"
+    "value": ["*"]
   }
 },
 {

--- a/fixtures/backup/org-and-project.json
+++ b/fixtures/backup/org-and-project.json
@@ -1,0 +1,64 @@
+[
+{
+  "model": "sentry.organization",
+  "pk": 1,
+  "fields": {
+    "name": "test-org",
+    "slug": "test-org",
+    "status": 0,
+    "date_added": "2023-06-22T22:54:28.773Z",
+    "default_role": "member",
+    "is_test": false,
+    "flags": "1"
+  }
+},
+{
+  "model": "sentry.organizationmember",
+  "pk": 3,
+  "fields": {
+    "organization": 1,
+    "user_id": null,
+    "email": "pending@example.com",
+    "role": "member",
+    "flags": "0",
+    "token": null,
+    "date_added": "2023-06-22T22:59:56.561Z",
+    "token_expires_at": null,
+    "has_global_access": true,
+    "inviter_id": 1,
+    "invite_status": 1,
+    "type": 50,
+    "user_is_active": true,
+    "user_email": null
+  }
+},
+{
+  "model": "sentry.team",
+  "pk": 1,
+  "fields": {
+    "organization": 1,
+    "slug": "devs",
+    "name": "Devs",
+    "status": 0,
+    "actor": 1,
+    "idp_provisioned": false,
+    "date_added": "2023-06-22T22:54:28.821Z"
+  }
+},
+{
+  "model": "sentry.project",
+  "pk": 1,
+  "fields": {
+    "slug": "internal",
+    "name": "Internal",
+    "forced_color": null,
+    "organization": 1,
+    "public": false,
+    "date_added": "2023-06-22T22:54:28.851Z",
+    "status": 0,
+    "first_event": null,
+    "flags": "10",
+    "platform": null
+  }
+}
+]

--- a/fixtures/backup/single-option.json
+++ b/fixtures/backup/single-option.json
@@ -6,7 +6,7 @@
             "key": "sentry:latest_version",
             "last_updated": "2023-06-22T00:00:00.000Z",
             "last_updated_by": "unknown",
-            "value": "\"23.6.1\""
+            "value": "23.6.1"
         }
     }
 ]

--- a/fixtures/backup/user-with-maximum-privileges.json
+++ b/fixtures/backup/user-with-maximum-privileges.json
@@ -40,7 +40,7 @@
             "created_at": "2023-07-27T16:30:53.325Z",
             "last_used_at": null,
             "type": 1,
-            "config": "\"\""
+            "config": ""
         }
     },
     {
@@ -74,7 +74,7 @@
             "project_id": null,
             "organization_id": null,
             "key": "timezone",
-            "value": "\"Europe/Vienna\""
+            "value": "Europe/Vienna"
         }
     },
     {
@@ -92,7 +92,7 @@
             "date_updated": "2023-06-22T23:00:00.123Z",
             "date_added": "2023-06-22T22:54:27.960Z",
             "name": "Super Admin",
-            "permissions": "['broadcasts.admin', 'users.admin', 'options.admin']"
+            "permissions": ["broadcasts.admin", "users.admin", "options.admin"]
         }
     },
     {

--- a/fixtures/backup/user-with-minimum-privileges.json
+++ b/fixtures/backup/user-with-minimum-privileges.json
@@ -40,7 +40,7 @@
             "created_at": "2023-07-27T16:30:53.325Z",
             "last_used_at": null,
             "type": 1,
-            "config": "\"\""
+            "config": ""
         }
     },
     {
@@ -74,7 +74,7 @@
             "project_id": null,
             "organization_id": null,
             "key": "timezone",
-            "value": "\"Europe/Vienna\""
+            "value": "Europe/Vienna"
         }
     }
 ]

--- a/fixtures/backup/user-with-roles-no-superadmin.json
+++ b/fixtures/backup/user-with-roles-no-superadmin.json
@@ -40,7 +40,7 @@
             "created_at": "2023-07-27T16:30:53.325Z",
             "last_used_at": null,
             "type": 1,
-            "config": "\"\""
+            "config": ""
         }
     },
     {
@@ -74,7 +74,7 @@
             "project_id": null,
             "organization_id": null,
             "key": "timezone",
-            "value": "\"Europe/Vienna\""
+            "value": "Europe/Vienna"
         }
     },
     {
@@ -92,7 +92,7 @@
             "date_updated": "2023-06-22T23:00:00.123Z",
             "date_added": "2023-06-22T22:54:27.960Z",
             "name": "Super Admin",
-            "permissions": "['broadcasts.admin', 'users.admin', 'options.admin']"
+            "permissions": ["broadcasts.admin", "users.admin", "options.admin"]
         }
     },
     {

--- a/fixtures/backup/user-with-superadmin-no-roles.json
+++ b/fixtures/backup/user-with-superadmin-no-roles.json
@@ -74,7 +74,7 @@
             "project_id": null,
             "organization_id": null,
             "key": "timezone",
-            "value": "\"Europe/Vienna\""
+            "value": "Europe/Vienna"
         }
     }
 ]

--- a/src/sentry/backup/imports.py
+++ b/src/sentry/backup/imports.py
@@ -26,7 +26,6 @@ from sentry.backup.dependencies import (
 )
 from sentry.backup.helpers import Filter, ImportFlags, Printer
 from sentry.backup.scopes import ImportScope
-from sentry.backup.services.import_export.impl import fixup_array_fields, fixup_json_fields
 from sentry.backup.services.import_export.model import (
     RpcFilter,
     RpcImportError,
@@ -174,11 +173,7 @@ def _import(
     content: bytes | str = (
         decrypt_encrypted_tarball(src, decryptor) if decryptor is not None else src.read()
     )
-
     content = remove_deleted_models_and_fields(content)
-
-    content = fixup_array_fields(content)
-    content = fixup_json_fields(content)
 
     filters = []
     if filter_by is not None:

--- a/src/sentry/backup/services/import_export/impl.py
+++ b/src/sentry/backup/services/import_export/impl.py
@@ -3,20 +3,16 @@
 # in modules such as this one where hybrid cloud data models or service classes are
 # defined, because we want to reflect on type annotations and avoid forward references.
 
-import ast
 import logging
 import traceback
 
 import psycopg2.errors
 import sentry_sdk
-from django.apps import apps
-from django.contrib.postgres.fields.array import ArrayField
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.serializers import deserialize, serialize
 from django.core.serializers.base import DeserializationError
 from django.db import DatabaseError, IntegrityError, connections, models, router, transaction
 from django.db.models import Q
-from django.db.models.fields.json import JSONField
 from django.forms import model_to_dict
 from rest_framework.serializers import ValidationError as DjangoRestFrameworkValidationError
 
@@ -56,7 +52,6 @@ from sentry.silo.base import SiloMode
 from sentry.users.models.user import User
 from sentry.users.models.userpermission import UserPermission
 from sentry.users.models.userrole import UserRoleUser
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -92,49 +87,6 @@ def get_existing_import_chunk(
         min_inserted_pk=found_data["min_inserted_pk"],
         max_inserted_pk=found_data["max_inserted_pk"],
     )
-
-
-def fixup_array_fields[T: (str, str | bytes)](json_data: T) -> T:
-    # preserve for 3 versions as per https://docs.sentry.io/concepts/migration/#version-support-window
-    # so probably 2025.09 this can go away?
-    try:
-        contents = json.loads(json_data)
-    except Exception:  # let the actual import/export produce a better message
-        return json_data
-
-    for dct in contents:
-        model = apps.get_model(dct["model"])
-        for k, v in dct["fields"].items():
-            if isinstance(model._meta.get_field(k), ArrayField) and isinstance(v, str):
-                try:
-                    json.loads(v)
-                except Exception:
-                    # old ArrayField: value was not properly encoded as json
-                    dct["fields"][k] = json.dumps(ast.literal_eval(v))
-                else:
-                    pass
-    return json.dumps(contents)
-
-
-def fixup_json_fields[T: (str, str | bytes)](json_data: T) -> T:
-    # preserve for 3 versions as per https://docs.sentry.io/concepts/migration/#version-support-window
-    # so probably 2025.11 this can go away?
-    try:
-        contents = json.loads(json_data)
-    except Exception:  # let the actual import/export produce a better message
-        return json_data
-
-    for dct in contents:
-        model = apps.get_model(dct["model"])
-        for k, v in dct["fields"].items():
-            if isinstance(model._meta.get_field(k), JSONField) and isinstance(v, str):
-                try:
-                    # old PickledObjectField / JSONField is serialized to a string
-                    dct["fields"][k] = json.loads(v)
-                except ValueError:
-                    pass  # new JSONField already represents data directly rather than encoding
-
-    return json.dumps(contents)
 
 
 class UniversalImportExportService(ImportExportService):
@@ -257,9 +209,6 @@ class UniversalImportExportService(ImportExportService):
                 min_inserted_pk: int | None = None
                 max_inserted_pk: int | None = None
                 last_seen_ordinal = min_ordinal - 1
-
-                json_data = fixup_array_fields(json_data)
-                json_data = fixup_json_fields(json_data)
 
                 for deserialized_object in deserialize(
                     "json", json_data, use_natural_keys=False, ignorenonexistent=True

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -953,6 +953,10 @@ class ExhaustiveFixtures(Fixtures):
     def import_export_then_validate(self, out_name, *, reset_pks: bool = True) -> Any:
         return import_export_then_validate(out_name, reset_pks=reset_pks)
 
+    def json_of_org_and_project(self) -> Any:
+        with open(get_fixture_path("backup", "org-and-project.json")) as backup_file:
+            return json.load(backup_file)
+
     @cached_property
     def _json_of_exhaustive_user_with_maximum_privileges(self) -> Any:
         with open(get_fixture_path("backup", "user-with-maximum-privileges.json")) as backup_file:

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -40,6 +40,7 @@ from sentry.models.importchunk import (
     RegionImportChunk,
 )
 from sentry.models.options.option import ControlOption, Option
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
@@ -643,6 +644,53 @@ class SanitizationTests(ImportTestCase):
 
                 assert err.value.context.get_kind() == RpcImportErrorKind.ValidationError
                 assert err.value.context.on.model == "sentry.useroption"
+
+    def test_org_and_project_option_type_preserve(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir).joinpath(f"{self._testMethodName}.json")
+            with open(tmp_path, "wb+") as tmp_file:
+                models = self.json_of_org_and_project()
+
+                # Add project options with several types that should be preserved
+                option_values = (
+                    ("filters:browser-extension", "1"),
+                    ("filters:legacy-browser", ["ie", "edge"]),
+                    ("string-list", '["a","b"]'),
+                    ("str-dict-val", '{"k":"v"}'),
+                    ("dict-val", {"k": "v"}),
+                )
+                for key, value in option_values:
+                    models.append(
+                        {
+                            "model": "sentry.projectoption",
+                            "pk": 3,
+                            "fields": {
+                                "project": 1,
+                                "key": key,
+                                "value": value,
+                            },
+                        }
+                    )
+
+                # Also check organization options
+                for key, value in option_values:
+                    models.append(
+                        {
+                            "model": "sentry.organizationoption",
+                            "pk": 2,
+                            "fields": {"organization": 1, "key": key, "value": value},
+                        }
+                    )
+
+                tmp_file.write(orjson.dumps(self.sort_in_memory_json(models)))
+
+            with open(tmp_path, "rb") as tmp_file:
+                import_in_organization_scope(tmp_file, printer=NOOP_PRINTER)
+
+        # Ensure that values come back out with the correct type.
+        for key, value in option_values:
+            assert ProjectOption.objects.get(key=key).value == value
+            assert OrganizationOption.objects.get(key=key).value == value
 
 
 class SignalingTests(ImportTestCase):

--- a/tests/sentry/backup/test_imports.py
+++ b/tests/sentry/backup/test_imports.py
@@ -653,8 +653,10 @@ class SanitizationTests(ImportTestCase):
 
                 # Add project options with several types that should be preserved
                 option_values = (
-                    ("filters:browser-extension", "1"),
-                    ("filters:legacy-browser", ["ie", "edge"]),
+                    ("bool-val", True),
+                    ("int-val", 0),
+                    ("str-int", "1"),
+                    ("list-val", ["ie", "edge"]),
                     ("string-list", '["a","b"]'),
                     ("str-dict-val", '{"k":"v"}'),
                     ("dict-val", {"k": "v"}),

--- a/tests/sentry/backup/test_rpc.py
+++ b/tests/sentry/backup/test_rpc.py
@@ -12,11 +12,7 @@ from django.db import models
 from sentry.backup.dependencies import NormalizedModelName, get_model_name
 from sentry.backup.helpers import ImportFlags
 from sentry.backup.services.import_export import import_export_service
-from sentry.backup.services.import_export.impl import (
-    fixup_array_fields,
-    fixup_json_fields,
-    get_existing_import_chunk,
-)
+from sentry.backup.services.import_export.impl import get_existing_import_chunk
 from sentry.backup.services.import_export.model import (
     RpcExportError,
     RpcExportErrorKind,
@@ -505,15 +501,3 @@ class RpcExportErrorTests(TestCase):
 
         assert isinstance(result, RpcExportError)
         assert result.get_kind() == RpcExportErrorKind.UnspecifiedScope
-
-
-def test_fixup_array_fields() -> None:
-    before = '[{"model":"sentry.dashboardwidgetquery","fields":{"aggregates":"[\'a\',\'b\']"}}]'
-    expect = '[{"model":"sentry.dashboardwidgetquery","fields":{"aggregates":"[\\"a\\",\\"b\\"]"}}]'
-    assert fixup_array_fields(before) == expect
-
-
-def test_fixup_json_fields() -> None:
-    before = r'[{"model":"sentry.releaseactivity","fields":{"data":"\"double\""}}]'
-    expect = r'[{"model":"sentry.releaseactivity","fields":{"data":"double"}}]'
-    assert fixup_json_fields(before) == expect


### PR DESCRIPTION
Backups dumps made with recent releases no longer include string wrapped values. The double parsing was causing string ints to have their types changed and values to int.
