### PR TITLE
fix(occurrences): blocklist span data out of event ingestion

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -31,7 +31,7 @@ def serialize_event_data_as_item(
         ),
         retention_days=event_data.get("retention_days", 90),
         attributes=encode_attributes(
-            event, event_data, ignore_fields={"event_id", "timestamp", "tags"}
+            event, event_data, ignore_fields={"event_id", "timestamp", "tags", "spans", "'spans'"}
         ),
     )
 


### PR DESCRIPTION
Don't want this in this unprocessed form. Might get key data out of it but cutting out full write.