### PR TITLE
fix(releases): paginate GitHub client compare_commits to avoid 250-commit limit

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -334,9 +334,6 @@ class GitHubBaseClient(
         """
         See https://docs.github.com/en/rest/commits/commits#compare-two-commits
         where start sha is oldest and end is most recent.
-
-        GitHub's compare endpoint returns at most 250 commits per page.
-        We paginate to fetch all commits in the range.
         """
         return self._get_with_pagination(
             f"/repos/{repo}/compare/{start_sha}...{end_sha}",

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -330,12 +330,18 @@ class GitHubBaseClient(
         """
         return self.get_cached(f"/repos/{repo}/commits", params={"sha": end_sha})
 
-    def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> Any:
+    def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> list[Any]:
         """
         See https://docs.github.com/en/rest/commits/commits#compare-two-commits
         where start sha is oldest and end is most recent.
+
+        GitHub's compare endpoint returns at most 250 commits per page.
+        We paginate to fetch all commits in the range.
         """
-        return self.get_cached(f"/repos/{repo}/compare/{start_sha}...{end_sha}")
+        return self._get_with_pagination(
+            f"/repos/{repo}/compare/{start_sha}...{end_sha}",
+            response_key="commits",
+        )
 
     def repo_hooks(self, repo: str) -> Sequence[Any]:
         """

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -72,8 +72,8 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
                 res = client.get_last_commits(name, end_sha)
                 return self._format_commits(client, name, res[:20])
             else:
-                res = client.compare_commits(name, start_sha, end_sha)
-                return self._format_commits(client, name, res["commits"])
+                commits = client.compare_commits(name, start_sha, end_sha)
+                return self._format_commits(client, name, commits)
 
         integration_id = repo.integration_id
         if integration_id is None:

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -136,16 +136,19 @@ class GitHubAppsProviderTest(TestCase):
             **page1_data["commits"][0],
             "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         }
-        compare_url = "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef"
 
         responses.add(
             responses.GET,
-            compare_url,
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
             json=page1_data,
-            headers={"Link": f'<{compare_url}?page=2>; rel="next"'},
+            headers={
+                "Link": '<https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef?page=2>; rel="next"'
+            },
         )
         responses.add(
-            responses.GET, f"{compare_url}?page=2", json={**page1_data, "commits": [page2_commit]}
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef?page=2",
+            json={**page1_data, "commits": [page2_commit]},
         )
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -129,6 +129,42 @@ class GitHubAppsProviderTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_compare_commits_pagination(self, get_jwt: mock.MagicMock) -> None:
+        """Test that compare_commits paginates to fetch all commits."""
+        page1_data = orjson.loads(COMPARE_COMMITS_EXAMPLE)
+        page2_commit = {
+            **page1_data["commits"][0],
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        }
+        compare_url = "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef"
+
+        responses.add(
+            responses.GET,
+            compare_url,
+            json=page1_data,
+            headers={"Link": f'<{compare_url}?page=2>; rel="next"'},
+        )
+        responses.add(
+            responses.GET, f"{compare_url}?page=2", json={**page1_data, "commits": [page2_commit]}
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
+        )
+        responses.add(
+            responses.GET,
+            "https://api.github.com/repos/getsentry/example-repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            json=orjson.loads(GET_COMMIT_EXAMPLE),
+        )
+
+        result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
+        assert len(result) == 2
+        assert result[0]["id"] == "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+        assert result[1]["id"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_compare_commits_patchset_handling(self, get_jwt: mock.MagicMock) -> None:
         responses.add(
             responses.GET,


### PR DESCRIPTION
Per https://sentry.slack.com/archives/C08AZ3MD2EQ/p1770657631215169

Our customers are experiencing problems with missing commits on their releases, and the limit seems to be 250 commits. This is because we use GitHub's compare_commits endpoint, which is limited to 250 commits when unpaginated. Here we paginate the endpoint to make sure we get the complete commits list.

---

Complete flow from sentry-cli to getting the fetched release commits:

1. `sentry-cli releases set-commits --auto` [resolves head shas](https://github.com/getsentry/sentry-cli/blob/83ac26ead78610cac9f24851793b9651e0169e2c/src/commands/releases/set_commits.rs#L96) from local git remotes via find_heads()
2. [`authenticated_api.set_release_refs()`](https://github.com/getsentry/sentry-cli/blob/83ac26ead78610cac9f24851793b9651e0169e2c/src/commands/releases/set_commits.rs#L181) sends a put request with the resolved shas to `/organizations/{org}/releases/{version}/`, or `OrganizationReleaseDetailsEndpoint.put()`
3. `OrganizationReleaseDetailsEndpoint.put()` [calls `release.set_refs()`](https://github.com/getsentry/sentry/blob/93dd427eebe391fcff318efa35bd7b522b4eebef/src/sentry/releases/endpoints/organization_release_details.py#L516)
4. `Release.set_refs()` [calls `fetch_commits()` task](https://github.com/getsentry/sentry/blob/93dd427eebe391fcff318efa35bd7b522b4eebef/src/sentry/models/release.py#L633)
5. `fetch_commits()` [calls `provider.compare_commits()`](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/tasks/commits.py#L175), for GitHub that would be [this function](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/integrations/github/repository.py#L65), which then hits the [GitHub compare_commits endpoint](https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#compare-two-commits).
6. Now that we have <=250 commits we [store the author info](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/integrations/github/repository.py#L117) then [set that release's commits](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/tasks/commits.py#L221) (thus [creating `CommitAuthors`](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/models/releases/set_commits.py#L64) using the stored author info from the fetched commits, and [linking `Commit` and `CommitAuthor` to `ReleaseCommit`](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/models/releases/set_commits.py#L159))
7. Finally, we [update `release.authors`](https://github.com/getsentry/sentry/blob/dd3b7e58f573e5365036b73054459bb80ece3c87/src/sentry/models/releases/set_commits.py#L99) to contain all the author ids for the `ReleaseCommits` for this release
8. Whenever we serialize a release, [`_get_authors_metadata()`](https://github.com/getsentry/sentry/blob/543ba1344d54206944c8a56dc76848ea51b5a779/src/sentry/api/serializers/models/release.py#L604) uses those author ids to query the corresponding `CommitAuthor` objects