### PR TITLE
feat(cmd-k): Add DSN lookup to both command palettes

### DIFF
--- a/src/sentry/api/endpoints/dsn_lookup.py
+++ b/src/sentry/api/endpoints/dsn_lookup.py
@@ -1,0 +1,72 @@
+from urllib.parse import urlparse
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, region_silo_endpoint
+from sentry.api.permissions import SentryIsAuthenticated
+from sentry.models.organizationmember import OrganizationMember
+from sentry.models.projectkey import ProjectKey
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+@region_silo_endpoint
+class DsnLookupEndpoint(Endpoint):
+    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (SentryIsAuthenticated,)
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.USER: RateLimit(limit=5, window=1),
+            }
+        }
+    )
+
+    def get(self, request: Request) -> Response:
+        dsn = request.GET.get("dsn")
+        if not dsn:
+            return Response({"detail": "Missing required parameter: dsn"}, status=400)
+
+        try:
+            parsed = urlparse(dsn)
+        except Exception:
+            return Response({"detail": "Invalid DSN"}, status=404)
+
+        public_key = parsed.username
+        if not public_key:
+            return Response({"detail": "Invalid DSN"}, status=404)
+
+        try:
+            project_key = ProjectKey.objects.select_related("project__organization").get(
+                public_key=public_key,
+            )
+        except ProjectKey.DoesNotExist:
+            return Response({"detail": "DSN not found"}, status=404)
+
+        organization = project_key.project.organization
+
+        is_member = OrganizationMember.objects.filter(
+            organization_id=organization.id,
+            user_id=request.user.id,
+        ).exists()
+        if not is_member:
+            return Response({"detail": "DSN not found"}, status=404)
+
+        return Response(
+            {
+                "organizationSlug": organization.slug,
+                "projectSlug": project_key.project.slug,
+                "projectId": str(project_key.project.id),
+                "projectName": project_key.project.name,
+                "projectPlatform": project_key.project.platform,
+                "keyLabel": project_key.label,
+                "keyId": str(project_key.id),
+            }
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from django.conf.urls import include
 from django.urls import URLPattern, URLResolver, re_path
 
+from sentry.api.endpoints.dsn_lookup import DsnLookupEndpoint
 from sentry.api.endpoints.organization_ai_conversation_details import (
     OrganizationAIConversationDetailsEndpoint,
 )
@@ -3801,6 +3802,12 @@ urlpatterns = [
         r"^secret-scanning/github/$",
         SecretScanningGitHubEndpoint.as_view(),
         name="sentry-api-0-secret-scanning-github",
+    ),
+    # DSN Lookup
+    re_path(
+        r"^dsn-lookup/$",
+        DsnLookupEndpoint.as_view(),
+        name="sentry-api-0-dsn-lookup",
     ),
     # Catch all
     re_path(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -689,6 +689,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:disable-grace-period", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables CMD+K supercharged (omni search)
     manager.add("organizations:cmd-k-supercharged", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enables DSN lookup in CMD+K palette
+    manager.add("organizations:cmd-k-dsn-lookup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:on-demand-gen-metrics-deprecation-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/static/app/components/commandPalette/types.tsx
+++ b/static/app/components/commandPalette/types.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
-export type CommandPaletteGroupKey = 'navigate' | 'add' | 'help';
+export type CommandPaletteGroupKey = 'search-result' | 'navigate' | 'add' | 'help';
 
 interface CommonCommandPaletteAction {
   display: {

--- a/static/app/components/commandPalette/ui/constants.tsx
+++ b/static/app/components/commandPalette/ui/constants.tsx
@@ -7,6 +7,9 @@ export const COMMAND_PALETTE_GROUP_KEY_CONFIG: Record<
     label: string;
   }
 > = {
+  'search-result': {
+    label: t('Search Results'),
+  },
   navigate: {
     label: t('Go to…'),
   },

--- a/static/app/components/commandPalette/ui/content.tsx
+++ b/static/app/components/commandPalette/ui/content.tsx
@@ -10,10 +10,12 @@ import type {CommandPaletteActionWithKey} from 'sentry/components/commandPalette
 import {COMMAND_PALETTE_GROUP_KEY_CONFIG} from 'sentry/components/commandPalette/ui/constants';
 import {CommandPaletteList} from 'sentry/components/commandPalette/ui/list';
 import {useCommandPaletteState} from 'sentry/components/commandPalette/ui/useCommandPaletteState';
+import {useDsnLookupActions} from 'sentry/components/commandPalette/useDsnLookupActions';
 import {SvgIcon} from 'sentry/icons/svgIcon';
 import {unreachable} from 'sentry/utils/unreachable';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import useOrganization from 'sentry/utils/useOrganization';
 
 type CommandPaletteActionMenuItem = MenuListItemProps & {
   children: CommandPaletteActionMenuItem[];
@@ -41,12 +43,20 @@ function actionToMenuItem(
 export function CommandPaletteContent() {
   const {actions, selectedAction, selectAction, clearSelection, query, setQuery} =
     useCommandPaletteState();
+  const organization = useOrganization({allowNull: true});
+  const hasDsnLookup = organization?.features?.includes('cmd-k-dsn-lookup') ?? false;
+  const dsnLookupActions = useDsnLookupActions(hasDsnLookup ? query : '');
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const mergedActions = useMemo(
+    () => [...dsnLookupActions, ...actions],
+    [dsnLookupActions, actions]
+  );
+
   const groupedMenuItems = useMemo<CommandPaletteActionMenuItem[]>(() => {
     const itemsBySection = new Map<string, CommandPaletteActionMenuItem[]>();
-    for (const action of actions) {
+    for (const action of mergedActions) {
       const sectionLabel = action.groupingKey
         ? (COMMAND_PALETTE_GROUP_KEY_CONFIG[action.groupingKey]?.label ?? '')
         : '';
@@ -65,7 +75,7 @@ export function CommandPaletteContent() {
         };
       })
       .filter(section => section.children.length > 0);
-  }, [actions]);
+  }, [mergedActions]);
 
   const handleSelect = useCallback(
     (action: CommandPaletteActionWithKey) => {
@@ -94,12 +104,12 @@ export function CommandPaletteContent() {
       if (selectionKey === null || selectionKey === undefined) {
         return;
       }
-      const action = actions.find(a => a.key === selectionKey);
+      const action = mergedActions.find(a => a.key === selectionKey);
       if (action) {
         handleSelect(action);
       }
     },
-    [actions, handleSelect]
+    [mergedActions, handleSelect]
   );
 
   // When an action has been selected, clear the query and focus the input

--- a/static/app/components/commandPalette/useDsnLookupActions.spec.tsx
+++ b/static/app/components/commandPalette/useDsnLookupActions.spec.tsx
@@ -1,0 +1,78 @@
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useDsnLookupActions} from 'sentry/components/commandPalette/useDsnLookupActions';
+
+describe('useDsnLookupActions', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('returns actions for a valid DSN', async () => {
+    const dsn = 'https://abc123def456abc123def456abc123de@o1.ingest.sentry.io/123';
+    MockApiClient.addMockResponse({
+      url: '/dsn-lookup/',
+      body: {
+        organizationSlug: 'test-org',
+        projectSlug: 'test-project',
+        projectId: '42',
+        projectName: 'Test Project',
+        projectPlatform: 'javascript',
+        keyLabel: 'Default',
+        keyId: '1',
+      },
+      match: [MockApiClient.matchQuery({dsn})],
+    });
+
+    const {result} = renderHookWithProviders(() => useDsnLookupActions(dsn));
+
+    await waitFor(() => {
+      expect(result.current.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'dsn-lookup-issues',
+          type: 'navigate',
+          to: '/organizations/test-org/issues/?project=42',
+        }),
+        expect.objectContaining({
+          key: 'dsn-lookup-project-settings',
+          type: 'navigate',
+          to: '/settings/test-org/projects/test-project/',
+        }),
+        expect.objectContaining({
+          key: 'dsn-lookup-client-keys',
+          type: 'navigate',
+          to: '/settings/test-org/projects/test-project/keys/',
+        }),
+      ])
+    );
+  });
+
+  it('returns empty array for non-DSN query', () => {
+    const mockApi = MockApiClient.addMockResponse({
+      url: '/dsn-lookup/',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() =>
+      useDsnLookupActions('some random text')
+    );
+
+    expect(result.current).toEqual([]);
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array for empty query', () => {
+    const mockApi = MockApiClient.addMockResponse({
+      url: '/dsn-lookup/',
+      body: {},
+    });
+
+    const {result} = renderHookWithProviders(() => useDsnLookupActions(''));
+
+    expect(result.current).toEqual([]);
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/commandPalette/useDsnLookupActions.tsx
+++ b/static/app/components/commandPalette/useDsnLookupActions.tsx
@@ -1,0 +1,81 @@
+import {useMemo} from 'react';
+
+import type {CommandPaletteActionWithKey} from 'sentry/components/commandPalette/types';
+import {IconIssues, IconList, IconSettings} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+
+const DSN_PATTERN = /^https?:\/\/([a-f0-9]{32})(:[a-f0-9]{32})?@[^/]+\/\d+$/;
+
+interface DsnLookupResponse {
+  keyId: string;
+  keyLabel: string;
+  organizationSlug: string;
+  projectId: string;
+  projectName: string;
+  projectPlatform: string | null;
+  projectSlug: string;
+}
+
+export function useDsnLookupActions(query: string): CommandPaletteActionWithKey[] {
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const isDsn = DSN_PATTERN.test(debouncedQuery);
+
+  const {data} = useApiQuery<DsnLookupResponse>(
+    [`/dsn-lookup/`, {query: {dsn: debouncedQuery}}],
+    {
+      staleTime: 30_000,
+      enabled: isDsn,
+    }
+  );
+
+  return useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    const orgSlug = data.organizationSlug;
+    const projectSlug = data.projectSlug;
+    const projectId = data.projectId;
+    const projectName = data.projectName;
+
+    const actions: CommandPaletteActionWithKey[] = [
+      {
+        key: 'dsn-lookup-issues',
+        type: 'navigate',
+        to: `/organizations/${orgSlug}/issues/?project=${projectId}`,
+        display: {
+          label: t('Issues for %s', projectName),
+          details: t('View issues'),
+          icon: <IconIssues />,
+        },
+        groupingKey: 'search-result',
+      },
+      {
+        key: 'dsn-lookup-project-settings',
+        type: 'navigate',
+        to: `/settings/${orgSlug}/projects/${projectSlug}/`,
+        display: {
+          label: t('%s Settings', projectName),
+          details: t('Project settings'),
+          icon: <IconSettings />,
+        },
+        groupingKey: 'search-result',
+      },
+      {
+        key: 'dsn-lookup-client-keys',
+        type: 'navigate',
+        to: `/settings/${orgSlug}/projects/${projectSlug}/keys/`,
+        display: {
+          label: t('Client Keys (DSN) for %s', projectName),
+          details: t('Manage DSN keys'),
+          icon: <IconList />,
+        },
+        groupingKey: 'search-result',
+      },
+    ];
+
+    return actions;
+  }, [data]);
+}

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -14,6 +14,7 @@ import useRouter from 'sentry/utils/useRouter';
 
 import ApiSource from './sources/apiSource';
 import CommandSource from './sources/commandSource';
+import DsnLookupSource from './sources/dsnLookupSource';
 import FormSource from './sources/formSource';
 import OrganizationsSource from './sources/organizationsSource';
 import RouteSource from './sources/routeSource';
@@ -203,6 +204,7 @@ function Search({
                     RouteSource,
                     OrganizationsSource,
                     CommandSource,
+                    DsnLookupSource,
                   ]
                 }
               >

--- a/static/app/components/search/sources/dsnLookupSource.tsx
+++ b/static/app/components/search/sources/dsnLookupSource.tsx
@@ -1,0 +1,105 @@
+import {useEffect, useMemo, useState} from 'react';
+
+import {Client} from 'sentry/api';
+import {t} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import type {ChildProps, ResultItem} from './types';
+import {makeResolvedTs} from './utils';
+
+const DSN_PATTERN = /^https?:\/\/([a-f0-9]{32})(:[a-f0-9]{32})?@[^/]+\/\d+$/;
+
+interface DsnLookupResponse {
+  keyId: string;
+  keyLabel: string;
+  organizationSlug: string;
+  projectId: string;
+  projectName: string;
+  projectPlatform: string | null;
+  projectSlug: string;
+}
+
+type Props = {
+  children: (props: ChildProps) => React.ReactElement;
+  query: string;
+};
+
+function DsnLookupSource({query, children}: Props) {
+  const organization = useOrganization();
+  const hasDsnLookup = organization.features.includes('cmd-k-dsn-lookup');
+  const isDsn = DSN_PATTERN.test(query);
+  const [isLoading, setIsLoading] = useState(false);
+  const [data, setData] = useState<DsnLookupResponse | null>(null);
+
+  useEffect(() => {
+    if (!hasDsnLookup || !isDsn) {
+      setData(null);
+      return undefined;
+    }
+
+    setIsLoading(true);
+    const api = new Client();
+    let cancelled = false;
+
+    api
+      .requestPromise('/dsn-lookup/', {query: {dsn: query}})
+      .then((response: DsnLookupResponse) => {
+        if (!cancelled) {
+          setData(response);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setData(null);
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasDsnLookup, isDsn, query]);
+
+  const results = useMemo(() => {
+    if (!data) {
+      return [];
+    }
+
+    const resolvedTs = makeResolvedTs();
+    const {organizationSlug, projectSlug, projectId, projectName} = data;
+
+    const items: ResultItem[] = [
+      {
+        title: t('Issues for %s', projectName),
+        description: t('View issues'),
+        sourceType: 'dsn-lookup',
+        resultType: 'route',
+        resolvedTs,
+        to: `/organizations/${organizationSlug}/issues/?project=${projectId}`,
+      },
+      {
+        title: t('%s Settings', projectName),
+        description: t('Project settings'),
+        sourceType: 'dsn-lookup',
+        resultType: 'route',
+        resolvedTs,
+        to: `/settings/${organizationSlug}/projects/${projectSlug}/`,
+      },
+      {
+        title: t('Client Keys (DSN) for %s', projectName),
+        description: t('Manage DSN keys'),
+        sourceType: 'dsn-lookup',
+        resultType: 'route',
+        resolvedTs,
+        to: `/settings/${organizationSlug}/projects/${projectSlug}/keys/`,
+      },
+    ];
+
+    return items.map((item, i) => ({item, score: 0, refIndex: i}));
+  }, [data]);
+
+  return children({isLoading, results});
+}
+
+export default DsnLookupSource;

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -44,7 +44,8 @@ export type ResultItem = {
     | 'integration'
     | 'sentryApp'
     | 'docIntegration'
-    | 'help';
+    | 'help'
+    | 'dsn-lookup';
   /**
    * The title to display in result options.
    */

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -35,6 +35,7 @@ export type KnownSentryApiUrls =
   | '/doc-integrations/'
   | '/doc-integrations/$docIntegrationIdOrSlug/'
   | '/doc-integrations/$docIntegrationIdOrSlug/avatar/'
+  | '/dsn-lookup/'
   | '/groups/$issueId/'
   | '/groups/$issueId/activities/'
   | '/groups/$issueId/attachments/'

--- a/tests/sentry/api/endpoints/test_dsn_lookup.py
+++ b/tests/sentry/api/endpoints/test_dsn_lookup.py
@@ -1,0 +1,53 @@
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class DsnLookupEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-dsn-lookup"
+
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.key = self.project.key_set.first()
+        self.dsn = self.key.dsn_public
+        self.login_as(self.user)
+
+    def test_valid_dsn_returns_project_info(self):
+        response = self.get_success_response(qs_params={"dsn": self.dsn})
+        assert response.data["organizationSlug"] == self.org.slug
+        assert response.data["projectSlug"] == self.project.slug
+        assert response.data["projectId"] == str(self.project.id)
+        assert response.data["projectName"] == self.project.name
+
+    def test_missing_dsn_param_returns_400(self):
+        response = self.get_response()
+        assert response.status_code == 400
+
+    def test_invalid_dsn_format_returns_404(self):
+        response = self.get_response(qs_params={"dsn": "not-a-dsn"})
+        assert response.status_code == 404
+
+    def test_dsn_not_member_returns_404(self):
+        other_user = self.create_user()
+        other_org = self.create_organization(owner=other_user)
+        other_project = self.create_project(organization=other_org)
+        other_key = other_project.key_set.first()
+
+        response = self.get_response(qs_params={"dsn": other_key.dsn_public})
+        assert response.status_code == 404
+
+    def test_cross_org_dsn_returns_200(self):
+        other_org = self.create_organization(owner=self.user)
+        other_project = self.create_project(organization=other_org)
+        other_key = other_project.key_set.first()
+
+        response = self.get_success_response(qs_params={"dsn": other_key.dsn_public})
+        assert response.data["organizationSlug"] == other_org.slug
+        assert response.data["projectSlug"] == other_project.slug
+
+    def test_unauthenticated_returns_401(self):
+        self.client.logout()
+        response = self.get_response(qs_params={"dsn": self.dsn})
+        assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Adds a `/dsn-lookup/` API endpoint that resolves a DSN to its project info (name, slug, org, key ID)
- Adds DSN lookup to the **supercharged** command palette via `useDsnLookupActions` hook
- Adds DSN lookup to the **deprecated** command palette via a new `DsnLookupSource` search source
- Gated behind `cmd-k-dsn-lookup` feature flag

When a user pastes a DSN into either Cmd+K palette, they get 3 results:
- "Issues for {projectName}" → project issues page
- "{projectName} Settings" → project settings
- "Client Keys (DSN) for {projectName}" → DSN keys management

## Test plan
- [x] `CI=true pnpm test static/app/components/commandPalette/useDsnLookupActions.spec.tsx` passes
- [x] Backend tests pass: `pytest tests/sentry/api/endpoints/test_dsn_lookup.py`
- [x] Manually verified: old palette shows DSN results with `cmd-k-supercharged` off, `cmd-k-dsn-lookup` on
- [ ] CI passes