### PR TITLE
feat(dashboards): text widget in widget builder

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/descriptionField.tsx
@@ -1,0 +1,64 @@
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
+import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+interface WidgetBuilderDescriptionFieldProps {
+  autosize?: boolean;
+  placeholder?: string;
+  rows?: number;
+}
+
+function WidgetBuilderDescriptionField({
+  rows = 4,
+  placeholder = t('Description'),
+  autosize = true,
+}: WidgetBuilderDescriptionFieldProps) {
+  const organization = useOrganization();
+  const {state, dispatch} = useWidgetBuilderContext();
+  const isEditing = useIsEditingWidget();
+  const source = useDashboardWidgetSource();
+
+  return (
+    <TextArea
+      autoComplete="off"
+      placeholder={placeholder}
+      aria-label={placeholder}
+      autosize={autosize}
+      rows={rows}
+      value={state.description}
+      onChange={e => {
+        dispatch(
+          {type: BuilderStateAction.SET_DESCRIPTION, payload: e.target.value},
+          {updateUrl: false}
+        );
+      }}
+      onBlur={e => {
+        dispatch(
+          {
+            type: BuilderStateAction.SET_DESCRIPTION,
+            payload: e.target.value,
+          },
+          {updateUrl: true}
+        );
+        trackAnalytics('dashboards_views.widget_builder.change', {
+          from: source,
+          widget_type: state.dataset ?? '',
+          builder_version: WidgetBuilderVersion.SLIDEOUT,
+          field: 'description',
+          value: '',
+          new_widget: !isEditing,
+          organization,
+        });
+      }}
+    />
+  );
+}
+
+export default WidgetBuilderDescriptionField;

--- a/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/nameAndDescFields.tsx
@@ -2,7 +2,6 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {TextArea} from '@sentry/scraps/textarea';
 
 import TextField from 'sentry/components/forms/fields/textField';
 import {t} from 'sentry/locale';
@@ -10,7 +9,9 @@ import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import useOrganization from 'sentry/utils/useOrganization';
+import {DisplayType} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
+import WidgetBuilderDescriptionField from 'sentry/views/dashboards/widgetBuilder/components/descriptionField';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import useDashboardWidgetSource from 'sentry/views/dashboards/widgetBuilder/hooks/useDashboardWidgetSource';
 import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useIsEditingWidget';
@@ -30,6 +31,7 @@ function WidgetBuilderNameAndDescription({
   const [isDescSelected, setIsDescSelected] = useState(state.description ? true : false);
   const isEditing = useIsEditingWidget();
   const source = useDashboardWidgetSource();
+  const isTextWidget = state.displayType === DisplayType.TEXT;
 
   return (
     <Fragment>
@@ -74,7 +76,7 @@ function WidgetBuilderNameAndDescription({
         error={error?.title}
         inline={false}
       />
-      {!isDescSelected && (
+      {!isTextWidget && !isDescSelected && (
         <Button
           priority="link"
           aria-label={t('Add Description')}
@@ -86,40 +88,7 @@ function WidgetBuilderNameAndDescription({
           {t('+ Add Description')}
         </Button>
       )}
-      {isDescSelected && (
-        <TextArea
-          autoComplete="off"
-          placeholder={t('Description')}
-          aria-label={t('Description')}
-          autosize
-          rows={4}
-          value={state.description}
-          onChange={e => {
-            dispatch(
-              {type: BuilderStateAction.SET_DESCRIPTION, payload: e.target.value},
-              {updateUrl: false}
-            );
-          }}
-          onBlur={e => {
-            dispatch(
-              {
-                type: BuilderStateAction.SET_DESCRIPTION,
-                payload: e.target.value,
-              },
-              {updateUrl: true}
-            );
-            trackAnalytics('dashboards_views.widget_builder.change', {
-              from: source,
-              widget_type: state.dataset ?? '',
-              builder_version: WidgetBuilderVersion.SLIDEOUT,
-              field: 'description',
-              value: '',
-              new_widget: !isEditing,
-              organization,
-            });
-          }}
-        />
-      )}
+      {!isTextWidget && isDescSelected && <WidgetBuilderDescriptionField rows={4} />}
     </Fragment>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -6,7 +6,7 @@ import {Select} from '@sentry/scraps/select';
 
 import {components} from 'sentry/components/forms/controls/reactSelectWrapper';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
-import {IconGraph, IconNumber, IconSettings, IconTable} from 'sentry/icons';
+import {IconCase, IconGraph, IconNumber, IconSettings, IconTable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
@@ -29,6 +29,7 @@ const typeIcons: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.BIG_NUMBER]: <IconNumber key="number" />,
   [DisplayType.DETAILS]: <IconSettings key="details" />,
   [DisplayType.CATEGORICAL_BAR]: <IconGraph key="categorical_bar" type="bar" />,
+  [DisplayType.TEXT]: <IconCase key="text" />,
 };
 
 interface WidgetBuilderTypeSelectorProps {
@@ -59,6 +60,7 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
   const hasCategoricalBar = organization.features.includes(
     'dashboards-categorical-bar-charts'
   );
+  const hasTextWidget = organization.features.includes('dashboards-text-widgets');
 
   // Use an array to define display type order explicitly.
   // Object key ordering in JS is technically specified but easy to break accidentally.
@@ -71,6 +73,7 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
     {type: DisplayType.LINE, label: t('Line')},
     {type: DisplayType.TABLE, label: t('Table')},
     {type: DisplayType.BIG_NUMBER, label: t('Big Number')},
+    ...(hasTextWidget ? [{type: DisplayType.TEXT, label: t('Text (Markdown)')}] : []),
     ...(hasDetailsWidget ? [{type: DisplayType.DETAILS, label: t('Details')}] : []),
   ];
 
@@ -124,7 +127,8 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
             label,
             value: type,
             disabled:
-              !config.supportedDisplayTypes.includes(type) ||
+              (type !== DisplayType.TEXT &&
+                !config.supportedDisplayTypes.includes(type)) ||
               shouldDisabledIssueDisplayType(type),
           }))}
           clearable={false}
@@ -149,6 +153,13 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
                 dispatch({
                   type: BuilderStateAction.SET_QUERY,
                   payload: [state.query[0]!],
+                });
+              }
+              // Clear queries when switching to text widget
+              if (newValue.value === DisplayType.TEXT) {
+                dispatch({
+                  type: BuilderStateAction.SET_QUERY,
+                  payload: [],
                 });
               }
             }

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -39,6 +39,7 @@ import {
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
+import WidgetBuilderDescriptionField from 'sentry/views/dashboards/widgetBuilder/components/descriptionField';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
 import WidgetBuilderGroupBySelector from 'sentry/views/dashboards/widgetBuilder/components/groupBySelector';
 import WidgetBuilderNameAndDescription from 'sentry/views/dashboards/widgetBuilder/components/nameAndDescFields';
@@ -134,17 +135,20 @@ function WidgetBuilderSlideout({
       : t('Custom Widget Builder');
   const isTimeSeriesWidget = usesTimeSeriesData(state.displayType);
   const isCategoricalBarWidget = state.displayType === DisplayType.CATEGORICAL_BAR;
+  const isTextWidget = state.displayType === DisplayType.TEXT;
 
-  const showVisualizeSection = state.displayType !== DisplayType.DETAILS;
-  const showQueryFilterBuilder = !(
-    state.dataset === WidgetType.ISSUE && usesTimeSeriesData(state.displayType)
-  );
+  const showVisualizeSection = state.displayType !== DisplayType.DETAILS && !isTextWidget;
+  const showQueryFilterBuilder =
+    !isTextWidget &&
+    !(state.dataset === WidgetType.ISSUE && usesTimeSeriesData(state.displayType));
 
   // Group By is used by time-series chart widgets to break down data by a field.
   // - Time-series widgets: show Group By to allow breaking down by fields
   // - Issue widgets: don't support Group By (issues have their own grouping)
   // - Categorical Bar widgets: group by is not supported yet, but may be in the future
-  const showGroupBySelector = isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE);
+  // - Text widgets: don't support Group By (no data visualization)
+  const showGroupBySelector =
+    !isTextWidget && isTimeSeriesWidget && !(state.dataset === WidgetType.ISSUE);
 
   // X-Axis selector is only for Categorical Bar widgets, other chart widgets
   // always use time as the X-axis
@@ -156,10 +160,12 @@ function WidgetBuilderSlideout({
   // - Table: Always show to control row ordering
   // - Line, Area, Bar (Time Series): Show to control which top N groups are displayed
   // - Bar (Categorical): Show to control category ordering (like tables)
+  // - Text widgets: don't need Sort By (no data)
   const showSortByStep =
-    isCategoricalBarWidget ||
-    (isTimeSeriesWidget && state.fields && state.fields.length > 0) ||
-    state.displayType === DisplayType.TABLE;
+    !isTextWidget &&
+    (isCategoricalBarWidget ||
+      (isTimeSeriesWidget && state.fields && state.fields.length > 0) ||
+      state.displayType === DisplayType.TABLE);
 
   const observer = useMemo(
     () =>
@@ -381,13 +387,24 @@ function WidgetBuilderSlideout({
                       />
                     </Section>
                   </DisableTransactionWidget>
-                  <Section>
-                    <WidgetBuilderDatasetSelector />
-                  </Section>
+                  {!isTextWidget && (
+                    <Section>
+                      <WidgetBuilderDatasetSelector />
+                    </Section>
+                  )}
                   <DisableTransactionWidget>
                     <Section>
                       <WidgetBuilderTypeSelector error={error} setError={setError} />
                     </Section>
+                    {isTextWidget && (
+                      <Section>
+                        <WidgetBuilderDescriptionField
+                          rows={12}
+                          placeholder={t('Write your markdown here...')}
+                          autosize={false}
+                        />
+                      </Section>
+                    )}
                     <div ref={observeForDraggablePreview}>
                       {isSmallScreen && (
                         <Section>

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -6,11 +6,15 @@ import type {Column} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
-import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {
+  useWidgetBuilderContext,
+  WidgetBuilderProvider,
+} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import useWidgetBuilderState, {
   BuilderStateAction,
   serializeFields,
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {TEXT_WIDGET_CONTENT_SESSION_KEY} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 jest.mock('sentry/utils/useLocation');
@@ -2331,6 +2335,145 @@ describe('useWidgetBuilderState', () => {
         }),
         expect.anything()
       );
+    });
+  });
+
+  describe('text widget', () => {
+    afterEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('reads textContent from sessionStorage on initial render for text display type', () => {
+      sessionStorage.setItem(TEXT_WIDGET_CONTENT_SESSION_KEY, 'stored content');
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TEXT},
+        })
+      );
+
+      // Use the context hook to access the provider's state instance, which is the
+      // one that initializes from sessionStorage on mount.
+      const {result} = renderHook(() => useWidgetBuilderContext(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.description).toBe('stored content');
+    });
+
+    it('removes the sessionStorage key after reading it', () => {
+      sessionStorage.setItem(TEXT_WIDGET_CONTENT_SESSION_KEY, 'stored content');
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TEXT},
+        })
+      );
+
+      renderHook(() => useWidgetBuilderContext(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY)).toBeNull();
+    });
+
+    it('does not read sessionStorage for non-text display types', () => {
+      sessionStorage.setItem(TEXT_WIDGET_CONTENT_SESSION_KEY, 'stored content');
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TABLE},
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderContext(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.description).toBeFalsy();
+      // Key should remain in sessionStorage since it was not consumed
+      expect(sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY)).toBe(
+        'stored content'
+      );
+    });
+
+    it('SET_DESCRIPTION stores in local state and does not update the URL for text widgets', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TEXT},
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DESCRIPTION,
+          payload: 'new text content',
+        });
+      });
+
+      jest.runAllTimers();
+
+      expect(result.current.state.description).toBe('new text content');
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({description: expect.anything()}),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('SET_DESCRIPTION updates the URL for non-text widgets', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TABLE},
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DESCRIPTION,
+          payload: 'table description',
+        });
+      });
+
+      jest.runAllTimers();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.objectContaining({description: 'table description'}),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('clears textContent when switching away from text display type', () => {
+      sessionStorage.setItem(TEXT_WIDGET_CONTENT_SESSION_KEY, 'stored content');
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {displayType: DisplayType.TEXT},
+        })
+      );
+
+      // Use the context hook so we test the single authoritative state instance.
+      const {result} = renderHook(() => useWidgetBuilderContext(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.description).toBe('stored content');
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.TABLE,
+        });
+      });
+
+      expect(result.current.state.description).toBeFalsy();
     });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import partition from 'lodash/partition';
 
 import {defined} from 'sentry/utils';
@@ -34,6 +34,7 @@ import {
   DEFAULT_RESULTS_LIMIT,
   getResultsLimit,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
+import {TEXT_WIDGET_CONTENT_SESSION_KEY} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {generateMetricAggregate} from 'sentry/views/dashboards/widgetBuilder/utils/generateMetricAggregate';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
@@ -144,6 +145,7 @@ export interface WidgetBuilderState {
   query?: string[];
   selectedAggregate?: number;
   sort?: Sort[];
+  textContent?: string;
   thresholds?: ThresholdsConfig | null;
   title?: string;
   traceMetric?: TraceMetric;
@@ -228,10 +230,27 @@ function useWidgetBuilderState(): {
     serializer: serializeTraceMetric,
   });
 
+  // Text widget content is stored in local state (not in the URL) because it can be
+  // arbitrarily long. All other widget types use the URL-backed `description` above.
+  // When editing an existing text widget, convertWidgetToBuilderStateParams stores the
+  // content in sessionStorage before navigating here — we consume it on first render.
+  const [textContent, setTextContent] = useState<string | undefined>(() => {
+    if (displayType === DisplayType.TEXT) {
+      const stored = sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY);
+      if (stored !== null) {
+        sessionStorage.removeItem(TEXT_WIDGET_CONTENT_SESSION_KEY);
+        return stored;
+      }
+    }
+    return undefined;
+  });
+
   const state = useMemo(
     () => ({
       title,
-      description,
+      // For text widgets, description is stored in local state to avoid URL length limits.
+      // All other widget types use the URL-backed description.
+      description: displayType === DisplayType.TEXT ? textContent : description,
       displayType,
       dataset,
       fields,
@@ -265,6 +284,7 @@ function useWidgetBuilderState(): {
       thresholds,
       linkedDashboards,
       traceMetric,
+      textContent,
     ]
   );
 
@@ -276,10 +296,19 @@ function useWidgetBuilderState(): {
           setTitle(action.payload, options);
           break;
         case BuilderStateAction.SET_DESCRIPTION:
-          setDescription(action.payload, options);
+          // Text widgets use local state to avoid URL length limits
+          if (displayType === DisplayType.TEXT) {
+            setTextContent(action.payload);
+          } else {
+            setDescription(action.payload, options);
+          }
           break;
         case BuilderStateAction.SET_DISPLAY_TYPE: {
           setDisplayType(action.payload, options);
+          // When leaving the text widget type, clear local text content
+          if (displayType === DisplayType.TEXT && action.payload !== DisplayType.TEXT) {
+            setTextContent(undefined);
+          }
           const [aggregates, columns] = partition(fields, field => {
             const fieldString = generateFieldAsString(field);
             return isAggregateFieldOrEquation(fieldString);
@@ -410,7 +439,11 @@ function useWidgetBuilderState(): {
             // Categorical bars show more categories than time-series groupings
             setLimit(DEFAULT_CATEGORICAL_BAR_LIMIT, options);
           } else if (action.payload === DisplayType.TEXT) {
-            // Text widgets don't need any data fields, just title and description
+            // Text widgets don't need any data fields, just title and description.
+            // Move any existing URL description into local state and clear the URL param
+            // to prevent excessively long URLs when the user types content.
+            setTextContent(description ?? '');
+            setDescription(undefined, options);
             setFields([], options);
             setYAxis([], options);
             setQuery([''], options);
@@ -764,7 +797,14 @@ function useWidgetBuilderState(): {
           break;
         case BuilderStateAction.SET_STATE:
           setDataset(action.payload.dataset, options);
-          setDescription(action.payload.description, options);
+          // Text widget content lives in local state to avoid URL length limits
+          if (action.payload.displayType === DisplayType.TEXT) {
+            setTextContent(action.payload.description);
+            setDescription(undefined, options);
+          } else {
+            setDescription(action.payload.description, options);
+            setTextContent(undefined);
+          }
           setDisplayType(action.payload.displayType, options);
           if (action.payload.field) {
             setFields(deserializeFields(action.payload.field), options);
@@ -950,6 +990,8 @@ function useWidgetBuilderState(): {
       limit,
       setTraceMetric,
       traceMetric,
+      setTextContent,
+      description,
     ]
   );
 

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -409,6 +409,15 @@ function useWidgetBuilderState(): {
             setQuery(query?.slice(0, 1), options);
             // Categorical bars show more categories than time-series groupings
             setLimit(DEFAULT_CATEGORICAL_BAR_LIMIT, options);
+          } else if (action.payload === DisplayType.TEXT) {
+            // Text widgets don't need any data fields, just title and description
+            setFields([], options);
+            setYAxis([], options);
+            setQuery([''], options);
+            setSort([], options);
+            setLimit(undefined, options);
+            setLegendAlias([], options);
+            setDataset(undefined, options);
           } else {
             setFields(columnsWithoutAlias, options);
             const nextAggregates = [

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -16,6 +16,20 @@ import {generateMetricAggregate} from 'sentry/views/dashboards/widgetBuilder/uti
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
+  // Text widgets don't need queries or data fields
+  if (state.displayType === DisplayType.TEXT) {
+    return {
+      title: state.title ?? '',
+      description: state.description,
+      displayType: DisplayType.TEXT,
+      interval: '1m',
+      queries: [],
+      widgetType: undefined,
+      limit: undefined,
+      thresholds: undefined,
+    };
+  }
+
   const datasetConfig = getDatasetConfig(state.dataset ?? WidgetType.ERRORS);
   const defaultQuery = datasetConfig.defaultWidgetQuery;
 

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -1,5 +1,8 @@
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
-import {convertWidgetToBuilderStateParams} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
+import {
+  convertWidgetToBuilderStateParams,
+  TEXT_WIDGET_CONTENT_SESSION_KEY,
+} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 import {getDefaultWidget} from 'sentry/views/dashboards/widgetBuilder/utils/getDefaultWidget';
 
 describe('convertWidgetToBuilderStateParams', () => {
@@ -119,5 +122,62 @@ describe('convertWidgetToBuilderStateParams', () => {
     expect(params.thresholds).toBe(
       '{"max_values":{"max1":200,"max2":300},"unit":"milliseconds"}'
     );
+  });
+
+  describe('text widget', () => {
+    afterEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('stores the description in sessionStorage', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.ERRORS),
+        displayType: DisplayType.TEXT,
+        description: 'My markdown content',
+      };
+      convertWidgetToBuilderStateParams(widget);
+      expect(sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY)).toBe(
+        'My markdown content'
+      );
+    });
+
+    it('stores an empty string in sessionStorage when description is undefined', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.ERRORS),
+        displayType: DisplayType.TEXT,
+        description: undefined,
+      };
+      convertWidgetToBuilderStateParams(widget);
+      expect(sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY)).toBe('');
+    });
+
+    it('does not include description in URL params', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.ERRORS),
+        displayType: DisplayType.TEXT,
+        description: 'My markdown content',
+      };
+      const params = convertWidgetToBuilderStateParams(widget);
+      expect(params.description).toBeUndefined();
+    });
+
+    it('does not include dataset in URL params', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.ERRORS),
+        displayType: DisplayType.TEXT,
+      };
+      const params = convertWidgetToBuilderStateParams(widget);
+      expect(params.dataset).toBeUndefined();
+    });
+
+    it('does not write to sessionStorage for non-text widgets', () => {
+      const widget = {
+        ...getDefaultWidget(WidgetType.ERRORS),
+        displayType: DisplayType.TABLE,
+        description: 'some description',
+      };
+      convertWidgetToBuilderStateParams(widget);
+      expect(sessionStorage.getItem(TEXT_WIDGET_CONTENT_SESSION_KEY)).toBeNull();
+    });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -14,6 +14,8 @@ import {
 } from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 
+export const TEXT_WIDGET_CONTENT_SESSION_KEY = 'dashboard:edit-widget:text-content';
+
 function stringifyFields(
   query: WidgetQuery,
   fieldKey: 'fields' | 'columns' | 'aggregates'
@@ -67,9 +69,13 @@ export function convertWidgetToBuilderStateParams(
     }
   }
 
+  if (widget.displayType === DisplayType.TEXT) {
+    sessionStorage.setItem(TEXT_WIDGET_CONTENT_SESSION_KEY, widget.description ?? '');
+  }
+
   return {
     title: widget.title,
-    description: widget.description ?? '',
+    description: widget.displayType === DisplayType.TEXT ? undefined : widget.description,
     dataset:
       widget.displayType === DisplayType.TEXT
         ? undefined

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -70,7 +70,10 @@ export function convertWidgetToBuilderStateParams(
   return {
     title: widget.title,
     description: widget.description ?? '',
-    dataset: widget.widgetType ?? WidgetType.ERRORS,
+    dataset:
+      widget.displayType === DisplayType.TEXT
+        ? undefined
+        : (widget.widgetType ?? WidgetType.ERRORS),
     displayType: widget.displayType ?? DisplayType.TABLE,
     limit: widget.limit,
     field,

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -24,7 +24,11 @@ import {
 import {safeURL} from 'sentry/utils/url/safeURL';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
-import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
+import {
+  DashboardWidgetSource,
+  DisplayType,
+  WidgetType,
+} from 'sentry/views/dashboards/types';
 import {
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
@@ -294,31 +298,33 @@ export function getMenuOptions(
   }
 
   if (organization.features.includes('dashboards-edit')) {
-    menuOptions.push({
-      key: 'add-to-dashboard',
-      label: t('Add to Dashboard'),
-      disabled: disableTransactionEdit,
-      tooltip: disableTransactionEdit
-        ? t('This dataset is no longer supported. Please use the Spans dataset.')
-        : undefined,
-      onAction: () => {
-        openAddToDashboardModal({
-          organization,
-          location,
-          selection,
-          widgets: [
-            {
-              ...widget,
-              id: undefined,
-              dashboardId: undefined,
-              layout: undefined,
-            },
-          ],
-          actions: ['add-and-stay-on-current-page', 'open-in-widget-builder'],
-          source: DashboardWidgetSource.DASHBOARDS,
-        });
-      },
-    });
+    if (widget.displayType !== DisplayType.TEXT) {
+      menuOptions.push({
+        key: 'add-to-dashboard',
+        label: t('Add to Dashboard'),
+        disabled: disableTransactionEdit,
+        tooltip: disableTransactionEdit
+          ? t('This dataset is no longer supported. Please use the Spans dataset.')
+          : undefined,
+        onAction: () => {
+          openAddToDashboardModal({
+            organization,
+            location,
+            selection,
+            widgets: [
+              {
+                ...widget,
+                id: undefined,
+                dashboardId: undefined,
+                layout: undefined,
+              },
+            ],
+            actions: ['add-and-stay-on-current-page', 'open-in-widget-builder'],
+            source: DashboardWidgetSource.DASHBOARDS,
+          });
+        },
+      });
+    }
     menuOptions.push({
       key: 'duplicate-widget',
       label: t('Duplicate Widget'),


### PR DESCRIPTION
add text widget into widget builder and construct the form accordingly. Also hooked it up to work with the url params so things reset and change accordingly when switching to and from the text widget type. Here's the form:
<img height="500" alt="image" src="https://github.com/user-attachments/assets/4e88ab9e-7b78-4903-9e60-05530ccf22cf" />

THIS MUST BE MERGED AFTER https://github.com/getsentry/sentry/pull/108539 because it is branched off of it