### PR TITLE
chore(hc): Adds Hybrid Cloud context docs in prep for skill creation, system prompt append testing

### DIFF
--- a/src/sentry/hybridcloud/AGENTS.md
+++ b/src/sentry/hybridcloud/AGENTS.md
@@ -32,16 +32,20 @@ Sentry uses a **hybrid cloud silo architecture** to support multi-region SaaS de
 
 ## Where Each Silo Lives
 
-| Area                | Path                                                      | Purpose                                           |
-| ------------------- | --------------------------------------------------------- | ------------------------------------------------- |
-| Silo core           | `src/sentry/silo/`                                        | Modes, client, safety, util, signatures           |
-| Hybrid cloud        | `src/sentry/hybridcloud/`                                 | Outboxes, RPC, API gateway, replica services      |
-| Model decorators    | `src/sentry/db/models/base.py`                            | `@control_silo_model`, `@region_silo_model`       |
-| Endpoint decorators | `src/sentry/api/base.py`                                  | `@control_silo_endpoint`, `@region_silo_endpoint` |
-| DB routing          | `src/sentry/db/router.py`                                 | `SiloRouter` routes queries to correct DB         |
-| Cross-silo FKs      | `src/sentry/db/models/fields/hybrid_cloud_foreign_key.py` | `HybridCloudForeignKey`                           |
-| Region client       | `src/sentry/silo/client.py`                               | `RegionSiloClient` (Control→Region HTTP proxy)    |
-| API gateway         | `src/sentry/hybridcloud/apigateway/apigateway.py`         | Request routing/proxying                          |
+| Area                | Path                                                      | Purpose                                                           |
+| ------------------- | --------------------------------------------------------- | ----------------------------------------------------------------- |
+| Silo core           | `src/sentry/silo/`                                        | Modes, client, safety, util, signatures                           |
+| Hybrid cloud        | `src/sentry/hybridcloud/`                                 | Outboxes, RPC, API gateway, replica services                      |
+| Model decorators    | `src/sentry/db/models/base.py`                            | `@control_silo_model`, `@region_silo_model`                       |
+| Endpoint decorators | `src/sentry/api/base.py`                                  | `@control_silo_endpoint`, `@region_silo_endpoint`                 |
+| DB routing          | `src/sentry/db/router.py`                                 | `SiloRouter` routes queries to correct DB                         |
+| Cross-silo FKs      | `src/sentry/db/models/fields/hybrid_cloud_foreign_key.py` | `HybridCloudForeignKey`                                           |
+| Region client       | `src/sentry/silo/client.py`                               | `RegionSiloClient` (Control→Region HTTP proxy)                    |
+| API gateway         | `src/sentry/hybridcloud/apigateway/apigateway.py`         | Request routing/proxying                                          |
+| RPC base classes    | `src/sentry/hybridcloud/rpc/service.py`                   | `RpcService`, `DelegatingRpcService`, `_RemoteSiloCall`           |
+| RPC models          | `src/sentry/hybridcloud/rpc/__init__.py`                  | `RpcModel` Pydantic base for all RPC transfer objects             |
+| Region resolvers    | `src/sentry/hybridcloud/rpc/resolvers.py`                 | `ByOrganizationId`, `ByOrganizationSlug`, `ByRegionName`, etc.    |
+| RPC endpoint        | `src/sentry/api/endpoints/internal/rpc.py`                | `InternalRpcServiceEndpoint` — receives inbound RPC POST requests |
 
 ## How Silos Interact (And Why Regions Never Talk to Each Other)
 
@@ -62,6 +66,8 @@ When a replicated model changes, an outbox record is written **atomically in the
 - `ControlOutbox` (Control→Region): e.g., user profile updated, auth token created
 - `src/sentry/hybridcloud/models/outbox.py`
 - `src/sentry/hybridcloud/tasks/deliver_from_outbox.py`
+
+> **Deep dive**: see [`outboxes.md`](outboxes.md) for the full model pattern, sharding mechanics, drain path details, locking behaviour, and common gotchas.
 
 #### C. HTTP Proxying (Control → Region)
 
@@ -97,10 +103,10 @@ The silo architecture is the primary mechanism for **data residency** compliance
 | Customer data stays in jurisdiction | Region silo has isolated database; data never replicated cross-region                                                |
 | User identity is global             | User auth/PII in Control silo, accessed via RPC from regions; no PII copied to region DBs                            |
 | Right to erasure                    | Deleting a User in Control triggers `ControlOutbox` → cascades to all regions via `HybridCloudForeignKey` tombstones |
-| Org↔region binding                  | `OrganizationMapping` in Control is immutable once set; org data is locked to one region                             |
+| Org↔region binding                  | `OrganizationMapping` regions in Control are immutable once set; org data is locked to one region                    |
 | Audit trail                         | All cross-silo mutations flow through outbox tables, which are retained until processed                              |
 
-## How to Define a New Silo
+## How to Define Silo Resources
 
 ### New Model
 
@@ -140,13 +146,29 @@ Returns 404 automatically if accessed from the wrong silo. Every endpoint that i
 
 ### New RPC Service (cross-silo call)
 
+Every RPC service follows a **4-file pattern** inside `src/sentry/<domain>/services/<name>/`:
+
+| File         | Purpose                                                                                  |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| `model.py`   | `RpcModel` subclasses used as arguments and return values                                |
+| `serial.py`  | Helpers to construct `RpcModel` objects from Django ORM instances                        |
+| `service.py` | Abstract `RpcService` with decorated methods; creates the module-level delegation object |
+| `impl.py`    | Concrete `DatabaseBacked*` subclass with real DB logic                                   |
+
+**Control-silo service** (data lives in Control):
+
 ```python
-# src/sentry/services/myservice/service.py
+# src/sentry/myapp/services/myservice/service.py
+# Please do not use `from __future__ import annotations` — Pydantic needs runtime type reflection.
+
+import abc
 from sentry.hybridcloud.rpc.service import RpcService, rpc_method
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.silo.base import SiloMode
 
 class MyService(RpcService):
-    key = "my_service"  # Must be unique; conflicting keys will fail
-    local_mode = SiloMode.CONTROL   # Where the real data lives
+    key = "my_service"          # unique slug; appears in /api/0/rpc/<key>/<method>/
+    local_mode = SiloMode.CONTROL
 
     @classmethod
     def get_local_implementation(cls) -> "MyService":
@@ -154,12 +176,40 @@ class MyService(RpcService):
         return DatabaseBackedMyService()
 
     @rpc_method
-    @abstractmethod
+    @abc.abstractmethod
     def get_thing(self, *, id: int) -> RpcThing | None: ...
 
 my_service = MyService.create_delegation()
-# Callers in any silo just call my_service.get_thing(id=...) — routing is automatic
+# Callers in any silo: my_service.get_thing(id=42) — routing is automatic
 ```
+
+**Region-silo service** (data lives in Region — every method needs a resolver):
+
+```python
+# src/sentry/myapp/services/myservice/service.py
+import abc
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
+from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.silo.base import SiloMode
+
+class MyRegionService(RpcService):
+    key = "my_region_service"
+    local_mode = SiloMode.REGION
+
+    @classmethod
+    def get_local_implementation(cls) -> "MyRegionService":
+        from .impl import DatabaseBackedMyRegionService
+        return DatabaseBackedMyRegionService()
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
+    def get_thing(self, *, organization_id: int, id: int) -> RpcThing | None: ...
+
+my_region_service = MyRegionService.create_delegation()
+```
+
+> **Deep dive**: see [`rpc_services.md`](rpc_services.md) for the full 4-file layout, all region resolvers, authentication/signing details, wire format, retry behaviour, and common gotchas.
 
 ### New Cross-Silo Foreign Key
 

--- a/src/sentry/hybridcloud/AGENTS.md
+++ b/src/sentry/hybridcloud/AGENTS.md
@@ -1,0 +1,295 @@
+# Sentry Silo Architecture
+
+Sentry uses a **hybrid cloud silo architecture** to support multi-region SaaS deployments with data residency guarantees. This is called "hybrid cloud" because a single global Control silo coexists with multiple isolated Region silos. The architecture is central to GDPR compliance, since it ensures customer event/project data never leaves its configured geographic region.
+
+## What Each Silo Is and Does
+
+### Control Silo (Single Global Instance)
+
+- Manages **global, cross-tenant data**: users, authentication, billing, subscriptions, API token metadata, and organization-to-region mappings.
+- Acts as the **routing authority**: knows which region each organization belongs to via `OrganizationMapping`.
+- Proxies incoming requests to the appropriate region when needed.
+- There is exactly **one** Control silo per Sentry SaaS deployment.
+
+### Region Silo (Multiple Geographic Instances)
+
+- Manages **customer-specific, jurisdiction-scoped data**: events, issues, projects, teams, and organization configurations.
+- Each region is an independent deployment (e.g., `us`, `eu`, `de`) with its own database.
+- Customer data in a Region silo **never leaves that region's database**.
+- Multiple region silos can exist simultaneously; they are fully independent of each other.
+
+### Monolith Mode
+
+- A third mode used for **self-hosted Sentry** and local development.
+- All data in a single database; all endpoints accessible. No routing or replication needed.
+- Decorators like `@region_silo_model` are no-ops in this mode.
+
+**Key files:**
+
+- `src/sentry/silo/base.py` — `SiloMode` enum, `SiloLimit`, `FunctionSiloLimit`
+- `src/sentry/types/region.py` — `Region` dataclass, `RegionDirectory`, `get_region_for_organization()`
+- `src/sentry/silo/README.md` — local dev setup
+
+## Where Each Silo Lives
+
+| Area                | Path                                                      | Purpose                                           |
+| ------------------- | --------------------------------------------------------- | ------------------------------------------------- |
+| Silo core           | `src/sentry/silo/`                                        | Modes, client, safety, util, signatures           |
+| Hybrid cloud        | `src/sentry/hybridcloud/`                                 | Outboxes, RPC, API gateway, replica services      |
+| Model decorators    | `src/sentry/db/models/base.py`                            | `@control_silo_model`, `@region_silo_model`       |
+| Endpoint decorators | `src/sentry/api/base.py`                                  | `@control_silo_endpoint`, `@region_silo_endpoint` |
+| DB routing          | `src/sentry/db/router.py`                                 | `SiloRouter` routes queries to correct DB         |
+| Cross-silo FKs      | `src/sentry/db/models/fields/hybrid_cloud_foreign_key.py` | `HybridCloudForeignKey`                           |
+| Region client       | `src/sentry/silo/client.py`                               | `RegionSiloClient` (Control→Region HTTP proxy)    |
+| API gateway         | `src/sentry/hybridcloud/apigateway/apigateway.py`         | Request routing/proxying                          |
+
+## How Silos Interact (And Why Regions Never Talk to Each Other)
+
+### Interaction Mechanisms
+
+#### A. Synchronous RPC (Control ↔ Region)
+
+Region silos call Control silo services transparently via `RpcService`. When code in a Region silo calls `user_service.get_many(...)`, the `DelegatingRpcService` detects the silo boundary and POSTs to `/api/0/rpc/<service>/<method>/` on the Control silo. Responses are deserialized as Pydantic `RpcModel` objects.
+
+- `src/sentry/hybridcloud/rpc/service.py` — `RpcService`, `DelegatingRpcService`, `_RemoteSiloCall`
+- `src/sentry/hybridcloud/rpc/resolvers.py` — `ByOrganizationId`, `ByRegionName`, etc.
+
+#### B. Async Outbox Replication (Eventual Consistency)
+
+When a replicated model changes, an outbox record is written **atomically in the same transaction**. A Taskbroker task later drains the outbox and notifies the other silo via RPC.
+
+- `RegionOutbox` (Region→Control): e.g., organization settings changed
+- `ControlOutbox` (Control→Region): e.g., user profile updated, auth token created
+- `src/sentry/hybridcloud/models/outbox.py`
+- `src/sentry/hybridcloud/tasks/deliver_from_outbox.py`
+
+#### C. HTTP Proxying (Control → Region)
+
+When Control receives a request for a `@region_silo_endpoint`, it uses `RegionSiloClient` to proxy the request to the correct region, determined by `OrganizationMapping`. All cross-silo HTTP requests are signed with HMAC-SHA256 using `SENTRY_SUBNET_SECRET`.
+
+- `src/sentry/silo/client.py` — `RegionSiloClient`
+- `src/sentry/silo/util.py` — `encode_subnet_signature()`, `verify_subnet_signature()`
+
+#### D. HybridCloudForeignKey (Cross-Silo References)
+
+References between silo-boundary models (e.g., a Region model referencing a Control-side User) use `HybridCloudForeignKey` — a `BigIntegerField` with no DB constraint. Cascade behavior (CASCADE, SET_NULL, DO_NOTHING) is handled by deletion tasks via tombstone records, not the database.
+
+### Why Region Silos Never Communicate Directly
+
+1. **Data residency**: EU data must stay in EU. If Region A (US) could call Region B (EU), EU data could flow into US infrastructure — a GDPR violation.
+2. **Single source of truth**: Only Control knows the authoritative organization→region mapping. Without it, cross-region routing would be undefined.
+3. **Consistency model**: The outbox pattern ensures changes flow through a single coordination point (Control), preventing split-brain scenarios.
+4. **Security**: All inter-silo calls require HMAC signatures issued by the Control subnet. Region silos have no way to authenticate peer region requests.
+5. **Auditability**: Routing all cross-region data through Control creates an auditable trail for compliance.
+
+```
+Region A cannot call Region B.
+Region A  →  Control  →  Region B   ✓
+Region A  →  Region B                ✗
+```
+
+## GDPR Compliance
+
+The silo architecture is the primary mechanism for **data residency** compliance:
+
+| Concern                             | How Silos Address It                                                                                                 |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Customer data stays in jurisdiction | Region silo has isolated database; data never replicated cross-region                                                |
+| User identity is global             | User auth/PII in Control silo, accessed via RPC from regions; no PII copied to region DBs                            |
+| Right to erasure                    | Deleting a User in Control triggers `ControlOutbox` → cascades to all regions via `HybridCloudForeignKey` tombstones |
+| Org↔region binding                  | `OrganizationMapping` in Control is immutable once set; org data is locked to one region                             |
+| Audit trail                         | All cross-silo mutations flow through outbox tables, which are retained until processed                              |
+
+## How to Define a New Silo
+
+### New Model
+
+```python
+# src/sentry/models/mymodel.py
+from sentry.db.models import region_silo_model   # or control_silo_model
+from sentry.hybridcloud.outbox.base import ReplicatedRegionModel
+from sentry.hybridcloud.outbox.category import OutboxCategory
+
+@region_silo_model
+class MyModel(ReplicatedRegionModel):
+    category = OutboxCategory.MY_MODEL_UPDATE  # Add to OutboxCategory enum
+
+    organization = FlexibleForeignKey("sentry.Organization")
+    name = models.CharField(max_length=255)
+
+    def handle_async_replication(self, shard_identifier: int) -> None:
+        # Optional: called when this model is replicated to other silo
+        pass
+```
+
+Every model **must** be decorated; tests enforce this (`tests/sentry/silo/test_base.py`).
+
+### New Endpoint
+
+```python
+# src/sentry/api/endpoints/my_endpoint.py
+from sentry.api.base import region_silo_endpoint   # or control_silo_endpoint / all_silo_endpoint
+
+@region_silo_endpoint
+class MyOrganizationEndpoint(OrganizationEndpoint):
+    def get(self, request, organization):
+        ...
+```
+
+Returns 404 automatically if accessed from the wrong silo. Every endpoint that is not decorated is assumed to be Region Silo scoped by default.
+
+### New RPC Service (cross-silo call)
+
+```python
+# src/sentry/services/myservice/service.py
+from sentry.hybridcloud.rpc.service import RpcService, rpc_method
+
+class MyService(RpcService):
+    key = "my_service"  # Must be unique; conflicting keys will fail
+    local_mode = SiloMode.CONTROL   # Where the real data lives
+
+    @classmethod
+    def get_local_implementation(cls) -> "MyService":
+        from .impl import DatabaseBackedMyService
+        return DatabaseBackedMyService()
+
+    @rpc_method
+    @abstractmethod
+    def get_thing(self, *, id: int) -> RpcThing | None: ...
+
+my_service = MyService.create_delegation()
+# Callers in any silo just call my_service.get_thing(id=...) — routing is automatic
+```
+
+### New Cross-Silo Foreign Key
+
+```python
+from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignKey
+
+@region_silo_model
+class MyModel(Model):
+    # References a Control-side model; no DB constraint, cascade via tombstones
+    user_id = HybridCloudForeignKey("sentry.User", on_delete="CASCADE")
+```
+
+## Diagrams
+
+### Overall Silo Topology
+
+```mermaid
+graph TD
+    subgraph Control["Control Silo (Single Instance)"]
+        CS_DB[(Control DB)]
+        CS_API[Control API]
+        OrganizationMapping[OrganizationMapping]
+        UserAuth[User / Auth / Billing]
+        ControlOutbox[ControlOutbox]
+    end
+
+    subgraph RegionUS["Region Silo: US"]
+        US_DB[(Region DB - US)]
+        US_API[Region API]
+    end
+
+    subgraph RegionEU["Region Silo: EU"]
+        EU_DB[(Region DB - EU)]
+        EU_API[Region API]
+    end
+
+    Browser[Browser / API Client] -->|"1. Request (any endpoint)"| CS_API
+    CS_API -->|"2a. Control endpoint: handle locally"| CS_DB
+    CS_API -->|"2b. Region endpoint: proxy via RegionSiloClient"| OrganizationMapping
+    OrganizationMapping -->|"3. Resolve org→region"| CS_DB
+    OrganizationMapping -->|"4a. Route to US"| US_API
+    OrganizationMapping -->|"4b. Route to EU"| EU_API
+
+    CS_API -.->|"RPC (forbidden)"| US_API
+    US_API -.->|"Direct (FORBIDDEN)"| EU_API
+
+    style Control fill:#1a3a5c,color:#fff
+    style RegionUS fill:#1a5c2a,color:#fff
+    style RegionEU fill:#5c3a1a,color:#fff
+```
+
+### Outbox Replication Flow (Control → Region)
+
+```mermaid
+sequenceDiagram
+    participant CS as Control Silo
+    participant CO as ControlOutbox (Control DB)
+    participant Task as Taskbroker Worker (Control)
+    participant RS as Region Silo RPC endpoint
+    participant RDB as Region DB
+
+    CS->>CO: BEGIN TRANSACTION<br/>UPDATE User SET name=...<br/>INSERT INTO ControlOutbox(region, category, object_id)
+    CO-->>CS: COMMIT (atomic)
+    Note over CS,CO: Outbox written atomically with model change
+
+    loop Async drain (every ~1s)
+        Task->>CO: SELECT unprocessed shards
+        CO-->>Task: [outbox record]
+        Task->>RS: POST /api/0/rpc/region_replica/upsert_user/<br/>(HMAC-signed)
+        RS->>RDB: UPDATE UserReplica SET name=...
+        RDB-->>RS: OK
+        RS-->>Task: 200 OK
+        Task->>CO: DELETE outbox record
+    end
+```
+
+### RPC Call (Region → Control)
+
+```mermaid
+sequenceDiagram
+    participant RegionCode as Region Silo Code
+    participant Delegator as DelegatingRpcService
+    participant RemoteCall as _RemoteSiloCall
+    participant ControlRPC as Control Silo /api/0/rpc/
+    participant ControlImpl as DatabaseBackedUserService
+
+    RegionCode->>Delegator: user_service.get_many(filter=...)
+    Delegator->>Delegator: SiloMode.get_current_mode() == REGION<br/>→ use remote delegator
+    Delegator->>RemoteCall: dispatch_remote_call(region=None, service="user", method="get_many", args)
+    RemoteCall->>ControlRPC: POST /api/0/rpc/user/get_many/<br/>body: serialized args<br/>header: X-Sentry-Subnet-Signature
+    ControlRPC->>ControlImpl: get_many(filter=...)
+    ControlImpl-->>ControlRPC: list[RpcUser]
+    ControlRPC-->>RemoteCall: 200 + serialized response
+    RemoteCall-->>RegionCode: list[RpcUser]
+```
+
+### Request Proxying (Control Acts as Gateway)
+
+```mermaid
+flowchart TD
+    Req[Incoming HTTP Request] --> Gateway[API Gateway\nproxy_request_if_needed]
+    Gateway --> CheckMode{Current silo\nmode?}
+    CheckMode -->|MONOLITH| Direct[Handle locally]
+    CheckMode -->|CONTROL| CheckEndpoint{Endpoint silo?}
+    CheckEndpoint -->|CONTROL or ALL| Direct
+    CheckEndpoint -->|REGION| Lookup[Lookup org→region\nvia OrganizationMapping]
+    Lookup --> RegionClient[RegionSiloClient\n.proxy_request]
+    RegionClient --> Sign[Add HMAC signature\nX-Sentry-Subnet-*]
+    Sign --> Forward[HTTP POST to\nregion address]
+    Forward --> RegionSilo[Region Silo API]
+    RegionSilo --> Response[Return response\nto original client]
+    CheckMode -->|REGION| CheckRegionEndpoint{Endpoint silo?}
+    CheckRegionEndpoint -->|REGION or ALL| Direct
+    CheckRegionEndpoint -->|CONTROL| Return404[Return 404]
+```
+
+### Why Regions Don't Talk to Each Other (GDPR)
+
+```mermaid
+graph LR
+    subgraph Forbidden["❌ Forbidden: Direct Region-to-Region"]
+        RUS2[Region US] -->|"Cross-border data flow\nGDPR violation"| REU2[Region EU]
+    end
+
+    subgraph Allowed["✅ Allowed: Via Control"]
+        RUS[Region US] -->|"RegionOutbox\n(async)"| CTRL[Control Silo]
+        CTRL -->|"ControlOutbox\n(async)"| REU[Region EU]
+        CTRL -->|"OrganizationMapping\n(single source of truth)"| CTRL
+    end
+
+    style Forbidden fill:#5c1a1a,color:#fff
+    style Allowed fill:#1a3a1a,color:#fff
+```

--- a/src/sentry/hybridcloud/outboxes.md
+++ b/src/sentry/hybridcloud/outboxes.md
@@ -1,0 +1,395 @@
+# Hybridcloud Outbox Deep Dive
+
+This document covers the outbox replication system in depth: how the model mixins work, how sharding affects correctness and performance, how the two drain paths interact, and the failure modes that arise from common mistakes.
+
+> **Quick reference**: For a one-page summary, see the "Async Outbox Replication" section in [`AGENTS.md`](AGENTS.md).
+> For RPC service patterns, see [`rpc_services.md`](rpc_services.md).
+
+## A. Overview
+
+Outboxes exist to replicate model changes across silo boundaries **atomically** without distributed transactions. When a model changes in one silo, an outbox record is written in the **same database transaction** as the model change. A separate drain process later reads the outbox and calls RPC endpoints on the other silo. If the drain fails, the outbox record remains and will be retried.
+
+**Two directions:**
+
+- `RegionOutbox` (Region → Control): e.g., an organization's settings change; Control's replica must be updated.
+- `ControlOutbox` (Control → Region): e.g., a user's profile updates; every region that has that user must be notified.
+
+**Delivery guarantee:** At-least-once. The same signal can fire multiple times for a single logical change (due to retries or concurrent drains). All handlers **must be idempotent**.
+
+## B. Key Classes
+
+| Class                                 | File                 | Responsibility                                                             |
+| ------------------------------------- | -------------------- | -------------------------------------------------------------------------- |
+| `OutboxBase`                          | `models/outbox.py`   | Abstract base; fields, drain methods, locking, coalescing                  |
+| `RegionOutboxBase` / `RegionOutbox`   | `models/outbox.py`   | Region→Control; shards on `(shard_scope, shard_identifier)`                |
+| `ControlOutboxBase` / `ControlOutbox` | `models/outbox.py`   | Control→Region; shards on `(region_name, shard_scope, shard_identifier)`   |
+| `ReplicatedRegionModel`               | `outbox/base.py`     | Mixin: intercepts save/update/delete, creates `RegionOutbox` automatically |
+| `ReplicatedControlModel`              | `outbox/base.py`     | Mixin: creates one `ControlOutbox` per target region on save/update/delete |
+| `RegionOutboxProducingModel`          | `outbox/base.py`     | Lower-level mixin; use when you need custom outbox creation logic          |
+| `OutboxCategory`                      | `outbox/category.py` | Enum of 45 message types; governs which Django signal fires on drain       |
+| `OutboxScope`                         | `outbox/category.py` | Enum of 13 scopes; determines what `shard_identifier` represents           |
+| `outbox_context()`                    | `models/outbox.py`   | Context manager controlling whether outboxes flush on transaction commit   |
+
+## C. The Replicated Model Pattern
+
+### Region model (Region → Control)
+
+Use `ReplicatedRegionModel` when a model lives in the Region silo and its changes need to reach Control.
+
+```python
+# src/sentry/models/team.py
+from sentry.db.models import region_silo_model
+from sentry.hybridcloud.outbox.base import ReplicatedRegionModel
+from sentry.hybridcloud.outbox.category import OutboxCategory
+
+@region_silo_model
+class Team(ReplicatedRegionModel):
+    category = OutboxCategory.TEAM_UPDATE  # registered in ORGANIZATION_SCOPE
+
+    organization = FlexibleForeignKey("sentry.Organization")
+    name = models.CharField(max_length=64)
+
+    def payload_for_update(self) -> dict[str, Any] | None:
+        # Optional: include hints so handlers can skip a DB lookup.
+        # WARNING: outboxes are coalesced — only the *latest* payload survives.
+        return {"slug": self.slug}
+
+    def handle_async_replication(self, shard_identifier: int) -> None:
+        # shard_identifier == self.organization_id (inferred by OutboxScope.ORGANIZATION_SCOPE)
+        from sentry.hybridcloud.services.replica import control_replica_service
+        control_replica_service.upsert_replicated_team(team_id=self.id)
+
+    @classmethod
+    def handle_async_deletion(
+        cls, identifier: int, shard_identifier: int, payload: Mapping[str, Any] | None
+    ) -> None:
+        from sentry.hybridcloud.services.replica import control_replica_service
+        control_replica_service.delete_replicated_team(team_id=identifier)
+```
+
+**Signal wiring** — in a `ready()` handler or module-level code:
+
+```python
+OutboxCategory.TEAM_UPDATE.connect_region_model_updates(Team)
+```
+
+This connects `process_region_outbox` to call `maybe_process_tombstone()`, then dispatch to `handle_async_replication()` or `handle_async_deletion()` depending on whether the object still exists.
+
+### Control model (Control → Region)
+
+Use `ReplicatedControlModel` when a model lives in the Control silo and its changes need to reach every relevant Region.
+
+```python
+# src/sentry/models/organizationslugreservation.py
+from sentry.db.models import control_silo_model
+from sentry.hybridcloud.outbox.base import ReplicatedControlModel
+from sentry.hybridcloud.outbox.category import OutboxCategory
+
+@control_silo_model
+class OrganizationSlugReservation(ReplicatedControlModel):
+    category = OutboxCategory.ORGANIZATION_SLUG_RESERVATION_UPDATE  # ORGANIZATION_SCOPE
+
+    organization_id = BoundedBigIntegerField()
+    slug = models.SlugField()
+
+    def outbox_region_names(self) -> Collection[str]:
+        # Must be overridden — returns the set of regions to notify.
+        # Default implementation checks for organization_id or user_id attributes.
+        return find_regions_for_orgs([self.organization_id])
+
+    def handle_async_replication(self, region_name: str, shard_identifier: int) -> None:
+        # region_name is the target region; shard_identifier == self.organization_id
+        from sentry.hybridcloud.services.replica import region_replica_service
+        region_replica_service.upsert_slug_reservation(
+            region_name=region_name, slug_reservation_id=self.id
+        )
+
+    @classmethod
+    def handle_async_deletion(
+        cls,
+        identifier: int,
+        region_name: str,
+        shard_identifier: int,
+        payload: Mapping[str, Any] | None,
+    ) -> None:
+        from sentry.hybridcloud.services.replica import region_replica_service
+        region_replica_service.delete_slug_reservation(
+            region_name=region_name, slug_reservation_id=identifier
+        )
+```
+
+**Signal wiring:**
+
+```python
+OutboxCategory.ORGANIZATION_SLUG_RESERVATION_UPDATE.connect_control_model_updates(
+    OrganizationSlugReservation
+)
+```
+
+### Fields to implement on `ReplicatedRegionModel`
+
+| Method / Attribute                                             | Required? | Notes                                                               |
+| -------------------------------------------------------------- | --------- | ------------------------------------------------------------------- |
+| `category: OutboxCategory`                                     | Yes       | Class variable; must match a value registered in the right scope    |
+| `handle_async_replication(shard_identifier)`                   | Usually   | Called when the object exists at drain time                         |
+| `handle_async_deletion(identifier, shard_identifier, payload)` | Usually   | Called when the object is gone at drain time                        |
+| `payload_for_update()`                                         | No        | Custom JSON coalesced with the outbox; **only the latest survives** |
+| `outbox_type`                                                  | No        | Override `RegionOutbox` with a custom subclass                      |
+
+### Fields to implement on `ReplicatedControlModel`
+
+Same as above, plus:
+
+| Method / Attribute                                                          | Required? | Notes                                                                 |
+| --------------------------------------------------------------------------- | --------- | --------------------------------------------------------------------- |
+| `outbox_region_names()`                                                     | Yes       | Returns `Collection[str]`; one `ControlOutbox` row created per region |
+| `handle_async_replication(region_name, shard_identifier)`                   | Usually   | Extra `region_name` param vs. Region version                          |
+| `handle_async_deletion(identifier, region_name, shard_identifier, payload)` | Usually   | Extra `region_name` param                                             |
+
+## D. Sharding: How It Works and Why It Matters
+
+### What a shard is
+
+A **shard** is defined by the `sharding_columns` of the outbox model:
+
+- `RegionOutbox`: `(shard_scope, shard_identifier)`
+- `ControlOutbox`: `(region_name, shard_scope, shard_identifier)`
+
+All outbox messages in the same shard are **processed serially** by one worker. Messages in different shards are **processed in parallel**. This is the key correctness and performance lever.
+
+### Choosing the right `shard_identifier`
+
+`OutboxScope` determines what `shard_identifier` means. `OutboxCategory.infer_identifiers()` in `category.py` walks the model for the correct field automatically when `shard_identifier` is not overridden:
+
+| Scope                | Inferred `shard_identifier`                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `ORGANIZATION_SCOPE` | `organization_id` (or `model.id` if model is `Organization`)      |
+| `USER_SCOPE`         | `user_id` (or `model.id` if model is `User`)                      |
+| `APP_SCOPE`          | `api_application_id` (or `model.id` if model is `ApiApplication`) |
+| `INTEGRATION_SCOPE`  | `integration_id` (or `model.id` if model is `Integration`)        |
+| `API_TOKEN_SCOPE`    | `api_token_id` (or `model.id` if model is `ApiToken`)             |
+
+**Rule**: use the natural owner of the data. For org-scoped data, `organization_id` is correct. For user-scoped data, `user_id`.
+
+### DB contention from bad sharding
+
+The `shard_identifier` is the **unit of serial processing**. If many unrelated objects share the same `shard_identifier`:
+
+1. All their outbox rows fall in one shard.
+2. Only one worker holds the `SELECT FOR UPDATE` lock at a time.
+3. All other workers must wait or skip.
+4. The shard grows faster than it drains.
+5. `scheduled_for` backoff compounds lag: each failure doubles the delay (up to 1 hour).
+6. In high-write scenarios this produces persistent lock contention on `sentry_regionoutbox` or `sentry_controloutbox`.
+
+**Bad patterns to avoid:**
+
+- `shard_identifier = 0` (or any constant) — collapses all messages into a single shard across the entire system.
+- Using `auth_provider_id` as `shard_identifier` for data that could use `organization_id` — wrong granularity.
+- Registering a new `OutboxCategory` in `ORGANIZATION_SCOPE` but accidentally passing `user_id` as `shard_identifier` — scope/identifier mismatch; also likely to group unrelated data together.
+- Each scope should conceptually contain interdependent updates — messages in a shard should need to be serialized relative to each other, not just happen to share a field.
+
+### Index alignment
+
+The existing indexes on both outbox tables are designed for the sharding pattern:
+
+**`sentry_regionoutbox` indexes:**
+
+- `(shard_scope, shard_identifier, category, object_identifier)` — coalescing queries
+- `(shard_scope, shard_identifier, scheduled_for)` — scheduling queries
+- `(shard_scope, shard_identifier, id)` — lock range queries
+
+**`sentry_controloutbox` indexes:**
+
+- `(region_name, shard_scope, shard_identifier, category, object_identifier)`
+- `(region_name, shard_scope, shard_identifier, scheduled_for)`
+- `(region_name, shard_scope, shard_identifier, id)`
+
+Queries that skip `shard_scope` or reorder columns do a sequential scan. Always filter by the full shard key in that order.
+
+## E. Synchronous vs Asynchronous Drain Flows
+
+### Post-commit synchronous drain
+
+When `outbox_context(flush=True)` is active (the default), saving an outbox row registers a `transaction.on_commit` callback:
+
+```
+model.save()
+  → ReplicatedRegionModel.prepare_outboxes()
+    → outbox_context(transaction.atomic(...), flush=True)
+      → RegionOutbox.save()
+        → Validate scope/category match
+        → transaction.on_commit(lambda: self.drain_shard())  ← registered here
+  → Transaction commits
+→ drain_shard(flush_all=False) runs OUTSIDE the transaction
+  → Sets latest_shard_row = last row in shard (upper bound)
+  → process_shard(latest_shard_row) — blocking SELECT FOR UPDATE (waits for any concurrent lock)
+  → Processes messages up to the upper bound; ignores messages written concurrently
+```
+
+**Key property of `flush_all=False`**: sets an upper bound (`latest_shard_row`) so the drain terminates even if new messages arrive concurrently. Uses a **blocking** lock in `process_shard`.
+
+> **Note**: Avoid relying on synchronous drains in application code. Most code should let the Taskbroker handle draining asynchronously. Synchronous drains are mainly useful when you need semi-consistent behavior (e.g., ensuring a replica is up-to-date before returning a response in tests).
+
+### Taskbroker async drain (background catch-up)
+
+```
+enqueue_outbox_jobs() / enqueue_outbox_jobs_control()   [Taskbroker, runs every ~1s]
+  → schedule_batch(outbox_model, concurrency=5)
+    → Find min/max ID in outbox table
+    → Emit drain_outbox_shards.delay(low, hi) × 5 tasks
+      → process_outbox_batch(low, hi, outbox_model)
+        → find_scheduled_shards(low, hi)   [DISTINCT shard keys WHERE scheduled_for <= now()]
+        → For each shard: prepare_next_from_shard(shard_attrs)
+            → SELECT FOR UPDATE NOWAIT  [skip if locked by another worker]
+            → Update scheduled_for for all messages in shard (exponential backoff)
+        → drain_shard(flush_all=True)
+            → process_shard(None)   [no upper bound; NOWAIT SELECT FOR UPDATE]
+            → Loops until no rows remain
+```
+
+**Key difference of `flush_all=True`**: no upper bound, so it drains everything. Uses **NOWAIT** in `process_shard` — if contended, the shard is skipped until the next scheduler cycle.
+
+### When each path runs
+
+| Path            | Trigger                                                  | `flush_all` in `drain_shard` | Lock in `process_shard`   |
+| --------------- | -------------------------------------------------------- | ---------------------------- | ------------------------- |
+| Post-commit     | `outbox_context(flush=True)` + `transaction.on_commit`   | `False` (has upper bound)    | Blocking (`nowait=False`) |
+| Taskbroker task | `enqueue_outbox_jobs` every ~1s                          | `True` (no upper bound)      | NOWAIT (`nowait=True`)    |
+| Manual (tests)  | `outbox_context(flush=False)` + explicit `drain_shard()` | either                       | either                    |
+
+### `outbox_context()` explained
+
+```python
+# src/sentry/hybridcloud/models/outbox.py
+@contextlib.contextmanager
+def outbox_context(inner: Atomic | None = None, flush: bool | None = None):
+    ...
+    assert not flush or inner, "Must either set a transaction or flush=False"
+```
+
+- **`flush=True` (default)**: registers `on_commit` drain; **requires** an active `atomic()` block passed as `inner`.
+- **`flush=False`**: disables auto-drain; caller is responsible for manual drain or relying on Taskbroker.
+- The thread-local `_outbox_context.flushing_enabled` propagates across nested saves; inner contexts inherit the outer setting if not explicitly set.
+
+## F. Locking and DB Contention
+
+### Lock acquisition in `prepare_next_from_shard()`
+
+Called by the Taskbroker path before draining. Uses `SELECT FOR UPDATE NOWAIT` inside a `savepoint=False` atomic block. If the lock is unavailable (another worker holds it), `LockNotAvailable` is caught and `None` is returned — the shard is skipped until the next scheduler cycle.
+
+After acquiring the lock, it updates `scheduled_for` on all messages in the shard to implement exponential backoff:
+
+```python
+next_outbox.next_schedule(now)  # = now + min(last_delay * 2, 1 hour)
+```
+
+This prevents tight-loop retries on failing shards.
+
+### Lock acquisition in `process_shard()`
+
+The local `flush_all` inside `process_shard` is computed as `not bool(latest_shard_row)`:
+
+- When called from the **Taskbroker path** (`drain_shard(flush_all=True)` → `latest_shard_row=None`): local `flush_all=True`, uses `SELECT FOR UPDATE NOWAIT`. If contended, returns `None` and the loop exits cleanly.
+- When called from the **post-commit path** (`drain_shard(flush_all=False)` → `latest_shard_row=<row>`): local `flush_all=False`, uses blocking `SELECT FOR UPDATE`. The drain waits for any concurrent lock to release.
+
+### Coalescing reduces lock hold time
+
+Before firing the signal, `process_coalesced()` deletes all prior messages for the same `(shard_scope, shard_identifier, category, object_identifier)` in batches of 50, then deletes the final coalesced row after the signal fires. This limits the number of RPC calls and the duration of the lock hold.
+
+### Why a hot shard is dangerous
+
+- Every save to a model in the shard extends the lock-hold window.
+- The Taskbroker `drain_outbox_shards` task backs up across worker slots if one shard is perpetually locked.
+- Exponential backoff on `scheduled_for` grows queue lag.
+- Monitor with `OutboxBase.get_shard_depths_descending()` — returns shards ordered by queue depth.
+
+## G. Diagrams
+
+### Full outbox lifecycle (Region → Control direction)
+
+```mermaid
+sequenceDiagram
+    participant Code as Region Code
+    participant DB as Region DB (sentry_regionoutbox)
+    participant OnCommit as on_commit callback
+    participant Worker as Drain Worker / Taskbroker Task
+    participant Signal as process_region_outbox signal
+    participant Handler as handle_async_replication()
+    participant CtrlRPC as Control RPC endpoint
+
+    Code->>DB: BEGIN TRANSACTION<br/>UPDATE MyModel...<br/>INSERT INTO sentry_regionoutbox<br/>(shard_scope, shard_identifier, category, object_identifier)
+    DB-->>Code: COMMIT
+    Code->>OnCommit: register drain_shard(flush_all=False)
+    OnCommit->>DB: SELECT FOR UPDATE (blocking, up to latest_shard_row)
+    DB-->>OnCommit: locked row
+    OnCommit->>DB: SELECT coalesced messages, DELETE prior dupes (batches of 50)
+    OnCommit->>Signal: process_region_outbox.send(category, object_identifier, shard_identifier)
+    Signal->>Handler: handle_async_replication(shard_identifier)
+    Handler->>CtrlRPC: control_replica_service.upsert_*(...)
+    CtrlRPC-->>Handler: OK
+    OnCommit->>DB: DELETE processed outbox row
+```
+
+### Taskbroker async drain decision tree
+
+```mermaid
+flowchart TD
+    Schedule["enqueue_outbox_jobs()\nevery ~1s"] --> FindShards["find_scheduled_shards(low, hi)\nSELECT DISTINCT shard keys\nWHERE scheduled_for <= now()"]
+    FindShards --> TryLock["prepare_next_from_shard()\nSELECT FOR UPDATE NOWAIT\n+ update scheduled_for (backoff)"]
+    TryLock -->|Lock acquired| Drain["drain_shard(flush_all=True)\nNOWAIT SELECT FOR UPDATE\nNo upper bound — loops until empty"]
+    TryLock -->|LockNotAvailable| Skip["Skip shard\n(another worker running)"]
+    Drain --> Coalesce["process_coalesced()\nDelete prior dupes in batches of 50"]
+    Coalesce --> SendSignal["send_signal()\nprocess_region_outbox.send(...)"]
+    SendSignal --> Handler["handle_async_replication() or\nhandle_async_deletion()"]
+    Handler --> Delete["Delete processed outbox row"]
+    Delete --> Next["Next shard row in loop"]
+    Skip --> Next
+    Next --> Done{More rows?}
+    Done -->|Yes| Drain
+    Done -->|No| End[Done]
+```
+
+## H. Gotchas
+
+### 1. Must be in a transaction to flush
+
+`outbox_context(flush=True)` (the default) asserts `inner is not None`. Saving an outbox with flushing enabled but without passing an `atomic()` block as `inner` raises `AssertionError: Must either set a transaction or flush=False`. The `RegionOutboxProducingModel.prepare_outboxes()` method wraps the save in `transaction.atomic(...)` automatically, so this is only an issue if you create outbox rows manually outside the mixin.
+
+### 2. Handlers must be idempotent
+
+At-least-once delivery means `handle_async_replication()` can fire multiple times for the same logical change. Always use upsert-style operations; never rely on the handler being called exactly once.
+
+### 3. No outbox drain inside a transaction (tests)
+
+`drain_shard()` calls `in_test_assert_no_transaction()`. Triggering a drain inside a `TestCase.atomic()` block raises. Either use `@pytest.mark.django_db(transaction=True)` or disable flushing with `outbox_context(flush=False)` and drain manually after the transaction.
+
+### 4. ControlOutbox needs one row per region
+
+`outboxes_for_update()` returns a **list** — one `ControlOutbox` per region name. Always use:
+
+```python
+ControlOutbox.objects.bulk_create(model.outboxes_for_update())
+```
+
+Not `.outbox_for_update().save()` (which is the `RegionOutbox` API).
+
+### 5. Coalescing requires stable `object_identifier`
+
+Messages are coalesced on `(shard_scope, shard_identifier, category, object_identifier)`. If your handler creates different `object_identifier` values for the same logical object, messages won't coalesce and every write generates a separate signal. This can produce large amounts of backpressure in high-volume scenarios.
+
+### 6. Deleting a replicated model requires a tombstone
+
+Deletion is signalled via the same outbox category. When the signal fires after deletion, `maybe_process_tombstone()` returns `None` because the object is gone from the DB, and `handle_async_deletion()` is called instead. Implement both `handle_async_replication()` and `handle_async_deletion()`.
+
+### 7. Scope/category mismatch raises at save time
+
+`OutboxScope.scope_has_category()` validates the combination on every `save()`. Assigning a category to the wrong scope raises `InvalidOutboxError` on the first save, not at registration time.
+
+### 8. Adding a new `OutboxCategory`
+
+1. Add the integer value to the `OutboxCategory` enum in `outbox/category.py`.
+2. Add it to the correct `scope_categories()` set in `OutboxScope`.
+3. Implement `handle_async_replication()` and `handle_async_deletion()` on the model.
+4. Call `OutboxCategory.YOUR_CATEGORY.connect_region_model_updates(YourModel)` (or `connect_control_model_updates`) in a `ready()` handler.
+5. Verify that `infer_identifiers()` will pick the correct `shard_identifier` for your model's fields, or pass it explicitly.

--- a/src/sentry/hybridcloud/rpc_services.md
+++ b/src/sentry/hybridcloud/rpc_services.md
@@ -1,0 +1,361 @@
+# RPC Services Deep Dive
+
+This document covers everything you need to define, consume, or debug a Sentry RPC service. For silo architecture context, see [`AGENTS.md`](AGENTS.md).
+
+---
+
+## The 4-File Pattern
+
+Every RPC service lives in a package under `src/sentry/<domain>/services/<name>/` and consists of four files:
+
+| File         | Purpose                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------- |
+| `model.py`   | Pydantic `RpcModel` subclasses used as arguments and return values                                      |
+| `serial.py`  | Helper functions to construct `RpcModel` objects from Django ORM instances                              |
+| `service.py` | Abstract `RpcService` subclass declaring the interface; creates the module-level delegation object      |
+| `impl.py`    | Concrete `DatabaseBacked*` subclass with real DB logic; imported only from `get_local_implementation()` |
+
+Example: `src/sentry/auth/services/auth/`
+
+```
+auth/
+├── __init__.py     # re-exports from model.py and service.py
+├── model.py        # RpcApiKey, RpcAuthProvider, ...
+├── serial.py       # serialize_auth_provider(), serialize_api_key(), ...
+├── service.py      # AuthService(RpcService); auth_service = AuthService.create_delegation()
+└── impl.py         # DatabaseBackedAuthService(AuthService)
+```
+
+### `model.py`
+
+```python
+# Please do not use
+#     from __future__ import annotations
+# in modules such as this one where hybrid cloud data models or service classes are
+# defined, because we want to reflect on type annotations and avoid forward references.
+
+from sentry.hybridcloud.rpc import RpcModel
+
+class RpcThing(RpcModel):
+    id: int = -1
+    organization_id: int = -1
+    name: str = ""
+```
+
+### `serial.py`
+
+```python
+from __future__ import annotations
+
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.myapp.models import Thing
+
+def serialize_thing(thing: Thing) -> RpcThing:
+    return RpcThing(
+        id=thing.id,
+        organization_id=thing.organization_id,
+        name=thing.name,
+    )
+```
+
+### `service.py` (Control-silo service)
+
+```python
+# Please do not use
+#     from __future__ import annotations
+# (Pydantic needs runtime type reflection)
+
+import abc
+from sentry.hybridcloud.rpc.service import RpcService, rpc_method
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.silo.base import SiloMode
+
+
+class MyService(RpcService):
+    key = "my_service"          # unique; appears in /api/0/rpc/<key>/<method>/
+    local_mode = SiloMode.CONTROL  # where the real data lives
+
+    @classmethod
+    def get_local_implementation(cls) -> "MyService":
+        from .impl import DatabaseBackedMyService
+        return DatabaseBackedMyService()
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_thing(self, *, id: int) -> RpcThing | None: ...
+
+    @rpc_method
+    @abc.abstractmethod
+    def get_many(self, *, ids: list[int]) -> list[RpcThing]: ...
+
+
+my_service = MyService.create_delegation()
+# Callers in any silo: my_service.get_thing(id=42)
+```
+
+### `service.py` (Region-silo service)
+
+```python
+# Please do not use
+#     from __future__ import annotations
+
+import abc
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId
+from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.silo.base import SiloMode
+
+
+class MyRegionService(RpcService):
+    key = "my_region_service"
+    local_mode = SiloMode.REGION
+
+    @classmethod
+    def get_local_implementation(cls) -> "MyRegionService":
+        from .impl import DatabaseBackedMyRegionService
+        return DatabaseBackedMyRegionService()
+
+    @regional_rpc_method(resolve=ByOrganizationId())
+    @abc.abstractmethod
+    def get_thing(self, *, organization_id: int, id: int) -> RpcThing | None: ...
+
+
+my_region_service = MyRegionService.create_delegation()
+```
+
+### `impl.py`
+
+```python
+from __future__ import annotations
+
+from sentry.myapp.models import Thing
+from sentry.myapp.services.myservice.model import RpcThing
+from sentry.myapp.services.myservice.serial import serialize_thing
+from sentry.myapp.services.myservice.service import MyService
+
+
+class DatabaseBackedMyService(MyService):
+    def get_thing(self, *, id: int) -> RpcThing | None:
+        try:
+            return serialize_thing(Thing.objects.get(id=id))
+        except Thing.DoesNotExist:
+            return None
+
+    def get_many(self, *, ids: list[int]) -> list[RpcThing]:
+        return [serialize_thing(t) for t in Thing.objects.filter(id__in=ids)]
+```
+
+---
+
+## Key Classes
+
+| Class                        | File                            | Responsibility                                                                            |
+| ---------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------- |
+| `RpcService`                 | `rpc/service.py`                | Abstract base; defines `key`, `local_mode`, `get_local_implementation()`                  |
+| `DelegatingRpcService`       | `rpc/service.py`                | Runtime proxy; routes calls to local impl or `_RemoteSiloCall` based on `SiloMode`        |
+| `DelegatedBySiloMode`        | `rpc/__init__.py`               | `__getattr__` dispatcher; lazily constructs the correct backend per silo mode             |
+| `_RemoteSiloCall`            | `rpc/service.py`                | Serializes args, signs, POSTs to `/api/0/rpc/<service>/<method>/`, deserializes response  |
+| `RpcMethodSignature`         | `rpc/service.py`                | Per-method contract; wraps Pydantic models for args and return; holds the region resolver |
+| `RpcModel`                   | `rpc/__init__.py`               | Pydantic base for all RPC transfer objects; `orm_mode = True` by default                  |
+| `InternalRpcServiceEndpoint` | `api/endpoints/internal/rpc.py` | Receives and dispatches inbound RPC POST requests                                         |
+| `RpcSignatureAuthentication` | `api/authentication.py`         | Verifies HMAC signature before the endpoint dispatches                                    |
+
+---
+
+## Method Decorators
+
+### `@rpc_method`
+
+Marks a method as an RPC endpoint on **Control-silo** services (or Monolith). Required on every abstract method in an `RpcService` subclass with `local_mode = SiloMode.CONTROL`.
+
+```python
+@rpc_method
+@abc.abstractmethod
+def get_thing(self, *, id: int) -> RpcThing | None: ...
+```
+
+### `@regional_rpc_method(resolve=...)`
+
+Required on every abstract method in services with `local_mode = SiloMode.REGION`. Must supply a `RegionResolutionStrategy` so the delegator knows which region to route the call to. Missing this raises `RpcServiceSetupException` at **class initialization time** (not call time).
+
+```python
+@regional_rpc_method(resolve=ByOrganizationId())
+@abc.abstractmethod
+def get_thing(self, *, organization_id: int, id: int) -> RpcThing | None: ...
+```
+
+The optional `return_none_if_mapping_not_found=True` flag causes the method to return `None` instead of raising `RegionMappingNotFound` when no `OrganizationMapping` row exists. Only valid on methods with `Optional[...]` return types.
+
+```python
+@regional_rpc_method(resolve=ByOrganizationId(), return_none_if_mapping_not_found=True)
+@abc.abstractmethod
+def get_thing(self, *, organization_id: int) -> RpcThing | None: ...
+```
+
+---
+
+## Region Resolvers
+
+All resolvers live in `src/sentry/hybridcloud/rpc/resolvers.py`. They look up the region by querying `OrganizationMapping` in the Control DB.
+
+| Resolver                                    | When to use                                                           |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| `ByOrganizationId()`                        | Method receives `organization_id: int` (default param name)           |
+| `ByOrganizationId(parameter_name="org_id")` | Method uses a different kwarg name for the org ID                     |
+| `ByOrganizationSlug()`                      | Method receives `slug: str`                                           |
+| `ByOrganizationIdAttribute("param_name")`   | Method receives an `RpcModel` that has an `organization_id` attribute |
+| `ByRegionName()`                            | Method receives explicit `region_name: str`                           |
+| `RequireSingleOrganization()`               | Single-org / self-hosted only; raises if multiple regions exist       |
+
+Example with attribute resolver:
+
+```python
+@regional_rpc_method(resolve=ByOrganizationIdAttribute("filter"))
+@abc.abstractmethod
+def get_things(self, *, filter: RpcThingFilter) -> list[RpcThing]: ...
+# filter.organization_id is used to resolve the region
+```
+
+---
+
+## Authentication & Signing
+
+RPC calls between silos are signed with HMAC-SHA256 using `settings.RPC_SHARED_SECRET` (a list to support key rotation):
+
+- **Signing** (`generate_request_signature`): uses `secret[0]`, produces `rpc0:<hexdigest>` over `url_path:body`
+- **Verification** (`compare_signature`): tries all secrets in order; allows seamless key rotation
+- **Header**: `Authorization: Rpcsignature rpc0:<hexdigest>`
+- **Verified by**: `RpcSignatureAuthentication` (a DRF authentication class) before `InternalRpcServiceEndpoint` dispatches
+
+The signature covers both the URL path and the raw request body, so the signature cannot be replayed against a different endpoint.
+
+```python
+# generate_request_signature in rpc/service.py
+signature_input = b"%s:%s" % (url_path.encode("utf8"), body)
+secret = settings.RPC_SHARED_SECRET[0]
+signature = hmac.new(secret.encode("utf-8"), signature_input, hashlib.sha256).hexdigest()
+# → "rpc0:<hexdigest>"
+
+# compare_signature tries every secret in the list
+for key in settings.RPC_SHARED_SECRET:
+    computed = hmac.new(key.encode("utf-8"), signature_input, hashlib.sha256).hexdigest()
+    if hmac.compare_digest(computed, signature_data):
+        return True
+```
+
+---
+
+## Wire Format
+
+**Request** (POST to `/api/0/rpc/<service_key>/<method_name>/`):
+
+```json
+{
+    "meta": {},
+    "args": { "<kwarg_name>": <serialized_value>, ... }
+}
+```
+
+**Response** (200 OK):
+
+```json
+{
+    "meta": {},
+    "value": <serialized_return_value>
+}
+```
+
+Serialization uses Pydantic. `RpcModel` subclasses have `orm_mode = True` in their `Config` class by default (inherited from `RpcModel`), so they can be constructed directly from Django ORM objects.
+
+---
+
+## RPC Delegation: Local vs Remote
+
+```mermaid
+flowchart TD
+    Caller["Caller: my_service.get_thing(id=42)"]
+    Caller --> Delegator["DelegatedBySiloMode.__getattr__\nreads SiloMode.get_current_mode()"]
+
+    Delegator -->|"MONOLITH or\nlocal_mode matches"| LocalImpl["DatabaseBacked*Service.get_thing()\n(direct DB call)"]
+    Delegator -->|"Remote silo\n(e.g. REGION calling CONTROL service)"| RemotePath
+
+    subgraph RemotePath["Remote call path"]
+        Resolve["If local_mode == REGION:\n  resolve region via RegionResolutionStrategy\n  (queries OrganizationMapping)"]
+        Serialize["serialize_arguments(kwargs)\n→ ArgumentDict"]
+        BuildCall["_RemoteSiloCall(\n  region, service_key, method_name, args\n)"]
+        Sign["generate_request_signature(path, body)\n→ Authorization: Rpcsignature rpc0:..."]
+        HTTP["POST /api/0/rpc/<service>/<method>/\nto SENTRY_CONTROL_ADDRESS or region.address"]
+        Endpoint["InternalRpcServiceEndpoint.post()\nverifies signature via RpcSignatureAuthentication\ncalls dispatch_to_local_service()"]
+        Deserialize["deserialize_rpc_response()\n→ typed RpcModel or primitive"]
+    end
+
+    Resolve --> Serialize --> BuildCall --> Sign --> HTTP --> Endpoint --> Deserialize
+    Deserialize --> Caller
+```
+
+---
+
+## Retry & Error Handling
+
+- **503 is retried** — configured via `Retry(status_forcelist=[503])` with `backoff_factor=0.1`. Default retry count from `options.get("hybridcloud.rpc.retries")`.
+- **Per-method overrides** — `options.get("hybridcloud.rpc.method_retry_overrides")` and `"hybridcloud.rpc.method_timeout_overrides"` accept `{"service.method": count}` dicts.
+- **Other errors**: any non-200 response raises `RpcRemoteException`. 400 logs a warning; 403 raises "Unauthorized service access"; everything else raises "Service unavailable".
+- **Disabled methods** — `options.get("hybrid_cloud.rpc.disabled-service-methods")` can disable specific `"service.method"` strings, raising `RpcDisabledException`.
+
+---
+
+## Common Gotchas
+
+1. **No `from __future__ import annotations`** in `model.py` or `service.py` — Pydantic needs runtime type reflection. Both files should have a comment at the top explaining this.
+
+2. **Regional services must use `@regional_rpc_method`** — enforcement happens at class initialization (`__init_subclass__`), not at call time. If you define a method on a `local_mode = SiloMode.REGION` service with only `@rpc_method`, the class will raise `RpcServiceSetupException` when the module is imported.
+
+3. **No RPC calls inside DB transactions in tests** — `_fire_test_request` calls `in_test_assert_no_transaction()`, which raises if there is an active transaction. Calling `my_service.get_thing()` inside a `TestCase` method that wraps everything in a transaction will fail. Call the service before opening a transaction, or use `@pytest.mark.django_db(transaction=True)`.
+
+4. **Key rotation** — `RPC_SHARED_SECRET` is a list. Index `[0]` is used for signing; all entries are tried during verification. Add a new secret as `[1]`, deploy everywhere, then promote it to `[0]` and remove the old one.
+
+5. **Only 503 is retried** — other HTTP errors (4xx, 5xx except 503) fail immediately with `RpcRemoteException`. Don't expect automatic retry on 500.
+
+6. **`RegionMappingNotFound`** — if `OrganizationMapping` has no row for the given org, the resolver raises `RegionMappingNotFound`. Unless `return_none_if_mapping_not_found=True` is set on `@regional_rpc_method`, this propagates to the caller. Use that flag only on methods with `... | None` return types.
+
+7. **`key` must be unique and stable** — it appears in the RPC URL. Changing `key` breaks in-flight calls during a rolling deploy. Conflicting keys raise `RpcServiceSetupException` when `create_delegation()` writes to the global registry.
+
+8. **`impl.py` is lazy-imported** — `get_local_implementation()` must import the implementation class inside the function body to avoid circular imports. This is the one place where intra-function imports are expected.
+
+9. \*\*Deployments are in Region -> Control order, meaning deprecations and modifications to the RPC signature must also be ordered with this in mind. Swapping a parameter on a Control RPC would look like:
+   1. Creating a new **optional** parameter on the service method, making the old option optional, deploying the change fully to production.
+   2. Make the old parameter optional, while updating the Control service handler code to use the new parameter by default, but gracefully handle the old case, deploying this change fully to production.
+   3. Remove the old optional parameter and its usage from the Control service code.
+
+---
+
+## Finding Existing Services
+
+RPC services are registered from these packages (see `list_all_service_method_signatures` in `rpc/service.py`):
+
+```
+sentry.auth.services
+sentry.audit_log.services
+sentry.backup.services
+sentry.hybridcloud.services
+sentry.identity.services
+sentry.integrations.services
+sentry.issues.services
+sentry.notifications.services
+sentry.organizations.services
+sentry.projects.services
+sentry.sentry_apps.services
+sentry.users.services
+```
+
+To find all services:
+
+```bash
+grep -r "local_mode = SiloMode" src/sentry --include="*.py" -l
+```
+
+To find all region-scoped service methods:
+
+```bash
+grep -r "@regional_rpc_method" src/sentry --include="*.py" -l
+```


### PR DESCRIPTION
Adds core documentation for Hybrid Cloud infrastructure, specifically:
1. RPC services
2. Outboxes & Replication

This will be used to synthesize skills, or at the very least, serve as system prompts to be appended
