### PR TITLE
feat(coding-agents): Detect GitHub App 403 permission errors and return structured failure_type

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -25,10 +25,11 @@ from sentry.seer.autofix.utils import AutofixTriggerSource
 logger = logging.getLogger(__name__)
 
 
-class LaunchFailure(TypedDict, total=False):
+class LaunchFailure(TypedDict):
     repo_name: str
     error_message: str
-    failure_type: str
+    failure_type: NotRequired[str]
+    github_installation_id: NotRequired[str]
 
 
 class LaunchResponse(TypedDict, total=False):

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -25,9 +25,10 @@ from sentry.seer.autofix.utils import AutofixTriggerSource
 logger = logging.getLogger(__name__)
 
 
-class LaunchFailure(TypedDict):
+class LaunchFailure(TypedDict, total=False):
     repo_name: str
     error_message: str
+    failure_type: str
 
 
 class LaunchResponse(TypedDict, total=False):

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -6,6 +6,7 @@ import string
 from typing import Any
 
 import orjson
+import sentry_sdk
 from django.conf import settings
 from requests import HTTPError
 from rest_framework.exceptions import APIException, NotFound, PermissionDenied, ValidationError
@@ -338,7 +339,7 @@ def _launch_agents_for_repos(
                             if sentry_integration:
                                 github_installation_id = sentry_integration.external_id
                         except Exception:
-                            pass
+                            sentry_sdk.capture_exception(level="warning")
                 elif e.code == 401:
                     error_message = f"Failed to make request to coding agent{url_part}. Please check that your API credentials are correct: {e.code} Error: {e.text}"
                 else:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -328,7 +328,7 @@ def _launch_agents_for_repos(
             github_installation_id: str | None = None
             if isinstance(e, ApiError):
                 url_part = f" ({e.url})" if e.url else ""
-                if e.code == 403 and client is None:
+                if e.code == 403 and client is not None:
                     failure_type = "github_app_permissions"
                     error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
                     if repo and repo.integration_id:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -294,6 +294,7 @@ def _launch_agents_for_repos(
                 {
                     "repo_name": repo_name,
                     "error_message": f"Repository {repo_name} not found in autofix state",
+                    "failure_type": "generic",
                 }
             )
             continue
@@ -322,19 +323,35 @@ def _launch_agents_for_repos(
                 },
             )
             error_message = str(e)
+            failure_type = "generic"
+            github_installation_id: str | None = None
             if isinstance(e, ApiError):
                 url_part = f" ({e.url})" if e.url else ""
-                if e.code == 401:
+                if e.code == 403:
+                    failure_type = "github_app_permissions"
+                    error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
+                    if repo and repo.integration_id:
+                        try:
+                            sentry_integration = integration_service.get_integration(
+                                integration_id=int(repo.integration_id)
+                            )
+                            if sentry_integration:
+                                github_installation_id = sentry_integration.external_id
+                        except Exception:
+                            pass
+                elif e.code == 401:
                     error_message = f"Failed to make request to coding agent{url_part}. Please check that your API credentials are correct: {e.code} Error: {e.text}"
                 else:
                     error_message = f"Failed to make request to coding agent{url_part}. {e.code} Error: {e.text}"
 
-            failures.append(
-                {
-                    "repo_name": repo_name,
-                    "error_message": error_message,
-                }
-            )
+            failure: dict = {
+                "repo_name": repo_name,
+                "error_message": error_message,
+                "failure_type": failure_type,
+            }
+            if github_installation_id:
+                failure["github_installation_id"] = github_installation_id
+            failures.append(failure)
             continue
 
         states_to_store.append(coding_agent_state)

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -328,7 +328,7 @@ def _launch_agents_for_repos(
             github_installation_id: str | None = None
             if isinstance(e, ApiError):
                 url_part = f" ({e.url})" if e.url else ""
-                if e.code == 403:
+                if e.code == 403 and client is None:
                     failure_type = "github_app_permissions"
                     error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
                     if repo and repo.integration_id:

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+import sentry_sdk
 from requests import HTTPError
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
@@ -158,7 +159,7 @@ def launch_coding_agents(
                     if github_integrations:
                         github_installation_id = github_integrations[0].external_id
                 except Exception:
-                    pass
+                    sentry_sdk.capture_exception(level="warning")
 
             failure: dict = {
                 "repo_name": repo_name,

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -148,7 +148,7 @@ def launch_coding_agents(
             failure_type = "generic"
             error_message = "Failed to launch coding agent"
             github_installation_id: str | None = None
-            if isinstance(e, ApiError) and e.code == 403 and not is_github_copilot:
+            if isinstance(e, ApiError) and e.code == 403 and is_github_copilot:
                 failure_type = "github_app_permissions"
                 error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
                 try:

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -148,7 +148,7 @@ def launch_coding_agents(
             failure_type = "generic"
             error_message = "Failed to launch coding agent"
             github_installation_id: str | None = None
-            if isinstance(e, ApiError) and e.code == 403:
+            if isinstance(e, ApiError) and e.code == 403 and not is_github_copilot:
                 failure_type = "github_app_permissions"
                 error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
                 try:

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -18,6 +18,7 @@ from sentry.integrations.coding_agent.integration import CodingAgentIntegration
 from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.github_copilot.client import GithubCopilotAgentClient
 from sentry.integrations.services.github_copilot_identity import github_copilot_identity_service
+from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.seer.autofix.coding_agent import (
     _validate_and_get_integration,
@@ -102,6 +103,7 @@ def launch_coding_agents(
                 {
                     "repo_name": repo_name,
                     "error_message": f"Invalid repository name format: {repo_name}",
+                    "failure_type": "generic",
                 }
             )
             continue
@@ -132,7 +134,7 @@ def launch_coding_agents(
                 coding_agent_state = installation.launch(launch_request)
             else:
                 raise ValidationError("No valid client or installation available")
-        except (HTTPError, ApiError):
+        except (HTTPError, ApiError) as e:
             logger.exception(
                 "explorer.coding_agent.launch_error",
                 extra={
@@ -142,12 +144,30 @@ def launch_coding_agents(
                     "provider": provider,
                 },
             )
-            failures.append(
-                {
-                    "repo_name": repo_name,
-                    "error_message": "Failed to launch coding agent",
-                }
-            )
+            failure_type = "generic"
+            error_message = "Failed to launch coding agent"
+            github_installation_id: str | None = None
+            if isinstance(e, ApiError) and e.code == 403:
+                failure_type = "github_app_permissions"
+                error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
+                try:
+                    github_integrations = integration_service.get_integrations(
+                        organization_id=organization.id,
+                        providers=["github"],
+                    )
+                    if github_integrations:
+                        github_installation_id = github_integrations[0].external_id
+                except Exception:
+                    pass
+
+            failure: dict = {
+                "repo_name": repo_name,
+                "error_message": error_message,
+                "failure_type": failure_type,
+            }
+            if github_installation_id:
+                failure["github_installation_id"] = github_installation_id
+            failures.append(failure)
             continue
 
         states_to_store.append(coding_agent_state)

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1087,6 +1087,107 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
             mock_store_to_seer.assert_called_once()
 
 
+class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgentsTest):
+    """Test class for POST endpoint 403 permission error handling."""
+
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
+    @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
+    @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_403_error_returns_github_app_permissions_failure_type(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_preferences,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint returns failure_type=github_app_permissions on 403."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt"
+        mock_get_preferences.return_value = PreferenceResponse(
+            preference=None, code_mapping_repos=[]
+        )
+
+        # Create mock installation that raises ApiError with 403
+        from sentry.shared_integrations.exceptions import ApiError
+
+        failing_installation = MagicMock(spec=MockCodingAgentInstallation)
+        failing_installation.launch.side_effect = ApiError(
+            "Resource not accessible by integration", code=403
+        )
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_rpc_integration.get_installation = MagicMock(return_value=failing_installation)
+
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+            assert response.data["failed_count"] >= 1
+            assert "failures" in response.data
+            assert len(response.data["failures"]) >= 1
+            failure = response.data["failures"][0]
+            assert failure["failure_type"] == "github_app_permissions"
+            assert "permissions" in failure["error_message"]
+
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
+    @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
+    @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
+    @patch(
+        "sentry.integrations.services.integration.integration_service.get_organization_integration"
+    )
+    @patch("sentry.integrations.services.integration.integration_service.get_integration")
+    def test_non_403_error_returns_generic_failure_type(
+        self,
+        mock_get_integration,
+        mock_get_org_integration,
+        mock_get_preferences,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint returns failure_type=generic for non-403 errors."""
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt"
+        mock_get_preferences.return_value = PreferenceResponse(
+            preference=None, code_mapping_repos=[]
+        )
+
+        from sentry.shared_integrations.exceptions import ApiError
+
+        failing_installation = MagicMock(spec=MockCodingAgentInstallation)
+        failing_installation.launch.side_effect = ApiError("Server error", code=500)
+
+        mock_rpc_integration = self._create_mock_rpc_integration()
+        mock_rpc_integration.get_installation = MagicMock(return_value=failing_installation)
+
+        mock_get_org_integration.return_value = self.rpc_org_integration
+        mock_get_integration.return_value = mock_rpc_integration
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {"integration_id": str(self.integration.id), "run_id": 123}
+
+        with self.feature("organizations:seer-coding-agent-integrations"):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+            assert response.data["failed_count"] >= 1
+            assert "failures" in response.data
+            failure = response.data["failures"][0]
+            assert failure["failure_type"] == "generic"
+
+
 class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgentsTest):
     """Test class for POST endpoint trigger source functionality."""
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -21,6 +21,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentStatus,
 )
 from sentry.seer.models import PreferenceResponse, SeerRepoDefinition
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import APITestCase
 
 
@@ -1098,7 +1099,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         "sentry.integrations.services.integration.integration_service.get_organization_integration"
     )
     @patch("sentry.integrations.services.integration.integration_service.get_integration")
-    def test_403_error_returns_github_app_permissions_failure_type(
+    def test_org_installation_403_returns_generic_failure_type(
         self,
         mock_get_integration,
         mock_get_org_integration,
@@ -1107,15 +1108,17 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         mock_get_autofix_state,
         mock_get_providers,
     ):
-        """Test POST endpoint returns failure_type=github_app_permissions on 403."""
+        """Test POST endpoint returns failure_type=generic for org installation 403s.
+
+        Only Copilot 403s indicate a GitHub App permissions issue. A 403 from an
+        org-installed integration (e.g. Cursor) is unrelated to Sentry GitHub App
+        permissions and should surface as a generic error.
+        """
         mock_get_providers.return_value = ["github"]
         mock_get_prompt.return_value = "Test prompt"
         mock_get_preferences.return_value = PreferenceResponse(
             preference=None, code_mapping_repos=[]
         )
-
-        # Create mock installation that raises ApiError with 403
-        from sentry.shared_integrations.exceptions import ApiError
 
         failing_installation = MagicMock(spec=MockCodingAgentInstallation)
         failing_installation.launch.side_effect = ApiError(
@@ -1135,11 +1138,56 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
             response = self.get_success_response(self.organization.slug, method="post", **data)
             assert response.data["success"] is True
             assert response.data["failed_count"] >= 1
-            assert "failures" in response.data
-            assert len(response.data["failures"]) >= 1
+            failure = response.data["failures"][0]
+            assert failure["failure_type"] == "generic"
+
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
+    @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
+    @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.coding_agent.GithubCopilotAgentClient")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_copilot_403_returns_github_app_permissions_failure_type(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_get_preferences,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint returns failure_type=github_app_permissions for Copilot 403s.
+
+        When GitHub Copilot returns a 403, it indicates the Sentry GitHub App installation
+        lacks the required permissions (e.g. contents:write). The OAuth token permissions
+        are the intersection of the user's GitHub permissions and the Sentry GitHub App's
+        installation permissions.
+        """
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt"
+        mock_get_preferences.return_value = PreferenceResponse(
+            preference=None, code_mapping_repos=[]
+        )
+        mock_identity_service.get_access_token_for_user.return_value = "test-copilot-token"
+
+        mock_client_instance = MagicMock()
+        mock_copilot_client_class.return_value = mock_client_instance
+        mock_client_instance.launch.side_effect = ApiError("Permission denied", code=403)
+
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {"provider": "github_copilot", "run_id": 123}
+
+        with (
+            self.feature("organizations:seer-coding-agent-integrations"),
+            self.feature("organizations:integrations-github-copilot-agent"),
+            patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
+        ):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is True
+            assert response.data["failed_count"] >= 1
             failure = response.data["failures"][0]
             assert failure["failure_type"] == "github_app_permissions"
-            assert "permissions" in failure["error_message"]
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1164,8 +1212,6 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         mock_get_preferences.return_value = PreferenceResponse(
             preference=None, code_mapping_repos=[]
         )
-
-        from sentry.shared_integrations.exceptions import ApiError
 
         failing_installation = MagicMock(spec=MockCodingAgentInstallation)
         failing_installation.launch.side_effect = ApiError("Server error", code=500)


### PR DESCRIPTION
When launching coding agents (GitHub Copilot, Cursor) fails with a 403 from the GitHub API, it typically means the Sentry GitHub App installation lacks the required `contents:write` permission. Users who installed the Sentry GitHub App before this permission was added hit this silently — the error surfaced as a cryptic "Failed to make request to coding agent... 403 Error" toast with no actionable guidance.

This PR adds structured error detection on the backend so the frontend can distinguish permission errors from generic failures and show a helpful modal that links users directly to their GitHub App installation settings to grant the missing permission.

**Changes:**
- `organization_coding_agents.py`: Add `failure_type` field to `LaunchFailure` TypedDict
- `coding_agent.py` (autofix): Detect `ApiError(code=403)`, set `failure_type="github_app_permissions"`, look up `github_installation_id` via `integration_service.get_integration()` using the repo's `integration_id`
- `coding_agent_handoff.py` (explorer): Same 403 detection; looks up installation ID via `integration_service.get_integrations(providers=["github"])` since explorer repos don't carry `integration_id`
- All other error paths get `failure_type="generic"` for consistency

The frontend PR (to be merged independently) uses `failure_type` to decide whether to show the permissions modal or fall back to the existing error toast. The frontend is fully backwards compatible — if the backend doesn't return `failure_type`, it falls through to the existing error toast behavior.