### PR TITLE
chore(agent-monitoring): add tag to cost warnings for ownership assignment

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -33,6 +33,7 @@ describe('getHighlightedSpanAttributes', () => {
     const expectedContext = {
       level: 'warning',
       tags: {
+        ai_cost_warning: 'true',
         feature: 'agent-monitoring',
         span_type: 'gen_ai',
         has_model: 'true',
@@ -119,6 +120,7 @@ describe('getHighlightedSpanAttributes', () => {
           platform: 'python',
           version: '2.0.0',
           org_id: '42',
+          ai_cost_warning: 'true',
         },
         extra: {
           total_costs: '-1',

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -193,6 +193,7 @@ function getAISpanAttributes({
         platform: platform?.toString() ?? 'unknown',
         version: version?.toString() ?? 'unknown',
         org_id: orgId?.toString() ?? 'unknown',
+        ai_cost_warning: 'true', // we use this for assigning ownership
       },
       extra: {
         total_costs: totalCosts,


### PR DESCRIPTION
- Our cost related sentry issues are currently not reliably assigned
- Add a tag to the issue so we can create an ownership rule to assign them