### PR TITLE
fix(api): Require project:write for transaction threshold override mutations

### DIFF
--- a/src/sentry/api/bases/project_transaction_threshold_override.py
+++ b/src/sentry/api/bases/project_transaction_threshold_override.py
@@ -3,8 +3,8 @@ from sentry.api.bases.organization import OrganizationPermission
 
 class ProjectTransactionThresholdOverridePermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read"],
-        "POST": ["org:read"],
-        "PUT": ["org:read"],
-        "DELETE": ["org:read"],
+        "GET": ["project:read", "project:write", "project:admin"],
+        "POST": ["project:write", "project:admin"],
+        "PUT": ["project:write", "project:admin"],
+        "DELETE": ["project:write", "project:admin"],
     }


### PR DESCRIPTION
The `ProjectTransactionThresholdOverridePermission` scope_map mapped all HTTP methods (GET/POST/PUT/DELETE) to `org:read`, allowing any org member — including the lowest-privilege `member` role — to create, update, and delete project-wide transaction threshold overrides. These overrides affect performance monitoring display for all users in the project.

This is inconsistent with the sibling `ProjectTransactionThresholdEndpoint`, which correctly uses `ProjectSettingPermission` requiring `project:write` for mutations.

The fix aligns the override endpoint's scope_map to match:
- **GET**: `project:read`, `project:write`, `project:admin`
- **POST/PUT/DELETE**: `project:write`, `project:admin`

Test added to verify that a member-role user receives 403 on POST and DELETE.