### PR TITLE
feat(github): Add get_check_run method to GitHub client

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -809,6 +809,15 @@ class GitHubBaseClient(
         endpoint = f"/repos/{repo}/check-runs"
         return self.post(endpoint, data=data)
 
+    def get_check_run(self, repo: str, check_run_id: int) -> Any:
+        """
+        https://docs.github.com/en/rest/checks/runs#get-a-check-run
+
+        The repo must be in the format of "owner/repo".
+        """
+        endpoint = f"/repos/{repo}/check-runs/{check_run_id}"
+        return self.get(endpoint)
+
     def get_check_runs(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -845,6 +845,34 @@ class GitHubCommitContextClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_get_check_run(self, get_jwt) -> None:
+        repo_name = "getsentry/sentry"
+        check_run_id = 123456
+
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{repo_name}/check-runs/{check_run_id}",
+            json={
+                "id": check_run_id,
+                "name": "Seer Code Review",
+                "head_sha": "abc123",
+                "status": "in_progress",
+                "conclusion": None,
+                "started_at": "2026-02-17T12:00:00Z",
+                "details_url": "https://example.com/check/123456",
+            },
+            status=200,
+        )
+
+        result = self.github_client.get_check_run(repo_name, check_run_id)
+
+        assert result["id"] == check_run_id
+        assert result["name"] == "Seer Code Review"
+        assert result["status"] == "in_progress"
+        assert result["conclusion"] is None
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_get_check_runs(self, get_jwt) -> None:
         repo_name = "getsentry/sentry"
         sha = "abc123"


### PR DESCRIPTION
## Summary

- Add `get_check_run(repo, check_run_id)` method to the GitHub client to fetch a single check run by ID via `GET /repos/{owner}/{repo}/check-runs/{check_run_id}`
- Follows the existing pattern of `create_check_run` and `get_check_runs`
- Enables diagnosing stuck code review checks (e.g., checks stuck "in_progress" for hours) by querying their state directly from GitHub

## Test plan

- [x] Added `test_get_check_run` test
- [x] Verified existing `test_create_check_run` and `test_get_check_runs` tests still pass


Made with [Cursor](https://cursor.com)