### PR TITLE
fix(tests): Clean up auth.allow-registration option to fix test pollution

### DIFF
--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -70,15 +70,19 @@ class SystemOptionsTest(APITestCase):
         with override_settings(SENTRY_SELF_HOSTED=True):
             self.login_as(user=self.user, superuser=True)
             response = self.client.put(self.url, {"auth.allow-registration": 1})
-            options.delete("auth.allow-registration")
-            assert response.status_code == 200
+            try:
+                assert response.status_code == 200
+            finally:
+                options.delete("auth.allow-registration")
 
     def test_put_int_for_boolean(self) -> None:
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
-        options.delete("auth.allow-registration")
-        assert response.status_code == 200
+        try:
+            assert response.status_code == 200
+        finally:
+            options.delete("auth.allow-registration")
 
     def test_put_unknown_option(self) -> None:
         self.login_as(user=self.user, superuser=True)
@@ -114,9 +118,11 @@ class SystemOptionsTest(APITestCase):
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
-        options.delete("auth.allow-registration")
-        assert response.status_code == 200
-        assert (
-            options.get_last_update_channel("auth.allow-registration")
-            == options.UpdateChannel.APPLICATION
-        )
+        try:
+            assert response.status_code == 200
+            assert (
+                options.get_last_update_channel("auth.allow-registration")
+                == options.UpdateChannel.APPLICATION
+            )
+        finally:
+            options.delete("auth.allow-registration")

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -71,6 +71,7 @@ class SystemOptionsTest(APITestCase):
             self.login_as(user=self.user, superuser=True)
             response = self.client.put(self.url, {"auth.allow-registration": 1})
             assert response.status_code == 200
+        options.delete("auth.allow-registration")
 
     def test_put_int_for_boolean(self) -> None:
         self.login_as(user=self.user, superuser=True)

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -70,13 +70,14 @@ class SystemOptionsTest(APITestCase):
         with override_settings(SENTRY_SELF_HOSTED=True):
             self.login_as(user=self.user, superuser=True)
             response = self.client.put(self.url, {"auth.allow-registration": 1})
+            options.delete("auth.allow-registration")
             assert response.status_code == 200
-        options.delete("auth.allow-registration")
 
     def test_put_int_for_boolean(self) -> None:
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
+        options.delete("auth.allow-registration")
         assert response.status_code == 200
 
     def test_put_unknown_option(self) -> None:
@@ -113,6 +114,7 @@ class SystemOptionsTest(APITestCase):
         self.login_as(user=self.user, superuser=True)
         self.add_user_permission(self.user, "options.admin")
         response = self.client.put(self.url, {"auth.allow-registration": 1})
+        options.delete("auth.allow-registration")
         assert response.status_code == 200
         assert (
             options.get_last_update_channel("auth.allow-registration")


### PR DESCRIPTION
## Summary

Fixes test pollution where `SystemOptionsTest::test_put_self_hosted_superuser_access_allowed` sets the `auth.allow-registration` system option to `1` via the API. This persists in the database when running with `--reuse-db`, causing `ClientConfigViewTest::test_customer_domain_feature` to fail because `auth:register` unexpectedly appears in the client config features list.

The fix calls `options.delete("auth.allow-registration")` after the API call to clean up the persisted option.

Reproduction command:
```
pytest --reuse-db tests/sentry/api/endpoints/test_system_options.py::SystemOptionsTest::test_put_self_hosted_superuser_access_allowed tests/sentry/web/test_api.py::ClientConfigViewTest::test_customer_domain_feature
```