### PR TITLE
fix(api): Check token expiration in OAuth userinfo endpoint

### DIFF
--- a/src/sentry/api/endpoints/oauth_userinfo.py
+++ b/src/sentry/api/endpoints/oauth_userinfo.py
@@ -85,6 +85,9 @@ class OAuthUserInfoEndpoint(Endpoint):
         except ApiToken.DoesNotExist:
             raise BearerTokenInvalid()
 
+        if token_details.is_expired():
+            raise BearerTokenInvalid()
+
         scopes = token_details.get_scopes()
         if "openid" not in scopes:
             raise BearerTokenInsufficientScope()


### PR DESCRIPTION
The `OAuthUserInfoEndpoint` bypasses standard DRF authentication (`authentication_classes = ()`) and performs manual token lookup via `ApiToken.objects.get()`. However, it never calls `token.is_expired()`, meaning expired OAuth tokens can be used to retrieve user information (user ID, name, email, avatar) indefinitely after the 30-day expiration.

The standard auth pipeline in `UserAuthTokenAuthentication.authenticate_token()` properly checks `is_expired()` and rejects expired tokens. This fix adds the same check to the manual token lookup path, returning `invalid_token` per RFC 6750 Section 3.1.