### PR TITLE
feat(uptime): Add AI-powered assertion suggestions backend

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -608,6 +608,9 @@ from sentry.uptime.endpoints.organization_uptime_alert_index_count import (
 from sentry.uptime.endpoints.organization_uptime_alert_preview_check import (
     OrganizationUptimeAlertPreviewCheckEndpoint,
 )
+from sentry.uptime.endpoints.organization_uptime_assertion_suggestions import (
+    OrganizationUptimeAssertionSuggestionsEndpoint,
+)
 from sentry.uptime.endpoints.organization_uptime_stats import OrganizationUptimeStatsEndpoint
 from sentry.uptime.endpoints.organization_uptime_summary import OrganizationUptimeSummaryEndpoint
 from sentry.uptime.endpoints.project_uptime_alert_checks_index import (
@@ -2648,6 +2651,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/uptime-preview-check/$",
         OrganizationUptimeAlertPreviewCheckEndpoint.as_view(),
         name="sentry-api-0-organization-uptime-alert-preview-check",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/uptime-assertion-suggestions/$",
+        OrganizationUptimeAssertionSuggestionsEndpoint.as_view(),
+        name="sentry-api-0-organization-uptime-assertion-suggestions",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/uptime-count/$",

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -1,0 +1,171 @@
+"""
+API endpoint for generating assertion suggestions using Seer.
+
+This endpoint runs a preview check and uses Seer to analyze the response
+and suggest assertions that would be useful for monitoring the endpoint.
+"""
+
+import logging
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_SUCCESS,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import GlobalParams
+from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.seer_setup import has_seer_access
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.uptime import checker_api
+from sentry.uptime.endpoints.validators import UptimeCheckPreviewValidator
+from sentry.uptime.seer_assertions import (
+    generate_assertion_suggestions,
+    suggestion_to_assertion_json,
+    suggestions_to_combined_assertion,
+)
+from sentry.uptime.subscriptions.regions import get_region_config
+from sentry.uptime.types import CheckConfig
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
+    """
+    Endpoint to generate assertion suggestions for an uptime monitor.
+
+    This runs a preview check against the specified URL and uses Seer AI
+    to analyze the response and suggest useful assertions.
+    """
+
+    owner = ApiOwner.CRONS
+    permission_classes = (OrganizationAlertRulePermission,)
+
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                # More restrictive rate limits since this calls Seer
+                RateLimitCategory.USER: RateLimit(limit=1, window=5, concurrent_limit=2),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=10, window=60, concurrent_limit=5),
+            },
+        }
+    )
+
+    @extend_schema(
+        operation_id="Generate assertion suggestions for an uptime monitor",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+        ],
+        responses={
+            200: RESPONSE_SUCCESS,
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(
+        self,
+        request: Request,
+        organization: Organization,
+    ) -> Response:
+        # Check if AI features are enabled (includes gen-ai-features flag + hide_ai_features opt-out)
+        if not has_seer_access(organization, actor=request.user):
+            return self.respond(
+                {"detail": "AI features are not enabled for this organization"},
+                status=403,
+            )
+
+        # Check if assertions are enabled
+        assertions_enabled = features.has(
+            "organizations:uptime-runtime-assertions", organization, actor=request.user
+        )
+        if not assertions_enabled:
+            return self.respond(
+                {"detail": "Uptime assertions are not enabled for this organization"},
+                status=403,
+            )
+
+        # Validate the request
+        validator = UptimeCheckPreviewValidator(
+            data=request.data, context={"organization": organization, "request": request}
+        )
+        if not validator.is_valid():
+            return self.respond(validator.errors, status=400)
+
+        check_config: CheckConfig = validator.save()
+
+        # Get region config
+        region = get_region_config(check_config["active_regions"][0])
+        if region is None:
+            return self.respond({"detail": "No uptime region configured"}, status=400)
+
+        # Run the preview check
+        result = checker_api.invoke_checker_preview(assertions_enabled, check_config, region)
+
+        if result is None:
+            return self.respond(
+                {"detail": "Failed to execute preview check"},
+                status=400,
+            )
+
+        if result.status_code >= 400 and result.status_code < 500:
+            return self.respond(result.json(), status=result.status_code)
+
+        result.raise_for_status()
+        preview_result = result.json()
+
+        # Generate suggestions using Seer
+        try:
+            suggestions, debug_info = generate_assertion_suggestions(
+                organization, request.user, preview_result
+            )
+            if debug_info:
+                logger.error("Seer suggestion generation issue: %s", debug_info)
+        except Exception:
+            logger.exception("Error generating assertion suggestions")
+            suggestions = None
+
+        # Build response
+        response_data = {
+            "preview_result": preview_result,
+            "suggestions": None,
+            "suggested_assertion": None,
+        }
+
+        if suggestions and suggestions.suggestions:
+            response_data["suggestions"] = [
+                {
+                    "assertion_type": s.assertion_type,
+                    "comparison": s.comparison,
+                    "expected_value": s.expected_value,
+                    "json_path": s.json_path,
+                    "header_name": s.header_name,
+                    "confidence": s.confidence,
+                    "explanation": s.explanation,
+                    "assertion_json": suggestion_to_assertion_json(s),
+                }
+                for s in suggestions.suggestions
+            ]
+            # Also provide a combined assertion that includes all suggestions
+            response_data["suggested_assertion"] = suggestions_to_combined_assertion(
+                suggestions.suggestions
+            )
+
+        return self.respond(response_data)

--- a/src/sentry/uptime/seer_assertions.py
+++ b/src/sentry/uptime/seer_assertions.py
@@ -1,0 +1,369 @@
+"""
+Seer-powered assertion suggestions for uptime monitoring.
+
+This module uses Seer's LLM proxy to generate assertion suggestions
+based on HTTP response data from uptime preview checks.
+"""
+
+import base64
+import logging
+from typing import Any
+
+import orjson
+import requests
+from django.conf import settings
+from pydantic import BaseModel, Field
+
+from sentry.models.organization import Organization
+from sentry.seer.seer_setup import has_seer_access
+from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.users.models.user import User
+from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+# JSON schema for structured LLM response
+ASSERTION_SUGGESTIONS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "suggestions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "assertion_type": {
+                        "type": "string",
+                        "description": "Type of assertion: 'status_code', 'json_path', or 'header'",
+                    },
+                    "comparison": {
+                        "type": "string",
+                        "description": "Comparison operator: 'equals', 'not_equal', 'less_than', 'greater_than', or 'always' (for existence checks)",
+                    },
+                    "expected_value": {
+                        "type": "string",
+                        "description": "The expected value as a string. For 'always' comparison (existence checks), use empty string.",
+                    },
+                    "json_path": {
+                        "type": "string",
+                        "description": "JSONPath expression (for json_path assertions), e.g. '$.status', '$.data.count'",
+                    },
+                    "header_name": {
+                        "type": "string",
+                        "description": "Header name (for header assertions)",
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "description": "Confidence score from 0.0 to 1.0",
+                    },
+                    "explanation": {
+                        "type": "string",
+                        "description": "Why this assertion is useful for detecting problems",
+                    },
+                },
+                "required": [
+                    "assertion_type",
+                    "comparison",
+                    "expected_value",
+                    "confidence",
+                    "explanation",
+                ],
+            },
+        }
+    },
+    "required": ["suggestions"],
+}
+
+SYSTEM_PROMPT = """You are an expert at analyzing HTTP responses and suggesting monitoring assertions \
+for an uptime checker. Given an HTTP response, suggest assertions that detect when the endpoint \
+is unhealthy or behaving incorrectly.
+
+## Assertion Types
+
+### status_code
+Check the HTTP status code.
+- comparison: "equals", expected_value: "200"
+
+### json_path
+Check values in a JSON response body using JSONPath expressions. You can:
+- **Check a value equals something**: comparison="equals", json_path="$.status", expected_value="healthy"
+- **Check a numeric value**: comparison="greater_than", json_path="$.data.count", expected_value="0"
+- **Check a key exists**: comparison="always", json_path="$.data.items", expected_value=""
+
+### header
+Check HTTP response headers.
+- comparison: "equals", header_name: "content-type", expected_value: "application/json"
+
+## Comparison Operators
+- "equals": Value must equal expected_value exactly (with type coercion for numbers)
+- "not_equal": Value must NOT equal expected_value
+- "less_than": Numeric less-than comparison
+- "greater_than": Numeric greater-than comparison
+- "always": Check that the path/key exists (no value comparison, use expected_value="")
+
+## Guidelines
+1. Always suggest a status_code assertion checking for the observed status code
+2. For JSON bodies, STRONGLY PREFER value equality checks ("equals") over existence checks ("always"). \
+If a field has a concrete value like a string or number, assert on that value.
+3. Use existence checks ("always") for fields whose values are expected to change between requests \
+(timestamps, request IDs, etc.) but whose presence is important
+4. For boolean fields (true/false), use existence checks ("always") since the assertion system \
+compares values as strings and cannot match JSON booleans directly
+5. For numeric fields, consider whether equality or a threshold (greater_than/less_than) is more appropriate
+6. Only suggest header assertions for headers meaningful for monitoring (content-type, cache-control, etc.)
+7. Use standard JSONPath syntax: $.field, $.nested.field, $[0].field, $.array[*].field
+8. Suggest 3-6 practical assertions total, prioritizing value checks over existence checks
+9. The confidence score (0.0-1.0) should represent the likelihood that this assertion will remain \
+true across repeated checks of the same URL without producing false positives. Score higher for \
+assertions checking stable values (status codes, constant fields) and lower for assertions on \
+values that may change between requests (timestamps, random IDs)."""
+
+
+# Pydantic models for Seer artifact schema
+class SuggestedAssertion(BaseModel):
+    """A single assertion suggestion from Seer."""
+
+    assertion_type: str = Field(
+        description="Type of assertion: 'status_code', 'json_path', or 'header'"
+    )
+    comparison: str = Field(
+        description="Comparison operator: 'equals', 'not_equal', 'less_than', 'greater_than', or 'always' (existence check)"
+    )
+    expected_value: str = Field(description="The expected value as a string")
+    json_path: str | None = Field(
+        default=None, description="JSONPath expression (for json_path assertions)"
+    )
+    header_name: str | None = Field(default=None, description="Header name (for header assertions)")
+    confidence: float = Field(description="Confidence score from 0.0 to 1.0")
+    explanation: str = Field(description="Why this assertion is useful")
+
+
+class AssertionSuggestions(BaseModel):
+    """Collection of assertion suggestions from Seer."""
+
+    suggestions: list[SuggestedAssertion]
+
+
+def parse_preview_response(preview_result: dict[str, Any]) -> dict[str, Any]:
+    """
+    Parse the preview check result into a format suitable for Seer.
+
+    Args:
+        preview_result: The JSON response from the uptime preview check endpoint
+
+    Returns:
+        Parsed response data with decoded body
+    """
+    check_result = preview_result.get("check_result", {})
+    request_info = check_result.get("request_info", {})
+
+    # Decode base64 response body if present
+    response_body = None
+    if request_info.get("response_body"):
+        try:
+            decoded = base64.b64decode(request_info["response_body"])
+            # Try to parse as JSON
+            try:
+                response_body = json.loads(decoded)
+            except json.JSONDecodeError:
+                # Not JSON, use as string
+                response_body = decoded.decode("utf-8", errors="replace")
+        except Exception as e:
+            logger.warning("Failed to decode response body: %s", e)
+
+    return {
+        "status_code": request_info.get("http_status_code"),
+        "response_time_ms": check_result.get("duration_ms"),
+        "headers": dict(request_info.get("response_headers", []) or []),
+        "body": response_body,
+    }
+
+
+def build_assertion_prompt(response_data: dict[str, Any]) -> str:
+    """
+    Build the prompt for Seer to generate assertion suggestions.
+
+    Args:
+        response_data: Parsed HTTP response data
+
+    Returns:
+        Prompt string for Seer
+    """
+    return f"""Analyze this HTTP response and suggest monitoring assertions:
+
+HTTP Response:
+- Status Code: {response_data.get("status_code")}
+- Response Time: {response_data.get("response_time_ms")}ms
+- Headers: {json.dumps(response_data.get("headers", {}), indent=2)}
+- Body: {json.dumps(response_data.get("body"), indent=2) if response_data.get("body") else "N/A"}"""
+
+
+def suggestion_to_assertion_json(suggestion: SuggestedAssertion) -> dict[str, Any]:
+    """
+    Convert a Seer suggestion to the uptime checker assertion JSON format.
+
+    Args:
+        suggestion: A SuggestedAssertion from Seer
+
+    Returns:
+        Assertion in the uptime checker JSON format
+    """
+    valid_comparisons = {"equals", "not_equal", "less_than", "greater_than", "always", "never"}
+    cmp = suggestion.comparison if suggestion.comparison in valid_comparisons else "equals"
+
+    if suggestion.assertion_type == "status_code":
+        try:
+            int_value = int(suggestion.expected_value)
+        except (ValueError, TypeError):
+            int_value = 200
+        return {
+            "op": "status_code_check",
+            "value": int_value,
+            "operator": {"cmp": cmp},
+        }
+    elif suggestion.assertion_type == "json_path":
+        # Boolean values can't be compared as strings by the uptime checker,
+        # so fall back to an existence check for boolean fields.
+        if cmp == "always" or suggestion.expected_value.lower() in ("true", "false"):
+            return {
+                "op": "json_path",
+                "value": suggestion.json_path or "$",
+                "operator": {"cmp": "always"},
+                "operand": {"jsonpath_op": "none"},
+            }
+        return {
+            "op": "json_path",
+            "value": suggestion.json_path or "$",
+            "operator": {"cmp": cmp},
+            "operand": {"jsonpath_op": "literal", "value": suggestion.expected_value},
+        }
+    elif suggestion.assertion_type == "header":
+        # "always" on a header means check the header exists with any value
+        if cmp == "always":
+            return {
+                "op": "header_check",
+                "key_op": {"cmp": "equals"},
+                "key_operand": {"header_op": "literal", "value": suggestion.header_name or ""},
+                "value_op": {"cmp": "always"},
+                "value_operand": {"header_op": "none"},
+            }
+        return {
+            "op": "header_check",
+            "key_op": {"cmp": "equals"},
+            "key_operand": {"header_op": "literal", "value": suggestion.header_name or ""},
+            "value_op": {"cmp": cmp},
+            "value_operand": {"header_op": "literal", "value": suggestion.expected_value},
+        }
+    else:
+        return {
+            "op": "status_code_check",
+            "value": 200,
+            "operator": {"cmp": "equals"},
+        }
+
+
+def suggestions_to_combined_assertion(
+    suggestions: list[SuggestedAssertion],
+) -> dict[str, Any]:
+    """
+    Convert multiple suggestions into a combined assertion with AND logic.
+
+    Args:
+        suggestions: List of SuggestedAssertion objects
+
+    Returns:
+        Combined assertion JSON with all suggestions ANDed together
+    """
+    if not suggestions:
+        return {"root": {"op": "status_code_check", "value": 200, "operator": {"cmp": "equals"}}}
+
+    if len(suggestions) == 1:
+        return {"root": suggestion_to_assertion_json(suggestions[0])}
+
+    return {
+        "root": {
+            "op": "and",
+            "children": [suggestion_to_assertion_json(s) for s in suggestions],
+        }
+    }
+
+
+def generate_assertion_suggestions(
+    organization: Organization,
+    user: User,
+    preview_result: dict[str, Any],
+) -> tuple[AssertionSuggestions | None, str | None]:
+    """
+    Generate assertion suggestions using Seer's LLM proxy based on preview check results.
+
+    Args:
+        organization: The organization making the request
+        user: The user making the request
+        preview_result: The JSON response from the uptime preview check
+
+    Returns:
+        Tuple of (AssertionSuggestions or None, debug_info string or None)
+    """
+    # Check Seer access (gen-ai-features flag + hide_ai_features org opt-out)
+    if not has_seer_access(organization, actor=user):
+        logger.info("Seer access not available for organization %s", organization.slug)
+        return None, "Seer access not available for organization"
+
+    # Parse the preview response
+    response_data = parse_preview_response(preview_result)
+    logger.info("Parsed response data: %s", response_data)
+
+    if not response_data.get("status_code"):
+        logger.warning("No status code in preview result, skipping Seer suggestions")
+        return None, f"No status_code in parsed response. Got: {response_data}"
+
+    # Build the prompt
+    prompt = build_assertion_prompt(response_data)
+    logger.info("Built prompt for Seer LLM proxy (length=%d)", len(prompt))
+
+    # Call Seer's LLM proxy endpoint
+    # Note: Using Gemini for structured output support (response_schema).
+    # Anthropic models don't support structured output in Seer's LLM proxy.
+    body = orjson.dumps(
+        {
+            "provider": "gemini",
+            "model": "flash",
+            "referrer": "sentry.uptime.assertion-suggestions",
+            "prompt": prompt,
+            "system_prompt": SYSTEM_PROMPT,
+            "temperature": 0.3,
+            "max_tokens": 1500,
+            "response_schema": ASSERTION_SUGGESTIONS_SCHEMA,
+        }
+    )
+
+    try:
+        response = requests.post(
+            f"{settings.SEER_AUTOFIX_URL}/v1/llm/generate",
+            data=body,
+            headers={
+                "content-type": "application/json;charset=utf-8",
+                **sign_with_seer_secret(body),
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.exception("Failed to call Seer LLM proxy")
+        return None, f"Seer LLM proxy request failed: {e}"
+
+    try:
+        data = response.json()
+        content = data.get("content")
+        if not content:
+            logger.warning("Empty content from Seer LLM proxy")
+            return None, "Seer LLM proxy returned empty content"
+
+        # Parse the structured JSON response
+        suggestions_data = json.loads(content)
+        suggestions = AssertionSuggestions.parse_obj(suggestions_data)
+
+        logger.info("Got %d suggestions from Seer LLM proxy", len(suggestions.suggestions))
+        return suggestions, None
+    except (json.JSONDecodeError, ValueError) as e:
+        logger.exception("Failed to parse Seer LLM proxy response")
+        return None, f"Failed to parse Seer response: {e}"

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -578,6 +578,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/traces/'
   | '/organizations/$organizationIdOrSlug/unsubscribe/issue/$id/'
   | '/organizations/$organizationIdOrSlug/unsubscribe/project/$id/'
+  | '/organizations/$organizationIdOrSlug/uptime-assertion-suggestions/'
   | '/organizations/$organizationIdOrSlug/uptime-count/'
   | '/organizations/$organizationIdOrSlug/uptime-preview-check/'
   | '/organizations/$organizationIdOrSlug/uptime-stats/'

--- a/tests/sentry/uptime/test_seer_assertions.py
+++ b/tests/sentry/uptime/test_seer_assertions.py
@@ -1,0 +1,401 @@
+import base64
+from unittest.mock import patch
+
+from sentry.testutils.cases import TestCase
+from sentry.uptime.seer_assertions import (
+    SuggestedAssertion,
+    build_assertion_prompt,
+    generate_assertion_suggestions,
+    parse_preview_response,
+    suggestion_to_assertion_json,
+    suggestions_to_combined_assertion,
+)
+
+
+class ParsePreviewResponseTest(TestCase):
+    def test_basic_json_body(self):
+        body_bytes = b'{"status": "ok", "count": 42}'
+        encoded = base64.b64encode(body_bytes).decode()
+
+        preview_result = {
+            "check_result": {
+                "duration_ms": 150,
+                "request_info": {
+                    "http_status_code": 200,
+                    "response_body": encoded,
+                    "response_headers": [
+                        ["content-type", "application/json"],
+                    ],
+                },
+            }
+        }
+
+        result = parse_preview_response(preview_result)
+
+        assert result["status_code"] == 200
+        assert result["response_time_ms"] == 150
+        assert result["headers"] == {"content-type": "application/json"}
+        assert result["body"] == {"status": "ok", "count": 42}
+
+    def test_non_json_body(self):
+        body_bytes = b"<html>Hello</html>"
+        encoded = base64.b64encode(body_bytes).decode()
+
+        preview_result = {
+            "check_result": {
+                "duration_ms": 80,
+                "request_info": {
+                    "http_status_code": 200,
+                    "response_body": encoded,
+                    "response_headers": [],
+                },
+            }
+        }
+
+        result = parse_preview_response(preview_result)
+
+        assert result["body"] == "<html>Hello</html>"
+
+    def test_empty_body(self):
+        preview_result = {
+            "check_result": {
+                "duration_ms": 100,
+                "request_info": {
+                    "http_status_code": 204,
+                    "response_body": None,
+                    "response_headers": [],
+                },
+            }
+        }
+
+        result = parse_preview_response(preview_result)
+
+        assert result["body"] is None
+        assert result["status_code"] == 204
+
+    def test_empty_preview_result(self):
+        result = parse_preview_response({})
+
+        assert result["status_code"] is None
+        assert result["body"] is None
+        assert result["headers"] == {}
+
+
+class BuildAssertionPromptTest(TestCase):
+    def test_includes_response_data(self):
+        response_data = {
+            "status_code": 200,
+            "response_time_ms": 150,
+            "headers": {"content-type": "application/json"},
+            "body": {"status": "ok"},
+        }
+
+        prompt = build_assertion_prompt(response_data)
+
+        assert "200" in prompt
+        assert "150" in prompt
+        assert "content-type" in prompt
+        assert "ok" in prompt
+
+
+class SuggestionToAssertionJsonTest(TestCase):
+    def test_status_code(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="status_code",
+            comparison="equals",
+            expected_value="200",
+            confidence=0.95,
+            explanation="Status code should be 200",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "status_code_check",
+            "value": 200,
+            "operator": {"cmp": "equals"},
+        }
+
+    def test_json_path_equals(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="json_path",
+            comparison="equals",
+            expected_value="ok",
+            json_path="$.status",
+            confidence=0.9,
+            explanation="Status should be ok",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "json_path",
+            "value": "$.status",
+            "operator": {"cmp": "equals"},
+            "operand": {"jsonpath_op": "literal", "value": "ok"},
+        }
+
+    def test_json_path_always(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="json_path",
+            comparison="always",
+            expected_value="",
+            json_path="$.data",
+            confidence=0.8,
+            explanation="Data should exist",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "json_path",
+            "value": "$.data",
+            "operator": {"cmp": "always"},
+            "operand": {"jsonpath_op": "none"},
+        }
+
+    def test_header_equals(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="header",
+            comparison="equals",
+            expected_value="application/json",
+            header_name="content-type",
+            confidence=0.85,
+            explanation="Content type should be JSON",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "header_check",
+            "key_op": {"cmp": "equals"},
+            "key_operand": {"header_op": "literal", "value": "content-type"},
+            "value_op": {"cmp": "equals"},
+            "value_operand": {"header_op": "literal", "value": "application/json"},
+        }
+
+    def test_header_always(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="header",
+            comparison="always",
+            expected_value="",
+            header_name="x-request-id",
+            confidence=0.7,
+            explanation="Request ID header should exist",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "header_check",
+            "key_op": {"cmp": "equals"},
+            "key_operand": {"header_op": "literal", "value": "x-request-id"},
+            "value_op": {"cmp": "always"},
+            "value_operand": {"header_op": "none"},
+        }
+
+    def test_invalid_comparison_falls_back_to_equals(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="status_code",
+            comparison="invalid_op",
+            expected_value="200",
+            confidence=0.5,
+            explanation="test",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result["operator"]["cmp"] == "equals"
+
+    def test_unknown_type_falls_back_to_status_code(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="unknown",
+            comparison="equals",
+            expected_value="200",
+            confidence=0.5,
+            explanation="test",
+        )
+
+        result = suggestion_to_assertion_json(suggestion)
+
+        assert result == {
+            "op": "status_code_check",
+            "value": 200,
+            "operator": {"cmp": "equals"},
+        }
+
+
+class SuggestionsToCombinedAssertionTest(TestCase):
+    def test_empty_suggestions(self):
+        result = suggestions_to_combined_assertion([])
+
+        assert result == {
+            "root": {"op": "status_code_check", "value": 200, "operator": {"cmp": "equals"}}
+        }
+
+    def test_single_suggestion(self):
+        suggestion = SuggestedAssertion(
+            assertion_type="status_code",
+            comparison="equals",
+            expected_value="200",
+            confidence=0.95,
+            explanation="test",
+        )
+
+        result = suggestions_to_combined_assertion([suggestion])
+
+        assert result == {
+            "root": {
+                "op": "status_code_check",
+                "value": 200,
+                "operator": {"cmp": "equals"},
+            }
+        }
+
+    def test_multiple_suggestions(self):
+        suggestions = [
+            SuggestedAssertion(
+                assertion_type="status_code",
+                comparison="equals",
+                expected_value="200",
+                confidence=0.95,
+                explanation="test",
+            ),
+            SuggestedAssertion(
+                assertion_type="json_path",
+                comparison="equals",
+                expected_value="ok",
+                json_path="$.status",
+                confidence=0.9,
+                explanation="test",
+            ),
+        ]
+
+        result = suggestions_to_combined_assertion(suggestions)
+
+        assert result["root"]["op"] == "and"
+        assert len(result["root"]["children"]) == 2
+        assert result["root"]["children"][0]["op"] == "status_code_check"
+        assert result["root"]["children"][1]["op"] == "json_path"
+
+
+class GenerateAssertionSuggestionsTest(TestCase):
+    def test_feature_flag_disabled(self):
+        with self.feature({"organizations:gen-ai-features": False}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                {"check_result": {"request_info": {"http_status_code": 200}}},
+            )
+
+        assert suggestions is None
+        assert "not available" in debug
+
+    def test_hide_ai_features_opt_out(self):
+        self.organization.update_option("sentry:hide_ai_features", True)
+
+        with self.feature({"organizations:gen-ai-features": True}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                {"check_result": {"request_info": {"http_status_code": 200}}},
+            )
+
+        assert suggestions is None
+        assert "not available" in debug
+
+    def test_no_status_code(self):
+        with self.feature({"organizations:gen-ai-features": True}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                {"check_result": {"request_info": {}}},
+            )
+
+        assert suggestions is None
+        assert "No status_code" in debug
+
+    @patch("sentry.uptime.seer_assertions.requests.post")
+    def test_seer_request_failure(self, mock_post):
+        import requests
+
+        mock_post.side_effect = requests.RequestException("Connection failed")
+
+        preview_result = {
+            "check_result": {
+                "duration_ms": 100,
+                "request_info": {
+                    "http_status_code": 200,
+                    "response_body": None,
+                    "response_headers": [],
+                },
+            }
+        }
+
+        with self.feature({"organizations:gen-ai-features": True}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                preview_result,
+            )
+
+        assert suggestions is None
+        assert "request failed" in debug
+
+    @patch("sentry.uptime.seer_assertions.requests.post")
+    def test_successful_generation(self, mock_post):
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "content": '{"suggestions": [{"assertion_type": "status_code", "comparison": "equals", "expected_value": "200", "confidence": 0.95, "explanation": "test"}]}'
+        }
+
+        preview_result = {
+            "check_result": {
+                "duration_ms": 100,
+                "request_info": {
+                    "http_status_code": 200,
+                    "response_body": None,
+                    "response_headers": [],
+                },
+            }
+        }
+
+        with self.feature({"organizations:gen-ai-features": True}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                preview_result,
+            )
+
+        assert suggestions is not None
+        assert len(suggestions.suggestions) == 1
+        assert suggestions.suggestions[0].assertion_type == "status_code"
+        assert debug is None
+
+    @patch("sentry.uptime.seer_assertions.requests.post")
+    def test_empty_seer_content(self, mock_post):
+        mock_response = mock_post.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"content": ""}
+
+        preview_result = {
+            "check_result": {
+                "duration_ms": 100,
+                "request_info": {
+                    "http_status_code": 200,
+                    "response_body": None,
+                    "response_headers": [],
+                },
+            }
+        }
+
+        with self.feature({"organizations:gen-ai-features": True}):
+            suggestions, debug = generate_assertion_suggestions(
+                self.organization,
+                self.user,
+                preview_result,
+            )
+
+        assert suggestions is None
+        assert "empty content" in debug


### PR DESCRIPTION
## Summary
- Adds a new API endpoint `POST /api/0/organizations/{org}/uptime-assertion-suggestions/` that runs a preview check and uses Seer's LLM proxy to analyze the HTTP response and suggest useful monitoring assertions
- Introduces `seer_assertions.py` module with prompt engineering, structured output parsing (via Gemini), and conversion logic to translate AI suggestions into the uptime checker's assertion JSON format
- Gates the endpoint behind `gen-ai-features` + `uptime-runtime-assertions` flags and respects `hide_ai_features` organization opt-out via `has_seer_access()`
- Includes rate limiting (1 req/5s per user, 10 req/60s per org) since each call hits both the uptime checker and Seer

### New files
- `src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py` — API endpoint
- `src/sentry/uptime/seer_assertions.py` — Seer integration, prompt, parsing, assertion conversion
- `tests/sentry/uptime/test_seer_assertions.py` — unit tests for parsing, prompting, and conversion logic

## Test plan
- [ ] Unit tests pass: `pytest tests/sentry/uptime/test_seer_assertions.py`
- [ ] Endpoint integration: verify 403 when flags disabled, 200 with valid preview check data
- [ ] Verify rate limiting behaves correctly
- [ ] Confirm `hide_ai_features` org option blocks access even when flags are enabled

Depends on: #108178 (feature flag registration, already merged)