### PR TITLE
feat(issues): Add AI Trace section

### DIFF
--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -36,6 +36,54 @@ interface AITraceSectionProps {
 
 const MCP_SERVER_URL = 'http://localhost:8080';
 
+// Demo mode: set to true to use hardcoded data for UI testing
+const USE_DEMO_DATA = true;
+
+const DEMO_DATA: AITraceData = {
+  metadata: {
+    model_id: 'claude-sonnet-4-5-20250929',
+    project_path: '/Users/antonis/git/vibetrace',
+    session_id: '04b613db-e3e7-43dd-b2d7-70fa5fbb1717',
+    summary: 'Implement Vibe Trace integration with Sentry',
+    timestamp: '2026-02-18T14:30:00Z',
+    tool_name: 'claude-code',
+  },
+  conversation: [
+    {
+      role: 'user',
+      content:
+        'I want to test the full end-to-end flow of Vibe Trace - linking AI conversations to Sentry errors',
+    },
+    {
+      role: 'assistant',
+      content:
+        "I'll help you test the complete Vibe Trace flow. Let me create a test scenario that demonstrates how AI-generated code errors are linked back to their conversation context in Sentry...",
+      tool_uses: [{name: 'Write'}, {name: 'Bash'}],
+    },
+    {
+      role: 'user',
+      content:
+        "Let's modify the Sentry codebase directly instead of using Tampermonkey. I'll deploy via Vercel for testing.",
+    },
+    {
+      role: 'assistant',
+      content:
+        "Great idea! I'll create a native React component in the Sentry codebase. This will be more maintainable and won't require browser extensions...",
+      tool_uses: [{name: 'Write'}, {name: 'Edit'}, {name: 'Read'}],
+    },
+    {
+      role: 'user',
+      content: 'Can you fix the TypeScript errors showing up in the build?',
+    },
+    {
+      role: 'assistant',
+      content:
+        "I'll fix the TypeScript errors related to Sentry's theme system. The theme uses tokens.* properties rather than direct color properties...",
+      tool_uses: [{name: 'Edit'}],
+    },
+  ],
+};
+
 export function AITraceSection({event}: AITraceSectionProps) {
   const [traceData, setTraceData] = useState<AITraceData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -49,6 +97,15 @@ export function AITraceSection({event}: AITraceSectionProps) {
   useEffect(() => {
     if (!commitHash) {
       setLoading(false);
+      return;
+    }
+
+    if (USE_DEMO_DATA) {
+      // Use hardcoded demo data for UI testing
+      setTimeout(() => {
+        setTraceData(DEMO_DATA);
+        setLoading(false);
+      }, 500); // Simulate network delay
       return;
     }
 
@@ -126,15 +183,17 @@ export function AITraceSection({event}: AITraceSectionProps) {
           </Button>
 
           <ToggleButton onClick={() => setShowConversation(!showConversation)}>
-            {showConversation ? '▼' : '▶'} {t('View Conversation')} (
-            {conversation.length})
+            {showConversation ? '▼' : '▶'} {t('View Conversation')} ({conversation.length}
+            )
           </ToggleButton>
 
           {showConversation && (
             <ConversationBox>
               {conversation.slice(0, 10).map((turn, i) => (
                 <Turn key={i}>
-                  <TurnLabel>{turn.role === 'user' ? '👤 User' : '🤖 Assistant'}</TurnLabel>
+                  <TurnLabel>
+                    {turn.role === 'user' ? '👤 User' : '🤖 Assistant'}
+                  </TurnLabel>
                   <TurnText>{turn.content.substring(0, 300)}...</TurnText>
                 </Turn>
               ))}

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -36,10 +36,11 @@ interface AITraceSectionProps {
 }
 
 const MCP_SERVER_URL = 'http://localhost:8080';
+const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4'; // For local testing only
 
 // Demo mode: set to true to use hardcoded data for UI testing
 // Use true for Vercel deployment since MCP server is not publicly accessible
-const USE_DEMO_DATA = true;
+const USE_DEMO_DATA = false;
 
 const DEMO_DATA: AITraceData = {
   metadata: {
@@ -119,7 +120,11 @@ export function AITraceSection({event}: AITraceSectionProps) {
       return;
     }
 
-    fetch(`${MCP_SERVER_URL}/v2/traces/by-commit/${commitHash}/conversation`)
+    fetch(`${MCP_SERVER_URL}/v2/traces/by-commit/${commitHash}/conversation`, {
+      headers: {
+        'X-API-Key': MCP_API_KEY,
+      },
+    })
       .then(response => response.json())
       .then(data => {
         if (data.found) {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -35,14 +35,12 @@ interface AITraceSectionProps {
   project: Project;
 }
 
-// For Vercel deployment, update this to your ngrok URL:
-// const MCP_SERVER_URL = 'https://your-ngrok-url.ngrok-free.app';
-const MCP_SERVER_URL = 'http://localhost:8080';
+// ngrok URL for Vercel deployment (real data)
+const MCP_SERVER_URL = 'https://unpargeted-superextreme-kenna.ngrok-free.dev';
 const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4';
 
 // Demo mode: set to false to use real data from MCP server
-// Set to true for Vercel demo (no ngrok needed)
-const USE_DEMO_DATA = true;
+const USE_DEMO_DATA = false;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 
+import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -157,7 +158,14 @@ export function AITraceSection({event}: AITraceSectionProps) {
         <InfoGrid>
           <InfoRow>
             <Label>{t('Session ID')}</Label>
-            <Value>{metadata.session_id.substring(0, 16)}...</Value>
+            <SessionIdValue>
+              <SessionIdText>{metadata.session_id}</SessionIdText>
+              <StyledCopyButton
+                text={metadata.session_id}
+                size="xs"
+                aria-label={t('Copy Session ID')}
+              />
+            </SessionIdValue>
           </InfoRow>
           <InfoRow>
             <Label>{t('Model')}</Label>
@@ -215,6 +223,7 @@ const InfoRow = styled('div')`
   display: grid;
   grid-template-columns: 120px 1fr;
   gap: ${space(2)};
+  align-items: start;
 `;
 
 const Label = styled('div')`
@@ -224,6 +233,24 @@ const Label = styled('div')`
 
 const Value = styled('div')`
   color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const SessionIdValue = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
+
+const SessionIdText = styled('code')`
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
+  word-break: break-all;
+`;
+
+const StyledCopyButton = styled(CopyToClipboardButton)`
+  min-width: auto;
+  height: 20px;
+  flex-shrink: 0;
 `;
 
 const ToggleButton = styled('div')`

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -35,13 +35,12 @@ interface AITraceSectionProps {
   project: Project;
 }
 
-// ngrok URL for Vercel deployment (real data)
+// ngrok URL for Vercel deployment (real data) - paid plan removes browser warning
 const MCP_SERVER_URL = 'https://unpargeted-superextreme-kenna.ngrok-free.dev';
 const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4';
 
 // Demo mode: set to false to use real data from MCP server
-// Using demo mode because ngrok free tier blocks browser requests
-const USE_DEMO_DATA = true;
+const USE_DEMO_DATA = false;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -3,14 +3,14 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 
-import {DataSection} from 'sentry/components/events/styles';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconChevron, IconOpen} from 'sentry/icons';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
+import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
 interface AITraceData {
   conversation: Array<{
@@ -87,7 +87,6 @@ const DEMO_DATA: AITraceData = {
 export function AITraceSection({event}: AITraceSectionProps) {
   const [traceData, setTraceData] = useState<AITraceData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [isExpanded, setIsExpanded] = useState(true);
   const [showConversation, setShowConversation] = useState(false);
 
   // Extract commit hash from git_commit tag or release field
@@ -135,14 +134,9 @@ export function AITraceSection({event}: AITraceSectionProps) {
 
   if (loading) {
     return (
-      <DataSection>
-        <SectionHeader>
-          <span>🤖 {t('AI Trace')}</span>
-        </SectionHeader>
-        <ContentBox>
-          <LoadingIndicator mini />
-        </ContentBox>
-      </DataSection>
+      <InterimSection type="agent-trace" title={t('Agent Trace')}>
+        <LoadingIndicator mini />
+      </InterimSection>
     );
   }
 
@@ -158,80 +152,56 @@ export function AITraceSection({event}: AITraceSectionProps) {
   const toolName = metadata.tool_name === 'cursor' ? 'Cursor' : 'Claude Code';
 
   return (
-    <DataSection>
-      <SectionHeader onClick={() => setIsExpanded(!isExpanded)}>
-        <ChevronIcon isExpanded={isExpanded} />
-        <span>🤖 {t('AI Trace')}</span>
-      </SectionHeader>
+    <InterimSection type="agent-trace" title={t('Agent Trace')}>
+      <ContentBox>
+        <InfoGrid>
+          <InfoRow>
+            <Label>{t('Session ID')}</Label>
+            <Value>{metadata.session_id.substring(0, 16)}...</Value>
+          </InfoRow>
+          <InfoRow>
+            <Label>{t('Model')}</Label>
+            <Value>{metadata.model_id}</Value>
+          </InfoRow>
+          <InfoRow>
+            <Label>{t('Summary')}</Label>
+            <Value>{metadata.summary}</Value>
+          </InfoRow>
+        </InfoGrid>
 
-      {isExpanded && (
-        <ContentBox>
-          <InfoGrid>
-            <InfoRow>
-              <Label>{t('Session ID')}</Label>
-              <Value>{metadata.session_id.substring(0, 16)}...</Value>
-            </InfoRow>
-            <InfoRow>
-              <Label>{t('Model')}</Label>
-              <Value>{metadata.model_id}</Value>
-            </InfoRow>
-            <InfoRow>
-              <Label>{t('Summary')}</Label>
-              <Value>{metadata.summary}</Value>
-            </InfoRow>
-          </InfoGrid>
+        <Button
+          size="sm"
+          icon={<IconOpen />}
+          onClick={() => {
+            window.location.href = deepLink;
+          }}
+        >
+          {t('Open in')} {toolName}
+        </Button>
 
-          <Button
-            size="sm"
-            icon={<IconOpen />}
-            onClick={() => {
-              window.location.href = deepLink;
-            }}
-          >
-            {t('Open in')} {toolName}
-          </Button>
+        <ToggleButton onClick={() => setShowConversation(!showConversation)}>
+          {showConversation ? '▼' : '▶'} {t('View Conversation')} ({conversation.length})
+        </ToggleButton>
 
-          <ToggleButton onClick={() => setShowConversation(!showConversation)}>
-            {showConversation ? '▼' : '▶'} {t('View Conversation')} ({conversation.length}
-            )
-          </ToggleButton>
-
-          {showConversation && (
-            <ConversationBox>
-              {conversation.slice(0, 10).map((turn, i) => (
-                <Turn key={i}>
-                  <TurnLabel>
-                    {turn.role === 'user' ? '👤 User' : '🤖 Assistant'}
-                  </TurnLabel>
-                  <TurnText>{turn.content.substring(0, 300)}...</TurnText>
-                </Turn>
-              ))}
-            </ConversationBox>
-          )}
-        </ContentBox>
-      )}
-    </DataSection>
+        {showConversation && (
+          <ConversationBox>
+            {conversation.slice(0, 10).map((turn, i) => (
+              <Turn key={i}>
+                <TurnLabel>{turn.role === 'user' ? '👤 User' : '🤖 Assistant'}</TurnLabel>
+                <TurnText>{turn.content.substring(0, 300)}...</TurnText>
+              </Turn>
+            ))}
+          </ConversationBox>
+        )}
+      </ContentBox>
+    </InterimSection>
   );
 }
 
-const SectionHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${space(1)};
-  cursor: pointer;
-  padding: ${space(2)} 0;
-  font-weight: 600;
-`;
-
-const ChevronIcon = styled(IconChevron)<{isExpanded: boolean}>`
-  transform: ${p => (p.isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)')};
-  transition: transform 0.15s;
-`;
-
 const ContentBox = styled('div')`
-  padding: ${space(2)};
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(2)};
 `;
 
 const InfoGrid = styled('div')`

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -41,7 +41,8 @@ const MCP_SERVER_URL = 'http://localhost:8080';
 const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4';
 
 // Demo mode: set to false to use real data from MCP server
-const USE_DEMO_DATA = false;
+// Set to true for Vercel demo (no ngrok needed)
+const USE_DEMO_DATA = true;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -87,17 +87,32 @@ const DEMO_DATA: AITraceData = {
   ],
 };
 
-export function AITraceSection({event}: AITraceSectionProps) {
+export function AITraceSection({event, group}: AITraceSectionProps) {
   const [traceData, setTraceData] = useState<AITraceData | null>(null);
   const [loading, setLoading] = useState(true);
   const [showConversation, setShowConversation] = useState(false);
 
-  // Extract commit hash from git_commit tag or release field
+  // Extract commit hash with priority order:
+  // 1. Sentry's suspect commits (automatic detection via repository integration)
+  // 2. Manual git_commit tag (backward compatibility)
+  // 3. Release field format (backward compatibility)
   let commitHash: string | undefined;
-  const gitCommitTag = event.tags?.find(tag => tag.key === 'git_commit');
-  if (gitCommitTag?.value) {
-    commitHash = gitCommitTag.value;
-  } else if (typeof event.release === 'string') {
+
+  // Priority 1: Use Sentry's suspect commits (most reliable)
+  if (group.suspectCommits && group.suspectCommits.length > 0) {
+    commitHash = group.suspectCommits[0].id;
+  }
+
+  // Priority 2: Fall back to manual git_commit tag
+  if (!commitHash) {
+    const gitCommitTag = event.tags?.find(tag => tag.key === 'git_commit');
+    if (gitCommitTag?.value) {
+      commitHash = gitCommitTag.value;
+    }
+  }
+
+  // Priority 3: Fall back to release field
+  if (!commitHash && typeof event.release === 'string') {
     const releaseString = event.release as string;
     const parts = releaseString.split('+');
     if (parts.length > 1) {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -38,7 +38,8 @@ interface AITraceSectionProps {
 const MCP_SERVER_URL = 'http://localhost:8080';
 
 // Demo mode: set to true to use hardcoded data for UI testing
-const USE_DEMO_DATA = false;
+// Use true for Vercel deployment since MCP server is not publicly accessible
+const USE_DEMO_DATA = true;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -90,9 +90,18 @@ export function AITraceSection({event}: AITraceSectionProps) {
   const [isExpanded, setIsExpanded] = useState(true);
   const [showConversation, setShowConversation] = useState(false);
 
-  const commitHash =
-    event.tags?.find(tag => tag.key === 'git_commit')?.value ||
-    (typeof event.release === 'string' ? event.release.split('+')[1] : undefined);
+  // Extract commit hash from git_commit tag or release field
+  let commitHash: string | undefined;
+  const gitCommitTag = event.tags?.find(tag => tag.key === 'git_commit');
+  if (gitCommitTag?.value) {
+    commitHash = gitCommitTag.value;
+  } else if (typeof event.release === 'string') {
+    const releaseString = event.release as string;
+    const parts = releaseString.split('+');
+    if (parts.length > 1) {
+      commitHash = parts[1];
+    }
+  }
 
   useEffect(() => {
     if (!commitHash) {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -35,11 +35,12 @@ interface AITraceSectionProps {
   project: Project;
 }
 
+// For Vercel deployment, update this to your ngrok URL:
+// const MCP_SERVER_URL = 'https://your-ngrok-url.ngrok-free.app';
 const MCP_SERVER_URL = 'http://localhost:8080';
-const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4'; // For local testing only
+const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4';
 
-// Demo mode: set to true to use hardcoded data for UI testing
-// Use true for Vercel deployment since MCP server is not publicly accessible
+// Demo mode: set to false to use real data from MCP server
 const USE_DEMO_DATA = false;
 
 const DEMO_DATA: AITraceData = {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -38,7 +38,7 @@ interface AITraceSectionProps {
 const MCP_SERVER_URL = 'http://localhost:8080';
 
 // Demo mode: set to true to use hardcoded data for UI testing
-const USE_DEMO_DATA = true;
+const USE_DEMO_DATA = false;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -40,7 +40,8 @@ const MCP_SERVER_URL = 'https://unpargeted-superextreme-kenna.ngrok-free.dev';
 const MCP_API_KEY = 'mwu18CWSSa7jSGHi53ZkcyoG9Z9s3S6B2uCX7FPPRy4';
 
 // Demo mode: set to false to use real data from MCP server
-const USE_DEMO_DATA = false;
+// Using demo mode because ngrok free tier blocks browser requests
+const USE_DEMO_DATA = true;
 
 const DEMO_DATA: AITraceData = {
   metadata: {

--- a/static/app/views/issueDetails/aiTrace/index.tsx
+++ b/static/app/views/issueDetails/aiTrace/index.tsx
@@ -1,0 +1,221 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+
+import {DataSection} from 'sentry/components/events/styles';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconChevron, IconOpen} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {Event} from 'sentry/types/event';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
+
+interface AITraceData {
+  conversation: Array<{
+    content: string;
+    role: string;
+    tool_uses?: Array<{name: string}>;
+  }>;
+  metadata: {
+    model_id: string;
+    project_path: string;
+    session_id: string;
+    summary: string;
+    timestamp: string;
+    tool_name: string;
+  };
+}
+
+interface AITraceSectionProps {
+  event: Event;
+  group: Group;
+  project: Project;
+}
+
+const MCP_SERVER_URL = 'http://localhost:8080';
+
+export function AITraceSection({event}: AITraceSectionProps) {
+  const [traceData, setTraceData] = useState<AITraceData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [showConversation, setShowConversation] = useState(false);
+
+  const commitHash =
+    event.tags?.find(tag => tag.key === 'git_commit')?.value ||
+    (typeof event.release === 'string' ? event.release.split('+')[1] : undefined);
+
+  useEffect(() => {
+    if (!commitHash) {
+      setLoading(false);
+      return;
+    }
+
+    fetch(`${MCP_SERVER_URL}/v2/traces/by-commit/${commitHash}/conversation`)
+      .then(response => response.json())
+      .then(data => {
+        if (data.found) {
+          setTraceData(data);
+        }
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [commitHash]);
+
+  if (!commitHash || (!loading && !traceData)) {
+    return null;
+  }
+
+  if (loading) {
+    return (
+      <DataSection>
+        <SectionHeader>
+          <span>🤖 {t('AI Trace')}</span>
+        </SectionHeader>
+        <ContentBox>
+          <LoadingIndicator mini />
+        </ContentBox>
+      </DataSection>
+    );
+  }
+
+  if (!traceData) {
+    return null;
+  }
+
+  const {metadata, conversation} = traceData;
+  const deepLink =
+    metadata.tool_name === 'cursor'
+      ? `cursor://open-conversation?id=${metadata.session_id}&project=${encodeURIComponent(metadata.project_path)}`
+      : `claude-code://open-session?id=${metadata.session_id}&project=${encodeURIComponent(metadata.project_path)}`;
+  const toolName = metadata.tool_name === 'cursor' ? 'Cursor' : 'Claude Code';
+
+  return (
+    <DataSection>
+      <SectionHeader onClick={() => setIsExpanded(!isExpanded)}>
+        <ChevronIcon isExpanded={isExpanded} />
+        <span>🤖 {t('AI Trace')}</span>
+      </SectionHeader>
+
+      {isExpanded && (
+        <ContentBox>
+          <InfoGrid>
+            <InfoRow>
+              <Label>{t('Session ID')}</Label>
+              <Value>{metadata.session_id.substring(0, 16)}...</Value>
+            </InfoRow>
+            <InfoRow>
+              <Label>{t('Model')}</Label>
+              <Value>{metadata.model_id}</Value>
+            </InfoRow>
+            <InfoRow>
+              <Label>{t('Summary')}</Label>
+              <Value>{metadata.summary}</Value>
+            </InfoRow>
+          </InfoGrid>
+
+          <Button
+            size="sm"
+            icon={<IconOpen />}
+            onClick={() => {
+              window.location.href = deepLink;
+            }}
+          >
+            {t('Open in')} {toolName}
+          </Button>
+
+          <ToggleButton onClick={() => setShowConversation(!showConversation)}>
+            {showConversation ? '▼' : '▶'} {t('View Conversation')} (
+            {conversation.length})
+          </ToggleButton>
+
+          {showConversation && (
+            <ConversationBox>
+              {conversation.slice(0, 10).map((turn, i) => (
+                <Turn key={i}>
+                  <TurnLabel>{turn.role === 'user' ? '👤 User' : '🤖 Assistant'}</TurnLabel>
+                  <TurnText>{turn.content.substring(0, 300)}...</TurnText>
+                </Turn>
+              ))}
+            </ConversationBox>
+          )}
+        </ContentBox>
+      )}
+    </DataSection>
+  );
+}
+
+const SectionHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(1)};
+  cursor: pointer;
+  padding: ${space(2)} 0;
+  font-weight: 600;
+`;
+
+const ChevronIcon = styled(IconChevron)<{isExpanded: boolean}>`
+  transform: ${p => (p.isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)')};
+  transition: transform 0.15s;
+`;
+
+const ContentBox = styled('div')`
+  padding: ${space(2)};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 4px;
+`;
+
+const InfoGrid = styled('div')`
+  display: flex;
+  flex-direction: column;
+  gap: ${space(1.5)};
+  margin-bottom: ${space(2)};
+`;
+
+const InfoRow = styled('div')`
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: ${space(2)};
+`;
+
+const Label = styled('div')`
+  color: ${p => p.theme.colors.gray600};
+  font-weight: 600;
+`;
+
+const Value = styled('div')`
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const ToggleButton = styled('div')`
+  margin-top: ${space(2)};
+  padding: ${space(1)} ${space(2)};
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+`;
+
+const ConversationBox = styled('div')`
+  margin-top: ${space(2)};
+  max-height: 400px;
+  overflow-y: auto;
+`;
+
+const Turn = styled('div')`
+  padding: ${space(1.5)};
+  margin-bottom: ${space(1)};
+  border-left: 3px solid ${p => p.theme.colors.blue300};
+  background: ${p => p.theme.tokens.background.secondary};
+`;
+
+const TurnLabel = styled('div')`
+  font-weight: 600;
+  margin-bottom: ${space(0.5)};
+`;
+
+const TurnText = styled('div')`
+  color: ${p => p.theme.tokens.content.secondary};
+`;

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -74,6 +74,7 @@ import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import {isJavascriptPlatform, isMobilePlatform} from 'sentry/utils/platform';
 import {getReplayIdFromEvent} from 'sentry/utils/replays/getReplayIdFromEvent';
 import useOrganization from 'sentry/utils/useOrganization';
+import {AITraceSection} from 'sentry/views/issueDetails/aiTrace';
 import {MetricIssuesSection} from 'sentry/views/issueDetails/metricIssues/metricIssuesSection';
 import {ProfilePreviewSection} from 'sentry/views/issueDetails/profilePreviewSection';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
@@ -82,7 +83,6 @@ import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/us
 import {InstrumentationFixSection} from 'sentry/views/issueDetails/streamline/instrumentationFixSection';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection';
-import {AITraceSection} from 'sentry/views/issueDetails/aiTrace';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -82,6 +82,7 @@ import {useCopyIssueDetails} from 'sentry/views/issueDetails/streamline/hooks/us
 import {InstrumentationFixSection} from 'sentry/views/issueDetails/streamline/instrumentationFixSection';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 import {MetricDetectorTriggeredSection} from 'sentry/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection';
+import {AITraceSection} from 'sentry/views/issueDetails/aiTrace';
 import {TraceDataSection} from 'sentry/views/issueDetails/traceDataSection';
 import {useHasStreamlinedUI} from 'sentry/views/issueDetails/utils';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
@@ -388,6 +389,9 @@ export function EventDetailsContent({
           <Template event={event} data={eventEntries[EntryType.TEMPLATE].data} />
         </EntryErrorBoundary>
       )}
+      <ErrorBoundary mini message={t('There was a problem loading AI trace.')}>
+        <AITraceSection event={event} group={group} project={project} />
+      </ErrorBoundary>
       <BreadcrumbsDataSection event={event} group={group} project={project} />
       <ErrorBoundary mini message={t('There was a problem loading logs.')}>
         <Feature features="ourlogs-enabled" organization={organization}>


### PR DESCRIPTION
<!-- Describe your PR here. -->

Add AI Trace section to show Claude Code conversation context

Adds native AI Trace section to issue detail pages that displays:
- Session ID and metadata from AI coding assistant
- Model used (Claude, etc.)
- Conversation summary
- Deep link button to open session in Claude Code/Cursor
- Full conversation viewer (collapsible)

The section:
- Fetches data from MCP server using git commit hash from event tags
- Appears between Stack Trace and Breadcrumbs sections
- Only shows when git_commit tag is present
- Handles loading/error states gracefully

This enables developers to see the exact AI conversation that generated the code causing an error, providing valuable context for debugging.

Technical details:
- New component: static/app/views/issueDetails/aiTrace/index.tsx
- Integrated into groupEventDetailsContent.tsx
- Uses ErrorBoundary for fault tolerance
- Styled to match Sentry's design system
- Supports deep linking to Claude Code and Cursor
