### PR TITLE
feat(explore): Disable save/compare when overlay charts are in use

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -848,4 +848,28 @@ describe('ExploreToolbar', () => {
       'true'
     );
   });
+
+  it('disables save as and compare when overlay charts are present', async () => {
+    render(<ExploreToolbar />, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            visualize: JSON.stringify({
+              yAxes: ['count(span.duration)', 'avg(span.duration)'],
+            }),
+          },
+        },
+      },
+    });
+
+    const section = await screen.findByTestId('section-save-as');
+    expect(within(section).getByRole('button', {name: 'Save as'})).toBeDisabled();
+    expect(within(section).getByRole('button', {name: 'Compare'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
 });

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -277,6 +277,8 @@ export function ToolbarSaveAs() {
 
   const crossEvents = useQueryParamsCrossEvents();
   const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
+  const hasOverlayCharts = visualizes.some(v => v.yAxes.length > 1);
+  const isSaveDisabled = hasCrossEvents || hasOverlayCharts;
 
   if (items.length === 0) {
     return null;
@@ -286,11 +288,15 @@ export function ToolbarSaveAs() {
     <StyledToolbarSection data-test-id="section-save-as">
       <Grid flow="column" align="center" gap="md">
         <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Saving cross event queries is not supported during early access.')}
+          disabled={!isSaveDisabled}
+          title={
+            hasCrossEvents
+              ? t('Saving cross event queries is not supported during early access.')
+              : t('Saving overlay charts is not supported during early access.')
+          }
         >
           <DropdownMenu
-            isDisabled={hasCrossEvents}
+            isDisabled={isSaveDisabled}
             items={items}
             trigger={triggerProps => (
               <SaveAsButton
@@ -310,12 +316,16 @@ export function ToolbarSaveAs() {
           />
         </Tooltip>
         <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Comparing cross event queries is not supported during early access.')}
+          disabled={!isSaveDisabled}
+          title={
+            hasCrossEvents
+              ? t('Comparing cross event queries is not supported during early access.')
+              : t('Comparing overlay charts is not supported during early access.')
+          }
         >
           <LinkButton
             aria-label={t('Compare')}
-            disabled={hasCrossEvents}
+            disabled={isSaveDisabled}
             onClick={() =>
               trackAnalytics('trace_explorer.compare', {
                 organization,


### PR DESCRIPTION
Disable the Save and Compare buttons when overlay charts (visualizations
with multiple yAxes) are present. Overlay charts could break if the
multi-yAxis feature is rolled back, so we prevent users from persisting
views that use them.

Follows the same disable pattern already in place for cross-event queries:
tooltip explains why the button is disabled, and both Save As and Compare
are blocked. When both conditions apply, cross-events takes priority in
the tooltip message.

>[!note]
>Requires: #108436

Ticket: BROWSE-318