### PR TITLE
fix(tests): Fix default action data

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -633,8 +633,8 @@ class Factories:
                 },
                 {
                     "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
-                    "service": "mail",
-                    "name": "Send a notification via mail",
+                    "service": "webhooks",
+                    "name": "Send a notification via webhooks",
                 },
             ]
             actions = action_data


### PR DESCRIPTION
I noticed that the default action data we pass in the `create_project_rule` test factory is a mix of email action data and webhook action data. This PR updates it to be webhook action data, but I could be convinced to update it to be an email user action.

A webhook action payload should look like:
```
{
    "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
    "service": "webhooks",
    "name": "Send a notification via webhooks",
}
```

an email action payload should look like:
```
{
    "id": "sentry.mail.actions.NotifyEmailAction",
    "targetIdentifier": 1,
    "targetType": "Member",
    "uuid": "some-uuid-1234-5678",
}
```