### PR TITLE
fix(csrf): Note that cookies must be enabled on the CSRF error page

### DIFF
--- a/src/sentry/templates/sentry/403-csrf-failure.html
+++ b/src/sentry/templates/sentry/403-csrf-failure.html
@@ -21,15 +21,10 @@
             <span id="csrf-status" style="margin-left: 10px;"></span>
         </div>
 
-        <p>{% trans "Why are you encountering a CSRF error after login?" %}</p>
-        <ul>
-          <li>See explanation from <a href="https://docs.djangoproject.com/en/5.2/ref/csrf/#why-might-a-user-encounter-a-csrf-validation-failure-after-logging-in" target="_blank">Django docs</a>.</li>
-          <li>Read more about <a href="https://en.wikipedia.org/wiki/Cross-site_request_forgery">CSRF on Wikipedia</a>.</li>
-        </ul>
-
         <p>{% trans "If you're continually seeing this issue, try the following steps:" %}</p>
 
         <ol>
+          <li>{% trans "Make sure cookies are enabled in your browser." %}</li>
           <li>{% trans "Close other tabs with Sentry loaded." %}</li>
           <li>{% trans "Clear cookies (at least for Sentry's domain)." %}</li>
           <li>{% trans "Reload the page you're trying to submit (don't re-submit data)." %}</li>


### PR DESCRIPTION
Adds a note to the CSRF validation failure page that cookies must be enabled in the browser to use Sentry.

Users who hit this page may have cookies disabled, which would also prevent the token rotation mechanism from working. Making this requirement visible helps users self-diagnose the issue without needing to dig through troubleshooting steps.