### PR TITLE
fix(hybridcloud): Fix test assertion

### DIFF
--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -149,4 +149,4 @@ def test_update_project() -> None:
         attrs={"status": 99},
     )
     project = Project.objects.get(id=project.id)
-    assert project.external_id != 99
+    assert project.external_id != "99"

--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -149,4 +149,4 @@ def test_update_project() -> None:
         attrs={"status": 99},
     )
     project = Project.objects.get(id=project.id)
-    assert project.external_id != "99"
+    assert project.status != 99


### PR DESCRIPTION
external_id is a str, so asserting it isn't equal to an int will always succeed.
It also appears to have been a typo, with 'status' more accurate to the intent of the test.
