### PR TITLE
feat(explore): Multi-select toolbar UI for aggregate overlays

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -35,12 +35,16 @@ export function ToolbarVisualizeHeader() {
 
 interface ToolbarVisualizeDropdownProps {
   aggregateOptions: Array<SelectOption<SelectKey>>;
+  aggregateValue: string | string[];
   canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;
-  onChangeAggregate: (option: SelectOption<SelectKey>) => void;
+  onChangeAggregate: (
+    option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>
+  ) => void;
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   onDelete: () => void;
   parsedFunction: ParsedFunction | null;
+  aggregateMultiple?: boolean;
   label?: ReactNode;
   loading?: boolean;
   onClose?: () => void;
@@ -48,7 +52,9 @@ interface ToolbarVisualizeDropdownProps {
 }
 
 export function ToolbarVisualizeDropdown({
+  aggregateMultiple = false,
   aggregateOptions,
+  aggregateValue,
   canDelete,
   fieldOptions,
   onChangeAggregate,
@@ -65,15 +71,34 @@ export function ToolbarVisualizeDropdown({
     ? getFieldDefinition(aggregateFunc, 'span')
     : undefined;
 
+  const singleAggregateValue = Array.isArray(aggregateValue)
+    ? (aggregateValue[0] ?? '')
+    : aggregateValue;
+  const multiAggregateValue = Array.isArray(aggregateValue)
+    ? aggregateValue
+    : aggregateValue
+      ? [aggregateValue]
+      : [];
+
   return (
     <ToolbarRow>
       {label}
-      <AggregateCompactSelect
-        searchable
-        options={aggregateOptions}
-        value={parsedFunction?.name ?? ''}
-        onChange={onChangeAggregate}
-      />
+      {aggregateMultiple ? (
+        <AggregateCompactSelect
+          multiple
+          searchable
+          options={aggregateOptions}
+          value={multiAggregateValue}
+          onChange={options => onChangeAggregate(options)}
+        />
+      ) : (
+        <AggregateCompactSelect
+          searchable
+          options={aggregateOptions}
+          value={singleAggregateValue}
+          onChange={option => onChangeAggregate(option)}
+        />
+      )}
       {aggregateDefinition?.parameters?.map((param, index) => {
         return (
           <FieldCompactSelect

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -2,7 +2,11 @@ import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
+import type {
+  SelectKey,
+  SelectOption,
+  SelectOptionOrSection,
+} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -34,7 +38,7 @@ export function ToolbarVisualizeHeader() {
 }
 
 interface ToolbarVisualizeDropdownProps {
-  aggregateOptions: Array<SelectOption<SelectKey>>;
+  aggregateOptions: Array<SelectOptionOrSection<SelectKey>>;
   aggregateValue: string | string[];
   canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -364,10 +364,14 @@ function VisualizeDropdown({
   }, [aggregateFunction, sortedBooleanKeys, sortedNumberKeys, sortedStringKeys]);
 
   const onChangeAggregate = useCallback(
-    (option: SelectOption<SelectKey>) => {
-      if (typeof option.value === 'string') {
+    (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
+      const selected = Array.isArray(option) ? option[0] : option;
+      if (!selected) {
+        return;
+      }
+      if (typeof selected.value === 'string') {
         const yAxis = updateVisualizeAggregate({
-          newAggregate: option.value,
+          newAggregate: selected.value,
           oldAggregate: aggregateFunction,
           oldArgument: aggregateParam,
           firstNumberKey: sortedNumberKeys[0] || null,
@@ -390,6 +394,7 @@ function VisualizeDropdown({
 
   return (
     <ToolbarVisualizeDropdown
+      aggregateValue={visualize.parsedFunction?.name ?? ''}
       aggregateOptions={aggregateOptions}
       fieldOptions={fieldOptions}
       canDelete={canDelete}

--- a/static/app/views/explore/toolbar/constants.tsx
+++ b/static/app/views/explore/toolbar/constants.tsx
@@ -1,0 +1,55 @@
+import type {SelectSection} from '@sentry/scraps/compactSelect';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {AggregationKey} from 'sentry/utils/fields';
+
+const toOption = (aggregate: AggregationKey, showDefault = false) => {
+  return {
+    label: aggregate,
+    value: aggregate,
+    textValue: aggregate,
+    trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
+  };
+};
+
+export const SPAN_AGGREGATE_OPTIONS: Array<SelectSection<string>> = [
+  {
+    key: 'count',
+    label: t('Count'),
+    options: [
+      toOption(AggregationKey.COUNT, true),
+      toOption(AggregationKey.COUNT_UNIQUE),
+      toOption(AggregationKey.SUM),
+    ],
+  },
+  {
+    key: 'percentiles',
+    label: t('Percentiles'),
+    options: [
+      AggregationKey.AVG,
+      AggregationKey.P50,
+      AggregationKey.P75,
+      AggregationKey.P90,
+      AggregationKey.P95,
+      AggregationKey.P99,
+      AggregationKey.P100,
+      AggregationKey.MIN,
+      AggregationKey.MAX,
+    ].map(aggregate => toOption(aggregate)),
+  },
+  {
+    key: 'rate',
+    label: t('Rate'),
+    options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
+      toOption(aggregate)
+    ),
+  },
+  {
+    key: 'error',
+    label: t('Error'),
+    options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(aggregate =>
+      toOption(aggregate)
+    ),
+  },
+];

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -311,7 +311,7 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
-  it('supports multi-aggregate overlays in a single visualize when feature is enabled', async () => {
+  it('supports multi-aggregate overlays within the same group when feature is enabled', async () => {
     let visualizes: any;
     function Component() {
       visualizes = useQueryParamsVisualizes();
@@ -329,23 +329,67 @@ describe('ExploreToolbar', () => {
     expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
 
     await userEvent.click(within(section).getByRole('button', {name: 'count'}));
-    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
-    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
-
-    expect(visualizes).toHaveLength(1);
-    expect(visualizes[0]!.yAxes).toEqual(['avg(span.duration)']);
-
+    await userEvent.click(within(section).getByRole('option', {name: 'p50'}));
     await userEvent.click(within(section).getByRole('option', {name: 'p95'}));
+
     expect(visualizes).toHaveLength(1);
     expect(visualizes[0]!.yAxes).toEqual(
-      expect.arrayContaining(['avg(span.duration)', 'p95(span.duration)'])
+      expect.arrayContaining(['p50(span.duration)', 'p95(span.duration)'])
     );
 
     await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
     await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
     expect(visualizes[0]!.yAxes).toEqual(
-      expect.arrayContaining(['avg(span.self_time)', 'p95(span.self_time)'])
+      expect.arrayContaining(['p50(span.self_time)', 'p95(span.self_time)'])
     );
+  });
+
+  it('clears selected aggregates from other groups in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['count(span.duration)', 'count_unique(span.op)'])
+    );
+
+    await userEvent.click(within(section).getByRole('option', {name: 'p50'}));
+    expect(visualizes[0]!.yAxes).toEqual(['p50(span.duration)']);
+  });
+
+  it('shows count as the default aggregate option', async () => {
+    function Component() {
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    expect(screen.getByText('Default')).toBeInTheDocument();
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    expect(screen.queryByText('Default')).not.toBeInTheDocument();
   });
 
   it('resets to default visualize when all aggregates are deselected in multi-select mode', async () => {

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -405,6 +405,40 @@ describe('ExploreToolbar', () => {
     ]);
   });
 
+  it('preserves remaining aggregate arguments when deselecting count_unique in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["count_unique(span.self_time)","sum(span.self_time)"]}',
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes[0]!.yAxes).toEqual([
+      'count_unique(span.self_time)',
+      'sum(span.self_time)',
+    ]);
+
+    await userEvent.click(within(section).getByRole('button', {name: /count_unique/i}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+
+    expect(visualizes[0]!.yAxes).toEqual(['sum(span.self_time)']);
+  });
+
   it('shows count as the default aggregate option', async () => {
     function Component() {
       return <ExploreToolbar />;

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -371,6 +371,40 @@ describe('ExploreToolbar', () => {
     expect(visualizes[0]!.yAxes).toEqual(['p50(span.duration)']);
   });
 
+  it('does not apply invalid field choices to every aggregate in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count_unique'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'sum'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
+
+    expect(visualizes[0]!.yAxes).toEqual(['count_unique(span.op)', 'sum(span.duration)']);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'span.op'}));
+    await userEvent.click(
+      within(section).getByRole('option', {name: 'span.description'})
+    );
+
+    expect(visualizes[0]!.yAxes).toEqual([
+      'count_unique(span.description)',
+      'sum(span.duration)',
+    ]);
+  });
+
   it('shows count as the default aggregate option', async () => {
     function Component() {
       return <ExploreToolbar />;

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -440,11 +440,7 @@ describe('ExploreToolbar', () => {
   });
 
   it('shows count as the default aggregate option', async () => {
-    function Component() {
-      return <ExploreToolbar />;
-    }
-
-    render(<Component />, {
+    render(<ExploreToolbar />, {
       additionalWrapper: Wrapper,
       organization: OrganizationFixture({
         features: ['dashboards-edit', 'traces-overlay-charts-ui'],

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -311,6 +311,73 @@ describe('ExploreToolbar', () => {
     expect(within(section).queryByLabelText('Remove Overlay')).not.toBeInTheDocument();
   });
 
+  it('supports multi-aggregate overlays in a single visualize when feature is enabled', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    expect(visualizes).toEqual([new VisualizeFunction('count(span.duration)')]);
+
+    await userEvent.click(within(section).getByRole('button', {name: 'count'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'count'}));
+
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(['avg(span.duration)']);
+
+    await userEvent.click(within(section).getByRole('option', {name: 'p95'}));
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['avg(span.duration)', 'p95(span.duration)'])
+    );
+
+    await userEvent.click(within(section).getByRole('button', {name: 'span.duration'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'span.self_time'}));
+    expect(visualizes[0]!.yAxes).toEqual(
+      expect.arrayContaining(['avg(span.self_time)', 'p95(span.self_time)'])
+    );
+  });
+
+  it('resets to default visualize when all aggregates are deselected in multi-select mode', async () => {
+    let visualizes: any;
+    function Component() {
+      visualizes = useQueryParamsVisualizes();
+      return <ExploreToolbar />;
+    }
+
+    render(<Component />, {
+      additionalWrapper: Wrapper,
+      organization: OrganizationFixture({
+        features: ['dashboards-edit', 'traces-overlay-charts-ui'],
+      }),
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/traces/',
+          query: {
+            visualize: '{"yAxes":["avg(span.duration)"]}',
+          },
+        },
+      },
+    });
+
+    const section = screen.getByTestId('section-visualizes');
+    await userEvent.click(within(section).getByRole('button', {name: 'avg'}));
+    await userEvent.click(within(section).getByRole('option', {name: 'avg'}));
+
+    expect(visualizes).toHaveLength(1);
+    expect(visualizes[0]!.yAxes).toEqual(['count(span.duration)']);
+  });
+
   it('allows changing group bys', async () => {
     let groupBys: any;
 

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -3,13 +3,11 @@ import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import type {SelectKey, SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
-import {Text} from '@sentry/scraps/text';
+import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 
 import {IconHide} from 'sentry/icons/iconHide';
-import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {AggregationKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -39,6 +37,7 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {SPAN_AGGREGATE_OPTIONS} from 'sentry/views/explore/toolbar/constants';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ToolbarVisualizeProps {
@@ -207,58 +206,6 @@ function VisualizeDropdown({
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
   const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
-  const aggregateOptions: Array<SelectSection<string>> = useMemo(() => {
-    const toOption = (aggregate: AggregationKey, showDefault = false) => {
-      return {
-        label: aggregate,
-        value: aggregate,
-        textValue: aggregate,
-        trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
-      };
-    };
-
-    return [
-      {
-        key: 'count',
-        label: t('Count'),
-        options: [
-          toOption(AggregationKey.COUNT, true),
-          toOption(AggregationKey.COUNT_UNIQUE),
-          toOption(AggregationKey.SUM),
-        ],
-      },
-      {
-        key: 'percentiles',
-        label: t('Percentiles'),
-        options: [
-          AggregationKey.AVG,
-          AggregationKey.P50,
-          AggregationKey.P75,
-          AggregationKey.P90,
-          AggregationKey.P95,
-          AggregationKey.P99,
-          AggregationKey.P100,
-          AggregationKey.MIN,
-          AggregationKey.MAX,
-        ].map(aggregate => toOption(aggregate)),
-      },
-      {
-        key: 'rate',
-        label: t('Rate'),
-        options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
-          toOption(aggregate)
-        ),
-      },
-      {
-        key: 'error',
-        label: t('Error'),
-        options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(
-          aggregate => toOption(aggregate)
-        ),
-      },
-    ];
-  }, []);
-
   const parsedFunctions = useMemo(
     () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
     [visualize.yAxes]
@@ -289,7 +236,7 @@ function VisualizeDropdown({
           aggregate => !previousAggregates.has(aggregate)
         );
         if (newlyAdded) {
-          const targetGroup = aggregateOptions.find(section =>
+          const targetGroup = SPAN_AGGREGATE_OPTIONS.find(section =>
             section.options.some(opt => opt.value === newlyAdded)
           );
           if (targetGroup) {
@@ -329,7 +276,13 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
+    [
+      onReplace,
+      parsedAggregates,
+      parsedFunction?.arguments,
+      parsedFunction?.name,
+      visualize,
+    ]
   );
 
   const getFieldValueType = useCallback(
@@ -433,7 +386,7 @@ function VisualizeDropdown({
   return (
     <ToolbarVisualizeDropdown
       aggregateMultiple={hasMultiSelect}
-      aggregateOptions={aggregateOptions}
+      aggregateOptions={SPAN_AGGREGATE_OPTIONS}
       aggregateValue={aggregateValue}
       fieldOptions={fieldOptions}
       canDelete={canDelete}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -231,6 +231,24 @@ function VisualizeDropdown({
           return typeof selected.value === 'string' ? [selected.value] : [];
         });
 
+        const previousAxesByAggregate = new Map(
+          parsedFunctions.flatMap((func, index) => {
+            if (!func) {
+              return [];
+            }
+            return [[func.name, visualize.yAxes[index] ?? ''] as const];
+          })
+        );
+
+        const previousFunctionsByAggregate = new Map(
+          parsedFunctions.flatMap(func => {
+            if (!func) {
+              return [];
+            }
+            return [[func.name, func] as const];
+          })
+        );
+
         const previousAggregates = new Set(parsedAggregates);
         const newlyAdded = selectedAggregates.find(
           aggregate => !previousAggregates.has(aggregate)
@@ -256,12 +274,19 @@ function VisualizeDropdown({
           return;
         }
 
-        const yAxes = selectedAggregates.map(aggregate =>
-          updateVisualizeAggregate({
-            newAggregate: aggregate,
-            oldAggregate: parsedFunction?.name,
-            oldArguments: parsedFunction?.arguments,
-          })
+        const baselineFunction =
+          selectedAggregates
+            .map(aggregate => previousFunctionsByAggregate.get(aggregate))
+            .find(Boolean) ?? parsedFunction;
+
+        const yAxes = selectedAggregates.map(
+          aggregate =>
+            previousAxesByAggregate.get(aggregate) ??
+            updateVisualizeAggregate({
+              newAggregate: aggregate,
+              oldAggregate: baselineFunction?.name,
+              oldArguments: baselineFunction?.arguments,
+            })
         );
         onReplace(visualize.replace({yAxes}));
         return;
@@ -276,13 +301,7 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [
-      onReplace,
-      parsedAggregates,
-      parsedFunction?.arguments,
-      parsedFunction?.name,
-      visualize,
-    ]
+    [onReplace, parsedAggregates, parsedFunction, parsedFunctions, visualize]
   );
 
   const getFieldValueType = useCallback(

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -3,11 +3,13 @@ import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
+import type {SelectKey, SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
+import {Text} from '@sentry/scraps/text';
 
 import {IconHide} from 'sentry/icons/iconHide';
+import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
+import {AggregationKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -205,23 +207,67 @@ function VisualizeDropdown({
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
   const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
-  const aggregateOptions = useMemo(
-    () =>
-      ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.map(aggregate => {
-        return {
-          label: aggregate,
-          value: aggregate,
-          textValue: aggregate,
-        };
-      }),
-    []
-  );
+  const aggregateOptions: Array<SelectSection<string>> = useMemo(() => {
+    const toOption = (aggregate: AggregationKey, showDefault = false) => {
+      return {
+        label: aggregate,
+        value: aggregate,
+        textValue: aggregate,
+        trailingItems: showDefault ? <Text size="xs">{t('Default')}</Text> : undefined,
+      };
+    };
+
+    return [
+      {
+        key: 'count',
+        label: t('Count'),
+        options: [
+          toOption(AggregationKey.COUNT, true),
+          toOption(AggregationKey.COUNT_UNIQUE),
+          toOption(AggregationKey.SUM),
+        ],
+      },
+      {
+        key: 'percentiles',
+        label: t('Percentiles'),
+        options: [
+          AggregationKey.AVG,
+          AggregationKey.P50,
+          AggregationKey.P75,
+          AggregationKey.P90,
+          AggregationKey.P95,
+          AggregationKey.P99,
+          AggregationKey.P100,
+          AggregationKey.MIN,
+          AggregationKey.MAX,
+        ].map(aggregate => toOption(aggregate)),
+      },
+      {
+        key: 'rate',
+        label: t('Rate'),
+        options: [AggregationKey.EPM, AggregationKey.EPS].map(aggregate =>
+          toOption(aggregate)
+        ),
+      },
+      {
+        key: 'error',
+        label: t('Error'),
+        options: [AggregationKey.FAILURE_RATE, AggregationKey.FAILURE_COUNT].map(
+          aggregate => toOption(aggregate)
+        ),
+      },
+    ];
+  }, []);
 
   const parsedFunctions = useMemo(
     () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
     [visualize.yAxes]
   );
   const parsedFunction = parsedFunctions[0] ?? null;
+  const parsedAggregates = useMemo(
+    () => parsedFunctions.flatMap(func => (func?.name ? [func.name] : [])),
+    [parsedFunctions]
+  );
 
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
@@ -234,9 +280,29 @@ function VisualizeDropdown({
   const onChangeAggregate = useCallback(
     (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
       if (Array.isArray(option)) {
-        const selectedAggregates = option.flatMap(selected => {
+        let selectedAggregates = option.flatMap(selected => {
           return typeof selected.value === 'string' ? [selected.value] : [];
         });
+
+        const previousAggregates = new Set(parsedAggregates);
+        const newlyAdded = selectedAggregates.find(
+          aggregate => !previousAggregates.has(aggregate)
+        );
+        if (newlyAdded) {
+          const targetGroup = aggregateOptions.find(section =>
+            section.options.some(opt => opt.value === newlyAdded)
+          );
+          if (targetGroup) {
+            const groupValues = new Set(
+              targetGroup.options.flatMap(opt =>
+                typeof opt.value === 'string' ? [opt.value] : []
+              )
+            );
+            selectedAggregates = selectedAggregates.filter(aggregate =>
+              groupValues.has(aggregate)
+            );
+          }
+        }
 
         if (selectedAggregates.length === 0) {
           onReplace(visualize.replace({yAxis: DEFAULT_VISUALIZATION}));
@@ -263,7 +329,7 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [onReplace, parsedFunction, visualize]
+    [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
   );
 
   const onChangeArgument = useCallback(
@@ -300,9 +366,7 @@ function VisualizeDropdown({
     [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
   );
 
-  const aggregateValue = hasMultiSelect
-    ? parsedFunctions.flatMap(func => (func?.name ? [func.name] : []))
-    : (parsedFunction?.name ?? '');
+  const aggregateValue = hasMultiSelect ? parsedAggregates : (parsedFunction?.name ?? '');
 
   return (
     <ToolbarVisualizeDropdown

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -9,6 +9,7 @@ import {IconHide} from 'sentry/icons/iconHide';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
+import useOrganization from 'sentry/utils/useOrganization';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -198,9 +199,11 @@ function VisualizeDropdown({
   onSearch,
   onClose,
 }: VisualizeDropdownProps & {onClose: () => void; onSearch: (search: string) => void}) {
+  const organization = useOrganization();
   const {tags: stringTags, isLoading: stringTagsLoading} = useTraceItemTags('string');
   const {tags: numberTags, isLoading: numberTagsLoading} = useTraceItemTags('number');
   const {tags: booleanTags, isLoading: booleanTagsLoading} = useTraceItemTags('boolean');
+  const hasMultiSelect = organization.features.includes('traces-overlay-charts-ui');
 
   const aggregateOptions = useMemo(
     () =>
@@ -214,7 +217,11 @@ function VisualizeDropdown({
     []
   );
 
-  const parsedFunction = useMemo(() => parseFunction(visualize.yAxis), [visualize.yAxis]);
+  const parsedFunctions = useMemo(
+    () => visualize.yAxes.map(yAxis => parseFunction(yAxis)),
+    [visualize.yAxes]
+  );
+  const parsedFunction = parsedFunctions[0] ?? null;
 
   const fieldOptions: Array<SelectOption<string>> = useVisualizeFields({
     numberTags,
@@ -225,7 +232,28 @@ function VisualizeDropdown({
   });
 
   const onChangeAggregate = useCallback(
-    (option: SelectOption<SelectKey>) => {
+    (option: SelectOption<SelectKey> | Array<SelectOption<SelectKey>>) => {
+      if (Array.isArray(option)) {
+        const selectedAggregates = option.flatMap(selected => {
+          return typeof selected.value === 'string' ? [selected.value] : [];
+        });
+
+        if (selectedAggregates.length === 0) {
+          onReplace(visualize.replace({yAxis: DEFAULT_VISUALIZATION}));
+          return;
+        }
+
+        const yAxes = selectedAggregates.map(aggregate =>
+          updateVisualizeAggregate({
+            newAggregate: aggregate,
+            oldAggregate: parsedFunction?.name,
+            oldArguments: parsedFunction?.arguments,
+          })
+        );
+        onReplace(visualize.replace({yAxes}));
+        return;
+      }
+
       if (typeof option.value === 'string') {
         const yAxis = updateVisualizeAggregate({
           newAggregate: option.value,
@@ -241,22 +269,46 @@ function VisualizeDropdown({
   const onChangeArgument = useCallback(
     (index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
+        const nextArgument = option.value;
+        if (hasMultiSelect && visualize.yAxes.length > 1) {
+          const yAxes = parsedFunctions.flatMap(func => {
+            if (!func) {
+              return [];
+            }
+            let args = cloneDeep(func.arguments);
+            if (args) {
+              args[index] = nextArgument;
+            } else {
+              args = [nextArgument];
+            }
+            return [`${func.name}(${args.join(',')})`];
+          });
+          onReplace(visualize.replace({yAxes}));
+          return;
+        }
+
         let args = cloneDeep(parsedFunction?.arguments);
         if (args) {
-          args[index] = option.value;
+          args[index] = nextArgument;
         } else {
-          args = [option.value];
+          args = [nextArgument];
         }
         const yAxis = `${parsedFunction?.name}(${args.join(',')})`;
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [onReplace, parsedFunction, visualize]
+    [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
   );
+
+  const aggregateValue = hasMultiSelect
+    ? parsedFunctions.flatMap(func => (func?.name ? [func.name] : []))
+    : (parsedFunction?.name ?? '');
 
   return (
     <ToolbarVisualizeDropdown
+      aggregateMultiple={hasMultiSelect}
       aggregateOptions={aggregateOptions}
+      aggregateValue={aggregateValue}
       fieldOptions={fieldOptions}
       canDelete={canDelete}
       onChangeAggregate={onChangeAggregate}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -9,7 +9,7 @@ import {Text} from '@sentry/scraps/text';
 import {IconHide} from 'sentry/icons/iconHide';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX, parseFunction} from 'sentry/utils/discover/fields';
-import {AggregationKey} from 'sentry/utils/fields';
+import {AggregationKey, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useOrganization from 'sentry/utils/useOrganization';
 import {
@@ -332,6 +332,50 @@ function VisualizeDropdown({
     [aggregateOptions, onReplace, parsedAggregates, parsedFunction, visualize]
   );
 
+  const getFieldValueType = useCallback(
+    (field: string): FieldValueType => {
+      const tag = numberTags[field] ?? stringTags[field] ?? booleanTags[field];
+      const fieldDefinition = tag
+        ? getFieldDefinition(field, 'span', tag.kind)
+        : getFieldDefinition(field, 'span');
+
+      if (fieldDefinition?.valueType) {
+        return fieldDefinition.valueType;
+      }
+
+      if (Object.hasOwn(numberTags, field)) {
+        return FieldValueType.NUMBER;
+      }
+      if (Object.hasOwn(booleanTags, field)) {
+        return FieldValueType.BOOLEAN;
+      }
+      return FieldValueType.STRING;
+    },
+    [booleanTags, numberTags, stringTags]
+  );
+
+  const canApplyArgumentToAggregate = useCallback(
+    (aggregate: string, index: number, nextArgument: string): boolean => {
+      const aggregateDefinition = getFieldDefinition(aggregate, 'span');
+      const parameter = aggregateDefinition?.parameters?.[index];
+
+      if (!parameter || parameter.kind !== 'column') {
+        return false;
+      }
+
+      const valueType = getFieldValueType(nextArgument);
+      if (typeof parameter.columnTypes === 'function') {
+        return parameter.columnTypes({
+          key: nextArgument,
+          valueType,
+        });
+      }
+
+      return parameter.columnTypes.includes(valueType);
+    },
+    [getFieldValueType]
+  );
+
   const onChangeArgument = useCallback(
     (index: number, option: SelectOption<SelectKey>) => {
       if (typeof option.value === 'string') {
@@ -341,6 +385,17 @@ function VisualizeDropdown({
             if (!func) {
               return [];
             }
+
+            if (!canApplyArgumentToAggregate(func.name, index, nextArgument)) {
+              return [
+                updateVisualizeAggregate({
+                  newAggregate: func.name,
+                  oldAggregate: func.name,
+                  oldArguments: func.arguments,
+                }),
+              ];
+            }
+
             let args = cloneDeep(func.arguments);
             if (args) {
               args[index] = nextArgument;
@@ -363,7 +418,14 @@ function VisualizeDropdown({
         onReplace(visualize.replace({yAxis}));
       }
     },
-    [hasMultiSelect, onReplace, parsedFunction, parsedFunctions, visualize]
+    [
+      canApplyArgumentToAggregate,
+      hasMultiSelect,
+      onReplace,
+      parsedFunction,
+      parsedFunctions,
+      visualize,
+    ]
   );
 
   const aggregateValue = hasMultiSelect ? parsedAggregates : (parsedFunction?.name ?? '');


### PR DESCRIPTION
Add multi-select aggregate overlay UI to the Explore toolbar, behind the `traces-overlay-charts-ui` feature flag.

Key changes:
- Multi-select dropdown for choosing aggregate overlays per visualize
- Aggregate options grouped into sections (count, avg/sum/p-values, min/max)
- Same-group enforcement: selecting from a new group clears the previous
- Incompatible field argument handling: skips updating field args when aggregates take different argument types
- Preserves aggregate args when deselecting in multi-select
- Extracts span aggregate option constants into their own file

Includes full test coverage for the toolbar interactions.

>[!note]
>Depends on #108436 (part 1 — data model).
>Can be reviewed in parallel with #108437 (part 2 — data flow).
>This is part 3 of 3 for BROWSE-316.

Ticket: BROWSE-316