### PR TITLE
fix(tracemetrics): Pass unit properly from backend for tracemetrics

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -327,22 +327,22 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
     def _get_rate_unit(self, field: str) -> str | None:
         """Get the rate unit for a field by checking for known rate functions."""
-        per_second_fns = {"eps", "sps", "tps", "sample_eps", "per_second"}
-        per_minute_fns = {"epm", "spm", "tpm", "sample_epm", "per_minute"}
+        # Only use the opening parenthesis to identify rate functions because
+        # some functions may contain arguments, making a direct string match not work.
+        per_second_fns = {"eps(", "sps(", "tps(", "sample_eps(", "per_second("}
+        per_minute_fns = {"epm(", "spm(", "tpm(", "sample_epm(", "per_minute("}
 
-        # Conduct the check with startswith to handle cases where functions, e.g. per_second,
-        # contain arguments, making
-        if any(field.startswith(f"{fn}(") for fn in per_second_fns):
+        if any(field.startswith(fn) for fn in per_second_fns):
             return "1/second"
-        if any(field.startswith(f"{fn}(") for fn in per_minute_fns):
+        if any(field.startswith(fn) for fn in per_minute_fns):
             return "1/minute"
         # For equation fields, check if any known rate function appears in the expression
         if field.startswith("equation|"):
             for fn in per_second_fns:
-                if any(field.startswith(f"{fn}(") for fn in per_second_fns):
+                if any(field.startswith(fn) for fn in per_second_fns):
                     return "1/second"
             for fn in per_minute_fns:
-                if any(field.startswith(f"{fn}(") for fn in per_minute_fns):
+                if any(field.startswith(fn) for fn in per_minute_fns):
                     return "1/minute"
         return None
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -327,19 +327,22 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
     def _get_rate_unit(self, field: str) -> str | None:
         """Get the rate unit for a field by checking for known rate functions."""
-        per_second_fns = {"eps()", "sps()", "tps()", "sample_eps()", "per_second()"}
-        per_minute_fns = {"epm()", "spm()", "tpm()", "sample_epm()", "per_minute()"}
-        if field in per_second_fns:
+        per_second_fns = {"eps", "sps", "tps", "sample_eps", "per_second"}
+        per_minute_fns = {"epm", "spm", "tpm", "sample_epm", "per_minute"}
+
+        # Conduct the check with startswith to handle cases where functions, e.g. per_second,
+        # contain arguments, making
+        if any(field.startswith(f"{fn}(") for fn in per_second_fns):
             return "1/second"
-        if field in per_minute_fns:
+        if any(field.startswith(f"{fn}(") for fn in per_minute_fns):
             return "1/minute"
         # For equation fields, check if any known rate function appears in the expression
         if field.startswith("equation|"):
             for fn in per_second_fns:
-                if fn in field:
+                if any(field.startswith(f"{fn}(") for fn in per_second_fns):
                     return "1/second"
             for fn in per_minute_fns:
-                if fn in field:
+                if any(field.startswith(f"{fn}(") for fn in per_minute_fns):
                     return "1/minute"
         return None
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -339,10 +339,10 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         # For equation fields, check if any known rate function appears in the expression
         if field.startswith("equation|"):
             for fn in per_second_fns:
-                if any(field.startswith(fn) for fn in per_second_fns):
+                if fn in field:
                     return "1/second"
             for fn in per_minute_fns:
-                if any(field.startswith(fn) for fn in per_minute_fns):
+                if fn in field:
                     return "1/minute"
         return None
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -334,6 +334,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     "request_count",
                     value,
                     "counter",
+                    "millisecond",
                     timestamp=self.start + timedelta(hours=hour),
                 )
             )
@@ -344,7 +345,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "start": self.start,
                 "end": self.end,
                 "interval": "1h",
-                "yAxis": "per_minute(value,request_count,counter,-)",
+                "yAxis": "per_minute(value,request_count,counter,millisecond)",
                 "project": self.project.id,
                 "dataset": "tracemetrics",
             },
@@ -354,7 +355,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
 
-        assert timeseries["yAxis"] == "per_minute(value,request_count,counter,-)"
+        assert timeseries["yAxis"] == "per_minute(value,request_count,counter,millisecond)"
 
         # The valueUnit should be '1/minute' since per_minute formula implies per minute rate
         assert timeseries["meta"]["valueType"] == "rate"

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -285,3 +285,77 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         # The valueUnit should be null since we used "-" for unit
         assert timeseries["meta"]["valueType"] == "number"
         assert timeseries["meta"]["valueUnit"] is None
+
+    def test_timeseries_with_per_second_formula_returns_unit_in_meta(self) -> None:
+        """Test that when a per_second formula is used, valueUnit is populated in the timeseries meta."""
+        metric_values = [6, 0, 6, 3, 0, 3]
+
+        trace_metrics = []
+        for hour, value in enumerate(metric_values):
+            trace_metrics.append(
+                self.create_trace_metric(
+                    "request_count",
+                    value,
+                    "counter",
+                    timestamp=self.start + timedelta(hours=hour),
+                )
+            )
+        self.store_trace_metrics(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "per_second(value,request_count,counter,-)",
+                "project": self.project.id,
+                "dataset": "tracemetrics",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+
+        assert timeseries["yAxis"] == "per_second(value,request_count,counter,-)"
+
+        # The valueUnit should be '1/second' since per_second formula implies per second rate
+        assert timeseries["meta"]["valueType"] == "rate"
+        assert timeseries["meta"]["valueUnit"] == "1/second"
+
+    def test_timeseries_with_per_minute_formula_returns_unit_in_meta(self) -> None:
+        """Test that when a per_minute formula is used, valueUnit is populated in the timeseries meta."""
+        metric_values = [6, 0, 6, 3, 0, 3]
+
+        trace_metrics = []
+        for hour, value in enumerate(metric_values):
+            trace_metrics.append(
+                self.create_trace_metric(
+                    "request_count",
+                    value,
+                    "counter",
+                    timestamp=self.start + timedelta(hours=hour),
+                )
+            )
+        self.store_trace_metrics(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "per_minute(value,request_count,counter,-)",
+                "project": self.project.id,
+                "dataset": "tracemetrics",
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+
+        assert timeseries["yAxis"] == "per_minute(value,request_count,counter,-)"
+
+        # The valueUnit should be '1/minute' since per_minute formula implies per minute rate
+        assert timeseries["meta"]["valueType"] == "rate"
+        assert timeseries["meta"]["valueUnit"] == "1/minute"

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -205,6 +205,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         assert len(data) == 1
         assert data[0]["per_minute(value)"] == 0.6
         assert meta["fields"]["per_minute(value)"] == "rate"
+        assert meta["units"]["per_minute(value)"] == "1/minute"
         assert meta["dataset"] == "tracemetrics"
 
     def test_per_second_formula(self) -> None:
@@ -231,6 +232,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             data[0]["per_second(value)"] == 0.01
         )  # Over ten minute period, 6 events / 600 seconds = 0.01 events per second
         assert meta["fields"]["per_second(value)"] == "rate"
+        assert meta["units"]["per_second(value)"] == "1/second"
         assert meta["dataset"] == "tracemetrics"
 
     def test_per_second_formula_with_counter_metric_type(self) -> None:


### PR DESCRIPTION
Functions like `per_second` and `per_minute` can take arguments so direct comparisons won't work. Instead change the evaluation to check for the aggregate name with an opening parens.

We could also implement this more strictly with a regex possibly but I didn't think it was necessary for this operation.