### PR TITLE
feat(explore): Disable save/compare when overlay charts are in use

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -848,4 +848,28 @@ describe('ExploreToolbar', () => {
       'true'
     );
   });
+
+  it('disables save as and compare when overlay charts are present', async () => {
+    render(<ExploreToolbar />, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: JSON.stringify({
+              yAxes: ['count(span.duration)', 'avg(span.duration)'],
+            }),
+          },
+        },
+      },
+    });
+
+    const section = await screen.findByTestId('section-save-as');
+    expect(within(section).getByRole('button', {name: 'Save as'})).toBeDisabled();
+    expect(within(section).getByRole('button', {name: 'Compare'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
 });

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -24,6 +24,7 @@ import {dedupeArray} from 'sentry/utils/dedupeArray';
 import {encodeSort} from 'sentry/utils/discover/eventView';
 import {parseFunction, prettifyParsedFunction} from 'sentry/utils/discover/fields';
 import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
+import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -46,7 +47,10 @@ import {
   useQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  isBaseVisualize,
+  isVisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
@@ -278,6 +282,20 @@ export function ToolbarSaveAs() {
   const crossEvents = useQueryParamsCrossEvents();
   const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
 
+  const hasOverlayCharts = useMemo(() => {
+    const rawVisualizes = decodeList(location.query?.visualize);
+    return rawVisualizes.some(raw => {
+      try {
+        const parsed = JSON.parse(raw);
+        return isBaseVisualize(parsed) && parsed.yAxes.length > 1;
+      } catch {
+        return false;
+      }
+    });
+  }, [location.query?.visualize]);
+
+  const isSaveDisabled = hasCrossEvents || hasOverlayCharts;
+
   if (items.length === 0) {
     return null;
   }
@@ -286,11 +304,15 @@ export function ToolbarSaveAs() {
     <StyledToolbarSection data-test-id="section-save-as">
       <Grid flow="column" align="center" gap="md">
         <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Saving cross event queries is not supported during early access.')}
+          disabled={!isSaveDisabled}
+          title={
+            hasCrossEvents
+              ? t('Saving cross event queries is not supported during early access.')
+              : t('Saving overlay chart queries is not supported during early access.')
+          }
         >
           <DropdownMenu
-            isDisabled={hasCrossEvents}
+            isDisabled={isSaveDisabled}
             items={items}
             trigger={triggerProps => (
               <SaveAsButton
@@ -310,12 +332,16 @@ export function ToolbarSaveAs() {
           />
         </Tooltip>
         <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Comparing cross event queries is not supported during early access.')}
+          disabled={!isSaveDisabled}
+          title={
+            hasCrossEvents
+              ? t('Comparing cross event queries is not supported during early access.')
+              : t('Comparing overlay chart queries is not supported during early access.')
+          }
         >
           <LinkButton
             aria-label={t('Compare')}
-            disabled={hasCrossEvents}
+            disabled={isSaveDisabled}
             onClick={() =>
               trackAnalytics('trace_explorer.compare', {
                 organization,


### PR DESCRIPTION
Disable the Save As and Compare buttons on the Explore Traces page when
overlay charts (visualizations with multiple yAxes) are present. This
prevents users from saving views that could break if the
`traces-overlay-charts-ui` feature flag is rolled back.

Follows the same disable pattern already used for cross-event queries:
parses the raw `visualize` URL query params and checks for any
visualization with `yAxes.length > 1`. Tooltip messages distinguish
between the cross-events and overlay-charts reasons.

Ticket: BROWSE-318