### PR TITLE
fix(userrole): Fix guaranteed-to-fail comparison

### DIFF
--- a/src/sentry/users/models/userrole.py
+++ b/src/sentry/users/models/userrole.py
@@ -87,7 +87,7 @@ def manage_default_super_admin_role(**kwargs: Any) -> None:
         name="Super Admin", defaults={"permissions": settings.SENTRY_USER_PERMISSIONS}
     )
     if role.permissions != list(settings.SENTRY_USER_PERMISSIONS):
-        role.permissions = settings.SENTRY_USER_PERMISSIONS
+        role.permissions = list(settings.SENTRY_USER_PERMISSIONS)
         role.save(update_fields=["permissions"])
 
 

--- a/src/sentry/users/models/userrole.py
+++ b/src/sentry/users/models/userrole.py
@@ -86,7 +86,7 @@ def manage_default_super_admin_role(**kwargs: Any) -> None:
     role, _ = UserRole.objects.get_or_create(
         name="Super Admin", defaults={"permissions": settings.SENTRY_USER_PERMISSIONS}
     )
-    if role.permissions != settings.SENTRY_USER_PERMISSIONS:
+    if role.permissions != list(settings.SENTRY_USER_PERMISSIONS):
         role.permissions = settings.SENTRY_USER_PERMISSIONS
         role.save(update_fields=["permissions"])
 


### PR DESCRIPTION
settings.SENTRY_USER_PERMISSIONS is a tuple, UserRole.permissions is typed as a list, so they are never expected to be equal.
By converting the tuple to a list, it is a meaningful comparison.

This paves the way for strict_equality = True in mypy.
