### PR TITLE
feat(integrations): add GitHub-only enhanced issue defaults

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -189,6 +189,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     manager.add("organizations:integrations-feature-flag-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-github-issue-defaults-enhanced", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Async lookup for integration external projects

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -38,9 +38,6 @@ MAX_TITLE_LENGTH = 255
 MAX_EVIDENCE_ITEMS = 8
 MAX_EVIDENCE_VALUE_LENGTH = 140
 MAX_EVENT_CONTEXT_LENGTH = 1200
-SQL_EVIDENCE_PREFIX_RE = re.compile(
-    r"^(db|database)\s*-\s*(select|insert|update|delete|with)\b", re.I
-)
 CODE_BLOCK_EVIDENCE_NAME_PARTS = frozenset({"query", "offending spans", "selector path"})
 
 
@@ -81,16 +78,14 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             return "Interaction Details"
         return "Details"
 
-    def _is_code_block_evidence(self, evidence_name: str, evidence_value: Any) -> bool:
+    def _is_code_block_evidence(self, evidence_name: str) -> bool:
         normalized_name = evidence_name.lower()
-        if any(part in normalized_name for part in CODE_BLOCK_EVIDENCE_NAME_PARTS):
-            return True
-        return bool(SQL_EVIDENCE_PREFIX_RE.search(str(evidence_value).strip()))
+        return any(part in normalized_name for part in CODE_BLOCK_EVIDENCE_NAME_PARTS)
 
     def _get_formatted_evidence_lines(self, evidence_name: str, evidence_value: Any) -> list[str]:
         name = self._normalize_text(evidence_name, normalize_whitespace=True)
         value = str(evidence_value)
-        if self._is_code_block_evidence(name, value):
+        if self._is_code_block_evidence(name):
             return [f"{name}:", "```", value, "```"]
         return [
             f"{name}: {self._normalize_text(value, MAX_EVIDENCE_VALUE_LENGTH, normalize_whitespace=True)}"

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -7,6 +7,7 @@ from typing import Any, NoReturn
 
 from django.urls import reverse
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
@@ -32,9 +33,188 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.strings import truncatechars
 
 PAGE_NUMBER_LIMIT = 1
+GITHUB_ENHANCED_DEFAULTS_FEATURE = "organizations:integrations-github-issue-defaults-enhanced"
+MAX_TITLE_LENGTH = 255
+MAX_EVIDENCE_ITEMS = 8
+MAX_EVIDENCE_VALUE_LENGTH = 140
+MAX_EVENT_CONTEXT_LENGTH = 1200
+SQL_EVIDENCE_PREFIX_RE = re.compile(
+    r"^(db|database)\s*-\s*(select|insert|update|delete|with)\b", re.I
+)
+CODE_BLOCK_EVIDENCE_NAME_PARTS = frozenset({"query", "offending spans", "selector path"})
 
 
 class GitHubIssuesSpec(SourceCodeIssueIntegration):
+    def _truncate_text(self, value: str, max_length: int | None = None) -> str:
+        if max_length and len(value) > max_length:
+            return f"{value[: max_length - 3]}..."
+        return value
+
+    def _normalize_text(
+        self, value: Any, max_length: int | None = None, normalize_whitespace: bool = False
+    ) -> str:
+        if value is None:
+            return ""
+        text = str(value)
+        if normalize_whitespace:
+            text = " ".join(text.split())
+        return self._truncate_text(text, max_length)
+
+    def _has_github_enhanced_defaults_flag(self, group: Group, user: User | RpcUser) -> bool:
+        return features.has(GITHUB_ENHANCED_DEFAULTS_FEATURE, group.organization, actor=user)
+
+    def _get_occurrence_evidence_section_title(self, occurrence: IssueOccurrence) -> str:
+        category = occurrence.type.category_v2
+        if category == GroupCategory.DB_QUERY.value:
+            return "Query Evidence"
+        if category == GroupCategory.HTTP_CLIENT.value:
+            return "Request Evidence"
+        if category == GroupCategory.FRONTEND.value:
+            return "Interaction Evidence"
+        return "Evidence"
+
+    def _get_occurrence_details_section_title(self, occurrence: IssueOccurrence) -> str:
+        category = occurrence.type.category_v2
+        if category == GroupCategory.METRIC.value:
+            return "Metric Details"
+        if category == GroupCategory.FRONTEND.value:
+            return "Interaction Details"
+        return "Details"
+
+    def _is_code_block_evidence(self, evidence_name: str, evidence_value: Any) -> bool:
+        normalized_name = evidence_name.lower()
+        if any(part in normalized_name for part in CODE_BLOCK_EVIDENCE_NAME_PARTS):
+            return True
+        return bool(SQL_EVIDENCE_PREFIX_RE.search(str(evidence_value).strip()))
+
+    def _get_formatted_evidence_lines(self, evidence_name: str, evidence_value: Any) -> list[str]:
+        name = self._normalize_text(evidence_name, normalize_whitespace=True)
+        value = str(evidence_value)
+        if self._is_code_block_evidence(name, value):
+            return [f"{name}:", "```", value, "```"]
+        return [
+            f"{name}: {self._normalize_text(value, MAX_EVIDENCE_VALUE_LENGTH, normalize_whitespace=True)}"
+        ]
+
+    def _get_occurrence_detail_lines(self, evidence_data: Mapping[str, Any]) -> list[str]:
+        lines: list[str] = []
+        added_items = 0
+        for key, value in evidence_data.items():
+            if value is None or not isinstance(value, (str, int, float, bool)):
+                continue
+            lines.extend(self._get_formatted_evidence_lines(str(key), value))
+            added_items += 1
+            if added_items >= MAX_EVIDENCE_ITEMS:
+                break
+        return lines
+
+    def _get_github_enhanced_title_description(
+        self, group: Group, event: Event | GroupEvent, **kwargs: Any
+    ) -> tuple[str, str]:
+        title = self._normalize_text(
+            self.get_group_title(group, event, **kwargs),
+            MAX_TITLE_LENGTH,
+            normalize_whitespace=True,
+        )
+        output = self.get_group_link(group, **kwargs)
+
+        if isinstance(event, GroupEvent) and event.occurrence is not None:
+            issue_title = self._normalize_text(
+                event.occurrence.issue_title,
+                MAX_TITLE_LENGTH,
+                normalize_whitespace=True,
+            )
+            if issue_title:
+                title = issue_title
+                output.extend(["", f"Issue Type: {issue_title}"])
+
+            subtitle = self._normalize_text(
+                event.occurrence.subtitle,
+                MAX_EVENT_CONTEXT_LENGTH,
+                normalize_whitespace=True,
+            )
+            if subtitle:
+                output.append(f"Summary: {subtitle}")
+
+            important_evidence = event.occurrence.important_evidence_display
+            if important_evidence:
+                important_value = self._normalize_text(
+                    important_evidence.value,
+                    MAX_EVIDENCE_VALUE_LENGTH,
+                    normalize_whitespace=True,
+                )
+                if important_value:
+                    title = self._normalize_text(
+                        f"{title}: {important_value}",
+                        MAX_TITLE_LENGTH,
+                        normalize_whitespace=True,
+                    )
+
+            evidence_items = sorted(
+                event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
+            )[:MAX_EVIDENCE_ITEMS]
+            if evidence_items:
+                output.extend(
+                    ["", f"{self._get_occurrence_evidence_section_title(event.occurrence)}:"]
+                )
+                for evidence in evidence_items:
+                    output.extend(self._get_formatted_evidence_lines(evidence.name, evidence.value))
+            else:
+                detail_lines = self._get_occurrence_detail_lines(event.occurrence.evidence_data)
+                if detail_lines:
+                    output.extend(
+                        [
+                            "",
+                            f"{self._get_occurrence_details_section_title(event.occurrence)}:",
+                            *detail_lines,
+                        ]
+                    )
+        else:
+            body = self.get_group_body(group, event)
+            if body:
+                output.extend(
+                    [
+                        "",
+                        "Event Context:",
+                        "```",
+                        self._truncate_text(body, MAX_EVENT_CONTEXT_LENGTH),
+                        "```",
+                    ]
+                )
+
+        return title, "\n".join(output)
+
+    def _get_create_issue_fields(
+        self, group: Group, user: User | RpcUser, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        event = group.get_latest_event()
+        if event is None:
+            return []
+
+        if self._has_github_enhanced_defaults_flag(group, user):
+            title, description = self._get_github_enhanced_title_description(group, event, **kwargs)
+        else:
+            title = self.get_group_title(group, event, **kwargs)
+            description = self.get_group_description(group, event, **kwargs)
+
+        return [
+            {
+                "name": "title",
+                "label": "Title",
+                "default": title,
+                "type": "string",
+                "required": True,
+            },
+            {
+                "name": "description",
+                "label": "Description",
+                "default": description,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            },
+        ]
+
     def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
         if isinstance(exc, ApiError):
             if exc.code == 422:
@@ -165,7 +345,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         kwargs["link_referrer"] = "github_integration"
 
         if group:
-            fields = super().get_create_issue_config(group, user, **kwargs)
+            fields = self._get_create_issue_fields(group, user, **kwargs)
             org = group.organization
         else:
             fields = []

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -12,11 +12,14 @@ from django.test import RequestFactory
 from django.utils import timezone
 from pytest import fixture
 
+from sentry.incidents.grouptype import MetricIssue
 from sentry.integrations.github import client
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.services.integration import integration_service
-from sentry.issues.grouptype import FeedbackGroup
+from sentry.issues.grouptype import FeedbackGroup, PerformanceNPlusOneGroupType, ReplayRageClickType
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.models.group import Group
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
     IntegrationConfigurationError,
@@ -151,6 +154,13 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             assert request.headers[PROXY_OI_HEADER] == str(self.install.org_integration.id)
             assert request.headers[PROXY_BASE_URL_HEADER] == "https://api.github.com"
             assert PROXY_SIGNATURE_HEADER in request.headers
+
+    def _stub_create_issue_config_dependencies(
+        self,
+    ) -> tuple[tuple[str, str], list[tuple[str, str]]]:
+        default_repo = "getsentry/sentry"
+        repo_choices = [("getsentry/sentry", "sentry")]
+        return (default_repo, repo_choices)
 
     @responses.activate
     def test_get_allowed_assignees(self) -> None:
@@ -574,6 +584,226 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert "oh no" in description
         title = self.install.get_group_title(event.group, event)
         assert title == event.title
+
+    def test_get_create_issue_config_uses_legacy_defaults_when_flag_disabled(self) -> None:
+        event = self.create_performance_issue()
+        assert event.group is not None
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+
+        with (
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            fields = self.install.get_create_issue_config(event.group, self.user)
+
+        description_field = next(field for field in fields if field["name"] == "description")
+        assert "|  |  |" in description_field["default"]
+        assert "Query Evidence:" not in description_field["default"]
+
+    def test_get_create_issue_config_uses_enhanced_defaults_for_db_query(self) -> None:
+        event = self.store_event(
+            data={
+                "event_id": "f" * 32,
+                "message": "query issue",
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        db_query = "db - SELECT * FROM `users` WHERE users.id = 1"
+        group_event = event.for_group(event.group)
+        group_event.occurrence = IssueOccurrence(
+            id="github-db-occurrence",
+            project_id=self.project.id,
+            event_id=event.event_id,
+            fingerprint=["performance-n-plus-one"],
+            issue_title="N+1 DB Query",
+            subtitle="Repeated DB queries detected",
+            resource_id=None,
+            evidence_data={"num_repeating_spans": "12"},
+            evidence_display=[
+                IssueEvidence(name="Offending Spans", value=db_query, important=True)
+            ],
+            type=PerformanceNPlusOneGroupType,
+            detection_time=before_now(minutes=1),
+            level="error",
+            culprit="",
+        )
+
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+        with (
+            self.feature("organizations:integrations-github-issue-defaults-enhanced"),
+            mock.patch.object(Group, "get_latest_event", return_value=group_event),
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            fields = self.install.get_create_issue_config(event.group, self.user)
+
+        title_field = next(field for field in fields if field["name"] == "title")
+        description_field = next(field for field in fields if field["name"] == "description")
+        assert (
+            title_field["default"] == "N+1 DB Query: db - SELECT * FROM `users` WHERE users.id = 1"
+        )
+        assert "Query Evidence:" in description_field["default"]
+        assert "Offending Spans:\n```" in description_field["default"]
+        assert f"{db_query}\n```" in description_field["default"]
+        assert "|  |  |" not in description_field["default"]
+
+    def test_get_create_issue_config_uses_enhanced_defaults_for_replay_issue(self) -> None:
+        event = self.store_event(
+            data={
+                "event_id": "e" * 32,
+                "message": "replay issue",
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        selector_path = "div.page > button[data-test-id='signup']"
+        group_event = event.for_group(event.group)
+        group_event.occurrence = IssueOccurrence(
+            id="github-replay-occurrence",
+            project_id=self.project.id,
+            event_id=event.event_id,
+            fingerprint=["replay-click-rage"],
+            issue_title="Rage Click",
+            subtitle=selector_path,
+            resource_id=None,
+            evidence_data={"selector": selector_path},
+            evidence_display=[
+                IssueEvidence(name="Clicked Element", value="button#signup", important=False),
+                IssueEvidence(name="Selector Path", value=selector_path, important=False),
+                IssueEvidence(name="React Component Name", value="StyledButton", important=True),
+            ],
+            type=ReplayRageClickType,
+            detection_time=before_now(minutes=1),
+            level="error",
+            culprit="",
+        )
+
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+        with (
+            self.feature("organizations:integrations-github-issue-defaults-enhanced"),
+            mock.patch.object(Group, "get_latest_event", return_value=group_event),
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            fields = self.install.get_create_issue_config(event.group, self.user)
+
+        title_field = next(field for field in fields if field["name"] == "title")
+        description_field = next(field for field in fields if field["name"] == "description")
+        assert title_field["default"] == "Rage Click: StyledButton"
+        assert "Interaction Evidence:" in description_field["default"]
+        assert "Selector Path:\n```" in description_field["default"]
+        assert f"{selector_path}\n```" in description_field["default"]
+
+    def test_get_create_issue_config_uses_enhanced_defaults_for_metric_issue(self) -> None:
+        event = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "message": "metric issue",
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        group_event = event.for_group(event.group)
+        group_event.occurrence = IssueOccurrence(
+            id="github-metric-occurrence",
+            project_id=self.project.id,
+            event_id=event.event_id,
+            fingerprint=["metric-issue"],
+            issue_title="Error Rate Alert",
+            subtitle="Critical: Number of events in the last 5 minutes above 100",
+            resource_id=None,
+            evidence_data={"alert_id": 42},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=before_now(minutes=1),
+            level="error",
+            culprit="",
+        )
+
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+        with (
+            self.feature("organizations:integrations-github-issue-defaults-enhanced"),
+            mock.patch.object(Group, "get_latest_event", return_value=group_event),
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            fields = self.install.get_create_issue_config(event.group, self.user)
+
+        description_field = next(field for field in fields if field["name"] == "description")
+        assert "Metric Details:" in description_field["default"]
+        assert "alert_id: 42" in description_field["default"]
+        assert "Evidence:" not in description_field["default"]
+
+    def test_get_create_issue_config_enhanced_defaults_preserves_event_context_markdown(
+        self,
+    ) -> None:
+        event = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "message": "error issue",
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+        with (
+            self.feature("organizations:integrations-github-issue-defaults-enhanced"),
+            mock.patch.object(
+                self.install, "get_group_body", return_value="line1\nSELECT * FROM `users`"
+            ),
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            fields = self.install.get_create_issue_config(event.group, self.user)
+
+        description_field = next(field for field in fields if field["name"] == "description")
+        assert "Event Context:\n```" in description_field["default"]
+        assert "SELECT * FROM `users`" in description_field["default"]
+        assert "```" in description_field["default"]
 
     @responses.activate
     def test_link_issue(self) -> None:

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -157,7 +157,7 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
     def _stub_create_issue_config_dependencies(
         self,
-    ) -> tuple[tuple[str, str], list[tuple[str, str]]]:
+    ) -> tuple[str, list[tuple[str, str]]]:
         default_repo = "getsentry/sentry"
         repo_choices = [("getsentry/sentry", "sentry")]
         return (default_repo, repo_choices)


### PR DESCRIPTION
This improves GitHub issue creation defaults by making create payloads more readable and issue-type aware, while preserving raw evidence content. It is gated behind `organizations:integrations-github-issue-defaults-enhanced`.

**Before**
Title:
`N+1 DB Query`

Description:
```
Sentry Issue: [ABC-123](...)
|  |  |
| ------------- | --------------- |
| **Offending Spans** | db - SELECT * FROM ... |
```

**After**
Title:
`N+1 DB Query: db - SELECT * FROM `users` WHERE users.id = 1`

Description:
````
Sentry Issue: [ABC-123](...)

Issue Type: N+1 DB Query
Summary: Repeated DB queries detected

Query Evidence:
Offending Spans:
```
db - SELECT * FROM `users` WHERE users.id = 1
```
````