### PR TITLE
fix(api): Scope member invite lookups to organization

### DIFF
--- a/src/sentry/core/endpoints/organization_member_invite/details.py
+++ b/src/sentry/core/endpoints/organization_member_invite/details.py
@@ -58,7 +58,8 @@ class OrganizationMemberInviteDetailsEndpoint(OrganizationEndpoint):
 
         try:
             kwargs["invited_member"] = OrganizationMemberInvite.objects.get(
-                id=int(member_invite_id)
+                id=int(member_invite_id),
+                organization_id=kwargs["organization"].id,
             )
         except OrganizationMemberInvite.DoesNotExist:
             raise ResourceDoesNotExist

--- a/src/sentry/core/endpoints/organization_member_invite/reinvite.py
+++ b/src/sentry/core/endpoints/organization_member_invite/reinvite.py
@@ -52,7 +52,8 @@ class OrganizationMemberReinviteEndpoint(OrganizationEndpoint):
 
         try:
             kwargs["invited_member"] = OrganizationMemberInvite.objects.get(
-                id=int(member_invite_id)
+                id=int(member_invite_id),
+                organization_id=kwargs["organization"].id,
             )
         except OrganizationMemberInvite.DoesNotExist:
             raise ResourceDoesNotExist


### PR DESCRIPTION
Fix cross-organization IDOR in `OrganizationMemberInviteDetailsEndpoint` and `OrganizationMemberReinviteEndpoint`. Both endpoints fetched `OrganizationMemberInvite` by primary key only in `convert_args`, without verifying the invite belongs to the organization in the URL. An authenticated user with appropriate scopes in org-A could read, modify, delete, and reinvite member invites belonging to org-B.

Adds `organization_id=kwargs["organization"].id` to both `.objects.get()` calls so mismatched invites return 404. Cross-organization tests added for GET, PUT, DELETE on the details endpoint and PUT on the reinvite endpoint.