### PR TITLE
Support spawning processes in multi process step

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "rfc3339-validator>=0.1.2",
     "rfc3986-validator>=0.1.1",
     # [end] jsonschema format validators
-    "sentry-arroyo>=2.38.0",
+    "sentry-arroyo>=2.38.1",
     "sentry-conventions>=0.3.0",
     "sentry-forked-email-reply-parser>=0.5.12.post1",
     "sentry-kafka-schemas>=2.1.23",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3879,6 +3879,18 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Forces ArroyoRunTaskWithMultiprocessing steps to instruct the SharedMemoryManager to
+# spawn processes rather than forking.
+# As this impacts the shared memory manager initialization, which happens during
+# the creation of the strategy, a rebalance or a restart is needed for this
+# option change to take effect.
+register(
+    "consumer.shared_memory_spawn_process",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 # Rate at which to forward events to eap_items. 1.0
 # means that 100% of projects will forward events to eap_items.

--- a/src/sentry/utils/arroyo.py
+++ b/src/sentry/utils/arroyo.py
@@ -20,6 +20,8 @@ from arroyo.utils.metrics import Metrics
 from arroyo.utils.stuck_detector import stuck_detector
 from django.conf import settings
 
+from sentry import options
+
 if TYPE_CHECKING:
     from sentry.metrics.base import MetricsBackend
 
@@ -208,7 +210,14 @@ def run_task_with_multiprocessing(
     else:
         assert pool.pool is not None
 
-        return ArroyoRunTaskWithMultiprocessing(pool=pool.pool, function=function, **kwargs)
+        spawn_shared_memory_process = options.get("consumer.shared_memory_spawn_process")
+
+        return ArroyoRunTaskWithMultiprocessing(
+            pool=pool.pool,
+            function=function,
+            spawn_shared_memory_process=spawn_shared_memory_process,
+            **kwargs,
+        )
 
 
 def _import_and_run(

--- a/uv.lock
+++ b/uv.lock
@@ -2279,7 +2279,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = ">=1.2.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
-    { name = "sentry-arroyo", specifier = ">=2.38.0" },
+    { name = "sentry-arroyo", specifier = ">=2.38.1" },
     { name = "sentry-conventions", specifier = ">=0.3.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.23" },
@@ -2368,13 +2368,13 @@ dev = [
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.38.0"
+version = "2.38.1"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.38.0-py3-none-any.whl", hash = "sha256:a5f63ed023487c5e9c7e58a2c5e161c161d3ae864f504b4a46fef87915f9ebd2" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.38.1-py3-none-any.whl", hash = "sha256:e86e02127bcfc884e94d5c36c4e6c97e3e39df033effe96a4eca4346852db1b4" },
 ]
 
 [[package]]


### PR DESCRIPTION
Support  https://github.com/getsentry/arroyo/pull/520.

We single node multi process conwsumer hanging at times while the SharedMemoryManager
starts. 
It seems the subprocess created by the SharedMemoryManager crashes due to a race condition
in the datadog integration. See the PR above for reference.

This allows us to configure consumers to use 'spawn' start mode rather than 'fork'
