### PR TITLE
ref(seer): Remove doc links from legacy Seer settings page

### DIFF
--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -1,16 +1,12 @@
 import {Fragment} from 'react';
 
-import {LinkButton} from '@sentry/scraps/button';
 import {Stack} from '@sentry/scraps/layout';
 
-import ExternalLink from 'sentry/components/links/externalLink';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t, tct} from 'sentry/locale';
-import {DataCategoryExact} from 'sentry/types/core';
+import {t} from 'sentry/locale';
 import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import useOrganization from 'sentry/utils/useOrganization';
-import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerAutomationDefault} from 'getsentry/views/seerAutomation/components/seerAutomationDefault';
@@ -31,25 +27,9 @@ export default function SeerAutomation() {
       <SentryDocumentTitle title={t('Seer Automation')} orgSlug={organization.slug} />
       <SettingsPageHeader
         title={t('Seer Automation')}
-        subtitle={tct(
-          "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the [link:standard rates] for Seer's Issue Scan and Issue Fix. See [spendlink:docs] on how to manage your Seer spend.",
-          {
-            link: <ExternalLink href="https://docs.sentry.io/pricing/#seer-pricing" />,
-            spendlink: (
-              <ExternalLink
-                href={getPricingDocsLinkForEventType(DataCategoryExact.SEER_AUTOFIX)}
-              />
-            ),
-          }
+        subtitle={t(
+          "Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them. This analysis is billed at the standard rates for Seer's Issue Scan and Issue Fix."
         )}
-        action={
-          <LinkButton
-            href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities"
-            external
-          >
-            {t('Read the docs')}
-          </LinkButton>
-        }
       />
 
       <NoProjectMessage organization={organization}>


### PR DESCRIPTION
Remove documentation links from the legacy Seer Automation settings page (shown to orgs with seer-added or code-review-beta feature flags). The new Seer settings page remains unchanged and keeps all documentation links.

Removed:
- "standard rates" link to pricing docs
- "docs" link to spend management docs
- "Read the docs" button

 
