### PR TITLE
fix(rules): Make WorkflowEngineRuleSerializer write owner properly

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -469,7 +469,7 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             owner = self._fetch_workflow_owner(workflow)
             if owner:
-                result[workflow]["created_by"] = owner
+                result[workflow]["owner"] = owner
 
             result[workflow]["environment"] = workflow.environment
             result[workflow]["projects"] = list(workflow_to_projects[workflow])

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -274,6 +274,8 @@ class WorkflowRuleSerializerTest(TestCase):
         ) == {workflow.id: timezone.now(), workflow_2.id: before_now(hours=1)}
 
     def test_rule_serializer(self) -> None:
+        self.issue_alert.update(owner_user_id=self.user.id)
+        self.issue_alert.refresh_from_db()
         self.assert_equal_serializers(self.issue_alert)
 
     def test_special_condition(self) -> None:


### PR DESCRIPTION
It looks like a typo in the initial implementation lead to 'owner' being overwritten by 'created_by' data.
This change tries to fix that, and includes owner data in our test so it'd be caught in the future.
