### PR TITLE
fix: Remove unused type exports

### DIFF
--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -43,7 +43,7 @@ type TypedTraceItemAttributesResult = TypedTraceItemAttributes &
 
 type TraceItemAttributeType = 'number' | 'string' | 'boolean';
 
-export type TraceItemAttributeResult = {
+type TraceItemAttributeResult = {
   attributes: TagCollection;
   isLoading: boolean;
   secondaryAliases: TagCollection;
@@ -53,7 +53,7 @@ const TraceItemAttributeContext = createContext<
   TypedTraceItemAttributesResult | undefined
 >(undefined);
 
-export type TraceItemAttributeConfig = {
+type TraceItemAttributeConfig = {
   enabled: boolean;
   traceItemType: TraceItemDataset;
   projects?: Project[];


### PR DESCRIPTION
Introduced in https://github.com/getsentry/sentry/pull/108019/ where Knip mysteriously passed, but `master` is complaining. 
