### PR TITLE
feat(explore): Support multi-yAxis visualize models

### DIFF
--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -384,7 +384,11 @@ describe('SpanQueryParamsProvider', () => {
         {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
-          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+          yAxes: ['min(span.self_time)'],
+        },
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['max(span.duration)'],
         },
       ],
     });
@@ -400,10 +404,10 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'max(span.duration)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction('min(span.self_time)', {
+          new VisualizeFunction(['min(span.self_time)'], {
             chartType: ChartType.AREA,
           }),
-          new VisualizeFunction('max(span.duration)', {
+          new VisualizeFunction(['max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -418,7 +422,11 @@ describe('SpanQueryParamsProvider', () => {
         {groupBy: 'span.op'},
         {
           chartType: ChartType.AREA,
-          yAxes: ['min(span.self_time)', 'max(span.duration)'],
+          yAxes: ['min(span.self_time)'],
+        },
+        {
+          chartType: ChartType.AREA,
+          yAxes: ['max(span.duration)'],
         },
       ],
     });
@@ -434,10 +442,10 @@ describe('SpanQueryParamsProvider', () => {
         aggregateSortBys: [{field: 'min(span.self_time)', kind: 'desc'}],
         aggregateFields: [
           {groupBy: 'span.op'},
-          new VisualizeFunction('min(span.self_time)', {
+          new VisualizeFunction(['min(span.self_time)'], {
             chartType: ChartType.AREA,
           }),
-          new VisualizeFunction('max(span.duration)', {
+          new VisualizeFunction(['max(span.duration)'], {
             chartType: ChartType.AREA,
           }),
         ],
@@ -538,7 +546,11 @@ describe('SpanQueryParamsProvider', () => {
         },
         {
           chartType: ChartType.LINE,
-          yAxes: ['avg(span.duration)', 'avg(span.self_time)'],
+          yAxes: ['avg(span.duration)'],
+        },
+        {
+          chartType: ChartType.LINE,
+          yAxes: ['avg(span.self_time)'],
         },
       ])
     );
@@ -555,10 +567,10 @@ describe('SpanQueryParamsProvider', () => {
           new VisualizeFunction('count(span.self_time)', {
             chartType: ChartType.AREA,
           }),
-          new VisualizeFunction('avg(span.duration)', {
+          new VisualizeFunction(['avg(span.duration)'], {
             chartType: ChartType.LINE,
           }),
-          new VisualizeFunction('avg(span.self_time)', {
+          new VisualizeFunction(['avg(span.self_time)'], {
             chartType: ChartType.LINE,
           }),
         ],

--- a/static/app/views/explore/logs/logsQueryParams.spec.tsx
+++ b/static/app/views/explore/logs/logsQueryParams.spec.tsx
@@ -218,8 +218,7 @@ describe('getReadableQueryParamsFromLocation', () => {
           aggregateFields: [
             new VisualizeFunction('count(message)', {chartType: ChartType.AREA}),
             {groupBy: 'message.template'},
-            new VisualizeFunction('p50(foo)'),
-            new VisualizeFunction('p75(bar)'),
+            new VisualizeFunction(['p50(foo)', 'p75(bar)']),
           ],
         })
       )

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -178,3 +178,20 @@ describe('VisualizeFunction', () => {
     ]);
   });
 });
+
+describe('VisualizeEquation', () => {
+  it('clones and preserves visible', () => {
+    const vis1 = new VisualizeEquation('equation|a+b', {
+      chartType: ChartType.LINE,
+      visible: false,
+    });
+    const vis2 = vis1.clone();
+    expect(vis2).toEqual(
+      new VisualizeEquation('equation|a+b', {
+        chartType: ChartType.LINE,
+        visible: false,
+      })
+    );
+    expect(vis2.visible).toBe(false);
+  });
+});

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -1,4 +1,8 @@
-import {Visualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  Visualize,
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 describe('VisualizeFunction', () => {
@@ -49,6 +53,20 @@ describe('VisualizeFunction', () => {
     expect(vis2).toEqual(
       new VisualizeFunction('avg(span.duration)', {chartType: ChartType.AREA})
     );
+    expect(vis2.yAxes).toEqual(['avg(span.duration)']);
+  });
+
+  it('replaces multiple yAxes', () => {
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
+    const vis2 = vis1.replace({yAxes: ['avg(span.duration)', 'p95(span.duration)']});
+    expect(vis2).toEqual(
+      new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+        chartType: ChartType.AREA,
+      })
+    );
+    expect(vis2.yAxis).toBe('avg(span.duration)');
   });
 
   it('replaces chart type', () => {
@@ -101,6 +119,62 @@ describe('VisualizeFunction', () => {
     });
     expect(visualize).toEqual([
       new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
+    ]);
+  });
+
+  it('converts multiple yAxes from JSON into one visualize', () => {
+    const visualize = Visualize.fromJSON({
+      yAxes: ['avg(span.duration)', 'p95(span.duration)'],
+      chartType: ChartType.LINE,
+    });
+    expect(visualize).toEqual([
+      new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+        chartType: ChartType.LINE,
+      }),
+    ]);
+    expect(visualize[0]!.yAxis).toBe('avg(span.duration)');
+    expect(visualize[0]!.yAxes).toEqual(['avg(span.duration)', 'p95(span.duration)']);
+  });
+
+  it('serializes all yAxes', () => {
+    const visualize = new VisualizeFunction(
+      ['avg(span.duration)', 'p95(span.duration)'],
+      {
+        chartType: ChartType.LINE,
+        visible: false,
+      }
+    );
+    expect(visualize.serialize()).toEqual({
+      yAxes: ['avg(span.duration)', 'p95(span.duration)'],
+      chartType: ChartType.LINE,
+      visible: false,
+    });
+  });
+
+  it('exposes parsedFunctions and parsedFunction', () => {
+    const visualize = new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)']);
+    expect(visualize.parsedFunction?.name).toBe('avg');
+    expect(visualize.parsedFunctions.map(func => func?.name)).toEqual(['avg', 'p95']);
+  });
+
+  it('clones multiple yAxes', () => {
+    const vis1 = new VisualizeFunction(['avg(span.duration)', 'p95(span.duration)'], {
+      chartType: ChartType.LINE,
+      visible: false,
+    });
+    const vis2 = vis1.clone();
+    expect(vis1).toEqual(vis2);
+    expect(vis2.yAxes).toEqual(['avg(span.duration)', 'p95(span.duration)']);
+  });
+
+  it('splits equation and function visualizes from JSON', () => {
+    const visualize = Visualize.fromJSON({
+      yAxes: ['equation|a+b', 'avg(span.duration)'],
+      chartType: ChartType.LINE,
+    });
+    expect(visualize).toEqual([
+      new VisualizeEquation('equation|a+b', {chartType: ChartType.LINE}),
+      new VisualizeFunction('avg(span.duration)', {chartType: ChartType.LINE}),
     ]);
   });
 });

--- a/static/app/views/explore/queryParams/visualize.spec.ts
+++ b/static/app/views/explore/queryParams/visualize.spec.ts
@@ -69,6 +69,18 @@ describe('VisualizeFunction', () => {
     expect(vis2.yAxis).toBe('avg(span.duration)');
   });
 
+  it('ignores empty yAxes when replacing', () => {
+    const vis1 = new VisualizeFunction('count(span.duration)', {
+      chartType: ChartType.AREA,
+    });
+    const vis2 = vis1.replace({yAxes: []});
+    expect(vis2).toEqual(
+      new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA})
+    );
+    expect(vis2.yAxis).toBe('count(span.duration)');
+    expect(vis2.parsedFunction).not.toBeNull();
+  });
+
   it('replaces chart type', () => {
     const vis1 = new VisualizeFunction('count(span.duration)', {
       chartType: ChartType.AREA,

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -133,7 +133,9 @@ export class VisualizeFunction extends Visualize {
     yAxes?: readonly string[];
     yAxis?: string;
   }): VisualizeFunction {
-    return new VisualizeFunction(yAxes ?? yAxis ?? this.yAxes, {
+    const nextYAxes = yAxes && yAxes.length > 0 ? yAxes : yAxis ? [yAxis] : this.yAxes;
+
+    return new VisualizeFunction(nextYAxes, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,
     });

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -152,6 +152,7 @@ export class VisualizeEquation extends Visualize {
   clone(): Visualize {
     return new VisualizeEquation(this.yAxis, {
       chartType: this.selectedChartType,
+      visible: this.visible,
     });
   }
 

--- a/static/app/views/explore/queryParams/visualize.ts
+++ b/static/app/views/explore/queryParams/visualize.ts
@@ -19,18 +19,29 @@ interface VisualizeOptions {
   visible?: boolean;
 }
 
+function normalizeYAxes(yAxis: string | readonly string[]): readonly string[] {
+  if (typeof yAxis === 'string') {
+    return [yAxis];
+  }
+  return [...yAxis];
+}
+
 export abstract class Visualize {
-  readonly yAxis: string;
+  readonly yAxes: readonly string[];
   readonly chartType: ChartType;
   readonly visible: boolean;
   protected readonly selectedChartType?: ChartType;
   abstract readonly kind: 'function' | 'equation';
 
-  constructor(yAxis: string, options?: VisualizeOptions) {
-    this.yAxis = yAxis;
+  constructor(yAxis: string | readonly string[], options?: VisualizeOptions) {
+    this.yAxes = normalizeYAxes(yAxis);
     this.selectedChartType = options?.chartType;
-    this.chartType = this.selectedChartType ?? determineDefaultChartType([yAxis]);
+    this.chartType = this.selectedChartType ?? determineDefaultChartType(this.yAxes);
     this.visible = options?.visible ?? true;
+  }
+
+  get yAxis(): string {
+    return this.yAxes[0] ?? '';
   }
 
   abstract clone(): Visualize;
@@ -38,15 +49,17 @@ export abstract class Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): Visualize;
 
   serialize(): BaseVisualize {
     const json: BaseVisualize = {
-      yAxes: [this.yAxis],
+      yAxes: this.yAxes,
     };
 
     if (defined(this.selectedChartType)) {
@@ -61,32 +74,49 @@ export abstract class Visualize {
   }
 
   static fromJSON(json: BaseVisualize): Visualize[] {
-    return json.yAxes.map(yAxis => {
-      if (isEquation(yAxis)) {
-        return new VisualizeEquation(yAxis, {
+    if (!json.yAxes.length) {
+      return [];
+    }
+
+    if (json.yAxes.some(isEquation)) {
+      return json.yAxes.map(yAxis => {
+        if (isEquation(yAxis)) {
+          return new VisualizeEquation(yAxis, {
+            chartType: json.chartType,
+            visible: json.visible,
+          });
+        }
+        return new VisualizeFunction(yAxis, {
           chartType: json.chartType,
           visible: json.visible,
         });
-      }
-      return new VisualizeFunction(yAxis, {
+      });
+    }
+
+    return [
+      new VisualizeFunction(json.yAxes, {
         chartType: json.chartType,
         visible: json.visible,
-      });
-    });
+      }),
+    ];
   }
 }
 
 export class VisualizeFunction extends Visualize {
   readonly kind = 'function';
-  readonly parsedFunction: ParsedFunction | null;
+  readonly parsedFunctions: ReadonlyArray<ParsedFunction | null>;
 
-  constructor(yAxis: string, options?: VisualizeOptions) {
+  constructor(yAxis: string | readonly string[], options?: VisualizeOptions) {
     super(yAxis, options);
-    this.parsedFunction = parseFunction(yAxis);
+    this.parsedFunctions = this.yAxes.map(axis => parseFunction(axis));
+  }
+
+  get parsedFunction(): ParsedFunction | null {
+    return this.parsedFunctions[0] ?? null;
   }
 
   clone(): VisualizeFunction {
-    return new VisualizeFunction(this.yAxis, {
+    return new VisualizeFunction(this.yAxes, {
       chartType: this.selectedChartType,
       visible: this.visible,
     });
@@ -96,12 +126,14 @@ export class VisualizeFunction extends Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): VisualizeFunction {
-    return new VisualizeFunction(yAxis ?? this.yAxis, {
+    return new VisualizeFunction(yAxes ?? yAxis ?? this.yAxes, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,
     });
@@ -127,12 +159,14 @@ export class VisualizeEquation extends Visualize {
     chartType,
     visible,
     yAxis,
+    yAxes,
   }: {
     chartType?: ChartType;
     visible?: boolean;
+    yAxes?: readonly string[];
     yAxis?: string;
   }): Visualize {
-    return new VisualizeEquation(yAxis ?? this.yAxis, {
+    return new VisualizeEquation(yAxes?.[0] ?? yAxis ?? this.yAxis, {
       chartType: chartType ?? this.selectedChartType,
       visible: visible ?? this.visible,
     });

--- a/static/app/views/explore/spans/spansQueryParams.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParams.spec.tsx
@@ -218,21 +218,17 @@ describe('getReadableQueryParamsFromLocation', () => {
       visualize: JSON.stringify({yAxes: ['count(span.duration)', 'avg(span.self_time)']}),
     });
     const queryParams = getReadableQueryParamsFromLocation(location);
-    expect(queryParams.aggregateFields).toHaveLength(3);
+    expect(queryParams.aggregateFields).toHaveLength(2);
     expect(queryParams.aggregateFields[0]).toEqual({groupBy: ''});
     expect(queryParams.aggregateFields[1]).toEqual(
-      new VisualizeFunction('count(span.duration)')
-    );
-    expect(queryParams.aggregateFields[2]).toEqual(
-      new VisualizeFunction('avg(span.self_time)')
+      new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)'])
     );
     expect(queryParams).toEqual(
       new ReadableQueryParams(
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new VisualizeFunction('count(span.duration)'),
-            new VisualizeFunction('avg(span.self_time)'),
+            new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)']),
           ],
         })
       )
@@ -252,8 +248,9 @@ describe('getReadableQueryParamsFromLocation', () => {
         readableQueryParamOptions({
           aggregateFields: [
             {groupBy: ''},
-            new VisualizeFunction('count(span.duration)', {chartType: ChartType.LINE}),
-            new VisualizeFunction('avg(span.self_time)', {chartType: ChartType.LINE}),
+            new VisualizeFunction(['count(span.duration)', 'avg(span.self_time)'], {
+              chartType: ChartType.LINE,
+            }),
           ],
         })
       )
@@ -275,8 +272,7 @@ describe('getReadableQueryParamsFromLocation', () => {
           aggregateFields: [
             new VisualizeFunction('count(span.duration)', {chartType: ChartType.AREA}),
             {groupBy: 'span.op'},
-            new VisualizeFunction('p50(span.duration)'),
-            new VisualizeFunction('p75(span.duration)'),
+            new VisualizeFunction(['p50(span.duration)', 'p75(span.duration)']),
           ],
         })
       )


### PR DESCRIPTION
Support multiple y-axes per Visualize instance as a foundation for multi-aggregate overlay charts.

Changes the `VisualizeFunction` model from a single `yAxis: string` to `yAxes: readonly string[]`, with bundling logic in `fromJSON()` that merges same-chartType entries. A backward-compatible `.yAxis` getter returns the first entry for existing single-axis consumers.

This is part 1 of 3 for BROWSE-316 (multi-aggregate support on the Traces page). Part 2 propagates multi-yAxis through data flow/rendering, and part 3 adds the toolbar UI.

Ticket: BROWSE-316