### PR TITLE
fix(api): Prevent IDOR in release threshold status via unvalidated project slugs

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -176,10 +176,9 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             release_query &= Q(
                 releaseprojectenvironment__environment__name__in=environments_list,
             )
-        if project_slug_list:
-            release_query &= Q(
-                projects__id__in=validated_project_ids,
-            )
+        release_query &= Q(
+            projects__id__in=validated_project_ids,
+        )
         if releases_list:
             release_query &= Q(
                 version__in=releases_list,
@@ -217,11 +216,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             # TODO:
             # We should update release model to preserve threshold states.
             # if release.failed_thresholds/passed_thresholds exists - then skip calculating and just return thresholds
-            project_list = [
-                p
-                for p in release.projects.all()
-                if (project_slug_list and p.id in validated_project_ids) or (not project_slug_list)
-            ]
+            project_list = [p for p in release.projects.all() if p.id in validated_project_ids]
 
             for project in project_list:
                 thresholds_list: list[ReleaseThreshold] = [

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -152,6 +152,11 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         except NoProjects:
             raise NoProjects("No projects available")
 
+        # Use validated project IDs from get_filter_params instead of raw user input.
+        # The raw project_slug_list could contain slugs for projects the user doesn't
+        # have access to, bypassing the permission checks in get_projects().
+        validated_project_ids = set(filter_params["project_id"])
+
         start: datetime | None = filter_params["start"]
         end: datetime | None = filter_params["end"]
         logger.info(
@@ -173,7 +178,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             )
         if project_slug_list:
             release_query &= Q(
-                projects__slug__in=project_slug_list,
+                projects__id__in=validated_project_ids,
             )
         if releases_list:
             release_query &= Q(
@@ -215,7 +220,7 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
             project_list = [
                 p
                 for p in release.projects.all()
-                if (project_slug_list and p.slug in project_slug_list) or (not project_slug_list)
+                if (project_slug_list and p.id in validated_project_ids) or (not project_slug_list)
             ]
 
             for project in project_list:

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -492,11 +492,14 @@ class ReleaseThresholdStatusProjectAccessTest(APITestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.user = self.create_user(is_staff=False, is_superuser=False)
-
-        # Disable open membership so project access is enforced by team membership
+        # Create a separate owner so self.user doesn't get the owner role,
+        # which has global project access and would bypass team-based filtering.
+        owner = self.create_user("owner@example.com")
+        self.organization = self.create_organization(owner=owner)
         self.organization.flags.allow_joinleave = False
         self.organization.save()
+
+        self.user = self.create_user(is_staff=False, is_superuser=False)
 
         self.team1 = self.create_team(organization=self.organization)
         self.team2 = self.create_team(organization=self.organization)
@@ -508,7 +511,7 @@ class ReleaseThresholdStatusProjectAccessTest(APITestCase):
             name="inaccessible", organization=self.organization, teams=[self.team2]
         )
 
-        # User only belongs to team1 (user is already a member from APITestCase setUp)
+        # User only belongs to team1, giving access to accessible_project only
         self.create_team_membership(team=self.team1, user=self.user)
 
         self.environment = Environment.objects.create(

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -482,3 +482,108 @@ class ReleaseThresholdStatusTest(APITestCase):
         assert mock_is_new_issue_count_healthy.call_count == 1
         assert mock_fetch_sessions_data.call_count == 1
         assert mock_is_crash_free_rate_healthy.call_count == 1
+
+
+class ReleaseThresholdStatusProjectAccessTest(APITestCase):
+    """Tests that release threshold status respects project-level access controls."""
+
+    endpoint = "sentry-api-0-organization-release-threshold-statuses"
+    method = "get"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user(is_staff=False, is_superuser=False)
+
+        # Disable open membership so project access is enforced by team membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        self.team1 = self.create_team(organization=self.organization)
+        self.team2 = self.create_team(organization=self.organization)
+
+        self.accessible_project = self.create_project(
+            name="accessible", organization=self.organization, teams=[self.team1]
+        )
+        self.inaccessible_project = self.create_project(
+            name="inaccessible", organization=self.organization, teams=[self.team2]
+        )
+
+        # User only belongs to team1
+        self.create_member(teams=[self.team1], user=self.user, organization=self.organization)
+
+        self.environment = Environment.objects.create(
+            organization_id=self.organization.id, name="production"
+        )
+
+        # Release attached to both projects
+        self.release = Release.objects.create(version="v1", organization=self.organization)
+        self.release.add_project(self.accessible_project)
+        self.release.add_project(self.inaccessible_project)
+
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release.id,
+            project_id=self.accessible_project.id,
+            environment_id=self.environment.id,
+        )
+        ReleaseProjectEnvironment.objects.create(
+            release_id=self.release.id,
+            project_id=self.inaccessible_project.id,
+            environment_id=self.environment.id,
+        )
+
+        # Thresholds on both projects
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            trigger_type=1,
+            value=100,
+            window_in_seconds=100,
+            project=self.accessible_project,
+            environment=self.environment,
+        )
+        ReleaseThreshold.objects.create(
+            threshold_type=ReleaseThresholdType.TOTAL_ERROR_COUNT,
+            trigger_type=1,
+            value=100,
+            window_in_seconds=100,
+            project=self.inaccessible_project,
+            environment=self.environment,
+        )
+
+        self.login_as(user=self.user)
+
+    def test_inaccessible_project_slug_returns_no_data(self) -> None:
+        """Requesting only an inaccessible project slug must not return its threshold data."""
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[self.inaccessible_project.slug],
+        )
+
+        # No valid projects → NoProjects is raised, so it should not be a 200
+        assert response.status_code != 200
+
+    def test_mixed_slugs_only_returns_accessible_project(self) -> None:
+        """When both accessible and inaccessible slugs are requested,
+        only accessible project data is returned."""
+        now = datetime.now(UTC)
+        yesterday = now - timedelta(hours=24)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            start=yesterday,
+            end=now,
+            projectSlug=[
+                self.accessible_project.slug,
+                self.inaccessible_project.slug,
+            ],
+        )
+
+        assert len(response.data) == 1
+        expected_key = f"{self.accessible_project.slug}-{self.release.version}"
+        assert expected_key in response.data
+        inaccessible_key = f"{self.inaccessible_project.slug}-{self.release.version}"
+        assert inaccessible_key not in response.data

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_threshold_status.py
@@ -508,8 +508,8 @@ class ReleaseThresholdStatusProjectAccessTest(APITestCase):
             name="inaccessible", organization=self.organization, teams=[self.team2]
         )
 
-        # User only belongs to team1
-        self.create_member(teams=[self.team1], user=self.user, organization=self.organization)
+        # User only belongs to team1 (user is already a member from APITestCase setUp)
+        self.create_team_membership(team=self.team1, user=self.user)
 
         self.environment = Environment.objects.create(
             organization_id=self.organization.id, name="production"


### PR DESCRIPTION
The release threshold status endpoint (`/api/0/organizations/{org}/release-threshold-statuses/`) used raw user-supplied `projectSlug` query parameters for filtering releases and projects in the response, bypassing the permission checks performed by `get_filter_params()`/`get_projects()`.

A user with access to at least one project in an organization could inject slugs for projects they don't have access to. Since `get_filter_params` wouldn't raise `NoProjects` (at least one valid project exists), the raw slug list was used for all subsequent queries, leaking release threshold data (release versions, threshold configurations, project slugs/IDs, health metrics like error counts and crash-free rates) for inaccessible projects.

The fix replaces all uses of the raw `project_slug_list` with validated project IDs derived from `filter_params["project_id"]` (which only contains projects the user has permission to access) for:
- The release query filter (line 181)
- The per-release project list filter (line 223)

Tests added to verify that requesting an inaccessible project slug (alone or mixed with accessible slugs) does not return threshold data for that project.