### PR TITLE
fix(codeowners): Add trailing slashes to directory patterns for recursive matching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,10 +77,10 @@ Makefile                                                 @getsentry/owners-sentr
 .pre-commit-config.yaml                                  @getsentry/owners-sentry-dev @getsentry/dev-infra
 .git-blame-ignore-revs                                   @getsentry/owners-sentry-dev
 
-/fixtures/stubs-for-mypy                                 @getsentry/python-typing
+/fixtures/stubs-for-mypy/                                @getsentry/python-typing
 /src/sentry/conf/types/                                  @getsentry/python-typing
 /src/sentry/types/                                       @getsentry/python-typing
-/tests/tools/mypy_helpers                                @getsentry/python-typing
+/tests/tools/mypy_helpers/                               @getsentry/python-typing
 /tools/mypy_helpers/                                     @getsentry/python-typing
 
 ## GitHub Routing Automations - notion.so/473791bae5bf43399d46093050b77bf0
@@ -108,7 +108,7 @@ Makefile                                                 @getsentry/owners-sentr
 /.github/workflows/release.yml                           @getsentry/release-approvers
 /scripts/bump-version.sh                                 @getsentry/release-approvers
 /scripts/post-release.sh                                 @getsentry/release-approvers
-/self-hosted                                             @getsentry/release-approvers
+/self-hosted/                                            @getsentry/release-approvers
 setup.cfg                                                @getsentry/release-approvers
 requirements*.txt                                        @getsentry/owners-python-build
 pyproject.toml                                           @getsentry/owners-python-build
@@ -136,19 +136,19 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 # always be the case.
 
 ## Auth v2
-/static/app/views/authV2                                 @getsentry/owners-auth @getsentry/security
-/src/sentry/auth_v2                                      @getsentry/owners-auth @getsentry/security
-/tests/sentry/auth_v2                                    @getsentry/owners-auth @getsentry/security
+/static/app/views/authV2/                                @getsentry/owners-auth @getsentry/security
+/src/sentry/auth_v2/                                     @getsentry/owners-auth @getsentry/security
+/tests/sentry/auth_v2/                                   @getsentry/owners-auth @getsentry/security
 ## End of Auth v2
 
 ## Crons
-/src/sentry/monitors                                     @getsentry/crons
-/tests/sentry/monitors                                   @getsentry/crons
+/src/sentry/monitors/                                    @getsentry/crons
+/tests/sentry/monitors/                                  @getsentry/crons
 ## End Crons
 
 ## Uptime
-/src/sentry/uptime                                       @getsentry/crons
-/tests/sentry/uptime                                     @getsentry/crons
+/src/sentry/uptime/                                      @getsentry/crons
+/tests/sentry/uptime/                                    @getsentry/crons
 ## End Uptime
 
 ## Issue Detection Lower Priority
@@ -158,7 +158,7 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 
 ## Hybrid Cloud
 /src/sentry/silo/                                        @getsentry/hybrid-cloud
-/src/sentry/hybridcloud                                  @getsentry/hybrid-cloud
+/src/sentry/hybridcloud/                                 @getsentry/hybrid-cloud
 /src/sentry/middleware/customer_domain.py                @getsentry/hybrid-cloud
 /src/sentry/middleware/subdomain.py                      @getsentry/hybrid-cloud
 /src/sentry/api/endpoints/internal/rpc.py                @getsentry/hybrid-cloud
@@ -244,8 +244,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 /static/app/components/events/eventStatisticalDetector/                     @getsentry/data-browsing @getsentry/profiling
 
-/src/sentry/statistical_detectors                                           @getsentry/data-browsing @getsentry/profiling
-/tests/sentry/statistical_detectors                                         @getsentry/data-browsing @getsentry/profiling
+/src/sentry/statistical_detectors/                                          @getsentry/data-browsing @getsentry/profiling
+/tests/sentry/statistical_detectors/                                        @getsentry/data-browsing @getsentry/profiling
 
 /src/sentry/tasks/statistical_detectors.py                                  @getsentry/data-browsing @getsentry/profiling
 /tests/sentry/tasks/test_statistical_detectors.py                           @getsentry/data-browsing @getsentry/profiling
@@ -298,15 +298,15 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 
 ## Profiling
-/static/app/components/profiling                                      @getsentry/profiling
+/static/app/components/profiling/                                     @getsentry/profiling
 /static/app/types/jsSelfProfiling.d.ts                                @getsentry/profiling
 /static/app/types/profiling.d.ts                                      @getsentry/profiling
-/static/app/utils/profiling                                           @getsentry/profiling
-/static/app/views/profiling                                           @getsentry/profiling
+/static/app/utils/profiling/                                          @getsentry/profiling
+/static/app/views/profiling/                                          @getsentry/profiling
 /src/sentry/api/endpoints/project_profiling_profile.py                @getsentry/profiling
 /src/sentry/api/endpoints/organization_profiling_profiles.py          @getsentry/profiling
-/src/sentry/profiles                                                  @getsentry/profiling
-/tests/sentry/profiles                                                @getsentry/profiling
+/src/sentry/profiles/                                                 @getsentry/profiling
+/tests/sentry/profiles/                                               @getsentry/profiling
 /tests/sentry/api/endpoints/test_project_profiling_profile.py         @getsentry/profiling
 /tests/sentry/api/endpoints/test_organization_profiling_profiles.py   @getsentry/profiling
 /tests/sentry/profiling/                                              @getsentry/profiling
@@ -380,7 +380,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 
 ## Integrations
 /src/sentry/sentry_apps/                                             @getsentry/product-owners-settings-integrations @getsentry/ecosystem
-/tests/sentry/sentry_apps                                            @getsentry/product-owners-settings-integrations @getsentry/ecosystem
+/tests/sentry/sentry_apps/                                           @getsentry/product-owners-settings-integrations @getsentry/ecosystem
 /src/sentry/utils/sentry_apps/                                       @getsentry/ecosystem
 /src/sentry/api/endpoints/project_rule*.py                           @getsentry/alerts-notifications
 /src/sentry/api/serializers/models/rule.py                           @getsentry/alerts-notifications
@@ -454,13 +454,13 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/auth/superuser.py                                           @getsentry/enterprise
 /src/sentry/middleware/staff.py                                         @getsentry/enterprise
 /src/sentry/middleware/superuser.py                                     @getsentry/enterprise
-/src/sentry/models/release_threshold                                    @getsentry/enterprise
+/src/sentry/models/release_threshold/                                   @getsentry/enterprise
 /src/sentry/scim/                                                       @getsentry/enterprise
 /src/sentry/integrations/github/                                        @getsentry/enterprise @getsentry/scm
 /src/sentry/web/frontend/auth_login.py                                  @getsentry/enterprise
 /static/app/components/superuserStaffAccessForm.tsx                     @getsentry/enterprise
 /static/app/constants/superuserAccessErrors.tsx                         @getsentry/enterprise
-/static/app/views/organizationStats                                     @getsentry/enterprise
+/static/app/views/organizationStats/                                    @getsentry/enterprise
 /static/app/views/settings/organizationAuth/                            @getsentry/enterprise
 /static/app/views/settings/organizationMembers/inviteBanner.tsx         @getsentry/enterprise
 /tests/sentry/api/endpoints/test_auth*.py                               @getsentry/enterprise
@@ -594,7 +594,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/events/eventTags/                    @getsentry/issue-workflow
 /static/app/components/events/highlights/                   @getsentry/issue-workflow
 /static/app/components/issues/                              @getsentry/issue-workflow
-/static/app/views/issueList                                 @getsentry/issue-workflow
+/static/app/views/issueList/                                @getsentry/issue-workflow
 /static/app/views/issueDetails/                             @getsentry/issue-workflow
 /static/app/views/nav/secondary/sections/issues/            @getsentry/issue-workflow
 /static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx @getsentry/issue-detection-frontend


### PR DESCRIPTION
Related: https://github.com/getsentry/sentry/pull/108485

Per GitHub's gitignore-style matching rules, a CODEOWNERS pattern like
`/src/sentry/monitors` only matches that exact path — not files inside
the directory. Adding a trailing `/` makes the pattern match recursively,
which is the intended behavior for directory ownership rules.

This fixes 22 directory patterns that were missing trailing slashes.
The 2 `emerge-tools` patterns (`/src/sentry/preprod`, `/static/app/views/preprod`)
are left unchanged as they are being handled separately.