### PR TITLE
feat(explore): Add analytics tracking to FloatingTrigger actions

### DIFF
--- a/static/app/utils/analytics/exploreAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/exploreAnalyticsEvents.tsx
@@ -2,6 +2,15 @@ import type {Organization} from 'sentry/types/organization';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 
 export type ExploreAnalyticsEventParameters = {
+  'explore.floating_trigger.clear_selection': {
+    organization: Organization;
+  };
+  'explore.floating_trigger.compare_attribute_breakdowns': {
+    organization: Organization;
+  };
+  'explore.floating_trigger.zoom_in': {
+    organization: Organization;
+  };
   'explore.table_exported': {
     export_type: 'browser_csv' | 'download';
     field: string[];
@@ -19,5 +28,9 @@ export type ExploreAnalyticsEventParameters = {
 type ExploreAnalyticsEventKey = keyof ExploreAnalyticsEventParameters;
 
 export const exploreAnalyticsEventMap: Record<ExploreAnalyticsEventKey, string | null> = {
+  'explore.floating_trigger.clear_selection': 'Explore: Floating Trigger Clear Selection',
+  'explore.floating_trigger.compare_attribute_breakdowns':
+    'Explore: Floating Trigger Compare Attribute Breakdowns',
+  'explore.floating_trigger.zoom_in': 'Explore: Floating Trigger Zoom In',
   'explore.table_exported': 'Explore: Table Exported',
 };

--- a/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/floatingTrigger.tsx
@@ -5,7 +5,9 @@ import type {SelectionCallbackParams} from 'sentry/components/charts/useChartXRa
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
+import useOrganization from 'sentry/utils/useOrganization';
 import useRouter from 'sentry/utils/useRouter';
 import {Tab} from 'sentry/views/explore/hooks/useTab';
 import type {Mode} from 'sentry/views/explore/queryParams/mode';
@@ -20,11 +22,14 @@ type Props = {
 
 export function FloatingTrigger({chartIndex, params, setTab}: Props) {
   const router = useRouter();
+  const organization = useOrganization();
   const {setChartSelection} = useChartSelection();
   const {selectionState, setSelectionState, clearSelection} = params;
 
   const handleZoomIn = useCallback(() => {
     if (!selectionState) return;
+
+    trackAnalytics('explore.floating_trigger.zoom_in', {organization});
 
     const coordRange = selectionState.selection.range;
     let startTimestamp = coordRange[0];
@@ -51,10 +56,14 @@ export function FloatingTrigger({chartIndex, params, setTab}: Props) {
     );
 
     clearSelection();
-  }, [clearSelection, selectionState, router]);
+  }, [clearSelection, selectionState, router, organization]);
 
   const handleFindAttributeBreakdowns = useCallback(() => {
     if (!selectionState) return;
+
+    trackAnalytics('explore.floating_trigger.compare_attribute_breakdowns', {
+      organization,
+    });
 
     setSelectionState({
       ...selectionState,
@@ -65,7 +74,14 @@ export function FloatingTrigger({chartIndex, params, setTab}: Props) {
       chartIndex,
     });
     setTab(Tab.ATTRIBUTE_BREAKDOWNS);
-  }, [selectionState, setSelectionState, chartIndex, setChartSelection, setTab]);
+  }, [
+    selectionState,
+    setSelectionState,
+    chartIndex,
+    setChartSelection,
+    setTab,
+    organization,
+  ]);
 
   return (
     <List>
@@ -73,7 +89,14 @@ export function FloatingTrigger({chartIndex, params, setTab}: Props) {
       <ListItem onClick={handleFindAttributeBreakdowns}>
         {t('Compare Attribute Breakdowns')}
       </ListItem>
-      <ListItem onClick={() => clearSelection()}>{t('Clear Selection')}</ListItem>
+      <ListItem
+        onClick={() => {
+          trackAnalytics('explore.floating_trigger.clear_selection', {organization});
+          clearSelection();
+        }}
+      >
+        {t('Clear Selection')}
+      </ListItem>
     </List>
   );
 }


### PR DESCRIPTION
Add Amplitude tracking to the three FloatingTrigger menu actions in the Explore
spans chart view: "Zoom in", "Compare Attribute Breakdowns", and "Clear Selection".

This gives us visibility into how users interact with the chart selection menu,
which helps inform whether these features are being discovered and used.