### PR TITLE
chore(flags): Remove 3 dead feature flags (batch 4)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -582,8 +582,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:view-hierarchies-options-dev", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable equations feature on the new explore page
     manager.add("organizations:visibility-explore-equations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable equations feature in dashboards
-    manager.add("organizations:visibility-dashboards-equations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable an async queue for dashboard widget queries
     manager.add("organizations:visibility-dashboards-async-queue", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new explore page
@@ -673,8 +671,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     # Enable feature flag to send expanded sentry apps webhooks (issue.created for all group categories)
     manager.add("organizations:expanded-sentry-apps-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable using paginated projects endpoint for Jira integration
-    manager.add("organizations:jira-paginated-projects", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable single trace summary
     manager.add("organizations:single-trace-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable seeing upsell modal when clicking upgrade for multi-org
@@ -749,12 +745,4 @@ def register_temporary_features(manager: FeatureManager) -> None:
         OrganizationFeature,
         FeatureHandlerStrategy.FLAGPOLE,
         api_expose=False,
-    )
-
-    # Control access to a new debug files role management
-    manager.add(
-        "organizations:debug-files-role-management",
-        OrganizationFeature,
-        FeatureHandlerStrategy.FLAGPOLE,
-        api_expose=True,
     )


### PR DESCRIPTION
## Summary
Remove unused feature flag registrations identified by the `scan_flags` management command. These flags have zero code references and no flagpole configuration.

**Flags removed:**
- `organizations:visibility-dashboards-equations`
- `organizations:jira-paginated-projects`
- `organizations:debug-files-role-management`

## Test plan
- These flags have no code usage, test references, or flagpole config — removing the registration is the only change needed.