### PR TITLE
fix(issues): Raise DoesNotExist for group IDs exceeding field max value

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -314,7 +314,7 @@ class BaseModel(models.Model):
 
 
 class Model(BaseModel):
-    id: models.Field[int, int] = BoundedBigAutoField(primary_key=True)
+    id = BoundedBigAutoField(primary_key=True)
 
     class Meta:
         abstract = True

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -704,7 +704,7 @@ def snapshot_alert_rule(alert_rule: AlertRule, user: RpcUser | User | None = Non
 
         TODO: Refactor to not violate the type system
         """
-        model.id = None  # type: ignore[assignment]
+        model.id = None
 
     # Creates an archived alert_rule using the same properties as the passed rule
     # It will also resolve any incidents attached to this rule.

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-import warnings
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
@@ -125,6 +124,11 @@ def get_group_with_redirect(id_or_qualified_short_id, queryset=None, organizatio
         }
     else:
         short_id = None
+        # Validate that the numeric ID doesn't exceed the max value for the
+        # bounded field, otherwise the ORM will raise an AssertionError.
+        max_id = Group._meta.get_field("id").MAX_VALUE
+        if int(id_or_qualified_short_id) > max_id:
+            raise Group.DoesNotExist()
         params = {"id": id_or_qualified_short_id}
 
     try:

--- a/src/sentry/receivers/owners.py
+++ b/src/sentry/receivers/owners.py
@@ -12,7 +12,7 @@ def _assert_org_has_owner_not_from_team(organization, top_role):
 def prevent_demoting_last_owner(instance: OrganizationMember, **kwargs):
     # if a member is being created
     if instance.id is None:
-        return  # type: ignore[unreachable]
+        return
 
     try:
         member = OrganizationMember.objects.get(id=instance.id)

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -598,7 +598,7 @@ def start_group_reprocessing(
 
         # Create a duplicate row that has the same attributes by nulling out
         # the primary key and saving
-        group.pk = group.id = None  # type: ignore[assignment]  # XXX: intentional resetting pk
+        group.pk = group.id = None  # XXX: intentional resetting pk
         new_group = group  # rename variable just to avoid confusion
         del group
 

--- a/src/sentry/utils/snowflake.py
+++ b/src/sentry/utils/snowflake.py
@@ -60,7 +60,7 @@ def save_with_snowflake_id(
                 save_callback()
             return
         except IntegrityError:
-            instance.id = None  # type: ignore[assignment]  # see typeddjango/django-stubs#2014
+            instance.id = None
     raise MaxSnowflakeRetryError
 
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -2554,7 +2554,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "permissions": {"isEditableByEveryone": "False"},
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2571,7 +2571,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "permissions": {"isEditableByEveryone": "false"},
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2591,7 +2591,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         }
 
         assert permission.is_editable_by_everyone is True
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2771,7 +2771,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             },
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2807,7 +2807,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             },
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2838,7 +2838,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             },
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2865,7 +2865,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         self.create_environment(project=mock_project, name="mock_env")
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data
@@ -2911,7 +2911,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             },
         }
 
-        user = User(id=self.dashboard.created_by_id)  # type: ignore[misc]
+        user = User(id=self.dashboard.created_by_id)
         self.login_as(user=user)
         response = self.do_request(
             "put", f"{self.url(self.dashboard.id)}?environment=mock_env", data=data

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -99,6 +99,10 @@ class GroupTest(TestCase, SnubaTestCase):
         with pytest.raises(Group.DoesNotExist):
             get_group_with_redirect(duplicate_id)
 
+    def test_get_group_with_redirect_overflow_id(self) -> None:
+        with pytest.raises(Group.DoesNotExist):
+            get_group_with_redirect("12345678901234567890")
+
     def test_get_group_with_redirect_from_qualified_short_id(self) -> None:
         group = self.create_group()
         assert group.qualified_short_id


### PR DESCRIPTION
Fixes SENTRY-5HYR

Note, this also removes the overly generic type annotation on Model.id which is where the vast majority of the diff here comes from - nice win to remove a bunch of type ignores.

The `models.Field[int, int]` annotation was added in 2023 when django-stubs couldn't infer the type from BoundedBigAutoField. This is no longer needed and was hiding the MAX_VALUE attribute from mypy, causing an attr-defined error in group.py.