### PR TITLE
build(useQuery): Override @tanstack/query-core `queryKey` with our typed `ApiQueryKey`

### DIFF
--- a/static/app/appQueryClient.tsx
+++ b/static/app/appQueryClient.tsx
@@ -73,6 +73,7 @@ export async function clearQueryCache() {
   if (hasIndexedDb) {
     // Mark queries as stale so they won't be re-cached
     appQueryClient.invalidateQueries({
+      // @ts-expect-error - Incorrectly typed query key
       queryKey: ['bootstrap-projects'],
       refetchType: 'none',
     });

--- a/static/app/bootstrap/bootstrapRequests.tsx
+++ b/static/app/bootstrap/bootstrapRequests.tsx
@@ -89,7 +89,7 @@ export function useBootstrapProjectsQuery(orgSlug: string | null) {
 
 export function getBootstrapOrganizationQueryOptions(orgSlug: string | null) {
   return queryOptions({
-    queryKey: ['bootstrap-organization', orgSlug],
+    queryKey: ['bootstrap-organization', orgSlug] as any,
     queryFn: orgSlug
       ? async (): Promise<Organization> => {
           // Get the preloaded data promise
@@ -138,7 +138,7 @@ function createTeamsObject(response: ApiResult): {
 
 export function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
   return queryOptions({
-    queryKey: ['bootstrap-teams', orgSlug],
+    queryKey: ['bootstrap-teams', orgSlug] as any,
     queryFn: orgSlug
       ? async (): Promise<{
           cursor: string | null;
@@ -174,7 +174,7 @@ export function getBoostrapTeamsQueryOptions(orgSlug: string | null) {
 
 export function getBootstrapProjectsQueryOptions(orgSlug: string | null) {
   return queryOptions({
-    queryKey: ['bootstrap-projects', orgSlug],
+    queryKey: ['bootstrap-projects', orgSlug] as any,
     queryFn: orgSlug
       ? async (): Promise<Project[]> => {
           // Get the preloaded data promise

--- a/static/app/components/charts/chartWidgetLoader.tsx
+++ b/static/app/components/charts/chartWidgetLoader.tsx
@@ -130,7 +130,7 @@ const CHART_MAP = {
  */
 export function ChartWidgetLoader(props: Props) {
   const query = useQuery<{default: React.FC<LoadableChartWidgetProps>}>({
-    queryKey: [`widget-${props.id}`],
+    queryKey: [`widget-${props.id}`] as any,
     queryFn: () => {
       if (CHART_MAP.hasOwnProperty(props.id)) {
         const importChartFn = CHART_MAP[props.id];

--- a/static/app/components/checkInTimeline/hooks/useMonitorDates.tsx
+++ b/static/app/components/checkInTimeline/hooks/useMonitorDates.tsx
@@ -49,7 +49,7 @@ export function usePageFilterDates(options: UsePageFilterDatesOptions = {}) {
   const queryKeyExtra = recomputeQueryKey ?? [];
 
   const {data} = useQuery({
-    queryKey: ['pageFilterDates', start, end, period, ...queryKeyExtra] as const,
+    queryKey: ['pageFilterDates', start, end, period, ...queryKeyExtra] as any,
     queryFn,
     initialData: queryFn(),
     staleTime: 0,

--- a/static/app/components/core/form/form.stories.tsx
+++ b/static/app/components/core/form/form.stories.tsx
@@ -67,7 +67,7 @@ const userSchema = baseUserSchema.refine(
 );
 
 const userQuery = queryOptions({
-  queryKey: ['user', 'example'],
+  queryKey: ['user', 'example'] as any,
   queryFn: async () => {
     await sleep(500);
     return userSchema.parse({
@@ -99,7 +99,7 @@ const addressMutationOptions = (client: QueryClient) =>
       };
     },
     onSuccess: data => {
-      client.setQueryData(['user', 'example'], oldData => {
+      client.setQueryData(['user', 'example'] as any, oldData => {
         if (!oldData) {
           return oldData;
         }
@@ -130,7 +130,7 @@ const userMutationOptions = (client: QueryClient) =>
       };
     },
     onSuccess: data => {
-      client.setQueryData(['user', 'example'], data);
+      client.setQueryData(['user', 'example'] as any, data);
     },
   });
 

--- a/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences.ts
@@ -4,6 +4,7 @@ import {
 } from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import type {Project} from 'sentry/types/project';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {
   fetchMutation,
   getApiQueryData,
@@ -69,7 +70,11 @@ export function useUpdateProjectSeerPreferences(project: Project) {
     onSettled: () => {
       queryClient.invalidateQueries({queryKey});
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${organization.slug}/autofix/automation-settings/`],
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/autofix/automation-settings/', {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
       });
     },
   });

--- a/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
+++ b/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
@@ -1,10 +1,13 @@
 import {promptsUpdate} from 'sentry/actionCreators/prompts';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export const setupCheckQueryKey = (orgSlug: string) =>
-  `/organizations/${orgSlug}/seer/setup-check/`;
+  getApiUrl('/organizations/$organizationIdOrSlug/seer/setup-check/', {
+    path: {organizationIdOrSlug: orgSlug},
+  });
 
 export function useSeerAcknowledgeMutation() {
   const api = useApi();

--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -84,7 +84,7 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
       <TransitionChart loading={isPending} reloading>
         <TransparentLoadingMask visible={isPending} />
         <Chart
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+          // @ts-expect-error - Dynamic string key indexing
           percentileData={data?.['p95(transaction.duration)']?.data ?? []}
           evidenceData={normalizedOccurrenceEvent}
           datetime={datetime}

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -170,6 +170,7 @@ function AsyncCompactSelectForIntegrationConfig<Value extends string = string>({
   }, [api]);
 
   const {data, isFetching} = useQuery({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: [url, buildQueryParams(debouncedQuery)],
     queryFn: async () => {
       // This exists because /extensions/type/search API is not prefixed with /api/0/

--- a/static/app/components/modals/privateGamingSdkAccessModal.tsx
+++ b/static/app/components/modals/privateGamingSdkAccessModal.tsx
@@ -133,7 +133,11 @@ export function PrivateGamingSdkAccessModal({
       }
 
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${organization.slug}/console-sdk-invites/`],
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/console-sdk-invites/', {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
       });
     },
     onError: errorResponse => {

--- a/static/app/components/prevent/repoSelector/useSyncRepos.tsx
+++ b/static/app/components/prevent/repoSelector/useSyncRepos.tsx
@@ -71,7 +71,10 @@ export function useSyncRepos({searchValue}: {searchValue?: string}) {
     if (!isSyncing) {
       queryClient.invalidateQueries({
         queryKey: [
-          `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repositories/`,
+          getApiUrl(
+            '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/',
+            {path: {organizationIdOrSlug: organization.slug, owner: integratedOrgId!}}
+          ),
           {query: {term: searchValue}},
         ],
       });

--- a/static/app/components/prevent/testSuiteDropdown/useTestSuites.tsx
+++ b/static/app/components/prevent/testSuiteDropdown/useTestSuites.tsx
@@ -17,6 +17,7 @@ export function useTestSuites() {
   const organization = useOrganization();
   const {integratedOrgId, repository} = usePreventContext();
 
+  // @ts-expect-error - Incorrectly typed query key
   const {data, ...rest} = useQuery<TestSuite, Error, TestSuite, QueryKey>({
     queryKey: [
       `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-suites/`,

--- a/static/app/components/replays/replayLiveIndicator.tsx
+++ b/static/app/components/replays/replayLiveIndicator.tsx
@@ -8,6 +8,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import usePollReplayRecord from 'sentry/utils/replays/hooks/usePollReplayRecord';
 import {useReplayProjectSlug} from 'sentry/utils/replays/hooks/useReplayProjectSlug';
@@ -139,13 +140,26 @@ export function useLiveRefresh({replay}: {replay: ReplayRecord | undefined}) {
   const doRefresh = useCallback(async () => {
     trackAnalytics('replay.details-refresh-clicked', {organization});
     await queryClient.refetchQueries({
-      queryKey: [`/organizations/${orgSlug}/replays/${replayId}/`],
+      queryKey: [
+        getApiUrl('/organizations/$organizationIdOrSlug/replays/$replayId/', {
+          path: {organizationIdOrSlug: orgSlug, replayId: replayId!},
+        }),
+      ],
       exact: true,
       type: 'all',
     });
     await queryClient.invalidateQueries({
       queryKey: [
-        `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/recording-segments/`,
+        getApiUrl(
+          '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/$replayId/recording-segments/',
+          {
+            path: {
+              organizationIdOrSlug: orgSlug,
+              projectIdOrSlug: projectSlug!,
+              replayId: replayId!,
+            },
+          }
+        ),
       ],
       type: 'all',
     });

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -381,8 +381,9 @@ function useFilterSuggestions({
 
   // TODO(malwilley): Display error states
   const {data, isFetching} = useQuery({
-    queryKey,
-    queryFn: ctx => getTagValues(...ctx.queryKey[1]),
+    queryKey: queryKey as any,
+    // @ts-expect-error - TS2556 spread with any type
+    queryFn: ctx => getTagValues(...(ctx.queryKey as any)[1]),
     placeholderData: keepPreviousData,
     enabled: shouldFetchValues,
   });

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -185,8 +185,8 @@ export function useSortedFilterKeyItems({
   const debouncedFilterValue = useDebouncedValue(filterValue);
   const {data: asyncKeys, isLoading: isQueryLoading} = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    queryKey: ['search-query-builder-tag-keys', debouncedFilterValue],
-    queryFn: ctx => getTagKeys!(ctx.queryKey[1] ?? ''),
+    queryKey: ['search-query-builder-tag-keys', debouncedFilterValue] as any,
+    queryFn: ctx => getTagKeys!((ctx.queryKey as any)[1] ?? ''),
     enabled: shouldFetchAsync,
   });
 

--- a/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
+++ b/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
@@ -19,6 +19,7 @@ type LayerData = {
 
 export function useAwsLambdaLayers() {
   const awsLambdaLayers = useQuery<Record<string, LayerData>>({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: ['aws-lambda-layers'],
     queryFn: async () => {
       const response = await fetch(
@@ -28,7 +29,7 @@ export function useAwsLambdaLayers() {
     },
   });
 
-  return awsLambdaLayers.data;
+  return awsLambdaLayers.data as Record<string, LayerData> | undefined;
 }
 
 export function AwsLambdaArnSelector({

--- a/static/app/stories/view/storySourceLinks.tsx
+++ b/static/app/stories/view/storySourceLinks.tsx
@@ -14,6 +14,7 @@ type GithubCommitResponse = Array<{commit: {committer: {date: string}}}>;
 
 export function StorySourceLinks() {
   const {story} = useStory();
+  // @ts-expect-error - Incorrectly typed query key
   const {data} = useQuery<GithubCommitResponse, Error, GithubCommitResponse, [string]>({
     queryKey: [
       `https://api.github.com/repos/getsentry/sentry/commits?&page=1per_page=1&path=static/${story.filename}`,

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -78,7 +78,9 @@ interface UseStoriesLoaderOptions {
 export function useStoriesLoader(
   options: UseStoriesLoaderOptions
 ): UseQueryResult<StoryDescriptor[], Error> {
+  // @ts-expect-error - Incorrectly typed query key
   return useQuery({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: [options.files],
     queryFn: (): Promise<StoryDescriptor[]> => {
       return Promise.all(options.files.map(importStory));

--- a/static/app/utils/api/tanstackQueryTypes.d.ts
+++ b/static/app/utils/api/tanstackQueryTypes.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Augments @tanstack/query-core's Register interface to constrain QueryKey to
+ * Sentry's API-typed query key shapes. This prevents arbitrary arrays from
+ * being used as query keys — only branded ApiUrl values (from getApiUrl()) are
+ * accepted.
+ *
+ * Types are defined inline to avoid circular imports through the augmentation
+ * chain (this file → queryKey types → getApiUrl → @tanstack/react-query →
+ * @tanstack/query-core).
+ *
+ * See: ApiQueryKey and InfiniteApiQueryKey in sentry/utils/queryClient.tsx
+ */
+declare module '@tanstack/query-core' {
+  /**
+   * Branded URL type — only produced by getApiUrl() in sentry/utils/api/getApiUrl.ts
+   * Inlined here to avoid importing through the circular chain.
+   */
+  type ApiUrl = string & {__apiUrl: true};
+
+  type SentryQueryKeyOptions = {
+    data?: Record<string, any>;
+    headers?: Record<string, string>;
+    host?: string;
+    method?: string;
+    query?: Record<string, any>;
+  };
+
+  interface Register {
+    queryKey:
+      | readonly [url: ApiUrl]
+      | readonly [url: ApiUrl, options: SentryQueryKeyOptions]
+      | readonly ['infinite', url: ApiUrl]
+      | readonly ['infinite', url: ApiUrl, options: SentryQueryKeyOptions];
+  }
+}
+
+export {};

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -130,6 +130,7 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
     }
 
     const queuedAggregatableBatch = queuedQueriesBatch.map(
+      // @ts-expect-error - Internal cache key accessing index 4
       ({queryKey}) => queryKey[4] as AggregatableQueryKey
     );
 
@@ -137,11 +138,13 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
 
     try {
       queryClient.removeQueries({
+        // @ts-expect-error - Internal cache key, not an API URL
         queryKey: ['aggregate', cacheKey, key, 'queued'],
         predicate: isQueryKeyInBatch,
       });
       queuedAggregatableBatch.forEach(queryKey => {
         queryClient.setQueryData<boolean>(
+          // @ts-expect-error - Internal cache key, not an API URL
           ['aggregate', cacheKey, key, 'inFlight', queryKey],
           true
         );
@@ -156,6 +159,7 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
       const observer = new QueryObserver(queryClient, {queryKey});
       const unsubscribe = observer.subscribe(_result => {
         queryClient.removeQueries({
+          // @ts-expect-error - Internal cache key, not an API URL
           queryKey: ['aggregate', cacheKey, key, 'inFlight'],
           predicate: isQueryKeyInBatch,
         });
@@ -200,6 +204,7 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
           queryKey: ['aggregate', cacheKey, key],
           predicate: isQueryKeyInList(prevQueryKeys.current),
         })
+        // @ts-expect-error - Internal cache key, not an API URL
         .map(({queryKey}) => queryKey[4] as AggregatableQueryKey);
 
       // Don't request aggregates multiple times.
@@ -208,6 +213,7 @@ export default function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
       // Cache sentinel data for the new cacheKeys
       newQueryKeys
         .map(agg => ['aggregate', cacheKey, key, 'queued', agg])
+        // @ts-expect-error - Internal cache key, not an API URL
         .forEach(queryKey => queryClient.setQueryData<boolean>(queryKey, true));
 
       if (newQueryKeys.length) {

--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -405,7 +405,7 @@ export function useGenericDiscoverQuery<T, P>(props: Props<T, P>) {
 
   const res = useQuery<[T, string | undefined, ResponseMeta<T> | undefined], QueryError>({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    queryKey: [...additionalQueryKey, route, apiPayload],
+    queryKey: [...additionalQueryKey, route, apiPayload] as any,
     queryFn: ({signal: _signal}) =>
       doDiscoverQuery<T>(api, url, apiPayload, {
         skipAbort: props.skipAbort,

--- a/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
+++ b/static/app/utils/replays/hooks/useExtractDiffMutations.tsx
@@ -261,7 +261,7 @@ export default function useExtractDiffMutations({
       replay,
       rangeStartTimestampMs,
       rangeEndTimestampMs,
-    ],
+    ] as any,
     queryFn: () =>
       extractDiffMutations({replay, rangeStartTimestampMs, rangeEndTimestampMs}),
     enabled: true,

--- a/static/app/utils/replays/hooks/useExtractDomNodes.tsx
+++ b/static/app/utils/replays/hooks/useExtractDomNodes.tsx
@@ -11,7 +11,7 @@ interface Params {
 
 export default function useExtractDomNodes({replay, frame, enabled = true}: Params) {
   return useQuery<Extraction | null>({
-    queryKey: ['getDomNodes', frame, replay],
+    queryKey: ['getDomNodes', frame, replay] as any,
     // Note: we filter out `style` mutations due to perf issues.
     // We can do this as long as we only need the HTML and not need to
     // visualize the rendered elements

--- a/static/app/utils/replays/hooks/useExtractPageHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractPageHtml.tsx
@@ -56,7 +56,7 @@ interface Props {
 
 export default function useExtractPageHtml({replay, offsetMsToStopAt}: Props) {
   return useQuery({
-    queryKey: ['extractPageHtml', replay, offsetMsToStopAt],
+    queryKey: ['extractPageHtml', replay, offsetMsToStopAt] as any,
     queryFn: () =>
       extractPageHtml({
         offsetMsToStopAt,

--- a/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
+++ b/static/app/utils/replays/hooks/useMarkReplayViewed.tsx
@@ -1,3 +1,4 @@
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -12,11 +13,29 @@ export default function useMarkReplayViewed() {
 
   return useMutation<TData, TError, TVariables, TContext>({
     mutationFn: ({projectSlug, replayId}) => {
-      const url = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;
+      const url = getApiUrl(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/$replayId/viewed-by/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectSlug,
+            replayId,
+          },
+        }
+      );
       return fetchMutation({method: 'POST', url});
     },
     onSuccess(_data, {projectSlug, replayId}) {
-      const url = `/projects/${organization.slug}/${projectSlug}/replays/${replayId}/viewed-by/`;
+      const url = getApiUrl(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/$replayId/viewed-by/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectSlug,
+            replayId,
+          },
+        }
+      );
       queryClient.refetchQueries({queryKey: [url]});
     },
     retry: false,

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -255,17 +255,34 @@ function useReplayData({
 
   const clearQueryCache = useCallback(() => {
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${orgSlug}/replays/${replayId}/`],
+      queryKey: [
+        getApiUrl('/organizations/$organizationIdOrSlug/replays/$replayId/', {
+          path: {organizationIdOrSlug: orgSlug, replayId: replayId!},
+        }),
+      ],
     });
     queryClient.invalidateQueries({
       queryKey: [
-        `/projects/${orgSlug}/${projectSlug}/replays/${replayId}/recording-segments/`,
+        getApiUrl(
+          '/projects/$organizationIdOrSlug/$projectIdOrSlug/replays/$replayId/recording-segments/',
+          {
+            path: {
+              organizationIdOrSlug: orgSlug,
+              projectIdOrSlug: projectSlug!,
+              replayId: replayId!,
+            },
+          }
+        ),
       ],
     });
     // The next one isn't optimized
     // This statement will invalidate the cache of fetched error events for all replayIds
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${orgSlug}/replays-events-meta/`],
+      queryKey: [
+        getApiUrl('/organizations/$organizationIdOrSlug/replays-events-meta/', {
+          path: {organizationIdOrSlug: orgSlug},
+        }),
+      ],
     });
   }, [orgSlug, replayId, projectSlug, queryClient]);
 

--- a/static/app/utils/useReopenGamingSdkModal.tsx
+++ b/static/app/utils/useReopenGamingSdkModal.tsx
@@ -4,6 +4,7 @@ import {useQueryState} from 'nuqs';
 
 import {openPrivateGamingSdkAccessModal} from 'sentry/actionCreators/modal';
 import type {PrivateGamingSdkAccessModalProps} from 'sentry/components/modals/privateGamingSdkAccessModal';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {parseAsBooleanLiteral} from 'sentry/utils/url/parseAsBooleanLiteral';
 
 export function useReopenGamingSdkModal(
@@ -20,7 +21,7 @@ export function useReopenGamingSdkModal(
   useEffect(() => {
     if (reopenModal) {
       queryClient.invalidateQueries({
-        queryKey: ['/users/me/user-identities/'],
+        queryKey: [getApiUrl('/users/$userId/user-identities/', {path: {userId: 'me'}})],
       });
       setReopenModal(null);
       openPrivateGamingSdkAccessModal(modalPropsRef.current);

--- a/static/app/utils/useServiceIncidents.tsx
+++ b/static/app/utils/useServiceIncidents.tsx
@@ -28,7 +28,7 @@ export function useServiceIncidents({
   const {statuspage} = useLegacyStore(ConfigStore);
   const {api_host, id} = statuspage ?? {};
 
-  return useQuery<StatuspageIncident[] | null>({
+  return useQuery<StatuspageIncident[] | null, Error, StatuspageIncident[] | null, any>({
     queryKey: ['statuspage-incidents', {api_host, id, includeResolved}],
     queryFn: async () => {
       if (!api_host || !id) {

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -31,6 +31,7 @@ import Panel from 'sentry/components/panels/panel';
 import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -140,7 +141,16 @@ export function UptimeAlertForm({handleDelete, rule}: Props) {
           if (ruleId) {
             queryClient.invalidateQueries({
               queryKey: [
-                `/projects/${organization.slug}/${projectSlug}/uptime/${ruleId}/`,
+                getApiUrl(
+                  '/projects/$organizationIdOrSlug/$projectIdOrSlug/uptime/$uptimeDetectorId/',
+                  {
+                    path: {
+                      organizationIdOrSlug: organization.slug,
+                      projectIdOrSlug: projectSlug,
+                      uptimeDetectorId: ruleId,
+                    },
+                  }
+                ),
               ],
               exact: true,
             });

--- a/static/app/views/dashboards/globalFilter/filterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/filterSelector.tsx
@@ -180,8 +180,11 @@ function FilterSelector({
   const queryKey = useDebouncedValue(baseQueryKey);
 
   const queryResult = useQuery({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey,
+    // @ts-expect-error - Incorrectly typed query key
     queryFn: async ctx => {
+      // @ts-expect-error - Incorrectly typed query key
       const result = await searchBarData.getTagValues(ctx.queryKey[1], ctx.queryKey[3]);
       return result ?? [];
     },
@@ -236,6 +239,7 @@ function FilterSelector({
       );
     });
     // Filter values fetched using getTagValues
+    // @ts-expect-error - Incorrectly typed query result
     fetchedFilterValues?.forEach(value => addOption(value, optionMap));
 
     // Allow setting a custom filter value based on search input
@@ -317,6 +321,7 @@ function FilterSelector({
       activeFilterValues={filterValues}
       operator={stagedOperator}
       options={translatedOptions}
+      // @ts-expect-error - Incorrectly typed query result
       queryResult={queryResult}
     />
   );

--- a/static/app/views/dashboards/hooks/useResetDashboardLists.tsx
+++ b/static/app/views/dashboards/hooks/useResetDashboardLists.tsx
@@ -1,5 +1,6 @@
 import {useCallback} from 'react';
 
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useGetStarredDashboards} from 'sentry/views/dashboards/hooks/useGetStarredDashboards';
@@ -11,7 +12,11 @@ export function useResetDashboardLists() {
 
   return useCallback(() => {
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${organization.slug}/dashboards/`],
+      queryKey: [
+        getApiUrl('/organizations/$organizationIdOrSlug/dashboards/', {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+      ],
     });
     getStarredDashboards.refetch();
   }, [queryClient, organization, getStarredDashboards]);

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -172,10 +172,14 @@ function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) {
     // a flicker from stale data on refetch
     return () => {
       queryClient.removeQueries({
-        queryKey: [`${ENDPOINT}${dashboardId}/`],
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/dashboards/$dashboardId/', {
+            path: {organizationIdOrSlug: organization.slug, dashboardId},
+          }),
+        ],
       });
     };
-  }, [dashboardId, ENDPOINT, queryClient]);
+  }, [dashboardId, organization.slug, queryClient]);
 
   const childrenProps = useMemo(
     () => ({

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
@@ -7,7 +7,9 @@ import type {ApiResult} from 'sentry/api';
 import {t} from 'sentry/locale';
 import type {Series} from 'sentry/types/echarts';
 import type {SessionApiResponse} from 'sentry/types/organization';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import type {WidgetQueryParams} from 'sentry/views/dashboards/datasetConfig/base';
@@ -79,9 +81,11 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
 
         return {
           queryKey: [
-            `/organizations/${organization.slug}/sessions/`,
+            getApiUrl(`/organizations/$organizationIdOrSlug/sessions/`, {
+              path: {organizationIdOrSlug: organization.slug},
+            }),
             {method: 'GET' as const, query: requestData},
-          ],
+          ] satisfies ApiQueryKey,
           queryIndex,
           useSessionAPI: requestData.useSessionAPI,
         };
@@ -272,9 +276,11 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
 
         return {
           queryKey: [
-            `/organizations/${organization.slug}/sessions/`,
+            getApiUrl(`/organizations/$organizationIdOrSlug/sessions/`, {
+              path: {organizationIdOrSlug: organization.slug},
+            }),
             {method: 'GET' as const, query: requestData},
-          ],
+          ] satisfies ApiQueryKey,
           queryIndex,
           useSessionAPI: requestData.useSessionAPI,
         };

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
@@ -130,7 +130,7 @@ export function useSpansSeriesQuery(
           method: 'GET' as const,
           query: queryParams,
         },
-      ] satisfies ApiQueryKey;
+      ] as ApiQueryKey;
     });
     return keys;
   }, [filteredWidget, organization, pageFilters, samplingMode]);
@@ -350,7 +350,7 @@ export function useSpansTableQuery(
           method: 'GET' as const,
           query: queryParams,
         },
-      ];
+      ] as ApiQueryKey;
 
       return [...STARRED_SEGMENT_TABLE_QUERY_KEY, ...baseQueryKey];
     });
@@ -385,6 +385,7 @@ export function useSpansTableQuery(
   // Use native useQueries with queue-integrated queryFn
   // React Query auto-refetches when keys change, but API calls go through the queue
   const queryResults = useQueries({
+    // @ts-expect-error - Incorrectly typed query key
     queries: queryKeys.map(queryKey => ({
       queryKey,
       queryFn: createQueryFnTable(),

--- a/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useDeleteDetectorsMutation.tsx
@@ -1,5 +1,6 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -28,7 +29,11 @@ export function useDeleteDetectorsMutation() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${org.slug}/detectors/`],
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/detectors/', {
+            path: {organizationIdOrSlug: org.slug},
+          }),
+        ],
       });
       addSuccessMessage(t('Monitors deleted'));
     },

--- a/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorsMutation.tsx
@@ -1,5 +1,6 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -29,7 +30,11 @@ export function useUpdateDetectorsMutation() {
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${org.slug}/detectors/`],
+        queryKey: [
+          getApiUrl('/organizations/$organizationIdOrSlug/detectors/', {
+            path: {organizationIdOrSlug: org.slug},
+          }),
+        ],
       });
       addSuccessMessage(
         variables.enabled ? t('Monitors enabled') : t('Monitors disabled')

--- a/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useProgressiveQuery.spec.tsx
@@ -25,6 +25,7 @@ function useMockHookImpl({
 }) {
   const api = useApi();
   const result = useQuery({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: ['/test', {query: {samplingMode: queryExtras?.samplingMode, query}}],
     queryFn: () =>
       api.requestPromise('/test', {

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -55,7 +55,7 @@ export function useTraceItemAttributeKeys({
 
   const {data, isFetching, error} = useQuery<TagCollection>({
     enabled,
-    queryKey: [...queryKey, search],
+    queryKey: [...queryKey, search] as any,
     queryFn: () => getTraceItemAttributeKeys(search),
   });
 

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -15,6 +15,7 @@ import {
   useInfiniteQuery,
   useQueryClient,
   type ApiQueryKey,
+  type InfiniteApiQueryKey,
   type InfiniteData,
   type QueryKeyEndpointOptions,
 } from 'sentry/utils/queryClient';
@@ -182,7 +183,8 @@ export function useLogsQueryKeyWithInfinite({
     highFidelity,
   });
   return {
-    queryKey: [...queryKey, 'infinite'] as QueryKey,
+    // @ts-expect-error - Incorrectly typed query key
+    queryKey: [...queryKey, 'infinite'] as InfiniteApiQueryKey,
     other,
   };
 }
@@ -396,11 +398,11 @@ function isFlexTimePageParam(pageParam: LogPageParam): pageParam is FlexTimePage
   return defined(pageParam) && 'cursor' in pageParam;
 }
 
-type QueryKey = [
-  url: ReturnType<typeof getApiUrl>,
-  endpointOptions: QueryKeyEndpointOptions,
-  'infinite',
-];
+// type QueryKey = [
+//   url: ReturnType<typeof getApiUrl>,
+//   endpointOptions: QueryKeyEndpointOptions,
+//   'infinite',
+// ];
 
 export function useInfiniteLogsQuery({
   disabled,
@@ -461,9 +463,10 @@ export function useInfiniteLogsQuery({
     ApiResult<EventsLogsResult>,
     Error,
     InfiniteData<ApiResult<EventsLogsResult>>,
-    QueryKey,
+    ApiQueryKey,
     LogPageParam
   >({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: queryKeyWithInfinite,
     queryFn: async ({
       pageParam,
@@ -494,7 +497,7 @@ export function useInfiniteLogsQuery({
       ) {
         endpointOptions = {
           ...endpointOptions,
-          query: {...endpointOptions.query, sampling: SAMPLING_MODE.HIGH_ACCURACY},
+          query: {...endpointOptions?.query, sampling: SAMPLING_MODE.HIGH_ACCURACY},
         };
         response = await fetchDataQuery({
           queryKey: [

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -24,7 +24,8 @@ type TableRow = Simplify<
 type TableResponse = [{confidence: any; meta: EventsMetaType; data?: TableRow[]}];
 
 // The query key used for the starred segments table request, this key is used to reference that query and update the starred segment state
-export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'];
+// @ts-expect-error - Incorrectly typed query key
+export const STARRED_SEGMENT_TABLE_QUERY_KEY = ['starred-segment-table'] as ApiQueryKey;
 
 export function StarredSegmentCell({segmentName, isStarred, projectSlug}: Props) {
   const queryClient = useQueryClient();

--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -3,6 +3,7 @@ import type {PageFilters} from 'sentry/types/core';
 import EventView from 'sentry/utils/discover/eventView';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import type {SamplingMode} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import type {ExtrapolationMode} from 'sentry/views/insights/common/queries/types';
@@ -18,7 +19,7 @@ import type {
 } from 'sentry/views/insights/types';
 
 interface UseDiscoverQueryOptions {
-  additonalQueryKey?: string[];
+  additonalQueryKey?: ApiQueryKey | InfiniteApiQueryKey;
   refetchInterval?: number;
 }
 

--- a/static/app/views/insights/common/queries/useSpansQuery.tsx
+++ b/static/app/views/insights/common/queries/useSpansQuery.tsx
@@ -12,7 +12,11 @@ import type {DiscoverQueryProps} from 'sentry/utils/discover/genericDiscoverQuer
 import {useGenericDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
-import {keepPreviousData as keepPreviousDataFn} from 'sentry/utils/queryClient';
+import {
+  keepPreviousData as keepPreviousDataFn,
+  type ApiQueryKey,
+  type InfiniteApiQueryKey,
+} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {
@@ -243,7 +247,7 @@ function useWrappedDiscoverTimeseriesQueryWithoutPageFilters<T>(
 
 type WrappedDiscoverQueryProps<T> = {
   eventView: EventView;
-  additionalQueryKey?: string[];
+  additionalQueryKey?: ApiQueryKey | InfiniteApiQueryKey;
   allowAggregateConditions?: boolean;
   caseInsensitive?: CaseInsensitive;
   cursor?: string;

--- a/static/app/views/issueDetails/groupMerged/index.tsx
+++ b/static/app/views/issueDetails/groupMerged/index.tsx
@@ -13,6 +13,7 @@ import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -58,7 +59,12 @@ function GroupMergedView(props: Props) {
 
   const {refetch} = useQuery({
     queryKey: [
-      `/organizations/${organization.slug}/issues/${groupId}/hashes/`,
+      getApiUrl(`/organizations/$organizationIdOrSlug/issues/$issueId/hashes/`, {
+        path: {
+          organizationIdOrSlug: organization.slug,
+          issueId: groupId,
+        },
+      }),
       {query: {...location.query, limit: 50, query: location.query.query ?? ''}},
     ] as const,
     queryFn: ({queryKey}) => {

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -23,6 +23,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {uniq} from 'sentry/utils/array/uniq';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
@@ -331,7 +332,14 @@ function IssueListActions({
             if (itemIds?.length) {
               for (const itemId of itemIds) {
                 queryClient.invalidateQueries({
-                  queryKey: [`/organizations/${organization.slug}/issues/${itemId}/`],
+                  queryKey: [
+                    getApiUrl(`/organizations/$organizationIdOrSlug/issues/$issueId/`, {
+                      path: {
+                        organizationIdOrSlug: organization.slug,
+                        issueId: itemId,
+                      },
+                    }),
+                  ],
                   exact: false,
                 });
               }
@@ -341,7 +349,11 @@ function IssueListActions({
                 predicate: apiQuery =>
                   typeof apiQuery.queryKey[0] === 'string' &&
                   apiQuery.queryKey[0].startsWith(
-                    `/organizations/${organization.slug}/issues/`
+                    getApiUrl(`/organizations/$organizationIdOrSlug/issues/`, {
+                      path: {
+                        organizationIdOrSlug: organization.slug,
+                      },
+                    })
                   ),
               });
             }

--- a/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTraceMeta.tsx
@@ -171,7 +171,12 @@ export function useTraceMeta(replayTraces: ReplayTrace[]): TraceMetaQueryResults
       apiErrors: Error[];
       meta: TraceMeta | EAPTraceMeta;
     },
-    Error
+    Error,
+    {
+      apiErrors: Error[];
+      meta: TraceMeta | EAPTraceMeta;
+    },
+    any
   >({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['traceData', replayTraces.map(trace => trace.traceSlug)],

--- a/static/app/views/performance/newTraceDetails/traceSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSummary.tsx
@@ -60,7 +60,11 @@ function useTraceSummary(traceSlug: string) {
 
   const refresh = () => {
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${organization.slug}/trace-summary/`],
+      queryKey: [
+        getApiUrl(`/organizations/$organizationIdOrSlug/trace-summary/`, {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+      ],
       exact: false,
     });
     refetch();

--- a/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
+++ b/static/app/views/prevent/tests/queries/useTestResultsAggregates.ts
@@ -1,7 +1,8 @@
 import {useMemo} from 'react';
 
 import {usePreventContext} from 'sentry/components/prevent/context/preventContext';
-import type {QueryKeyEndpointOptions} from 'sentry/utils/queryClient';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -24,8 +25,6 @@ type TestResultAggregate = {
   totalSlowTestsPercentChange: number | null;
 };
 
-type QueryKey = [url: string, endpointOptions: QueryKeyEndpointOptions];
-
 export function useTestResultsAggregates() {
   const api = useApi();
   const organization = useOrganization();
@@ -43,10 +42,19 @@ export function useTestResultsAggregates() {
     TestResultAggregate,
     Error,
     TestResultAggregate,
-    QueryKey
+    ApiQueryKey
   >({
     queryKey: [
-      `/organizations/${organization.slug}/prevent/owner/${integratedOrgId}/repository/${repository}/test-results-aggregates/`,
+      getApiUrl(
+        `/organizations/$organizationIdOrSlug/prevent/owner/$owner/repository/$repository/test-results-aggregates/`,
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            owner: integratedOrgId!,
+            repository: repository!,
+          },
+        }
+      ),
       {query: {preventPeriod, branch}},
     ],
     queryFn: async ({queryKey: [url]}): Promise<TestResultAggregate> => {

--- a/static/app/views/prevent/tokens/repoTokenTable/hooks/useRegenerateRepositoryToken.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/hooks/useRegenerateRepositoryToken.tsx
@@ -1,5 +1,6 @@
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openTokenRegenerationConfirmationModal} from 'sentry/actionCreators/modal';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 
@@ -29,13 +30,30 @@ export function useRegenerateRepositoryToken() {
       // Invalidate the query responsible for fetching the repository tokens to update the table
       queryClient.invalidateQueries({
         queryKey: [
-          `/organizations/${variables.orgSlug}/prevent/owner/${variables.integratedOrgId}/repositories/tokens/`,
+          getApiUrl(
+            `/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/tokens/`,
+            {
+              path: {
+                organizationIdOrSlug: variables.orgSlug,
+                owner: variables.integratedOrgId,
+              },
+            }
+          ),
         ],
       });
       // Invalidate the specific repository query
       queryClient.invalidateQueries({
         queryKey: [
-          `/organizations/${variables.orgSlug}/prevent/owner/${variables.integratedOrgId}/repository/${variables.repository}/`,
+          getApiUrl(
+            `/organizations/$organizationIdOrSlug/prevent/owner/$owner/repository/$repository/`,
+            {
+              path: {
+                organizationIdOrSlug: variables.orgSlug,
+                owner: variables.integratedOrgId,
+                repository: variables.repository,
+              },
+            }
+          ),
         ],
       });
     },

--- a/static/app/views/releases/drawer/useReleasesDrawer.tsx
+++ b/static/app/views/releases/drawer/useReleasesDrawer.tsx
@@ -23,6 +23,7 @@ export function useReleasesDrawer() {
   const {openDrawer} = useDrawer();
   // Dynamically import the ReleasesDrawer component to avoid unnecessary bundle size + circular deps with version & versionHoverCard components
   const {data: ReleasesDrawer, isPending} = useQuery({
+    // @ts-expect-error - Incorrectly typed query key
     queryKey: ['ReleasesDrawerComponent'],
     queryFn: async () => {
       return (await import('sentry/views/releases/drawer/releasesDrawer')).ReleasesDrawer;
@@ -32,6 +33,7 @@ export function useReleasesDrawer() {
   useEffect(() => {
     if (rd === 'show') {
       openDrawer(
+        // @ts-expect-error - Incorrectly typed data
         () => (!isPending && ReleasesDrawer ? <ReleasesDrawer /> : <LoadingIndicator />),
         {
           shouldCloseOnLocationChange: nextLocation => {

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -21,6 +21,7 @@ export default function AccountSecurityWrapper() {
   const {authId} = useParams<{authId?: string}>();
 
   const orgRequest = useQuery<OrganizationSummary[]>({
+    // @ts-expect-error - Incorrectly typed query key
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: ['organizations'],
     queryFn: () => fetchOrganizations(api),
@@ -96,6 +97,7 @@ export default function AccountSecurityWrapper() {
   const enrolled =
     authenticators.filter(auth => auth.isEnrolled && !auth.isBackupInterface) || [];
   const countEnrolled = enrolled.length;
+  // @ts-expect-error - Incorrectly typed data
   const orgsRequire2fa = organizations.filter(org => org.require2FA) || [];
   const deleteDisabled = orgsRequire2fa.length > 0 && countEnrolled === 1;
   const hasVerifiedEmail = emails.some(({isVerified}) => isVerified);

--- a/static/app/views/settings/organizationConsoleSdkInvites/hooks.tsx
+++ b/static/app/views/settings/organizationConsoleSdkInvites/hooks.tsx
@@ -87,7 +87,11 @@ export function useRevokeConsoleSdkPlatformInvite() {
     },
     onSettled: (_data, _error, {orgSlug}: UseRevokeConsoleSdkPlatformInviteParams) => {
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${orgSlug}/console-sdk-invites/`],
+        queryKey: [
+          getApiUrl(`/organizations/$organizationIdOrSlug/console-sdk-invites/`, {
+            path: {organizationIdOrSlug: orgSlug},
+          }),
+        ],
       });
     },
   });

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -192,7 +192,11 @@ function ConfigureIntegration() {
     refetchPlugins();
 
     queryClient.removeQueries({
-      queryKey: [`/organizations/${organization.slug}/config/integrations/`],
+      queryKey: [
+        getApiUrl(`/organizations/$organizationIdOrSlug/config/integrations/`, {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+      ],
     });
     refetchConfig();
 

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -123,7 +123,11 @@ function useDeletePathConfig() {
     },
     onSettled: () => {
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${organization.slug}/code-mappings/`],
+        queryKey: [
+          getApiUrl(`/organizations/$organizationIdOrSlug/code-mappings/`, {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
       });
     },
   });
@@ -200,7 +204,11 @@ export default function IntegrationCodeMappings({
 
   const invalidateCodeMappings = useCallback(() => {
     queryClient.invalidateQueries({
-      queryKey: [`/organizations/${organization.slug}/code-mappings/`],
+      queryKey: [
+        getApiUrl(`/organizations/$organizationIdOrSlug/code-mappings/`, {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+      ],
     });
   }, [queryClient, organization.slug]);
 

--- a/static/app/views/settings/projectPlugins/useTogglePluginMutation.tsx
+++ b/static/app/views/settings/projectPlugins/useTogglePluginMutation.tsx
@@ -91,12 +91,30 @@ export function useTogglePluginMutation({
       addErrorMessage(
         shouldEnable ? t('Unable to enable plugin') : t('Unable to disable plugin')
       );
-      const pluginDetailsQueryKey = `/projects/${organization.slug}/${projectSlug}/plugins/${pluginId}/`;
+      const pluginDetailsQueryKey = getApiUrl(
+        `/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/`,
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectSlug,
+            pluginId,
+          },
+        }
+      );
       queryClient.invalidateQueries({queryKey: [pluginsQueryKey]});
       queryClient.invalidateQueries({queryKey: [pluginDetailsQueryKey]});
     },
     onSettled: (_data, _error, {pluginId}) => {
-      const pluginDetailsQueryKey = `/projects/${organization.slug}/${projectSlug}/plugins/${pluginId}/`;
+      const pluginDetailsQueryKey = getApiUrl(
+        `/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/`,
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectSlug,
+            pluginId,
+          },
+        }
+      );
       queryClient.invalidateQueries({queryKey: [pluginsQueryKey]});
       queryClient.invalidateQueries({queryKey: [pluginDetailsQueryKey]});
     },

--- a/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
+++ b/static/app/views/setupWizard/utils/useOrganizationsWithRegion.tsx
@@ -1,6 +1,7 @@
 import ConfigStore from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Region} from 'sentry/types/system';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useQuery} from 'sentry/utils/queryClient';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -10,7 +11,7 @@ export function useOrganizationsWithRegion() {
   const api = useApi();
 
   return useQuery<OrganizationWithRegion[], RequestError>({
-    queryKey: ['/organizations/'],
+    queryKey: [getApiUrl('/organizations/')],
     queryFn: async () => {
       const regions = ConfigStore.get('memberRegions');
       const results = await Promise.all(

--- a/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
+++ b/static/gsAdmin/components/toggleConsolePlatformsModal.tsx
@@ -26,6 +26,7 @@ import {
   type ConsolePlatform,
 } from 'sentry/constants/consolePlatforms';
 import type {Organization} from 'sentry/types/organization';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {
   useConsoleSdkInvites,
@@ -230,7 +231,11 @@ function ToggleConsolePlatformsModal({
       })
       .finally(() => {
         queryClient.invalidateQueries({
-          queryKey: [`/organizations/${organization.slug}/console-sdk-invites/`],
+          queryKey: [
+            getApiUrl(`/organizations/$organizationIdOrSlug/console-sdk-invites/`, {
+              path: {organizationIdOrSlug: organization.slug},
+            }),
+          ],
         });
       });
   };

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/useBulkUpdateRepositorySettings.tsx
@@ -1,4 +1,5 @@
 import type {RepositoryWithSettings} from 'sentry/types/integrations';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {
   fetchMutation,
   useMutation,
@@ -46,7 +47,11 @@ export function useBulkUpdateRepositorySettings(
     ...options,
     onSettled: (data, error, variables, context) => {
       queryClient.invalidateQueries({
-        queryKey: [`/organizations/${organization.slug}/repos/`],
+        queryKey: [
+          getApiUrl(`/organizations/$organizationIdOrSlug/repos/`, {
+            path: {organizationIdOrSlug: organization.slug},
+          }),
+        ],
       });
       (data ?? []).forEach(repo => {
         const queryKey = getRepositoryWithSettingsQueryKey(organization, repo.id);


### PR DESCRIPTION
This PR makes it so that all @tanstack/react-query calls require the use of `ApiQueryKey` instead of simply passing a string to `queryKey: `

There are plenty of places where we're using something other than an `ApiQueryKey`, but by and large it seems like we're mostly doing it in order to treat the queryCache like a global store, and cache things for use later, or in multiple spots. Sometimes those things are transformed api responses, but other times it's just some kind of random object.

Going forward I would prefer to use [`select`](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) field on useQuery to do the transforms, and for the non-api related stuff we can use Context & state, there's not that many instances.

`static/app/utils/api/tanstackQueryTypes.d.ts` is the new file that transforms the types across the app. So if people import from `@tanstack/react-query` directly, or from `queryClient` it doesn't matter, they'll be affected.

My goal with this is to be able to have the capability to import the raw `@tanstack/react-query` functions/types and let them be safe to use across the side. Currently there are two ways to import those functions, via the `@tanstack/react-query` package, and from queryClient which re-exports them. We have our own wrappers, `useApiQuery` which prevent things like `select` from working, so i'd like to deprecate that and transition to a world where regular `useQuery` and `queryOptions` are used throughout.

See https://github.com/getsentry/sentry/pull/108498 which is a followup and includes those apis.