### PR TITLE
fix(servicehooks): Make servicehook updating idempotent

### DIFF
--- a/src/sentry/sentry_apps/services/hook/impl.py
+++ b/src/sentry/sentry_apps/services/hook/impl.py
@@ -104,6 +104,7 @@ class DatabaseBackedHookService(HookService):
                     installation_id=installation_id,
                     application_id=application_id,
                     actor_id=installation_id,
+                    organization_id=organization_id,
                     url=webhook_url,
                     events=expand_events(events),
                 )

--- a/src/sentry/sentry_apps/services/hook/impl.py
+++ b/src/sentry/sentry_apps/services/hook/impl.py
@@ -94,38 +94,36 @@ class DatabaseBackedHookService(HookService):
     ) -> list[RpcServiceHook]:
         with transaction.atomic(router.db_for_write(ServiceHook)):
             if webhook_url:
-                hook, created = ServiceHook.objects.update_or_create(
+                hooks = ServiceHook.objects.filter(
                     installation_id=installation_id,
                     application_id=application_id,
-                    defaults={
-                        "application_id": application_id,
-                        "actor_id": installation_id,
-                        "installation_id": installation_id,
-                        "url": webhook_url,
-                        "events": expand_events(events),
-                    },
+                )
+                deletions.exec_sync_many(list(hooks))
+
+                new_hook = ServiceHook.objects.create(
+                    installation_id=installation_id,
+                    application_id=application_id,
+                    actor_id=installation_id,
+                    url=webhook_url,
+                    events=expand_events(events),
                 )
                 logger.info(
                     "create_or_update_webhook_and_events_for_installation.created_or_updated_hook",
                     extra={
-                        "hook_id": hook.id,
-                        "created_hook": created,
+                        "hook_id": new_hook.id,
                         "organization_id": organization_id,
                         "installation_id": installation_id,
                         "application_id": application_id,
                         "events": events,
                     },
                 )
-                return [serialize_service_hook(hook)]
+                return [serialize_service_hook(new_hook)]
             else:
-                # If no webhook_url, try to find and delete existing hook
-                try:
-                    hook = ServiceHook.objects.get(
-                        installation_id=installation_id, application_id=application_id
-                    )
-                    deletions.exec_sync(hook)
-                except ServiceHook.DoesNotExist:
-                    pass
+                # If no webhook_url, try to find and delete existing hooks
+                hooks = ServiceHook.objects.filter(
+                    installation_id=installation_id, application_id=application_id
+                )
+                deletions.exec_sync_many(list(hooks))
                 return []
 
     def create_service_hook(


### PR DESCRIPTION
### Description
Fixes a `MultipleObjectsReturned` error in `create_or_update_webhook_and_events_for_installation` caused by duplicate `ServiceHook` rows for the same (installation_id, application_id) pair.

Due to concurrency issues, some installations ended up with multiple ServiceHook objects. The previous implementation used update_or_create() and get(), which both fail when duplicates exist. This changes the function to a delete-and-recreate pattern, making it fully idempotent regardless of how many hooks exist.

### Test info
- Updated existing test to not assert on hook ID stability (since we now delete and recreate)
- Added test for duplicate hooks with webhook_url provided — verifies duplicates are cleaned up and exactly one hook remains
- Added test for duplicate hooks with webhook_url=None — verifies all duplicates are deleted