### PR TITLE
fix(incidents): Add failure_count to EAP_FUNCTIONS

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1853,6 +1853,7 @@ EAP_FUNCTIONS = [
     "min",
     "sum",
     "epm",
+    "failure_count",
     "failure_rate",
     "eps",
     "apdex",


### PR DESCRIPTION
failure_count is a valid EAP formula but was missing from the allowlist, causing it to fall through to legacy resolve_field validation which doesn't support it.

Fixes SENTRY-5C1H.