### PR TITLE
Revert "chore(context engine): New RPC endpoint for project instrumentation details"

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -42,7 +42,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
 from sentry.api.base import Endpoint, internal_region_silo_endpoint
 from sentry.api.endpoints.project_trace_item_details import convert_rpc_attribute_to_json
-from sentry.api.serializers.models.project import get_has_logs, get_has_trace_metrics
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
@@ -53,7 +52,6 @@ from sentry.integrations.models.repository_project_path_config import Repository
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
-from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
@@ -105,7 +103,6 @@ from sentry.seer.explorer.tools import (
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
 from sentry.seer.issue_detection import create_issue_occurrence
 from sentry.seer.utils import filter_repo_by_provider
-from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
@@ -275,6 +272,8 @@ def get_organization_slug(*, org_id: int) -> dict:
 
 def get_organization_project_ids(*, org_id: int) -> dict:
     """Get all active projects (IDs and slugs) for an organization"""
+    from sentry.models.project import Project
+
     try:
         organization = Organization.objects.get(id=org_id)
     except Organization.DoesNotExist:
@@ -287,28 +286,6 @@ def get_organization_project_ids(*, org_id: int) -> dict:
     )
 
     return {"projects": projects}
-
-
-def get_organization_projects_with_instrumentation(*, org_id: int) -> dict:
-    """Get all active projects for an organization with instrumentation feature flags."""
-    organization = Organization.objects.get(id=org_id)
-
-    projects = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
-
-    return {
-        "projects": [
-            {
-                "id": project.id,
-                "slug": project.slug,
-                "hasSessions": bool(project.flags.has_sessions),
-                "hasReplays": bool(project.flags.has_replays),
-                "hasProfiles": bool(project.flags.has_profiles),
-                "hasTraceMetrics": get_has_trace_metrics(project),
-                "hasLogs": get_has_logs(project),
-            }
-            for project in projects
-        ]
-    }
 
 
 class SentryOrganizaionIdsAndSlugs(TypedDict):
@@ -545,6 +522,8 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
         dict: Status of the webhook sending operation
     """
     # Validate event_name by constructing the full event type and checking if it's valid
+    from sentry.sentry_apps.metrics import SentryAppEventType
+
     event_type = f"seer.{event_name}"
     try:
         sentry_app_event_type = SentryAppEventType(event_type)
@@ -785,7 +764,6 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     # Common to Seer features
     "get_github_enterprise_integration_config": get_github_enterprise_integration_config,
     "get_organization_project_ids": get_organization_project_ids,
-    "get_organization_projects_with_instrumentation": get_organization_projects_with_instrumentation,
     "check_repository_integrations_status": check_repository_integrations_status,
     "validate_repo": validate_repo,
     #

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -52,6 +52,7 @@ from sentry.integrations.models.repository_project_path_config import Repository
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.replays.usecases.summarize import rpc_get_replay_summary_logs
 from sentry.search.eap.resolver import SearchResolver
@@ -103,6 +104,7 @@ from sentry.seer.explorer.tools import (
 from sentry.seer.fetch_issues import by_error_type, by_function_name, by_text_query, utils
 from sentry.seer.issue_detection import create_issue_occurrence
 from sentry.seer.utils import filter_repo_by_provider
+from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
 from sentry.silo.base import SiloMode
 from sentry.snuba.referrer import Referrer
@@ -272,8 +274,6 @@ def get_organization_slug(*, org_id: int) -> dict:
 
 def get_organization_project_ids(*, org_id: int) -> dict:
     """Get all active projects (IDs and slugs) for an organization"""
-    from sentry.models.project import Project
-
     try:
         organization = Organization.objects.get(id=org_id)
     except Organization.DoesNotExist:
@@ -522,8 +522,6 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
         dict: Status of the webhook sending operation
     """
     # Validate event_name by constructing the full event type and checking if it's valid
-    from sentry.sentry_apps.metrics import SentryAppEventType
-
     event_type = f"seer.{event_name}"
     try:
         sentry_app_event_type = SentryAppEventType(event_type)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -20,7 +20,6 @@ from sentry.seer.endpoints.seer_rpc import (
     generate_request_signature,
     get_attributes_for_span,
     get_github_enterprise_integration_config,
-    get_organization_projects_with_instrumentation,
     has_repo_code_mappings,
     validate_repo,
 )
@@ -1348,35 +1347,3 @@ class TestSeerRpcMethods(APITestCase):
         )
 
         assert result == {"valid": True, "integration_id": integration.id}
-
-
-class TestGetOrganizationProjectsWithInstrumentation(APITestCase):
-    def test_returns_projects_with_flags(self) -> None:
-        project = self.project
-        project.flags.has_sessions = True
-        project.flags.has_replays = True
-        project.flags.has_profiles = False
-        project.save()
-
-        result = get_organization_projects_with_instrumentation(org_id=self.organization.id)
-
-        assert len(result["projects"]) >= 1
-        matching = next(p for p in result["projects"] if p["id"] == project.id)
-        assert matching["slug"] == project.slug
-        assert matching["hasSessions"] is True
-        assert matching["hasReplays"] is True
-        assert matching["hasProfiles"] is False
-        assert "hasTraceMetrics" in matching
-        assert "hasLogs" in matching
-
-    def test_excludes_inactive_projects(self) -> None:
-        active_project = self.project
-        inactive_project = self.create_project(organization=self.organization)
-        inactive_project.status = ObjectStatus.PENDING_DELETION
-        inactive_project.save()
-
-        result = get_organization_projects_with_instrumentation(org_id=self.organization.id)
-
-        project_ids = [p["id"] for p in result["projects"]]
-        assert active_project.id in project_ids
-        assert inactive_project.id not in project_ids


### PR DESCRIPTION
+ Reverts getsentry/sentry#108413
+ Reverting this since this ROC might not be needed due to the refactor in this PR - https://github.com/getsentry/seer/pull/4900