### PR TITLE
Increase product trial extension limit from 90 to 180 days

### DIFF
--- a/static/gsAdmin/components/extendProductTrialAction.spec.tsx
+++ b/static/gsAdmin/components/extendProductTrialAction.spec.tsx
@@ -83,12 +83,12 @@ describe('ExtendProductTrialAction', () => {
     expect(defaultProps.disableConfirmButton).toHaveBeenCalledWith(true);
   });
 
-  it('disables confirm button for values greater than 90', async () => {
+  it('disables confirm button for values greater than 180', async () => {
     render(<ExtendProductTrialAction {...defaultProps} />);
 
     const input = screen.getByDisplayValue('14');
     await userEvent.clear(input);
-    await userEvent.type(input, '91');
+    await userEvent.type(input, '181');
 
     expect(defaultProps.disableConfirmButton).toHaveBeenCalledWith(true);
   });

--- a/static/gsAdmin/components/extendProductTrialAction.tsx
+++ b/static/gsAdmin/components/extendProductTrialAction.tsx
@@ -50,7 +50,7 @@ function ExtendProductTrialAction({
   const handleDaysChange = (value: string) => {
     const days = parseInt(value, 10) || 0;
     setExtendDays(days);
-    disableConfirmButton(days < 1 || days > 90);
+    disableConfirmButton(days < 1 || days > 180);
   };
 
   const currentEndDate = moment.utc(activeProductTrial.endDate);
@@ -76,7 +76,7 @@ function ExtendProductTrialAction({
         }
         name="extendDays"
         min={1}
-        max={90}
+        max={180}
         value={extendDays}
         onChange={handleDaysChange}
       />


### PR DESCRIPTION
## Description

Updates the maximum allowed extension period for product trials from 90 days to 180 days.

### Changes

- Updated the validation logic in `handleDaysChange` to allow values up to 180 days (previously 90)
- Updated the `max` attribute on the days input field to 180
- Updated the corresponding test to verify the new 180-day limit

### Test Plan

Existing unit tests have been updated and will verify that:
- The confirm button is disabled for values greater than 180 days
- The input field respects the new maximum value of 180 days

https://claude.ai/code/session_01Hc3DjZgVnor4NW6ymbBehM