### PR TITLE
docs: Add feature flag and PR splitting guidance to AGENTS.md

### DIFF
--- a/.claude/commands/gh-pr.md
+++ b/.claude/commands/gh-pr.md
@@ -12,3 +12,5 @@ If we already have one:
 - Verify our changes against the base branch and update the PR title and description to maintain accuracy.
 
 We should never focus on a test plan in the PR, but rather a concise description of the changes (features, breaking changes, major bug fixes, and architectural changes). Only include changes if they're present. We're always contrasting against our base branch when we describe these changes.
+
+Before creating the PR, check whether the diff mixes frontend (`static/`) and backend (`src/`, `tests/`) changes. If it does, split into two PRs — backend first if the frontend depends on new API changes. A CI check will reject mixed PRs.


### PR DESCRIPTION
## Summary
- Add **Feature Flags (FlagPole)** section to `AGENTS.md` covering registration, Python/frontend checks, testing, and rollout
- Add **Pull Requests** section documenting the frontend/backend PR splitting rule enforced by CI
- Add pre-flight frontend/backend split check to `.claude/commands/gh-pr.md`