### PR TITLE
fix(search): Preserve scroll position in multi-select filter combobox

### DIFF
--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2638,6 +2638,25 @@ describe('SearchQueryBuilder', () => {
         expect(within(valueButton).getAllByText('or')).toHaveLength(2);
       });
 
+      it('moves selected values to the top when opening a predefined multi-select', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:[Firefox,Chrome]"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(
+          within(await screen.findByRole('listbox'))
+            .getAllByRole('option')
+            .map(option => option.textContent)
+        ).toEqual(['Firefox', 'Chrome', 'Safari', 'Edge']);
+      });
+
       it('does not reorder items when toggling a selection', async () => {
         render(
           <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
@@ -2667,6 +2686,79 @@ describe('SearchQueryBuilder', () => {
           .getAllByRole('option')
           .map(option => option.textContent);
         expect(optionsAfterToggle).toEqual(initialOptions);
+      });
+
+      it('does not reset frozen order when predefined sections rebuild', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="assigned:[person1@sentry.io,me]"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: assigned'})
+        );
+
+        const listbox = await screen.findByRole('listbox');
+        const initialOptions = within(listbox)
+          .getAllByRole('option')
+          .map(option => option.textContent);
+
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle person1@sentry.io'})
+        );
+
+        expect(await screen.findByRole('row', {name: 'assigned:me'})).toBeInTheDocument();
+
+        const optionsAfterToggle = within(screen.getByRole('listbox'))
+          .getAllByRole('option')
+          .map(option => option.textContent);
+        expect(optionsAfterToggle).toEqual(initialOptions);
+      });
+
+      it('recomputes the initial ordering when reopened with new suggestion values', async () => {
+        const {rerender} = render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:Firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(
+          within(await screen.findByRole('listbox'))
+            .getAllByRole('option')
+            .map(option => option.textContent)
+        ).toEqual(['Firefox', 'Chrome', 'Safari', 'Edge']);
+
+        await userEvent.click(document.body);
+
+        const updatedFilterKeys = {
+          ...defaultProps.filterKeys,
+          [FieldKey.BROWSER_NAME]: {
+            ...defaultProps.filterKeys[FieldKey.BROWSER_NAME],
+            values: ['Safari', 'Opera', 'Firefox', 'Chrome'],
+          },
+        };
+
+        rerender(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:Firefox"
+            filterKeys={updatedFilterKeys}
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        expect(
+          within(await screen.findByRole('listbox'))
+            .getAllByRole('option')
+            .map(option => option.textContent)
+        ).toEqual(['Firefox', 'Safari', 'Opera', 'Chrome']);
       });
 
       it('does not reorder items when deselecting a value', async () => {

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2638,6 +2638,71 @@ describe('SearchQueryBuilder', () => {
         expect(within(valueButton).getAllByText('or')).toHaveLength(2);
       });
 
+      it('does not reorder items when toggling a selection', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="browser.name:firefox" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        const listbox = await screen.findByRole('listbox');
+        const initialOptions = within(listbox)
+          .getAllByRole('option')
+          .map(option => option.textContent);
+
+        // Toggle Chrome on via checkbox
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle Chrome'})
+        );
+
+        // Wait for the value to be committed
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:[firefox,Chrome]'})
+        ).toBeInTheDocument();
+
+        // Options should remain in the same order
+        const optionsAfterToggle = within(screen.getByRole('listbox'))
+          .getAllByRole('option')
+          .map(option => option.textContent);
+        expect(optionsAfterToggle).toEqual(initialOptions);
+      });
+
+      it('does not reorder items when deselecting a value', async () => {
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:[Chrome,Firefox]"
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+
+        const listbox = await screen.findByRole('listbox');
+        const initialOptions = within(listbox)
+          .getAllByRole('option')
+          .map(option => option.textContent);
+
+        // Deselect Chrome via checkbox
+        await userEvent.click(
+          await screen.findByRole('checkbox', {name: 'Toggle Chrome'})
+        );
+
+        // Wait for the value to be committed
+        expect(
+          await screen.findByRole('row', {name: 'browser.name:Firefox'})
+        ).toBeInTheDocument();
+
+        // Options should remain in the same order
+        const optionsAfterToggle = within(screen.getByRole('listbox'))
+          .getAllByRole('option')
+          .map(option => option.textContent);
+        expect(optionsAfterToggle).toEqual(initialOptions);
+      });
+
       it.each([
         ['spaces', 'a b', '"a b"'],
         ['quotes', 'a"b', '"a\\"b"'],

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -2734,13 +2734,14 @@ describe('SearchQueryBuilder', () => {
 
         await userEvent.click(document.body);
 
-        const updatedFilterKeys = {
-          ...defaultProps.filterKeys,
-          [FieldKey.BROWSER_NAME]: {
-            ...defaultProps.filterKeys[FieldKey.BROWSER_NAME],
-            values: ['Safari', 'Opera', 'Firefox', 'Chrome'],
-          },
-        };
+        const updatedFilterKeys: ComponentProps<typeof SearchQueryBuilder>['filterKeys'] =
+          {
+            ...defaultProps.filterKeys,
+            [FieldKey.BROWSER_NAME]: {
+              ...defaultProps.filterKeys[FieldKey.BROWSER_NAME]!,
+              values: ['Safari', 'Opera', 'Firefox', 'Chrome'],
+            },
+          };
 
         rerender(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -40,7 +40,6 @@ import type {Token, TokenResult} from 'sentry/components/searchSyntax/parser';
 import {defined} from 'sentry/utils';
 import {isCtrlKeyPressed} from 'sentry/utils/isCtrlKeyPressed';
 import useOverlay from 'sentry/utils/useOverlay';
-import usePrevious from 'sentry/utils/usePrevious';
 
 type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<string>> = {
   children: CollectionChildren<T>;
@@ -485,12 +484,17 @@ export function SearchQueryBuilderCombobox<
     state
   );
 
-  const previousInputValue = usePrevious(inputValue);
-  useEffect(() => {
-    if (inputValue !== previousInputValue) {
+  // Reset the focused key when the user types in the input.
+  // This is intentionally done in the onChange handler (not an effect watching
+  // inputValue) so that programmatic inputValue changes (e.g. multi-select
+  // checkbox toggles) don't reset focus and scroll position.
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    e => {
+      onInputChange?.(e);
       state.selectionManager.setFocusedKey(null);
-    }
-  }, [inputValue, previousInputValue, state.selectionManager]);
+    },
+    [onInputChange, state.selectionManager]
+  );
 
   const totalOptions = items.reduce(
     (acc, item) => acc + (itemIsSection(item) ? item.options.length : 1),
@@ -609,7 +613,7 @@ export function SearchQueryBuilderCombobox<
         placeholder={placeholder}
         onClick={handleInputClick}
         value={inputValue}
-        onChange={onInputChange}
+        onChange={handleInputChange}
         tabIndex={tabIndex}
         onPaste={onPaste}
         disabled={disabled}

--- a/static/app/components/searchQueryBuilder/tokens/filter/useFrozenSuggestionSectionItems.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useFrozenSuggestionSectionItems.ts
@@ -1,0 +1,164 @@
+import {useMemo, useRef} from 'react';
+
+import {getItemsWithKeys, type SelectOptionWithKey} from '@sentry/scraps/compactSelect';
+
+import type {
+  SuggestionItem,
+  SuggestionSection,
+  SuggestionSectionItem,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
+
+type FrozenSuggestionOrder = Array<{sectionText: string; values: string[]}>;
+
+type Props = {
+  createItem: (suggestion: SuggestionItem) => Omit<SelectOptionWithKey<string>, 'key'>;
+  selectedValues: Array<{selected: boolean; value: string}>;
+  suggestionGroups: SuggestionSection[];
+};
+
+function suggestionGroupsAffectOrderChanged(
+  previousSuggestionGroups: SuggestionSection[] | null,
+  nextSuggestionGroups: SuggestionSection[]
+) {
+  if (!previousSuggestionGroups) {
+    return true;
+  }
+
+  if (previousSuggestionGroups === nextSuggestionGroups) {
+    return false;
+  }
+
+  if (previousSuggestionGroups.length !== nextSuggestionGroups.length) {
+    return true;
+  }
+
+  return !previousSuggestionGroups.every((previousGroup, index) => {
+    const nextGroup = nextSuggestionGroups[index];
+
+    return (
+      previousGroup.sectionText === nextGroup?.sectionText &&
+      previousGroup.suggestions.length === nextGroup?.suggestions.length &&
+      previousGroup.suggestions.every(
+        (suggestion, suggestionIndex) =>
+          suggestion.value === nextGroup?.suggestions[suggestionIndex]?.value
+      )
+    );
+  });
+}
+
+function frozenOrderAffectsVisibleValuesChanged(
+  frozenOrder: FrozenSuggestionOrder | null,
+  suggestionGroups: SuggestionSection[],
+  selectedValues: Array<{selected: boolean; value: string}>
+) {
+  if (!frozenOrder) {
+    return false;
+  }
+
+  const visibleValues = new Set([
+    ...selectedValues.map(selectedValue => selectedValue.value),
+    ...suggestionGroups.flatMap(group =>
+      group.suggestions.map(suggestion => suggestion.value)
+    ),
+  ]);
+  const frozenValues = new Set(frozenOrder.flatMap(section => section.values));
+
+  if (visibleValues.size !== frozenValues.size) {
+    return true;
+  }
+
+  return [...visibleValues].some(value => !frozenValues.has(value));
+}
+
+// In multi-select mode we want selected values to move to the top when the
+// menu opens, but we do not want the list order to keep changing after each
+// checkbox toggle because that resets scroll position.
+export function useFrozenSuggestionSectionItems({
+  createItem,
+  selectedValues,
+  suggestionGroups,
+}: Props) {
+  // Read the latest selected values without making checkbox toggles invalidate
+  // the frozen ordering calculation on every render.
+  const selectedValuesRef = useRef(selectedValues);
+  selectedValuesRef.current = selectedValues;
+
+  const previousSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
+  const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
+
+  // Predefined suggestions can rebuild equivalent arrays when the token text
+  // changes, so only reset when the visible suggestion contents actually do or
+  // when selected custom values enter or leave the visible set.
+  if (
+    suggestionGroupsAffectOrderChanged(
+      previousSuggestionGroupsRef.current,
+      suggestionGroups
+    ) ||
+    frozenOrderAffectsVisibleValuesChanged(
+      frozenOrderRef.current,
+      suggestionGroups,
+      selectedValues
+    )
+  ) {
+    previousSuggestionGroupsRef.current = suggestionGroups;
+    frozenOrderRef.current = null;
+  }
+
+  return useMemo<SuggestionSectionItem[]>(() => {
+    const currentSelectedValues = selectedValuesRef.current;
+    const selectedValueSet = new Set(
+      currentSelectedValues.map(selectedValue => selectedValue.value)
+    );
+    const allSuggestions = new Map(
+      suggestionGroups.flatMap(group =>
+        group.suggestions.map(suggestion => [suggestion.value, suggestion] as const)
+      )
+    );
+
+    if (!frozenOrderRef.current) {
+      const unsectionedSuggestions = suggestionGroups
+        .filter(group => group.sectionText === '')
+        .flatMap(group => group.suggestions)
+        .filter(suggestion => !selectedValueSet.has(suggestion.value));
+      const sections = suggestionGroups.filter(group => group.sectionText !== '');
+
+      const nextSuggestionSectionItems: SuggestionSectionItem[] = [
+        {
+          sectionText: '',
+          items: getItemsWithKeys([
+            ...currentSelectedValues.map(selectedValue => {
+              const matchingSuggestion = allSuggestions.get(selectedValue.value);
+              return createItem(matchingSuggestion ?? {value: selectedValue.value});
+            }),
+            ...unsectionedSuggestions.map(suggestion => createItem(suggestion)),
+          ]),
+        },
+        ...sections.map(group => ({
+          sectionText: group.sectionText,
+          items: getItemsWithKeys(
+            group.suggestions
+              .filter(suggestion => !selectedValueSet.has(suggestion.value))
+              .map(suggestion => createItem(suggestion))
+          ),
+        })),
+      ];
+
+      frozenOrderRef.current = nextSuggestionSectionItems.map(section => ({
+        sectionText: section.sectionText,
+        values: section.items.map(item => item.value),
+      }));
+
+      return nextSuggestionSectionItems;
+    }
+
+    return frozenOrderRef.current.map(section => ({
+      sectionText: section.sectionText,
+      items: getItemsWithKeys(
+        section.values.map(value => {
+          const suggestion = allSuggestions.get(value) ?? {value};
+          return createItem(suggestion);
+        })
+      ),
+    }));
+  }, [createItem, suggestionGroups]);
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/useFrozenSuggestionSectionItems.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/useFrozenSuggestionSectionItems.ts
@@ -1,4 +1,4 @@
-import {useMemo, useRef} from 'react';
+import {useMemo, useRef, useState} from 'react';
 
 import {getItemsWithKeys, type SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
@@ -85,6 +85,7 @@ export function useFrozenSuggestionSectionItems({
 
   const previousSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
   const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
+  const [frozenVersion, setFrozenVersion] = useState(0);
 
   // Predefined suggestions can rebuild equivalent arrays when the token text
   // changes, so only reset when the visible suggestion contents actually do or
@@ -102,6 +103,7 @@ export function useFrozenSuggestionSectionItems({
   ) {
     previousSuggestionGroupsRef.current = suggestionGroups;
     frozenOrderRef.current = null;
+    setFrozenVersion(v => v + 1);
   }
 
   return useMemo<SuggestionSectionItem[]>(() => {
@@ -160,5 +162,6 @@ export function useFrozenSuggestionSectionItems({
         })
       ),
     }));
-  }, [createItem, suggestionGroups]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- frozenVersion forces recomputation when the render-time check resets frozenOrderRef
+  }, [createItem, suggestionGroups, frozenVersion]);
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -321,108 +321,6 @@ function useSelectionIndex({
   };
 }
 
-type FrozenSuggestionOrder = Array<{sectionText: string; values: string[]}>;
-
-// In multi-select mode we want the currently selected values to float to the top
-// when the menu opens, but we do not want the list order to keep changing after
-// each checkbox toggle. If it re-sorts on every selection, the listbox scroll
-// position jumps back to the top and makes bulk selection frustrating.
-//
-// This hook computes the initial "selected values first" ordering once per
-// suggestion set, stores only the ordered values, and then rebuilds items in
-// that frozen order on later renders so checkbox state can update without
-// disturbing the list position.
-function useFrozenSuggestionSectionItems({
-  createItem,
-  selectedValues,
-  suggestionGroups,
-}: {
-  createItem: (suggestion: SuggestionItem) => Omit<SelectOptionWithKey<string>, 'key'>;
-  selectedValues: Array<{selected: boolean; value: string}>;
-  suggestionGroups: SuggestionSection[];
-}) {
-  // Read the latest selected values during memoized ordering work without
-  // making selection toggles invalidate the frozen ordering.
-  const selectedValuesRef = useRef(selectedValues);
-  selectedValuesRef.current = selectedValues;
-
-  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
-  const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
-
-  // A new suggestion group identity means the menu effectively has a new result
-  // set (reopened, new data, different key/filter), so the frozen ordering
-  // should be recalculated from scratch.
-  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
-    prevSuggestionGroupsRef.current = suggestionGroups;
-    frozenOrderRef.current = null;
-  }
-
-  return useMemo<SuggestionSectionItem[]>(() => {
-    const currentSelectedValues = selectedValuesRef.current;
-    const selectedValueSet = new Set(
-      currentSelectedValues.map(selectedValue => selectedValue.value)
-    );
-    const allSuggestions = new Map(
-      suggestionGroups.flatMap(group =>
-        group.suggestions.map(suggestion => [suggestion.value, suggestion] as const)
-      )
-    );
-
-    if (!frozenOrderRef.current) {
-      // First render for this suggestion set: move selected values to the top
-      // and omit duplicates from the rest of the sections.
-      const unsectionedSuggestions = suggestionGroups
-        .filter(group => group.sectionText === '')
-        .flatMap(group => group.suggestions)
-        .filter(suggestion => !selectedValueSet.has(suggestion.value));
-      const sections = suggestionGroups.filter(group => group.sectionText !== '');
-
-      const sortedSections: SuggestionSectionItem[] = [
-        {
-          sectionText: '',
-          items: getItemsWithKeys([
-            ...currentSelectedValues.map(selectedValue => {
-              const matchingSuggestion = allSuggestions.get(selectedValue.value);
-              return createItem(matchingSuggestion ?? {value: selectedValue.value});
-            }),
-            ...unsectionedSuggestions.map(suggestion => createItem(suggestion)),
-          ]),
-        },
-        ...sections.map(group => ({
-          sectionText: group.sectionText,
-          items: getItemsWithKeys(
-            group.suggestions
-              .filter(suggestion => !selectedValueSet.has(suggestion.value))
-              .map(suggestion => createItem(suggestion))
-          ),
-        })),
-      ];
-
-      // Persist just the ordered values. Recomputing full item objects here
-      // would be wasted work, and storing values lets us rebuild against the
-      // latest suggestion metadata if descriptions/labels change.
-      frozenOrderRef.current = sortedSections.map(section => ({
-        sectionText: section.sectionText,
-        values: section.items.map(item => item.value),
-      }));
-
-      return sortedSections;
-    }
-
-    // Later renders keep the same visible order and only rebuild item objects,
-    // which lets checkbox state reflect current selection without re-sorting.
-    return frozenOrderRef.current.map(section => ({
-      sectionText: section.sectionText,
-      items: getItemsWithKeys(
-        section.values.map(value => {
-          const suggestion = allSuggestions.get(value) ?? {value};
-          return createItem(suggestion);
-        })
-      ),
-    }));
-  }, [createItem, suggestionGroups]);
-}
-
 function useFilterSuggestions({
   token,
   filterValue,
@@ -483,6 +381,11 @@ function useFilterSuggestions({
     enabled: shouldFetchValues,
   });
 
+  // Keep selected values in a ref so ordering calculations can read latest
+  // values without rebuilding suggestion items on every checkbox toggle.
+  const selectedValuesRef = useRef(selectedValues);
+  selectedValuesRef.current = selectedValues;
+
   const createItem = useCallback(
     (suggestion: SuggestionItem) => {
       return {
@@ -531,11 +434,86 @@ function useFilterSuggestions({
 
     return [{sectionText: '', suggestions: suggestions ?? []}];
   }, [data, predefinedValues, shouldFetchValues, key?.key]);
-  const suggestionSectionItems = useFrozenSuggestionSectionItems({
-    createItem,
-    selectedValues,
-    suggestionGroups,
-  });
+
+  // Track suggestion groups identity to detect when a fresh sort is needed
+  // (e.g. combobox reopened, filter key changed, or new data fetched)
+  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
+  const frozenOrderRef = useRef<Array<{sectionText: string; values: string[]}> | null>(
+    null
+  );
+
+  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
+    prevSuggestionGroupsRef.current = suggestionGroups;
+    frozenOrderRef.current = null;
+  }
+
+  // Grouped sections for rendering purposes.
+  // On fresh open (frozenOrderRef is null): sorts selected items to the top, then
+  // freezes the order. On subsequent toggles: returns the cached result — checkbox
+  // states are read from context at render time, so item objects stay
+  // referentially stable and downstream memos/components skip re-computation.
+  const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
+    const currentSelectedValues = selectedValuesRef.current;
+    const allSuggestions = new Map(
+      suggestionGroups.flatMap(group => group.suggestions.map(s => [s.value, s] as const))
+    );
+
+    if (!frozenOrderRef.current) {
+      // Fresh open — sort selected items to top (original behavior)
+      const itemsWithoutSection = suggestionGroups
+        .filter(group => group.sectionText === '')
+        .flatMap(group => group.suggestions)
+        .filter(
+          suggestion => !currentSelectedValues.some(v => v.value === suggestion.value)
+        );
+      const sections = suggestionGroups.filter(group => group.sectionText !== '');
+
+      const result: SuggestionSectionItem[] = [
+        {
+          sectionText: '',
+          items: getItemsWithKeys([
+            ...currentSelectedValues.map(value => {
+              const matchingSuggestion = allSuggestions.get(value.value);
+              return createItem(matchingSuggestion ?? {value: value.value});
+            }),
+            ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
+          ]),
+        },
+        ...sections.map(group => ({
+          sectionText: group.sectionText,
+          items: getItemsWithKeys(
+            group.suggestions
+              .filter(
+                suggestion =>
+                  !currentSelectedValues.some(v => v.value === suggestion.value)
+              )
+              .map(suggestion => createItem(suggestion))
+          ),
+        })),
+      ];
+
+      // Freeze the item order for subsequent renders within this session
+      frozenOrderRef.current = result.map(section => ({
+        sectionText: section.sectionText,
+        values: section.items.map(item => item.value),
+      }));
+
+      return result;
+    }
+
+    // Subsequent toggle — return cached items. Checkbox states are read from
+    // context inside the trailingItems render prop, so the same
+    // item objects render the correct state without needing reconstruction.
+    return frozenOrderRef.current.map(section => ({
+      sectionText: section.sectionText,
+      items: getItemsWithKeys(
+        section.values.map(value => {
+          const suggestion = allSuggestions.get(value) ?? {value};
+          return createItem(suggestion);
+        })
+      ),
+    }));
+  }, [createItem, suggestionGroups]);
 
   // Flat list used for state management
   const items = useMemo(() => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -322,6 +322,108 @@ function useSelectionIndex({
   };
 }
 
+type FrozenSuggestionOrder = Array<{sectionText: string; values: string[]}>;
+
+// In multi-select mode we want the currently selected values to float to the top
+// when the menu opens, but we do not want the list order to keep changing after
+// each checkbox toggle. If it re-sorts on every selection, the listbox scroll
+// position jumps back to the top and makes bulk selection frustrating.
+//
+// This hook computes the initial "selected values first" ordering once per
+// suggestion set, stores only the ordered values, and then rebuilds items in
+// that frozen order on later renders so checkbox state can update without
+// disturbing the list position.
+function useFrozenSuggestionSectionItems({
+  createItem,
+  selectedValues,
+  suggestionGroups,
+}: {
+  createItem: (suggestion: SuggestionItem) => Omit<SelectOptionWithKey<string>, 'key'>;
+  selectedValues: Array<{selected: boolean; value: string}>;
+  suggestionGroups: SuggestionSection[];
+}) {
+  // Read the latest selected values during memoized ordering work without
+  // making selection toggles invalidate the frozen ordering.
+  const selectedValuesRef = useRef(selectedValues);
+  selectedValuesRef.current = selectedValues;
+
+  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
+  const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
+
+  // A new suggestion group identity means the menu effectively has a new result
+  // set (reopened, new data, different key/filter), so the frozen ordering
+  // should be recalculated from scratch.
+  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
+    prevSuggestionGroupsRef.current = suggestionGroups;
+    frozenOrderRef.current = null;
+  }
+
+  return useMemo<SuggestionSectionItem[]>(() => {
+    const currentSelectedValues = selectedValuesRef.current;
+    const selectedValueSet = new Set(
+      currentSelectedValues.map(selectedValue => selectedValue.value)
+    );
+    const allSuggestions = new Map(
+      suggestionGroups.flatMap(group =>
+        group.suggestions.map(suggestion => [suggestion.value, suggestion] as const)
+      )
+    );
+
+    if (!frozenOrderRef.current) {
+      // First render for this suggestion set: move selected values to the top
+      // and omit duplicates from the rest of the sections.
+      const unsectionedSuggestions = suggestionGroups
+        .filter(group => group.sectionText === '')
+        .flatMap(group => group.suggestions)
+        .filter(suggestion => !selectedValueSet.has(suggestion.value));
+      const sections = suggestionGroups.filter(group => group.sectionText !== '');
+
+      const sortedSections: SuggestionSectionItem[] = [
+        {
+          sectionText: '',
+          items: getItemsWithKeys([
+            ...currentSelectedValues.map(selectedValue => {
+              const matchingSuggestion = allSuggestions.get(selectedValue.value);
+              return createItem(matchingSuggestion ?? {value: selectedValue.value});
+            }),
+            ...unsectionedSuggestions.map(suggestion => createItem(suggestion)),
+          ]),
+        },
+        ...sections.map(group => ({
+          sectionText: group.sectionText,
+          items: getItemsWithKeys(
+            group.suggestions
+              .filter(suggestion => !selectedValueSet.has(suggestion.value))
+              .map(suggestion => createItem(suggestion))
+          ),
+        })),
+      ];
+
+      // Persist just the ordered values. Recomputing full item objects here
+      // would be wasted work, and storing values lets us rebuild against the
+      // latest suggestion metadata if descriptions/labels change.
+      frozenOrderRef.current = sortedSections.map(section => ({
+        sectionText: section.sectionText,
+        values: section.items.map(item => item.value),
+      }));
+
+      return sortedSections;
+    }
+
+    // Later renders keep the same visible order and only rebuild item objects,
+    // which lets checkbox state reflect current selection without re-sorting.
+    return frozenOrderRef.current.map(section => ({
+      sectionText: section.sectionText,
+      items: getItemsWithKeys(
+        section.values.map(value => {
+          const suggestion = allSuggestions.get(value) ?? {value};
+          return createItem(suggestion);
+        })
+      ),
+    }));
+  }, [createItem, suggestionGroups]);
+}
+
 function useFilterSuggestions({
   token,
   filterValue,
@@ -382,11 +484,6 @@ function useFilterSuggestions({
     enabled: shouldFetchValues,
   });
 
-  // Keep selected values in a ref so ordering calculations can read latest
-  // values without rebuilding suggestion items on every checkbox toggle.
-  const selectedValuesRef = useRef(selectedValues);
-  selectedValuesRef.current = selectedValues;
-
   const createItem = useCallback(
     (suggestion: SuggestionItem) => {
       return {
@@ -435,86 +532,11 @@ function useFilterSuggestions({
 
     return [{sectionText: '', suggestions: suggestions ?? []}];
   }, [data, predefinedValues, shouldFetchValues, key?.key]);
-
-  // Track suggestion groups identity to detect when a fresh sort is needed
-  // (e.g. combobox reopened, filter key changed, or new data fetched)
-  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
-  const frozenOrderRef = useRef<Array<{sectionText: string; values: string[]}> | null>(
-    null
-  );
-
-  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
-    prevSuggestionGroupsRef.current = suggestionGroups;
-    frozenOrderRef.current = null;
-  }
-
-  // Grouped sections for rendering purposes.
-  // On fresh open (frozenOrderRef is null): sorts selected items to the top, then
-  // freezes the order. On subsequent toggles: returns the cached result — checkbox
-  // states are read from context at render time, so item objects stay
-  // referentially stable and downstream memos/components skip re-computation.
-  const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
-    const currentSelectedValues = selectedValuesRef.current;
-    const allSuggestions = new Map(
-      suggestionGroups.flatMap(group => group.suggestions.map(s => [s.value, s] as const))
-    );
-
-    if (!frozenOrderRef.current) {
-      // Fresh open — sort selected items to top (original behavior)
-      const itemsWithoutSection = suggestionGroups
-        .filter(group => group.sectionText === '')
-        .flatMap(group => group.suggestions)
-        .filter(
-          suggestion => !currentSelectedValues.some(v => v.value === suggestion.value)
-        );
-      const sections = suggestionGroups.filter(group => group.sectionText !== '');
-
-      const result: SuggestionSectionItem[] = [
-        {
-          sectionText: '',
-          items: getItemsWithKeys([
-            ...currentSelectedValues.map(value => {
-              const matchingSuggestion = allSuggestions.get(value.value);
-              return createItem(matchingSuggestion ?? {value: value.value});
-            }),
-            ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
-          ]),
-        },
-        ...sections.map(group => ({
-          sectionText: group.sectionText,
-          items: getItemsWithKeys(
-            group.suggestions
-              .filter(
-                suggestion =>
-                  !currentSelectedValues.some(v => v.value === suggestion.value)
-              )
-              .map(suggestion => createItem(suggestion))
-          ),
-        })),
-      ];
-
-      // Freeze the item order for subsequent renders within this session
-      frozenOrderRef.current = result.map(section => ({
-        sectionText: section.sectionText,
-        values: section.items.map(item => item.value),
-      }));
-
-      return result;
-    }
-
-    // Subsequent toggle — return cached items. Checkbox states are read from
-    // context inside the trailingItems render prop, so the same
-    // item objects render the correct state without needing reconstruction.
-    return frozenOrderRef.current.map(section => ({
-      sectionText: section.sectionText,
-      items: getItemsWithKeys(
-        section.values.map(value => {
-          const suggestion = allSuggestions.get(value) ?? {value};
-          return createItem(suggestion);
-        })
-      ),
-    }));
-  }, [createItem, suggestionGroups]);
+  const suggestionSectionItems = useFrozenSuggestionSectionItems({
+    createItem,
+    selectedValues,
+    suggestionGroups,
+  });
 
   // Flat list used for state management
   const items = useMemo(() => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -323,29 +323,6 @@ function useSelectionIndex({
 
 type FrozenSuggestionOrder = Array<{sectionText: string; values: string[]}>;
 
-// Shallow comparison of suggestion groups by section text and suggestion values.
-// Used by `useFrozenSuggestionSectionItems` to avoid resetting the frozen item
-// order when the suggestion arrays are reconstructed with identical contents
-// (e.g. toggling a multi-select checkbox rebuilds the array but doesn't change
-// the set of available suggestions).
-function suggestionGroupsAffectOrderChanged(
-  previousSuggestionGroups: SuggestionSection[] | null,
-  nextSuggestionGroups: SuggestionSection[]
-) {
-  if (!previousSuggestionGroups) return true;
-  if (previousSuggestionGroups === nextSuggestionGroups) return false;
-  if (previousSuggestionGroups.length !== nextSuggestionGroups.length) return true;
-
-  return !previousSuggestionGroups.every((prevGroup, i) => {
-    const nextGroup = nextSuggestionGroups[i];
-    return (
-      prevGroup.sectionText === nextGroup?.sectionText &&
-      prevGroup.suggestions.length === nextGroup.suggestions.length &&
-      prevGroup.suggestions.every((s, j) => s.value === nextGroup.suggestions[j]?.value)
-    );
-  });
-}
-
 // In multi-select mode we want the currently selected values to float to the top
 // when the menu opens, but we do not want the list order to keep changing after
 // each checkbox toggle. If it re-sorts on every selection, the listbox scroll
@@ -372,12 +349,10 @@ function useFrozenSuggestionSectionItems({
   const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
   const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
 
-  // Some callers rebuild suggestion group arrays even when the visible values
-  // are unchanged (for example when toggling a predefined multi-select value).
-  // Reset only when the actual suggestion contents change.
-  if (
-    suggestionGroupsAffectOrderChanged(prevSuggestionGroupsRef.current, suggestionGroups)
-  ) {
+  // A new suggestion group identity means the menu effectively has a new result
+  // set (reopened, new data, different key/filter), so the frozen ordering
+  // should be recalculated from scratch.
+  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
     prevSuggestionGroupsRef.current = suggestionGroups;
     frozenOrderRef.current = null;
   }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -6,7 +6,6 @@ import type {KeyboardEvent} from '@react-types/shared';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
-import {getItemsWithKeys} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 
 import {DeviceName} from 'sentry/components/deviceName';
@@ -26,6 +25,7 @@ import {
 import {parseMultiSelectFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/string/parser';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue';
 import {SpecificDatePicker} from 'sentry/components/searchQueryBuilder/tokens/filter/specificDatePicker';
+import {useFrozenSuggestionSectionItems} from 'sentry/components/searchQueryBuilder/tokens/filter/useFrozenSuggestionSectionItems';
 import {
   escapeTagValue,
   formatFilterValue,
@@ -43,7 +43,6 @@ import {getDefaultAbsoluteDateValue} from 'sentry/components/searchQueryBuilder/
 import type {
   SuggestionItem,
   SuggestionSection,
-  SuggestionSectionItem,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/types';
 import {
   cleanFilterValue,
@@ -384,11 +383,6 @@ function useFilterSuggestions({
     enabled: shouldFetchValues,
   });
 
-  // Keep selected values in a ref so ordering calculations can read latest
-  // values without rebuilding suggestion items on every checkbox toggle.
-  const selectedValuesRef = useRef(selectedValues);
-  selectedValuesRef.current = selectedValues;
-
   const createItem = useCallback(
     (suggestion: SuggestionItem) => {
       return {
@@ -438,85 +432,11 @@ function useFilterSuggestions({
     return [{sectionText: '', suggestions: suggestions ?? []}];
   }, [data, predefinedValues, shouldFetchValues, key?.key]);
 
-  // Track suggestion groups identity to detect when a fresh sort is needed
-  // (e.g. combobox reopened, filter key changed, or new data fetched)
-  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
-  const frozenOrderRef = useRef<Array<{sectionText: string; values: string[]}> | null>(
-    null
-  );
-
-  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
-    prevSuggestionGroupsRef.current = suggestionGroups;
-    frozenOrderRef.current = null;
-  }
-
-  // Grouped sections for rendering purposes.
-  // On fresh open (frozenOrderRef is null): sorts selected items to the top, then
-  // freezes the order. On subsequent toggles: returns the cached result — checkbox
-  // states are read from context at render time, so item objects stay
-  // referentially stable and downstream memos/components skip re-computation.
-  const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
-    const currentSelectedValues = selectedValuesRef.current;
-    const allSuggestions = new Map(
-      suggestionGroups.flatMap(group => group.suggestions.map(s => [s.value, s] as const))
-    );
-
-    if (!frozenOrderRef.current) {
-      // Fresh open — sort selected items to top (original behavior)
-      const itemsWithoutSection = suggestionGroups
-        .filter(group => group.sectionText === '')
-        .flatMap(group => group.suggestions)
-        .filter(
-          suggestion => !currentSelectedValues.some(v => v.value === suggestion.value)
-        );
-      const sections = suggestionGroups.filter(group => group.sectionText !== '');
-
-      const result: SuggestionSectionItem[] = [
-        {
-          sectionText: '',
-          items: getItemsWithKeys([
-            ...currentSelectedValues.map(value => {
-              const matchingSuggestion = allSuggestions.get(value.value);
-              return createItem(matchingSuggestion ?? {value: value.value});
-            }),
-            ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
-          ]),
-        },
-        ...sections.map(group => ({
-          sectionText: group.sectionText,
-          items: getItemsWithKeys(
-            group.suggestions
-              .filter(
-                suggestion =>
-                  !currentSelectedValues.some(v => v.value === suggestion.value)
-              )
-              .map(suggestion => createItem(suggestion))
-          ),
-        })),
-      ];
-
-      // Freeze the item order for subsequent renders within this session
-      frozenOrderRef.current = result.map(section => ({
-        sectionText: section.sectionText,
-        values: section.items.map(item => item.value),
-      }));
-
-      return result;
-    }
-
-    // Subsequent toggle — return cached items. Checkbox states are read from
-    // context inside the trailingItems render prop, so the same
-    // item objects render the correct state without needing reconstruction.
-    return frozenOrderRef.current.map(section => ({
-      sectionText: section.sectionText,
-      items: getItemsWithKeys(
-        section.values.map(value => {
-          const suggestion = allSuggestions.get(value) ?? {value};
-          return createItem(suggestion);
-        })
-      ),
-    }));
-  }, [createItem, suggestionGroups]);
+  const suggestionSectionItems = useFrozenSuggestionSectionItems({
+    createItem,
+    selectedValues,
+    suggestionGroups,
+  });
 
   // Flat list used for state management
   const items = useMemo(() => {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -21,7 +21,6 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {
   SearchQueryBuilderCombobox,
   type CustomComboboxMenu,
-  type CustomComboboxMenuProps,
 } from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {parseMultiSelectFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/string/parser';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue';
@@ -614,58 +613,6 @@ function ItemCheckbox({
   );
 }
 
-function ValueComboboxCustomMenu(
-  props: CustomComboboxMenuProps<SelectOptionWithKey<string>>
-) {
-  const {
-    canSelectMultipleValues,
-    canUseWildcard,
-    inputValue,
-    isFetching,
-    items,
-    onBackFromAbsoluteDate,
-    onSaveAbsoluteDate,
-    onSelectAbsoluteDate,
-    showDatePicker,
-    token,
-    wrapperRef,
-  } = useValueComboboxContext();
-
-  if (showDatePicker) {
-    return (
-      <SpecificDatePicker
-        {...props}
-        dateString={inputValue || getDefaultAbsoluteDateValue(token)}
-        handleSelectDateTime={onSelectAbsoluteDate}
-        handleBack={onBackFromAbsoluteDate}
-        handleSave={onSaveAbsoluteDate}
-      />
-    );
-  }
-
-  // Remove Ask Seer items from the value listbox since they are not shown here.
-  const hiddenOptions = new Set(props.hiddenOptions);
-  hiddenOptions.delete(ASK_SEER_ITEM_KEY);
-  hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
-
-  return (
-    <ValueListBox
-      {...props}
-      hiddenOptions={hiddenOptions}
-      wrapperRef={wrapperRef}
-      isMultiSelect={canSelectMultipleValues}
-      items={items}
-      isLoading={isFetching}
-      canUseWildcard={canUseWildcard}
-      token={token}
-    />
-  );
-}
-
-const renderValueComboboxCustomMenu: CustomComboboxMenu<
-  SelectOptionWithKey<string>
-> = props => <ValueComboboxCustomMenu {...props} />;
-
 export function getInitialInputValue(
   token: TokenResult<Token.FILTER>,
   canSelectMultipleValues: boolean
@@ -744,6 +691,10 @@ export function SearchQueryBuilderValueCombobox({
     () => new Map(selectedValuesUnescaped.map(v => [v.value, v.selected] as const)),
     [selectedValuesUnescaped]
   );
+  const valueComboboxContextValue = useMemo(
+    () => ({token, ctrlKeyPressed, selectedValueMap}),
+    [token, ctrlKeyPressed, selectedValueMap]
+  );
 
   useEffect(() => {
     if (canSelectMultipleValues) {
@@ -782,70 +733,6 @@ export function SearchQueryBuilderValueCombobox({
       new_experience: true,
     }),
     [organization, recentSearches, searchSource, keyName, token, fieldDefinition]
-  );
-
-  const handleSelectAbsoluteDate = useCallback(
-    (newDateTimeValue: string) => {
-      setInputValue(newDateTimeValue);
-      inputRef.current?.focus();
-      trackAnalytics('search.value_autocompleted', {
-        ...analyticsData,
-        filter_value: newDateTimeValue,
-        filter_value_type: 'absolute_date',
-      });
-    },
-    [analyticsData]
-  );
-
-  const handleBackFromAbsoluteDate = useCallback(() => {
-    setShowDatePicker(false);
-    setInputValue('');
-    inputRef.current?.focus();
-  }, []);
-
-  const handleSaveAbsoluteDate = useCallback(
-    (newDateTimeValue: string) => {
-      dispatch({
-        type: 'UPDATE_TOKEN_VALUE',
-        token,
-        value: newDateTimeValue,
-      });
-      onCommit();
-    },
-    [dispatch, onCommit, token]
-  );
-
-  const valueComboboxContextValue = useMemo(
-    () => ({
-      canSelectMultipleValues,
-      canUseWildcard,
-      ctrlKeyPressed,
-      inputValue,
-      isFetching,
-      items,
-      onBackFromAbsoluteDate: handleBackFromAbsoluteDate,
-      onSaveAbsoluteDate: handleSaveAbsoluteDate,
-      onSelectAbsoluteDate: handleSelectAbsoluteDate,
-      selectedValueMap,
-      showDatePicker,
-      token,
-      wrapperRef: topLevelWrapperRef,
-    }),
-    [
-      canSelectMultipleValues,
-      canUseWildcard,
-      ctrlKeyPressed,
-      inputValue,
-      isFetching,
-      items,
-      handleBackFromAbsoluteDate,
-      handleSaveAbsoluteDate,
-      handleSelectAbsoluteDate,
-      selectedValueMap,
-      showDatePicker,
-      token,
-      topLevelWrapperRef,
-    ]
   );
 
   const updateFilterValue = useCallback(
@@ -1055,6 +942,85 @@ export function SearchQueryBuilderValueCombobox({
     [wrapperRef]
   );
 
+  // Refs for volatile values used in customMenu so the memo stays stable
+  // during checkbox toggles (items, isFetching, token, inputValue all change).
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const isFetchingRef = useRef(isFetching);
+  isFetchingRef.current = isFetching;
+  const tokenRef = useRef(token);
+  tokenRef.current = token;
+  const inputValueRef = useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const analyticsDataRef = useRef(analyticsData);
+  analyticsDataRef.current = analyticsData;
+
+  const customMenu: CustomComboboxMenu<SelectOptionWithKey<string>> | undefined =
+    useMemo(() => {
+      if (!showDatePicker) {
+        return function (props) {
+          // Removing the ask seer options from the value list box props as we don't
+          // display and ask seer option in this list box.
+          const hiddenOptions = new Set(props.hiddenOptions);
+          hiddenOptions.delete(ASK_SEER_ITEM_KEY);
+          hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
+
+          return (
+            <ValueListBox
+              {...props}
+              hiddenOptions={hiddenOptions}
+              wrapperRef={topLevelWrapperRef}
+              isMultiSelect={canSelectMultipleValues}
+              items={itemsRef.current}
+              isLoading={isFetchingRef.current}
+              canUseWildcard={canUseWildcard}
+              token={tokenRef.current}
+            />
+          );
+        };
+      }
+
+      return function (props) {
+        return (
+          <SpecificDatePicker
+            {...props}
+            dateString={
+              inputValueRef.current || getDefaultAbsoluteDateValue(tokenRef.current)
+            }
+            handleSelectDateTime={newDateTimeValue => {
+              setInputValue(newDateTimeValue);
+              inputRef.current?.focus();
+              trackAnalytics('search.value_autocompleted', {
+                ...analyticsDataRef.current,
+                filter_value: newDateTimeValue,
+                filter_value_type: 'absolute_date',
+              });
+            }}
+            handleBack={() => {
+              setShowDatePicker(false);
+              setInputValue('');
+              inputRef.current?.focus();
+            }}
+            handleSave={newDateTimeValue => {
+              dispatch({
+                type: 'UPDATE_TOKEN_VALUE',
+                token: tokenRef.current,
+                value: newDateTimeValue,
+              });
+              onCommit();
+            }}
+          />
+        );
+      };
+    }, [
+      showDatePicker,
+      topLevelWrapperRef,
+      canSelectMultipleValues,
+      canUseWildcard,
+      dispatch,
+      onCommit,
+    ]);
+
   const placeholder =
     token.filter === FilterType.HAS
       ? prettifyTagKey(token.value.text)
@@ -1092,7 +1058,7 @@ export function SearchQueryBuilderValueCombobox({
           autoFocus
           maxOptions={50}
           openOnFocus
-          customMenu={renderValueComboboxCustomMenu}
+          customMenu={customMenu}
           shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         >
           {suggestionSectionItems.map(section => (

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -31,6 +31,10 @@ import {
   getFilterValueType,
   unescapeTagValue,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
+import {
+  useValueComboboxContext,
+  ValueComboboxContext,
+} from 'sentry/components/searchQueryBuilder/tokens/filter/valueComboboxContext';
 import {ValueListBox} from 'sentry/components/searchQueryBuilder/tokens/filter/valueListBox';
 import {getDefaultAbsoluteDateValue} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
 import type {
@@ -321,9 +325,7 @@ function useFilterSuggestions({
   token,
   filterValue,
   selectedValues,
-  ctrlKeyPressed,
 }: {
-  ctrlKeyPressed: boolean;
   filterValue: string;
   selectedValues: Array<{selected: boolean; value: string}>;
   token: TokenResult<Token.FILTER>;
@@ -379,19 +381,10 @@ function useFilterSuggestions({
     enabled: shouldFetchValues,
   });
 
-  // Use refs for values that change frequently (every toggle) so that
-  // createItem and suggestionSectionItems stay referentially stable.
-  // The trailingItems render prop reads from these refs at render time.
-  const tokenRef = useRef(token);
-  tokenRef.current = token;
-  const ctrlKeyPressedRef = useRef(ctrlKeyPressed);
-  ctrlKeyPressedRef.current = ctrlKeyPressed;
+  // Keep selected values in a ref so ordering calculations can read latest
+  // values without rebuilding suggestion items on every checkbox toggle.
   const selectedValuesRef = useRef(selectedValues);
   selectedValuesRef.current = selectedValues;
-  const selectedValueMapRef = useRef(new Map<string, boolean>());
-  selectedValueMapRef.current = new Map(
-    selectedValues.map(v => [v.value, v.selected] as const)
-  );
 
   const createItem = useCallback(
     (suggestion: SuggestionItem) => {
@@ -410,11 +403,8 @@ function useFilterSuggestions({
           return (
             <ItemCheckbox
               isFocused={isFocused}
-              selected={selectedValueMapRef.current.get(suggestion.value) ?? false}
-              token={tokenRef.current}
               disabled={disabled}
               value={suggestion.value}
-              ctrlKeyPressed={ctrlKeyPressedRef.current}
             />
           );
         },
@@ -460,7 +450,7 @@ function useFilterSuggestions({
   // Grouped sections for rendering purposes.
   // On fresh open (frozenOrderRef is null): sorts selected items to the top, then
   // freezes the order. On subsequent toggles: returns the cached result — checkbox
-  // states are read from selectedValueMapRef at render time, so item objects stay
+  // states are read from context at render time, so item objects stay
   // referentially stable and downstream memos/components skip re-computation.
   const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
     const currentSelectedValues = selectedValuesRef.current;
@@ -512,7 +502,7 @@ function useFilterSuggestions({
     }
 
     // Subsequent toggle — return cached items. Checkbox states are read from
-    // selectedValueMapRef inside the trailingItems render prop, so the same
+    // context inside the trailingItems render prop, so the same
     // item objects render the correct state without needing reconstruction.
     return frozenOrderRef.current.map(section => ({
       sectionText: section.sectionText,
@@ -538,21 +528,17 @@ function useFilterSuggestions({
 }
 
 function ItemCheckbox({
-  token,
   isFocused,
-  selected,
   disabled,
   value,
-  ctrlKeyPressed,
 }: {
-  ctrlKeyPressed: boolean;
   disabled: boolean;
   isFocused: boolean;
-  selected: boolean;
-  token: TokenResult<Token.FILTER>;
   value: string;
 }) {
+  const {ctrlKeyPressed, selectedValueMap, token} = useValueComboboxContext();
   const {dispatch} = useSearchQueryBuilder();
+  const selected = selectedValueMap.get(value) ?? false;
 
   return (
     <TrailingWrap
@@ -654,6 +640,14 @@ export function SearchQueryBuilderValueCombobox({
     isMac() ? 'Meta' : 'Control',
     topLevelWrapperRef.current
   );
+  const selectedValueMap = useMemo(
+    () => new Map(selectedValuesUnescaped.map(v => [v.value, v.selected] as const)),
+    [selectedValuesUnescaped]
+  );
+  const valueComboboxContextValue = useMemo(
+    () => ({token, ctrlKeyPressed, selectedValueMap}),
+    [token, ctrlKeyPressed, selectedValueMap]
+  );
 
   useEffect(() => {
     if (canSelectMultipleValues) {
@@ -679,7 +673,6 @@ export function SearchQueryBuilderValueCombobox({
     token,
     filterValue,
     selectedValues: selectedValuesUnescaped,
-    ctrlKeyPressed,
   });
 
   const analyticsData = useMemo(
@@ -991,46 +984,48 @@ export function SearchQueryBuilderValueCombobox({
           });
 
   return (
-    <Flex
-      align="center"
-      maxWidth="400px"
-      height="100%"
-      ref={ref}
-      data-test-id="filter-value-editing"
-    >
-      <SearchQueryBuilderCombobox
-        ref={inputRef}
-        items={items}
-        onOptionSelected={handleOptionSelected}
-        onCustomValueBlurred={handleInputValueConfirmed}
-        onCustomValueCommitted={handleInputValueConfirmed}
-        onExit={onCommit}
-        inputValue={inputValue}
-        filterValue={filterValue}
-        placeholder={placeholder}
-        token={token}
-        inputLabel={t('Edit filter value')}
-        onInputChange={e => setInputValue(e.target.value)}
-        onKeyDown={onKeyDown}
-        onKeyUp={updateSelectionIndex}
-        onClick={updateSelectionIndex}
-        autoFocus
-        maxOptions={50}
-        openOnFocus
-        customMenu={customMenu}
-        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+    <ValueComboboxContext.Provider value={valueComboboxContextValue}>
+      <Flex
+        align="center"
+        maxWidth="400px"
+        height="100%"
+        ref={ref}
+        data-test-id="filter-value-editing"
       >
-        {suggestionSectionItems.map(section => (
-          <Section key={section.sectionText} title={section.sectionText}>
-            {section.items.map(item => (
-              <Item {...item} key={item.key}>
-                {item.label}
-              </Item>
-            ))}
-          </Section>
-        ))}
-      </SearchQueryBuilderCombobox>
-    </Flex>
+        <SearchQueryBuilderCombobox
+          ref={inputRef}
+          items={items}
+          onOptionSelected={handleOptionSelected}
+          onCustomValueBlurred={handleInputValueConfirmed}
+          onCustomValueCommitted={handleInputValueConfirmed}
+          onExit={onCommit}
+          inputValue={inputValue}
+          filterValue={filterValue}
+          placeholder={placeholder}
+          token={token}
+          inputLabel={t('Edit filter value')}
+          onInputChange={e => setInputValue(e.target.value)}
+          onKeyDown={onKeyDown}
+          onKeyUp={updateSelectionIndex}
+          onClick={updateSelectionIndex}
+          autoFocus
+          maxOptions={50}
+          openOnFocus
+          customMenu={customMenu}
+          shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+        >
+          {suggestionSectionItems.map(section => (
+            <Section key={section.sectionText} title={section.sectionText}>
+              {section.items.map(item => (
+                <Item {...item} key={item.key}>
+                  {item.label}
+                </Item>
+              ))}
+            </Section>
+          ))}
+        </SearchQueryBuilderCombobox>
+      </Flex>
+    </ValueComboboxContext.Provider>
   );
 }
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -21,6 +21,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {
   SearchQueryBuilderCombobox,
   type CustomComboboxMenu,
+  type CustomComboboxMenuProps,
 } from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {parseMultiSelectFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/string/parser';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue';
@@ -566,6 +567,58 @@ function ItemCheckbox({
   );
 }
 
+function ValueComboboxCustomMenu(
+  props: CustomComboboxMenuProps<SelectOptionWithKey<string>>
+) {
+  const {
+    canSelectMultipleValues,
+    canUseWildcard,
+    inputValue,
+    isFetching,
+    items,
+    onBackFromAbsoluteDate,
+    onSaveAbsoluteDate,
+    onSelectAbsoluteDate,
+    showDatePicker,
+    token,
+    wrapperRef,
+  } = useValueComboboxContext();
+
+  if (showDatePicker) {
+    return (
+      <SpecificDatePicker
+        {...props}
+        dateString={inputValue || getDefaultAbsoluteDateValue(token)}
+        handleSelectDateTime={onSelectAbsoluteDate}
+        handleBack={onBackFromAbsoluteDate}
+        handleSave={onSaveAbsoluteDate}
+      />
+    );
+  }
+
+  // Remove Ask Seer items from the value listbox since they are not shown here.
+  const hiddenOptions = new Set(props.hiddenOptions);
+  hiddenOptions.delete(ASK_SEER_ITEM_KEY);
+  hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
+
+  return (
+    <ValueListBox
+      {...props}
+      hiddenOptions={hiddenOptions}
+      wrapperRef={wrapperRef}
+      isMultiSelect={canSelectMultipleValues}
+      items={items}
+      isLoading={isFetching}
+      canUseWildcard={canUseWildcard}
+      token={token}
+    />
+  );
+}
+
+const renderValueComboboxCustomMenu: CustomComboboxMenu<
+  SelectOptionWithKey<string>
+> = props => <ValueComboboxCustomMenu {...props} />;
+
 export function getInitialInputValue(
   token: TokenResult<Token.FILTER>,
   canSelectMultipleValues: boolean
@@ -644,10 +697,6 @@ export function SearchQueryBuilderValueCombobox({
     () => new Map(selectedValuesUnescaped.map(v => [v.value, v.selected] as const)),
     [selectedValuesUnescaped]
   );
-  const valueComboboxContextValue = useMemo(
-    () => ({token, ctrlKeyPressed, selectedValueMap}),
-    [token, ctrlKeyPressed, selectedValueMap]
-  );
 
   useEffect(() => {
     if (canSelectMultipleValues) {
@@ -686,6 +735,70 @@ export function SearchQueryBuilderValueCombobox({
       new_experience: true,
     }),
     [organization, recentSearches, searchSource, keyName, token, fieldDefinition]
+  );
+
+  const handleSelectAbsoluteDate = useCallback(
+    (newDateTimeValue: string) => {
+      setInputValue(newDateTimeValue);
+      inputRef.current?.focus();
+      trackAnalytics('search.value_autocompleted', {
+        ...analyticsData,
+        filter_value: newDateTimeValue,
+        filter_value_type: 'absolute_date',
+      });
+    },
+    [analyticsData]
+  );
+
+  const handleBackFromAbsoluteDate = useCallback(() => {
+    setShowDatePicker(false);
+    setInputValue('');
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSaveAbsoluteDate = useCallback(
+    (newDateTimeValue: string) => {
+      dispatch({
+        type: 'UPDATE_TOKEN_VALUE',
+        token,
+        value: newDateTimeValue,
+      });
+      onCommit();
+    },
+    [dispatch, onCommit, token]
+  );
+
+  const valueComboboxContextValue = useMemo(
+    () => ({
+      canSelectMultipleValues,
+      canUseWildcard,
+      ctrlKeyPressed,
+      inputValue,
+      isFetching,
+      items,
+      onBackFromAbsoluteDate: handleBackFromAbsoluteDate,
+      onSaveAbsoluteDate: handleSaveAbsoluteDate,
+      onSelectAbsoluteDate: handleSelectAbsoluteDate,
+      selectedValueMap,
+      showDatePicker,
+      token,
+      wrapperRef: topLevelWrapperRef,
+    }),
+    [
+      canSelectMultipleValues,
+      canUseWildcard,
+      ctrlKeyPressed,
+      inputValue,
+      isFetching,
+      items,
+      handleBackFromAbsoluteDate,
+      handleSaveAbsoluteDate,
+      handleSelectAbsoluteDate,
+      selectedValueMap,
+      showDatePicker,
+      token,
+      topLevelWrapperRef,
+    ]
   );
 
   const updateFilterValue = useCallback(
@@ -895,85 +1008,6 @@ export function SearchQueryBuilderValueCombobox({
     [wrapperRef]
   );
 
-  // Refs for volatile values used in customMenu so the memo stays stable
-  // during checkbox toggles (items, isFetching, token, inputValue all change).
-  const itemsRef = useRef(items);
-  itemsRef.current = items;
-  const isFetchingRef = useRef(isFetching);
-  isFetchingRef.current = isFetching;
-  const tokenRef = useRef(token);
-  tokenRef.current = token;
-  const inputValueRef = useRef(inputValue);
-  inputValueRef.current = inputValue;
-  const analyticsDataRef = useRef(analyticsData);
-  analyticsDataRef.current = analyticsData;
-
-  const customMenu: CustomComboboxMenu<SelectOptionWithKey<string>> | undefined =
-    useMemo(() => {
-      if (!showDatePicker) {
-        return function (props) {
-          // Removing the ask seer options from the value list box props as we don't
-          // display and ask seer option in this list box.
-          const hiddenOptions = new Set(props.hiddenOptions);
-          hiddenOptions.delete(ASK_SEER_ITEM_KEY);
-          hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
-
-          return (
-            <ValueListBox
-              {...props}
-              hiddenOptions={hiddenOptions}
-              wrapperRef={topLevelWrapperRef}
-              isMultiSelect={canSelectMultipleValues}
-              items={itemsRef.current}
-              isLoading={isFetchingRef.current}
-              canUseWildcard={canUseWildcard}
-              token={tokenRef.current}
-            />
-          );
-        };
-      }
-
-      return function (props) {
-        return (
-          <SpecificDatePicker
-            {...props}
-            dateString={
-              inputValueRef.current || getDefaultAbsoluteDateValue(tokenRef.current)
-            }
-            handleSelectDateTime={newDateTimeValue => {
-              setInputValue(newDateTimeValue);
-              inputRef.current?.focus();
-              trackAnalytics('search.value_autocompleted', {
-                ...analyticsDataRef.current,
-                filter_value: newDateTimeValue,
-                filter_value_type: 'absolute_date',
-              });
-            }}
-            handleBack={() => {
-              setShowDatePicker(false);
-              setInputValue('');
-              inputRef.current?.focus();
-            }}
-            handleSave={newDateTimeValue => {
-              dispatch({
-                type: 'UPDATE_TOKEN_VALUE',
-                token: tokenRef.current,
-                value: newDateTimeValue,
-              });
-              onCommit();
-            }}
-          />
-        );
-      };
-    }, [
-      showDatePicker,
-      topLevelWrapperRef,
-      canSelectMultipleValues,
-      canUseWildcard,
-      dispatch,
-      onCommit,
-    ]);
-
   const placeholder =
     token.filter === FilterType.HAS
       ? prettifyTagKey(token.value.text)
@@ -1011,7 +1045,7 @@ export function SearchQueryBuilderValueCombobox({
           autoFocus
           maxOptions={50}
           openOnFocus
-          customMenu={customMenu}
+          customMenu={renderValueComboboxCustomMenu}
           shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
         >
           {suggestionSectionItems.map(section => (

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -324,6 +324,29 @@ function useSelectionIndex({
 
 type FrozenSuggestionOrder = Array<{sectionText: string; values: string[]}>;
 
+// Shallow comparison of suggestion groups by section text and suggestion values.
+// Used by `useFrozenSuggestionSectionItems` to avoid resetting the frozen item
+// order when the suggestion arrays are reconstructed with identical contents
+// (e.g. toggling a multi-select checkbox rebuilds the array but doesn't change
+// the set of available suggestions).
+function suggestionGroupsAffectOrderChanged(
+  previousSuggestionGroups: SuggestionSection[] | null,
+  nextSuggestionGroups: SuggestionSection[]
+) {
+  if (!previousSuggestionGroups) return true;
+  if (previousSuggestionGroups === nextSuggestionGroups) return false;
+  if (previousSuggestionGroups.length !== nextSuggestionGroups.length) return true;
+
+  return !previousSuggestionGroups.every((prevGroup, i) => {
+    const nextGroup = nextSuggestionGroups[i];
+    return (
+      prevGroup.sectionText === nextGroup?.sectionText &&
+      prevGroup.suggestions.length === nextGroup.suggestions.length &&
+      prevGroup.suggestions.every((s, j) => s.value === nextGroup.suggestions[j]?.value)
+    );
+  });
+}
+
 // In multi-select mode we want the currently selected values to float to the top
 // when the menu opens, but we do not want the list order to keep changing after
 // each checkbox toggle. If it re-sorts on every selection, the listbox scroll
@@ -350,10 +373,12 @@ function useFrozenSuggestionSectionItems({
   const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
   const frozenOrderRef = useRef<FrozenSuggestionOrder | null>(null);
 
-  // A new suggestion group identity means the menu effectively has a new result
-  // set (reopened, new data, different key/filter), so the frozen ordering
-  // should be recalculated from scratch.
-  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
+  // Some callers rebuild suggestion group arrays even when the visible values
+  // are unchanged (for example when toggling a predefined multi-select value).
+  // Reset only when the actual suggestion contents change.
+  if (
+    suggestionGroupsAffectOrderChanged(prevSuggestionGroupsRef.current, suggestionGroups)
+  ) {
     prevSuggestionGroupsRef.current = suggestionGroups;
     frozenOrderRef.current = null;
   }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -379,8 +379,22 @@ function useFilterSuggestions({
     enabled: shouldFetchValues,
   });
 
+  // Use refs for values that change frequently (every toggle) so that
+  // createItem and suggestionSectionItems stay referentially stable.
+  // The trailingItems render prop reads from these refs at render time.
+  const tokenRef = useRef(token);
+  tokenRef.current = token;
+  const ctrlKeyPressedRef = useRef(ctrlKeyPressed);
+  ctrlKeyPressedRef.current = ctrlKeyPressed;
+  const selectedValuesRef = useRef(selectedValues);
+  selectedValuesRef.current = selectedValues;
+  const selectedValueMapRef = useRef(new Map<string, boolean>());
+  selectedValueMapRef.current = new Map(
+    selectedValues.map(v => [v.value, v.selected] as const)
+  );
+
   const createItem = useCallback(
-    (suggestion: SuggestionItem, selected = false) => {
+    (suggestion: SuggestionItem) => {
       return {
         label: suggestion.label ?? suggestion.value,
         value: suggestion.value,
@@ -396,17 +410,17 @@ function useFilterSuggestions({
           return (
             <ItemCheckbox
               isFocused={isFocused}
-              selected={selected}
-              token={token}
+              selected={selectedValueMapRef.current.get(suggestion.value) ?? false}
+              token={tokenRef.current}
               disabled={disabled}
               value={suggestion.value}
-              ctrlKeyPressed={ctrlKeyPressed}
+              ctrlKeyPressed={ctrlKeyPressedRef.current}
             />
           );
         },
       };
     },
-    [canSelectMultipleValues, token, ctrlKeyPressed]
+    [canSelectMultipleValues]
   );
 
   const suggestionGroups = useMemo(() => {
@@ -444,35 +458,33 @@ function useFilterSuggestions({
   }
 
   // Grouped sections for rendering purposes.
-  // Uses two paths:
-  //   Path A (fresh open): sorts selected items to the top, then freezes the order.
-  //   Path B (subsequent toggles): preserves frozen order, only updates checkbox states.
+  // On fresh open (frozenOrderRef is null): sorts selected items to the top, then
+  // freezes the order. On subsequent toggles: returns the cached result — checkbox
+  // states are read from selectedValueMapRef at render time, so item objects stay
+  // referentially stable and downstream memos/components skip re-computation.
   const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
-    const selectedValueMap = new Map(
-      selectedValues.map(v => [v.value, v.selected] as const)
-    );
+    const currentSelectedValues = selectedValuesRef.current;
     const allSuggestions = new Map(
       suggestionGroups.flatMap(group => group.suggestions.map(s => [s.value, s] as const))
     );
 
     if (!frozenOrderRef.current) {
-      // PATH A: Fresh open — sort selected items to top (original behavior)
+      // Fresh open — sort selected items to top (original behavior)
       const itemsWithoutSection = suggestionGroups
         .filter(group => group.sectionText === '')
         .flatMap(group => group.suggestions)
-        .filter(suggestion => !selectedValues.some(v => v.value === suggestion.value));
+        .filter(
+          suggestion => !currentSelectedValues.some(v => v.value === suggestion.value)
+        );
       const sections = suggestionGroups.filter(group => group.sectionText !== '');
 
       const result: SuggestionSectionItem[] = [
         {
           sectionText: '',
           items: getItemsWithKeys([
-            ...selectedValues.map(value => {
+            ...currentSelectedValues.map(value => {
               const matchingSuggestion = allSuggestions.get(value.value);
-              if (matchingSuggestion) {
-                return createItem(matchingSuggestion, value.selected);
-              }
-              return createItem({value: value.value}, value.selected);
+              return createItem(matchingSuggestion ?? {value: value.value});
             }),
             ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
           ]),
@@ -482,7 +494,8 @@ function useFilterSuggestions({
           items: getItemsWithKeys(
             group.suggestions
               .filter(
-                suggestion => !selectedValues.some(v => v.value === suggestion.value)
+                suggestion =>
+                  !currentSelectedValues.some(v => v.value === suggestion.value)
               )
               .map(suggestion => createItem(suggestion))
           ),
@@ -498,26 +511,19 @@ function useFilterSuggestions({
       return result;
     }
 
-    // PATH B: Subsequent toggle — preserve frozen order, update checkbox states only
-    const frozenValues = new Set(frozenOrderRef.current.flatMap(s => s.values));
-    const newCustomValues = selectedValues.filter(
-      v => !frozenValues.has(v.value) && !allSuggestions.has(v.value)
-    );
-
-    return frozenOrderRef.current.map((section, i) => ({
+    // Subsequent toggle — return cached items. Checkbox states are read from
+    // selectedValueMapRef inside the trailingItems render prop, so the same
+    // item objects render the correct state without needing reconstruction.
+    return frozenOrderRef.current.map(section => ({
       sectionText: section.sectionText,
-      items: getItemsWithKeys([
-        ...(i === 0
-          ? newCustomValues.map(v => createItem({value: v.value}, v.selected))
-          : []),
-        ...section.values.map(value => {
+      items: getItemsWithKeys(
+        section.values.map(value => {
           const suggestion = allSuggestions.get(value) ?? {value};
-          const isSelected = selectedValueMap.get(value);
-          return createItem(suggestion, isSelected ?? false);
-        }),
-      ]),
+          return createItem(suggestion);
+        })
+      ),
     }));
-  }, [createItem, selectedValues, suggestionGroups]);
+  }, [createItem, suggestionGroups]);
 
   // Flat list used for state management
   const items = useMemo(() => {
@@ -896,6 +902,19 @@ export function SearchQueryBuilderValueCombobox({
     [wrapperRef]
   );
 
+  // Refs for volatile values used in customMenu so the memo stays stable
+  // during checkbox toggles (items, isFetching, token, inputValue all change).
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const isFetchingRef = useRef(isFetching);
+  isFetchingRef.current = isFetching;
+  const tokenRef = useRef(token);
+  tokenRef.current = token;
+  const inputValueRef = useRef(inputValue);
+  inputValueRef.current = inputValue;
+  const analyticsDataRef = useRef(analyticsData);
+  analyticsDataRef.current = analyticsData;
+
   const customMenu: CustomComboboxMenu<SelectOptionWithKey<string>> | undefined =
     useMemo(() => {
       if (!showDatePicker) {
@@ -912,10 +931,10 @@ export function SearchQueryBuilderValueCombobox({
               hiddenOptions={hiddenOptions}
               wrapperRef={topLevelWrapperRef}
               isMultiSelect={canSelectMultipleValues}
-              items={items}
-              isLoading={isFetching}
+              items={itemsRef.current}
+              isLoading={isFetchingRef.current}
               canUseWildcard={canUseWildcard}
-              token={token}
+              token={tokenRef.current}
             />
           );
         };
@@ -925,12 +944,14 @@ export function SearchQueryBuilderValueCombobox({
         return (
           <SpecificDatePicker
             {...props}
-            dateString={inputValue || getDefaultAbsoluteDateValue(token)}
+            dateString={
+              inputValueRef.current || getDefaultAbsoluteDateValue(tokenRef.current)
+            }
             handleSelectDateTime={newDateTimeValue => {
               setInputValue(newDateTimeValue);
               inputRef.current?.focus();
               trackAnalytics('search.value_autocompleted', {
-                ...analyticsData,
+                ...analyticsDataRef.current,
                 filter_value: newDateTimeValue,
                 filter_value_type: 'absolute_date',
               });
@@ -943,7 +964,7 @@ export function SearchQueryBuilderValueCombobox({
             handleSave={newDateTimeValue => {
               dispatch({
                 type: 'UPDATE_TOKEN_VALUE',
-                token,
+                token: tokenRef.current,
                 value: newDateTimeValue,
               });
               onCommit();
@@ -955,12 +976,7 @@ export function SearchQueryBuilderValueCombobox({
       showDatePicker,
       topLevelWrapperRef,
       canSelectMultipleValues,
-      items,
-      isFetching,
       canUseWildcard,
-      inputValue,
-      token,
-      analyticsData,
       dispatch,
       onCommit,
     ]);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -293,23 +293,14 @@ function keySupportsWildcard(fieldDefinition: FieldDefinition | null) {
 
 function useSelectionIndex({
   inputRef,
-  inputValue,
-  canSelectMultipleValues,
+  initialLength,
 }: {
-  canSelectMultipleValues: boolean;
+  initialLength: number;
   inputRef: React.RefObject<HTMLInputElement | null>;
-  inputValue: string;
 }) {
   const [selectionIndex, setSelectionIndex] = useState<number | null>(
-    () => inputValue.length
+    () => initialLength
   );
-
-  useEffect(() => {
-    if (canSelectMultipleValues) {
-      // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
-      setSelectionIndex(inputValue.length);
-    }
-  }, [canSelectMultipleValues, inputValue]);
 
   const updateSelectionIndex = useCallback(() => {
     if (inputRef.current?.selectionStart === inputRef.current?.selectionEnd) {
@@ -321,6 +312,7 @@ function useSelectionIndex({
 
   return {
     selectionIndex,
+    setSelectionIndex,
     updateSelectionIndex,
   };
 }
@@ -439,41 +431,92 @@ function useFilterSuggestions({
     return [{sectionText: '', suggestions: suggestions ?? []}];
   }, [data, predefinedValues, shouldFetchValues, key?.key]);
 
-  // Grouped sections for rendering purposes
+  // Track suggestion groups identity to detect when a fresh sort is needed
+  // (e.g. combobox reopened, filter key changed, or new data fetched)
+  const prevSuggestionGroupsRef = useRef<SuggestionSection[] | null>(null);
+  const frozenOrderRef = useRef<Array<{sectionText: string; values: string[]}> | null>(
+    null
+  );
+
+  if (prevSuggestionGroupsRef.current !== suggestionGroups) {
+    prevSuggestionGroupsRef.current = suggestionGroups;
+    frozenOrderRef.current = null;
+  }
+
+  // Grouped sections for rendering purposes.
+  // Uses two paths:
+  //   Path A (fresh open): sorts selected items to the top, then freezes the order.
+  //   Path B (subsequent toggles): preserves frozen order, only updates checkbox states.
   const suggestionSectionItems = useMemo<SuggestionSectionItem[]>(() => {
-    const itemsWithoutSection = suggestionGroups
-      .filter(group => group.sectionText === '')
-      .flatMap(group => group.suggestions)
-      .filter(suggestion => !selectedValues.some(v => v.value === suggestion.value));
-    const sections = suggestionGroups.filter(group => group.sectionText !== '');
+    const selectedValueMap = new Map(
+      selectedValues.map(v => [v.value, v.selected] as const)
+    );
+    const allSuggestions = new Map(
+      suggestionGroups.flatMap(group => group.suggestions.map(s => [s.value, s] as const))
+    );
 
-    return [
-      {
-        sectionText: '',
-        items: getItemsWithKeys([
-          ...selectedValues.map(value => {
-            const matchingSuggestion = suggestionGroups
-              .flatMap(group => group.suggestions)
-              .find(suggestion => suggestion.value === value.value);
+    if (!frozenOrderRef.current) {
+      // PATH A: Fresh open — sort selected items to top (original behavior)
+      const itemsWithoutSection = suggestionGroups
+        .filter(group => group.sectionText === '')
+        .flatMap(group => group.suggestions)
+        .filter(suggestion => !selectedValues.some(v => v.value === suggestion.value));
+      const sections = suggestionGroups.filter(group => group.sectionText !== '');
 
-            if (matchingSuggestion) {
-              return createItem(matchingSuggestion, value.selected);
-            }
+      const result: SuggestionSectionItem[] = [
+        {
+          sectionText: '',
+          items: getItemsWithKeys([
+            ...selectedValues.map(value => {
+              const matchingSuggestion = allSuggestions.get(value.value);
+              if (matchingSuggestion) {
+                return createItem(matchingSuggestion, value.selected);
+              }
+              return createItem({value: value.value}, value.selected);
+            }),
+            ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
+          ]),
+        },
+        ...sections.map(group => ({
+          sectionText: group.sectionText,
+          items: getItemsWithKeys(
+            group.suggestions
+              .filter(
+                suggestion => !selectedValues.some(v => v.value === suggestion.value)
+              )
+              .map(suggestion => createItem(suggestion))
+          ),
+        })),
+      ];
 
-            return createItem({value: value.value}, value.selected);
-          }),
-          ...itemsWithoutSection.map(suggestion => createItem(suggestion)),
-        ]),
-      },
-      ...sections.map(group => ({
-        sectionText: group.sectionText,
-        items: getItemsWithKeys(
-          group.suggestions
-            .filter(suggestion => !selectedValues.some(v => v.value === suggestion.value))
-            .map(suggestion => createItem(suggestion))
-        ),
-      })),
-    ];
+      // Freeze the item order for subsequent renders within this session
+      frozenOrderRef.current = result.map(section => ({
+        sectionText: section.sectionText,
+        values: section.items.map(item => item.value),
+      }));
+
+      return result;
+    }
+
+    // PATH B: Subsequent toggle — preserve frozen order, update checkbox states only
+    const frozenValues = new Set(frozenOrderRef.current.flatMap(s => s.values));
+    const newCustomValues = selectedValues.filter(
+      v => !frozenValues.has(v.value) && !allSuggestions.has(v.value)
+    );
+
+    return frozenOrderRef.current.map((section, i) => ({
+      sectionText: section.sectionText,
+      items: getItemsWithKeys([
+        ...(i === 0
+          ? newCustomValues.map(v => createItem({value: v.value}, v.selected))
+          : []),
+        ...section.values.map(value => {
+          const suggestion = allSuggestions.get(value) ?? {value};
+          const isSelected = selectedValueMap.get(value);
+          return createItem(suggestion, isSelected ?? false);
+        }),
+      ]),
+    }));
   }, [createItem, selectedValues, suggestionGroups]);
 
   // Flat list used for state management
@@ -577,10 +620,9 @@ export function SearchQueryBuilderValueCombobox({
   const [inputValue, setInputValue] = useState(() =>
     getInitialInputValue(token, canSelectMultipleValues)
   );
-  const {selectionIndex, updateSelectionIndex} = useSelectionIndex({
+  const {selectionIndex, setSelectionIndex, updateSelectionIndex} = useSelectionIndex({
     inputRef,
-    inputValue,
-    canSelectMultipleValues,
+    initialLength: inputValue.length,
   });
 
   const [showDatePicker, setShowDatePicker] = useState(() => {
@@ -609,7 +651,12 @@ export function SearchQueryBuilderValueCombobox({
 
   useEffect(() => {
     if (canSelectMultipleValues) {
-      setInputValue(getMultiSelectInputValue(token));
+      const newInputValue = getMultiSelectInputValue(token);
+      // Batch both updates to avoid an intermediate render where
+      // selectionIndex is stale, which would cause filterValue to
+      // temporarily change and trigger item filtering flicker.
+      setInputValue(newInputValue);
+      setSelectionIndex(newInputValue.length);
     }
     // We want to avoid resetting the input value if the token text doesn't actually change
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -21,6 +21,7 @@ import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/contex
 import {
   SearchQueryBuilderCombobox,
   type CustomComboboxMenu,
+  type CustomComboboxMenuProps,
 } from 'sentry/components/searchQueryBuilder/tokens/combobox';
 import {parseMultiSelectFilterValue} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/string/parser';
 import {replaceCommaSeparatedValue} from 'sentry/components/searchQueryBuilder/tokens/filter/replaceCommaSeparatedValue';
@@ -33,7 +34,9 @@ import {
 } from 'sentry/components/searchQueryBuilder/tokens/filter/utils';
 import {
   useValueComboboxContext,
+  useValueComboboxMenuContext,
   ValueComboboxContext,
+  ValueComboboxMenuContext,
 } from 'sentry/components/searchQueryBuilder/tokens/filter/valueComboboxContext';
 import {ValueListBox} from 'sentry/components/searchQueryBuilder/tokens/filter/valueListBox';
 import {getDefaultAbsoluteDateValue} from 'sentry/components/searchQueryBuilder/tokens/filter/valueSuggestions/date';
@@ -566,6 +569,54 @@ function ItemCheckbox({
   );
 }
 
+function ValueComboboxCustomMenu(
+  props: CustomComboboxMenuProps<SelectOptionWithKey<string>>
+) {
+  const {
+    canSelectMultipleValues,
+    canUseWildcard,
+    inputValue,
+    isFetching,
+    items,
+    onBackFromAbsoluteDate,
+    onSaveAbsoluteDate,
+    onSelectAbsoluteDate,
+    showDatePicker,
+    token,
+    wrapperRef,
+  } = useValueComboboxMenuContext();
+
+  if (showDatePicker) {
+    return (
+      <SpecificDatePicker
+        {...props}
+        dateString={inputValue || getDefaultAbsoluteDateValue(token)}
+        handleSelectDateTime={onSelectAbsoluteDate}
+        handleBack={onBackFromAbsoluteDate}
+        handleSave={onSaveAbsoluteDate}
+      />
+    );
+  }
+
+  // Remove Ask Seer items from the value list box since they are not shown here.
+  const hiddenOptions = new Set(props.hiddenOptions);
+  hiddenOptions.delete(ASK_SEER_ITEM_KEY);
+  hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
+
+  return (
+    <ValueListBox
+      {...props}
+      hiddenOptions={hiddenOptions}
+      wrapperRef={wrapperRef}
+      isMultiSelect={canSelectMultipleValues}
+      items={items}
+      isLoading={isFetching}
+      canUseWildcard={canUseWildcard}
+      token={token}
+    />
+  );
+}
+
 export function getInitialInputValue(
   token: TokenResult<Token.FILTER>,
   canSelectMultipleValues: boolean
@@ -686,6 +737,66 @@ export function SearchQueryBuilderValueCombobox({
       new_experience: true,
     }),
     [organization, recentSearches, searchSource, keyName, token, fieldDefinition]
+  );
+
+  const handleSelectAbsoluteDate = useCallback(
+    (newDateTimeValue: string) => {
+      setInputValue(newDateTimeValue);
+      inputRef.current?.focus();
+      trackAnalytics('search.value_autocompleted', {
+        ...analyticsData,
+        filter_value: newDateTimeValue,
+        filter_value_type: 'absolute_date',
+      });
+    },
+    [analyticsData]
+  );
+
+  const handleBackFromAbsoluteDate = useCallback(() => {
+    setShowDatePicker(false);
+    setInputValue('');
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSaveAbsoluteDate = useCallback(
+    (newDateTimeValue: string) => {
+      dispatch({
+        type: 'UPDATE_TOKEN_VALUE',
+        token,
+        value: newDateTimeValue,
+      });
+      onCommit();
+    },
+    [dispatch, onCommit, token]
+  );
+
+  const menuContextValue = useMemo(
+    () => ({
+      canSelectMultipleValues,
+      canUseWildcard,
+      inputValue,
+      isFetching,
+      items,
+      onBackFromAbsoluteDate: handleBackFromAbsoluteDate,
+      onSaveAbsoluteDate: handleSaveAbsoluteDate,
+      onSelectAbsoluteDate: handleSelectAbsoluteDate,
+      showDatePicker,
+      token,
+      wrapperRef: topLevelWrapperRef,
+    }),
+    [
+      canSelectMultipleValues,
+      canUseWildcard,
+      inputValue,
+      isFetching,
+      items,
+      handleBackFromAbsoluteDate,
+      handleSaveAbsoluteDate,
+      handleSelectAbsoluteDate,
+      showDatePicker,
+      token,
+      topLevelWrapperRef,
+    ]
   );
 
   const updateFilterValue = useCallback(
@@ -895,84 +1006,14 @@ export function SearchQueryBuilderValueCombobox({
     [wrapperRef]
   );
 
-  // Refs for volatile values used in customMenu so the memo stays stable
-  // during checkbox toggles (items, isFetching, token, inputValue all change).
-  const itemsRef = useRef(items);
-  itemsRef.current = items;
-  const isFetchingRef = useRef(isFetching);
-  isFetchingRef.current = isFetching;
-  const tokenRef = useRef(token);
-  tokenRef.current = token;
-  const inputValueRef = useRef(inputValue);
-  inputValueRef.current = inputValue;
-  const analyticsDataRef = useRef(analyticsData);
-  analyticsDataRef.current = analyticsData;
-
-  const customMenu: CustomComboboxMenu<SelectOptionWithKey<string>> | undefined =
-    useMemo(() => {
-      if (!showDatePicker) {
-        return function (props) {
-          // Removing the ask seer options from the value list box props as we don't
-          // display and ask seer option in this list box.
-          const hiddenOptions = new Set(props.hiddenOptions);
-          hiddenOptions.delete(ASK_SEER_ITEM_KEY);
-          hiddenOptions.delete(ASK_SEER_CONSENT_ITEM_KEY);
-
-          return (
-            <ValueListBox
-              {...props}
-              hiddenOptions={hiddenOptions}
-              wrapperRef={topLevelWrapperRef}
-              isMultiSelect={canSelectMultipleValues}
-              items={itemsRef.current}
-              isLoading={isFetchingRef.current}
-              canUseWildcard={canUseWildcard}
-              token={tokenRef.current}
-            />
-          );
-        };
-      }
-
-      return function (props) {
-        return (
-          <SpecificDatePicker
-            {...props}
-            dateString={
-              inputValueRef.current || getDefaultAbsoluteDateValue(tokenRef.current)
-            }
-            handleSelectDateTime={newDateTimeValue => {
-              setInputValue(newDateTimeValue);
-              inputRef.current?.focus();
-              trackAnalytics('search.value_autocompleted', {
-                ...analyticsDataRef.current,
-                filter_value: newDateTimeValue,
-                filter_value_type: 'absolute_date',
-              });
-            }}
-            handleBack={() => {
-              setShowDatePicker(false);
-              setInputValue('');
-              inputRef.current?.focus();
-            }}
-            handleSave={newDateTimeValue => {
-              dispatch({
-                type: 'UPDATE_TOKEN_VALUE',
-                token: tokenRef.current,
-                value: newDateTimeValue,
-              });
-              onCommit();
-            }}
-          />
-        );
-      };
-    }, [
-      showDatePicker,
-      topLevelWrapperRef,
-      canSelectMultipleValues,
-      canUseWildcard,
-      dispatch,
-      onCommit,
-    ]);
+  // The combobox re-runs ariaHideOutside when the custom menu identity changes.
+  // Only recreate it when switching between the listbox and the date picker.
+  const customMenu = useMemo<CustomComboboxMenu<SelectOptionWithKey<string>>>(() => {
+    const menuMode = showDatePicker ? 'date-picker' : 'list-box';
+    return function (props) {
+      return <ValueComboboxCustomMenu key={menuMode} {...props} />;
+    };
+  }, [showDatePicker]);
 
   const placeholder =
     token.filter === FilterType.HAS
@@ -985,46 +1026,48 @@ export function SearchQueryBuilderValueCombobox({
 
   return (
     <ValueComboboxContext.Provider value={valueComboboxContextValue}>
-      <Flex
-        align="center"
-        maxWidth="400px"
-        height="100%"
-        ref={ref}
-        data-test-id="filter-value-editing"
-      >
-        <SearchQueryBuilderCombobox
-          ref={inputRef}
-          items={items}
-          onOptionSelected={handleOptionSelected}
-          onCustomValueBlurred={handleInputValueConfirmed}
-          onCustomValueCommitted={handleInputValueConfirmed}
-          onExit={onCommit}
-          inputValue={inputValue}
-          filterValue={filterValue}
-          placeholder={placeholder}
-          token={token}
-          inputLabel={t('Edit filter value')}
-          onInputChange={e => setInputValue(e.target.value)}
-          onKeyDown={onKeyDown}
-          onKeyUp={updateSelectionIndex}
-          onClick={updateSelectionIndex}
-          autoFocus
-          maxOptions={50}
-          openOnFocus
-          customMenu={customMenu}
-          shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+      <ValueComboboxMenuContext.Provider value={menuContextValue}>
+        <Flex
+          align="center"
+          maxWidth="400px"
+          height="100%"
+          ref={ref}
+          data-test-id="filter-value-editing"
         >
-          {suggestionSectionItems.map(section => (
-            <Section key={section.sectionText} title={section.sectionText}>
-              {section.items.map(item => (
-                <Item {...item} key={item.key}>
-                  {item.label}
-                </Item>
-              ))}
-            </Section>
-          ))}
-        </SearchQueryBuilderCombobox>
-      </Flex>
+          <SearchQueryBuilderCombobox
+            ref={inputRef}
+            items={items}
+            onOptionSelected={handleOptionSelected}
+            onCustomValueBlurred={handleInputValueConfirmed}
+            onCustomValueCommitted={handleInputValueConfirmed}
+            onExit={onCommit}
+            inputValue={inputValue}
+            filterValue={filterValue}
+            placeholder={placeholder}
+            token={token}
+            inputLabel={t('Edit filter value')}
+            onInputChange={e => setInputValue(e.target.value)}
+            onKeyDown={onKeyDown}
+            onKeyUp={updateSelectionIndex}
+            onClick={updateSelectionIndex}
+            autoFocus
+            maxOptions={50}
+            openOnFocus
+            customMenu={customMenu}
+            shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+          >
+            {suggestionSectionItems.map(section => (
+              <Section key={section.sectionText} title={section.sectionText}>
+                {section.items.map(item => (
+                  <Item {...item} key={item.key}>
+                    {item.label}
+                  </Item>
+                ))}
+              </Section>
+            ))}
+          </SearchQueryBuilderCombobox>
+        </Flex>
+      </ValueComboboxMenuContext.Provider>
     </ValueComboboxContext.Provider>
   );
 }

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -1,23 +1,11 @@
-import {createContext, useContext, type RefObject} from 'react';
-
-import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
+import {createContext, useContext} from 'react';
 
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 
 type ValueComboboxContextValue = {
-  canSelectMultipleValues: boolean;
-  canUseWildcard: boolean;
   ctrlKeyPressed: boolean;
-  inputValue: string;
-  isFetching: boolean;
-  items: Array<SelectOptionWithKey<string>>;
-  onBackFromAbsoluteDate: () => void;
-  onSaveAbsoluteDate: (newDateTimeValue: string) => void;
-  onSelectAbsoluteDate: (newDateTimeValue: string) => void;
   selectedValueMap: ReadonlyMap<string, boolean>;
-  showDatePicker: boolean;
   token: TokenResult<Token.FILTER>;
-  wrapperRef: RefObject<HTMLDivElement | null>;
 };
 
 export const ValueComboboxContext = createContext<ValueComboboxContextValue | null>(null);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -1,11 +1,23 @@
-import {createContext, useContext} from 'react';
+import {createContext, useContext, type RefObject} from 'react';
+
+import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 
 type ValueComboboxContextValue = {
+  canSelectMultipleValues: boolean;
+  canUseWildcard: boolean;
   ctrlKeyPressed: boolean;
+  inputValue: string;
+  isFetching: boolean;
+  items: Array<SelectOptionWithKey<string>>;
+  onBackFromAbsoluteDate: () => void;
+  onSaveAbsoluteDate: (newDateTimeValue: string) => void;
+  onSelectAbsoluteDate: (newDateTimeValue: string) => void;
   selectedValueMap: ReadonlyMap<string, boolean>;
+  showDatePicker: boolean;
   token: TokenResult<Token.FILTER>;
+  wrapperRef: RefObject<HTMLDivElement | null>;
 };
 
 export const ValueComboboxContext = createContext<ValueComboboxContextValue | null>(null);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -1,0 +1,21 @@
+import {createContext, useContext} from 'react';
+
+import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
+
+export type ValueComboboxContextValue = {
+  ctrlKeyPressed: boolean;
+  selectedValueMap: ReadonlyMap<string, boolean>;
+  token: TokenResult<Token.FILTER>;
+};
+
+export const ValueComboboxContext = createContext<ValueComboboxContextValue | null>(null);
+
+export function useValueComboboxContext() {
+  const context = useContext(ValueComboboxContext);
+  if (!context) {
+    throw new Error(
+      'useValueComboboxContext must be used within SearchQueryBuilderValueCombobox'
+    );
+  }
+  return context;
+}

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -1,4 +1,6 @@
-import {createContext, useContext} from 'react';
+import {createContext, useContext, type RefObject} from 'react';
+
+import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 
@@ -8,13 +10,39 @@ type ValueComboboxContextValue = {
   token: TokenResult<Token.FILTER>;
 };
 
+type ValueComboboxMenuContextValue = {
+  canSelectMultipleValues: boolean;
+  canUseWildcard: boolean;
+  inputValue: string;
+  isFetching: boolean;
+  items: Array<SelectOptionWithKey<string>>;
+  onBackFromAbsoluteDate: () => void;
+  onSaveAbsoluteDate: (newDateTimeValue: string) => void;
+  onSelectAbsoluteDate: (newDateTimeValue: string) => void;
+  showDatePicker: boolean;
+  token: TokenResult<Token.FILTER>;
+  wrapperRef: RefObject<HTMLDivElement | null>;
+};
+
 export const ValueComboboxContext = createContext<ValueComboboxContextValue | null>(null);
+export const ValueComboboxMenuContext =
+  createContext<ValueComboboxMenuContextValue | null>(null);
 
 export function useValueComboboxContext() {
   const context = useContext(ValueComboboxContext);
   if (!context) {
     throw new Error(
       'useValueComboboxContext must be used within SearchQueryBuilderValueCombobox'
+    );
+  }
+  return context;
+}
+
+export function useValueComboboxMenuContext() {
+  const context = useContext(ValueComboboxMenuContext);
+  if (!context) {
+    throw new Error(
+      'useValueComboboxMenuContext must be used within SearchQueryBuilderValueCombobox'
     );
   }
   return context;

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -2,7 +2,7 @@ import {createContext, useContext} from 'react';
 
 import {Token, type TokenResult} from 'sentry/components/searchSyntax/parser';
 
-export type ValueComboboxContextValue = {
+type ValueComboboxContextValue = {
   ctrlKeyPressed: boolean;
   selectedValueMap: ReadonlyMap<string, boolean>;
   token: TokenResult<Token.FILTER>;


### PR DESCRIPTION
Preserve keyboard focus, scroll position, and option ordering when toggling values in a multi-select filter combobox such as `browser.name:[Chrome,Firefox]`.

Checkbox toggles were effectively treated like new user input: the combobox cleared its focused item, multi-select input state could briefly fall out of sync, and predefined suggestions were rebuilt in a way that kept moving selected values around while the menu stayed open. That made multi-select editing feel jumpy and caused unnecessary menu/listbox work on every toggle.

This change makes `SearchQueryBuilderCombobox` reset `focusedKey` only for real typing, batches the multi-select `inputValue` and `selectionIndex` updates, and freezes the initial selected-first suggestion ordering for the lifetime of an open menu so toggles only update checkbox state. The supporting refactor extracts that ordering behavior into `useFrozenSuggestionSectionItems` and splits value-combobox state into focused contexts so the custom menu and trailing checkboxes can read fresh values without forcing the menu identity to churn.

The frozen ordering still resets when the visible suggestion set actually changes, so reopening with new suggestions or adding/removing visible custom values recomputes the initial order instead of holding onto stale state.

Also adds regression coverage for selected-first ordering on open, stable ordering while selecting and deselecting values, predefined section rebuilds, and reopening with a changed suggestion set.

Refs EXP-357