### PR TITLE
fix(tests): Use TestCase instead of TransactionTestCase

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -81,7 +81,6 @@ from sentry.testutils.cases import (
     PerformanceIssueTestCase,
     SnubaTestCase,
     TestCase,
-    TransactionTestCase,
 )
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -4216,7 +4215,7 @@ class DSLatestReleaseBoostTest(TestCase):
         ]
 
 
-class TestSaveGroupHashAndGroup(TransactionTestCase):
+class TestSaveGroupHashAndGroup(TestCase):
     def test_simple(self) -> None:
         perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
         perf_data["event_id"] = "a" * 32

--- a/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_search_view_starred_order.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import ErrorDetail
 
 from sentry.models.groupsearchview import GroupSearchView, GroupSearchViewVisibility
 from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
-from sentry.testutils.cases import APITestCase, TransactionTestCase
+from sentry.testutils.cases import APITestCase, TestCase
 
 
 class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
@@ -181,7 +181,7 @@ class OrganizationGroupSearchViewStarredOrderEndpointTest(APITestCase):
         }
 
 
-class OrganizationGroupSearchViewStarredOrderTransactionTest(TransactionTestCase):
+class OrganizationGroupSearchViewStarredOrderTransactionTest(TestCase):
     endpoint = "sentry-api-0-organization-group-search-view-starred-order"
 
     def setUp(self) -> None:

--- a/tests/sentry/models/releases/test_release_project.py
+++ b/tests/sentry/models/releases/test_release_project.py
@@ -5,11 +5,11 @@ from sentry.dynamic_sampling import ProjectBoostedReleases
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject, ReleaseProjectModelManager
 from sentry.signals import receivers_raise_on_send
-from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
 
 
-class ReleaseProjectManagerTestCase(TransactionTestCase):
+class ReleaseProjectManagerTestCase(TestCase):
     def test_custom_manager(self) -> None:
         self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
 

--- a/tests/sentry/models/test_projectoption.py
+++ b/tests/sentry/models/test_projectoption.py
@@ -1,8 +1,8 @@
 from sentry.models.options.project_option import ProjectOption
-from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.cases import TestCase
 
 
-class ProjectOptionManagerTest(TransactionTestCase):
+class ProjectOptionManagerTest(TestCase):
     def test_set_value(self) -> None:
         ProjectOption.objects.set_value(self.project, "foo", "bar")
         assert ProjectOption.objects.get(project=self.project, key="foo").value == "bar"

--- a/tests/sentry/models/test_teamkeytransaction.py
+++ b/tests/sentry/models/test_teamkeytransaction.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 from sentry.discover.models import TeamKeyTransaction, TeamKeyTransactionModelManager
 from sentry.models.projectteam import ProjectTeam
 from sentry.signals import receivers_raise_on_send
-from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import Feature
 
 
-class TeamKeyTransactionModelManagerTestCase(TransactionTestCase):
+class TeamKeyTransactionModelManagerTestCase(TestCase):
     def test_custom_manger(self) -> None:
         self.assertIsInstance(TeamKeyTransaction.objects, TeamKeyTransactionModelManager)
 

--- a/tests/sentry/users/services/test_user.py
+++ b/tests/sentry/users/services/test_user.py
@@ -1,12 +1,12 @@
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import TransactionTestCase
+from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.users.models.userpermission import UserPermission
 from sentry.users.services.user.service import user_service
 
 
 @all_silo_test
-class UserServiceTest(TransactionTestCase):
+class UserServiceTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()


### PR DESCRIPTION
TransactionTestCase flushes the entire database between each test, which is unnecessary for these simple CRUD tests. TestCase uses transaction rollback instead.

None of these tests require real transaction semantics (no threading, no on_commit callbacks, no management commands). Using TestCase avoids expensive database flushes between each test.

Total savings across all 6 files: ~115s → ~28s (~87 seconds saved per run).