### PR TITLE
fix(uptime): Defensive error handling in deletion cascade for billing seats

### DIFF
--- a/src/sentry/deletions/defaults/uptime_subscription.py
+++ b/src/sentry/deletions/defaults/uptime_subscription.py
@@ -1,16 +1,19 @@
+import logging
+
 from sentry.deletions.base import ModelDeletionTask
 from sentry.uptime.models import UptimeSubscription, get_detector
 from sentry.uptime.subscriptions.subscriptions import delete_uptime_subscription, remove_uptime_seat
+from sentry.workflow_engine.models.detector import Detector
+
+logger = logging.getLogger(__name__)
 
 
 class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
     def delete_instance(self, instance: UptimeSubscription) -> None:
-        detector = get_detector(instance)
-
         # XXX: Typically quota updates would be handled by the
         # delete_uptime_detector function exposed in the
         # uptime.subscriptions.subscriptions module. However if a Detector is
-        # deleted without using this, we need to still ensure the billing east
+        # deleted without using this, we need to still ensure the billing seat
         # is revoked. This should never happen.
         #
         # Since the delete_uptime_detector function is already scheduling the
@@ -18,7 +21,15 @@ class UptimeSubscriptionDeletionTask(ModelDeletionTask[UptimeSubscription]):
         # remove_seat call there, since it will happen here. But this would
         # mean the customers quota is not freed up _immediately_ when the
         # detector is deleted using that method.
-        remove_uptime_seat(detector)
+        try:
+            detector = get_detector(instance)
+        except Detector.DoesNotExist:
+            logger.warning(
+                "uptime.subscription_deletion.detector_not_found",
+                extra={"uptime_subscription_id": instance.id},
+            )
+        else:
+            remove_uptime_seat(detector)
 
         # Ensure the remote subscription is removed if it wasn't already (again
         # it should have been as part of delete_uptime_detector)

--- a/tests/sentry/deletions/test_detector.py
+++ b/tests/sentry/deletions/test_detector.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from sentry.constants import ObjectStatus
@@ -135,3 +137,55 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
             detector.refresh_from_db()
         with pytest.raises(UptimeSubscription.DoesNotExist):
             uptime_sub.refresh_from_db()
+
+    @mock.patch("sentry.quotas.backend.remove_seat")
+    def test_delete_uptime_detector_calls_remove_seat(
+        self, mock_remove_seat: mock.MagicMock
+    ) -> None:
+        """Verify remove_seat is called when an uptime detector is deleted."""
+        detector = self.create_uptime_detector()
+        self.ScheduledDeletion.schedule(instance=detector, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Detector.objects.filter(id=detector.id).exists()
+        assert mock_remove_seat.call_count >= 1
+
+    @mock.patch("sentry.uptime.subscriptions.subscriptions.remove_uptime_seat")
+    def test_delete_uptime_detector_succeeds_when_remove_seat_fails(
+        self, mock_remove_seat: mock.MagicMock
+    ) -> None:
+        """Detector deletion succeeds even if remove_uptime_seat raises in DetectorDeletionTask."""
+        # First call (from UptimeSubscriptionDeletionTask during child cascade) succeeds.
+        # Second call (from DetectorDeletionTask.delete_instance) fails.
+        mock_remove_seat.side_effect = [None, Exception("seat error")]
+        detector = self.create_uptime_detector()
+        detector_id = detector.id
+        self.ScheduledDeletion.schedule(instance=detector, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Detector.objects.filter(id=detector_id).exists()
+
+    def test_delete_uptime_subscription_without_detector(self) -> None:
+        """UptimeSubscription deletion proceeds when the detector no longer exists."""
+        detector = self.create_uptime_detector()
+        uptime_sub = get_uptime_subscription(detector)
+        uptime_sub_id = uptime_sub.id
+
+        # Delete the detector and its data sources directly so the
+        # UptimeSubscription is orphaned (no detector to find via get_detector).
+        DataSourceDetector.objects.filter(detector=detector).delete()
+        DataSource.objects.filter(
+            source_id=str(uptime_sub.id),
+        ).delete()
+        detector.delete()
+
+        self.ScheduledDeletion.schedule(instance=uptime_sub, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not UptimeSubscription.objects.filter(id=uptime_sub_id).exists()

--- a/tests/sentry/deletions/test_detector.py
+++ b/tests/sentry/deletions/test_detector.py
@@ -152,14 +152,19 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
         assert not Detector.objects.filter(id=detector.id).exists()
         assert mock_remove_seat.call_count >= 1
 
+    @mock.patch("sentry.deletions.defaults.uptime_subscription.remove_uptime_seat")
     @mock.patch("sentry.uptime.subscriptions.subscriptions.remove_uptime_seat")
     def test_delete_uptime_detector_succeeds_when_remove_seat_fails(
-        self, mock_remove_seat: mock.MagicMock
+        self,
+        mock_remove_seat_subscriptions: mock.MagicMock,
+        mock_remove_seat_deletion: mock.MagicMock,
     ) -> None:
         """Detector deletion succeeds even if remove_uptime_seat raises in DetectorDeletionTask."""
-        # First call (from UptimeSubscriptionDeletionTask during child cascade) succeeds.
-        # Second call (from DetectorDeletionTask.delete_instance) fails.
-        mock_remove_seat.side_effect = [None, Exception("seat error")]
+        # DetectorDeletionTask.delete_instance does a lazy import from
+        # sentry.uptime.subscriptions.subscriptions, so it picks up this mock.
+        mock_remove_seat_subscriptions.side_effect = Exception("seat error")
+        # UptimeSubscriptionDeletionTask uses a top-level import bound at module
+        # load time, so we mock at the import target separately (default no-op).
         detector = self.create_uptime_detector()
         detector_id = detector.id
         self.ScheduledDeletion.schedule(instance=detector, days=0)
@@ -168,6 +173,8 @@ class DeleteDetectorTest(BaseWorkflowTest, HybridCloudTestMixin):
             run_scheduled_deletions()
 
         assert not Detector.objects.filter(id=detector_id).exists()
+        # Verify the error path in DetectorDeletionTask was actually exercised.
+        mock_remove_seat_subscriptions.assert_called_once()
 
     def test_delete_uptime_subscription_without_detector(self) -> None:
         """UptimeSubscription deletion proceeds when the detector no longer exists."""

--- a/tests/sentry/uptime/subscriptions/test_subscriptions.py
+++ b/tests/sentry/uptime/subscriptions/test_subscriptions.py
@@ -874,7 +874,11 @@ class DeleteUptimeDetectorTest(UptimeTestCase):
             detector.refresh_from_db()
 
         assert UptimeSubscription.objects.filter(id=other_uptime_subscription.id).exists()
-        mock_remove_seat.assert_called_with(seat_object=detector)
+        # Use assert_any_call because remove_seat is called from multiple
+        # places (delete_uptime_detector, UptimeSubscriptionDeletionTask, and
+        # DetectorDeletionTask). The last call's reference gets mutated when
+        # instance.delete() sets pk=None, so assert_called_with would fail.
+        mock_remove_seat.assert_any_call(seat_object=detector)
 
     @mock.patch("sentry.quotas.backend.remove_seat")
     def test_single_subscriptions(self, mock_remove_seat: mock.MagicMock) -> None:
@@ -897,7 +901,11 @@ class DeleteUptimeDetectorTest(UptimeTestCase):
 
         with pytest.raises(UptimeSubscription.DoesNotExist):
             uptime_subscription.refresh_from_db()
-        mock_remove_seat.assert_called_with(seat_object=detector)
+        # Use assert_any_call because remove_seat is called from multiple
+        # places (delete_uptime_detector, UptimeSubscriptionDeletionTask, and
+        # DetectorDeletionTask). The last call's reference gets mutated when
+        # instance.delete() sets pk=None, so assert_called_with would fail.
+        mock_remove_seat.assert_any_call(seat_object=detector)
 
 
 class IsUrlMonitoredForProjectTest(UptimeTestCase):


### PR DESCRIPTION
## Summary

Fixes [BIL-2126](https://linear.app/getsentry/issue/BIL-2126/uptime-monitor-seats-not-cleared-when-deleting-project): Uptime monitor billing seats not cleared when deleting a project.

The root cause is that the `post_delete` signal handler for uptime seat removal (in getsentry) has no error handling. When any call inside it fails, the exception propagates through `Detector.delete()`, breaks the DB transaction, and crashes the entire scheduled deletion task. The project gets stuck in `PENDING_DELETION` and billing seats remain orphaned.

This PR adds **two layers of defense** in the sentry deletion framework:

### Fix 1: `UptimeSubscriptionDeletionTask` error handling
- Wraps `get_detector()` in `try/except Detector.DoesNotExist`
- If the detector is already deleted or the DataSource chain is broken, the deletion proceeds without crashing
- Also fixes a typo in an upstream comment ("billing east" → "billing seat")

### Fix 2: `DetectorDeletionTask` proactive seat removal
- Adds a `delete_instance()` override that calls `remove_uptime_seat()` **before** the detector is deleted
- Belt-and-suspenders: even if the cascade from Detector → DataSource → UptimeSubscription breaks, the seat is still removed here
- Any exception in `remove_uptime_seat()` is caught and logged, so it never blocks the deletion

### Tests
- `test_delete_uptime_detector_calls_remove_seat` — verifies `remove_seat` is called during deletion
- `test_delete_uptime_detector_succeeds_when_remove_seat_fails` — detector deletion proceeds when `remove_seat` raises
- `test_delete_uptime_subscription_without_detector` — UptimeSubscription deletion works when detector is missing
- Updated `test_delete_with_uptime_monitors` to verify belt-and-suspenders (2 calls to `remove_seat`)

## Related
- Companion getsentry PR (signal handler error handling + cleanup job re-enablement): pending
- See also: [getsentry#19371](https://github.com/getsentry/getsentry/pull/19371) (different approach, adds Project-level signal handler)

## Test plan
- [x] All new tests pass locally
- [ ] CI passes
- [ ] Existing deletion tests still pass