### PR TITLE
fix(charts): fix timezone offset problem

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -59,6 +59,7 @@ import {
 import XAxis from './components/xAxis';
 import YAxis from './components/yAxis';
 import LineSeries from './series/lineSeries';
+import {shiftSeriesData, shiftTimestampToFakeUtc} from './timezoneShift';
 import {
   computeEchartsAriaLabels,
   getDiffInMinutes,
@@ -490,6 +491,14 @@ function BaseChart({
   const chartId = useId();
 
   const chartOption = useMemo(() => {
+    // When utc is false, we shift all timestamps into "fake UTC" so that
+    // ECharts (with useUTC: true) places tick boundaries at nice values
+    // in the user's configured timezone. Formatters then read the shifted
+    // UTC wall-clock, which matches user-timezone wall-clock.
+    const shouldShift = !utc;
+
+    const finalSeries = shouldShift ? shiftSeriesData(resolvedSeries) : resolvedSeries;
+
     const seriesData =
       Array.isArray(series?.[0]?.data) && series[0].data.length > 1
         ? series[0].data
@@ -516,7 +525,7 @@ function BaseChart({
           );
 
     const aria = computeEchartsAriaLabels(
-      {series: resolvedSeries, useUTC: utc},
+      {series: finalSeries, useUTC: utc},
       isGroupedByDate
     );
     const defaultAxesProps = {theme};
@@ -529,11 +538,45 @@ function BaseChart({
         ? undefined
         : YAxis({theme, ...yAxis});
 
+    // Shift xAxis min/max if explicitly provided and we're shifting timestamps
+    const shiftXAxisBounds = (axisConfig: XAXisComponentOption): XAXisComponentOption => {
+      if (!shouldShift) {
+        return axisConfig;
+      }
+      const shifted = {...axisConfig};
+      if (typeof shifted.min === 'number') {
+        shifted.min = shiftTimestampToFakeUtc(shifted.min);
+      }
+      if (typeof shifted.max === 'number') {
+        shifted.max = shiftTimestampToFakeUtc(shifted.max);
+      }
+      return shifted;
+    };
+
     const xAxisOrCustom = xAxes
       ? Array.isArray(xAxes)
         ? xAxes.map(axis =>
+            shiftXAxisBounds(
+              XAxis({
+                ...axis,
+                theme,
+                useShortDate,
+                useMultilineDate,
+                start,
+                end,
+                period,
+                isGroupedByDate,
+                addSecondsToTimeFormat,
+                utc,
+              })
+            )
+          )
+        : [XAxis(defaultAxesProps), XAxis(defaultAxesProps)]
+      : xAxis === null
+        ? undefined
+        : shiftXAxisBounds(
             XAxis({
-              ...axis,
+              ...xAxis,
               theme,
               useShortDate,
               useMultilineDate,
@@ -544,34 +587,19 @@ function BaseChart({
               addSecondsToTimeFormat,
               utc,
             })
-          )
-        : [XAxis(defaultAxesProps), XAxis(defaultAxesProps)]
-      : xAxis === null
-        ? undefined
-        : XAxis({
-            ...xAxis,
-            theme,
-            useShortDate,
-            useMultilineDate,
-            start,
-            end,
-            period,
-            isGroupedByDate,
-            addSecondsToTimeFormat,
-            utc,
-          });
+          );
 
     return {
       ...options,
       animation,
-      useUTC: utc,
+      useUTC: true,
       color: color as string[],
       grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),
       tooltip: tooltipOrNone,
       legend: legend ? Legend({theme, ...legend}) : undefined,
       yAxis: yAxisOrCustom,
       xAxis: xAxisOrCustom,
-      series: resolvedSeries,
+      series: finalSeries,
       toolbox: toolBox,
       axisPointer,
       dataZoom,

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -491,11 +491,13 @@ function BaseChart({
   const chartId = useId();
 
   const chartOption = useMemo(() => {
-    // When utc is false, we shift all timestamps into "fake UTC" so that
-    // ECharts (with useUTC: true) places tick boundaries at nice values
-    // in the user's configured timezone. Formatters then read the shifted
-    // UTC wall-clock, which matches user-timezone wall-clock.
-    const shouldShift = !utc;
+    // When utc is explicitly false, we shift all timestamps into "fake UTC"
+    // so that ECharts (with useUTC: true) places tick boundaries at nice
+    // values in the user's configured timezone. Formatters then read the
+    // shifted UTC wall-clock, which matches user-timezone wall-clock.
+    // When utc is undefined (not set), we don't shift to preserve existing
+    // behavior and avoid inconsistencies with zoom handlers.
+    const shouldShift = utc === false;
 
     const finalSeries = shouldShift ? shiftSeriesData(resolvedSeries) : resolvedSeries;
 
@@ -525,7 +527,7 @@ function BaseChart({
           );
 
     const aria = computeEchartsAriaLabels(
-      {series: finalSeries, useUTC: utc},
+      {series: finalSeries, useUTC: shouldShift ? true : utc},
       isGroupedByDate
     );
     const defaultAxesProps = {theme};
@@ -592,7 +594,7 @@ function BaseChart({
     return {
       ...options,
       animation,
-      useUTC: true,
+      useUTC: shouldShift ? true : utc,
       color: color as string[],
       grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),
       tooltip: tooltipOrNone,

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -10,6 +10,7 @@ import * as qs from 'query-string';
 
 import DataZoomInside from 'sentry/components/charts/components/dataZoomInside';
 import ToolBox from 'sentry/components/charts/components/toolBox';
+import {unshiftTimestampFromFakeUtc} from 'sentry/components/charts/timezoneShift';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import type {DateString} from 'sentry/types/core';
 import type {
@@ -277,10 +278,19 @@ class ChartZoom extends Component<Props> {
 
       this.setPeriod(previousPeriod);
     } else {
-      const start = moment.utc(startValue);
+      // When utc is explicitly false, chart data is timezone-shifted ("fake UTC").
+      // Unshift zoom coordinates back to real UTC before updating filters.
+      let realStartValue = startValue;
+      let realEndValue = endValue;
+      if (this.props.utc === false) {
+        realStartValue = unshiftTimestampFromFakeUtc(startValue);
+        realEndValue = unshiftTimestampFromFakeUtc(endValue);
+      }
+
+      const start = moment.utc(realStartValue);
 
       // Add a day so we go until the end of the day (e.g. next day at midnight)
-      const end = moment.utc(endValue);
+      const end = moment.utc(realEndValue);
 
       this.setPeriod({period: null, start, end}, true);
     }

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -21,7 +21,7 @@ type ChartProps = React.ComponentProps<typeof BaseChart>;
 export function defaultFormatAxisLabel(
   value: number,
   isTimestamp: boolean,
-  utc: boolean,
+  utc: boolean | undefined,
   showTimeInTooltip: boolean,
   addSecondsToTimeFormat: boolean,
   bucketSize?: number
@@ -30,18 +30,27 @@ export function defaultFormatAxisLabel(
     return value;
   }
 
-  // With timezone shifting in BaseChart, UTC wall-clock matches
-  // the user's configured timezone. Always parse as UTC.
-  const formatOptions = {local: false};
+  // When utc is explicitly false, BaseChart shifts data to "fake UTC"
+  // so we parse as UTC. When utc is true, data is real UTC.
+  // When utc is undefined (not set), preserve old behavior (local parse).
+  const local = utc === undefined;
+  const formatOptions = {local};
 
   const timeFormat = showTimeInTooltip
     ? getTimeFormat({seconds: addSecondsToTimeFormat})
     : '';
 
-  // Compute timezone abbreviation from the real (unshifted) timestamp
-  const tzAbbr = utc
-    ? 'UTC'
-    : moment.tz(unshiftTimestampFromFakeUtc(value), getUserTimezone()).format('z');
+  // Compute timezone abbreviation
+  let tzAbbr: string;
+  if (utc === true) {
+    tzAbbr = 'UTC';
+  } else if (utc === false) {
+    // Data is shifted — unshift to get real UTC, then format in user timezone
+    tzAbbr = moment.tz(unshiftTimestampFromFakeUtc(value), getUserTimezone()).format('z');
+  } else {
+    // utc is undefined — use local timezone abbreviation (old behavior)
+    tzAbbr = moment(value).format('z');
+  }
 
   if (!bucketSize) {
     const format = `MMM D, YYYY ${timeFormat}`.trim();
@@ -49,9 +58,10 @@ export function defaultFormatAxisLabel(
     return `${formatted} ${tzAbbr}`.trim();
   }
 
-  const now = moment.utc();
-  const bucketStart = moment.utc(value);
-  const bucketEnd = moment.utc(value + bucketSize);
+  const parser = local ? moment : moment.utc;
+  const now = parser();
+  const bucketStart = parser(value);
+  const bucketEnd = parser(value + bucketSize);
 
   const showYear = now.year() !== bucketStart.year() || now.year() !== bucketEnd.year();
   const showEndDate = bucketStart.date() !== bucketEnd.date();
@@ -184,7 +194,7 @@ export function getFormatter({
       const label = axisFormatterOrDefault(
         timestamp,
         !!isGroupedByDate,
-        !!utc,
+        utc,
         !!showTimeInTooltip,
         addSecondsToTimeFormat,
         bucketSize,
@@ -226,7 +236,7 @@ export function getFormatter({
       axisFormatterOrDefault(
         timestamp,
         !!isGroupedByDate,
-        !!utc,
+        utc,
         !!showTimeInTooltip,
         addSecondsToTimeFormat,
         bucketSize,

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -7,11 +7,12 @@ import moment from 'moment-timezone';
 
 import type BaseChart from 'sentry/components/charts/baseChart';
 import type {BaseChartProps} from 'sentry/components/charts/baseChart';
+import {unshiftTimestampFromFakeUtc} from 'sentry/components/charts/timezoneShift';
 import {truncationFormatter} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import type {DataPoint} from 'sentry/types/echarts';
 import toArray from 'sentry/utils/array/toArray';
-import {getFormattedDate, getTimeFormat} from 'sentry/utils/dates';
+import {getFormattedDate, getTimeFormat, getUserTimezone} from 'sentry/utils/dates';
 
 export const CHART_TOOLTIP_VIEWPORT_OFFSET = 20;
 
@@ -29,20 +30,28 @@ export function defaultFormatAxisLabel(
     return value;
   }
 
-  const formatOptions = {local: !utc};
+  // With timezone shifting in BaseChart, UTC wall-clock matches
+  // the user's configured timezone. Always parse as UTC.
+  const formatOptions = {local: false};
 
   const timeFormat = showTimeInTooltip
     ? getTimeFormat({seconds: addSecondsToTimeFormat})
     : '';
 
+  // Compute timezone abbreviation from the real (unshifted) timestamp
+  const tzAbbr = utc
+    ? 'UTC'
+    : moment.tz(unshiftTimestampFromFakeUtc(value), getUserTimezone()).format('z');
+
   if (!bucketSize) {
-    const format = `MMM D, YYYY ${timeFormat} z`.trim();
-    return getFormattedDate(value, format, formatOptions);
+    const format = `MMM D, YYYY ${timeFormat}`.trim();
+    const formatted = getFormattedDate(value, format, formatOptions);
+    return `${formatted} ${tzAbbr}`.trim();
   }
 
-  const now = moment();
-  const bucketStart = moment(value);
-  const bucketEnd = moment(value + bucketSize);
+  const now = moment.utc();
+  const bucketStart = moment.utc(value);
+  const bucketEnd = moment.utc(value + bucketSize);
 
   const showYear = now.year() !== bucketStart.year() || now.year() !== bucketEnd.year();
   const showEndDate = bucketStart.date() !== bucketEnd.date();
@@ -54,9 +63,8 @@ export function defaultFormatAxisLabel(
 
   const start = getFormattedDate(bucketStart, formatStart, formatOptions);
   const end = getFormattedDate(bucketEnd, formatEnd, formatOptions);
-  const timezone = getFormattedDate(bucketEnd, 'z', formatOptions);
 
-  return `${start} — ${end} (${timezone})`;
+  return `${start} — ${end} (${tzAbbr})`;
 }
 
 function defaultValueFormatter(value: string | number) {

--- a/static/app/components/charts/components/xAxis.spec.tsx
+++ b/static/app/components/charts/components/xAxis.spec.tsx
@@ -1,14 +1,16 @@
+import moment from 'moment-timezone';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
 import type {XAxisProps} from 'sentry/components/charts/components/xAxis';
 import XAxis from 'sentry/components/charts/components/xAxis';
+import {shiftTimestampToFakeUtc} from 'sentry/components/charts/timezoneShift';
 
 const theme = ThemeFixture();
 
 jest.mock('moment-timezone', () => {
-  const moment = jest.requireActual('moment-timezone');
-  moment.tz.setDefault('America/Los_Angeles'); // Whatever timezone you want
-  return moment;
+  const momentActual = jest.requireActual('moment-timezone');
+  momentActual.tz.setDefault('America/Los_Angeles');
+  return momentActual;
 });
 
 describe('Chart XAxis', () => {
@@ -18,11 +20,21 @@ describe('Chart XAxis', () => {
     isGroupedByDate: true,
     theme,
   };
+  // 2018-07-09T00:00:00Z
   const timestamp = 1531094400000;
 
   describe('axisLabel', () => {
     describe('With Period > 24h', () => {
-      describe('Local timezone', () => {
+      describe('Local timezone (pre-shifted timestamps)', () => {
+        // In the new timezone-shifting approach, BaseChart shifts timestamps
+        // to "fake UTC" before passing to ECharts. The formatter always
+        // parses as UTC. For local-timezone display, we simulate the
+        // pre-shifted timestamp that BaseChart would produce.
+        const shiftedTimestamp = shiftTimestampToFakeUtc(
+          timestamp,
+          'America/Los_Angeles'
+        );
+
         beforeEach(() => {
           xAxisObj = XAxis({
             ...props,
@@ -35,11 +47,11 @@ describe('Chart XAxis', () => {
         });
 
         it('formats axis label for first data point', () => {
-          expect(axisLabelFormatter(timestamp, 0)).toBe('Jul 8 5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 0)).toBe('Jul 8 5:00 PM');
         });
 
         it('formats axis label for second data point', () => {
-          expect(axisLabelFormatter(timestamp, 1)).toBe('Jul 8 5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 1)).toBe('Jul 8 5:00 PM');
         });
       });
 
@@ -64,7 +76,12 @@ describe('Chart XAxis', () => {
         });
       });
 
-      describe('Multiline', () => {
+      describe('Multiline (pre-shifted timestamps)', () => {
+        const shiftedTimestamp = shiftTimestampToFakeUtc(
+          timestamp,
+          'America/Los_Angeles'
+        );
+
         beforeEach(() => {
           xAxisObj = XAxis({
             ...props,
@@ -77,17 +94,22 @@ describe('Chart XAxis', () => {
         });
 
         it('formats axis label for first data point', () => {
-          expect(axisLabelFormatter(timestamp, 0)).toBe('Jul 8\n5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 0)).toBe('Jul 8\n5:00 PM');
         });
 
         it('formats axis label for second data point', () => {
-          expect(axisLabelFormatter(timestamp, 1)).toBe('Jul 8\n5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 1)).toBe('Jul 8\n5:00 PM');
         });
       });
     });
 
     describe('With Period <= 24h', () => {
-      describe('Local timezone', () => {
+      describe('Local timezone (pre-shifted timestamps)', () => {
+        const shiftedTimestamp = shiftTimestampToFakeUtc(
+          timestamp,
+          'America/Los_Angeles'
+        );
+
         beforeEach(() => {
           xAxisObj = XAxis({
             ...props,
@@ -100,11 +122,11 @@ describe('Chart XAxis', () => {
         });
 
         it('formats axis label for first data point', () => {
-          expect(axisLabelFormatter(timestamp, 0)).toBe('Jul 8 5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 0)).toBe('Jul 8 5:00 PM');
         });
 
         it('formats axis label for second data point', () => {
-          expect(axisLabelFormatter(timestamp, 1)).toBe('5:00 PM');
+          expect(axisLabelFormatter(shiftedTimestamp, 1)).toBe('5:00 PM');
         });
       });
 
@@ -150,6 +172,37 @@ describe('Chart XAxis', () => {
           expect(axisLabelFormatter(timestamp, 1)).toBe('12:00 AM');
         });
       });
+    });
+  });
+
+  describe('timezone shifting produces correct display', () => {
+    it('shows non-repeating times at nice boundaries when user tz differs from UTC', () => {
+      // Simulate timestamps at midnight, 6am, noon, 6pm EST (UTC-5)
+      // In real UTC these would be: 05:00, 11:00, 17:00, 23:00
+      const midnightEst = moment.utc('2024-01-15T05:00:00').valueOf();
+      const sixAmEst = moment.utc('2024-01-15T11:00:00').valueOf();
+      const noonEst = moment.utc('2024-01-15T17:00:00').valueOf();
+
+      // After shifting to fake UTC: 00:00, 06:00, 12:00
+      const shiftedMidnight = shiftTimestampToFakeUtc(midnightEst, 'America/New_York');
+      const shiftedSixAm = shiftTimestampToFakeUtc(sixAmEst, 'America/New_York');
+      const shiftedNoon = shiftTimestampToFakeUtc(noonEst, 'America/New_York');
+
+      xAxisObj = XAxis({...props, period: '24h', utc: false});
+      // @ts-expect-error formatter type is missing
+      axisLabelFormatter = xAxisObj.axisLabel!.formatter;
+
+      // Formatter should show distinct, non-repeating times
+      const label1 = axisLabelFormatter(shiftedMidnight, 1);
+      const label2 = axisLabelFormatter(shiftedSixAm, 2);
+      const label3 = axisLabelFormatter(shiftedNoon, 3);
+
+      expect(label1).toBe('12:00 AM');
+      expect(label2).toBe('6:00 AM');
+      expect(label3).toBe('12:00 PM');
+
+      // All labels are different — the original bug was that all showed the same time
+      expect(new Set([label1, label2, label3]).size).toBe(3);
     });
   });
 });

--- a/static/app/components/charts/components/xAxis.spec.tsx
+++ b/static/app/components/charts/components/xAxis.spec.tsx
@@ -87,6 +87,7 @@ describe('Chart XAxis', () => {
             ...props,
             useMultilineDate: true,
             period: '7d',
+            utc: false,
           });
 
           // @ts-expect-error formatter type is missing

--- a/static/app/components/charts/components/xAxis.tsx
+++ b/static/app/components/charts/components/xAxis.tsx
@@ -27,7 +27,7 @@ function XAxis({
   start,
   end,
   period,
-  utc: _utc,
+  utc,
   addSecondsToTimeFormat = false,
   ...props
 }: XAxisProps): XAXisComponentOption {
@@ -38,12 +38,14 @@ function XAxis({
 
     if (isGroupedByDate) {
       const dateFormat = useShortDate ? 'MMM Do' : `MMM D`;
-      // With timezone shifting in BaseChart, UTC wall-clock already matches
-      // the user's configured timezone. Always parse as UTC.
-      const dateString = getFormattedDate(value, dateFormat, {local: false});
+      // When utc is explicitly false, BaseChart shifts data to "fake UTC"
+      // so we parse as UTC. When utc is true, data is real UTC.
+      // When utc is undefined (not set), preserve old behavior (local parse).
+      const local = utc === undefined;
+      const dateString = getFormattedDate(value, dateFormat, {local});
 
       const timeFormat = getTimeFormat({seconds: addSecondsToTimeFormat});
-      const timeString = getFormattedDate(value, timeFormat, {local: false});
+      const timeString = getFormattedDate(value, timeFormat, {local});
 
       const delimiter = useMultilineDate ? '\n' : ' ';
 

--- a/static/app/components/charts/components/xAxis.tsx
+++ b/static/app/components/charts/components/xAxis.tsx
@@ -27,7 +27,7 @@ function XAxis({
   start,
   end,
   period,
-  utc,
+  utc: _utc,
   addSecondsToTimeFormat = false,
   ...props
 }: XAxisProps): XAXisComponentOption {
@@ -38,10 +38,12 @@ function XAxis({
 
     if (isGroupedByDate) {
       const dateFormat = useShortDate ? 'MMM Do' : `MMM D`;
-      const dateString = getFormattedDate(value, dateFormat, {local: !utc});
+      // With timezone shifting in BaseChart, UTC wall-clock already matches
+      // the user's configured timezone. Always parse as UTC.
+      const dateString = getFormattedDate(value, dateFormat, {local: false});
 
       const timeFormat = getTimeFormat({seconds: addSecondsToTimeFormat});
-      const timeString = getFormattedDate(value, timeFormat, {local: !utc});
+      const timeString = getFormattedDate(value, timeFormat, {local: false});
 
       const delimiter = useMultilineDate ? '\n' : ' ';
 

--- a/static/app/components/charts/timezoneShift.spec.ts
+++ b/static/app/components/charts/timezoneShift.spec.ts
@@ -1,0 +1,118 @@
+import moment from 'moment-timezone';
+
+import {
+  shiftSeriesData,
+  shiftTimestampToFakeUtc,
+  unshiftTimestampFromFakeUtc,
+} from 'sentry/components/charts/timezoneShift';
+
+describe('timezoneShift', () => {
+  describe('shiftTimestampToFakeUtc', () => {
+    it('shifts UTC timestamp so fake-UTC wall-clock matches target timezone', () => {
+      // 2024-01-15 05:00:00 UTC = midnight EST (UTC-5)
+      const realUtc = moment.utc('2024-01-15T05:00:00').valueOf();
+      const shifted = shiftTimestampToFakeUtc(realUtc, 'America/New_York');
+
+      // Shifted should be 2024-01-15 00:00:00 UTC (subtract 5h)
+      const expected = moment.utc('2024-01-15T00:00:00').valueOf();
+      expect(shifted).toBe(expected);
+    });
+
+    it('shifts for positive UTC offset timezone', () => {
+      // 2024-01-15 00:00:00 UTC = 2024-01-15 09:00:00 Asia/Tokyo (UTC+9)
+      const realUtc = moment.utc('2024-01-15T00:00:00').valueOf();
+      const shifted = shiftTimestampToFakeUtc(realUtc, 'Asia/Tokyo');
+
+      // Should shift forward by 9h to 09:00:00 UTC
+      const expected = moment.utc('2024-01-15T09:00:00').valueOf();
+      expect(shifted).toBe(expected);
+    });
+
+    it('handles DST transitions correctly', () => {
+      // During US EDT (UTC-4): 2024-07-15 04:00:00 UTC = midnight EDT
+      const summerUtc = moment.utc('2024-07-15T04:00:00').valueOf();
+      const summerShifted = shiftTimestampToFakeUtc(summerUtc, 'America/New_York');
+      const expectedSummer = moment.utc('2024-07-15T00:00:00').valueOf();
+      expect(summerShifted).toBe(expectedSummer);
+
+      // During US EST (UTC-5): 2024-01-15 05:00:00 UTC = midnight EST
+      const winterUtc = moment.utc('2024-01-15T05:00:00').valueOf();
+      const winterShifted = shiftTimestampToFakeUtc(winterUtc, 'America/New_York');
+      const expectedWinter = moment.utc('2024-01-15T00:00:00').valueOf();
+      expect(winterShifted).toBe(expectedWinter);
+    });
+
+    it('is identity for UTC timezone', () => {
+      const timestamp = moment.utc('2024-01-15T12:00:00').valueOf();
+      expect(shiftTimestampToFakeUtc(timestamp, 'UTC')).toBe(timestamp);
+    });
+  });
+
+  describe('unshiftTimestampFromFakeUtc', () => {
+    it('recovers real UTC from shifted fake-UTC timestamp', () => {
+      // Fake UTC midnight = real 05:00 UTC for EST (UTC-5)
+      const fakeUtc = moment.utc('2024-01-15T00:00:00').valueOf();
+      const real = unshiftTimestampFromFakeUtc(fakeUtc, 'America/New_York');
+
+      const expected = moment.utc('2024-01-15T05:00:00').valueOf();
+      expect(real).toBe(expected);
+    });
+
+    it('round-trips with shiftTimestampToFakeUtc', () => {
+      const original = moment.utc('2024-06-20T14:30:00').valueOf();
+      const shifted = shiftTimestampToFakeUtc(original, 'Europe/Berlin');
+      const recovered = unshiftTimestampFromFakeUtc(shifted, 'Europe/Berlin');
+      expect(recovered).toBe(original);
+    });
+  });
+
+  describe('shiftSeriesData', () => {
+    it('shifts tuple format [timestamp, value] data', () => {
+      const ts1 = moment.utc('2024-01-15T05:00:00').valueOf();
+      const ts2 = moment.utc('2024-01-15T06:00:00').valueOf();
+
+      const series = [
+        {
+          type: 'line' as const,
+          data: [
+            [ts1, 100],
+            [ts2, 200],
+          ],
+        },
+      ];
+
+      const result = shiftSeriesData(series, 'America/New_York');
+      const expected1 = moment.utc('2024-01-15T00:00:00').valueOf();
+      const expected2 = moment.utc('2024-01-15T01:00:00').valueOf();
+
+      expect((result[0] as any).data[0][0]).toBe(expected1);
+      expect((result[0] as any).data[0][1]).toBe(100);
+      expect((result[0] as any).data[1][0]).toBe(expected2);
+      expect((result[0] as any).data[1][1]).toBe(200);
+    });
+
+    it('shifts object format {name, value} data', () => {
+      const ts = moment.utc('2024-01-15T05:00:00').valueOf();
+
+      const series = [
+        {
+          type: 'line' as const,
+          data: [{name: ts, value: [ts, 100]}],
+        },
+      ];
+
+      const result = shiftSeriesData(series, 'America/New_York');
+      const expected = moment.utc('2024-01-15T00:00:00').valueOf();
+
+      expect((result[0] as any).data[0].name).toBe(expected);
+      expect((result[0] as any).data[0].value[0]).toBe(expected);
+      expect((result[0] as any).data[0].value[1]).toBe(100);
+    });
+
+    it('passes through series without data', () => {
+      const series = [{type: 'line' as const, markLine: {data: []}}];
+      const result = shiftSeriesData(series, 'America/New_York');
+      expect(result).toEqual(series);
+    });
+  });
+});

--- a/static/app/components/charts/timezoneShift.ts
+++ b/static/app/components/charts/timezoneShift.ts
@@ -60,7 +60,7 @@ export function shiftSeriesData(
         if (typeof obj.name === 'number') {
           const shifted: Record<string, unknown> = {
             ...obj,
-            name: shiftTimestampToFakeUtc(obj.name as number, timezone),
+            name: shiftTimestampToFakeUtc(obj.name, timezone),
           };
 
           // Also shift value[0] if it's a tuple with a timestamp

--- a/static/app/components/charts/timezoneShift.ts
+++ b/static/app/components/charts/timezoneShift.ts
@@ -23,11 +23,19 @@ export function shiftTimestampToFakeUtc(timestamp: number, timezone?: string): n
 
 /**
  * Reverse: recover real UTC from a shifted "fake UTC" timestamp.
+ *
+ * Uses a two-step approach to handle DST boundaries correctly:
+ * the shifted timestamp may be on a different side of a DST transition
+ * than the real timestamp, so we first estimate, then refine.
  */
 export function unshiftTimestampFromFakeUtc(shifted: number, timezone?: string): number {
   const tz = timezone ?? getUserTimezone();
-  const offsetMs = moment.tz(shifted, tz).utcOffset() * 60_000;
-  return shifted - offsetMs;
+  // First approximation: offset at the shifted timestamp
+  const approxOffsetMs = moment.tz(shifted, tz).utcOffset() * 60_000;
+  const estimatedReal = shifted - approxOffsetMs;
+  // Refinement: offset at the estimated real timestamp
+  const refinedOffsetMs = moment.tz(estimatedReal, tz).utcOffset() * 60_000;
+  return shifted - refinedOffsetMs;
 }
 
 /**

--- a/static/app/components/charts/timezoneShift.ts
+++ b/static/app/components/charts/timezoneShift.ts
@@ -1,0 +1,81 @@
+import type {SeriesOption} from 'echarts';
+import moment from 'moment-timezone';
+
+import {getUserTimezone} from 'sentry/utils/dates';
+
+/**
+ * Shift a real UTC timestamp into "fake UTC" where the UTC wall-clock
+ * matches the wall-clock in the target timezone.
+ *
+ * Used so ECharts (with useUTC: true) calculates nice tick boundaries
+ * that align with the user's configured timezone.
+ *
+ * Example (user timezone EST = UTC-5):
+ *   Real: 2024-01-15 05:00:00 UTC (= midnight EST)
+ *   Shifted: 2024-01-15 00:00:00 UTC (midnight "fake UTC")
+ *   ECharts sees midnight UTC → places a "nice" tick here
+ */
+export function shiftTimestampToFakeUtc(timestamp: number, timezone?: string): number {
+  const tz = timezone ?? getUserTimezone();
+  const offsetMs = moment.tz(timestamp, tz).utcOffset() * 60_000;
+  return timestamp + offsetMs;
+}
+
+/**
+ * Reverse: recover real UTC from a shifted "fake UTC" timestamp.
+ */
+export function unshiftTimestampFromFakeUtc(shifted: number, timezone?: string): number {
+  const tz = timezone ?? getUserTimezone();
+  const offsetMs = moment.tz(shifted, tz).utcOffset() * 60_000;
+  return shifted - offsetMs;
+}
+
+/**
+ * Walk ECharts series data and shift every leading timestamp.
+ * Handles the common Sentry format: [[timestamp, value, ...], ...]
+ * as well as object format: [{name: timestamp, value: [timestamp, ...]}, ...]
+ */
+export function shiftSeriesData(
+  seriesList: SeriesOption[],
+  timezone?: string
+): SeriesOption[] {
+  return seriesList.map(s => {
+    if (!('data' in s) || !Array.isArray(s.data)) {
+      return s;
+    }
+
+    const shiftedData = s.data.map((item: unknown) => {
+      if (Array.isArray(item)) {
+        // Tuple format: [timestamp, value, ...]
+        const [ts, ...rest] = item;
+        if (typeof ts === 'number') {
+          return [shiftTimestampToFakeUtc(ts, timezone), ...rest];
+        }
+        return item;
+      }
+      if (item && typeof item === 'object') {
+        const obj = item as Record<string, unknown>;
+
+        // Object format with name as timestamp
+        if (typeof obj.name === 'number') {
+          const shifted: Record<string, unknown> = {
+            ...obj,
+            name: shiftTimestampToFakeUtc(obj.name as number, timezone),
+          };
+
+          // Also shift value[0] if it's a tuple with a timestamp
+          if (Array.isArray(obj.value)) {
+            const [ts, ...rest] = obj.value;
+            if (typeof ts === 'number') {
+              shifted.value = [shiftTimestampToFakeUtc(ts, timezone), ...rest];
+            }
+          }
+          return shifted;
+        }
+      }
+      return item;
+    });
+
+    return {...s, data: shiftedData} as SeriesOption;
+  });
+}

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -4,6 +4,7 @@ import * as qs from 'query-string';
 
 import DataZoomInside from 'sentry/components/charts/components/dataZoomInside';
 import ToolBox from 'sentry/components/charts/components/toolBox';
+import {unshiftTimestampFromFakeUtc} from 'sentry/components/charts/timezoneShift';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import type {DateString} from 'sentry/types/core';
 import type {
@@ -53,6 +54,11 @@ interface Props {
    * Sets the pageStart and pageEnd query params
    */
   usePageDate?: boolean;
+  /**
+   * Whether chart is displaying UTC. When false, chart data is timezone-shifted
+   * and zoom coordinates need to be unshifted back to real UTC.
+   */
+  utc?: boolean;
   xAxisIndex?: number | number[];
 }
 
@@ -127,6 +133,7 @@ export function useChartZoom({
   usePageDate,
   saveOnZoom,
   xAxisIndex,
+  utc,
 }: Omit<Props, 'children'>): ZoomRenderProps {
   const {handleChartReady} = useChartZoomCancel();
   const location = useLocation();
@@ -198,6 +205,13 @@ export function useChartZoom({
 
       // if `rangeStart` and `rangeEnd` are null, then we are going back
       if (startValue && endValue) {
+        // When !utc, chart data is timezone-shifted ("fake UTC").
+        // Unshift zoom coordinates back to real UTC before updating filters.
+        if (!utc) {
+          startValue = unshiftTimestampFromFakeUtc(startValue);
+          endValue = unshiftTimestampFromFakeUtc(endValue);
+        }
+
         // round off the bounds to the minute
         startValue = Math.floor(startValue / 60_000) * 60_000;
         endValue = Math.ceil(endValue / 60_000) * 60_000;
@@ -212,7 +226,7 @@ export function useChartZoom({
         });
       }
     },
-    [setPeriod]
+    [setPeriod, utc]
   );
 
   /**

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -207,7 +207,7 @@ export function useChartZoom({
       if (startValue && endValue) {
         // When !utc, chart data is timezone-shifted ("fake UTC").
         // Unshift zoom coordinates back to real UTC before updating filters.
-        if (!utc) {
+        if (utc === false) {
           startValue = unshiftTimestampFromFakeUtc(startValue);
           endValue = unshiftTimestampFromFakeUtc(endValue);
         }

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -17,9 +17,11 @@ import {getParser, getTimeFormat} from 'sentry/utils/dates';
  */
 export function formatXAxisTimestamp(
   value: number,
-  options: {utc?: boolean} = {utc: false}
+  _options: {utc?: boolean} = {utc: false}
 ): string {
-  const parsed = getParser(!options.utc)(value);
+  // With timezone shifting in BaseChart, UTC wall-clock already matches
+  // the user's configured timezone. Always parse as UTC.
+  const parsed = getParser(false)(value);
 
   // Granularity-aware parsing, adjusts the format based on the
   // granularity of the object This works well with ECharts since the

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatXAxisTimestamp.tsx
@@ -17,11 +17,13 @@ import {getParser, getTimeFormat} from 'sentry/utils/dates';
  */
 export function formatXAxisTimestamp(
   value: number,
-  _options: {utc?: boolean} = {utc: false}
+  options: {utc?: boolean} = {utc: false}
 ): string {
-  // With timezone shifting in BaseChart, UTC wall-clock already matches
-  // the user's configured timezone. Always parse as UTC.
-  const parsed = getParser(false)(value);
+  // When utc is explicitly false, BaseChart shifts data to "fake UTC"
+  // so we parse as UTC. When utc is true, data is real UTC.
+  // When utc is undefined (not set), preserve old behavior (local parse).
+  const local = options.utc === undefined;
+  const parsed = getParser(local)(value);
 
   // Granularity-aware parsing, adjusts the format based on the
   // granularity of the object This works well with ECharts since the


### PR DESCRIPTION
- Fix ECharts x-axis ticks showing repeated times (e.g. "23:00" on every tick) when the user's configured Sentry timezone differs from the browser's system timezone. ECharts only supports UTC or browser-local time for tick placement. When Sentry's timezone setting doesn't match the browser, ticks placed at browser-midnight get formatted as the wrong time in the user's timezone, repeating on every tick. Solution is shifting all chart timestamps into "fake UTC" — where the UTC  wall-clock matches the user's configured timezone — so ECharts (with useUTC: true) calculates nice tick boundaries that align with the user's timezone. Formatters then read the shifted values as UTC, producing correct labels.

Changes:
  - Add timezoneShift utility (shift/unshift timestamps, shift series data)
  - BaseChart: always set useUTC: true; shift series data when utc=false
  - xAxis/tooltip/formatXAxisTimestamp formatters: always parse as UTC
  - Tooltip: compute timezone abbreviation (EST/PST) from real unshifted timestamp
  - useChartZoom: unshift zoom coordinates back to real UTC before updating filters
  - Shift xAxis min/max bounds when explicitly provided

Before:
<img width="551" height="387" alt="Screenshot 2026-02-18 at 11 50 31" src="https://github.com/user-attachments/assets/699efe6e-27d8-43f3-a5ff-2d72461cb522" />

After:
<img width="545" height="393" alt="Screenshot 2026-02-18 at 11 50 35" src="https://github.com/user-attachments/assets/e476218a-01ed-4c4f-8b94-7c7c7c5779f7" />


Fixes DAIN-594

Co-authored-by: Claude <noreply@anthropic.com>