### PR TITLE
fix(api): Validate linked dashboard org membership in field links

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -996,6 +996,25 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                     "Linked dashboard does not appear in the fields of the query"
                 )
 
+            # Validate all linked dashboard IDs belong to this organization
+            linked_dashboard_ids = {
+                int(ld["dashboard_id"])
+                for ld in linked_dashboards
+                if ld.get("field") and ld.get("dashboard_id")
+            }
+            if linked_dashboard_ids:
+                valid_ids = set(
+                    Dashboard.objects.filter(
+                        id__in=linked_dashboard_ids,
+                        organization_id=organization.id,
+                    ).values_list("id", flat=True)
+                )
+                invalid_ids = linked_dashboard_ids - valid_ids
+                if invalid_ids:
+                    raise serializers.ValidationError(
+                        "Linked dashboard does not belong to this organization"
+                    )
+
             for link_data in linked_dashboards:
                 field = link_data.get("field")
                 dashboard_id = link_data.get("dashboard_id")

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1011,9 +1011,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
                 )
                 invalid_ids = linked_dashboard_ids - valid_ids
                 if invalid_ids:
-                    raise serializers.ValidationError(
-                        "Linked dashboard does not belong to this organization"
-                    )
+                    raise serializers.ValidationError("Linked dashboard does not exist")
 
             for link_data in linked_dashboards:
                 field = link_data.get("field")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3538,6 +3538,115 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 400, response.data
         assert b"Linked dashboard does not appear in the fields of the query" in response.content
 
+    def test_rejects_cross_org_linked_dashboard(self) -> None:
+        other_org = self.create_organization(name="other-org")
+        other_dashboard = Dashboard.objects.create(
+            title="Other Org Dashboard",
+            created_by_id=self.user.id,
+            organization=other_org,
+        )
+
+        data: dict[str, Any] = {
+            "title": "Dashboard with Cross-Org Link",
+            "widgets": [
+                {
+                    "title": "Widget with Links",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "Query with Links",
+                            "fields": ["count()", "project"],
+                            "columns": ["project"],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:error",
+                            "linkedDashboards": [
+                                {"field": "project", "dashboardId": other_dashboard.id}
+                            ],
+                        }
+                    ],
+                    "datasetSource": "user",
+                }
+            ],
+        }
+
+        with self.feature("organizations:dashboards-drilldown-flow"):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 400, response.data
+        assert b"Linked dashboard does not belong to this organization" in response.content
+
+        # Verify no DashboardFieldLink was created
+        assert DashboardFieldLink.objects.count() == 0
+
+    def test_allows_same_org_linked_dashboard_after_fix(self) -> None:
+        same_org_dashboard = Dashboard.objects.create(
+            title="Same Org Dashboard",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+
+        data: dict[str, Any] = {
+            "title": "Dashboard with Same-Org Link",
+            "widgets": [
+                {
+                    "title": "Widget with Links",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "Query with Links",
+                            "fields": ["count()", "project"],
+                            "columns": ["project"],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:error",
+                            "linkedDashboards": [
+                                {"field": "project", "dashboardId": same_org_dashboard.id}
+                            ],
+                        }
+                    ],
+                    "datasetSource": "user",
+                }
+            ],
+        }
+
+        with self.feature("organizations:dashboards-drilldown-flow"):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+        assert response.data.get("widgets")[0].get("queries")[0].get("linkedDashboards") == [
+            {
+                "field": "project",
+                "dashboardId": same_org_dashboard.id,
+            }
+        ]
+
+    def test_rejects_nonexistent_linked_dashboard(self) -> None:
+        data: dict[str, Any] = {
+            "title": "Dashboard with Nonexistent Link",
+            "widgets": [
+                {
+                    "title": "Widget with Links",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "Query with Links",
+                            "fields": ["count()", "project"],
+                            "columns": ["project"],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:error",
+                            "linkedDashboards": [{"field": "project", "dashboardId": 999999999}],
+                        }
+                    ],
+                    "datasetSource": "user",
+                }
+            ],
+        }
+
+        with self.feature("organizations:dashboards-drilldown-flow"):
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 400, response.data
+        assert b"Linked dashboard does not belong to this organization" in response.content
+
     def test_cannot_delete_prebuilt_insights_dashboard(self) -> None:
         dashboard = Dashboard.objects.create(
             title="Frontend Session Health",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3573,7 +3573,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         with self.feature("organizations:dashboards-drilldown-flow"):
             response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 400, response.data
-        assert b"Linked dashboard does not belong to this organization" in response.content
+        assert b"Linked dashboard does not exist" in response.content
 
         # Verify no DashboardFieldLink was created
         assert DashboardFieldLink.objects.count() == 0
@@ -3645,7 +3645,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         with self.feature("organizations:dashboards-drilldown-flow"):
             response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 400, response.data
-        assert b"Linked dashboard does not belong to this organization" in response.content
+        assert b"Linked dashboard does not exist" in response.content
 
     def test_cannot_delete_prebuilt_insights_dashboard(self) -> None:
         dashboard = Dashboard.objects.create(


### PR DESCRIPTION
Fix cross-organization IDOR in dashboard field links.

`_update_or_create_field_links` in the dashboard serializer accepted any
`dashboard_id` value in `linkedDashboards` without verifying it belongs to
the same organization. This allowed an authenticated user to create
`DashboardFieldLink` records referencing dashboards from other organizations.

The fix validates all linked dashboard IDs against the organization before
creating field links, returning a 400 if any dashboard belongs to a different
org or doesn't exist. This is consistent with how the main dashboard ID is
validated at the endpoint level via `Dashboard.objects.get(id=..., organization_id=...)`.

Tests added:
- Cross-org linked dashboard is rejected (400)
- Same-org linked dashboard still works (200)
- Nonexistent linked dashboard is rejected (400)