### PR TITLE
feat(spans-buffer): Split SUNIONSTORE timing and use stage tags for metrics

### DIFF
--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -128,13 +128,20 @@ table.insert(latency_table, {"sunionstore_args_step_latency_ms", sunionstore_arg
 local spop_end_time_ms = -1
 if #sunionstore_args > 0 then
     local start_output_size = redis.call("scard", set_key)
-    local output_size = redis.call("sunionstore", set_key, set_key, unpack(sunionstore_args))
-    redis.call("unlink", unpack(sunionstore_args))
+    local scard_end_time_ms = get_time_ms()
+    table.insert(latency_table, {"scard_step_latency_ms", scard_end_time_ms - sunionstore_args_end_time_ms})
 
+    local output_size = redis.call("sunionstore", set_key, set_key, unpack(sunionstore_args))
     local sunionstore_end_time_ms = get_time_ms()
-    table.insert(latency_table, {"sunionstore_step_latency_ms", sunionstore_end_time_ms - sunionstore_args_end_time_ms})
+    table.insert(latency_table, {"sunionstore_step_latency_ms", sunionstore_end_time_ms - scard_end_time_ms})
+
+    redis.call("unlink", unpack(sunionstore_args))
+    local unlink_end_time_ms = get_time_ms()
+    table.insert(latency_table, {"unlink_step_latency_ms", unlink_end_time_ms - sunionstore_end_time_ms})
+
     table.insert(metrics_table, {"parent_span_set_before_size", start_output_size})
     table.insert(metrics_table, {"parent_span_set_after_size", output_size})
+    table.insert(metrics_table, {"elements_added", output_size - start_output_size})
 
     -- Merge ingested count keys for merged spans
     local ingested_count_key = string.format("span-buf:ic:%s", set_key)
@@ -156,7 +163,7 @@ if #sunionstore_args > 0 then
     end
 
     local arg_cleanup_end_time_ms = get_time_ms()
-    table.insert(latency_table, {"arg_cleanup_step_latency_ms", arg_cleanup_end_time_ms - sunionstore_end_time_ms})
+    table.insert(latency_table, {"arg_cleanup_step_latency_ms", arg_cleanup_end_time_ms - unlink_end_time_ms})
 
     local spopcalls = 0
     while (redis.call("memory", "usage", set_key) or 0) > max_segment_bytes do

--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -126,17 +126,29 @@ def emit_observability_metrics(
                 )
 
     for metric, (min_value, max_value, sum_value, count) in latency_metrics_dict.items():
-        metrics.timing(f"spans.buffer.process_spans.avg_{metric}", sum_value / count)
-        metrics.timing(f"spans.buffer.process_spans.min_{metric}", min_value)
-        metrics.timing(f"spans.buffer.process_spans.max_{metric}", max_value)
+        tags = {"stage": metric}
+        metrics.timing(
+            "spans.buffer.process_spans.avg_step_latency_ms", sum_value / count, tags=tags
+        )
+        metrics.timing("spans.buffer.process_spans.min_step_latency_ms", min_value, tags=tags)
+        metrics.timing("spans.buffer.process_spans.max_step_latency_ms", max_value, tags=tags)
     for metric, (min_value, max_value, sum_value, count) in gauge_metrics_dict.items():
-        metrics.gauge(f"spans.buffer.avg_{metric}", sum_value / count)
-        metrics.gauge(f"spans.buffer.min_{metric}", min_value)
-        metrics.gauge(f"spans.buffer.max_{metric}", max_value)
+        tags = {"stage": metric}
+        metrics.gauge("spans.buffer.avg_gauge_metric", sum_value / count, tags=tags)
+        metrics.gauge("spans.buffer.min_gauge_metric", min_value, tags=tags)
+        metrics.gauge("spans.buffer.max_gauge_metric", max_value, tags=tags)
 
-    for data_point in longest_evalsha_data[1]:  # latency_metrics
-        key = data_point[0].decode("utf-8")
-        metrics.timing(f"spans.buffer.process_spans.longest_evalsha.latency.{key}", data_point[1])
-    for data_point in longest_evalsha_data[2]:  # gauge_metrics
-        key = data_point[0].decode("utf-8")
-        metrics.gauge(f"spans.buffer.process_spans.longest_evalsha.{key}", data_point[1])
+    for raw_key, value in longest_evalsha_data[1]:  # latency_metrics
+        key = raw_key.decode("utf-8")
+        metrics.timing(
+            "spans.buffer.process_spans.longest_evalsha.step_latency_ms",
+            value,
+            tags={"stage": key},
+        )
+    for raw_key, value in longest_evalsha_data[2]:  # gauge_metrics
+        key = raw_key.decode("utf-8")
+        metrics.gauge(
+            "spans.buffer.process_spans.longest_evalsha.gauge_metric",
+            value,
+            tags={"stage": key},
+        )

--- a/tests/sentry/spans/test_buffer_logger.py
+++ b/tests/sentry/spans/test_buffer_logger.py
@@ -181,91 +181,155 @@ class TestEmitObservabilityMetrics:
             longest_evalsha_data=self.data()["longest_evalsha_data"],
         )
 
-        # Expected timing calls: 7 timing metrics * 3 (min, max, avg) + 8 for longest evalsha
+        LE = "spans.buffer.process_spans.longest_evalsha.step_latency_ms"
+
+        def t(stage):
+            return {"stage": stage}
+
         mock_timing.assert_has_calls(
             [
-                # Aggregated latency metrics (min, max, avg for each metric)
-                call("spans.buffer.process_spans.avg_redirect_step_latency_ms", 1.0),
-                call("spans.buffer.process_spans.min_redirect_step_latency_ms", 1),
-                call("spans.buffer.process_spans.max_redirect_step_latency_ms", 1),
-                call("spans.buffer.process_spans.avg_sunionstore_args_step_latency_ms", 1.0),
-                call("spans.buffer.process_spans.min_sunionstore_args_step_latency_ms", 1),
-                call("spans.buffer.process_spans.max_sunionstore_args_step_latency_ms", 1),
-                call("spans.buffer.process_spans.avg_sunionstore_step_latency_ms", 2.0),
-                call("spans.buffer.process_spans.min_sunionstore_step_latency_ms", 2),
-                call("spans.buffer.process_spans.max_sunionstore_step_latency_ms", 2),
-                call("spans.buffer.process_spans.avg_arg_cleanup_step_latency_ms", 3.0),
-                call("spans.buffer.process_spans.min_arg_cleanup_step_latency_ms", 3),
-                call("spans.buffer.process_spans.max_arg_cleanup_step_latency_ms", 3),
-                call("spans.buffer.process_spans.avg_spop_step_latency_ms", 5.0),
-                call("spans.buffer.process_spans.min_spop_step_latency_ms", 5),
-                call("spans.buffer.process_spans.max_spop_step_latency_ms", 5),
-                call("spans.buffer.process_spans.avg_ingested_count_step_latency_ms", 5.0),
-                call("spans.buffer.process_spans.min_ingested_count_step_latency_ms", 2),
-                call("spans.buffer.process_spans.max_ingested_count_step_latency_ms", 8),
-                call("spans.buffer.process_spans.avg_total_step_latency_ms", 8.0),
-                call("spans.buffer.process_spans.min_total_step_latency_ms", 3),
-                call("spans.buffer.process_spans.max_total_step_latency_ms", 13),
-                # Longest evalsha metrics
+                # Aggregated latency metrics (avg, min, max for each stage)
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.redirect_step_latency_ms",
-                    1,
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    1.0,
+                    tags=t("redirect_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.sunionstore_args_step_latency_ms",
+                    "spans.buffer.process_spans.min_step_latency_ms",
                     1,
+                    tags=t("redirect_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.sunionstore_step_latency_ms",
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    1,
+                    tags=t("redirect_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    1.0,
+                    tags=t("sunionstore_args_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
+                    1,
+                    tags=t("sunionstore_args_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    1,
+                    tags=t("sunionstore_args_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    2.0,
+                    tags=t("sunionstore_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
                     2,
+                    tags=t("sunionstore_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.arg_cleanup_step_latency_ms",
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    2,
+                    tags=t("sunionstore_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    3.0,
+                    tags=t("arg_cleanup_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
                     3,
+                    tags=t("arg_cleanup_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.spop_step_latency_ms",
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    3,
+                    tags=t("arg_cleanup_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    5.0,
+                    tags=t("spop_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
                     5,
+                    tags=t("spop_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.ingested_count_step_latency_ms",
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    5,
+                    tags=t("spop_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    5.0,
+                    tags=t("ingested_count_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
+                    2,
+                    tags=t("ingested_count_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.max_step_latency_ms",
                     8,
+                    tags=t("ingested_count_step_latency_ms"),
                 ),
                 call(
-                    "spans.buffer.process_spans.longest_evalsha.latency.total_step_latency_ms",
-                    13,
+                    "spans.buffer.process_spans.avg_step_latency_ms",
+                    8.0,
+                    tags=t("total_step_latency_ms"),
                 ),
+                call(
+                    "spans.buffer.process_spans.min_step_latency_ms",
+                    3,
+                    tags=t("total_step_latency_ms"),
+                ),
+                call(
+                    "spans.buffer.process_spans.max_step_latency_ms",
+                    13,
+                    tags=t("total_step_latency_ms"),
+                ),
+                # Longest evalsha metrics
+                call(LE, 1, tags=t("redirect_step_latency_ms")),
+                call(LE, 1, tags=t("sunionstore_args_step_latency_ms")),
+                call(LE, 2, tags=t("sunionstore_step_latency_ms")),
+                call(LE, 3, tags=t("arg_cleanup_step_latency_ms")),
+                call(LE, 5, tags=t("spop_step_latency_ms")),
+                call(LE, 8, tags=t("ingested_count_step_latency_ms")),
+                call(LE, 13, tags=t("total_step_latency_ms")),
             ]
         )
 
-        # Expected gauge calls: 5 gauge metrics * 3 (min, max, avg) + 5 for longest evalsha
+        LG = "spans.buffer.process_spans.longest_evalsha.gauge_metric"
+
         mock_gauge.assert_has_calls(
             [
-                # Aggregated gauge metrics (min, max, avg for each metric)
-                call("spans.buffer.avg_redirect_table_size", 1123.0),
-                call("spans.buffer.min_redirect_table_size", 1123.0),
-                call("spans.buffer.max_redirect_table_size", 1123.0),
-                call("spans.buffer.avg_redirect_depth", 5.0),
-                call("spans.buffer.min_redirect_depth", 5.0),
-                call("spans.buffer.max_redirect_depth", 5.0),
-                call("spans.buffer.avg_parent_span_set_before_size", 813.0),
-                call("spans.buffer.min_parent_span_set_before_size", 813.0),
-                call("spans.buffer.max_parent_span_set_before_size", 813.0),
-                call("spans.buffer.avg_parent_span_set_after_size", 2134.0),
-                call("spans.buffer.min_parent_span_set_after_size", 2134.0),
-                call("spans.buffer.max_parent_span_set_after_size", 2134.0),
-                call("spans.buffer.avg_spopcalls", 55.0),
-                call("spans.buffer.min_spopcalls", 55.0),
-                call("spans.buffer.max_spopcalls", 55.0),
+                # Aggregated gauge metrics (avg, min, max for each stage)
+                call("spans.buffer.avg_gauge_metric", 1123.0, tags=t("redirect_table_size")),
+                call("spans.buffer.min_gauge_metric", 1123.0, tags=t("redirect_table_size")),
+                call("spans.buffer.max_gauge_metric", 1123.0, tags=t("redirect_table_size")),
+                call("spans.buffer.avg_gauge_metric", 5.0, tags=t("redirect_depth")),
+                call("spans.buffer.min_gauge_metric", 5.0, tags=t("redirect_depth")),
+                call("spans.buffer.max_gauge_metric", 5.0, tags=t("redirect_depth")),
+                call("spans.buffer.avg_gauge_metric", 813.0, tags=t("parent_span_set_before_size")),
+                call("spans.buffer.min_gauge_metric", 813.0, tags=t("parent_span_set_before_size")),
+                call("spans.buffer.max_gauge_metric", 813.0, tags=t("parent_span_set_before_size")),
+                call("spans.buffer.avg_gauge_metric", 2134.0, tags=t("parent_span_set_after_size")),
+                call("spans.buffer.min_gauge_metric", 2134.0, tags=t("parent_span_set_after_size")),
+                call("spans.buffer.max_gauge_metric", 2134.0, tags=t("parent_span_set_after_size")),
+                call("spans.buffer.avg_gauge_metric", 55.0, tags=t("spopcalls")),
+                call("spans.buffer.min_gauge_metric", 55.0, tags=t("spopcalls")),
+                call("spans.buffer.max_gauge_metric", 55.0, tags=t("spopcalls")),
                 # Longest evalsha gauge metrics
-                call("spans.buffer.process_spans.longest_evalsha.redirect_table_size", 1123.0),
-                call("spans.buffer.process_spans.longest_evalsha.redirect_depth", 5.0),
-                call(
-                    "spans.buffer.process_spans.longest_evalsha.parent_span_set_before_size", 813.0
-                ),
-                call(
-                    "spans.buffer.process_spans.longest_evalsha.parent_span_set_after_size", 2134.0
-                ),
-                call("spans.buffer.process_spans.longest_evalsha.spopcalls", 55.0),
+                call(LG, 1123.0, tags=t("redirect_table_size")),
+                call(LG, 5.0, tags=t("redirect_depth")),
+                call(LG, 813.0, tags=t("parent_span_set_before_size")),
+                call(LG, 2134.0, tags=t("parent_span_set_after_size")),
+                call(LG, 55.0, tags=t("spopcalls")),
             ]
         )


### PR DESCRIPTION
* split up sunionstore stage into many stages, not sure if we can 100% conclude it's SUNIONSTORE every time otherwise?
* it's easier to have one metric with a tag for the stage instead of many metrics. the dashboard widget will need less maintenance
* add a metric for by how many elements a set grew, because we cannot actually get that from the two before/after metrics directly.