### PR TITLE
feat(code-review): add PR author id and other GH event metadata to Seer request log

### DIFF
--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -411,6 +411,7 @@ def extract_github_info(
         "github_event_action": None,
         "github_actor_login": None,
         "github_actor_id": None,
+        "github_pr_author_id": None,
     }
 
     repository = event.get("repository", {})

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -400,6 +400,7 @@ def extract_github_info(
             - github_event_action: The event action (e.g., "opened", "closed", "created")
             - github_actor_login: The GitHub username who triggered the action
             - github_actor_id: The GitHub user ID (as string)
+            - github_pr_author_id: The GitHub user ID of the PR author (as string)
     """
     result: dict[str, str | None] = {
         "github_owner": None,
@@ -447,6 +448,9 @@ def extract_github_info(
             result["github_actor_login"] = actor_login
         if actor_id := sender.get("id"):
             result["github_actor_id"] = str(actor_id)
+
+    if pr_author_id := get_pr_author_id(event):
+        result["github_pr_author_id"] = pr_author_id
 
     return result
 

--- a/src/sentry/seer/code_review/webhooks/check_run.py
+++ b/src/sentry/seer/code_review/webhooks/check_run.py
@@ -128,6 +128,7 @@ def handle_check_run_event(
         action=validated_event.action,
         html_url=validated_event.check_run.html_url,
         enqueued_at_str=datetime.now(timezone.utc).isoformat(),
+        extra=dict(extra) if extra else None,
     )
     record_webhook_enqueued(github_event, action)
 

--- a/src/sentry/seer/code_review/webhooks/issue_comment.py
+++ b/src/sentry/seer/code_review/webhooks/issue_comment.py
@@ -118,4 +118,5 @@ def handle_issue_comment_event(
         organization=organization,
         repo=repo,
         target_commit_sha=target_commit_sha,
+        extra=extra,
     )

--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -176,4 +176,5 @@ def handle_pull_request_event(
         organization=organization,
         repo=repo,
         target_commit_sha=_get_target_commit_sha(github_event, event, repo, integration),
+        extra=extra,
     )

--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -42,6 +42,7 @@ def schedule_task(
     organization: Organization,
     repo: Repository,
     target_commit_sha: str,
+    extra: Mapping[str, str | None] | None = None,
 ) -> None:
     """Transform and forward a webhook event to Seer for processing."""
     from .task import process_github_webhook_event
@@ -62,10 +63,12 @@ def schedule_task(
         return
 
     # Convert enum to string for Celery serialization
+    # extra must remain JSON-serializable since it is passed through Celery
     process_github_webhook_event.delay(
         github_event=github_event.value,
         event_payload=transformed_event,
         enqueued_at_str=datetime.now(timezone.utc).isoformat(),
+        extra=dict(extra) if extra else None,
     )
     record_webhook_enqueued(github_event, github_event_action)
 
@@ -81,6 +84,7 @@ def process_github_webhook_event(
     enqueued_at_str: str,
     github_event: str,
     event_payload: Mapping[str, Any],
+    extra: Mapping[str, str | None] | None = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -90,6 +94,7 @@ def process_github_webhook_event(
         enqueued_at_str: The timestamp when the task was enqueued
         github_event: The GitHub webhook event type from X-GitHub-Event header (e.g., "check_run", "pull_request")
         event_payload: The payload of the webhook event
+        extra: Logging context from the webhook handler (must be JSON-serializable)
         **kwargs: Parameters to pass to webhook handler functions
     """
     status = "success"
@@ -118,7 +123,7 @@ def process_github_webhook_event(
         else:
             payload = event_payload
 
-        log_seer_request(event_payload, github_event)
+        log_seer_request(event_payload, github_event, extra=extra)
         make_seer_request(path=path, payload=payload)
     except Exception as e:
         status = e.__class__.__name__
@@ -135,16 +140,19 @@ def process_github_webhook_event(
             record_latency(status, enqueued_at_str)
 
 
-def log_seer_request(event_payload: Mapping[str, Any], github_event: str) -> None:
+def log_seer_request(
+    event_payload: Mapping[str, Any],
+    github_event: str,
+    extra: Mapping[str, str | None] | None = None,
+) -> None:
     repo_data = event_payload.get("data", {}).get("repo", {})
     trigger_at_str = event_payload.get("data", {}).get("config", {}).get("trigger_at")
     logger.info(
         "%s.sending_request_to_seer",
         PREFIX,
         extra={
+            **(extra or {}),
             "provider": repo_data.get("provider"),
-            "repo_owner": repo_data.get("owner"),
-            "repo_name": repo_data.get("name"),
             "pr_id": event_payload.get("data", {}).get("pr_id"),
             "commit_sha": repo_data.get("base_commit_sha"),
             "request_type": event_payload.get("request_type"),

--- a/tests/sentry/seer/code_review/test_utils.py
+++ b/tests/sentry/seer/code_review/test_utils.py
@@ -523,6 +523,7 @@ class TestExtractGithubInfo:
         assert result["github_event_action"] == "opened"
         assert result["github_actor_login"] == "baxterthehacker"
         assert result["github_actor_id"] == "6752317"
+        assert result["github_pr_author_id"] == "6752317"
 
     def test_extract_from_check_run_event(self) -> None:
         event = orjson.loads(CHECK_RUN_REREQUESTED_ACTION_EVENT_EXAMPLE)
@@ -536,6 +537,8 @@ class TestExtractGithubInfo:
         assert result["github_event_action"] == "rerequested"
         assert result["github_actor_login"] == "test-user"
         assert result["github_actor_id"] == "12345678"
+        # check_run events have no PR user; falls back to sender via get_pr_author_id
+        assert result["github_pr_author_id"] == "12345678"
 
     def test_extract_from_check_run_completed_event(self) -> None:
         event = orjson.loads(CHECK_RUN_COMPLETED_EVENT_EXAMPLE)
@@ -560,6 +563,7 @@ class TestExtractGithubInfo:
             },
             "issue": {
                 "number": 42,
+                "user": {"login": "pr-author", "id": 42},
                 "pull_request": {
                     "html_url": "https://github.com/comment-owner/comment-repo/pull/42"
                 },
@@ -586,6 +590,29 @@ class TestExtractGithubInfo:
         assert result["github_event_action"] == "created"
         assert result["github_actor_login"] == "commenter-user"
         assert result["github_actor_id"] == "98765"
+        # PR author is issue.user, not the commenter (sender)
+        assert result["github_pr_author_id"] == "42"
+
+    def test_extract_pr_author_differs_from_sender(self) -> None:
+        """PR author and sender can be different (e.g., collaborator pushes commits)."""
+        event = {
+            "action": "synchronize",
+            "pull_request": {
+                "html_url": "https://github.com/owner/repo/pull/1",
+                "user": {"login": "pr-author", "id": 111},
+            },
+            "sender": {"login": "collaborator", "id": 222},
+            "repository": {
+                "name": "repo",
+                "full_name": "owner/repo",
+                "owner": {"login": "owner"},
+            },
+        }
+        result = extract_github_info(event, github_event="pull_request")
+
+        assert result["github_actor_login"] == "collaborator"
+        assert result["github_actor_id"] == "222"
+        assert result["github_pr_author_id"] == "111"
 
     def test_comment_url_takes_precedence_over_pr_url(self) -> None:
         event = {
@@ -641,6 +668,7 @@ class TestExtractGithubInfo:
         assert result["github_event_action"] is None
         assert result["github_actor_login"] is None
         assert result["github_actor_id"] is None
+        assert result["github_pr_author_id"] is None
 
     def test_missing_repository_owner_returns_none(self) -> None:
         event = {"repository": {"name": "repo-without-owner"}}


### PR DESCRIPTION
relates to CW-810

Ultimate goal: get stats on how many seer requests are getting sent per org contributor. The contributor is always the PR author and not necessarily the actor (eg if a different user pushes a commit or uses the command phrase). 

Add PR author id (and other github event metadata) to the `seer.code_review.task.sending_request_to_seer` log. In doing so we add an extra field `"github_pr_author_id"` to the debuggability `extra` dict, and pass a bunch of extra metadata from `extra` to `seer.code_review.task.sending_request_to_seer`.

The updated metadata for `seer.code_review.task.sending_request_to_seer` would ultimately look like:
```
    github_actor_id: '6752317'                      
    github_actor_login: 'baxterthehacker'           
    github_delivery_id: '390c85d9-bc2e-4471-9614-aaa35a18b76d'
    github_event: 'pull_request'
    github_event_action: 'opened'
    github_event_url: 'https://github.com/baxterthehacker/public-repo/pull/1'
    github_owner: 'baxterthehacker'
    github_pr_author_id: '6752317'
    github_repo_full_name: 'baxterthehacker/public-repo'
    github_repo_name: 'public-repo'
    github_to_seer_latency_ms: 340500628696
    commit_sha: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
    organization_slug: 'baz'
    pr_id: 1
    provider: 'github'
    request_type: 'pr-review'
```

While I really only need `github_pr_author_id` for my own purposes, the extra metadata can't hurt to add to this log.