### PR TITLE
fix(cleanup): Move partition validation before environment setup

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -301,10 +301,7 @@ def _cleanup(
     partition_total: int | None = None,
     partition_key: str = "id",
 ) -> None:
-    start_time = time.time()
-    _validate_and_setup_environment(concurrency, silent)
-
-    # Validate partition flags
+    # Validate partition flags before modifying environment
     parsed_partition: tuple[int, int, str] | None = None
     if partition_bucket is not None or partition_total is not None:
         if partition_bucket is None or partition_total is None:
@@ -324,6 +321,9 @@ def _cleanup(
                 f"Invalid --partition-bucket: {partition_bucket} must be less than --partition-total {partition_total}."
             )
         parsed_partition = (partition_bucket, partition_total, partition_key)
+
+    start_time = time.time()
+    _validate_and_setup_environment(concurrency, silent)
     # Make sure we fork off multiprocessing pool
     # before we import or configure the app
     pool, task_queue = _start_pool(concurrency)


### PR DESCRIPTION
## Summary

Fixes test pollution where `PartitionValidationTest` tests in the cleanup command would leave `os.environ["_SENTRY_CLEANUP"]` set, causing subsequent tests to fail.

**Reproduction:**
```
pytest --reuse-db tests/sentry/runner/commands/test_cleanup.py::PartitionValidationTest::test_partition_bucket_exceeds_total tests/sentry/deletions/test_project.py::DeleteProjectTest::test_delete_error_events
```

**Root cause:** `_cleanup()` called `_validate_and_setup_environment()` (which sets `_SENTRY_CLEANUP` env var) *before* partition flag validation. When validation raised a `ClickException`, the env var persisted and caused group deletion to skip `ErrorEventsDeletionTask`, so error events were never deleted.

**Fix:** Move partition validation before `_validate_and_setup_environment()` so invalid input is rejected before any environment modifications.