### PR TITLE
perf(sdk): Sample S4S upstream metrics at 1%

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -431,9 +431,9 @@ def configure_sdk():
             # it is most isolated from the sentry installation.
             if sentry4sentry_transport:
                 if self._should_drop_s4s(method_name, *args):
-                    metrics.incr("internal.captured.events.upstream.s4s_dropped")
+                    metrics.incr("internal.captured.events.upstream.s4s_dropped", sample_rate=0.01)
                 else:
-                    metrics.incr("internal.captured.events.upstream")
+                    metrics.incr("internal.captured.events.upstream", sample_rate=0.01)
                     # TODO(mattrobenolt): Bring this back safely.
                     # from sentry import options
                     # install_id = options.get('sentry:install-id')


### PR DESCRIPTION
Sample both `internal.captured.events.upstream` and `internal.captured.events.upstream.s4s_dropped` at 1% instead of recording every single event.

These metrics fire on every event that passes through `MultiplexingTransport._capture_anything`, which is extremely high volume — particularly the `s4s_dropped` counter when running with a low transaction sample rate (e.g. at 5%, 95% of transactions hit the dropped path).

The Sentry metrics SDK respects `sample_rate` in `metrics.incr()` — it randomly drops recordings and tags the metric with `sentry.client_sample_rate=0.01`, so Relay scales the counts back up by 100× to keep the numbers accurate.