### PR TITLE
Release list local times

### DIFF
--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -13,11 +13,11 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import Collapsible from 'sentry/components/collapsible';
+import {DateTime} from 'sentry/components/dateTime';
 import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import Panel from 'sentry/components/panels/panel';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import TextOverflow from 'sentry/components/textOverflow';
-import TimeSince from 'sentry/components/timeSince';
 import Version from 'sentry/components/version';
 import {IconCheckmark} from 'sentry/icons/iconCheckmark';
 import {t, tct, tn} from 'sentry/locale';
@@ -152,12 +152,11 @@ function ReleaseCard({
                   </TextOverflow>
                 )}
               </PackageName>
-              <TimeSince
-                tooltipPrefix={lastDeploy?.dateFinished ? t('Finished:') : t('Created:')}
-                date={lastDeploy?.dateFinished || dateCreated}
-              />
-              {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
-              &nbsp;
+              <div>
+                {lastDeploy?.dateFinished ? t('Finished:') : t('Created:')}{' '}
+                <DateTime date={lastDeploy?.dateFinished || dateCreated} seconds={false} />
+                {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
+              </div>
             </Container>
             <FinalizeWrapper>
               {release.dateReleased ? (

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -154,7 +154,10 @@ function ReleaseCard({
               </PackageName>
               <div>
                 {lastDeploy?.dateFinished ? t('Finished:') : t('Created:')}{' '}
-                <DateTime date={lastDeploy?.dateFinished || dateCreated} seconds={false} />
+                <DateTime
+                  date={lastDeploy?.dateFinished || dateCreated}
+                  seconds={false}
+                />
                 {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
               </div>
             </Container>


### PR DESCRIPTION
<!-- Replaces relative "time since" with absolute user-local timestamps in the release list. This provides more valuable and precise information about when releases were created or finished, leveraging the existing `DateTime` component for consistent formatting and timezone handling. -->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/CQDHVRS2W/p1771444382758339?thread_ts=1771444382.758339&cid=CQDHVRS2W)

<p><a href="https://cursor.com/background-agent?bcId=bc-9b6c2972-8bd7-5a0c-89b5-7f8938c2545b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b6c2972-8bd7-5a0c-89b5-7f8938c2545b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

