### PR TITLE
ref: Delete SessionsQueryConfig and inline AllowedResolution.ten_seconds

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -116,14 +116,11 @@ class OrganizationSessionsEndpoint(OrganizationEndpoint):
         except NoProjects:
             raise NoProjects("No projects available")  # give it a description
 
-        query_config = release_health.backend.sessions_query_config(organization)
-
         return QueryDefinition(
             query=request.GET,
             params=params,
             offset=offset,
             limit=limit,
-            query_config=query_config,
         )
 
     @contextmanager

--- a/src/sentry/api/endpoints/release_thresholds/utils/fetch_sessions_data.py
+++ b/src/sentry/api/endpoints/release_thresholds/utils/fetch_sessions_data.py
@@ -42,15 +42,10 @@ def fetch_sessions_data(
         query_params["start"] = start.isoformat()
         query_params["end"] = end.isoformat()
 
-        # crash free rates are on a dynamic INTERVAL basis
-        # TODO: determine how this affects results for new releases
-        query_config = release_health.backend.sessions_query_config(organization)
-
         # NOTE: params start/end are overwritten by query start/end
         query = QueryDefinition(
             query=query_params,
             params=params,
-            query_config=query_config,
         )
 
         return release_health.backend.run_sessions_query(

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Mapping, Sequence
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeIs, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, TypedDict, TypeIs, TypeVar, Union
 
 from sentry.utils.services import Service
 
@@ -16,8 +15,6 @@ OrganizationId = int
 ReleaseName = str
 EnvironmentName = str
 DateString = str
-
-SnubaAppID = "metrics.release_health"
 
 #: The functions supported by `run_sessions_query`
 SessionsQueryFunction = Literal[
@@ -58,25 +55,6 @@ class AllowedResolution(Enum):
     one_hour = (3600, "one hour")
     one_minute = (60, "one minute")
     ten_seconds = (10, "ten seconds")
-
-
-@dataclass(frozen=True)
-class SessionsQueryConfig:
-    """Backend-dependent config for sessions_v2 query"""
-
-    allowed_resolution: AllowedResolution
-    allow_session_status_query: bool
-    restrict_date_range: bool
-
-
-class SessionsQuery(TypedDict):
-    org_id: OrganizationId
-    project_ids: Sequence[ProjectId]
-    select_fields: Sequence[SessionsQueryFunction]
-    filter_query: Mapping[FilterFieldName, str]
-    start: datetime
-    end: datetime
-    rollup: int  # seconds
 
 
 SessionsQueryValue = Union[None, float]
@@ -251,7 +229,6 @@ class ReleaseHealthBackend(Service):
         "check_has_health_data",
         "get_release_sessions_time_bounds",
         "check_releases_have_health_data",
-        "sessions_query_config",
         "run_sessions_query",
         "get_release_health_data_overview",
         "get_crash_free_breakdown",
@@ -325,10 +302,6 @@ class ReleaseHealthBackend(Service):
             that. Omit if you're not sure.
         """
 
-        raise NotImplementedError()
-
-    def sessions_query_config(self, organization: Any) -> SessionsQueryConfig:
-        """Return the backend-dependent config for sessions_v2.QueryDefinition"""
         raise NotImplementedError()
 
     def run_sessions_query(

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -10,7 +10,6 @@ from snuba_sdk.expressions import Granularity, Limit, Offset
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.release_health.base import (
-    AllowedResolution,
     CrashFreeBreakdown,
     CurrentAndPreviousCrashFreeRates,
     EnvironmentName,
@@ -28,7 +27,6 @@ from sentry.release_health.base import (
     ReleaseName,
     ReleasesAdoption,
     ReleaseSessionsTimeBounds,
-    SessionsQueryConfig,
     SessionsQueryResult,
     StatsPeriod,
 )
@@ -401,13 +399,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             rv[project_id, release] = adoption
 
         return rv
-
-    def sessions_query_config(self, organization: Any) -> SessionsQueryConfig:
-        return SessionsQueryConfig(
-            allowed_resolution=AllowedResolution.ten_seconds,
-            allow_session_status_query=True,
-            restrict_date_range=False,
-        )
 
     def run_sessions_query(
         self,
@@ -1006,10 +997,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             projects, where, org_id, rollup, summary_start, now
         )
 
-        # XXX: In order to be able to dual-read and compare results from both
-        # old and new backend, this should really go back through the
-        # release_health service instead of directly calling `self`. For now
-        # that makes the entire backend too hard to test though.
         release_adoption = self.get_release_adoption(project_releases, environments)
 
         rv: dict[ProjectRelease, ReleaseHealthOverview] = {}

--- a/src/sentry/seer/anomaly_detection/utils.py
+++ b/src/sentry/seer/anomaly_detection/utils.py
@@ -124,7 +124,6 @@ def get_crash_free_historical_data(
         params=params,
         offset=None,
         limit=None,
-        query_config=release_health.backend.sessions_query_config(organization),
     )
     result = release_health.backend.run_sessions_query(
         organization.id, query, span_op="sessions.anomaly_detection"


### PR DESCRIPTION
SessionsQueryConfig was a single-field dataclass wrapping AllowedResolution, always set to ten_seconds in production. Remove the dataclass, the SESSIONS_QUERY_CONFIG constant, and the sessions_query_config() method on ReleaseHealthBackend. Hardcode AllowedResolution.ten_seconds directly in QueryDefinition.__init__ and remove the query_config parameter from all callers.
