### PR TITLE
feat(support): Add Intercom backend for identity verification

### DIFF
--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -1,0 +1,104 @@
+import datetime
+import logging
+
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features, options
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import ControlSiloOrganizationEndpoint
+from sentry.organizations.services.organization.model import (
+    RpcOrganization,
+    RpcUserOrganizationContext,
+)
+from sentry.utils import jwt
+
+logger = logging.getLogger(__name__)
+
+# JWT is valid for 5 minutes
+JWT_VALIDITY_WINDOW_SECONDS = 300
+
+
+@control_silo_endpoint
+class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
+    """
+    Generates a JWT for Intercom identity verification.
+
+    This endpoint creates a signed JWT that Intercom uses to verify user identity
+    in the Intercom Messenger. The JWT includes user and organization information.
+    """
+
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ENTERPRISE
+
+    def get(
+        self,
+        request: Request,
+        organization_context: RpcUserOrganizationContext,
+        organization: RpcOrganization,
+    ) -> Response:
+        """
+        Generate a JWT for Intercom identity verification.
+
+        Returns a JWT signed with HS256 containing user identity claims,
+        along with user data for the frontend to pass to Intercom.
+        """
+        if not features.has("organizations:intercom-support", organization):
+            return Response(
+                {"detail": "Intercom support is not enabled for this organization."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        signing_secret = options.get("intercom.identity-verification-secret")
+        if not signing_secret:
+            logger.warning("intercom.identity-verification-secret is not configured")
+            return Response(
+                {"detail": "Intercom identity verification is not configured."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        user = request.user
+        now = int(datetime.datetime.now(datetime.UTC).timestamp())
+        exp = now + JWT_VALIDITY_WINDOW_SECONDS
+
+        # Build JWT claims - user_id is required by Intercom
+        claims = {
+            "user_id": str(user.id),
+            "email": user.email,
+            "name": user.get_display_name(),
+            "iat": now,
+            "exp": exp,
+        }
+
+        # Generate the JWT using HS256 (required by Intercom)
+        token = jwt.encode(claims, signing_secret, algorithm="HS256")
+
+        # Return JWT and user data for frontend to use with Intercom boot
+        # Note: RpcUser doesn't have date_joined, so we use last_active as a fallback
+        created_at = now
+        if hasattr(user, "date_joined") and user.date_joined:
+            created_at = int(user.date_joined.timestamp())
+        elif hasattr(user, "last_active") and user.last_active:
+            created_at = int(user.last_active.timestamp())
+
+        user_data = {
+            "userId": str(user.id),
+            "email": user.email,
+            "name": user.get_display_name(),
+            "createdAt": created_at,
+            "organizationId": str(organization.id),
+            "organizationName": organization.name,
+        }
+
+        return Response(
+            {
+                "jwt": token,
+                "userData": user_data,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -53,6 +54,9 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
                 {"detail": "Intercom support is not enabled for this organization."},
                 status=status.HTTP_403_FORBIDDEN,
             )
+
+        if isinstance(request.user, AnonymousUser):
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         signing_secret = options.get("intercom.identity-verification-secret")
         if not signing_secret:

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -58,9 +58,9 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         if isinstance(request.user, AnonymousUser):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        signing_secret = options.get("intercom.api-secret")
+        signing_secret = options.get("intercom.sentry-api-secret")
         if not signing_secret:
-            logger.warning("intercom.intercom.api-secret is not configured")
+            logger.warning("intercom.sentry-api-secret is not configured")
             return Response(
                 {"detail": "Intercom identity verification is not configured."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -58,7 +58,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         if isinstance(request.user, AnonymousUser):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        signing_secret = options.get("intercom.identity-verification-secret")
+        signing_secret = options.get("intercom.api-secret")
         if not signing_secret:
             logger.warning("intercom.identity-verification-secret is not configured")
             return Response(
@@ -74,7 +74,6 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         claims = {
             "user_id": str(user.id),
             "email": user.email,
-            "name": user.get_display_name(),
             "iat": now,
             "exp": exp,
         }

--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -60,7 +60,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
 
         signing_secret = options.get("intercom.api-secret")
         if not signing_secret:
-            logger.warning("intercom.identity-verification-secret is not configured")
+            logger.warning("intercom.intercom.api-secret is not configured")
             return Response(
                 {"detail": "Intercom identity verification is not configured."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -17,6 +17,7 @@ from sentry.api.endpoints.organization_events_root_cause_analysis import (
 )
 from sentry.api.endpoints.organization_fork import OrganizationForkEndpoint
 from sentry.api.endpoints.organization_insights_tree import OrganizationInsightsTreeEndpoint
+from sentry.api.endpoints.organization_intercom_jwt import OrganizationIntercomJwtEndpoint
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
 from sentry.api.endpoints.organization_plugin_deprecation_info import (
     OrganizationPluginDeprecationInfoEndpoint,
@@ -1416,6 +1417,12 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/data-secrecy/$",
         WaiveDataSecrecyEndpoint.as_view(),
         name="sentry-api-0-data-secrecy",
+    ),
+    # Intercom JWT for identity verification
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/intercom-jwt/$",
+        OrganizationIntercomJwtEndpoint.as_view(),
+        name="sentry-api-0-organization-intercom-jwt",
     ),
     # Incidents
     re_path(

--- a/src/sentry/data_secrecy/models/data_access_grant.py
+++ b/src/sentry/data_secrecy/models/data_access_grant.py
@@ -16,6 +16,7 @@ class DataAccessGrant(DefaultFieldsModel):
 
     class GrantType(StrEnum):
         ZENDESK = "zendesk"
+        INTERCOM = "intercom"
         MANUAL = "manual"
 
     class RevocationReason(StrEnum):
@@ -103,14 +104,15 @@ def get_active_tickets_for_organization(organization_id: int) -> list[str]:
     Separate function to get ticket info for UI display.
     Called only when needed (not on every access check).
     Fast query since we can filter by time.
+    Returns ticket/conversation IDs from both Zendesk and Intercom.
     """
     now = timezone.now()
-    active_zendesk_tickets = DataAccessGrant.objects.filter(
+    active_tickets = DataAccessGrant.objects.filter(
         organization_id=organization_id,
-        grant_type=DataAccessGrant.GrantType.ZENDESK,
+        grant_type__in=[DataAccessGrant.GrantType.ZENDESK, DataAccessGrant.GrantType.INTERCOM],
         grant_start__lte=now,
         grant_end__gt=now,
         revocation_date__isnull=True,
         ticket_id__isnull=False,
     ).values_list("ticket_id", flat=True)
-    return [ticket_id for ticket_id in active_zendesk_tickets if ticket_id is not None]
+    return [ticket_id for ticket_id in active_tickets if ticket_id is not None]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -98,6 +98,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)
     manager.add("organizations:data-secrecy-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Intercom support widget (replaces Zendesk when enabled)
+    manager.add("organizations:intercom-support", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables synthesis of device.class in ingest

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -742,6 +742,7 @@ register(
 )
 register("codecov.forward-webhooks.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)
@@ -891,6 +892,9 @@ register("aws-lambda.python.layer-version", flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("aws-lambda.host-region", default="us-east-2", flags=FLAG_AUTOMATOR_MODIFIABLE)
 # the number of threads we should use to install Lambdas
 register("aws-lambda.thread-count", default=100, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
+# Intercom Integration
+register("intercom.sentry-api-secret", flags=FLAG_NOSTORE | FLAG_CREDENTIAL, default="")
 
 # Snuba
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -742,11 +742,6 @@ register(
 )
 register("codecov.forward-webhooks.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
-# Intercom Integration
-register("intercom.app-id", default="", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
-register("intercom.identity-verification-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
-
-
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register("github-app.name", default="", flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -742,6 +742,10 @@ register(
 )
 register("codecov.forward-webhooks.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Intercom Integration
+register("intercom.app-id", default="", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
+register("intercom.identity-verification-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+
 
 # GitHub Integration
 register("github-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -66,7 +66,7 @@
 
   {% injected_script_assets as injected_assets %}
   {% for asset_url in injected_assets %}
-    {% script src=asset_url crossorigin="anonymous" defer=True %}{% endscript %}
+    {% script src=asset_url crossorigin="anonymous" %}{% endscript %}
   {% endfor %}
 
   {% asset_url 'sentry' 'js/ads.js' as asset_url %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -66,7 +66,7 @@
 
   {% injected_script_assets as injected_assets %}
   {% for asset_url in injected_assets %}
-    {% script src=asset_url crossorigin="anonymous" %}{% endscript %}
+    {% script src=asset_url crossorigin="anonymous" defer=True %}{% endscript %}
   {% endfor %}
 
   {% asset_url 'sentry' 'js/ads.js' as asset_url %}

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -67,6 +67,7 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^get-cli/$'),
   new RegExp('^get-cli/[^/]+/[^/]+/?$'),
   new RegExp('^api/0/organizations/[^/]+/data-secrecy/$'),
+  new RegExp('^api/0/organizations/[^/]+/intercom-jwt/$'),
   new RegExp('^api/0/organizations/[^/]+/api-keys/$'),
   new RegExp('^api/0/organizations/[^/]+/api-keys/[^/]+/$'),
   new RegExp('^api/0/organizations/[^/]+/audit-logs/$'),

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -361,6 +361,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/'
   | '/organizations/$organizationIdOrSlug/integrations/$integrationId/serverless-functions/'
   | '/organizations/$organizationIdOrSlug/integrations/coding-agents/'
+  | '/organizations/$organizationIdOrSlug/intercom-jwt/'
   | '/organizations/$organizationIdOrSlug/invite-requests/'
   | '/organizations/$organizationIdOrSlug/invite-requests/$memberId/'
   | '/organizations/$organizationIdOrSlug/invited-members/'

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -30,7 +30,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
 
         with (
             self.feature("organizations:intercom-support"),
-            self.options({"intercom.api-secret": test_secret}),
+            self.options({"intercom.sentry-api-secret": test_secret}),
         ):
             response = self.get_success_response(self.organization.slug)
 

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -1,0 +1,61 @@
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import control_silo_test
+from sentry.utils import jwt
+
+
+@control_silo_test
+class OrganizationIntercomJwtEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-intercom-jwt"
+
+    def setUp(self) -> None:
+        self.login_as(self.user)
+
+    def test_get_jwt_without_feature_flag(self) -> None:
+        """Without the feature flag, the endpoint should return 403."""
+        response = self.get_response(self.organization.slug)
+        assert response.status_code == 403
+        assert response.data["detail"] == "Intercom support is not enabled for this organization."
+
+    def test_get_jwt_without_secret_configured(self) -> None:
+        """Without the secret configured, the endpoint should return 503."""
+        with self.feature("organizations:intercom-support"):
+            response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 503
+        assert response.data["detail"] == "Intercom identity verification is not configured."
+
+    def test_get_jwt_success(self) -> None:
+        """With feature flag and secret configured, should return JWT and user data."""
+        test_secret = "test-intercom-secret-key"
+
+        with (
+            self.feature("organizations:intercom-support"),
+            self.options({"intercom.identity-verification-secret": test_secret}),
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+        assert "jwt" in response.data
+        assert "userData" in response.data
+
+        # Verify user data
+        user_data = response.data["userData"]
+        assert user_data["userId"] == str(self.user.id)
+        assert user_data["email"] == self.user.email
+        assert user_data["organizationId"] == str(self.organization.id)
+        assert user_data["organizationName"] == self.organization.name
+        assert "createdAt" in user_data
+
+        # Verify JWT can be decoded with the secret
+        token = response.data["jwt"]
+        decoded = jwt.decode(token, test_secret, algorithms=["HS256"], audience=False)
+
+        assert decoded["user_id"] == str(self.user.id)
+        assert decoded["email"] == self.user.email
+        assert "iat" in decoded
+        assert "exp" in decoded
+
+    def test_get_jwt_unauthenticated(self) -> None:
+        """Unauthenticated requests should return 401."""
+        self.client.logout()
+        response = self.get_response(self.organization.slug)
+        assert response.status_code == 401

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -30,7 +30,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
 
         with (
             self.feature("organizations:intercom-support"),
-            self.options({"intercom.identity-verification-secret": test_secret}),
+            self.options({"intercom.api-secret": test_secret}),
         ):
             response = self.get_success_response(self.organization.slug)
 


### PR DESCRIPTION
**End goal:**
We want to replace Zendesk with Intercom in product. Here is a helpful diagram about how the pieces get connected in the end: https://www.notion.so/sentry/Migration-Plan-Zendesk-to-Intercom-Chat-in-Sentry-Product-30a8b10e4b5d807c9bcdef3105761dda?source=copy_link#30a8b10e4b5d80e7aa7af9b9a58f2c47

**This PR:**
Add backend support for Intercom messenger with JWT-based identity verification. Zendesk Auth was session based and didn't need this in the past which is why we need a new endpoint:
- Add intercom.app-id and intercom.identity-verification-secret options
- Create OrganizationIntercomJwtEndpoint for generating signed JWTs ([docs](https://www.intercom.com/help/en/articles/10589769-authenticating-users-in-the-messenger-with-json-web-tokens-jwts))
- Add INTERCOM grant type to DataAccessGrant model for ticket tracking
- Update get_active_tickets_for_organization to include both providers
- Add organizations:intercom-support feature flag for gradual rollout
- Register /api/0/organizations/{org}/intercom-jwt/ endpoint

The JWT is signed with HS256 and includes user_id, email, name, and organization context. Tokens expire after 5 minutes for security.

The feature flag allows gradual rollout and serves as a killswitch to instantly revert to Zendesk without code deployment.

**E2E testing**:
Tested using ngrok and the next PR in stack. Request goes through in happy path denied from unknown domains.
