### PR TITLE
fix(flags): Convert Unleash createdByUserId to str in _get_user

### DIFF
--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -303,7 +303,7 @@ def _get_user(validated_event: dict[str, Any]) -> tuple[str, int]:
     except ValidationError:
         pass
 
-    if "createdByUserId" in validated_event:
+    if validated_event.get("createdByUserId") is not None:
         return str(validated_event["createdByUserId"]), CREATED_BY_TYPE_MAP["id"]
     return created_by, CREATED_BY_TYPE_MAP["name"]
 

--- a/src/sentry/flags/providers.py
+++ b/src/sentry/flags/providers.py
@@ -304,7 +304,7 @@ def _get_user(validated_event: dict[str, Any]) -> tuple[str, int]:
         pass
 
     if "createdByUserId" in validated_event:
-        return validated_event["createdByUserId"], CREATED_BY_TYPE_MAP["id"]
+        return str(validated_event["createdByUserId"]), CREATED_BY_TYPE_MAP["id"]
     return created_by, CREATED_BY_TYPE_MAP["name"]
 
 

--- a/tests/sentry/flags/providers/test_unleash.py
+++ b/tests/sentry/flags/providers/test_unleash.py
@@ -21,7 +21,7 @@ def test_handle_update_no_email() -> None:
     assert len(items) == 1
     assert items[0]["action"] == 2
     assert items[0]["created_at"] == datetime(2024, 12, 30, 0, 0, tzinfo=timezone.utc)
-    assert items[0]["created_by"] == 1
+    assert items[0]["created_by"] == "1"
     assert items[0]["created_by_type"] == 1
     assert items[0]["flag"] == "test-flag"
     assert items[0]["organization_id"] == 123


### PR DESCRIPTION
The createdByUserId code path returned a raw int, but FlagAuditLogRow expects created_by to be str.
