### PR TITLE
feat(autofix): Support explorer autofix steps in slack operator

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -27,7 +27,10 @@ from sentry.notifications.platform.templates.seer import (
     SeerAutofixTrigger,
     SeerAutofixUpdate,
 )
-from sentry.notifications.platform.types import NotificationData, NotificationRenderedTemplate
+from sentry.notifications.platform.types import (
+    NotificationData,
+    NotificationRenderedTemplate,
+)
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 
 if TYPE_CHECKING:
@@ -179,7 +182,12 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
 
     @classmethod
     def _render_link_button(
-        cls, *, organization_id: int, project_id: int, group_link: str, text: str = "View in Sentry"
+        cls,
+        *,
+        organization_id: int,
+        project_id: int,
+        group_link: str,
+        text: str = "View in Sentry",
     ) -> LinkButtonElement:
         from sentry.integrations.slack.message_builder.routing import encode_action_id
         from sentry.integrations.slack.message_builder.types import SlackAction

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -46,6 +46,25 @@ class AutofixStep(StrEnum):
     IMPACT_ASSESSMENT = "impact_assessment"
     TRIAGE = "triage"
 
+    @staticmethod
+    def from_autofix_stopping_point(
+        autofix_stopping_point: AutofixStoppingPoint,
+    ) -> AutofixStep:
+        match autofix_stopping_point:
+            case AutofixStoppingPoint.ROOT_CAUSE:
+                return AutofixStep.ROOT_CAUSE
+            case AutofixStoppingPoint.SOLUTION:
+                return AutofixStep.SOLUTION
+            case AutofixStoppingPoint.CODE_CHANGES:
+                return AutofixStep.CODE_CHANGES
+            case AutofixStoppingPoint.OPEN_PR:
+                # This depends on the last step being
+                # code changes and we should look for
+                # the PR elsewhere in the explorer results
+                return AutofixStep.CODE_CHANGES
+            case _:
+                raise ValueError(f"Unsupported AutofixStoppingPoint: {autofix_stopping_point}")
+
 
 class StepConfig:
     """Configuration for an autofix step."""

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -77,6 +77,13 @@ class SeerOperator[CachePayloadT]:
         if not has_seer_access(organization):
             return False
 
+        # Currently, this feature is built around legacy autofix
+        # The explorer autofix pipeline and history is entirely separate, so the runs we trigger
+        # at the moment, won't be visible in-app to users with this flag.
+        # This check can only be removed once this feature migrates to explorer-based autofix.
+        if features.has("organizations:autofix-on-explorer", organization):
+            return False
+
         if entrypoint_key:
             if entrypoint_key not in entrypoint_registry.registrations:
                 logger.error(
@@ -526,6 +533,9 @@ def get_autofix_explorer_status(
             continue
 
         step_str = metadata.get("step")
+        if step_str is None:
+            continue
+
         try:
             step = AutofixStep(step_str)
         except ValueError:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -7,9 +7,8 @@ from sentry import features
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.models.organization import Organization
-from sentry.seer.autofix.autofix import trigger_autofix as _trigger_autofix
-from sentry.seer.autofix.autofix import update_autofix
-from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.autofix import trigger_autofix, update_autofix
+from sentry.seer.autofix.constants import AutofixReferrer, AutofixStatus
 from sentry.seer.autofix.types import (
     AutofixCreatePRPayload,
     AutofixSelectRootCausePayload,
@@ -27,6 +26,7 @@ from sentry.seer.entrypoints.metrics import (
 )
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey
+from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.tasks.base import instrumented_task
@@ -77,13 +77,6 @@ class SeerOperator[CachePayloadT]:
         if not has_seer_access(organization):
             return False
 
-        # Currently, this feature is built around legacy autofix
-        # The explorer autofix pipeline and history is entirely separate, so the runs we trigger
-        # at the moment, won't be visible in-app to users with this flag.
-        # This check can only be removed once this feature migrates to explorer-based autofix.
-        if features.has("organizations:autofix-on-explorer", organization):
-            return False
-
         if entrypoint_key:
             if entrypoint_key not in entrypoint_registry.registrations:
                 logger.error(
@@ -122,6 +115,144 @@ class SeerOperator[CachePayloadT]:
         )
 
     def trigger_autofix(
+        self,
+        *,
+        group: Group,
+        user: User | RpcUser,
+        stopping_point: AutofixStoppingPoint,
+        instruction: str | None = None,
+        run_id: int | None = None,
+    ) -> None:
+        if features.has("organizations:autofix-on-explorer", group.organization):
+            self.trigger_autofix_explorer(
+                group=group,
+                user=user,
+                stopping_point=stopping_point,
+                instruction=instruction,
+                run_id=run_id,
+            )
+        else:
+            self.trigger_autofix_legacy(
+                group=group,
+                user=user,
+                stopping_point=stopping_point,
+                instruction=instruction,
+                run_id=run_id,
+            )
+
+    def trigger_autofix_explorer(
+        self,
+        *,
+        group: Group,
+        user: User | RpcUser,
+        stopping_point: AutofixStoppingPoint,
+        instruction: str | None = None,
+        run_id: int | None = None,
+    ) -> None:
+        from sentry.seer.autofix.autofix_agent import (
+            AutofixStep,
+            get_autofix_explorer_state,
+            trigger_autofix_explorer,
+        )
+
+        event_lifecyle = SeerOperatorEventLifecycleMetric(
+            interaction_type=SeerOperatorInteractionType.OPERATOR_TRIGGER_AUTOFIX,
+            entrypoint_key=self.entrypoint.key,
+        )
+
+        with event_lifecyle.capture() as lifecycle:
+            lifecycle.add_extras(
+                {
+                    "group_id": str(group.id),
+                    "user_id": str(user.id),
+                    "stopping_point": str(stopping_point),
+                }
+            )
+
+            try:
+                existing_state = get_autofix_explorer_state(group.organization, group.id)
+            except Exception as e:
+                with SeerOperatorEventLifecycleMetric(
+                    interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,
+                    entrypoint_key=self.entrypoint.key,
+                ).capture():
+                    self.entrypoint.on_trigger_autofix_error(
+                        error="Encountered an error while talking to Seer"
+                    )
+                lifecycle.record_failure(failure_reason=e)
+                return
+            if existing_state:
+                has_complete_stage = get_autofix_explorer_status(stopping_point, existing_state)
+                lifecycle.add_extras(
+                    {
+                        "existing_run_id": str(existing_state.run_id),
+                        "existing_run_status": str(existing_state.status),
+                    }
+                )
+
+                # For now, we don't support re-runs over slack -- it causes a confusing UX without
+                # reliably being able to edit messages.
+                if has_complete_stage is not None:
+                    with SeerOperatorEventLifecycleMetric(
+                        interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ALREADY_EXISTS,
+                        entrypoint_key=self.entrypoint.key,
+                    ).capture():
+                        self.entrypoint.on_trigger_autofix_already_exists(
+                            run_id=existing_state.run_id,
+                            has_complete_stage=has_complete_stage,
+                        )
+                    return
+
+            if not run_id:
+                run_id = trigger_autofix_explorer(
+                    group=group,
+                    step=AutofixStep.ROOT_CAUSE,
+                    run_id=None,
+                )
+            elif stopping_point == AutofixStoppingPoint.OPEN_PR:
+                pass  # TODO: OPENING PRs is a little more complicated so putting it off for now
+            else:
+                # NOTE: Stopping point here is really just what
+                # step to run next. Not the same as the stopping_point
+                # argument supported by `trigger_autofix_explorer` which allows one
+                # to run multiple steps at once
+                run_id = trigger_autofix_explorer(
+                    group=group,
+                    step=AutofixStep.from_autofix_stopping_point(stopping_point),
+                    run_id=run_id,
+                )
+
+            lifecycle.add_extra("run_id", str(run_id))
+
+            # Let the entrypoint signal to the external service that the run started
+            with SeerOperatorEventLifecycleMetric(
+                interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_SUCCESS,
+                entrypoint_key=self.entrypoint.key,
+            ).capture():
+                self.entrypoint.on_trigger_autofix_success(run_id=run_id)
+
+            # Create a cache payload that will be picked up for subsequent updates
+            with SeerOperatorEventLifecycleMetric(
+                interaction_type=SeerOperatorInteractionType.ENTRYPOINT_CREATE_AUTOFIX_CACHE_PAYLOAD,
+                entrypoint_key=self.entrypoint.key,
+            ).capture():
+                cache_payload = self.entrypoint.create_autofix_cache_payload()
+
+            if not cache_payload:
+                return
+            cache_result = SeerOperatorAutofixCache.populate_post_autofix_cache(
+                entrypoint_key=str(self.entrypoint.key),
+                cache_payload=cache_payload,
+                run_id=run_id,
+            )
+            lifecycle.add_extras(
+                {
+                    "cache_key": cache_result["key"],
+                    "cache_source": cache_result["source"],
+                }
+            )
+
+    def trigger_autofix_legacy(
         self,
         *,
         group: Group,
@@ -173,13 +304,20 @@ class SeerOperator[CachePayloadT]:
                         interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ALREADY_EXISTS,
                         entrypoint_key=self.entrypoint.key,
                     ).capture():
+                        has_complete_stage = (
+                            False
+                            if stopping_point_step.get("key")
+                            in {"root_cause_analysis_processing", "solution_processing"}
+                            else stopping_point_step.get("status") == AutofixStatus.COMPLETED
+                        )
                         self.entrypoint.on_trigger_autofix_already_exists(
-                            state=existing_state, step_state=stopping_point_step
+                            run_id=existing_state.run_id,
+                            has_complete_stage=has_complete_stage,
                         )
                     return
 
             if not run_id:
-                raw_response = _trigger_autofix(
+                raw_response = trigger_autofix(
                     group=group,
                     user=user,
                     referrer=AutofixReferrer.SLACK,
@@ -372,6 +510,56 @@ def get_stopping_point_status(
                 None,
             )
     return step
+
+
+def get_autofix_explorer_status(
+    stopping_point: AutofixStoppingPoint, autofix_state: SeerRunState
+) -> bool | None:
+    from sentry.seer.autofix.autofix_agent import AutofixStep
+
+    expected_step = AutofixStep.from_autofix_stopping_point(stopping_point)
+
+    is_last = True
+    for block in reversed(autofix_state.blocks):
+        metadata = block.message.metadata
+        if metadata is None:
+            continue
+
+        step_str = metadata.get("step")
+        try:
+            step = AutofixStep(step_str)
+        except ValueError:
+            continue
+
+        if step == expected_step:
+            # If the expected step is not the last step
+            # then we can assume it is already completed
+            # so return True to indicate that
+            if not is_last:
+                return True
+
+            # If the expected step is the last step, then
+            # we check the run state to see if it's processing
+            #
+            # Everything except the processing status
+            # is considered as some form of completed
+            completed = autofix_state.status != "processing"
+
+            # OPEN_PR step gets special treatment to also
+            # check on the status of the pr creation
+            if step == AutofixStoppingPoint.OPEN_PR and completed:
+                return all(
+                    pr_state.pr_creation_status != "creating"
+                    for pr_state in autofix_state.repo_pr_states.values()
+                )
+
+            return completed
+
+        is_last = False
+
+    # no block matching the stopping point found, so return None
+    # to indicate the step has not run before
+    return None
 
 
 def get_latest_cause_id(autofix_state: AutofixState | None) -> int:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -557,7 +557,7 @@ def get_autofix_explorer_status(
 
             # OPEN_PR step gets special treatment to also
             # check on the status of the pr creation
-            if step == AutofixStoppingPoint.OPEN_PR and completed:
+            if stopping_point == AutofixStoppingPoint.OPEN_PR and completed:
                 return all(
                     pr_state.pr_creation_status != "creating"
                     for pr_state in autofix_state.repo_pr_states.values()

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -2,7 +2,6 @@ from enum import StrEnum
 from typing import Any, Literal, Protocol, TypedDict
 
 from sentry.models.organization import Organization
-from sentry.seer.autofix.utils import AutofixState
 from sentry.sentry_apps.metrics import SentryAppEventType
 
 
@@ -31,7 +30,7 @@ class SeerEntrypoint[CachePayloadT](Protocol):
         """
         ...
 
-    def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
+    def on_trigger_autofix_already_exists(self, *, run_id: int, has_complete_stage: bool) -> None:
         """
         Called when an autofix run already exists for the group.
         Also passes the most recent state from the matching stopping_point step for convenience.
@@ -66,7 +65,9 @@ class SeerEntrypoint[CachePayloadT](Protocol):
 
     @staticmethod
     def on_autofix_update(
-        event_type: SentryAppEventType, event_payload: dict[str, Any], cache_payload: CachePayloadT
+        event_type: SentryAppEventType,
+        event_payload: dict[str, Any],
+        cache_payload: CachePayloadT,
     ) -> None:
         """
         Called when an autofix update is received (via Seer's webhooks).

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -45,7 +45,6 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
         return True
 
     def on_trigger_autofix_already_exists(self, *, run_id: int, has_complete_stage: bool) -> None:
-        # def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
         self.autofix_already_exists_states.append((run_id, has_complete_stage))
 
     def on_trigger_autofix_error(self, *, error: str) -> None:

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -15,7 +15,11 @@ from sentry.seer.entrypoints.operator import (
     process_autofix_updates,
 )
 from sentry.seer.entrypoints.registry import entrypoint_registry
-from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey, SeerOperatorCacheResult
+from sentry.seer.entrypoints.types import (
+    SeerEntrypoint,
+    SeerEntrypointKey,
+    SeerOperatorCacheResult,
+)
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import TestCase
 
@@ -34,14 +38,15 @@ class MockEntrypoint(SeerEntrypoint[MockCachePayload]):
         self.autofix_errors = []
         self.autofix_run_ids = []
         self.autofix_update_cache_payloads = []
-        self.autofix_already_exists_states: list[tuple[AutofixState, dict]] = []
+        self.autofix_already_exists_states: list[tuple[int, bool]] = []
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
         return True
 
-    def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
-        self.autofix_already_exists_states.append((state, step_state))
+    def on_trigger_autofix_already_exists(self, *, run_id: int, has_complete_stage: bool) -> None:
+        # def on_trigger_autofix_already_exists(self, *, state: AutofixState, step_state: dict) -> None:
+        self.autofix_already_exists_states.append((run_id, has_complete_stage))
 
     def on_trigger_autofix_error(self, *, error: str) -> None:
         self.autofix_errors.append(error)
@@ -83,7 +88,8 @@ class SeerOperatorTest(TestCase):
         ):
             assert SeerOperator.has_access(organization=self.group.project.organization)
             assert SeerOperator.has_access(
-                organization=self.group.project.organization, entrypoint_key=MockEntrypoint.key
+                organization=self.group.project.organization,
+                entrypoint_key=MockEntrypoint.key,
             )
             assert not SeerOperator.has_access(
                 organization=self.group.project.organization,
@@ -104,15 +110,20 @@ class SeerOperatorTest(TestCase):
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch(
-        "sentry.seer.entrypoints.operator._trigger_autofix",
+        "sentry.seer.entrypoints.operator.trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
     def test_trigger_autofix_pathway(
-        self, _mock_get_autofix_state, mock_trigger_autofix_helper, mock_update_autofix_helper
+        self,
+        mock_get_autofix_state,
+        mock_trigger_autofix_helper,
+        mock_update_autofix_helper,
     ):
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
         assert mock_trigger_autofix_helper.call_count == 1
         assert mock_update_autofix_helper.call_count == 0
@@ -128,24 +139,29 @@ class SeerOperatorTest(TestCase):
         assert mock_update_autofix_helper.call_count == 1
 
     @patch(
-        "sentry.seer.entrypoints.operator._trigger_autofix",
+        "sentry.seer.entrypoints.operator.trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
-    def test_trigger_autofix_success(self, _mock_get_autofix_state, mock_trigger_autofix_helper):
+    def test_trigger_autofix_success(self, mock_get_autofix_state, mock_trigger_autofix_helper):
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
         assert mock_trigger_autofix_helper.call_count == 1
         assert self.entrypoint.autofix_errors == []
         assert self.entrypoint.autofix_run_ids == [MOCK_RUN_ID]
 
-    @patch("sentry.seer.entrypoints.operator._trigger_autofix")
+    @patch("sentry.seer.entrypoints.operator.trigger_autofix")
     @patch("sentry.seer.entrypoints.operator.get_autofix_state")
     def test_trigger_autofix_already_exists(
         self, mock_get_autofix_state, mock_trigger_autofix_helper
     ):
-        existing_rca_step_state = {"key": "root_cause_analysis", "status": AutofixStatus.COMPLETED}
+        existing_rca_step_state = {
+            "key": "root_cause_analysis",
+            "status": AutofixStatus.COMPLETED,
+        }
         existing_state = AutofixState(
             run_id=MOCK_RUN_ID,
             request={
@@ -161,18 +177,18 @@ class SeerOperatorTest(TestCase):
         mock_get_autofix_state.return_value = existing_state
 
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
 
         mock_trigger_autofix_helper.assert_not_called()
-        assert self.entrypoint.autofix_already_exists_states == [
-            (existing_state, existing_rca_step_state)
-        ]
+        assert self.entrypoint.autofix_already_exists_states == [(existing_state.run_id, True)]
         assert self.entrypoint.autofix_run_ids == []
         assert self.entrypoint.autofix_errors == []
 
     @patch(
-        "sentry.seer.entrypoints.operator._trigger_autofix",
+        "sentry.seer.entrypoints.operator.trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch("sentry.seer.entrypoints.operator.get_autofix_state")
@@ -193,25 +209,31 @@ class SeerOperatorTest(TestCase):
         mock_get_autofix_state.return_value = existing_state
 
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
 
         mock_trigger_autofix_helper.assert_called_once()
         assert self.entrypoint.autofix_already_exists_states == []
         assert self.entrypoint.autofix_run_ids == [MOCK_RUN_ID]
 
-    @patch("sentry.seer.entrypoints.operator._trigger_autofix")
+    @patch("sentry.seer.entrypoints.operator.trigger_autofix")
     @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
-    def test_trigger_autofix_error(self, _mock_get_autofix_state, mock_trigger_autofix_helper):
+    def test_trigger_autofix_error(self, mock_get_autofix_state, mock_trigger_autofix_helper):
         mock_trigger_autofix_helper.return_value = Response(
             {"detail": "Invalid request"}, status=400
         )
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
         mock_trigger_autofix_helper.return_value = Response({"run_id": None}, status=202)
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
         assert mock_trigger_autofix_helper.call_count == 2
         self.operator.trigger_autofix(
@@ -228,7 +250,7 @@ class SeerOperatorTest(TestCase):
         assert self.entrypoint.autofix_run_ids == []
 
     @patch(
-        "sentry.seer.entrypoints.operator._trigger_autofix",
+        "sentry.seer.entrypoints.operator.trigger_autofix",
         return_value=Response({"run_id": MOCK_RUN_ID}, status=202),
     )
     @patch("sentry.seer.entrypoints.operator.get_autofix_state", return_value=None)
@@ -236,11 +258,13 @@ class SeerOperatorTest(TestCase):
     def test_trigger_autofix_creates_cache_payload(
         self,
         mock_populate_post_autofix_cache,
-        _mock_get_autofix_state,
-        _mock_trigger_autofix_helper,
+        mock_get_autofix_state,
+        mock_trigger_autofix_helper,
     ):
         self.operator.trigger_autofix(
-            group=self.group, user=self.user, stopping_point=AutofixStoppingPoint.ROOT_CAUSE
+            group=self.group,
+            user=self.user,
+            stopping_point=AutofixStoppingPoint.ROOT_CAUSE,
         )
         mock_populate_post_autofix_cache.assert_called_with(
             entrypoint_key=MockEntrypoint.key,


### PR DESCRIPTION
Add basic support for explorer autofix in the slack operator to trigger various steps in the integration.

Missing:
- support for opening PRs
- handling the webhooks and new response format