### PR TITLE
fix(integrations): Add metric issue information to github issue description

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -42,6 +42,25 @@ CODE_BLOCK_EVIDENCE_NAME_PARTS = frozenset({"query", "offending spans", "selecto
 
 
 class GitHubIssuesSpec(SourceCodeIssueIntegration):
+    def _get_metric_issue_body(self, occurrence: IssueOccurrence) -> str:
+        details = ["Metric Details:"]
+        details_added = 0
+
+        for key, value in occurrence.evidence_data.items():
+            if value is None or not isinstance(value, (str, int, float, bool)):
+                continue
+
+            details.append(f"- **{key}**: {value}")
+            details_added += 1
+
+            if details_added >= MAX_EVIDENCE_ITEMS:
+                break
+
+        if details_added == 0:
+            details.append("- No metric details available.")
+
+        return "\n".join(details)
+
     def _truncate_text(self, value: str, max_length: int | None = None) -> str:
         if max_length and len(value) > max_length:
             return f"{value[: max_length - 3]}..."
@@ -272,6 +291,12 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         return body.rstrip("\n")  # remove the last new line
 
     def get_generic_issue_body(self, occurrence: IssueOccurrence) -> str:
+        if (
+            occurrence.type.category_v2 == GroupCategory.METRIC.value
+            and len(occurrence.evidence_display) == 0
+        ):
+            return self._get_metric_issue_body(occurrence)
+
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
         for evidence in sorted(

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -9,6 +9,8 @@ from django.urls import reverse
 
 from sentry import features
 from sentry.constants import ObjectStatus
+from sentry.incidents.utils.format_duration import format_duration_idiomatic
+from sentry.integrations.metric_alerts import build_title_link
 from sentry.integrations.mixins.issues import MAX_CHAR
 from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.source_code_management.issues import SourceCodeIssueIntegration
@@ -42,21 +44,115 @@ CODE_BLOCK_EVIDENCE_NAME_PARTS = frozenset({"query", "offending spans", "selecto
 
 
 class GitHubIssuesSpec(SourceCodeIssueIntegration):
-    def _get_metric_issue_body(self, occurrence: IssueOccurrence) -> str:
-        details = ["Metric Details:"]
-        details_added = 0
+    _METRIC_CONDITION_LABELS = {
+        "gt": "Above",
+        "gte": "At or above",
+        "lt": "Below",
+        "lte": "At or below",
+        "eq": "Equal to",
+        "ne": "Not equal to",
+    }
 
-        for key, value in occurrence.evidence_data.items():
-            if value is None or not isinstance(value, (str, int, float, bool)):
-                continue
+    def _get_metric_issue_body(self, group: Group, occurrence: IssueOccurrence) -> str:
+        details: list[str] = ["Metric Details:"]
 
-            details.append(f"- **{key}**: {value}")
-            details_added += 1
+        alert_id = occurrence.evidence_data.get("alert_id")
+        try:
+            alert_rule_id = int(alert_id)
+        except (TypeError, ValueError):
+            alert_rule_id = None
 
-            if details_added >= MAX_EVIDENCE_ITEMS:
-                break
+        if alert_rule_id is not None:
+            details.append(
+                "- **Metric Alert**: "
+                f"[View alert rule]({build_title_link(alert_rule_id, group.organization, {'referrer': 'github_integration'})})"
+            )
 
-        if details_added == 0:
+        snuba_query: Mapping[str, Any] = {}
+        raw_data_sources = occurrence.evidence_data.get("data_sources")
+        if isinstance(raw_data_sources, list):
+            for data_source in raw_data_sources:
+                if not isinstance(data_source, Mapping):
+                    continue
+                query_obj = data_source.get("query_obj")
+                if not isinstance(query_obj, Mapping):
+                    continue
+                maybe_query = query_obj.get("snuba_query")
+                if isinstance(maybe_query, Mapping):
+                    snuba_query = maybe_query
+                    break
+
+        dataset = self._normalize_text(
+            snuba_query.get("dataset"), normalize_whitespace=True
+        ).replace("_", " ")
+        if dataset:
+            details.append(f"- **Dataset**: {dataset.capitalize()}")
+
+        aggregate = self._normalize_text(
+            snuba_query.get("aggregate"), MAX_EVIDENCE_VALUE_LENGTH, normalize_whitespace=True
+        )
+        if aggregate:
+            details.append(f"- **Aggregate**: {aggregate}")
+
+        raw_time_window = snuba_query.get("time_window", snuba_query.get("timeWindow"))
+        try:
+            time_window_minutes = int(float(raw_time_window)) // 60
+        except (TypeError, ValueError):
+            time_window_minutes = 0
+        if time_window_minutes > 0:
+            interval = format_duration_idiomatic(time_window_minutes)
+            if " " not in interval:
+                interval = f"1 {interval}"
+            details.append(f"- **Interval**: {interval}")
+
+        raw_conditions = occurrence.evidence_data.get("conditions")
+        selected_condition: Mapping[str, Any] | None = None
+        if isinstance(raw_conditions, list):
+            priority = occurrence.priority
+            if priority is not None:
+                selected_condition = next(
+                    (
+                        condition
+                        for condition in raw_conditions
+                        if isinstance(condition, Mapping)
+                        and (
+                            condition.get("condition_result") == priority
+                            or str(condition.get("condition_result")) == str(priority)
+                        )
+                    ),
+                    None,
+                )
+            if selected_condition is None:
+                selected_condition = next(
+                    (condition for condition in raw_conditions if isinstance(condition, Mapping)),
+                    None,
+                )
+
+        if selected_condition is not None:
+            condition_type = self._normalize_text(
+                selected_condition.get("type"), normalize_whitespace=True
+            ).lower()
+            comparison = self._normalize_text(
+                selected_condition.get("comparison"), normalize_whitespace=True
+            )
+            condition = self._METRIC_CONDITION_LABELS.get(condition_type, condition_type)
+            if comparison:
+                condition = f"{condition} {comparison}"
+            details.append(f"- **Condition**: {condition}")
+
+        raw_value = occurrence.evidence_data.get("value")
+        if isinstance(raw_value, bool):
+            value = str(raw_value)
+        elif isinstance(raw_value, (int, float)):
+            value = f"{raw_value:,}"
+        else:
+            value = self._normalize_text(
+                raw_value, MAX_EVIDENCE_VALUE_LENGTH, normalize_whitespace=True
+            )
+        if value:
+            details.append(f"- **Evaluated Value**: {value}")
+
+        if len(details) == 1:
             details.append("- No metric details available.")
 
         return "\n".join(details)
@@ -174,15 +270,23 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
                 for evidence in evidence_items:
                     output.extend(self._get_formatted_evidence_lines(evidence.name, evidence.value))
             else:
-                detail_lines = self._get_occurrence_detail_lines(event.occurrence.evidence_data)
-                if detail_lines:
+                if event.occurrence.type.category_v2 == GroupCategory.METRIC.value:
                     output.extend(
                         [
                             "",
-                            f"{self._get_occurrence_details_section_title(event.occurrence)}:",
-                            *detail_lines,
+                            self._get_metric_issue_body(group, event.occurrence),
                         ]
                     )
+                else:
+                    detail_lines = self._get_occurrence_detail_lines(event.occurrence.evidence_data)
+                    if detail_lines:
+                        output.extend(
+                            [
+                                "",
+                                f"{self._get_occurrence_details_section_title(event.occurrence)}:",
+                                *detail_lines,
+                            ]
+                        )
         else:
             body = self.get_group_body(group, event)
             if body:
@@ -290,12 +394,12 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         return body.rstrip("\n")  # remove the last new line
 
-    def get_generic_issue_body(self, occurrence: IssueOccurrence) -> str:
+    def get_generic_issue_body(self, group: Group, occurrence: IssueOccurrence) -> str:
         if (
             occurrence.type.category_v2 == GroupCategory.METRIC.value
             and len(occurrence.evidence_display) == 0
         ):
-            return self._get_metric_issue_body(occurrence)
+            return self._get_metric_issue_body(group, occurrence)
 
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
@@ -314,7 +418,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             if group.issue_category == GroupCategory.FEEDBACK:
                 body = self.get_feedback_issue_body(event.occurrence)
             else:
-                body = self.get_generic_issue_body(event.occurrence)
+                body = self.get_generic_issue_body(group, event.occurrence)
             output.extend([body])
         else:
             body = self.get_group_body(group, event)

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -562,11 +562,48 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         group_event.occurrence = occurrence
 
         description = self.install.get_group_description(group_event.group, group_event)
+        assert "|  |  |" in description
+        assert "| ------------- | --------------- |" in description
         assert occurrence.evidence_display[0].value in description
         assert occurrence.evidence_display[1].value in description
         assert occurrence.evidence_display[2].value in description
         title = self.install.get_group_title(group_event.group, group_event)
         assert title == occurrence.issue_title
+
+    def test_metric_issue_content_falls_back_to_evidence_data_when_display_is_empty(self) -> None:
+        event = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "metric issue",
+                "timestamp": before_now(minutes=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        group_event = event.for_group(event.group)
+        group_event.occurrence = IssueOccurrence(
+            id="metric-occurrence-description",
+            project_id=self.project.id,
+            event_id=event.event_id,
+            fingerprint=["metric-issue"],
+            issue_title="Error Rate Alert",
+            subtitle="Critical: Number of events in the last 5 minutes above 100",
+            resource_id=None,
+            evidence_data={"alert_id": 42, "window": "5m"},
+            evidence_display=[],
+            type=MetricIssue,
+            detection_time=before_now(minutes=1),
+            level="error",
+            culprit="",
+        )
+
+        description = self.install.get_group_description(group_event.group, group_event)
+
+        assert "Metric Details:" in description
+        assert "- **alert_id**: 42" in description
+        assert "- **window**: 5m" in description
+        assert "|  |  |" not in description
 
     def test_error_issues_content(self) -> None:
         """Test that a GitHub issue created from an error issue has the expected title and descriptionn"""

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -590,7 +590,28 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             issue_title="Error Rate Alert",
             subtitle="Critical: Number of events in the last 5 minutes above 100",
             resource_id=None,
-            evidence_data={"alert_id": 42, "window": "5m"},
+            evidence_data={
+                "alert_id": 42,
+                "value": 5026.1,
+                "conditions": [
+                    {
+                        "type": "gt",
+                        "comparison": 0,
+                        "condition_result": 1,
+                    }
+                ],
+                "data_sources": [
+                    {
+                        "query_obj": {
+                            "snuba_query": {
+                                "dataset": "metrics",
+                                "aggregate": "p50(value,dashboards.widget_query_queue.time_to_empty,distribution,-)",
+                                "time_window": 3600,
+                            }
+                        }
+                    }
+                ],
+            },
             evidence_display=[],
             type=MetricIssue,
             detection_time=before_now(minutes=1),
@@ -601,8 +622,16 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         description = self.install.get_group_description(group_event.group, group_event)
 
         assert "Metric Details:" in description
-        assert "- **alert_id**: 42" in description
-        assert "- **window**: 5m" in description
+        assert "- **Metric Alert**: [View alert rule](" in description
+        assert "/alerts/rules/" in description
+        assert "- **Dataset**: Metrics" in description
+        assert (
+            "- **Aggregate**: p50(value,dashboards.widget_query_queue.time_to_empty,distribution,-)"
+            in description
+        )
+        assert "- **Interval**: 1 hour" in description
+        assert "- **Condition**: Above 0" in description
+        assert "- **Evaluated Value**: 5,026.1" in description
         assert "|  |  |" not in description
 
     def test_error_issues_content(self) -> None:
@@ -777,7 +806,28 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             issue_title="Error Rate Alert",
             subtitle="Critical: Number of events in the last 5 minutes above 100",
             resource_id=None,
-            evidence_data={"alert_id": 42},
+            evidence_data={
+                "alert_id": 42,
+                "value": 5026.1,
+                "conditions": [
+                    {
+                        "type": "gt",
+                        "comparison": 0,
+                        "condition_result": 1,
+                    }
+                ],
+                "data_sources": [
+                    {
+                        "query_obj": {
+                            "snuba_query": {
+                                "dataset": "metrics",
+                                "aggregate": "p50(value,dashboards.widget_query_queue.time_to_empty,distribution,-)",
+                                "time_window": 3600,
+                            }
+                        }
+                    }
+                ],
+            },
             evidence_display=[],
             type=MetricIssue,
             detection_time=before_now(minutes=1),
@@ -803,7 +853,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
 
         description_field = next(field for field in fields if field["name"] == "description")
         assert "Metric Details:" in description_field["default"]
-        assert "alert_id: 42" in description_field["default"]
+        assert "- **Metric Alert**: [View alert rule](" in description_field["default"]
+        assert "- **Condition**: Above 0" in description_field["default"]
+        assert "- **Evaluated Value**: 5,026.1" in description_field["default"]
         assert "Evidence:" not in description_field["default"]
 
     def test_get_create_issue_config_enhanced_defaults_preserves_event_context_markdown(

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,5 +1,6 @@
 import datetime
 from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
 from functools import cached_property
 from typing import cast
 from unittest import mock
@@ -161,6 +162,22 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         default_repo = "getsentry/sentry"
         repo_choices = [("getsentry/sentry", "sentry")]
         return (default_repo, repo_choices)
+
+    @contextmanager
+    def _mock_create_issue_config_form_dependencies(self):
+        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
+        with (
+            mock.patch.object(
+                self.install,
+                "get_repository_choices",
+                return_value=(default_repo, repo_choices),
+            ),
+            mock.patch.object(
+                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
+            ),
+            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+        ):
+            yield
 
     @responses.activate
     def test_get_allowed_assignees(self) -> None:
@@ -654,19 +671,8 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
     def test_get_create_issue_config_uses_legacy_defaults_when_flag_disabled(self) -> None:
         event = self.create_performance_issue()
         assert event.group is not None
-        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
 
-        with (
-            mock.patch.object(
-                self.install,
-                "get_repository_choices",
-                return_value=(default_repo, repo_choices),
-            ),
-            mock.patch.object(
-                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
-            ),
-            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
-        ):
+        with self._mock_create_issue_config_form_dependencies():
             fields = self.install.get_create_issue_config(event.group, self.user)
 
         description_field = next(field for field in fields if field["name"] == "description")
@@ -704,19 +710,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             culprit="",
         )
 
-        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
         with (
             self.feature("organizations:integrations-github-issue-defaults-enhanced"),
             mock.patch.object(Group, "get_latest_event", return_value=group_event),
-            mock.patch.object(
-                self.install,
-                "get_repository_choices",
-                return_value=(default_repo, repo_choices),
-            ),
-            mock.patch.object(
-                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
-            ),
-            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+            self._mock_create_issue_config_form_dependencies(),
         ):
             fields = self.install.get_create_issue_config(event.group, self.user)
 
@@ -763,19 +760,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             culprit="",
         )
 
-        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
         with (
             self.feature("organizations:integrations-github-issue-defaults-enhanced"),
             mock.patch.object(Group, "get_latest_event", return_value=group_event),
-            mock.patch.object(
-                self.install,
-                "get_repository_choices",
-                return_value=(default_repo, repo_choices),
-            ),
-            mock.patch.object(
-                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
-            ),
-            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+            self._mock_create_issue_config_form_dependencies(),
         ):
             fields = self.install.get_create_issue_config(event.group, self.user)
 
@@ -835,19 +823,10 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             culprit="",
         )
 
-        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
         with (
             self.feature("organizations:integrations-github-issue-defaults-enhanced"),
             mock.patch.object(Group, "get_latest_event", return_value=group_event),
-            mock.patch.object(
-                self.install,
-                "get_repository_choices",
-                return_value=(default_repo, repo_choices),
-            ),
-            mock.patch.object(
-                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
-            ),
-            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+            self._mock_create_issue_config_form_dependencies(),
         ):
             fields = self.install.get_create_issue_config(event.group, self.user)
 
@@ -871,21 +850,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         )
         assert event.group is not None
 
-        default_repo, repo_choices = self._stub_create_issue_config_dependencies()
         with (
             self.feature("organizations:integrations-github-issue-defaults-enhanced"),
             mock.patch.object(
                 self.install, "get_group_body", return_value="line1\nSELECT * FROM `users`"
             ),
-            mock.patch.object(
-                self.install,
-                "get_repository_choices",
-                return_value=(default_repo, repo_choices),
-            ),
-            mock.patch.object(
-                self.install, "get_allowed_assignees", return_value=(("", "Unassigned"),)
-            ),
-            mock.patch.object(self.install, "get_repo_labels", return_value=(("bug", "bug"),)),
+            self._mock_create_issue_config_form_dependencies(),
         ):
             fields = self.install.get_create_issue_config(event.group, self.user)
 


### PR DESCRIPTION
GitHub metric issue defaults now include a direct metric alert link and trigger context (dataset, aggregate, interval, condition, evaluated value), so the created issue is actionable without jumping through raw evidence data.

Before
```text
Sentry Issue: [ABC-123](...)
|  |  |
| ------------- | --------------- |
```

After
```text
Sentry Issue: [ABC-123](...)
Metric Details:
- **Metric Alert**: [View alert rule](https://sentry.sentry.io/organizations/acme/alerts/rules/details/42/?referrer=github_integration)
- **Dataset**: Metrics
- **Aggregate**: p50(value,dashboards.widget_query_queue.time_to_empty,distribution,-)
- **Interval**: 1 hour
- **Condition**: Above 0
- **Evaluated Value**: 5,026.1
```