### PR TITLE
fix(idp): Use auth base template for IDP email verification pages

### DIFF
--- a/src/sentry/templates/sentry/idp_account_not_verified.html
+++ b/src/sentry/templates/sentry/idp_account_not_verified.html
@@ -8,5 +8,5 @@
         Something went wrong and your email could not be confirmed. Click the button below to go back to the login page.
     </p>
 
-    <a href="/auth/login/" class="btn">Go back</a>
+    <a href="/auth/login/" class="btn btn-primary">Go back</a>
 {% endblock %}

--- a/src/sentry/templates/sentry/idp_account_not_verified.html
+++ b/src/sentry/templates/sentry/idp_account_not_verified.html
@@ -1,8 +1,8 @@
-{% extends "sentry/emails/base.html" %}
+{% extends "sentry/bases/auth.html" %}
 
 {% load i18n %}
 
-{% block main %}
+{% block auth_main %}
     <h3>Sorry,</h3>
     <p>
         Something went wrong and your email could not be confirmed. Click the button below to go back to the login page.

--- a/src/sentry/templates/sentry/idp_account_verified.html
+++ b/src/sentry/templates/sentry/idp_account_verified.html
@@ -1,8 +1,8 @@
-{% extends "sentry/emails/base.html" %}
+{% extends "sentry/bases/auth.html" %}
 
 {% load i18n %}
 
-{% block main %}
+{% block auth_main %}
     <h3>Thank you!</h3>
     <p>
         Your email has been confirmed. Click the button below to log in to your Sentry account.


### PR DESCRIPTION
These templates have incorrectly extended `sentry/emails/base.html` since their creation in 2021 (PR #29003). They are web pages rendered in the browser, not emails, so they should use `sentry/bases/auth.html`.

The immediate motivation is CSRF failures on `/account/user-confirm/`. The verified page contains a form that POSTs to `/auth/login/{org}/`, but because it extended the email base, the CSRF token sync script (added to `bases/auth.html` to handle multi-tab session rotation) was never loaded on this page. This meant the CSRF cookie and form token could diverge between page load and form submission.

Switching to the auth base also gives these pages the correct visual treatment (standard auth page) instead of email table layout with an unsubscribe footer.

Expect [these](https://sentry.sentry.io/organizations/sentry/explore/logs/?logsFields=timestamp&logsFields=message&logsQuery=reason%3A%22CSRF%20token%20from%20POST%20incorrect.%22%20referer%3A%EF%80%8DContains%EF%80%8D%22user-confirm%22&logsSortBys=-timestamp&mode=samples&project=1&statsPeriod=24h) to stop after

Before:
<img width="763" height="470" alt="Screenshot 2026-02-17 at 7 15 25 PM" src="https://github.com/user-attachments/assets/6481c94f-883d-4f0e-bd5e-63e2785f9a07" />

<img width="787" height="509" alt="Screenshot 2026-02-17 at 7 15 13 PM" src="https://github.com/user-attachments/assets/8ed3dda0-d826-4516-b1a1-66a2980417a7" />

After:

<img width="774" height="389" alt="Screenshot 2026-02-17 at 7 14 48 PM" src="https://github.com/user-attachments/assets/bae91633-aac8-4567-81da-47dbb847438c" />
<img width="1024" height="700" alt="Screenshot 2026-02-17 at 7 11 22 PM" src="https://github.com/user-attachments/assets/32afc38c-2310-40f8-a014-5ade90bc7f90" />

