### PR TITLE
fix(api): Validate scope_list in ApiKey serializer

### DIFF
--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -12,6 +12,7 @@ from sentry.api.bases.organization import (
 )
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.conf.server import SENTRY_SCOPES
 from sentry.models.apikey import ApiKey
 from sentry.organizations.services.organization.model import RpcOrganization
 
@@ -20,6 +21,14 @@ class ApiKeySerializer(serializers.ModelSerializer):
     class Meta:
         model = ApiKey
         fields = ("label", "scope_list", "allowed_origins")
+
+    def validate_scope_list(self, value):
+        invalid_scopes = set(value) - SENTRY_SCOPES
+        if invalid_scopes:
+            raise serializers.ValidationError(
+                f"Invalid scopes: {', '.join(sorted(invalid_scopes))}"
+            )
+        return value
 
 
 @control_silo_endpoint


### PR DESCRIPTION
Add scope validation to `ApiKeySerializer` so that invalid scope strings
are rejected with a 400 response instead of being silently persisted.

The `OrgAuthToken` model validates `scope_list` against `SENTRY_SCOPES`
via `validate_scope_list`, but the legacy `ApiKey` serializer accepted
arbitrary strings. While invalid scopes are inert at enforcement time
(they never match any endpoint's `allowed_scopes`), the inconsistency
represents an oversight and violates defense-in-depth principles.

The fix adds a `validate_scope_list` method to `ApiKeySerializer` that
checks each scope against `SENTRY_SCOPES` and returns a descriptive
error for any invalid entries. Existing tests that relied on saving
invalid scopes have been updated to use valid scopes, and new tests
cover both fully-invalid and mixed-valid/invalid scope lists.