### PR TITLE
fix(issues): Remove broken scope tag

### DIFF
--- a/src/sentry/issues/endpoints/project_stacktrace_link.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_link.py
@@ -88,10 +88,6 @@ def set_tags(scope: Scope, result: StacktraceLinkOutcome, integrations: list[Non
             "stacktrace_link.tried_url", result["current_config"]["outcome"].get("attemptedUrl")
         )
         scope.set_tag(
-            "stacktrace_link.empty_root",
-            result["current_config"]["config"].automatically_generated == "",
-        )
-        scope.set_tag(
             "stacktrace_link.auto_derived",
             result["current_config"]["config"].automatically_generated is True,
         )


### PR DESCRIPTION
The value of stacktrace_link.empty_root hasn't been reliably accurate since it was added in 2024.
We could figure out which _root field to use and fix it, but given that it has been wrong this long, it seems 
this tag is unnecessary and can be removed.
