### PR TITLE
fix(cursor): Mark branchName and autoCreatePr as optional in CursorAgentResponseTarget

### DIFF
--- a/src/sentry/integrations/cursor/models.py
+++ b/src/sentry/integrations/cursor/models.py
@@ -39,9 +39,9 @@ class CursorAgentLaunchRequestBody(BaseModel):
 
 
 class CursorAgentResponseTarget(BaseModel):
-    autoCreatePr: bool
-    branchName: str
     url: str
+    branchName: str | None = None
+    autoCreatePr: bool | None = None
 
 
 class CursorAgentLaunchResponse(BaseModel):


### PR DESCRIPTION
Per Cursor's [OpenAPI spec](https://cursor.com/docs-static/cloud-agents-openapi.yaml), only `url` is required in the `target` object of the agent launch response. `branchName` and `autoCreatePr` are both optional — Cursor may omit them when an agent is first created (status `CREATING`) before a branch has been assigned.

Having these fields marked as required in `CursorAgentResponseTarget` was causing a `pydantic.ValidationError` on the `/api/0/organizations/{org}/issues/{id}/autofix/` endpoint whenever Cursor returned a response without them.

Also adds a regression test that asserts `launch()` succeeds when the response target contains only the required `url` field.