### PR TITLE
feat(autofix): Add seer-slack-workflows-explorer flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -443,6 +443,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Workflows in Slack
     manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Additionally allow users with `autofix-on-explorer` flags to use this feature.
+    manager.add("organizations:seer-slack-workflows-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new compact issue alert UI in Slack
     manager.add("organizations:slack-compact-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer in Slack via @mentions

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -82,7 +82,7 @@ class SeerOperator[CachePayloadT]:
         # at the moment, won't be visible in-app to users with this flag.
         # This check can only be removed once this feature migrates to explorer-based autofix.
         if features.has("organizations:autofix-on-explorer", organization):
-            return False
+            return not features.has("organizations:seer-slack-workflows-explorer", organization)
 
         if entrypoint_key:
             if entrypoint_key not in entrypoint_registry.registrations:

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -81,8 +81,10 @@ class SeerOperator[CachePayloadT]:
         # The explorer autofix pipeline and history is entirely separate, so the runs we trigger
         # at the moment, won't be visible in-app to users with this flag.
         # This check can only be removed once this feature migrates to explorer-based autofix.
-        if features.has("organizations:autofix-on-explorer", organization):
-            return not features.has("organizations:seer-slack-workflows-explorer", organization)
+        if features.has("organizations:autofix-on-explorer", organization) and not features.has(
+            "organizations:seer-slack-workflows-explorer", organization
+        ):
+            return False
 
         if entrypoint_key:
             if entrypoint_key not in entrypoint_registry.registrations:


### PR DESCRIPTION
This new flag means we can roll out seer-slack-workflows for users on autofix-on-explorer via another feature flag so the 2 can be rolled out in a decoupled way.