### PR TITLE
chore(ACI): Add actions data to WorkflowEngineRuleSerializer

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, TypedDict
 
-from django.db.models import Max, Prefetch, Q, prefetch_related_objects
+from django.db.models import Max, Prefetch, Q, Subquery, prefetch_related_objects
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer, register
@@ -21,9 +21,11 @@ from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.models import (
+    Action,
     AlertRuleWorkflow,
     DataCondition,
     DataConditionGroup,
+    DataConditionGroupAction,
     Workflow,
     WorkflowDataConditionGroup,
 )
@@ -408,6 +410,12 @@ class WorkflowEngineRuleSerializer(Serializer):
             return actor.identifier
         return None
 
+    def _fetch_actions(self, condition_group: DataConditionGroup) -> BaseQuerySet[Action]:
+        dcgas = DataConditionGroupAction.objects.filter(
+            condition_group=condition_group
+        ).values_list("action_id", flat=True)
+        return Action.objects.filter(id__in=Subquery(dcgas))
+
     def _generate_rule_conditions_filters(
         self, workflow: Workflow, project: Project, workflow_dcg: WorkflowDataConditionGroup
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
@@ -451,7 +459,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         # Bulk fetch projects for workflows (attached through detectors)
         workflow_to_projects = self._fetch_workflow_projects(item_list)
 
-        # Bulk fetch wokflows with trigger and filter conditionx
+        # Bulk fetch wokflows with trigger and filter conditions
         workflows = self._fetch_workflows(item_list)
 
         # Bulk fetch workflow -> rule ids
@@ -460,8 +468,6 @@ class WorkflowEngineRuleSerializer(Serializer):
         last_triggered_lookup: dict[int, datetime] = {}
         if "lastTriggered" in self.expand:
             last_triggered_lookup = self._fetch_workflow_last_triggered(item_list)
-
-        # TODO: SERIALIZE ACTIONS
 
         result: dict[Workflow, dict[str, Any]] = defaultdict(dict)
         for workflow in workflows:
@@ -482,6 +488,22 @@ class WorkflowEngineRuleSerializer(Serializer):
             workflow_dcg = workflow.prefetched_wdcgs[0]  # type: ignore[attr-defined]
             result[workflow]["filter_match"] = workflow_dcg.condition_group.logic_type
 
+            serialized_actions = []
+            for action in self._fetch_actions(workflow_dcg.condition_group):
+                serialized_actions.append(
+                    {
+                        "workspace": "1",
+                        "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                        "channel": "slack-demo",
+                        "channel_id": "C06H93DSF2T",
+                        "notes": "",
+                        "tags": "",
+                        "uuid": "142d5d2e-a2f4-45e2-bb03-8c9b2975bff2",
+                        "name": "Send a notification to the Sentry Slack workspace to #slack-demo",
+                    }
+                )
+                # TODO actually format like a rule action
+
             # Generate conditions and filters
             conditions, filters = self._generate_rule_conditions_filters(
                 workflow, result[workflow]["projects"][0], workflow_dcg
@@ -492,6 +514,8 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             if workflow.id in last_triggered_lookup:
                 result[workflow]["last_triggered"] = last_triggered_lookup[workflow.id]
+
+            result[workflow]["actions"] = serialized_actions
 
         return result
 
@@ -510,7 +534,7 @@ class WorkflowEngineRuleSerializer(Serializer):
             "id": str(attrs["rule_id"]) if attrs.get("rule_id") else None,
             "conditions": attrs["conditions"],
             "filters": attrs["filters"],
-            "actions": [],  # TODO: reverse translate actions
+            "actions": attrs["actions"],
             "actionMatch": action_match,
             "filterMatch": filter_match,
             "frequency": obj.config.get("frequency", 0),

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -491,14 +491,10 @@ class WorkflowEngineRuleSerializer(Serializer):
             result[workflow]["filter_match"] = workflow_dcg.condition_group.logic_type
 
             serialized_actions = []
-            project = result[workflow]["projects"][0]
             for action in self._fetch_actions(workflow_dcg.condition_group):
                 handler = issue_alert_handler_registry.get(action.type)
                 action_data = handler.build_rule_action_blob(action, workflow.organization_id)
-                # XXX: I don't love using this but it's the only way to get the name
-                action_data["name"] = generate_rule_label(
-                    project=project, rule=None, data=action_data
-                )
+                action_data["name"] = handler.render_label(workflow.organization_id, action_data)
                 # XXX: manually remove notes which would only apply to legacy metric alerts or single written alerts
                 action_data.pop("notes", None)
                 serialized_actions.append(action_data)

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -491,11 +491,17 @@ class WorkflowEngineRuleSerializer(Serializer):
             result[workflow]["filter_match"] = workflow_dcg.condition_group.logic_type
 
             serialized_actions = []
+            project = result[workflow]["projects"][0]
             for action in self._fetch_actions(workflow_dcg.condition_group):
                 handler = issue_alert_handler_registry.get(action.type)
                 action_data = handler.build_rule_action_blob(action, workflow.organization_id)
+                # XXX: I don't love using this but it's the only way to get the name
+                action_data["name"] = generate_rule_label(
+                    project=project, rule=None, data=action_data
+                )
+                # XXX: manually remove notes which would only apply to legacy metric alerts or single written alerts
+                action_data.pop("notes", None)
                 serialized_actions.append(action_data)
-                # this _sort of_ is the same data, but not exactly
 
             # Generate conditions and filters
             conditions, filters = self._generate_rule_conditions_filters(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -453,6 +453,8 @@ class WorkflowEngineRuleSerializer(Serializer):
         return {wf_id: date for wf_id, date in results.items() if date is not None}
 
     def get_attrs(self, item_list: Sequence[Workflow], user, **kwargs):
+        from sentry.notifications.notification_action.registry import issue_alert_handler_registry
+
         # Bulk fetch users that created workflows
         users = self._fetch_workflow_users(item_list)
 
@@ -490,19 +492,10 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             serialized_actions = []
             for action in self._fetch_actions(workflow_dcg.condition_group):
-                serialized_actions.append(
-                    {
-                        "workspace": "1",
-                        "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                        "channel": "slack-demo",
-                        "channel_id": "C06H93DSF2T",
-                        "notes": "",
-                        "tags": "",
-                        "uuid": "142d5d2e-a2f4-45e2-bb03-8c9b2975bff2",
-                        "name": "Send a notification to the Sentry Slack workspace to #slack-demo",
-                    }
-                )
-                # TODO actually format like a rule action
+                handler = issue_alert_handler_registry.get(action.type)
+                action_data = handler.build_rule_action_blob(action, workflow.organization_id)
+                serialized_actions.append(action_data)
+                # this _sort of_ is the same data, but not exactly
 
             # Generate conditions and filters
             conditions, filters = self._generate_rule_conditions_filters(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -503,8 +503,11 @@ class WorkflowEngineRuleSerializer(Serializer):
                     action_data["fallthroughType"] = action_data.get("fallthrough_type")
                     del action_data["fallthrough_type"]
 
-                # XXX: add a targetIdentifier empty string
-                if action_data.get("targetIdentifier") is None:
+                # XXX: add a targetIdentifier empty string for email only
+                if (
+                    action.type == Action.Type.EMAIL.value
+                    and action_data.get("targetIdentifier") is None
+                ):
                     action_data["targetIdentifier"] = ""
 
                 # XXX: manually remove notes which would only apply to legacy metric alerts or single written alerts

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -495,6 +495,18 @@ class WorkflowEngineRuleSerializer(Serializer):
                 handler = issue_alert_handler_registry.get(action.type)
                 action_data = handler.build_rule_action_blob(action, workflow.organization_id)
                 action_data["name"] = handler.render_label(workflow.organization_id, action_data)
+
+                # HACKs below - we don't want to change the underlying data we render for ACI but we need to return it in the expected issue alert format
+
+                # XXX: convert fallthrough_type to fallthroughType
+                if action_data.get("fallthrough_type"):
+                    action_data["fallthroughType"] = action_data.get("fallthrough_type")
+                    del action_data["fallthrough_type"]
+
+                # XXX: add a targetIdentifier empty string
+                if action_data.get("targetIdentifier") is None:
+                    action_data["targetIdentifier"] = ""
+
                 # XXX: manually remove notes which would only apply to legacy metric alerts or single written alerts
                 action_data.pop("notes", None)
                 serialized_actions.append(action_data)

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -461,7 +461,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         # Bulk fetch projects for workflows (attached through detectors)
         workflow_to_projects = self._fetch_workflow_projects(item_list)
 
-        # Bulk fetch wokflows with trigger and filter conditions
+        # Bulk fetch workflows with trigger and filter conditions
         workflows = self._fetch_workflows(item_list)
 
         # Bulk fetch workflow -> rule ids

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any, TypedDict
 
-from django.db.models import Max, Prefetch, Q, Subquery, prefetch_related_objects
+from django.db.models import Max, Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer, register
@@ -25,7 +25,6 @@ from sentry.workflow_engine.models import (
     AlertRuleWorkflow,
     DataCondition,
     DataConditionGroup,
-    DataConditionGroupAction,
     Workflow,
     WorkflowDataConditionGroup,
 )
@@ -411,10 +410,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         return None
 
     def _fetch_actions(self, condition_group: DataConditionGroup) -> BaseQuerySet[Action]:
-        dcgas = DataConditionGroupAction.objects.filter(
-            condition_group=condition_group
-        ).values_list("action_id", flat=True)
-        return Action.objects.filter(id__in=Subquery(dcgas))
+        return Action.objects.filter(dataconditiongroupaction__condition_group=condition_group)
 
     def _generate_rule_conditions_filters(
         self, workflow: Workflow, project: Project, workflow_dcg: WorkflowDataConditionGroup
@@ -510,8 +506,10 @@ class WorkflowEngineRuleSerializer(Serializer):
                 ):
                     action_data["targetIdentifier"] = ""
 
-                # XXX: manually remove notes which would only apply to legacy metric alerts or single written alerts
-                action_data.pop("notes", None)
+                # XXX: remove notes unless it actually has content
+                if action.data.get("notes") == "":
+                    action_data.pop("notes")
+
                 serialized_actions.append(action_data)
 
             # Generate conditions and filters

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -508,7 +508,7 @@ class WorkflowEngineRuleSerializer(Serializer):
 
                 # XXX: remove notes unless it actually has content
                 if action.data.get("notes") == "":
-                    action_data.pop("notes")
+                    action_data.pop("notes", None)
 
                 serialized_actions.append(action_data)
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -488,7 +488,12 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             serialized_actions = []
             for action in self._fetch_actions(workflow_dcg.condition_group):
-                handler = issue_alert_handler_registry.get(action.type)
+                try:
+                    handler = issue_alert_handler_registry.get(action.type)
+                except Exception:
+                    # just keep iterating through the actions in case we have valid ones in there
+                    continue
+
                 action_data = handler.build_rule_action_blob(action, workflow.organization_id)
                 action_data["name"] = handler.render_label(workflow.organization_id, action_data)
 

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/discord_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/discord_issue_alert_handler.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.workflow_engine.models import Action
@@ -16,3 +18,19 @@ class DiscordIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         return {}
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        integration = integration_service.get_integration(
+            integration_id=blob["server"],
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if not integration:
+            return ""
+
+        server = integration.name
+        channel_id = blob["channel_id"]
+        tags = [s.strip() for s in blob["tags"].split(",")]
+        formatted_tags = "[{}]".format(", ".join(tags))
+        return f"Send a notification to the {server} Discord server in the channel with ID or URL: {channel_id} and show tags {formatted_tags} in the notification."

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -55,3 +55,9 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
             final_blob[EmailFieldMappingKeys.FALLTHROUGH_TYPE_KEY.value] = blob.fallthrough_type
 
         return final_blob
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        # TODO: is this ever anything other than 'mail'? If not, can just hard code that
+        label = "Send a notification via {}"
+        return label.format(blob.target_id.get("service"))

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -3,6 +3,7 @@ from typing import Any
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
+from sentry.notifications.types import FallthroughChoiceType
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
@@ -58,6 +59,7 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
-        # TODO: beef this up
-        label = "Send a notification to Member and if none can be found then send a notification to ActiveMembers"
+        target_type = blob["targetType"]
+        fallthrough_type = blob.get("fallthrough_type", FallthroughChoiceType.ACTIVE_MEMBERS.value)
+        label = f"Send a notification to {target_type} and if none can be found then send a notification to {fallthrough_type}"
         return label

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/email_issue_alert_handler.py
@@ -58,6 +58,6 @@ class EmailIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
-        # TODO: is this ever anything other than 'mail'? If not, can just hard code that
-        label = "Send a notification via {}"
-        return label.format(blob.target_id.get("service"))
+        # TODO: beef this up
+        label = "Send a notification to Member and if none can be found then send a notification to ActiveMembers"
+        return label

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/msteams_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/msteams_issue_alert_handler.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.workflow_engine.models import Action
@@ -5,4 +9,16 @@ from sentry.workflow_engine.models import Action
 
 @issue_alert_handler_registry.register(Action.Type.MSTEAMS)
 class MSTeamsIssueAlertHandler(BaseIssueAlertHandler):
-    pass
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        integration = integration_service.get_integration(
+            integration_id=blob["team"],
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if not integration:
+            return ""
+
+        team = integration.name
+        channel = blob["channel"]
+        return f"Send a notification to the {team} Team to {channel}"

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/opsgenie_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/opsgenie_issue_alert_handler.py
@@ -1,9 +1,14 @@
 from typing import Any
 
+from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import ActionFieldMapping, OnCallDataBlob
+from sentry.workflow_engine.typings.notification_action import (
+    OPSGENIE_DEFAULT_PRIORITY,
+    ActionFieldMapping,
+    OnCallDataBlob,
+)
 
 
 @issue_alert_handler_registry.register(Action.Type.OPSGENIE)
@@ -16,3 +21,24 @@ class OpsgenieIssueAlertHandler(BaseIssueAlertHandler):
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         blob = OnCallDataBlob(**action.data)
         return {"priority": blob.priority}
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        from sentry.integrations.opsgenie.utils import get_team
+
+        result = integration_service.organization_context(
+            organization_id=organization_id,
+            integration_id=blob["account"],
+        )
+        integration = result.integration
+        org_integration = result.organization_integration
+
+        if not integration:
+            return ""
+
+        account = integration.name
+        team = get_team(blob["team"], org_integration)
+        team_name = team["team"] if team else "[removed]"
+        priority = blob.get("priority") or OPSGENIE_DEFAULT_PRIORITY
+
+        return f"Send a notification to Opsgenie account {account} and team {team_name} with {priority} priority"

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/opsgenie_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/opsgenie_issue_alert_handler.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from sentry.integrations.opsgenie.utils import get_team
 from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
@@ -24,8 +25,6 @@ class OpsgenieIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
-        from sentry.integrations.opsgenie.utils import get_team
-
         result = integration_service.organization_context(
             organization_id=organization_id,
             integration_id=blob["account"],

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/pagerduty_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/pagerduty_issue_alert_handler.py
@@ -1,9 +1,15 @@
 from typing import Any
 
+from sentry.integrations.pagerduty.utils import get_service
+from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.typings.notification_action import ActionFieldMapping, OnCallDataBlob
+from sentry.workflow_engine.typings.notification_action import (
+    PAGERDUTY_DEFAULT_SEVERITY,
+    ActionFieldMapping,
+    OnCallDataBlob,
+)
 
 
 @issue_alert_handler_registry.register(Action.Type.PAGERDUTY)
@@ -16,3 +22,22 @@ class PagerDutyIssueAlertHandler(BaseIssueAlertHandler):
     def get_additional_fields(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         blob = OnCallDataBlob(**action.data)
         return {"severity": blob.priority}
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        result = integration_service.organization_context(
+            organization_id=organization_id,
+            integration_id=blob["account"],
+        )
+        integration = result.integration
+        org_integration = result.organization_integration
+
+        if not integration:
+            return ""
+
+        account = integration.name
+        service = get_service(org_integration, blob["service"])
+        service_name = service["service_name"] if service else "[removed]"
+        severity = blob.get("severity") or PAGERDUTY_DEFAULT_SEVERITY
+
+        return f"Send a notification to PagerDuty account {account} and service {service_name} with {severity} severity"

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/plugin_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/plugin_issue_alert_handler.py
@@ -21,3 +21,7 @@ class PluginIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         return {}
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        return "Send a notification (for all legacy integrations)"

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/slack_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/slack_issue_alert_handler.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.services.integration import integration_service
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.workflow_engine.models import Action
@@ -15,3 +17,33 @@ class SlackIssueAlertHandler(BaseIssueAlertHandler):
             "tags": blob.tags,
             "notes": blob.notes,
         }
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        integration = integration_service.get_integration(
+            integration_id=blob["workspace"],
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+        )
+        if not integration:
+            return ""
+
+        workspace = integration.name
+        channel = blob["channel"]
+        label = f"Send a notification to the {workspace} Slack workspace to #{channel}"
+        has_tags = True if blob["tags"] != "" else False
+        if has_tags:
+            formatted_tags = "[{}]".format(", ".join(blob["tags"]))
+            label += f" and show tags {formatted_tags}"
+
+        notes = blob["notes"]
+        if notes != "":
+            if has_tags:
+                label += f' and notes "{notes}"'
+            else:
+                label += f' and show notes "{notes}"'
+
+        if notes or has_tags:
+            label += " in notification"
+
+        return label

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/slack_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/slack_issue_alert_handler.py
@@ -33,7 +33,9 @@ class SlackIssueAlertHandler(BaseIssueAlertHandler):
         label = f"Send a notification to the {workspace} Slack workspace to #{channel}"
         has_tags = True if blob["tags"] != "" else False
         if has_tags:
-            formatted_tags = "[{}]".format(", ".join(blob["tags"]))
+            formatted_tags = "[{}]".format(
+                ", ".join(tag.strip() for tag in blob["tags"].split(","))
+            )
             label += f" and show tags {formatted_tags}"
 
         notes = blob["notes"]

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/webhook_issue_alert_handler.py
@@ -15,3 +15,7 @@ class WebhookIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_target_display(cls, action: Action, mapping: ActionFieldMapping) -> dict[str, Any]:
         return {}
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        return "Send a notification via webhooks"

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -150,15 +150,24 @@ class BaseIssueAlertHandler(ABC):
         return {}
 
     @classmethod
+    def get_action_mapping(cls, action: Action) -> ActionFieldMapping:
+        mapping = ACTION_FIELD_MAPPINGS.get(Action.Type(action.type))
+        if mapping is None:
+            raise ValueError(f"No mapping found for action type: {action.type}")
+        return mapping
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        return "Send a notification"
+
+    @classmethod
     def build_rule_action_blob(
         cls,
         action: Action,
         organization_id: int,
     ) -> dict[str, Any]:
         """Build the base action blob using the standard mapping"""
-        mapping = ACTION_FIELD_MAPPINGS.get(Action.Type(action.type))
-        if mapping is None:
-            raise ValueError(f"No mapping found for action type: {action.type}")
+        mapping = cls.get_action_mapping(action)
         blob: dict[str, Any] = {
             "id": mapping["id"],
         }

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
@@ -12,8 +14,10 @@ from sentry.rules.conditions.tagged_event import TaggedEventCondition
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.rules.filters.event_attribute import EventAttributeFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import WorkflowDataConditionGroup, WorkflowFireHistory
@@ -70,7 +74,7 @@ class RuleSerializerTest(TestCase):
 @freeze_time()
 class WorkflowRuleSerializerTest(TestCase):
     def setUp(self) -> None:
-        conditions = [
+        self.conditions = [
             {"id": ReappearedEventCondition.id},
             {"id": RegressionEventCondition.id},
             {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
@@ -89,7 +93,7 @@ class WorkflowRuleSerializerTest(TestCase):
         ]
         self.issue_alert = self.create_project_rule(
             name="test",
-            condition_data=conditions,
+            condition_data=self.conditions,
             action_match="any",
             filter_match="any",
             frequency=5,
@@ -324,3 +328,28 @@ class WorkflowRuleSerializerTest(TestCase):
         )
 
         self.assert_equal_serializers(issue_alert)
+
+    def test_slack_action(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="slack",
+                provider="slack",
+                external_id="slack:1",
+                metadata={"access_token": "xoxb-access-token"},
+            )
+        self.uuid = "5bac5dcc-e201-4cb2-8da2-bac39788a13d"
+        self.action_data = {
+            "workspace": str(self.integration.id),
+            "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+            "channel_id": "C0123456789",
+            "tags": "",
+            "channel": "test-notifications",
+            "uuid": self.uuid,
+        }
+        self.rule = self.create_project_rule(
+            project=self.project,
+            action_data=[deepcopy(self.action_data)],
+            condition_data=self.conditions,
+        )
+        self.assert_equal_serializers(self.rule)

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -122,9 +122,12 @@ class WorkflowRuleSerializerTest(TestCase):
         for filter in rule_filters:
             assert filter in workflow_filters
 
-        # TODO: test with actions
-        serialized_rule.pop("actions")
-        serialized_workflow_rule.pop("actions")
+        rule_actions = serialized_rule.pop("actions")
+        workflow_actions = serialized_workflow_rule.pop("actions")
+
+        assert len(rule_actions) == len(workflow_actions)
+        for action in rule_actions:
+            assert action in workflow_actions
 
         assert serialized_rule == serialized_workflow_rule
 

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -433,6 +433,30 @@ class WorkflowRuleSerializerTest(TestCase):
         )
         self.assert_equal_serializers(rule)
 
+    def test_msteams_action(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="My Team",
+                provider="msteams",
+                external_id="msteams:1",
+                metadata={"installation_type": "team"},
+            )
+        action_data = {
+            "team": self.integration.id,
+            "id": "sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction",
+            "channel_id": "19:abc123@thread.tacv2",
+            "channel": "General",
+        }
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
     def test_opsgenie_action(self) -> None:
         team = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
@@ -97,6 +95,8 @@ class WorkflowRuleSerializerTest(TestCase):
             action_match="any",
             filter_match="any",
             frequency=5,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
         )
 
     def assert_equal_serializers(self, issue_alert):
@@ -325,6 +325,8 @@ class WorkflowRuleSerializerTest(TestCase):
             action_match="all",
             filter_match="all",
             frequency=30,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
         )
 
         self.assert_equal_serializers(issue_alert)
@@ -340,16 +342,17 @@ class WorkflowRuleSerializerTest(TestCase):
             )
         self.uuid = "5bac5dcc-e201-4cb2-8da2-bac39788a13d"
         self.action_data = {
-            "workspace": str(self.integration.id),
+            "workspace": self.integration.id,
             "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
             "channel_id": "C0123456789",
             "tags": "",
             "channel": "test-notifications",
-            "uuid": self.uuid,
         }
         self.rule = self.create_project_rule(
             project=self.project,
-            action_data=[deepcopy(self.action_data)],
+            action_data=[self.action_data],
             condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
         )
         self.assert_equal_serializers(self.rule)

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
 from sentry.integrations.models import OrganizationIntegration
+from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
@@ -476,6 +477,36 @@ class WorkflowRuleSerializerTest(TestCase):
             "team": team["id"],
             "priority": "P2",
             "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
+        }
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
+    def test_pagerduty_action(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration, org_integration = self.create_provider_integration_for(
+                self.organization,
+                self.user,
+                provider="pagerduty",
+                name="Example",
+                external_id="pagerduty:1",
+                metadata={},
+            )
+            service = add_service(
+                org_integration,
+                service_name="Critical",
+                integration_key="PND4F9",
+            )
+        action_data = {
+            "account": integration.id,
+            "service": str(service["id"]),
+            "severity": "warning",
+            "id": "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
         }
         rule = self.create_project_rule(
             project=self.project,

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
+from sentry.integrations.models import OrganizationIntegration
 from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
@@ -281,6 +282,7 @@ class WorkflowRuleSerializerTest(TestCase):
         ) == {workflow.id: timezone.now(), workflow_2.id: before_now(hours=1)}
 
     def test_rule_serializer(self) -> None:
+        # default issue alert rule has legacy plugins and webhook actions
         self.issue_alert.update(owner_user_id=self.user.id)
         self.issue_alert.refresh_from_db()
         self.assert_equal_serializers(self.issue_alert)
@@ -331,6 +333,58 @@ class WorkflowRuleSerializerTest(TestCase):
 
         self.assert_equal_serializers(issue_alert)
 
+    def test_email_action_simple(self) -> None:
+        action_data = [
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": str(self.user.id),
+                "targetType": "Member",
+            },
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": str(self.team.id),
+                "targetType": "Team",
+            },
+        ]
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=action_data,
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
+    def test_email_action_issue_owners(self) -> None:
+        action_data = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "AllMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "NoOne",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+        ]
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=action_data,
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
     def test_discord_action(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration = self.create_integration(
@@ -379,52 +433,29 @@ class WorkflowRuleSerializerTest(TestCase):
         )
         self.assert_equal_serializers(rule)
 
-    def test_email_action_simple(self) -> None:
-        action_data = [
-            {
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": str(self.user.id),
-                "targetType": "Member",
-            },
-            {
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": str(self.team.id),
-                "targetType": "Team",
-            },
-        ]
+    def test_opsgenie_action(self) -> None:
+        team = {"id": "123-id", "team": "cool-team", "integration_key": "1234-5678"}
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = self.create_integration(
+                organization=self.organization,
+                provider="opsgenie",
+                name="test-app",
+                external_id="opsgenie:1",
+            )
+            org_integration = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration_id=integration.id
+            )
+            org_integration.config = {"team_table": [team]}
+            org_integration.save()
+        action_data = {
+            "account": integration.id,
+            "team": team["id"],
+            "priority": "P2",
+            "id": "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
+        }
         rule = self.create_project_rule(
             project=self.project,
-            action_data=action_data,
-            condition_data=self.conditions,
-            include_legacy_rule_id=False,
-            include_workflow_id=False,
-        )
-        self.assert_equal_serializers(rule)
-
-    def test_email_action_issue_owners(self) -> None:
-        action_data = [
-            {
-                "targetType": "IssueOwners",
-                "fallthroughType": "ActiveMembers",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "",
-            },
-            {
-                "targetType": "IssueOwners",
-                "fallthroughType": "AllMembers",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "",
-            },
-            {
-                "targetType": "IssueOwners",
-                "fallthroughType": "NoOne",
-                "id": "sentry.mail.actions.NotifyEmailAction",
-                "targetIdentifier": "",
-            },
-        ]
-        rule = self.create_project_rule(
-            project=self.project,
-            action_data=action_data,
+            action_data=[action_data],
             condition_data=self.conditions,
             include_legacy_rule_id=False,
             include_workflow_id=False,

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -422,7 +422,8 @@ class WorkflowRuleSerializerTest(TestCase):
             "workspace": self.integration.id,
             "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
             "channel_id": "C0123456789",
-            "tags": "",
+            "tags": "hellboy, meow",
+            "notes": "this is a note",
             "channel": "test-notifications",
         }
         rule = self.create_project_rule(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -334,11 +334,10 @@ class WorkflowRuleSerializerTest(TestCase):
     def test_discord_action(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration = self.create_integration(
-                organization=self.organization,
-                name="discord",
                 provider="discord",
-                external_id="discord:1",
-                metadata={"guild_id": "1234567890"},
+                name="Cool server",
+                external_id="guild-id",
+                organization=self.organization,
             )
         self.action_data = {
             "server": self.integration.id,

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -331,6 +331,30 @@ class WorkflowRuleSerializerTest(TestCase):
 
         self.assert_equal_serializers(issue_alert)
 
+    def test_discord_action(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.integration = self.create_integration(
+                organization=self.organization,
+                name="discord",
+                provider="discord",
+                external_id="discord:1",
+                metadata={"guild_id": "1234567890"},
+            )
+        self.action_data = {
+            "server": self.integration.id,
+            "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+            "channel_id": "channel-id-123",
+            "tags": "",
+        }
+        self.rule = self.create_project_rule(
+            project=self.project,
+            action_data=[self.action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(self.rule)
+
     def test_slack_action(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration = self.create_integration(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -339,20 +339,20 @@ class WorkflowRuleSerializerTest(TestCase):
                 external_id="guild-id",
                 organization=self.organization,
             )
-        self.action_data = {
+        action_data = {
             "server": self.integration.id,
             "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
             "channel_id": "channel-id-123",
             "tags": "",
         }
-        self.rule = self.create_project_rule(
+        rule = self.create_project_rule(
             project=self.project,
-            action_data=[self.action_data],
+            action_data=[action_data],
             condition_data=self.conditions,
             include_legacy_rule_id=False,
             include_workflow_id=False,
         )
-        self.assert_equal_serializers(self.rule)
+        self.assert_equal_serializers(rule)
 
     def test_slack_action(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -363,19 +363,70 @@ class WorkflowRuleSerializerTest(TestCase):
                 external_id="slack:1",
                 metadata={"access_token": "xoxb-access-token"},
             )
-        self.uuid = "5bac5dcc-e201-4cb2-8da2-bac39788a13d"
-        self.action_data = {
+        action_data = {
             "workspace": self.integration.id,
             "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
             "channel_id": "C0123456789",
             "tags": "",
             "channel": "test-notifications",
         }
-        self.rule = self.create_project_rule(
+        rule = self.create_project_rule(
             project=self.project,
-            action_data=[self.action_data],
+            action_data=[action_data],
             condition_data=self.conditions,
             include_legacy_rule_id=False,
             include_workflow_id=False,
         )
-        self.assert_equal_serializers(self.rule)
+        self.assert_equal_serializers(rule)
+
+    def test_email_action_simple(self) -> None:
+        action_data = [
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": str(self.user.id),
+                "targetType": "Member",
+            },
+            {
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": str(self.team.id),
+                "targetType": "Team",
+            },
+        ]
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=action_data,
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
+    def test_email_action_issue_owners(self) -> None:
+        action_data = [
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "ActiveMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "AllMembers",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+            {
+                "targetType": "IssueOwners",
+                "fallthroughType": "NoOne",
+                "id": "sentry.mail.actions.NotifyEmailAction",
+                "targetIdentifier": "",
+            },
+        ]
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=action_data,
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)


### PR DESCRIPTION
In order to use the `WorkflowEngineRuleSerializer` in the old rule endpoints to read from the ACI models we need to finish it up by adding action data to the serializer response. To accomplish this we add new `render_label` methods to the issue alert handlers a la the old `____NotifyServiceAction`'s `render_label` methods (e.g. `SlackNotifyServiceAction`) for the `name` field and pull the rest of the data from the rule blob. 

In a few instances we have to massage the data to fit the expected format rather than change the data that is returned by the workflow engine code. 

A follow up PR will go back and remove the usage of `generate_rule_label` in `update_condition_name` so that we are not using any code tightly coupled with `Rule`. 

Note: This PR is getting large so I'm going to add the rest of the `render_label` methods in a follow up. 

TODO add `render_label` and tests for remaining actions
[ ] azure devops - 
[ ] github enterprise
[ ] github
[ ] jira
[ ] jira server
[x] msteams
[x] opsgenie
[x] pagerduty
[ ] sentry apps