### PR TITLE
fix(forms): hash-based scroll + focus

### DIFF
--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -1,11 +1,9 @@
-import {useEffect, useRef, type Ref} from 'react';
+import {useEffect, useRef, useSyncExternalStore, type Ref} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
 import {Checkmark, Spinner, Warning} from '@sentry/scraps/form/icons';
 import {Tooltip} from '@sentry/scraps/tooltip';
-
-import {useLocation} from 'sentry/utils/useLocation';
 
 export type BaseFieldProps = Record<never, unknown>;
 
@@ -55,6 +53,24 @@ export const useHintTextId = () => {
   return `${fieldId}-hint`;
 };
 
+// Subscribe only to hash changes, not full location
+function useHash() {
+  return useSyncExternalStore(
+    callback => {
+      window.addEventListener('hashchange', callback);
+      return () => window.removeEventListener('hashchange', callback);
+    },
+    () => {
+      try {
+        return decodeURIComponent(window.location.hash.slice(1));
+      } catch {
+        return '';
+      }
+    },
+    () => ''
+  );
+}
+
 export function BaseField(
   props: BaseFieldProps & {
     children: (props: FieldChildrenProps) => React.ReactNode;
@@ -64,22 +80,16 @@ export function BaseField(
   const ref = useRef<HTMLElement>(null);
   const fieldId = useFieldId();
   const hintTextId = useHintTextId();
-  const location = useLocation();
+  const hash = useHash();
 
   useEffect(() => {
-    let hash = '';
-    try {
-      hash = decodeURIComponent(location.hash.slice(1));
-    } catch {
-      return;
-    }
     if (hash !== field.name) {
       return;
     }
     ref.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
     ref.current?.focus({focusVisible: true});
     animateRowHighlight(ref.current);
-  }, [location.hash, field.name]);
+  }, [hash, field.name]);
 
   return props.children({
     ref,

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -1,7 +1,11 @@
+import {useEffect, useRef, type Ref} from 'react';
+
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
 import {Checkmark, Spinner, Warning} from '@sentry/scraps/form/icons';
 import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {useLocation} from 'sentry/utils/useLocation';
 
 export type BaseFieldProps = Record<never, unknown>;
 
@@ -11,6 +15,7 @@ type FieldChildrenProps = {
   id: string;
   name: string;
   onBlur: () => void;
+  ref: Ref<HTMLElement>;
 };
 
 export const useFieldStateIndicator = () => {
@@ -56,14 +61,46 @@ export function BaseField(
   }
 ) {
   const field = useFieldContext();
+  const ref = useRef<HTMLElement>(null);
   const fieldId = useFieldId();
   const hintTextId = useHintTextId();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash.slice(1) !== field.name) {
+      return;
+    }
+    ref.current?.scrollIntoView({block: 'nearest', behavior: 'smooth'});
+    ref.current?.focus({focusVisible: true});
+    animateRowHighlight(ref.current);
+  }, [location.hash, field.name]);
 
   return props.children({
+    ref,
     'aria-invalid': !field.state.meta.isValid,
     'aria-describedby': hintTextId,
     onBlur: field.handleBlur,
     name: field.name,
     id: fieldId,
   });
+}
+
+declare global {
+  interface FocusOptions {
+    /** https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible */
+    focusVisible?: boolean;
+  }
+}
+
+function animateRowHighlight(node: HTMLElement | null) {
+  if (!node) return;
+  const name = node.getAttribute('name');
+  if (!name) return;
+  const fieldRow = node.closest<HTMLElement>(`#${CSS.escape(name)}`);
+  if (fieldRow) {
+    fieldRow.dataset.highlight = '';
+    fieldRow.addEventListener('animationend', () => delete fieldRow.dataset.highlight, {
+      once: true,
+    });
+  }
 }

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useSyncExternalStore, type Ref} from 'react';
+import {useEffect, useRef, type Ref} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
@@ -53,22 +53,26 @@ export const useHintTextId = () => {
   return `${fieldId}-hint`;
 };
 
-function useHash() {
-  const onHashChange = useCallback((callback: () => void) => {
-    window.addEventListener('hashchange', callback);
-    return () => window.removeEventListener('hashchange', callback);
-  }, []);
-  return useSyncExternalStore(
-    onHashChange,
-    () => {
+function useScrollToHash(fieldName: string, ref: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    function handleHashChange() {
       try {
-        return decodeURIComponent(window.location.hash.slice(1));
+        const hash = decodeURIComponent(window.location.hash.slice(1));
+        if (hash !== fieldName) {
+          return;
+        }
       } catch {
-        return '';
+        return;
       }
-    },
-    () => ''
-  );
+      ref.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
+      ref.current?.focus({focusVisible: true});
+      animateRowHighlight(ref.current);
+    }
+    // Check on mount (page loaded with hash already in URL)
+    handleHashChange();
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, [fieldName, ref]);
 }
 
 export function BaseField(
@@ -80,16 +84,7 @@ export function BaseField(
   const ref = useRef<HTMLElement>(null);
   const fieldId = useFieldId();
   const hintTextId = useHintTextId();
-  const hash = useHash();
-
-  useEffect(() => {
-    if (hash !== field.name) {
-      return;
-    }
-    ref.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
-    ref.current?.focus({focusVisible: true});
-    animateRowHighlight(ref.current);
-  }, [hash, field.name]);
+  useScrollToHash(field.name, ref);
 
   return props.children({
     ref,

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -91,13 +91,6 @@ export function BaseField(
   });
 }
 
-declare global {
-  interface FocusOptions {
-    /** https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible */
-    focusVisible?: boolean;
-  }
-}
-
 function animateRowHighlight(node: HTMLElement | null) {
   if (!node) return;
   const name = node.getAttribute('name');

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -76,7 +76,7 @@ export function BaseField(
     if (hash !== field.name) {
       return;
     }
-    ref.current?.scrollIntoView({block: 'nearest', behavior: 'smooth'});
+    ref.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
     ref.current?.focus({focusVisible: true});
     animateRowHighlight(ref.current);
   }, [location.hash, field.name]);

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useSyncExternalStore, type Ref} from 'react';
+import {useCallback, useEffect, useRef, useSyncExternalStore, type Ref} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
@@ -53,13 +53,13 @@ export const useHintTextId = () => {
   return `${fieldId}-hint`;
 };
 
-// Subscribe only to hash changes, not full location
 function useHash() {
+  const onHashChange = useCallback((callback: () => void) => {
+    window.addEventListener('hashchange', callback);
+    return () => window.removeEventListener('hashchange', callback);
+  }, []);
   return useSyncExternalStore(
-    callback => {
-      window.addEventListener('hashchange', callback);
-      return () => window.removeEventListener('hashchange', callback);
-    },
+    onHashChange,
     () => {
       try {
         return decodeURIComponent(window.location.hash.slice(1));

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -67,7 +67,13 @@ export function BaseField(
   const location = useLocation();
 
   useEffect(() => {
-    if (location.hash.slice(1) !== field.name) {
+    let hash = '';
+    try {
+      hash = decodeURIComponent(location.hash.slice(1));
+    } catch {
+      return;
+    }
+    if (hash !== field.name) {
       return;
     }
     ref.current?.scrollIntoView({block: 'nearest', behavior: 'smooth'});

--- a/static/app/components/core/form/field/inputField.tsx
+++ b/static/app/components/core/form/field/inputField.tsx
@@ -1,3 +1,6 @@
+import type {Ref} from 'react';
+import {mergeRefs} from '@react-aria/utils';
+
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {type InputProps} from '@sentry/scraps/input';
 import {InputGroup} from '@sentry/scraps/input/inputGroup';
@@ -28,6 +31,7 @@ export function InputField(props: InputFieldProps) {
             <InputGroup.Input
               {...fieldProps}
               {...rest}
+              ref={mergeRefs(fieldProps.ref as Ref<HTMLInputElement>, rest.ref)}
               aria-disabled={isDisabled}
               readOnly={isDisabled}
               onChange={e => onChange(e.target.value)}

--- a/static/app/components/core/form/field/meta.tsx
+++ b/static/app/components/core/form/field/meta.tsx
@@ -1,7 +1,6 @@
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 import {useFieldId, useHintTextId} from '@sentry/scraps/form/field/baseField';
-import {useFieldContext} from '@sentry/scraps/form/formContext';
 import {RequiredIndicator} from '@sentry/scraps/form/icons';
 import {InfoText} from '@sentry/scraps/info';
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -21,37 +20,11 @@ function HintText(props: {children: React.ReactNode}) {
   );
 }
 
-declare global {
-  interface FocusOptions {
-    /** https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible */
-    focusVisible?: boolean;
-  }
-}
-
-const scrollToFieldRef = (node: HTMLLabelElement | null) => {
-  if (!node) {
-    return;
-  }
-  let hash: string;
-  try {
-    hash = decodeURIComponent(window.location.hash.slice(1));
-  } catch {
-    return;
-  }
-  if (hash === node.dataset.field) {
-    requestAnimationFrame(() => {
-      node.scrollIntoView({block: 'center', behavior: 'smooth'});
-      node.control?.focus({focusVisible: true});
-    });
-  }
-};
-
 function Label(props: {
   children: React.ReactNode;
   description?: React.ReactNode;
   required?: boolean;
 }) {
-  const {name: fieldName} = useFieldContext();
   const fieldId = useFieldId();
   const hintTextId = useHintTextId();
 
@@ -65,14 +38,7 @@ function Label(props: {
     <Container width="fit-content">
       {containerProps => (
         <Flex gap="xs">
-          <Text
-            {...containerProps}
-            as="label"
-            data-field={fieldName}
-            htmlFor={fieldId}
-            bold={false}
-            ref={scrollToFieldRef}
-          >
+          <Text {...containerProps} as="label" htmlFor={fieldId} bold={false}>
             {labelContent}
           </Text>
           {props.required ? <RequiredIndicator /> : null}

--- a/static/app/components/core/form/field/rangeField.tsx
+++ b/static/app/components/core/form/field/rangeField.tsx
@@ -1,3 +1,5 @@
+import type {Ref} from 'react';
+import {mergeRefs} from '@react-aria/utils';
 import type {DistributedOmit} from 'type-fest';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
@@ -31,6 +33,7 @@ export function RangeField({
             <Slider
               {...fieldProps}
               {...props}
+              ref={mergeRefs(fieldProps.ref as Ref<HTMLInputElement>, props.ref)}
               disabled={isDisabled}
               value={value}
               onChange={onChange}

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useRef, type ComponentProps, type Ref} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Flex} from '@sentry/scraps/layout';
@@ -14,6 +14,7 @@ function SelectInput({
   selectProps,
   ...props
 }: React.ComponentProps<typeof components.Input> & {
+  ref: Ref<{input: HTMLInputElement}>;
   selectProps: {'aria-invalid': boolean};
 }) {
   return <components.Input {...props} aria-invalid={selectProps['aria-invalid']} />;
@@ -72,6 +73,21 @@ export type SelectFieldProps<TValue = string> =
   | SingleClearableSelectFieldProps<TValue>
   | MultipleSelectFieldProps<TValue>;
 
+// HACK: react-select types are bad, ref is a custom StateManager
+// This converts the `ref` value of SelectInput into a format
+// that works for BaseField, which expects `fieldProps.ref: Ref<HTMLElement>`
+const applyInputToRef =
+  (ref: Ref<HTMLElement>) =>
+  (instance: null | {input: HTMLInputElement}): void => {
+    if (instance) {
+      if (typeof ref === 'function') {
+        ref(instance.input);
+      } else if (ref) {
+        ref.current = instance.input;
+      }
+    }
+  };
+
 export function SelectField<TValue = string>({
   onChange,
   disabled,
@@ -93,14 +109,15 @@ export function SelectField<TValue = string>({
           <Select
             {...fieldProps}
             {...props}
-            innerRef={ref}
             inputId={id}
             disabled={isDisabled}
             multiple={multiple}
             value={value}
             components={{
               ...props.components,
-              Input: SelectInput,
+              Input: (p: ComponentProps<typeof SelectInput>) => (
+                <SelectInput {...p} ref={applyInputToRef(ref)} />
+              ),
               IndicatorsContainer: SelectIndicatorsContainer,
             }}
             onMenuOpen={() => {

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -1,4 +1,4 @@
-import {useRef, type ComponentProps, type Ref} from 'react';
+import {useRef, type Ref} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Flex} from '@sentry/scraps/layout';
@@ -14,10 +14,15 @@ function SelectInput({
   selectProps,
   ...props
 }: React.ComponentProps<typeof components.Input> & {
-  ref: Ref<{input: HTMLInputElement}>;
-  selectProps: {'aria-invalid': boolean};
+  selectProps: {'aria-invalid': boolean; inputRef: Ref<{input: HTMLInputElement}>};
 }) {
-  return <components.Input {...props} aria-invalid={selectProps['aria-invalid']} />;
+  return (
+    <components.Input
+      {...props}
+      {...{ref: selectProps.inputRef}}
+      aria-invalid={selectProps['aria-invalid']}
+    />
+  );
 }
 
 function SelectIndicatorsContainer({
@@ -113,11 +118,10 @@ export function SelectField<TValue = string>({
             disabled={isDisabled}
             multiple={multiple}
             value={value}
+            inputRef={applyInputToRef(ref)}
             components={{
               ...props.components,
-              Input: (p: ComponentProps<typeof SelectInput>) => (
-                <SelectInput {...p} ref={applyInputToRef(ref)} />
-              ),
+              Input: SelectInput,
               IndicatorsContainer: SelectIndicatorsContainer,
             }}
             onMenuOpen={() => {

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -88,11 +88,12 @@ export function SelectField<TValue = string>({
 
   return (
     <BaseField>
-      {({id, ...fieldProps}) => {
+      {({id, ref, ...fieldProps}) => {
         const select = (
           <Select
             {...fieldProps}
             {...props}
+            innerRef={ref}
             inputId={id}
             disabled={isDisabled}
             multiple={multiple}

--- a/static/app/components/core/form/field/switchField.tsx
+++ b/static/app/components/core/form/field/switchField.tsx
@@ -1,3 +1,6 @@
+import type {Ref} from 'react';
+import {mergeRefs} from '@react-aria/utils';
+
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Flex} from '@sentry/scraps/layout';
 import {Switch, type SwitchProps} from '@sentry/scraps/switch';
@@ -29,6 +32,7 @@ export function SwitchField({
               size="lg"
               {...fieldProps}
               {...props}
+              ref={mergeRefs(fieldProps.ref as Ref<HTMLInputElement>, props.ref)}
               disabled={isDisabled}
               onChange={e => {
                 onChange(e.target.checked);

--- a/static/app/components/core/form/field/textAreaField.tsx
+++ b/static/app/components/core/form/field/textAreaField.tsx
@@ -1,3 +1,6 @@
+import type {Ref} from 'react';
+import {mergeRefs} from '@react-aria/utils';
+
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {InputGroup} from '@sentry/scraps/input/inputGroup';
 import {type TextAreaProps} from '@sentry/scraps/textarea';
@@ -28,6 +31,7 @@ export function TextAreaField({
             <InputGroup.TextArea
               {...fieldProps}
               {...props}
+              ref={mergeRefs(fieldProps.ref as Ref<HTMLTextAreaElement>, props.ref)}
               aria-disabled={isDisabled}
               readOnly={isDisabled}
               onChange={e => onChange(e.target.value)}

--- a/static/app/components/core/form/layout/index.tsx
+++ b/static/app/components/core/form/layout/index.tsx
@@ -1,3 +1,6 @@
+import {keyframes} from '@emotion/react';
+import styled from '@emotion/styled';
+
 import {FieldMeta} from '@sentry/scraps/form/field/meta';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
 import {
@@ -25,8 +28,9 @@ function RowLayout(props: RowLayoutProps) {
   const field = useFieldContext();
 
   return (
-    <Flex
+    <HighlightableFlex
       id={field.name}
+      direction="row"
       gap="sm"
       align="center"
       justify="between"
@@ -47,7 +51,7 @@ function RowLayout(props: RowLayoutProps) {
       </Stack>
 
       <Container flexGrow={1}>{props.children}</Container>
-    </Flex>
+    </HighlightableFlex>
   );
 }
 
@@ -60,7 +64,7 @@ function StackLayout(props: StackLayoutProps) {
   const field = useFieldContext();
 
   return (
-    <Stack id={field.name} gap="md" padding={props.padding}>
+    <HighlightableFlex id={field.name} direction="column" gap="md" padding={props.padding}>
       <Flex gap="xs" align="center">
         <FieldMeta.Label
           required={props.required}
@@ -73,7 +77,7 @@ function StackLayout(props: StackLayoutProps) {
       {props.hintText && !isCompact ? (
         <FieldMeta.HintText>{props.hintText}</FieldMeta.HintText>
       ) : null}
-    </Stack>
+    </HighlightableFlex>
   );
 }
 
@@ -83,3 +87,22 @@ export function FieldLayout() {
 
 FieldLayout.Row = RowLayout;
 FieldLayout.Stack = StackLayout;
+
+const highlightFade = keyframes`
+  0% {
+    background-color: var(--highlight-color);
+  }
+  100% {
+    background-color: transparent;
+  }
+`;
+
+const HighlightableFlex = styled(Flex)`
+  --highlight-color: ${p => p.theme.tokens.background.transparent.accent.muted};
+  margin: calc(${p => p.theme.space.xl} * -1);
+  padding: ${p => p.theme.space.xl};
+
+  &[data-highlight] {
+    animation: ${highlightFade} ${p => p.theme.motion.smooth.slow};
+  }
+`;

--- a/static/app/components/core/form/layout/index.tsx
+++ b/static/app/components/core/form/layout/index.tsx
@@ -64,7 +64,12 @@ function StackLayout(props: StackLayoutProps) {
   const field = useFieldContext();
 
   return (
-    <HighlightableFlex id={field.name} direction="column" gap="md" padding={props.padding}>
+    <HighlightableFlex
+      id={field.name}
+      direction="column"
+      gap="md"
+      padding={props.padding}
+    >
       <Flex gap="xs" align="center">
         <FieldMeta.Label
           required={props.required}

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -126,6 +126,12 @@ declare global {
      */
     superUserCookieName?: string;
   }
+  interface FocusOptions {
+    /**
+     * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#focusvisible
+     */
+    focusVisible?: boolean;
+  }
 }
 
 export interface Region {


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/108414, https://github.com/getsentry/sentry/pull/108376

Implements hash-based scroll and focus with a highlight animation for new Scraps forms

Adds refs to all base form fields.

https://github.com/user-attachments/assets/ac4c5dbd-72c5-4616-b46f-624f584e2872

Closes DE-954