### PR TITLE
fix(issues): Handle None from event serialization in wrap_event_response

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -246,4 +246,6 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             start=start,
             end=end,
         )
+        if data is None:
+            return Response({"detail": "Failed to load event"}, status=500)
         return Response(data)

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -36,13 +36,17 @@ def wrap_event_response(
     conditions: list[Condition] | None = None,
     start: datetime | None = None,
     end: datetime | None = None,
-) -> GroupEventDetailsResponse:
+) -> GroupEventDetailsResponse | None:
     event_data = serialize(
         event,
         request_user,
         IssueEventSerializer(),
         include_full_release_data=include_full_release_data,
     )
+
+    if event_data is None:
+        return None
+
     # Used for paginating through events of a single issue in group details
     # Skip next/prev for issueless events
     next_event_id = None
@@ -146,6 +150,8 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             start=start,
             end=end,
         )
+        if data is None:
+            return Response({"detail": "Failed to load event"}, status=500)
         return Response(data)
 
 


### PR DESCRIPTION
When event serialization fails (e.g. due to Snuba timeouts fetching release tags), `_serialize()` catches the exception and returns None. `wrap_event_response` didn't handle this, causing a secondary TypeError on `event_data["nextEventID"]`. Return a proper 500 instead.

Fixes SENTRY-5H40

There is further work to be done here to gracefully degrade when this occurs, for now this will at least help simplify the ways these problems are surfaced.