### PR TITLE
fix(api): Add org membership check to onboarding continuation email endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -7,8 +7,7 @@ from sentry.analytics.events.onboarding_continuation_sent import OnboardingConti
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.api.permissions import SentryIsAuthenticated
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.models.organization import Organization
 from sentry.users.models.user import User
@@ -42,6 +41,10 @@ def get_request_builder_args(user: User, organization: Organization, platforms: 
     }
 
 
+class OnboardingContinuationPermission(OrganizationPermission):
+    scope_map = {"POST": ["org:read", "org:write", "org:admin"]}
+
+
 @region_silo_endpoint
 class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
     publish_status = {
@@ -49,7 +52,7 @@ class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     # let anyone in the org use this endpoint
-    permission_classes = (SentryIsAuthenticated,)
+    permission_classes = (OnboardingContinuationPermission,)
 
     def post(self, request: Request, organization: Organization):
         serializer = OnboardingContinuationSerializer(data=request.data)

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -51,7 +51,6 @@ class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
-    # let anyone in the org use this endpoint
     permission_classes = (OnboardingContinuationPermission,)
 
     def post(self, request: Request, organization: Organization):

--- a/tests/sentry/api/endpoints/test_organization_onboarding_continuation.py
+++ b/tests/sentry/api/endpoints/test_organization_onboarding_continuation.py
@@ -41,3 +41,12 @@ class OrganizationOnboardingContinuation(APITestCase):
         data = {"platforms": "not a list"}
         resp = self.get_error_response(self.organization.slug, status_code=400, **data)
         assert resp.data["platforms"][0].code == "not_a_list"
+
+    @mock.patch("sentry.api.endpoints.organization_onboarding_continuation_email.MessageBuilder")
+    def test_non_member_rejected(self, builder: mock.MagicMock) -> None:
+        other_user = self.create_user()
+        other_org = self.create_organization(owner=other_user)
+        # self.user is not a member of other_org
+        data = {"platforms": ["javascript"]}
+        self.get_error_response(other_org.slug, status_code=403, **data)
+        builder.assert_not_called()


### PR DESCRIPTION
The `OrganizationOnboardingContinuationEmail` endpoint used `SentryIsAuthenticated` as its
permission class, which only verifies that the user is logged in. This allowed any authenticated
user to trigger onboarding continuation emails for any organization, leaking the org name in
the email and polluting analytics with bogus `OnboardingContinuationSent` events.

The code comment states the intent was to "let anyone in the org use this endpoint," but
`SentryIsAuthenticated` doesn't perform any org membership check — it delegates to
`BasePermission.has_object_permission` which unconditionally returns `True`.

This replaces `SentryIsAuthenticated` with an `OrganizationPermission`-based permission class
that requires `org:read` scope for POST, matching the pattern used by the sibling
`OrganizationOnboardingTaskEndpoint`. This ensures org membership is verified via
`determine_access()` while still allowing any org member (including the lowest `member` role)
to use the endpoint.