### PR TITLE
fix(workflow_engine): Fix integration_id type mismatch in action translator

### DIFF
--- a/src/sentry/testutils/helpers/data_blobs.py
+++ b/src/sentry/testutils/helpers/data_blobs.py
@@ -105,7 +105,7 @@ GITHUB_ACTION_DATA_BLOBS = [
     },
     # Complete example
     {
-        "integration": "00000",
+        "integration": "33333",
         "id": "sentry.integrations.github.notify_action.GitHubCreateTicketAction",
         "dynamic_form_fields": [
             {

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -217,7 +217,8 @@ class BaseActionTranslator(ABC):
         """Return the integration ID for this action, if any"""
         if mapping := ACTION_FIELD_MAPPINGS.get(self.action_type):
             if ActionFieldMappingKeys.INTEGRATION_ID_KEY.value in mapping:
-                return self.action.get(mapping[ActionFieldMappingKeys.INTEGRATION_ID_KEY.value])
+                value = self.action.get(mapping[ActionFieldMappingKeys.INTEGRATION_ID_KEY.value])
+                return int(value) if value is not None else None
         return None
 
     @property

--- a/src/sentry/workflow_engine/typings/notification_action.py
+++ b/src/sentry/workflow_engine/typings/notification_action.py
@@ -472,8 +472,9 @@ class TicketActionTranslator(BaseActionTranslator, TicketingActionDataBlobHelper
         ]
 
     @property
-    def integration_id(self) -> Any | None:
-        return self.action.get("integration")
+    def integration_id(self) -> int | None:
+        value = self.action.get("integration")
+        return int(value) if value is not None else None
 
     @property
     def target_type(self) -> int:

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -20,6 +20,7 @@ from sentry.workflow_engine.migration_helpers.rule_action import (
 from sentry.workflow_engine.models.action import Action
 from sentry.workflow_engine.typings.notification_action import (
     EXCLUDED_ACTION_DATA_KEYS,
+    ActionType,
     SentryAppDataBlob,
     SentryAppIdentifier,
     TicketDataBlob,
@@ -165,7 +166,7 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         # Assert integration_id matches if specified
         if integration_id_key:
-            assert action.integration_id == compare_dict.get(integration_id_key)
+            assert str(action.integration_id) == compare_dict.get(integration_id_key)
 
         # Assert target_identifier matches if specified
         if target_identifier_key:
@@ -201,6 +202,7 @@ class TestNotificationActionMigrationUtils(TestCase):
 
         for action, rule_data in zip(actions, rule_data_actions):
             assert isinstance(action, Action)
+            action.refresh_from_db()
             self.assert_action_attributes(
                 action,
                 rule_data,
@@ -720,47 +722,47 @@ class TestNotificationActionMigrationUtils(TestCase):
         test_cases = [
             (
                 "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
-                Action.Type.SLACK,
+                ActionType.SLACK,
             ),
             (
                 "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
-                Action.Type.DISCORD,
+                ActionType.DISCORD,
             ),
             (
                 "sentry.integrations.msteams.notify_action.MsTeamsNotifyServiceAction",
-                Action.Type.MSTEAMS,
+                ActionType.MSTEAMS,
             ),
             (
                 "sentry.integrations.pagerduty.notify_action.PagerDutyNotifyServiceAction",
-                Action.Type.PAGERDUTY,
+                ActionType.PAGERDUTY,
             ),
             (
                 "sentry.integrations.opsgenie.notify_action.OpsgenieNotifyTeamAction",
-                Action.Type.OPSGENIE,
+                ActionType.OPSGENIE,
             ),
             (
                 "sentry.integrations.github.notify_action.GitHubCreateTicketAction",
-                Action.Type.GITHUB,
+                ActionType.GITHUB,
             ),
             (
                 "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
-                Action.Type.GITHUB_ENTERPRISE,
+                ActionType.GITHUB_ENTERPRISE,
             ),
             (
                 "sentry.integrations.vsts.notify_action.AzureDevopsCreateTicketAction",
-                Action.Type.AZURE_DEVOPS,
+                ActionType.AZURE_DEVOPS,
             ),
             (
                 "sentry.mail.actions.NotifyEmailAction",
-                Action.Type.EMAIL,
+                ActionType.EMAIL,
             ),
             (
                 "sentry.rules.actions.notify_event.NotifyEventAction",
-                Action.Type.PLUGIN,
+                ActionType.PLUGIN,
             ),
             (
                 "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                Action.Type.WEBHOOK,
+                ActionType.WEBHOOK,
             ),
         ]
 


### PR DESCRIPTION
The BaseActionTranslator.integration_id property was annotated as returning int | None but actually returned str | None from the action dict. Fix the property to actually return int, and add refresh_from_db() in tests so the assertion operates on DB-coerced types.
Unclear this was an actual misbehavior in prod code due to type coercion, but better to be verifiably correct.

Also, Action.Type and ActionType aren't the same, despite having identical values. Made it consistent, though
we should probably go back and consider whether we need two identical enums.