### PR TITLE
feat(repos): Add the X-Hits response header to /api/0/organizations/$org/repos/

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -103,6 +103,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
             order_by="name",
             on_results=lambda x: serialize(x, request.user, RepositorySerializer(expand=expand)),
             paginator_cls=OffsetPaginator,
+            count_hits=True,
         )
 
     def post(self, request: Request, organization) -> Response:

--- a/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
@@ -26,6 +26,8 @@ class OrganizationRepositoriesListTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
+        assert "X-Hits" in response
+        assert int(response["X-Hits"]) == 1
         assert response.data[0]["id"] == str(repo.id)
         assert response.data[0]["externalSlug"] is None
 
@@ -67,6 +69,8 @@ class OrganizationRepositoriesListTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
+        assert "X-Hits" in response
+        assert int(response["X-Hits"]) == 2
 
         first_row = response.data[0]
         assert first_row["id"] == str(repo1.id)


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/108231