### PR TITLE
fix(similar-issues): Fix overflow in issue diff modal

### DIFF
--- a/static/app/components/modals/diffModal.tsx
+++ b/static/app/components/modals/diffModal.tsx
@@ -1,8 +1,6 @@
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 
-import {Flex} from '@sentry/scraps/layout';
-
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {IssueDiff} from 'sentry/components/issueDiff';
 import {t} from 'sentry/locale';
@@ -39,18 +37,12 @@ function DiffModal({
       <Header closeButton>
         <h4>{t('Issue Diff')}</h4>
       </Header>
-      <Flex height="100%" flex={1} align="center" justify="center">
-        {p => {
-          return (
-            <Body {...p}>
-              <IssueDiff
-                hasSimilarityEmbeddingsProjectFeature={similarityEmbeddingsProjectFeature}
-                {...props}
-              />
-            </Body>
-          );
-        }}
-      </Flex>
+      <Body>
+        <IssueDiff
+          hasSimilarityEmbeddingsProjectFeature={similarityEmbeddingsProjectFeature}
+          {...props}
+        />
+      </Body>
     </Fragment>
   );
 }
@@ -63,7 +55,15 @@ const modalCss = css`
 
   [role='document'] {
     height: 100%;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+
+    > section {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+    }
   }
 `;
 

--- a/static/app/components/splitDiff.tsx
+++ b/static/app/components/splitDiff.tsx
@@ -149,6 +149,7 @@ const SplitBody = styled('tbody')`
 
 const Cell = styled('td')<{isAdded?: Change; isRemoved?: Change}>`
   vertical-align: top;
+  overflow: hidden;
   ${p => p.isRemoved && `background-color: ${DIFF_COLORS.removedRow}`};
   ${p => p.isAdded && `background-color: ${DIFF_COLORS.addedRow}`};
 `;


### PR DESCRIPTION
Remove Flex render-prop wrapper that was making the modal body a centered row flex container, causing diff content to size to its intrinsic width and overflow the modal. Instead, use a flex column layout on the document container so the header stays fixed and only the body scrolls.

After (small):

<img width="1721" height="840" alt="Screenshot 2026-02-18 at 8 56 09 AM" src="https://github.com/user-attachments/assets/7368f07a-2f1b-46f2-9f80-5f902609e361" />

After (large, scrolled partially):

<img width="1715" height="838" alt="Screenshot 2026-02-18 at 9 00 48 AM" src="https://github.com/user-attachments/assets/6a64af51-1aab-4b79-8a78-ad54d3c55089" />
