### PR TITLE
fix(frameRegisters): Sort registers numerically instead of lexicographically

### DIFF
--- a/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
@@ -1,6 +1,7 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {FrameRegisters} from 'sentry/components/events/interfaces/frame/frameRegisters';
+import {getSortedRegisters} from 'sentry/components/events/interfaces/frame/frameRegisters/utils';
 import {FrameRegisterValue} from 'sentry/components/events/interfaces/frame/frameRegisters/value';
 
 describe('FrameRegisters', () => {
@@ -27,6 +28,88 @@ describe('FrameRegisters', () => {
     expect(screen.getByText('r10')).toBeInTheDocument();
     expect(screen.getByText('0x00007fff9300bf70')).toBeInTheDocument();
     expect(screen.queryByText('r11')).not.toBeInTheDocument();
+  });
+
+  it('should sort registers numerically without deviceArch', () => {
+    const registers = {
+      r0: '0x0000000000000000',
+      r1: '0x0000000000000001',
+      r10: '0x000000000000000a',
+      r12: '0x000000000000000c',
+      r2: '0x0000000000000002',
+      r3: '0x0000000000000003',
+    };
+
+    const sorted = getSortedRegisters(registers);
+    expect(sorted.map(([name]) => name)).toEqual(['r0', 'r1', 'r2', 'r3', 'r10', 'r12']);
+  });
+
+  it('should sort registers numerically with deviceArch', () => {
+    const registers = {
+      r0: '0x0000000000000000',
+      r1: '0x0000000000000001',
+      r10: '0x000000000000000a',
+      r12: '0x000000000000000c',
+      r2: '0x0000000000000002',
+      r3: '0x0000000000000003',
+    };
+
+    const sorted = getSortedRegisters(registers, 'arm');
+    expect(sorted.map(([name]) => name)).toEqual(['r0', 'r1', 'r2', 'r3', 'r10', 'r12']);
+  });
+
+  it('should sort x86_64 registers by map index with numeric fallback for unmapped', () => {
+    // Simulate x86_64 registers in lexicographic (wrong) insertion order
+    const registers = {
+      r10: '0x000000000000000a',
+      r11: '0x000000000000000b',
+      r8: '0x0000000000000008',
+      r9: '0x0000000000000009',
+      rax: '0x0000000000000000',
+      rbx: '0x0000000000000003',
+      rip: '0x0000000000000010',
+    };
+
+    const sorted = getSortedRegisters(registers, 'x86_64');
+    expect(sorted.map(([name]) => name)).toEqual([
+      'rax',
+      'rbx',
+      'r8',
+      'r9',
+      'r10',
+      'r11',
+      'rip',
+    ]);
+  });
+
+  it('should sort arm64 registers numerically without deviceArch', () => {
+    // Registers as they might arrive from the server in insertion order
+    const registers = {
+      fp: '0x0000000000000001',
+      lr: '0x0000000000000002',
+      pc: '0x0000000000000003',
+      sp: '0x0000000000000004',
+      x0: '0x0000000000000005',
+      x1: '0x0000000000000006',
+      x10: '0x0000000000000007',
+      x2: '0x0000000000000008',
+      x20: '0x0000000000000009',
+      x3: '0x000000000000000a',
+    };
+
+    const sorted = getSortedRegisters(registers);
+    expect(sorted.map(([name]) => name)).toEqual([
+      'fp',
+      'lr',
+      'pc',
+      'sp',
+      'x0',
+      'x1',
+      'x2',
+      'x3',
+      'x10',
+      'x20',
+    ]);
   });
 });
 

--- a/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/utils.tsx
@@ -46,18 +46,24 @@ export function getSortedRegisters(
   deviceArch?: string
 ) {
   const entries = Object.entries(registers);
+  const registerMap = deviceArch ? getRegisterMap(deviceArch) : undefined;
 
-  if (!deviceArch) {
-    return entries;
-  }
+  return entries.sort((a, b) => {
+    if (registerMap) {
+      const indexA = getRegisterIndex(a[0], registerMap);
+      const indexB = getRegisterIndex(b[0], registerMap);
 
-  const registerMap = getRegisterMap(deviceArch);
+      // If both registers are in the map, sort by index
+      if (indexA !== -1 && indexB !== -1) {
+        return indexA - indexB;
+      }
 
-  if (!registerMap) {
-    return entries;
-  }
+      // Mapped registers come before unmapped ones
+      if (indexA !== -1) return -1;
+      if (indexB !== -1) return 1;
+    }
 
-  return entries.sort(
-    (a, b) => getRegisterIndex(a[0], registerMap) - getRegisterIndex(b[0], registerMap)
-  );
+    // Fallback: natural sort (handles numeric suffixes correctly)
+    return a[0].localeCompare(b[0], undefined, {numeric: true});
+  });
 }


### PR DESCRIPTION
Registers like r0, r1, r10, r2 were displayed in lexicographic order instead of numeric order (r0, r1, r2, ..., r10). This affected all architectures when deviceArch was missing, and unmapped registers when a register map was available. Use localeCompare with numeric option as a fallback sort for all cases.

Fixes #76773