### PR TITLE
 feat(uptime-traces): Linking uptime issues to check-ins in traces

### DIFF
--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -619,7 +619,7 @@ def query_trace_data(
                 errors = id_to_error.pop(span["id"])
                 span["errors"].extend(errors)
             if span["id"] in id_to_occurrence:
-                occurrence_events: list[TraceOccurrenceEvent] = [
+                occurrences: list[TraceOccurrenceEvent] = [
                     {
                         "event_type": "occurrence",
                         "event_data": {
@@ -632,7 +632,7 @@ def query_trace_data(
                     }
                     for occurrence in id_to_occurrence[span["id"]]
                 ]
-                span["occurrences"].extend(occurrence_events)
+                span["occurrences"].extend(occurrences)
 
         # These are offset from the params start & end
         if span_min_ts is not None:

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -1,8 +1,9 @@
 import logging
 from collections import defaultdict
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 from sentry.uptime.subscriptions.regions import get_region_config
 
@@ -53,7 +54,7 @@ class SerializedIssue(SerializedEvent):
     issue_id: int
     level: str
     start_timestamp: float
-    end_timestamp: NotRequired[datetime]
+    end_timestamp: NotRequired[float]
     culprit: str | None
     short_id: str | None
     issue_type: str
@@ -90,6 +91,24 @@ class SerializedUptimeCheck(SerializedEvent):
     name: str
     region_name: str
     additional_attributes: dict[str, Any]
+
+
+class TraceIssueOccurrenceData(TypedDict):
+    occurrence: IssueOccurrence
+    issue_id: int
+
+
+class TraceOccurenceEventData(TypedDict):
+    start_timestamp: float
+    end_timestamp: float
+    project_slug: str
+    transaction: str
+
+
+class TraceOccurrenceEvent(TypedDict):
+    event_type: Literal["occurrence"]
+    event_data: TraceOccurenceEventData
+    issue_data: TraceIssueOccurrenceData
 
 
 def _serialize_rpc_issue(event: dict[str, Any], group_cache: dict[int, Group]) -> SerializedIssue:
@@ -302,7 +321,9 @@ def _perf_issues_query(snuba_params: SnubaParams, trace_id: str) -> DiscoverQuer
 
 
 @sentry_sdk.tracing.trace
-def _run_perf_issues_query(occurrence_query: DiscoverQueryBuilder):
+def _run_perf_issues_query(
+    occurrence_query: DiscoverQueryBuilder,
+) -> list[TraceIssueOccurrenceData]:
     result = occurrence_query.run_query(Referrer.API_TRACE_VIEW_GET_EVENTS.value)
     occurrence_data = occurrence_query.process_results(result)["data"]
 
@@ -320,7 +341,7 @@ def _run_perf_issues_query(occurrence_query: DiscoverQueryBuilder):
                 project_id,
             )
         )
-    result = []
+    result: list[TraceIssueOccurrenceData] = []
     for issue in issue_occurrences:
         if issue:
             for issue_id in occurrence_issue_ids.get(issue.id, []):
@@ -375,7 +396,7 @@ def _run_uptime_results_query(uptime_query: TraceItemTableRequest) -> list[Trace
 def _serialize_columnar_uptime_item(
     row_dict: dict[str, AttributeValue],
     project_slugs: dict[int, str],
-    check_id_to_occurrences: dict[str, list[dict[str, Any]]] | None = None,
+    check_id_to_occurrences: Mapping[str, list[TraceIssueOccurrenceData]] | None = None,
 ) -> dict[str, Any]:
     """Convert a columnar uptime row to a serialized uptime check span format"""
     columns_by_name = {col.internal_name: col for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()}
@@ -425,7 +446,7 @@ def _serialize_columnar_uptime_item(
 
     check_id_attr = row_dict.get("check_id")
     check_id = check_id_attr.val_str if check_id_attr else None
-    occurrences = (
+    occurrences: list[TraceOccurrenceEvent] = (
         [
             {
                 "event_type": "occurrence",
@@ -544,7 +565,9 @@ def query_trace_data(
                 )
             }
 
-            check_id_to_occurrences: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+            check_id_to_occurrences: defaultdict[str, list[TraceIssueOccurrenceData]] = defaultdict(
+                list
+            )
             for event in occurrence_data:
                 occurrence = event["occurrence"]
                 check_id = occurrence.evidence_data.get("check_id")
@@ -596,21 +619,20 @@ def query_trace_data(
                 errors = id_to_error.pop(span["id"])
                 span["errors"].extend(errors)
             if span["id"] in id_to_occurrence:
-                span["occurrences"].extend(
-                    [
-                        {
-                            "event_type": "occurrence",
-                            "event_data": {
-                                "start_timestamp": span["precise.start_ts"],
-                                "end_timestamp": span["precise.finish_ts"],
-                                "project_slug": span["project.slug"],
-                                "transaction": span["transaction"],
-                            },
-                            "issue_data": occurrence,
-                        }
-                        for occurrence in id_to_occurrence[span["id"]]
-                    ]
-                )
+                occurrence_events: list[TraceOccurrenceEvent] = [
+                    {
+                        "event_type": "occurrence",
+                        "event_data": {
+                            "start_timestamp": span["precise.start_ts"],
+                            "end_timestamp": span["precise.finish_ts"],
+                            "project_slug": span["project.slug"],
+                            "transaction": span["transaction"],
+                        },
+                        "issue_data": occurrence,
+                    }
+                    for occurrence in id_to_occurrence[span["id"]]
+                ]
+                span["occurrences"].extend(occurrence_events)
 
         # These are offset from the params start & end
         if span_min_ts is not None:

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -324,8 +324,8 @@ def _perf_issues_query(snuba_params: SnubaParams, trace_id: str) -> DiscoverQuer
 def _run_perf_issues_query(
     occurrence_query: DiscoverQueryBuilder,
 ) -> list[TraceIssueOccurrenceData]:
-    result = occurrence_query.run_query(Referrer.API_TRACE_VIEW_GET_EVENTS.value)
-    occurrence_data = occurrence_query.process_results(result)["data"]
+    snuba_result = occurrence_query.run_query(Referrer.API_TRACE_VIEW_GET_EVENTS.value)
+    occurrence_data = occurrence_query.process_results(snuba_result)["data"]
 
     occurrence_ids = defaultdict(list)
     occurrence_issue_ids = defaultdict(list)
@@ -458,7 +458,7 @@ def _serialize_columnar_uptime_item(
                 },
                 "issue_data": issue_data,
             }
-            for issue_data in check_id_to_occurrences.get(check_id, [])
+            for issue_data in (check_id_to_occurrences or {}).get(check_id or "", [])
         ]
         if check_id
         else []

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -103,7 +103,7 @@ def _serialize_rpc_issue(event: dict[str, Any], group_cache: dict[int, Group]) -
 
     if event.get("event_type") == "occurrence":
         occurrence = event["issue_data"]["occurrence"]
-        span = event["span"]
+        event_data = event["event_data"]
         issue_id = event["issue_data"]["issue_id"]
         if issue_id in group_cache:
             issue = group_cache[issue_id]
@@ -113,16 +113,16 @@ def _serialize_rpc_issue(event: dict[str, Any], group_cache: dict[int, Group]) -
         return SerializedIssue(
             event_id=occurrence.event_id,
             project_id=occurrence.project_id,
-            project_slug=span["project.slug"],
-            start_timestamp=span["precise.start_ts"],
-            end_timestamp=span["precise.finish_ts"],
-            transaction=span["transaction"],
+            project_slug=event_data["project_slug"],
+            start_timestamp=event_data["start_timestamp"],
+            end_timestamp=event_data["end_timestamp"],
+            transaction=event_data["transaction"],
             description=occurrence.issue_title,
             level=occurrence.level,
             issue_id=issue_id,
             event_type="occurrence",
             culprit=issue.culprit,
-            short_id=_qualify_short_id(span["project.slug"], issue.short_id),
+            short_id=_qualify_short_id(event_data["project_slug"], issue.short_id),
             issue_type=issue.type,
         )
     elif event.get("event_type") == "error":
@@ -375,6 +375,7 @@ def _run_uptime_results_query(uptime_query: TraceItemTableRequest) -> list[Trace
 def _serialize_columnar_uptime_item(
     row_dict: dict[str, AttributeValue],
     project_slugs: dict[int, str],
+    check_id_to_occurrences: dict[str, list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     """Convert a columnar uptime row to a serialized uptime check span format"""
     columns_by_name = {col.internal_name: col for col in UPTIME_ATTRIBUTE_DEFINITIONS.values()}
@@ -419,6 +420,29 @@ def _serialize_columnar_uptime_item(
             if resolved_val is not None:
                 additional_attrs[resolved_column.public_alias] = resolved_val
 
+    start_timestamp = actual_check_time_us / 1_000_000
+    end_timestamp = (actual_check_time_us + check_duration_us) / 1_000_000
+
+    check_id_attr = row_dict.get("check_id")
+    check_id = check_id_attr.val_str if check_id_attr else None
+    occurrences = (
+        [
+            {
+                "event_type": "occurrence",
+                "event_data": {
+                    "start_timestamp": start_timestamp,
+                    "end_timestamp": end_timestamp,
+                    "project_slug": project_slug,
+                    "transaction": "uptime.check",
+                },
+                "issue_data": issue_data,
+            }
+            for issue_data in check_id_to_occurrences.get(check_id, [])
+        ]
+        if check_id
+        else []
+    )
+
     uptime_check = {
         "event_type": "uptime_check",
         "event_id": item_id_str,
@@ -428,15 +452,15 @@ def _serialize_columnar_uptime_item(
         "transaction_id": trace_id,
         "name": request_url,
         "op": "uptime.request",
-        "start_timestamp": actual_check_time_us / 1_000_000,
-        "end_timestamp": (actual_check_time_us + check_duration_us) / 1_000_000,
+        "start_timestamp": start_timestamp,
+        "end_timestamp": end_timestamp,
         "duration": check_duration_us / 1_000.0,
         "description": f"Uptime Check Request [{check_status}]",
         "region_name": region_name,
         "additional_attributes": additional_attrs,
         "children": [],
         "errors": [],
-        "occurrences": [],
+        "occurrences": occurrences,
     }
 
     return uptime_check
@@ -519,8 +543,17 @@ def query_trace_data(
                     "id", "slug"
                 )
             }
+
+            check_id_to_occurrences: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+            for event in occurrence_data:
+                occurrence = event["occurrence"]
+                check_id = occurrence.evidence_data.get("check_id")
+                if check_id:
+                    check_id_to_occurrences[check_id].append(event)
+
             uptime_checks = [
-                _serialize_columnar_uptime_item(item, project_slugs) for item in trace_items
+                _serialize_columnar_uptime_item(item, project_slugs, check_id_to_occurrences)
+                for item in trace_items
             ]
             uptime_checks.sort(
                 key=lambda s: s.get("additional_attributes", {}).get("request_sequence", 0)
@@ -567,7 +600,12 @@ def query_trace_data(
                     [
                         {
                             "event_type": "occurrence",
-                            "span": span,
+                            "event_data": {
+                                "start_timestamp": span["precise.start_ts"],
+                                "end_timestamp": span["precise.finish_ts"],
+                                "project_slug": span["project.slug"],
+                                "transaction": span["transaction"],
+                            },
                             "issue_data": occurrence,
                         }
                         for occurrence in id_to_occurrence[span["id"]]

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -98,7 +98,7 @@ class TraceIssueOccurrenceData(TypedDict):
     issue_id: int
 
 
-class TraceOccurenceEventData(TypedDict):
+class TraceOccurrenceEventData(TypedDict):
     start_timestamp: float
     end_timestamp: float
     project_slug: str
@@ -107,7 +107,7 @@ class TraceOccurenceEventData(TypedDict):
 
 class TraceOccurrenceEvent(TypedDict):
     event_type: Literal["occurrence"]
-    event_data: TraceOccurenceEventData
+    event_data: TraceOccurrenceEventData
     issue_data: TraceIssueOccurrenceData
 
 
@@ -458,7 +458,7 @@ def _serialize_columnar_uptime_item(
                 },
                 "issue_data": issue_data,
             }
-            for issue_data in (check_id_to_occurrences or {}).get(check_id or "", [])
+            for issue_data in (check_id_to_occurrences or {}).get(check_id, [])
         ]
         if check_id
         else []

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -3166,19 +3166,22 @@ class UptimeTestCaseMixin:
     def create_uptime_result(
         self,
         subscription_id: str | None = None,
+        guid: str | None = None,
         status: CheckStatus = CHECKSTATUS_FAILURE,
         scheduled_check_time: datetime | None = None,
         uptime_region: str | None = "us-west",
     ) -> CheckResult:
         if subscription_id is None:
             subscription_id = uuid.uuid4().hex
+        if guid is None:
+            guid = uuid.uuid4().hex
         if scheduled_check_time is None:
             scheduled_check_time = datetime.now().replace(microsecond=0)
         optional_fields: _OptionalCheckResult = {}
         if uptime_region is not None:
             optional_fields["region"] = uptime_region
         return {
-            "guid": uuid.uuid4().hex,
+            "guid": guid,
             "subscription_id": subscription_id,
             "status": status,
             "status_reason": {

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -240,6 +240,10 @@ class UptimeDetectorHandler(StatefulDetectorHandler[UptimePacketValue, CheckStat
         if assertion_failure_data is not None:
             evidence_data["assertion_failure_data"] = json.dumps(assertion_failure_data)
 
+        check_id = result.get("guid")
+        if check_id:
+            evidence_data["check_id"] = check_id
+
         occurrence = DetectorOccurrence(
             issue_title=f"Downtime detected for {uptime_subscription.url}",
             subtitle="Your monitored domain is down",

--- a/tests/sentry/uptime/test_grouptype.py
+++ b/tests/sentry/uptime/test_grouptype.py
@@ -238,6 +238,32 @@ class TestUptimeHandler(UptimeTestCase):
             MOCK_ASSERTION_FAILURE_DATA
         )
 
+    def test_check_id_evidence_data(self) -> None:
+        check_id = uuid.uuid4().hex
+        detector = self.create_uptime_detector(downtime_threshold=2, recovery_threshold=1)
+        uptime_subscription = get_uptime_subscription(detector)
+
+        now = datetime.now()
+
+        self.handle_result(
+            detector,
+            uptime_subscription,
+            self.create_uptime_result(
+                scheduled_check_time=now - timedelta(minutes=5), guid=check_id
+            ),
+        )
+
+        evaluation = self.handle_result(
+            detector,
+            uptime_subscription,
+            self.create_uptime_result(
+                scheduled_check_time=now - timedelta(minutes=4), guid=check_id
+            ),
+        )
+        assert evaluation is not None
+        assert isinstance(evaluation.result, IssueOccurrence)
+        assert evaluation.result.evidence_data["check_id"] == check_id
+
     def test_occurrence_excludes_old_response_capture(self) -> None:
         detector = self.create_uptime_detector(downtime_threshold=2, recovery_threshold=1)
         uptime_subscription = get_uptime_subscription(detector)

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -821,6 +821,5 @@ class OrganizationEventsTraceEndpointTest(
         occurrences = uptime_checks[0]["occurrences"]
         assert len(occurrences) == 1
         occurrence = occurrences[0]
-        assert occurrence["event_id"] == self.root_event.event_id
         assert occurrence["transaction"] == "uptime.check"
         assert occurrence["level"] == "error"

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -5,13 +5,17 @@ from uuid import uuid4
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
+from django.utils import timezone
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 
 from sentry.conf.types.uptime import UptimeRegionConfig
+from sentry.issues.ingest import save_issue_occurrence
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.search.events.types import SnubaParams
 from sentry.testutils.cases import UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.options import override_options
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.utils.samples import load_data
 from tests.snuba.api.endpoints.test_organization_events_trace import (
     OrganizationEventsTraceEndpointBase,
@@ -765,3 +769,58 @@ class OrganizationEventsTraceEndpointTest(
         data = response.data
 
         self.assert_expected_results(data, [uptime_result], expected_children_ids=["root"])
+
+    def test_uptime_occurrences(self):
+        """Test that uptime occurrences are included in the response"""
+        self.load_trace()
+
+        check_id = "check-occur-1"
+        uptime_result = self._create_uptime_result_with_original_url(
+            organization=self.organization,
+            project=self.project,
+            trace_id=self.trace_id,
+            guid=check_id,
+            check_id=check_id,
+            subscription_id="sub-occur-1",
+            check_status="failure",
+            http_status_code=500,
+            request_sequence=0,
+            request_url="https://test.com",
+            scheduled_check_time=self.day_ago,
+            check_duration_us=200000,
+        )
+        self.store_uptime_results([uptime_result])
+
+        occurrence = IssueOccurrence(
+            id=uuid4().hex,
+            resource_id=None,
+            project_id=self.project.id,
+            event_id=self.root_event.event_id,
+            fingerprint=[uuid4().hex],
+            type=UptimeDomainCheckFailure,
+            issue_title="Downtime detected for https://test.com",
+            subtitle="Your monitored domain is down",
+            evidence_display=[],
+            evidence_data={"check_id": check_id},
+            culprit="",
+            detection_time=timezone.now(),
+            level="error",
+        )
+        _, group_info = save_issue_occurrence(occurrence.to_dict(), self.root_event)
+        assert group_info is not None
+
+        with self.feature(self.FEATURES):
+            response = self.client_get(data={"timestamp": self.day_ago, "include_uptime": "1"})
+
+        assert response.status_code == 200, response.content
+        data = response.data
+
+        uptime_checks = self._find_uptime_checks(data)
+        assert len(uptime_checks) == 1
+
+        occurrences = uptime_checks[0]["occurrences"]
+        assert len(occurrences) == 1
+        occurrence = occurrences[0]
+        assert occurrence["event_id"] == self.root_event.event_id
+        assert occurrence["transaction"] == "uptime.check"
+        assert occurrence["level"] == "error"


### PR DESCRIPTION
- `check_id` is the most relevant uptime field to map occurrences to a check-in
- Passed the `check_id` to the issue.occurence
- Added some typing around occurrence linking, since I struggled while trying to implement this change overall