### PR TITLE
feat(replays): Add DOM inspect button to send replay elements to Seer…

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -59,6 +59,12 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   getMirror: () => Mirror | null;
 
   /**
+   * Returns the replay iframe element, if available.
+   * Useful for direct DOM interaction like element inspection.
+   */
+  getReplayIframe: () => HTMLIFrameElement | null;
+
+  /**
    * Set to true while the library is reconstructing the DOM
    */
   isBuffering: boolean;
@@ -138,6 +144,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   setRoot: () => {},
   togglePlayPause: () => {},
   getMirror: () => null,
+  getReplayIframe: () => null,
 });
 
 type Props = {
@@ -622,6 +629,7 @@ export function Provider({
           setCurrentTime,
           togglePlayPause,
           getMirror: () => replayerRef.current?.getMirror() ?? null,
+          getReplayIframe: () => replayerRef.current?.iframe ?? null,
           ...value,
         }}
       >

--- a/static/app/components/replays/replayDOMInspectButton.tsx
+++ b/static/app/components/replays/replayDOMInspectButton.tsx
@@ -1,0 +1,208 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconCursorArrow} from 'sentry/icons/iconCursorArrow';
+import {t} from 'sentry/locale';
+import {openSeerExplorer} from 'sentry/views/seerExplorer/openSeerExplorer';
+
+import ReplayInspectQueryModal from './replayInspectQueryModal';
+
+const HIGHLIGHT_STYLE =
+  'outline: 2px solid #6C5FC7 !important; outline-offset: -1px !important; cursor: crosshair !important;';
+
+/**
+ * Button that enables DOM inspection mode in the replay iframe.
+ * When active, users can click on elements in the replay to select them,
+ * then provide a query to send to Seer Explorer along with the selected HTML.
+ */
+export default function ReplayDOMInspectButton() {
+  const {getReplayIframe, togglePlayPause, isPlaying} = useReplayContext();
+  const [isInspecting, setIsInspecting] = useState(false);
+  const wasPlayingRef = useRef(false);
+  const previousHighlightRef = useRef<HTMLElement | null>(null);
+  const previousStyleRef = useRef<string>('');
+
+  const cleanupHighlight = useCallback(() => {
+    if (previousHighlightRef.current) {
+      previousHighlightRef.current.style.cssText = previousStyleRef.current;
+      previousHighlightRef.current = null;
+      previousStyleRef.current = '';
+    }
+  }, []);
+
+  const stopInspecting = useCallback(() => {
+    setIsInspecting(false);
+    cleanupHighlight();
+
+    const iframe = getReplayIframe();
+    if (iframe?.contentDocument) {
+      iframe.contentDocument.body.style.cursor = '';
+    }
+
+    // Resume playback if it was playing before
+    if (wasPlayingRef.current) {
+      togglePlayPause(true);
+      wasPlayingRef.current = false;
+    }
+  }, [getReplayIframe, cleanupHighlight, togglePlayPause]);
+
+  const handleElementSelected = useCallback(
+    (html: string) => {
+      stopInspecting();
+      openModal(
+        deps => (
+          <ReplayInspectQueryModal
+            {...deps}
+            selectedHtml={html}
+            onSubmit={query => {
+              deps.closeModal();
+              const prompt = buildSeerPrompt(query, html);
+              openSeerExplorer({
+                startNewRun: true,
+                initialMessage: prompt,
+              });
+            }}
+          />
+        ),
+        {closeEvents: 'escape-key'}
+      );
+    },
+    [stopInspecting]
+  );
+
+  // Set up event listeners on the replay iframe when inspecting
+  useEffect(() => {
+    if (!isInspecting) {
+      return undefined;
+    }
+
+    const iframe = getReplayIframe();
+    if (!iframe?.contentDocument) {
+      setIsInspecting(false);
+      return undefined;
+    }
+
+    const doc = iframe.contentDocument;
+    doc.body.style.cursor = 'crosshair';
+
+    function handleMouseOver(e: MouseEvent) {
+      const target = e.target as HTMLElement;
+      if (!target || target === doc?.body || target === doc?.documentElement) {
+        return;
+      }
+
+      cleanupHighlight();
+
+      previousHighlightRef.current = target;
+      previousStyleRef.current = target.style.cssText;
+      target.style.cssText += HIGHLIGHT_STYLE;
+    }
+
+    function handleMouseOut(e: MouseEvent) {
+      const target = e.target as HTMLElement;
+      if (target === previousHighlightRef.current) {
+        cleanupHighlight();
+      }
+    }
+
+    function handleClick(e: MouseEvent) {
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+
+      const target = e.target as HTMLElement;
+      if (!target || target === doc?.body || target === doc?.documentElement) {
+        return;
+      }
+
+      // Extract the outerHTML of the selected element, truncated to a reasonable size
+      const html = target.outerHTML.slice(0, 10000);
+      handleElementSelected(html);
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        stopInspecting();
+      }
+    }
+
+    doc.addEventListener('mouseover', handleMouseOver, true);
+    doc.addEventListener('mouseout', handleMouseOut, true);
+    doc.addEventListener('click', handleClick, true);
+    doc.addEventListener('keydown', handleKeyDown, true);
+    // Also listen on parent document for Escape
+    document.addEventListener('keydown', handleKeyDown, true);
+
+    return () => {
+      doc.removeEventListener('mouseover', handleMouseOver, true);
+      doc.removeEventListener('mouseout', handleMouseOut, true);
+      doc.removeEventListener('click', handleClick, true);
+      doc.removeEventListener('keydown', handleKeyDown, true);
+      document.removeEventListener('keydown', handleKeyDown, true);
+    };
+  }, [
+    isInspecting,
+    getReplayIframe,
+    cleanupHighlight,
+    handleElementSelected,
+    stopInspecting,
+  ]);
+
+  const handleToggleInspect = useCallback(() => {
+    if (isInspecting) {
+      stopInspecting();
+      return;
+    }
+
+    const iframe = getReplayIframe();
+    if (!iframe?.contentDocument) {
+      return;
+    }
+
+    // Pause playback while inspecting
+    if (isPlaying) {
+      wasPlayingRef.current = true;
+      togglePlayPause(false);
+    }
+
+    setIsInspecting(true);
+  }, [isInspecting, isPlaying, getReplayIframe, stopInspecting, togglePlayPause]);
+
+  return (
+    <Tooltip
+      title={
+        isInspecting
+          ? t('Click an element in the replay, or press Escape to cancel')
+          : t('Inspect element and ask Seer')
+      }
+    >
+      <Button
+        size="xs"
+        icon={<IconCursorArrow />}
+        aria-label={t('Inspect DOM element')}
+        onClick={handleToggleInspect}
+        priority={isInspecting ? 'primary' : 'default'}
+      />
+    </Tooltip>
+  );
+}
+
+function buildSeerPrompt(userQuery: string, html: string): string {
+  // Truncate HTML if extremely long to keep prompt reasonable
+  const truncatedHtml =
+    html.length > 5000 ? html.slice(0, 5000) + '\n... (truncated)' : html;
+
+  return `${userQuery}
+
+The user selected the following DOM element from a Session Replay recording. Use this HTML context to focus your investigation:
+
+\`\`\`html
+${truncatedHtml}
+\`\`\`
+
+Please use this HTML as context to help investigate the user's query. The HTML represents a specific element the user identified in their session replay as relevant to their question.`;
+}

--- a/static/app/components/replays/replayInspectQueryModal.tsx
+++ b/static/app/components/replays/replayInspectQueryModal.tsx
@@ -1,0 +1,91 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Input} from '@sentry/scraps/input';
+import {TextArea} from '@sentry/scraps/textarea';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+
+interface Props extends ModalRenderProps {
+  onSubmit: (query: string) => void;
+  selectedHtml: string;
+}
+
+export default function ReplayInspectQueryModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  onSubmit,
+  selectedHtml,
+}: Props) {
+  const [query, setQuery] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) {
+      onSubmit(query.trim());
+    }
+  };
+
+  // Show a truncated preview of the selected HTML
+  const htmlPreview =
+    selectedHtml.length > 200 ? selectedHtml.slice(0, 200) + '...' : selectedHtml;
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('Ask Seer About This Element')}</h4>
+      </Header>
+      <form onSubmit={handleSubmit}>
+        <Body>
+          <FieldGroup>
+            <Label>{t('Selected Element')}</Label>
+            <StyledTextarea value={htmlPreview} readOnly rows={4} />
+          </FieldGroup>
+          <FieldGroup>
+            <Label>{t('What would you like to know?')}</Label>
+            <Input
+              type="text"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder={t(
+                'e.g. Why is this button not working? What errors relate to this component?'
+              )}
+              autoFocus
+            />
+          </FieldGroup>
+        </Body>
+        <Footer>
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button type="submit" priority="primary" disabled={!query.trim()}>
+            {t('Ask Seer')}
+          </Button>
+        </Footer>
+      </form>
+    </Fragment>
+  );
+}
+
+const FieldGroup = styled('div')`
+  margin-bottom: ${space(2)};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+const Label = styled('label')`
+  display: block;
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  margin-bottom: ${space(1)};
+`;
+
+const StyledTextarea = styled(TextArea)`
+  font-family: ${p => p.theme.font.family.mono};
+  font-size: ${p => p.theme.font.size.sm};
+  resize: none;
+`;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -17,6 +17,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentScreen from 'sentry/components/replays/replayCurrentScreen';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
+import ReplayDOMInspectButton from 'sentry/components/replays/replayDOMInspectButton';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import ReplayProcessingError from 'sentry/components/replays/replayProcessingError';
 import {ReplaySidebarToggleButton} from 'sentry/components/replays/replaySidebarToggleButton';
@@ -25,11 +26,13 @@ import {IconFatal} from 'sentry/icons/iconFatal';
 import {tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import useOrganization from 'sentry/utils/useOrganization';
 import useIsFullscreen from 'sentry/utils/window/useIsFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import BrowserOSIcons from 'sentry/views/replays/detail/browserOSIcons';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import ReplayViewScale from 'sentry/views/replays/detail/replayViewScale';
+import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 type Props = {
   isLoading: boolean;
@@ -49,7 +52,9 @@ export default function ReplayView({toggleFullscreen, isLoading}: Props) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const replay = useReplayReader();
   const {isFetching} = useReplayContext();
+  const organization = useOrganization();
   const isVideoReplay = replay?.isVideoReplay();
+  const showInspectButton = !isVideoReplay && isSeerExplorerEnabled(organization);
   const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({
     replays: replay ? [replay.getReplay()] : [],
   });
@@ -86,7 +91,7 @@ export default function ReplayView({toggleFullscreen, isLoading}: Props) {
             ) : (
               <ReplayCurrentUrl />
             )}
-
+            {showInspectButton ? <ReplayDOMInspectButton /> : null}
             <ErrorBoundary customComponent={FatalIconTooltip}>
               <BrowserOSIcons showBrowser={!isVideoReplay} isLoading={isLoading} />
             </ErrorBoundary>


### PR DESCRIPTION
… Explorer

Add a feature-flagged (seer-explorer) "Inspect element" button to the replay URL bar that lets users select DOM elements inside the replay iframe and send them to Seer Explorer with a user-provided query.

Flow: click inspect button -> replay pauses, hover highlights elements ->
click element to select -> modal asks what to investigate -> submits to Seer Explorer with the HTML context and user query.

New files:
- replayDOMInspectButton.tsx: toggle button, iframe event listeners, highlight logic, and Seer prompt builder
- replayInspectQueryModal.tsx: modal for entering the investigation query

Modified:
- replayContext.tsx: expose getReplayIframe() from the replay context
- replayView.tsx: render the inspect button when seer-explorer is enabled

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
