### PR TITLE
Add additional project directories to Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,7 +87,8 @@
       "WebFetch(domain:modelcontextprotocol.io)",
       "WebFetch(domain:react.dev)"
     ],
-    "deny": []
+    "deny": [],
+    "additionalDirectories": ["../seer", "../getsentry"]
   },
   "enableAllProjectMcpServers": true,
   "includeCoAuthoredBy": false,


### PR DESCRIPTION
## Description

This change expands the Claude settings configuration to include two additional project directories: `../seer` and `../getsentry`. These directories are now included in the `additionalDirectories` array within the MCP server configuration, allowing Claude to access and work with files from these related projects.

## Changes

- Added `additionalDirectories` configuration with paths to `../seer` and `../getsentry` projects in `.claude/settings.json`

## Test Plan

N/A - Configuration change only. The settings will be applied when Claude initializes with this configuration.

---

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

https://claude.ai/code/session_01VpAY5kJhAwzPhGRxi3mYRU