### PR TITLE
fix(sentry-security): Improve severity classification for cross-flow enforcement

### DIFF
--- a/.claude/skills/sentry-security/SKILL.md
+++ b/.claude/skills/sentry-security/SKILL.md
@@ -67,6 +67,9 @@ The most common vulnerability. An endpoint accepts an ID from the request but do
 - Query includes `organization_id=organization.id` where `organization` comes from `convert_args()`
 - Uses `self.get_projects()` which scopes by org internally
 - Object is fetched via URL kwargs resolved by `convert_args()`
+- Unscoped query is a guard that only raises an error (never returns data), AND
+  a downstream query in the same flow IS org-scoped and raises the same error —
+  no differential behavior means no information leak
 
 ### Check 2: Missing Authorization Checks — 10 patches last year
 

--- a/.claude/skills/sentry-security/SKILL.md
+++ b/.claude/skills/sentry-security/SKILL.md
@@ -137,9 +137,13 @@ For each potential finding, trace the **complete** request flow end-to-end. Do n
 7. Serializer             → do validate_*() methods enforce it?
 ```
 
-**A check at ANY layer is enforcement.** Before marking HIGH, confirm the check is absent from all 7 layers using the checklist in `enforcement-layers.md`.
+**A check at ANY layer is enforcement.** Before marking HIGH, confirm the check is absent from all layers using the checklist in `enforcement-layers.md`.
 
 If you cannot confirm the check is absent from every layer, mark the finding as **MEDIUM** (needs verification), not HIGH.
+
+**Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all DRF endpoints). If the credential is effectively inert, cap the finding at **MEDIUM** regardless of the issuance-time gap. See `enforcement-layers.md` "Cross-Flow Enforcement."
+
+**Non-DRF views:** OAuth views are plain Django views — the 7-layer DRF model does not apply to the view itself. Check the view's own decorators and handler logic. But tokens issued by these views are later used at DRF endpoints where the full enforcement chain applies.
 
 ## Step 4: Report Findings
 

--- a/.claude/skills/sentry-security/SKILL.md
+++ b/.claude/skills/sentry-security/SKILL.md
@@ -146,7 +146,7 @@ If you cannot confirm the check is absent from every layer, mark the finding as 
 
 **Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all DRF endpoints). Classify based on the enforcement scope:
 
-- **Centralized enforcement** (check lives in a base class ALL endpoints inherit, e.g., `SentryPermission.determine_access()`) → the credential is truly inert → **LOW** (do not report)
+- **Centralized enforcement** (check runs in a permission class inherited by all endpoints in the affected scope) → the credential is effectively inert → **LOW** (do not report)
 - **Scattered enforcement** (only some endpoints or serializers check, others may not) → **MEDIUM** (report as needs verification)
 
 See `enforcement-layers.md` "Cross-Flow Enforcement."

--- a/.claude/skills/sentry-security/SKILL.md
+++ b/.claude/skills/sentry-security/SKILL.md
@@ -144,7 +144,7 @@ For each potential finding, trace the **complete** request flow end-to-end. Do n
 
 If you cannot confirm the check is absent from every layer, mark the finding as **MEDIUM** (needs verification), not HIGH.
 
-**Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all DRF endpoints). Classify based on the enforcement scope:
+**Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all endpoints in the relevant scope). Classify based on the enforcement scope:
 
 - **Centralized enforcement** (check runs in a permission class inherited by all endpoints in the affected scope) → the credential is effectively inert → **LOW** (do not report)
 - **Scattered enforcement** (only some endpoints or serializers check, others may not) → **MEDIUM** (report as needs verification)

--- a/.claude/skills/sentry-security/SKILL.md
+++ b/.claude/skills/sentry-security/SKILL.md
@@ -141,7 +141,12 @@ For each potential finding, trace the **complete** request flow end-to-end. Do n
 
 If you cannot confirm the check is absent from every layer, mark the finding as **MEDIUM** (needs verification), not HIGH.
 
-**Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all DRF endpoints). If the credential is effectively inert, cap the finding at **MEDIUM** regardless of the issuance-time gap. See `enforcement-layers.md` "Cross-Flow Enforcement."
+**Cross-flow enforcement for token issuance:** For token/credential issuance flows, also check whether the issued credential is blocked at **usage time** (e.g., `determine_access()` rejects it at all DRF endpoints). Classify based on the enforcement scope:
+
+- **Centralized enforcement** (check lives in a base class ALL endpoints inherit, e.g., `SentryPermission.determine_access()`) → the credential is truly inert → **LOW** (do not report)
+- **Scattered enforcement** (only some endpoints or serializers check, others may not) → **MEDIUM** (report as needs verification)
+
+See `enforcement-layers.md` "Cross-Flow Enforcement."
 
 **Non-DRF views:** OAuth views are plain Django views — the 7-layer DRF model does not apply to the view itself. Check the view's own decorators and handler logic. But tokens issued by these views are later used at DRF endpoints where the full enforcement chain applies.
 

--- a/.claude/skills/sentry-security/references/enforcement-layers.md
+++ b/.claude/skills/sentry-security/references/enforcement-layers.md
@@ -82,9 +82,14 @@ For token and credential issuance, enforcement may exist in a **different reques
 - **Issuance flow**: The OAuth authorize/token view that creates the credential
 - **Usage flow**: The DRF API endpoints where the credential is subsequently used
 
-If the issued credential cannot be used because a separate enforcement point blocks it (e.g., `determine_access()` raises `MemberDisabledOverLimit` for all DRF endpoints), the credential is effectively inert. This is still a defense-in-depth gap worth noting, but it is **not** a HIGH finding — classify as **MEDIUM** at most.
+If the issued credential cannot be used because a separate enforcement point blocks it, classify based on where the enforcement lives:
 
-**Example:** OAuth authorize view issues a token to a `member-limit:restricted` member. The token exists, but every DRF endpoint rejects it via `is_member_disabled_from_limit()` in `api/permissions.py`. Severity: MEDIUM (defense-in-depth), not HIGH.
+- **Centralized enforcement** — the check is in a base class that ALL endpoints inherit (e.g., `SentryPermission.determine_access()` which runs for every DRF endpoint). The credential is truly inert. Classify as **LOW** (do not report).
+- **Scattered enforcement** — the check exists in some endpoints or serializers but not all. The credential may be usable against unchecked endpoints. Classify as **MEDIUM** (report as needs verification).
+
+**Example (LOW — centralized):** OAuth authorize view issues a token to a `member-limit:restricted` member. The token exists, but `is_member_disabled_from_limit()` in `SentryPermission.determine_access()` (`api/permissions.py`) rejects it at every DRF endpoint. The enforcement is in the base permission class — no endpoint can bypass it. Do not report.
+
+**Example (MEDIUM — scattered):** A token is issued without checking X, and X is only validated in specific endpoint subclasses (not the base). Some endpoints may not inherit the check. Report as needs verification.
 
 ## Tracing Requirements
 
@@ -101,4 +106,4 @@ Before marking a finding as **HIGH**, confirm the check is absent from **all** l
 □ Cross-flow: the issued credential is not blocked at usage time
 ```
 
-If the check exists in any layer or in a cross-flow enforcement point, the finding is either invalid or at most **MEDIUM** (if the enforcement is indirect or fragile).
+If the check exists in any layer or in a cross-flow enforcement point, the finding is either invalid, **LOW** (if enforcement is centralized in a base class), or at most **MEDIUM** (if enforcement is scattered or fragile).

--- a/.claude/skills/sentry-security/references/enforcement-layers.md
+++ b/.claude/skills/sentry-security/references/enforcement-layers.md
@@ -84,10 +84,10 @@ For token and credential issuance, enforcement may exist in a **different reques
 
 If the issued credential cannot be used because a separate enforcement point blocks it, classify based on where the enforcement lives:
 
-- **Centralized enforcement** — the check is in a base class that ALL endpoints inherit (e.g., `SentryPermission.determine_access()` which runs for every DRF endpoint). The credential is truly inert. Classify as **LOW** (do not report).
+- **Centralized enforcement** — the check runs in a permission class inherited by all endpoints within the affected scope. The credential cannot reach any endpoint that lacks the check. Classify as **LOW** (do not report).
 - **Scattered enforcement** — the check exists in some endpoints or serializers but not all. The credential may be usable against unchecked endpoints. Classify as **MEDIUM** (report as needs verification).
 
-**Example (LOW — centralized):** OAuth authorize view issues a token to a `member-limit:restricted` member. The token exists, but `is_member_disabled_from_limit()` in `SentryPermission.determine_access()` (`api/permissions.py`) rejects it at every DRF endpoint. The enforcement is in the base permission class — no endpoint can bypass it. Do not report.
+**Example (LOW — centralized):** OAuth authorize view issues a token to a `member-limit:restricted` member. The token exists, but `is_member_disabled_from_limit()` in `OrganizationPermission.determine_access()` rejects it at every organization-scoped DRF endpoint. Since the token is only usable against organization endpoints (which all inherit this permission class), the enforcement covers all relevant paths. Do not report.
 
 **Example (MEDIUM — scattered):** A token is issued without checking X, and X is only validated in specific endpoint subclasses (not the base). Some endpoints may not inherit the check. Report as needs verification.
 

--- a/.claude/skills/sentry-security/references/enforcement-layers.md
+++ b/.claude/skills/sentry-security/references/enforcement-layers.md
@@ -69,9 +69,26 @@ Classes like `Validator`, `ManualTokenRefresher`, `GrantExchanger`, and `Refresh
 
 `validate_*()` methods and field-level validators may enforce org/project scoping on FK references.
 
+## Non-DRF Views
+
+OAuth views (`OAuthAuthorizeView`, `OAuthDeviceView`, `OAuthTokenView`) are plain Django views, **not** DRF endpoints. Layers 1–4 do not apply to the view itself. Check the view's own authentication decorators, `dispatch()`, and handler logic directly.
+
+However, tokens issued by these views are later used at DRF API endpoints where layers 1–7 **do** apply. See "Cross-Flow Enforcement" below.
+
+## Cross-Flow Enforcement
+
+For token and credential issuance, enforcement may exist in a **different request flow** than the one being reviewed:
+
+- **Issuance flow**: The OAuth authorize/token view that creates the credential
+- **Usage flow**: The DRF API endpoints where the credential is subsequently used
+
+If the issued credential cannot be used because a separate enforcement point blocks it (e.g., `determine_access()` raises `MemberDisabledOverLimit` for all DRF endpoints), the credential is effectively inert. This is still a defense-in-depth gap worth noting, but it is **not** a HIGH finding — classify as **MEDIUM** at most.
+
+**Example:** OAuth authorize view issues a token to a `member-limit:restricted` member. The token exists, but every DRF endpoint rejects it via `is_member_disabled_from_limit()` in `api/permissions.py`. Severity: MEDIUM (defense-in-depth), not HIGH.
+
 ## Tracing Requirements
 
-Before marking a finding as **HIGH**, confirm the check is absent from **all** layers:
+Before marking a finding as **HIGH**, confirm the check is absent from **all** layers AND from cross-flow enforcement:
 
 ```
 □ Authentication class does not enforce it
@@ -81,6 +98,7 @@ Before marking a finding as **HIGH**, confirm the check is absent from **all** l
 □ Handler method does not enforce it
 □ Business logic classes do not enforce it
 □ Serializer does not enforce it
+□ Cross-flow: the issued credential is not blocked at usage time
 ```
 
-If the check exists in any layer, the finding is either invalid or at most **MEDIUM** (if the enforcement is indirect or fragile).
+If the check exists in any layer or in a cross-flow enforcement point, the finding is either invalid or at most **MEDIUM** (if the enforcement is indirect or fragile).

--- a/.claude/skills/sentry-security/references/token-lifecycle.md
+++ b/.claude/skills/sentry-security/references/token-lifecycle.md
@@ -71,7 +71,7 @@ if member.is_pending or not member.user_is_active:
     return Response({"detail": "Member is not active"}, status=403)
 ```
 
-**Known downstream enforcement:** PR #92616 added `is_member_disabled_from_limit()` checks in `SentryPermission.determine_access()` (`api/permissions.py`). This is **centralized enforcement** — it runs for every DRF endpoint via the base permission class. Tokens held by seat-limit restricted members are blocked at all API endpoints with no exceptions. Because the enforcement is centralized, this specific pattern is **LOW** (do not report). See `enforcement-layers.md` "Cross-Flow Enforcement."
+**Known downstream enforcement:** PR #92616 added `is_member_disabled_from_limit()` checks via the organization permission base class. This is **centralized enforcement** — the check runs for every organization-scoped DRF endpoint via `OrganizationPermission.determine_access()`. Tokens held by seat-limit restricted members are blocked at all organization API endpoints. Because the enforcement covers all endpoints the token can be used against, this pattern is **LOW** (do not report). See `enforcement-layers.md` "Cross-Flow Enforcement."
 
 ### Real vulnerability: Personal tokens managing org tokens (PR #99457)
 

--- a/.claude/skills/sentry-security/references/token-lifecycle.md
+++ b/.claude/skills/sentry-security/references/token-lifecycle.md
@@ -47,13 +47,13 @@ OAuth applications with org-level access did not require `organization_id`, allo
 
 ### Member disabled states in Sentry
 
-| State                 | Field / Flag                                          | Can log in? | Reachable in OAuth? | Where enforced                                                                     |
-| --------------------- | ----------------------------------------------------- | ----------- | ------------------- | ---------------------------------------------------------------------------------- |
-| Account deactivated   | `OrganizationMember.user_is_active=False`             | No          | No — login blocked  | Login flow                                                                         |
-| Pending invitation    | `OrganizationMember.is_pending`                       | No          | No — requires login | Login flow                                                                         |
-| Seat-limit restricted | `OrganizationMember.flags["member-limit:restricted"]` | **Yes**     | **Yes**             | `determine_access()` via `is_member_disabled_from_limit()` in `api/permissions.py` |
+| State                 | Field / Flag                                          | Can log in? | Reachable in OAuth? | Where enforced                                                                    |
+| --------------------- | ----------------------------------------------------- | ----------- | ------------------- | --------------------------------------------------------------------------------- |
+| Account deactivated   | `OrganizationMember.user_is_active=False`             | No          | No — login blocked  | Login flow                                                                        |
+| Pending invitation    | `OrganizationMember.is_pending`                       | No          | No — requires login | Login flow                                                                        |
+| Seat-limit restricted | `OrganizationMember.flags["member-limit:restricted"]` | **Yes**     | **Yes**             | `OrganizationPermission.determine_access()` via `is_member_disabled_from_limit()` |
 
-The seat-limit restricted state is the one that matters for OAuth and token issuance reviews. The user can still log in and complete an OAuth flow, but all DRF API endpoints block the resulting token via `is_member_disabled_from_limit()`.
+The seat-limit restricted state is the one that matters for OAuth and token issuance reviews. The user can still log in and complete an OAuth flow, but all organization-scoped DRF endpoints block the resulting token via `is_member_disabled_from_limit()` in `OrganizationPermission`.
 
 ### Real vulnerability: Disabled member tokens (PR #92616)
 
@@ -94,7 +94,7 @@ Impersonated sessions (staff acting as a user) had no rate limiting, allowing un
 □ Token issuance/refresh endpoints for org-scoped tokens require and validate organization_id
   (authentication classes reading existing tokens are exempt — org scoping is enforced by from_rpc_auth())
 □ Member active status is checked before token issuance
-  If missing at issuance but enforced at usage via is_member_disabled_from_limit() in base SentryPermission → LOW (centralized, do not report)
+  If missing at issuance but enforced at usage via is_member_disabled_from_limit() in OrganizationPermission → LOW (centralized, do not report)
   If enforced only in specific endpoint subclasses → MEDIUM
 □ Auth method is appropriate for the operation (org token vs personal token)
 □ Impersonated sessions are rate-limited

--- a/.claude/skills/sentry-security/references/token-lifecycle.md
+++ b/.claude/skills/sentry-security/references/token-lifecycle.md
@@ -45,6 +45,16 @@ OAuth applications with org-level access did not require `organization_id`, allo
 
 ## Member Status Checks
 
+### Member disabled states in Sentry
+
+| State                 | Field / Flag                                          | Can log in? | Reachable in OAuth? | Where enforced                                                                     |
+| --------------------- | ----------------------------------------------------- | ----------- | ------------------- | ---------------------------------------------------------------------------------- |
+| Account deactivated   | `OrganizationMember.user_is_active=False`             | No          | No — login blocked  | Login flow                                                                         |
+| Pending invitation    | `OrganizationMember.is_pending`                       | No          | No — requires login | Login flow                                                                         |
+| Seat-limit restricted | `OrganizationMember.flags["member-limit:restricted"]` | **Yes**     | **Yes**             | `determine_access()` via `is_member_disabled_from_limit()` in `api/permissions.py` |
+
+The seat-limit restricted state is the one that matters for OAuth and token issuance reviews. The user can still log in and complete an OAuth flow, but all DRF API endpoints block the resulting token via `is_member_disabled_from_limit()`.
+
 ### Real vulnerability: Disabled member tokens (PR #92616)
 
 Disabled organization members could still request auth tokens.
@@ -60,6 +70,8 @@ member = OrganizationMember.objects.get(
 if member.is_pending or not member.user_is_active:
     return Response({"detail": "Member is not active"}, status=403)
 ```
+
+**Known downstream enforcement:** PR #92616 added `is_member_disabled_from_limit()` checks in `api/permissions.py:determine_access()`. This blocks all DRF API usage of tokens held by seat-limit restricted members. If the only gap is that token issuance proceeds but usage is blocked, classify as **MEDIUM** (defense-in-depth gap), not HIGH. See `enforcement-layers.md` "Cross-Flow Enforcement."
 
 ### Real vulnerability: Personal tokens managing org tokens (PR #99457)
 
@@ -82,6 +94,7 @@ Impersonated sessions (staff acting as a user) had no rate limiting, allowing un
 □ Token issuance/refresh endpoints for org-scoped tokens require and validate organization_id
   (authentication classes reading existing tokens are exempt — org scoping is enforced by from_rpc_auth())
 □ Member active status is checked before token issuance
+  If missing at issuance but enforced at usage via is_member_disabled_from_limit() → MEDIUM, not HIGH
 □ Auth method is appropriate for the operation (org token vs personal token)
 □ Impersonated sessions are rate-limited
 □ Token revocation cascades properly (revoking app revokes all its tokens)

--- a/.claude/skills/sentry-security/references/token-lifecycle.md
+++ b/.claude/skills/sentry-security/references/token-lifecycle.md
@@ -71,7 +71,7 @@ if member.is_pending or not member.user_is_active:
     return Response({"detail": "Member is not active"}, status=403)
 ```
 
-**Known downstream enforcement:** PR #92616 added `is_member_disabled_from_limit()` checks in `api/permissions.py:determine_access()`. This blocks all DRF API usage of tokens held by seat-limit restricted members. If the only gap is that token issuance proceeds but usage is blocked, classify as **MEDIUM** (defense-in-depth gap), not HIGH. See `enforcement-layers.md` "Cross-Flow Enforcement."
+**Known downstream enforcement:** PR #92616 added `is_member_disabled_from_limit()` checks in `SentryPermission.determine_access()` (`api/permissions.py`). This is **centralized enforcement** — it runs for every DRF endpoint via the base permission class. Tokens held by seat-limit restricted members are blocked at all API endpoints with no exceptions. Because the enforcement is centralized, this specific pattern is **LOW** (do not report). See `enforcement-layers.md` "Cross-Flow Enforcement."
 
 ### Real vulnerability: Personal tokens managing org tokens (PR #99457)
 
@@ -94,7 +94,8 @@ Impersonated sessions (staff acting as a user) had no rate limiting, allowing un
 □ Token issuance/refresh endpoints for org-scoped tokens require and validate organization_id
   (authentication classes reading existing tokens are exempt — org scoping is enforced by from_rpc_auth())
 □ Member active status is checked before token issuance
-  If missing at issuance but enforced at usage via is_member_disabled_from_limit() → MEDIUM, not HIGH
+  If missing at issuance but enforced at usage via is_member_disabled_from_limit() in base SentryPermission → LOW (centralized, do not report)
+  If enforced only in specific endpoint subclasses → MEDIUM
 □ Auth method is appropriate for the operation (org token vs personal token)
 □ Impersonated sessions are rate-limited
 □ Token revocation cascades properly (revoking app revokes all its tokens)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.warden/logs
 .env
 .cache/
 .code-workspace


### PR DESCRIPTION
## Summary

- Adds **cross-flow enforcement** concept to the sentry-security skill so token issuance findings account for usage-time enforcement (e.g., `is_member_disabled_from_limit()` blocking all DRF API usage via the base `SentryPermission` class)
- Distinguishes **centralized** enforcement (base class all endpoints inherit → LOW, don't report) from **scattered** enforcement (only some endpoints check → MEDIUM, needs verification) to reduce false positives
- Clarifies that OAuth views are plain Django views and bypass the 7-layer DRF model, while tokens they issue are subject to full DRF enforcement
- Adds member disabled states taxonomy to `token-lifecycle.md` and updates the tracing checklist with a cross-flow checkpoint