### PR TITLE
perf(tests): Reduce session count in test_batch_query_percent_decimal

### DIFF
--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -462,7 +462,7 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
         assert batch_query == {self.event3.group_id: percent_of_sessions}
 
     def test_batch_query_percent_decimal(self) -> None:
-        self._make_sessions(600, self.environment.name)
+        self._make_sessions(60, self.environment.name)
 
         assert self.event.group_id
         groups = list(
@@ -480,7 +480,7 @@ class PercentSessionsQueryTest(BaseEventFrequencyPercentTest, EventFrequencyQuer
             end=self.end,
             environment_id=self.environment.id,
         )
-        assert round(batch_query[self.event.group_id], 4) == 0.17
+        assert round(batch_query[self.event.group_id], 4) == 1.67
 
     @patch(
         "sentry.workflow_engine.handlers.condition.event_frequency_query_handlers.MIN_SESSIONS_TO_FIRE",


### PR DESCRIPTION
The test creates sessions to verify decimal percentage rounding precision. 600 sessions was far more than needed — 60 still exceeds MIN_SESSIONS_TO_FIRE (50) and produces a decimal result (1.67%) that exercises the same rounding code path. Reduces test runtime from ~32s to ~7s.