### PR TITLE
fix(billing): Prevent API queries for non-billing users

### DIFF
--- a/static/gsApp/hooks/useCurrentBillingHistory.tsx
+++ b/static/gsApp/hooks/useCurrentBillingHistory.tsx
@@ -8,6 +8,7 @@ import type {BillingHistory} from 'getsentry/types';
 
 export function useCurrentBillingHistory() {
   const organization = useOrganization();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: history,
@@ -21,6 +22,7 @@ export function useCurrentBillingHistory() {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 

--- a/static/gsApp/views/subscriptionPage/paymentHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/paymentHistory.tsx
@@ -47,6 +47,7 @@ enum ReceiptStatus {
 function PaymentHistory() {
   const organization = useOrganization();
   const location = useLocation();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: payments,
@@ -64,10 +65,10 @@ function PaymentHistory() {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 
-  const hasBillingPerms = organization.access?.includes('org:billing');
   const paymentsPageLinks = getResponseHeader?.('Link');
 
   return (

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -85,6 +85,7 @@ function getCategoryDisplay({
 function UsageHistory({subscription}: Props) {
   const organization = useOrganization();
   const location = useLocation();
+  const hasBillingPerms = organization.access?.includes('org:billing');
 
   const {
     data: usageList,
@@ -103,11 +104,11 @@ function UsageHistory({subscription}: Props) {
     ],
     {
       staleTime: 0,
+      enabled: hasBillingPerms,
     }
   );
 
   const usageListPageLinks = getResponseHeader?.('Link');
-  const hasBillingPerms = organization.access?.includes('org:billing');
 
   return (
     <SubscriptionPageContainer background="primary">


### PR DESCRIPTION
## Problem

When users without billing permissions access Usage History or Payment History pages, the frontend makes API calls to billing endpoints before checking permissions. This results in:
- API errors displayed to users
- Poor user experience (errors instead of proper "Contact Billing Members" screen)
- Unnecessary server load from unauthorized requests

**Expected behavior**: Users without billing permissions should see the "Contact Billing Members" screen immediately without any API errors.

## Solution

This PR adds conditional query execution using React Query's `enabled` flag. The queries now only execute when the user has `org:billing` permissions, preventing unauthorized API calls before the permission check completes.

### Implementation Pattern

```typescript
const hasBillingPerms = organization.access?.includes('org:billing');

const { data, isPending, isError } = useApiQuery(
  [...queryKey],
  {
    staleTime: 0,
    enabled: hasBillingPerms, // Query only runs if user has permissions
  }
);
```

## Changes

- **`static/gsApp/views/subscriptionPage/usageHistory.tsx`**: Added `enabled: hasBillingPerms` to prevent usage history queries
- **`static/gsApp/hooks/useCurrentBillingHistory.tsx`**: Added `enabled: hasBillingPerms` to prevent current billing period queries
- **`static/gsApp/views/subscriptionPage/paymentHistory.tsx`**: Added `enabled: hasBillingPerms` to prevent invoice queries

## Testing

### For Non-Billing Users:
- ✅ No API errors in console
- ✅ "Contact Billing Members" screen displays immediately
- ✅ No network requests to billing endpoints
- ✅ Clean user experience

### For Billing Users:
- ✅ Full functionality retained
- ✅ All data loads as expected
- ✅ No regression in behavior

## Risk Assessment

- **Complexity**: Low
- **Risk Level**: Low
- **Type**: Frontend-only changes
- **Why Low Risk?**: Using React Query's built-in `enabled` flag (standard pattern), no backend changes, additive and defensive changes only

## References

- Fixes [MIKE-48](https://linear.app/ihbe/issue/MIKE-48/dont-attempt-to-query-history-endpoint-for-non-billing-users)
- Implementation plan available in `plan.md` on branch