### PR TITLE
fix(relocation) Align max upload size with nginx limits

### DIFF
--- a/static/gsAdmin/views/relocationCreate.tsx
+++ b/static/gsAdmin/views/relocationCreate.tsx
@@ -110,7 +110,7 @@ function RelocationForm() {
           <li>This API has a ratelimit of 1 request per org per day</li>
           <li>Owner must be a single username</li>
           <li>Orgs can be entered as a comma separated list of slugs</li>
-          <li>Uploaded files have a maximum size of 200 MB</li>
+          <li>Uploaded files have a maximum size of 100 MB</li>
           <li>Files must be tar archives (.tar) </li>
         </ul>
         <CompactSelect


### PR DESCRIPTION
Update the max size of relocation tar files to align with nginx configuration in saas.

Refs INFRENG-270
Refs getsentry/ops#19191