### PR TITLE
fix(billing): Prevent API queries for non-billing users

### DIFF
--- a/static/gsApp/hooks/useCurrentBillingHistory.tsx
+++ b/static/gsApp/hooks/useCurrentBillingHistory.tsx
@@ -8,6 +8,7 @@ import type {BillingHistory} from 'getsentry/types';
 
 export function useCurrentBillingHistory() {
   const organization = useOrganization();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: history,
@@ -21,6 +22,7 @@ export function useCurrentBillingHistory() {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 

--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -47,6 +47,7 @@ enum ReceiptStatus {
 function PaymentHistory() {
   const organization = useOrganization();
   const location = useLocation();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: payments,
@@ -64,10 +65,10 @@ function PaymentHistory() {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 
-  const hasBillingPerms = organization.access?.includes('org:billing');
   const paymentsPageLinks = getResponseHeader?.('Link');
 
   return (

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -85,6 +85,7 @@ function getCategoryDisplay({
 function UsageHistory({subscription}: Props) {
   const organization = useOrganization();
   const location = useLocation();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: usageList,
@@ -103,11 +104,11 @@ function UsageHistory({subscription}: Props) {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 
   const usageListPageLinks = getResponseHeader?.('Link');
-  const hasBillingPerms = organization.access?.includes('org:billing');
 
   return (
     <SubscriptionPageContainer background="primary">

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/actions.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/actions.tsx
@@ -28,7 +28,7 @@ function UsageOverviewActions({organization}: {organization: Organization}) {
   const shouldCollapseActions = shouldCollapseOnLargeScreen || shouldCollapseOnMobile;
 
   const {currentHistory, isPending, isError} = useCurrentBillingHistory();
-  const hasBillingPerms = organization.access.includes('org:billing');
+  const hasBillingPerms = organization.access?.includes('org:billing');
   if (!hasBillingPerms) {
     return null;
   }


### PR DESCRIPTION
## Problem

Users without billing permissions encounter API errors when accessing Usage History or Payment History pages. The application makes API calls to billing endpoints before checking permissions, resulting in:
- API errors for unauthorized users
- Poor user experience (errors instead of permission screen)
- Unnecessary server load from failed requests

## Solution

Add `enabled: hasBillingPerms` to all billing-related `useApiQuery` calls to conditionally execute queries only when users have proper permissions. This prevents unauthorized API calls from executing before permission checks.

## Changes

### Files Modified (4 total):

1. **`static/gsApp/views/subscriptionPage/usageHistory.tsx`**
   - Moved `hasBillingPerms` check before the `useApiQuery` call
   - Added `enabled: hasBillingPerms` to query options
   
2. **`static/gsApp/hooks/useCurrentBillingHistory.tsx`**
   - Added permission check: `hasBillingPerms = organization.access?.includes('org:billing')`
   - Added `enabled: hasBillingPerms` to query options
   - This hook is used by multiple components, providing broader protection

3. **`static/gsApp/views/subscriptionPage/paymentHistory.tsx`**
   - Moved `hasBillingPerms` check before the `useApiQuery` call
   - Added `enabled: hasBillingPerms` to query options

4. **`static/gsApp/views/subscriptionPage/usageOverview/components/actions.tsx`**
   - Added optional chaining: `organization.access?.includes()` (defensive programming)

## Expected Behavior

### For Non-Billing Users
- ✅ No API errors in console
- ✅ "Contact Billing Members" screen displays immediately
- ✅ No network requests to billing endpoints

### For Billing Users
- ✅ Full functionality retained
- ✅ All data loads as expected
- ✅ No regression in behavior

## Testing

**Manual Testing Required:**
1. Access Usage History page as non-billing user → Should show "Contact Billing Members" screen without errors
2. Check browser Network tab → No failed API requests to `/customers/.../history/` endpoints
3. Access same pages as billing user → Should work normally

## Risk Assessment

- **Complexity**: Low
- **Risk Level**: Low
- **Type**: Frontend-only changes

This uses React Query's built-in `enabled` flag (standard pattern). Only adding query guards, not changing business logic.

Fixes [MIKE-47](https://linear.app/ihbe/issue/MIKE-47)