### PR TITLE
fix(issues): Fix a problem were `0` may be rendered

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -149,7 +149,13 @@ export function SimilarStackTraceItem(props: Props) {
               {hasSimilarityEmbeddingsFeature ? (
                 <ScoreBar vertical score={scoreValue} />
               ) : (
-                <Hovercard body={<SimilarScoreCard scoreList={scoreList} />}>
+                <Hovercard
+                  body={
+                    scoreList.length > 0 ? (
+                      <SimilarScoreCard scoreList={scoreList} />
+                    ) : null
+                  }
+                >
                   <ScoreBar vertical score={Math.round(scoreValue * 5)} />
                 </Hovercard>
               )}

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -146,14 +146,13 @@ export function SimilarStackTraceItem(props: Props) {
 
           return (
             <Column key={interfaceName}>
-              {!hasSimilarityEmbeddingsFeature && (
-                <Hovercard
-                  body={scoreList.length && <SimilarScoreCard scoreList={scoreList} />}
-                >
+              {hasSimilarityEmbeddingsFeature ? (
+                <ScoreBar vertical score={scoreValue} />
+              ) : (
+                <Hovercard body={<SimilarScoreCard scoreList={scoreList} />}>
                   <ScoreBar vertical score={Math.round(scoreValue * 5)} />
                 </Hovercard>
               )}
-              {hasSimilarityEmbeddingsFeature && <ScoreBar vertical score={scoreValue} />}
             </Column>
           );
         })}


### PR DESCRIPTION
Remember that `&&` is an operator that returns the value of the first falsy operand from left to right, and if all are truthy you get the value of the last operand.

So if `a.length` is `0` then it'll return `0`. React is happy to render `0`.

I strongly recommend to people not to use `&&` for this reason. Use a ternary `? :` and handle both case!