### PR TITLE
fix(seer): Rollback to the single Enable AI Code Review (beta) settings toggle for legacy orgs

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -161,10 +161,10 @@ function useReminderCopywriting() {
     [Steps.SETUP_CODE_REVIEW]: {
       title: t('Start using Seer\u2019s AI Code Review'),
       description: t(
-        'Seer is enabled but Code Review is not configured for any repos. Configure Seer to automatically review PRs and flag potential issues.'
+        'Seer is enabled but Code Review is not configured. Configure Seer to automatically review PRs and flag potential issues.'
       ),
       pathname: hasLegacySeer
-        ? `/settings/${organization.slug}/seer/?tab=repos`
+        ? `/settings/${organization.slug}/#enablePrReviewTestGeneration`
         : `/settings/${organization.slug}/seer/onboarding/`,
     },
     [Steps.SETUP_DEFAULTS]: null,

--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -1,9 +1,7 @@
 import {Fragment} from 'react';
-import {parseAsStringEnum, useQueryState} from 'nuqs';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Stack} from '@sentry/scraps/layout';
-import {TabList, Tabs} from '@sentry/scraps/tabs';
+import {Stack} from '@sentry/scraps/layout';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -15,7 +13,6 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
-import SeerRepoTable from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
 import {SeerAutomationDefault} from 'getsentry/views/seerAutomation/components/seerAutomationDefault';
 import {SeerAutomationProjectList} from 'getsentry/views/seerAutomation/components/seerAutomationProjectList';
 import SeerConnectGitHubBanner from 'getsentry/views/seerAutomation/components/seerConnectGitHubBanner';
@@ -23,11 +20,6 @@ import SeerAutomationSettings from 'getsentry/views/seerAutomation/settings';
 
 export default function SeerAutomation() {
   const organization = useOrganization();
-
-  const [tab, setTab] = useQueryState<'settings' | 'repos'>(
-    'tab',
-    parseAsStringEnum(['settings', 'repos']).withDefault('settings')
-  );
 
   if (showNewSeer(organization)) {
     return <SeerAutomationSettings />;
@@ -63,22 +55,10 @@ export default function SeerAutomation() {
       <NoProjectMessage organization={organization}>
         <Stack gap="lg">
           <SeerConnectGitHubBanner />
-          <Container borderBottom="primary">
-            <Tabs value={tab} onChange={setTab}>
-              <TabList>
-                <TabList.Item key="settings">{t('Settings')}</TabList.Item>
-                <TabList.Item key="repos">{t('Repos')}</TabList.Item>
-              </TabList>
-            </Tabs>
-          </Container>
-          {tab === 'repos' ? <SeerRepoTable /> : null}
-          {tab === 'settings' ? (
-            <Fragment>
-              <SeerAutomationProjectList />
-              <br />
-              <SeerAutomationDefault />
-            </Fragment>
-          ) : null}
+
+          <SeerAutomationProjectList />
+          <br />
+          <SeerAutomationDefault />
         </Stack>
       </NoProjectMessage>
     </Fragment>


### PR DESCRIPTION
This went in as part of https://github.com/getsentry/sentry/pull/106931, now it's out again while there are many legacy orgs.