### PR TITLE
feat(cells): introduce locality concept in configuration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -23,7 +23,7 @@ from sentry.conf.types.bgtask import BgTaskConfig
 from sentry.conf.types.encrypted_field import EncryptedFieldSettings
 from sentry.conf.types.kafka_definition import ConsumerDefinition
 from sentry.conf.types.logging_config import LoggingConfig
-from sentry.conf.types.region_config import RegionConfig
+from sentry.conf.types.region_config import CellConfig, LocalityConfig
 from sentry.conf.types.role_dict import RoleDict
 from sentry.conf.types.sdk_config import ServerSdkConfig
 from sentry.conf.types.sentry_config import SentryMode
@@ -753,8 +753,11 @@ SENTRY_REGION = os.environ.get("SENTRY_REGION", None)
 # Returns the customer single tenant ID.
 CUSTOMER_ID = os.environ.get("CUSTOMER_ID", None)
 
-# List of the available regions
-SENTRY_REGION_CONFIG: list[RegionConfig] = []
+# List of the available cells (e.g. "us1", "us2", "de1")
+SENTRY_REGION_CONFIG: list[CellConfig] = []
+
+# Mapping of localities (e.g. "us", "de") to their constituent cells (e.g. "us1", "us2")
+SENTRY_LOCALITIES: list[LocalityConfig] = []
 
 # Shared secret used to sign cross-region RPC requests.
 RPC_SHARED_SECRET: list[str] | None = None

--- a/src/sentry/conf/types/region_config.py
+++ b/src/sentry/conf/types/region_config.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 from typing import NotRequired, TypedDict
 
 
-class RegionConfig(TypedDict):
+class CellConfig(TypedDict):
     name: str
     snowflake_id: int
     address: str
     category: str
     visible: NotRequired[bool]
+
+
+# Locality is a collection of cells
+class LocalityConfig(TypedDict):
+    name: str
+    cells: list[str]

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -468,6 +468,7 @@ class ControlOutboxBase(OutboxBase):
         "object_identifier",
     )
 
+    # TODO(cells): rename to cell_name
     region_name = models.CharField(max_length=REGION_NAME_LENGTH)
 
     def send_signal(self) -> None:

--- a/src/sentry/hybridcloud/models/webhookpayload.py
+++ b/src/sentry/hybridcloud/models/webhookpayload.py
@@ -36,6 +36,7 @@ class WebhookPayload(Model):
     destination_type = models.CharField(
         choices=DestinationType.choices, null=False, db_default=DestinationType.SENTRY_REGION
     )
+    # TODO(cells): rename to cell_name
     region_name = models.CharField(null=True)
 
     # May need to add organization_id in the future for debugging.

--- a/src/sentry/models/organizationmapping.py
+++ b/src/sentry/models/organizationmapping.py
@@ -38,6 +38,7 @@ class OrganizationMapping(Model):
     # If a record already exists with the same slug, the organization_id can only be
     # updated IF the idempotency key is identical.
     idempotency_key = models.CharField(max_length=IDEMPOTENCY_KEY_LENGTH)
+    # TODO(cells): rename to cell_name
     region_name = models.CharField(max_length=REGION_NAME_LENGTH)
     status = BoundedBigIntegerField(choices=OrganizationStatus.as_choices(), null=True)
 

--- a/src/sentry/models/organizationslugreservation.py
+++ b/src/sentry/models/organizationslugreservation.py
@@ -35,6 +35,7 @@ class OrganizationSlugReservation(ReplicatedControlModel):
     slug = models.SlugField(unique=True, null=False)
     organization_id = HybridCloudForeignKey("sentry.organization", null=False, on_delete="CASCADE")
     user_id = BoundedBigIntegerField(db_index=True, null=True)
+    # TODO(cells): rename to cell_name
     region_name = models.CharField(max_length=REGION_NAME_LENGTH, null=False)
     reservation_type = BoundedBigIntegerField(
         choices=OrganizationSlugReservationType.as_choices(),

--- a/src/sentry/models/organizationslugreservationreplica.py
+++ b/src/sentry/models/organizationslugreservationreplica.py
@@ -20,6 +20,7 @@ class OrganizationSlugReservationReplica(Model):
     slug = models.SlugField(unique=True, db_index=True)
     organization_id = BoundedBigIntegerField(db_index=True)
     user_id = BoundedBigIntegerField(db_index=True, null=True)
+    # TODO(cells): rename to cell_name
     region_name = models.CharField(max_length=REGION_NAME_LENGTH, null=False)
     reservation_type = BoundedBigIntegerField(
         choices=OrganizationSlugReservationType.as_choices(),

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -442,7 +442,7 @@ def validate_regions(settings: Any) -> None:
     if not settings.SENTRY_REGION_CONFIG:
         return
 
-    load_from_config(settings.SENTRY_REGION_CONFIG).validate_all()
+    load_from_config(settings.SENTRY_REGION_CONFIG, settings.SENTRY_LOCALITIES).validate_all()
 
 
 def monkeypatch_django_migrations() -> None:

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -22,7 +22,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.region import TestEnvRegionDirectory
 from sentry.testutils.silo import monkey_patch_single_process_silo_mode_state
 from sentry.types import region
-from sentry.types.region import Locality, Region, RegionCategory
+from sentry.types.region import Region, RegionCategory
 from sentry.utils.warnings import UnsupportedBackend
 
 K = TypeVar("K")
@@ -74,7 +74,6 @@ def _configure_test_env_regions() -> None:
     default_region = Region(
         region_name, 0, settings.SENTRY_OPTIONS["system.url-prefix"], RegionCategory.MULTI_TENANT
     )
-    default_locality = Locality(name=default_region.name, cells=frozenset([default_region.name]))
 
     settings.SENTRY_REGION = region_name
     settings.SENTRY_MONOLITH_REGION = region_name
@@ -82,7 +81,7 @@ def _configure_test_env_regions() -> None:
     # This not only populates the environment with the default region, but also
     # ensures that a TestEnvRegionDirectory instance is injected into global state.
     # See sentry.testutils.region.get_test_env_directory, which relies on it.
-    region.set_global_directory(TestEnvRegionDirectory([default_region], [default_locality]))
+    region.set_global_directory(TestEnvRegionDirectory([default_region]))
 
     settings.SENTRY_SUBNET_SECRET = "secret"
     settings.SENTRY_CONTROL_ADDRESS = "http://controlserver/"

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -22,7 +22,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.region import TestEnvRegionDirectory
 from sentry.testutils.silo import monkey_patch_single_process_silo_mode_state
 from sentry.types import region
-from sentry.types.region import Region, RegionCategory
+from sentry.types.region import Locality, Region, RegionCategory
 from sentry.utils.warnings import UnsupportedBackend
 
 K = TypeVar("K")
@@ -74,6 +74,7 @@ def _configure_test_env_regions() -> None:
     default_region = Region(
         region_name, 0, settings.SENTRY_OPTIONS["system.url-prefix"], RegionCategory.MULTI_TENANT
     )
+    default_locality = Locality(name=default_region.name, cells=frozenset([default_region.name]))
 
     settings.SENTRY_REGION = region_name
     settings.SENTRY_MONOLITH_REGION = region_name
@@ -81,7 +82,7 @@ def _configure_test_env_regions() -> None:
     # This not only populates the environment with the default region, but also
     # ensures that a TestEnvRegionDirectory instance is injected into global state.
     # See sentry.testutils.region.get_test_env_directory, which relies on it.
-    region.set_global_directory(TestEnvRegionDirectory([default_region]))
+    region.set_global_directory(TestEnvRegionDirectory([default_region], [default_locality]))
 
     settings.SENTRY_SUBNET_SECRET = "secret"
     settings.SENTRY_CONTROL_ADDRESS = "http://controlserver/"

--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Generator, Sequence
+from collections.abc import Collection, Generator, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 
@@ -18,11 +18,14 @@ class _TemporaryRegionDirectoryState:
 class TestEnvRegionDirectory(RegionDirectory):
     __test__ = False
 
-    def __init__(self, regions: Collection[Region], localities: Collection[Locality]) -> None:
-        super().__init__(regions, localities)
+    def __init__(self, regions: Collection[Region]) -> None:
+        super().__init__(regions, self.localities_from_regions(regions))
         self._tmp_state = _TemporaryRegionDirectoryState(
             regions=super().regions, default_region=next(iter(regions))
         )
+
+    def localities_from_regions(self, regions: Collection[Region]) -> frozenset[Locality]:
+        return frozenset(Locality(name=cell.name, cells=frozenset([cell.name])) for cell in regions)
 
     @contextmanager
     def swap_state(
@@ -31,8 +34,9 @@ class TestEnvRegionDirectory(RegionDirectory):
         local_region: Region | None = None,
     ) -> Generator[None]:
         monolith_region = regions[0]
+        new_regions = self.regions if regions is None else frozenset(regions)
         new_state = _TemporaryRegionDirectoryState(
-            regions=self.regions if regions is None else frozenset(regions),
+            regions=new_regions,
             default_region=local_region or monolith_region,
         )
 
@@ -75,6 +79,18 @@ class TestEnvRegionDirectory(RegionDirectory):
             return next(match)
         except StopIteration:
             return None
+
+    def get_locality_for_cell(self, cell_name: str) -> Locality | None:
+        region = self.get_by_name(cell_name)
+        if region is None:
+            return None
+        return Locality(name=cell_name, cells=frozenset([cell_name]))
+
+    def get_cells_for_locality(self, locality_name: str) -> Iterable[Region]:
+        region = self.get_by_name(locality_name)
+        if region is None:
+            return ()
+        return (region,)
 
 
 def get_test_env_directory() -> TestEnvRegionDirectory:

--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 from django.test import override_settings
 
-from sentry.types.region import Region, RegionDirectory, get_global_directory
+from sentry.types.region import Locality, Region, RegionDirectory, get_global_directory
 
 
 @dataclass(frozen=True)
@@ -18,8 +18,8 @@ class _TemporaryRegionDirectoryState:
 class TestEnvRegionDirectory(RegionDirectory):
     __test__ = False
 
-    def __init__(self, regions: Collection[Region]) -> None:
-        super().__init__(regions)
+    def __init__(self, regions: Collection[Region], localities: Collection[Locality]) -> None:
+        super().__init__(regions, localities)
         self._tmp_state = _TemporaryRegionDirectoryState(
             regions=super().regions, default_region=next(iter(regions))
         )

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -11,7 +11,7 @@ from django.http import HttpRequest
 from pydantic.dataclasses import dataclass
 
 from sentry import options
-from sentry.conf.types.region_config import RegionConfig
+from sentry.conf.types.region_config import CellConfig, LocalityConfig
 from sentry.silo.base import SiloMode, SingleProcessSiloModeState, control_silo_function
 from sentry.utils.env import in_test_environment
 
@@ -19,15 +19,28 @@ if TYPE_CHECKING:
     from sentry.sentry_apps.models.sentry_app import SentryApp
 
 
+@dataclass(frozen=True, eq=True)
+class Locality:
+    """A grouping of one or more cells (e.g. "us" contains "us1", "us2")."""
+
+    name: str
+    """The locality's unique identifier (e.g. "us", "de")."""
+
+    cells: frozenset[str]
+    """The set of cell names that belong to this locality."""
+
+
 class RegionCategory(Enum):
     MULTI_TENANT = "MULTI_TENANT"
     SINGLE_TENANT = "SINGLE_TENANT"
 
 
+# TODO(cells): rename to LocalityConfigurationError
 class RegionConfigurationError(Exception):
     """Indicate that a region was misconfigured or could not be initialized."""
 
 
+# TODO(cells): this class represents a cell (e.g. "us1", "de1"); rename to Cell
 @dataclass(frozen=True, eq=True)
 class Region:
     """A region of the Sentry platform, hosted by a region silo."""
@@ -128,13 +141,24 @@ class RegionDirectory:
     but affords overrides by the subclass TestEnvRegionDirectory.
     """
 
-    def __init__(self, regions: Collection[Region]) -> None:
-        self._regions = frozenset(regions)
-        self._by_name = {r.name: r for r in self._regions}
+    def __init__(
+        self,
+        regions: Collection[Region],
+        localities: Collection[Locality],
+    ) -> None:
+        self._cells = frozenset(regions)
+        self._by_name = {r.name: r for r in self._cells}
+        self._localities = frozenset(localities)
+        self._localities_by_name = {loc.name: loc for loc in self._localities}
+        self._cell_to_locality = {cell_name: loc for loc in localities for cell_name in loc.cells}
 
     @property
     def regions(self) -> frozenset[Region]:
-        return self._regions
+        return self._cells
+
+    @property
+    def localities(self) -> frozenset[Locality]:
+        return self._localities
 
     def get_by_name(self, region_name: str) -> Region | None:
         return self._by_name.get(region_name)
@@ -145,12 +169,40 @@ class RegionDirectory:
     def get_region_names(self, category: RegionCategory | None = None) -> Iterable[str]:
         return (r.name for r in self.regions if (category is None or r.category == category))
 
+    def get_locality_for_cell(self, cell_name: str) -> Locality | None:
+        return self._cell_to_locality.get(cell_name)
+
+    def get_cells_for_locality(self, locality_name: str) -> Iterable[Region]:
+        loc = self._localities_by_name.get(locality_name)
+        if loc is None:
+            return ()
+        return (r for name in loc.cells if (r := self._by_name.get(name)) is not None)
+
     def validate_all(self) -> None:
         for region in self.regions:
             region.validate()
 
+        # Ensure that a cell cannot be registed to more than one locality
+        all_cell_refs = [cell_name for loc in self.localities for cell_name in loc.cells]
+        assigned_cells = set(all_cell_refs)
+        defined_cells = set(self._by_name.keys())
 
-def _parse_raw_config(region_config: list[RegionConfig]) -> Iterable[Region]:
+        if len(all_cell_refs) != len(assigned_cells):
+            duplicates = {c for c in all_cell_refs if all_cell_refs.count(c) > 1}
+            raise RegionConfigurationError(
+                f"Cells assigned to more than one locality: {duplicates!r}"
+            )
+
+        # Ensure that all cells are assigned to a locality, and that all localities only reference defined cells
+        if assigned_cells != defined_cells:
+            raise RegionConfigurationError(
+                f"Cells in locality config do not match cell config: "
+                f"locality-only={assigned_cells - defined_cells!r}, "
+                f"cell-only={defined_cells - assigned_cells!r}"
+            )
+
+
+def _parse_raw_config(region_config: list[CellConfig]) -> Iterable[Region]:
     for config_value in region_config:
         yield Region(
             name=config_value["name"],
@@ -187,11 +239,33 @@ def _generate_monolith_region_if_needed(regions: Collection[Region]) -> Iterable
         )
 
 
-def load_from_config(region_config: list[RegionConfig]) -> RegionDirectory:
+def _parse_locality_config(
+    locality_config: list[LocalityConfig],
+) -> Iterable[Locality]:
+    for config_value in locality_config:
+        yield Locality(
+            name=config_value["name"],
+            cells=frozenset(config_value["cells"]),
+        )
+
+
+def load_from_config(
+    region_config: list[CellConfig],
+    locality_config: list[LocalityConfig],
+) -> RegionDirectory:
     try:
         regions = set(_parse_raw_config(region_config))
         regions |= set(_generate_monolith_region_if_needed(regions))
-        return RegionDirectory(regions)
+        localities = set(_parse_locality_config(locality_config))
+
+        if not locality_config:
+            # TODO(cells): If no locality config present — create a synthetic 1:1 locality per cell
+            # as a temporary fallback. Once SENTRY_LOCALITIES is configured, all cells
+            # must be explicitly assigned; missing cells will have no locality mapping.
+            for region in regions:
+                localities.add(Locality(name=region.name, cells=frozenset([region.name])))
+
+        return RegionDirectory(regions, localities)
     except RegionConfigurationError as e:
         sentry_sdk.capture_exception(e)
         raise
@@ -224,7 +298,7 @@ def get_global_directory() -> RegionDirectory:
     # For now, assume that all region configs can be taken in through Django
     # settings. We may investigate other ways of delivering those configs in
     # production.
-    _global_regions = load_from_config(settings.SENTRY_REGION_CONFIG)
+    _global_regions = load_from_config(settings.SENTRY_REGION_CONFIG, settings.SENTRY_LOCALITIES)
     return _global_regions
 
 

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -182,7 +182,7 @@ class RegionDirectory:
         for region in self.regions:
             region.validate()
 
-        # Ensure that a cell cannot be registed to more than one locality
+        # Ensure that a cell cannot be registered to more than one locality
         all_cell_refs = [cell_name for loc in self.localities for cell_name in loc.cells]
         assigned_cells = set(all_cell_refs)
         defined_cells = set(self._by_name.keys())

--- a/tests/sentry/synapse/endpoints/test_org_cell_mappings.py
+++ b/tests/sentry/synapse/endpoints/test_org_cell_mappings.py
@@ -150,7 +150,7 @@ class OrgCellMappingsTest(APITestCase):
         url = reverse("sentry-api-0-org-cell-mappings")
         res = self.client.get(
             url,
-            data={"locale": "de"},
+            data={"locality": "de"},
             HTTP_AUTHORIZATION=self.auth_header(url),
         )
         assert res.status_code == 200

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -171,7 +171,7 @@ def test_client_config_default_region_data() -> None:
 @no_silo_test
 @django_db_all
 def test_client_config_empty_region_data() -> None:
-    region_directory = region.load_from_config([])
+    region_directory = region.load_from_config([], [])
 
     # Usually, we would want to use other testutils functions rather than calling
     # `swap_state` directly. We make an exception here in order to test the default


### PR DESCRIPTION
This is a small initial PR to introduce the locality concept. Locality is a group of cells (which represent the geographic region, or tenant in the case of single-tenant deployments). The existing region_name / sentry-region terminology is deprecated in favor of locality + cells. This naming will contiue to be migrated in subsequent PRs / database migrations.

This PR includes the following:
- introduce SENTRY_LOCALITIES setting to configure the cell -> locality mapping
- when SENTRY_LOCALITIES is not present (rollout phase), synthesize a 1:1 locality per cell as a fallback
- update the OrgCellMappingsEndpoint to return the real cell to locality map from config instead of the hardcoded value
- update the OrgCellMappingsEndpoint to support multiple localities being requested
- add TODO(cells) comments next to model fields where region_name should be later updated to cell_name in the DB
