### PR TITLE
fix(codeowners): Add trailing slashes to preprod directory rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -700,8 +700,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /fixtures/safe_migrations_apps/                          @getsentry/owners-migrations
 
 # Preprod build artifact analysis
-/src/sentry/preprod                                   @getsentry/emerge-tools
-/static/app/views/preprod                             @getsentry/emerge-tools
+/src/sentry/preprod/                                   @getsentry/emerge-tools
+/static/app/views/preprod/                             @getsentry/emerge-tools
 /tests/sentry/preprod/                                @getsentry/emerge-tools
 # End of preprod
 


### PR DESCRIPTION
The preprod CODEOWNERS rules for `src/sentry/preprod` and `static/app/views/preprod` were missing trailing slashes, causing them to potentially match files with the `preprod` prefix rather than just the directories.

Adding trailing slashes ensures consistent directory-only matching, aligning with the existing `tests/sentry/preprod/` rule that already had it.