### PR TITLE
RFC: feat(typing): Type model int primary keys as Id[Model].

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -21,6 +21,7 @@ from sentry.backup.scopes import ImportScope, RelocationScope
 from sentry.db.models.fields.uuid import UUIDField
 from sentry.db.models.manager.base import BaseManager, create_silo_limited_copy
 from sentry.silo.base import SiloLimit, SiloMode
+from sentry.types.id import Id
 
 from .fields.bounded import BoundedBigAutoField
 from .query import update
@@ -314,7 +315,7 @@ class BaseModel(models.Model):
 
 
 class Model(BaseModel):
-    id: models.Field[int, int] = BoundedBigAutoField(primary_key=True)
+    id: models.Field[int, Id[Self]] = BoundedBigAutoField(primary_key=True)
 
     class Meta:
         abstract = True

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -131,6 +131,7 @@ from sentry.tasks.process_buffer import buffer_incr
 from sentry.tsdb.base import TSDBModel
 from sentry.types.activity import ActivityType
 from sentry.types.group import GroupSubStatus, PriorityLevel
+from sentry.types.id import Id
 from sentry.usage_accountant import record
 from sentry.utils import metrics
 from sentry.utils.audit import create_system_audit_entry
@@ -333,7 +334,7 @@ def increment_group_tombstone_hit_counter(tombstone_id: int | None, event: Event
         logger.exception("Failed to update GroupTombstone count for id: %s", tombstone_id)
 
 
-ProjectsMapping = Mapping[int, Project]
+ProjectsMapping = Mapping[Id[Project], Project]
 
 Job = MutableMapping[str, Any]
 
@@ -1448,7 +1449,9 @@ def handle_existing_grouphash(
     # this function had races around group creation which made this race
     # more user visible. For more context, see 84c6f75a and d0e22787, as
     # well as GH-5085.
-    group = Group.objects.get(id=existing_grouphash.group_id)
+    group_id = existing_grouphash.group_id
+    assert group_id is not None
+    group = Group.objects.get(id=group_id)
 
     # As far as we know this has never happened, but in theory at least, the error event hashing
     # algorithm and other event hashing algorithms could come up with the same hash value in the

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-import warnings
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable, Mapping, Sequence
 from datetime import datetime, timedelta
@@ -54,6 +53,7 @@ from sentry.types.group import (
     UNRESOLVED_SUBSTATUS_CHOICES,
     GroupSubStatus,
 )
+from sentry.types.id import Id
 from sentry.utils import metrics
 from sentry.utils.dates import outside_retention_with_modified_start
 from sentry.utils.numbers import base32_decode, base32_encode
@@ -332,11 +332,11 @@ class GroupManager(BaseManager["Group"]):
             .with_post_update_signal(options.get("groups.enable-post-update-signal"))
         )
 
-    def by_qualified_short_id(self, organization_id: int, short_id: str):
+    def by_qualified_short_id(self, organization_id: Id[Organization], short_id: str):
         return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]
 
     def by_qualified_short_id_bulk(
-        self, organization_id: int, short_ids_raw: list[str]
+        self, organization_id: Id[Organization], short_ids_raw: list[str]
     ) -> Sequence[Group]:
         short_ids = []
         for short_id_raw in short_ids_raw:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -41,6 +41,7 @@ from sentry.locks import locks
 from sentry.models.grouplink import GroupLink
 from sentry.models.team import Team
 from sentry.notifications.services import notifications_service
+from sentry.types.id import Id
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
@@ -174,7 +175,7 @@ GETTING_STARTED_DOCS_PLATFORMS = [
 
 
 class ProjectManager(BaseManager["Project"]):
-    def get_by_users(self, users: Iterable[User | RpcUser]) -> dict[int, set[int]]:
+    def get_by_users(self, users: Iterable[User | RpcUser]) -> dict[int, set[Id[Project]]]:
         """Given a list of users, return a mapping of each user to the projects they are a member of."""
         project_rows = self.filter(
             projectteam__team__organizationmemberteam__is_active=True,
@@ -185,7 +186,7 @@ class ProjectManager(BaseManager["Project"]):
             "id", "projectteam__team__organizationmemberteam__organizationmember__user_id"
         )
 
-        projects_by_user_id = defaultdict(set)
+        projects_by_user_id = defaultdict[int, set[Id["Project"]]](set)
         for project_id, user_id in project_rows:
             if user_id is not None:
                 projects_by_user_id[user_id].add(project_id)
@@ -551,14 +552,14 @@ class Project(Model):
             for model in ReleaseProject, ReleaseProjectEnvironment, EnvironmentProject:
                 model.objects.filter(project_id=self.id).delete()
 
-        rules_by_environment_id = defaultdict(set)
+        rules_by_environment_id = defaultdict[int, set[Id[Rule]]](set)
         for rule_id, environment_id in Rule.objects.filter(
             project_id=self.id, environment_id__isnull=False
         ).values_list("id", "environment_id"):
             assert environment_id is not None
             rules_by_environment_id[environment_id].add(rule_id)
 
-        environment_names = dict(
+        environment_names = dict[int, str](
             Environment.objects.filter(organization_id=old_org_id).values_list("id", "name")
         )
 
@@ -618,7 +619,7 @@ class Project(Model):
 
         # [Rule, AlertRule(SnubaQuery->Environment)]
         # id -> name
-        environment_names_with_alerts = {
+        environment_names_with_alerts: dict[int, str] = {
             **environment_names,
             **{
                 env_id: env_name

--- a/src/sentry/types/__init__.py
+++ b/src/sentry/types/__init__.py
@@ -7,3 +7,5 @@ anywhere in this directory.
 There are going to naming collisions between classes like "Type" and "Status".
 The best way to resolve this is to prefix them with more context.
 """
+
+from sentry.types.id import Id as Id

--- a/src/sentry/types/id.py
+++ b/src/sentry/types/id.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+_M = TypeVar("_M")
+
+
+class Id(int, Generic[_M]):
+    """
+    Typed integer ID parameterized by model type.
+
+    Id[Organization] and Id[Project] are distinct at type-check time
+    but both are plain ints at runtime.
+    """
+
+    pass

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_group_history_serializer.py
@@ -39,10 +39,12 @@ class _Result(TypedDict):
 
 
 def convert_results(results: Sequence[_Result]) -> Sequence[WorkflowGroupHistory]:
-    group_lookup = {g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])}
+    group_lookup: dict[int, Group] = {
+        g.id: g for g in Group.objects.filter(id__in=[r["group"] for r in results])
+    }
 
     detector_ids = [r["group_detector_id"] for r in results if r["group_detector_id"] is not None]
-    detector_lookup = {}
+    detector_lookup: dict[int, Detector] = {}
     if detector_ids:
         detector_lookup = {d.id: d for d in Detector.objects.filter(id__in=detector_ids)}
 

--- a/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/workflow_serializer.py
@@ -92,8 +92,9 @@ class WorkflowSerializer(Serializer):
             detectors_map[workflow_id].append(str(detector_id))
 
         for item in item_list:
-            attrs[item]["triggers"] = trigger_condition_map.get(
-                item.when_condition_group_id
+            wdcg_id = item.when_condition_group_id
+            attrs[item]["triggers"] = (
+                trigger_condition_map.get(wdcg_id) if wdcg_id is not None else None
             )  # when condition group
             attrs[item]["actionFilters"] = dcg_map.get(
                 item.id, []

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -15,6 +15,9 @@ from sentry.issues.constants import (
     get_issue_tsdb_user_group_model,
 )
 from sentry.issues.grouptype import GroupCategory, get_group_type_by_type_id
+from sentry.models.group import Group
+from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.rules.conditions.event_attribute import ATTR_CHOICES
 from sentry.rules.conditions.event_frequency import (
     MIN_SESSIONS_TO_FIRE,
@@ -24,6 +27,7 @@ from sentry.rules.conditions.event_frequency import (
 )
 from sentry.rules.match import MatchType
 from sentry.tsdb.base import SnubaCondition, TSDBKey, TSDBModel
+from sentry.types.id import Id
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import Registry
 from sentry.utils.snuba import options_override
@@ -34,10 +38,10 @@ QueryResult = dict[int, int | float]
 
 
 class GroupValues(TypedDict):
-    id: int
+    id: Id[Group]
     type: int
-    project_id: int
-    project__organization_id: int
+    project_id: Id[Project]
+    project__organization_id: Id[Organization]
 
 
 class TSDBFunction(Protocol):
@@ -338,7 +342,7 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
         category_group_ids = self.get_group_ids_by_category(groups)
         organization_id = self.get_value_from_groups(groups, "project__organization_id")
         # Build project_ids list from incoming groups
-        project_ids = list({g["project_id"] for g in groups}) if groups else []
+        project_ids: list[int] = list({g["project_id"] for g in groups}) if groups else []
 
         if not organization_id:
             return batch_sums

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -129,7 +129,7 @@ def update_workflow_action_group_statuses(
     with connection.cursor() as cursor:
         # Build values for batch insert
         values_placeholders = []
-        values_data = []
+        values_data: list[int | datetime] = []
         for s in missing_statuses:
             values_placeholders.append("(%s, %s, %s, %s, %s)")
             values_data.extend([s.workflow_id, s.action_id, s.group_id, now, now])
@@ -146,7 +146,7 @@ def update_workflow_action_group_statuses(
         created_rows = set(cursor.fetchall())  # Only returns newly inserted rows
 
     # Figure out which ones conflicted (weren't returned)
-    conflicted_statuses = [
+    conflicted_statuses: ConflictedStatuses = [
         (s.workflow_id, s.action_id)
         for s in missing_statuses
         if (s.workflow_id, s.action_id) not in created_rows
@@ -241,10 +241,10 @@ def filter_recently_fired_workflow_actions(
     )
 
     # if statuses were not created for some reason, we should not fire for them
-    for workflow_id, action_id in conflicted_statuses:
-        action_to_workflows_ids[action_id].remove(workflow_id)
-        if not action_to_workflows_ids[action_id]:
-            action_to_workflows_ids.pop(action_id)
+    for conflicted_wf_id, conflicted_act_id in conflicted_statuses:
+        action_to_workflows_ids[conflicted_act_id].remove(conflicted_wf_id)
+        if not action_to_workflows_ids[conflicted_act_id]:
+            action_to_workflows_ids.pop(conflicted_act_id)
 
     actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
 

--- a/src/sentry/workflow_engine/processors/data_condition_group.py
+++ b/src/sentry/workflow_engine/processors/data_condition_group.py
@@ -5,6 +5,7 @@ from typing import ClassVar, NoReturn, TypeVar
 
 import sentry_sdk
 
+from sentry.types.id import Id
 from sentry.utils.function_cache import cache_func_for_models
 from sentry.workflow_engine.models import DataCondition, DataConditionGroup
 from sentry.workflow_engine.models.data_condition import is_slow_condition
@@ -185,7 +186,7 @@ DataConditionGroupResult = tuple[ProcessedDataConditionGroup, list[DataCondition
 
 # We use a defined function rather than a lambda below because otherwise
 # parameter type becomes Any.
-def _group_id_from_condition(condition: DataCondition) -> tuple[int]:
+def _group_id_from_condition(condition: DataCondition) -> tuple[Id[DataConditionGroup]]:
     return (condition.condition_group_id,)
 
 
@@ -193,12 +194,16 @@ def _group_id_from_condition(condition: DataCondition) -> tuple[int]:
     [(DataCondition, _group_id_from_condition)],
     recalculate=False,
 )
-def get_data_conditions_for_group(data_condition_group_id: int) -> list[DataCondition]:
+def get_data_conditions_for_group(
+    data_condition_group_id: Id[DataConditionGroup],
+) -> list[DataCondition]:
     return list(DataCondition.objects.filter(condition_group_id=data_condition_group_id))
 
 
 @scopedstats.timer()
-def _get_data_conditions_for_group_shim(data_condition_group_id: int) -> list[DataCondition]:
+def _get_data_conditions_for_group_shim(
+    data_condition_group_id: Id[DataConditionGroup],
+) -> list[DataCondition]:
     """
     Wrapper for single item use case so we can easily time it.
     We can't timer() get_data_conditions_for_group because it's a CachedFunction, and
@@ -209,8 +214,8 @@ def _get_data_conditions_for_group_shim(data_condition_group_id: int) -> list[Da
 
 @sentry_sdk.trace
 def get_slow_conditions_for_groups(
-    data_condition_group_ids: list[int],
-) -> dict[int, list[DataCondition]]:
+    data_condition_group_ids: list[Id[DataConditionGroup]],
+) -> dict[Id[DataConditionGroup], list[DataCondition]]:
     """
     Takes a list of DataConditionGroup IDs and returns a dict with
     the slow conditions associated with each ID.

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, validator
 
 from sentry import features, nodestore
 from sentry.issues.issue_occurrence import IssueOccurrence
+from sentry.models.environment import Environment
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -21,6 +22,7 @@ from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.post_process import should_retry_fetch
 from sentry.taskworker.retry import retry_task
 from sentry.taskworker.state import current_task
+from sentry.types.id import Id
 from sentry.utils import metrics
 from sentry.utils.iterators import chunked
 from sentry.utils.registry import NoRegistrationExistsError
@@ -58,9 +60,10 @@ logger = log_context.get_logger("sentry.workflow_engine.processors.delayed_workf
 EVENT_LIMIT = 100
 COMPARISON_INTERVALS_VALUES = {k: v[1] for k, v in COMPARISON_INTERVALS.items()}
 
-GroupId: TypeAlias = int
-DataConditionGroupId: TypeAlias = int
-WorkflowId: TypeAlias = int
+EnvironmentId: TypeAlias = Id[Environment]
+GroupId: TypeAlias = Id[Group]
+DataConditionGroupId: TypeAlias = Id[DataConditionGroup]
+WorkflowId: TypeAlias = Id[Workflow]
 
 
 class EventInstance(BaseModel):
@@ -113,11 +116,11 @@ class EventKey:
         if len(parts) != 5:
             raise ValueError(f"Invalid key: {key}")
         return cls(
-            workflow_id=int(parts[0]),
-            group_id=int(parts[1]),
-            when_dcg_id=int(parts[2]) if parts[2] else None,
-            if_dcg_ids=frozenset(int(dcg_id) for dcg_id in parts[3].split(",") if dcg_id),
-            passing_dcg_ids=frozenset(int(dcg_id) for dcg_id in parts[4].split(",") if dcg_id),
+            workflow_id=Id(int(parts[0])),
+            group_id=Id(int(parts[1])),
+            when_dcg_id=Id(int(parts[2])) if parts[2] else None,
+            if_dcg_ids=frozenset(Id(int(dcg_id)) for dcg_id in parts[3].split(",") if dcg_id),
+            passing_dcg_ids=frozenset(Id(int(dcg_id)) for dcg_id in parts[4].split(",") if dcg_id),
             original_key=key,
         )
 
@@ -273,7 +276,7 @@ class UniqueConditionQuery:
 
     handler: type[BaseEventFrequencyQueryHandler]
     interval: str
-    environment_id: int | None
+    environment_id: EnvironmentId | None
     comparison_interval: str | None = None
     # Hashable representation of the filters
     frozen_filters: Sequence[frozenset[tuple[str, Any]]] | None = None
@@ -313,13 +316,9 @@ def fetch_project(project_id: int) -> Project | None:
 
 def fetch_workflows_envs(
     workflow_ids: list[WorkflowId],
-) -> Mapping[WorkflowId, int | None]:
-    return {
-        workflow_id: env_id
-        for workflow_id, env_id in Workflow.objects.filter(id__in=workflow_ids).values_list(
-            "id", "environment_id"
-        )
-    }
+) -> Mapping[WorkflowId, EnvironmentId | None]:
+    rows = Workflow.objects.filter(id__in=workflow_ids).values_list("id", "environment_id")
+    return {workflow_id: env_id for workflow_id, env_id in rows}
 
 
 def fetch_data_condition_groups(
@@ -333,7 +332,7 @@ def fetch_data_condition_groups(
 
 
 def generate_unique_queries(
-    condition: DataCondition, environment_id: int | None
+    condition: DataCondition, environment_id: EnvironmentId | None
 ) -> list[UniqueConditionQuery]:
     """
     Returns a list of all unique condition queries that must be made for the
@@ -390,7 +389,7 @@ def generate_unique_queries(
 def get_condition_query_groups(
     data_condition_groups: list[DataConditionGroup],
     event_data: EventRedisData,
-    workflows_to_envs: Mapping[WorkflowId, int | None],
+    workflows_to_envs: Mapping[WorkflowId, EnvironmentId | None],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
 ) -> dict[UniqueConditionQuery, GroupQueryParams]:
     """
@@ -472,7 +471,7 @@ def get_condition_group_results(
                 comparison_interval=comparison_interval,
                 filters=unique_condition.filters,
             )
-            absent_group_ids = group_ids - set(result.keys())
+            absent_group_ids = group_ids - result.keys()
             if absent_group_ids:
                 logger.warning(
                     "workflow_engine.delayed_workflow.absent_group_ids",
@@ -508,7 +507,7 @@ def _evaluate_group_result_for_dcg(
     dcg: DataConditionGroup,
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],
     group_id: GroupId,
-    workflow_env: int | None,
+    workflow_env: EnvironmentId | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
 ) -> TriggerResult:
     slow_conditions = dcg_to_slow_conditions[dcg.id]
@@ -530,7 +529,7 @@ def _evaluate_group_result_for_dcg(
 def _group_result_for_dcg(
     group_id: GroupId,
     dcg: DataConditionGroup,
-    workflow_env: int | None,
+    workflow_env: EnvironmentId | None,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     slow_conditions: list[DataCondition],
 ) -> TriggerResult:
@@ -559,7 +558,7 @@ class _ConditionEvaluationStats:
 @sentry_sdk.trace
 def get_groups_to_fire(
     data_condition_groups: list[DataConditionGroup],
-    workflows_to_envs: Mapping[WorkflowId, int | None],
+    workflows_to_envs: Mapping[WorkflowId, EnvironmentId | None],
     event_data: EventRedisData,
     condition_group_results: dict[UniqueConditionQuery, QueryResult],
     dcg_to_slow_conditions: dict[DataConditionGroupId, list[DataCondition]],

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -11,6 +11,7 @@ from sentry import features
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.services.eventstore.models import GroupEvent
+from sentry.types.id import Id
 from sentry.workflow_engine.buffer.batch_client import DelayedWorkflowClient, DelayedWorkflowItem
 from sentry.workflow_engine.caches.workflow import get_workflows_by_detectors
 from sentry.workflow_engine.models import DataConditionGroup, Detector, DetectorWorkflow, Workflow
@@ -83,7 +84,9 @@ def enqueue_workflows(
 
 
 @scopedstats.timer()
-def _get_data_conditions_for_group_by_dcg(dcg_ids: Sequence[int]) -> dict[int, list[DataCondition]]:
+def _get_data_conditions_for_group_by_dcg(
+    dcg_ids: Sequence[Id[DataConditionGroup]],
+) -> dict[Id[DataConditionGroup], list[DataCondition]]:
     """
     Given a list of DataConditionGroup IDs, return a dict mapping them to their DataConditions.
     Fetching them individually as needed is typically simple; this is for cases where the performance

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -12,6 +12,7 @@ from sentry_sdk import logger as sentry_logger
 
 from sentry import features, options
 from sentry.types.group import PriorityLevel
+from sentry.types.id import Id
 
 if TYPE_CHECKING:
     from sentry.deletions.base import ModelRelation
@@ -120,7 +121,7 @@ class WorkflowEvaluationSnapshot(TypedDict):
     associated_detector: DetectorSnapshot | None
     event_id: str | None  # ID in NodeStore
     group: Group | None
-    workflow_ids: list[int] | None
+    workflow_ids: list[Id[Workflow]] | None
     triggered_workflows: list[WorkflowSnapshot] | None
     delayed_conditions: list[str] | None
     action_filter_conditions: list[DataConditionGroupSnapshot] | None

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -214,6 +214,7 @@ class DetectorValidatorTest(BaseValidatorTest):
         assert data_source.organization_id == self.project.organization_id
 
         # Verify condition group in DB
+        assert detector.workflow_condition_group_id is not None
         condition_group = DataConditionGroup.objects.get(id=detector.workflow_condition_group_id)
         assert condition_group.logic_type == DataConditionGroup.Type.ANY
         assert condition_group.organization_id == self.project.organization_id

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -154,7 +154,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status = WorkflowActionGroupStatus.objects.create(
             workflow=self.workflow, action=self.action, group=self.group
         )
-        workflow_ids = {self.workflow.id, workflow.id}
+        workflow_ids: set[int] = {self.workflow.id, workflow.id}
 
         action_to_statuses = get_workflow_action_group_statuses(
             {self.action.id: {self.workflow.id}}, self.group, workflow_ids
@@ -181,8 +181,14 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         status_2.update(date_updated=timezone.now() - timedelta(days=1, minutes=1))
 
         workflows = Workflow.objects.all()
-        action_to_statuses = {self.action.id: [status], action.id: [status_2]}
-        action_to_workflows_ids = {self.action.id: {self.workflow.id}, action.id: {workflow.id}}
+        action_to_statuses: dict[int, list[WorkflowActionGroupStatus]] = {
+            self.action.id: [status],
+            action.id: [status_2],
+        }
+        action_to_workflows_ids: dict[int, set[int]] = {
+            self.action.id: {self.workflow.id},
+            action.id: {workflow.id},
+        }
 
         action_to_workflow_ids, statuses_to_update, missing_statuses = (
             process_workflow_action_group_statuses(

--- a/tests/sentry/workflow_engine/processors/test_data_condition_group.py
+++ b/tests/sentry/workflow_engine/processors/test_data_condition_group.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from sentry.testutils.cases import TestCase
+from sentry.types.id import Id
 from sentry.workflow_engine.models import DataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.processors.data_condition_group import (
@@ -18,7 +19,7 @@ from sentry.workflow_engine.types import ConditionError, DetectorPriorityLevel
 
 class TestGetDataConditionsForGroup(TestCase):
     def test_get_data_conditions_for_group(self) -> None:
-        assert get_data_conditions_for_group(0) == []
+        assert get_data_conditions_for_group(Id[DataConditionGroup](0)) == []
 
     def test_get_data_conditions_for_group__exists(self) -> None:
         data_condition_group = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_delayed_workflow.py
@@ -46,8 +46,10 @@ from sentry.workflow_engine.processors.delayed_workflow import (
     EventInstance,
     EventKey,
     EventRedisData,
+    GroupId,
     GroupQueryParams,
     UniqueConditionQuery,
+    WorkflowId,
     bulk_fetch_events,
     cleanup_redis_buffer,
     fetch_project,
@@ -447,7 +449,7 @@ class TestDelayedWorkflowQueries(BaseWorkflowTest):
             other_workflow_filters.id: current_time + timedelta(minutes=2),
             detector_dcg.id: current_time + timedelta(minutes=3),
         }
-        workflows_to_envs: dict[int, int | None] = {self.workflow.id: None}
+        workflows_to_envs = {self.workflow.id: None}
 
         # Create mock event data with just the required properties
         mock_event_data = Mock(spec=EventRedisData)
@@ -612,7 +614,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
         )
 
         condition_groups = {
-            unique_query: GroupQueryParams(group_ids={1}, timestamp=None)
+            unique_query: GroupQueryParams(group_ids={GroupId(1)}, timestamp=None)
         }  # One group ID to query
 
         with pytest.raises(ValueError, match="Escaping exception"):
@@ -636,7 +638,7 @@ class TestGetSnubaResults(BaseWorkflowTest):
             environment_id=None,
         )
 
-        condition_groups = {unique_query: GroupQueryParams(group_ids={1}, timestamp=None)}
+        condition_groups = {unique_query: GroupQueryParams(group_ids={GroupId(1)}, timestamp=None)}
 
         # Should not raise, returns empty results
         result = get_condition_group_results(condition_groups)
@@ -1274,10 +1276,10 @@ class TestEventKeyAndInstance:
         }
         event_data = EventRedisData.from_redis_data(redis_data, continue_on_error=False)
 
-        filtered = event_data.filter_by_workflow_ids({1, 2})
+        filtered = event_data.filter_by_workflow_ids({WorkflowId(1), WorkflowId(2)})
 
         assert len(filtered.events) == 3
-        assert filtered.workflow_ids == {1, 2}
+        assert filtered.workflow_ids == {WorkflowId(1), WorkflowId(2)}
         assert 3 not in filtered.workflow_ids
 
     def test_filter_by_workflow_ids_empty_valid_ids(self) -> None:
@@ -1297,7 +1299,7 @@ class TestEventKeyAndInstance:
         }
         event_data = EventRedisData.from_redis_data(redis_data, continue_on_error=False)
 
-        filtered = event_data.filter_by_workflow_ids({999})
+        filtered = event_data.filter_by_workflow_ids({WorkflowId(999)})
 
         assert len(filtered.events) == 0
 
@@ -1308,9 +1310,9 @@ class TestEventKeyAndInstance:
         }
         event_data = EventRedisData.from_redis_data(redis_data, continue_on_error=False)
 
-        filtered = event_data.filter_by_workflow_ids({1})
+        filtered = event_data.filter_by_workflow_ids({WorkflowId(1)})
 
-        assert filtered.workflow_ids == {1}
+        assert filtered.workflow_ids == {WorkflowId(1)}
         assert filtered.group_ids == {100}
         assert filtered.dcg_ids == {10, 1, 2, 3}
         assert 20 not in filtered.dcg_ids

--- a/tests/tools/mypy_helpers/test_plugin.py
+++ b/tests/tools/mypy_helpers/test_plugin.py
@@ -310,3 +310,41 @@ Found 1 error in 1 file (checked 1 source file)
     ret, out = call_mypy(src)
     assert ret
     assert out == expected
+
+
+def test_fk_id_attribute_hook_registration() -> None:
+    """The get_attribute_hook returns a callback for _id attrs on sentry classes."""
+    from tools.mypy_helpers.plugin import SentryMypyPlugin
+
+    plugin = SentryMypyPlugin.__new__(SentryMypyPlugin)
+
+    # FK _id attributes on sentry classes should get a callback.
+    assert plugin.get_attribute_hook("sentry.models.project.Project.organization_id") is not None
+    assert (
+        plugin.get_attribute_hook("sentry.workflow_engine.models.workflow.Workflow.environment_id")
+        is not None
+    )
+
+    # Non-_id attributes should not.
+    assert plugin.get_attribute_hook("sentry.models.project.Project.name") is None
+
+    # Non-sentry classes should not match.
+    assert plugin.get_attribute_hook("django.db.models.base.Model.some_id") is None
+
+    # LazyServiceWrapper should still work (not intercepted by the FK hook).
+    assert (
+        plugin.get_attribute_hook("sentry.utils.lazy_service_wrapper.LazyServiceWrapper.foo")
+        is not None
+    )
+
+
+def test_fk_field_cache_graceful_without_django() -> None:
+    """_get_fk_fields returns empty dict when Django isn't available."""
+    from tools.mypy_helpers.plugin import _fk_field_cache, _get_fk_fields
+
+    # Use a class name that definitely won't match any Django model.
+    result = _get_fk_fields("nonexistent.module.FakeModel")
+    assert result == {}
+    # Verify it was cached.
+    assert "nonexistent.module.FakeModel" in _fk_field_cache
+    _fk_field_cache.pop("nonexistent.module.FakeModel", None)

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -275,6 +275,7 @@ def _get_fk_fields(model_fullname: str) -> dict[str, tuple[str, bool]]:
 
         module, _, class_name = model_fullname.rpartition(".")
         model_cls = None
+        # TODO: Load into a global dict if this becomes a bottleneck
         for m in apps.get_models(include_auto_created=True):
             if m.__module__ == module and m.__name__ == class_name:
                 model_cls = m

--- a/tools/mypy_helpers/plugin.py
+++ b/tools/mypy_helpers/plugin.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from mypy.build import PRI_MYPY
 from mypy.errorcodes import ATTR_DEFINED
 from mypy.messages import format_type
-from mypy.nodes import ARG_POS, MypyFile, TypeInfo
+from mypy.nodes import ARG_POS, MypyFile, TypeInfo, Var
 from mypy.plugin import (
     AttributeContext,
     ClassDefContext,
@@ -27,6 +27,7 @@ from mypy.types import (
     NoneType,
     Type,
     TypeOfAny,
+    TypeVarType,
     UnionType,
 )
 
@@ -187,6 +188,162 @@ def _lazy_service_wrapper_attribute(ctx: AttributeContext, *, attr: str) -> Type
         return member
 
 
+def _type_contains_self(typ: Type) -> bool:
+    """Check if a type tree contains a Self TypeVarType."""
+    if isinstance(typ, TypeVarType):
+        return typ.id.is_self()
+    if isinstance(typ, Instance):
+        return any(_type_contains_self(arg) for arg in typ.args)
+    if isinstance(typ, UnionType):
+        return any(_type_contains_self(item) for item in typ.items)
+    return False
+
+
+def _replace_self_in_type(typ: Type, replacement: Type) -> Type:
+    """Replace Self TypeVarType with a concrete type throughout a type tree."""
+    if isinstance(typ, TypeVarType) and typ.id.is_self():
+        return replacement
+    if isinstance(typ, Instance):
+        if not typ.args:
+            return typ
+        new_args = [_replace_self_in_type(arg, replacement) for arg in typ.args]
+        return typ.copy_modified(args=new_args)
+    if isinstance(typ, UnionType):
+        new_items = [_replace_self_in_type(item, replacement) for item in typ.items]
+        return UnionType(new_items)
+    return typ
+
+
+def _resolve_model_id_self(ctx: ClassDefContext) -> None:
+    """
+    Resolve Self in the inherited ``id`` field type for model subclasses.
+
+    The base Model declares ``id: Field[int, Id[Self]]``.  django-stubs reads
+    field types from TypeInfo without resolving Self, causing unresolved types
+    in ``.values()``, ``.values_list()``, and FK ``.filter()`` contexts.  This
+    hook creates a class-local override with Self resolved to the concrete
+    model type so that, e.g., ``Organization.id`` is typed
+    ``Field[int, Id[Organization]]``.
+    """
+    info = ctx.cls.info
+    if not info.mro:
+        return
+
+    # If this class already defines id locally without Self, nothing to do.
+    if "id" in info.names:
+        node = info.names["id"].node
+        if isinstance(node, Var) and isinstance(node.type, Instance):
+            if not _type_contains_self(node.type):
+                return
+
+    # Walk the MRO (skipping self) to find the original id definition with Self.
+    original_type: Instance | None = None
+    for base_info in info.mro[1:]:
+        if "id" in base_info.names:
+            node = base_info.names["id"].node
+            if isinstance(node, Var) and isinstance(node.type, Instance):
+                if _type_contains_self(node.type):
+                    original_type = node.type
+                    break
+
+    if original_type is None:
+        return
+
+    concrete_type = Instance(info, [])
+    resolved_type = _replace_self_in_type(original_type, concrete_type)
+
+    add_attribute_to_class(ctx.api, ctx.cls, "id", resolved_type)
+
+
+# Cache: model fullname -> {attname: (related_model_fullname, nullable)}
+_fk_field_cache: dict[str, dict[str, tuple[str, bool]]] = {}
+
+
+def _get_fk_fields(model_fullname: str) -> dict[str, tuple[str, bool]]:
+    """Look up FK fields for a model class via Django's runtime _meta API.
+
+    Returns a dict mapping attname (e.g. "organization_id") to
+    (related_model_fullname, nullable).
+    """
+    if model_fullname in _fk_field_cache:
+        return _fk_field_cache[model_fullname]
+
+    result: dict[str, tuple[str, bool]] = {}
+    try:
+        from django.apps import apps
+        from django.db.models.fields.related import ForeignKey
+
+        module, _, class_name = model_fullname.rpartition(".")
+        model_cls = None
+        for m in apps.get_models(include_auto_created=True):
+            if m.__module__ == module and m.__name__ == class_name:
+                model_cls = m
+                break
+
+        if model_cls is not None:
+            for field in model_cls._meta.get_fields():
+                if isinstance(field, ForeignKey):
+                    related = field.related_model
+                    related_fullname = f"{related.__module__}.{related.__name__}"
+                    result[field.attname] = (related_fullname, field.null)
+    except Exception:
+        pass
+
+    _fk_field_cache[model_fullname] = result
+    return result
+
+
+_id_type_info: TypeInfo | None = None
+
+
+def _lookup_typeinfo(ctx: AttributeContext, fullname: str) -> TypeInfo | None:
+    """Look up a TypeInfo by fully qualified name via the checker's module graph."""
+    # Access the TypeChecker's modules dict (not in the official API but stable).
+    modules = getattr(ctx.api, "modules", None)
+    if modules is None:
+        return None
+    module_name, _, class_name = fullname.rpartition(".")
+    module = modules.get(module_name)
+    if module is None:
+        return None
+    sym = module.names.get(class_name)
+    if sym is None or not isinstance(sym.node, TypeInfo):
+        return None
+    return sym.node
+
+
+def _resolve_fk_id_attribute(ctx: AttributeContext, *, class_fullname: str, attr_name: str) -> Type:
+    """Resolve a FK _id attribute to Id[RelatedModel] at type-checking time."""
+    if not isinstance(ctx.default_attr_type, AnyType):
+        return ctx.default_attr_type
+
+    fk_fields = _get_fk_fields(class_fullname)
+    if attr_name not in fk_fields:
+        return ctx.default_attr_type
+
+    related_fullname, nullable = fk_fields[attr_name]
+
+    global _id_type_info
+    if _id_type_info is None:
+        _id_type_info = _lookup_typeinfo(ctx, "sentry.types.id.Id")
+    if _id_type_info is None:
+        return ctx.default_attr_type
+
+    related_info = _lookup_typeinfo(ctx, related_fullname)
+    if related_info is None:
+        return ctx.default_attr_type
+
+    id_type: Type = Instance(_id_type_info, [Instance(related_info, [])])
+    if nullable:
+        id_type = UnionType([id_type, NoneType()])
+    return id_type
+
+
+def _process_silo_model(ctx: ClassDefContext) -> None:
+    """Process a model decorated with @region_silo_model or @control_silo_model."""
+    _resolve_model_id_self(ctx)
+
+
 class SentryMypyPlugin(Plugin):
     def get_function_signature_hook(
         self, fullname: str
@@ -224,12 +381,31 @@ class SentryMypyPlugin(Plugin):
         else:
             return None
 
+    def get_class_decorator_hook(self, fullname: str) -> Callable[[ClassDefContext], None] | None:
+        if fullname in (
+            "sentry.db.models.base.region_silo_model",
+            "sentry.db.models.base.control_silo_model",
+        ):
+            return _process_silo_model
+        return None
+
     def get_attribute_hook(self, fullname: str) -> Callable[[AttributeContext], Type] | None:
         if fullname.startswith("sentry.utils.lazy_service_wrapper.LazyServiceWrapper."):
             _, attr = fullname.rsplit(".", 1)
             return functools.partial(_lazy_service_wrapper_attribute, attr=attr)
-        else:
-            return None
+
+        # Resolve FK _id attributes to Id[RelatedModel] on Sentry model classes.
+        # The _id suffix is a cheap pre-filter; actual FK validation happens in
+        # _resolve_fk_id_attribute via Django's _meta API (not all _id attrs are FKs).
+        if fullname.startswith("sentry.") and fullname.endswith("_id"):
+            class_fullname, _, attr_name = fullname.rpartition(".")
+            return functools.partial(
+                _resolve_fk_id_attribute,
+                class_fullname=class_fullname,
+                attr_name=attr_name,
+            )
+
+        return None
 
     def get_additional_deps(self, file: MypyFile) -> list[tuple[int, str, int]]:
         if file.fullname in {"django.http", "django.http.request", "rest_framework.request"}:


### PR DESCRIPTION
Unclear if this is worth the hassle.
But, it types our primary key and foreign key ids more specifically, and gives us a precise way of typing IDs that we store and pass around. 
However, there's a lot to fix, and some more generic code is a bit tricky to type.
The primary payoff here is that ids are automatically typed by what they refer to,
even in more nuanced contexts, so we don't need to talk in `int` any more and potentially
confuse one category of int for another.

```
gid = group.id
dg : DetectorGroup
if dg.id == gid:  # mypy will fail this
   ...

def old_code(v: int): ..
old_code(gid)   # allowed

known_groups: set(Group.objects.filter(whatever).values("id"))
for (did, gid) in DetectorGroup.objects.filter(..).values("detector_id", "group_id"):
     if did in known_groups: # This will also be flagged
```