### PR TITLE
docs(api): Warn that SentryIsAuthenticated bypasses base class access controls

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -348,6 +348,12 @@ class DemoSafePermission(SentryPermission):
 class SentryIsAuthenticated(IsAuthenticated):
     """
     Used to deny access for demo users in both view and object permission checks.
+
+    WARNING: Setting ``permission_classes = (SentryIsAuthenticated,)`` on an endpoint grants
+    access to ANY authenticated user, regardless of the endpoint's base class. For example,
+    an endpoint that extends ``OrganizationEndpoint`` will NOT enforce organization membership
+    or scoped access — any logged-in user can call it. Only use this permission class on
+    endpoints that are intentionally open to all authenticated users.
     """
 
     def has_permission(self, request: Request, view: APIView) -> bool:


### PR DESCRIPTION
`SentryIsAuthenticated` is used on a number of endpoints to require only that a user is logged in. The footgun is that endpoints inheriting from a base class like `OrganizationEndpoint` get their organization-level access controls completely bypassed when `permission_classes = (SentryIsAuthenticated,)` is set — any authenticated user can call the endpoint regardless of org membership or token scopes.

This adds a docstring warning to make the behavior explicit so developers don't accidentally expose organization-scoped endpoints to all authenticated users.