### PR TITLE
ref(performance): Remove performance-otel-friendly-ui feature flag definition

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -327,8 +327,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-transaction-summary-cleanup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the EAP-powered transactions summary view
     manager.add("organizations:performance-transaction-summary-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable OTel-friendly UI. Updates copy and small UI elements to align closer with OTel definitions and concepts
-    manager.add("organizations:performance-otel-friendly-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the new UI for span summary and the spans tab
     manager.add("organizations:performance-spans-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:performance-use-metrics", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)


### PR DESCRIPTION
Remove the `performance-otel-friendly-ui` feature flag definition from `temporary.py`.

References to it were removed in https://github.com/getsentry/sentry/pull/108369 and the flagpole config was removed in https://github.com/getsentry/sentry-options-automator/pull/6496.