### PR TITLE
ref(ui): Remove GroupStore usage from StreamGroup

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -344,7 +344,6 @@ function GroupList({
                 return (
                   <StreamGroup
                     key={group.id}
-                    id={group.id}
                     group={group}
                     canSelect={canSelectGroups}
                     withChart={withChart}

--- a/static/app/utils/dashboards/issueAssignee.tsx
+++ b/static/app/utils/dashboards/issueAssignee.tsx
@@ -1,11 +1,17 @@
+import {useCallback} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+
 import {
   AssigneeSelector,
   useHandleAssigneeChange,
 } from 'sentry/components/group/assigneeSelector';
 import MemberListStore from 'sentry/stores/memberListStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {Group} from 'sentry/types/group';
+import {setApiQueryData} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useGroup} from 'sentry/views/issueDetails/useGroup';
+import {makeFetchGroupQueryKey, useGroup} from 'sentry/views/issueDetails/useGroup';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 
 interface IssueAssigneeProps {
   groupId: string;
@@ -13,11 +19,31 @@ interface IssueAssigneeProps {
 
 export function IssueAssignee({groupId}: IssueAssigneeProps) {
   const organization = useOrganization();
+  const environments = useEnvironmentsFromUrl();
+  const queryClient = useQueryClient();
   const {data: group} = useGroup({groupId});
   const memberListState = useLegacyStore(MemberListStore);
+
+  // Update useGroup() query cache
+  const onSuccess = useCallback(
+    (assignedTo: Group['assignedTo']) => {
+      setApiQueryData<Group>(
+        queryClient,
+        makeFetchGroupQueryKey({
+          organizationSlug: organization.slug,
+          groupId,
+          environments,
+        }),
+        prev => (prev ? {...prev, assignedTo} : prev)
+      );
+    },
+    [queryClient, organization.slug, groupId, environments]
+  );
+
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
     group: group!,
     organization,
+    onSuccess,
   });
 
   if (!group) {

--- a/static/app/utils/dashboards/issueAssignee.tsx
+++ b/static/app/utils/dashboards/issueAssignee.tsx
@@ -2,11 +2,10 @@ import {
   AssigneeSelector,
   useHandleAssigneeChange,
 } from 'sentry/components/group/assigneeSelector';
-import GroupStore from 'sentry/stores/groupStore';
 import MemberListStore from 'sentry/stores/memberListStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import type {Group} from 'sentry/types/group';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useGroup} from 'sentry/views/issueDetails/useGroup';
 
 interface IssueAssigneeProps {
   groupId: string;
@@ -14,8 +13,7 @@ interface IssueAssigneeProps {
 
 export function IssueAssignee({groupId}: IssueAssigneeProps) {
   const organization = useOrganization();
-  const groups = useLegacyStore(GroupStore);
-  const group = groups.find(item => item.id === groupId) as Group | undefined;
+  const {data: group} = useGroup({groupId});
   const memberListState = useLegacyStore(MemberListStore);
   const {handleAssigneeChange, assigneeLoading} = useHandleAssigneeChange({
     group: group!,

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -5,7 +5,6 @@ import {UserFixture} from 'sentry-fixture/user';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import GroupStore from 'sentry/stores/groupStore';
 import MemberListStore from 'sentry/stores/memberListStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {getIssueFieldRenderer} from 'sentry/utils/dashboards/issueFieldRenderers';
@@ -98,7 +97,10 @@ describe('getIssueFieldRenderer', () => {
           name: 'Test User',
         },
       });
-      GroupStore.add([group]);
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${group.id}/`,
+        body: group,
+      });
       const renderer = getIssueFieldRenderer('assignee', {});
 
       render(
@@ -108,7 +110,7 @@ describe('getIssueFieldRenderer', () => {
           theme,
         }) as React.ReactElement
       );
-      await userEvent.hover(screen.getByText('TU'));
+      await userEvent.hover(await screen.findByText('TU'));
       expect(await screen.findByText('Assigned to Test User')).toBeInTheDocument();
     });
 

--- a/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.spec.tsx
@@ -3,7 +3,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import MemberListStore from 'sentry/stores/memberListStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -112,6 +112,78 @@ describe('getIssueFieldRenderer', () => {
       );
       await userEvent.hover(await screen.findByText('TU'));
       expect(await screen.findByText('Assigned to Test User')).toBeInTheDocument();
+    });
+
+    it('updates assignee when changed', async () => {
+      MemberListStore.loadInitialData([
+        UserFixture({
+          id: '1',
+          name: 'Test User',
+          email: 'test@sentry.io',
+        }),
+        UserFixture({
+          id: '2',
+          name: 'Next User',
+          email: 'next@sentry.io',
+        }),
+      ]);
+
+      const group = GroupFixture({
+        id: data.id,
+        project,
+        assignedTo: {
+          email: 'test@sentry.io',
+          type: 'user',
+          id: '1',
+          name: 'Test User',
+        },
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/${group.id}/`,
+        body: group,
+      });
+
+      const assignMock = MockApiClient.addMockResponse({
+        method: 'PUT',
+        url: `/organizations/${organization.slug}/issues/${group.id}/`,
+        body: {
+          ...group,
+          assignedTo: {
+            email: 'next@sentry.io',
+            type: 'user',
+            id: '2',
+            name: 'Next User',
+          },
+        },
+      });
+
+      const renderer = getIssueFieldRenderer('assignee', {});
+
+      render(
+        renderer(data, {
+          location,
+          organization,
+          theme,
+        }) as React.ReactElement
+      );
+
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Modify issue assignee'})
+      );
+      await userEvent.click(await screen.findByText('Next User'));
+
+      await waitFor(() =>
+        expect(assignMock).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/issues/${group.id}/`,
+          expect.objectContaining({
+            data: {assignedTo: 'user:2', assignedBy: 'assignee_selector'},
+          })
+        )
+      );
+
+      await userEvent.hover(await screen.findByText('NU'));
+      expect(await screen.findByText('Assigned to Next User')).toBeInTheDocument();
     });
 
     it('can render counts', async () => {

--- a/static/app/views/alerts/rules/issue/previewIssues.tsx
+++ b/static/app/views/alerts/rules/issue/previewIssues.tsx
@@ -5,6 +5,7 @@ import debounce from 'lodash/debounce';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import type {AssignableEntity} from 'sentry/components/assigneeSelectorDropdown';
 import {FieldHelp} from 'sentry/components/forms/fieldGroup/fieldHelp';
 import ListItem from 'sentry/components/list/listItem';
 import type {CursorHandler} from 'sentry/components/pagination';
@@ -160,6 +161,25 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
     fetchApiData(relevantRuleData, cursor);
   };
 
+  const handleAssigneeChange = useCallback(
+    (groupId: string, newAssignee: AssignableEntity | null) => {
+      setPreviewGroups(prev =>
+        prev.map(group => {
+          if (group.id !== groupId) {
+            return group;
+          }
+          return {
+            ...group,
+            assignedTo: newAssignee
+              ? {id: newAssignee.id, name: '', type: newAssignee.type}
+              : null,
+          };
+        })
+      );
+    },
+    []
+  );
+
   const errorMessage = previewError
     ? rule?.conditions.length || rule?.filters.length
       ? t('Preview is not supported for these conditions')
@@ -180,6 +200,7 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
           members={members}
           pageLinks={pageLinks}
           onCursor={onPreviewCursor}
+          onAssigneeChange={handleAssigneeChange}
           issueCount={issueCount}
           page={previewPage}
           isLoading={isLoading}

--- a/static/app/views/alerts/rules/issue/previewIssues.tsx
+++ b/static/app/views/alerts/rules/issue/previewIssues.tsx
@@ -171,7 +171,11 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
           return {
             ...group,
             assignedTo: newAssignee
-              ? {id: newAssignee.id, name: '', type: newAssignee.type}
+              ? {
+                  id: newAssignee.id,
+                  name: newAssignee.assignee.name,
+                  type: newAssignee.type,
+                }
               : null,
           };
         })

--- a/static/app/views/alerts/rules/issue/previewIssues.tsx
+++ b/static/app/views/alerts/rules/issue/previewIssues.tsx
@@ -9,9 +9,9 @@ import {FieldHelp} from 'sentry/components/forms/fieldGroup/fieldHelp';
 import ListItem from 'sentry/components/list/listItem';
 import type {CursorHandler} from 'sentry/components/pagination';
 import {t, tct} from 'sentry/locale';
-import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import type {IssueAlertRule, UnsavedIssueAlertRule} from 'sentry/types/alerts';
+import type {Group} from 'sentry/types/group';
 import type {Member} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import useApi from 'sentry/utils/useApi';
@@ -59,7 +59,7 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
   const isMounted = useIsMountedRef();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [previewError, setPreviewError] = useState<boolean>(false);
-  const [previewGroups, setPreviewGroups] = useState<string[]>([]);
+  const [previewGroups, setPreviewGroups] = useState<Group[]>([]);
   const [previewPage, setPreviewPage] = useState<number>(0);
   const [pageLinks, setPageLinks] = useState<string>('');
   const [issueCount, setIssueCount] = useState<number>(0);
@@ -112,11 +112,9 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
             return;
           }
 
-          GroupStore.add(data);
-
           const hits = resp?.getResponseHeader('X-Hits');
           const count = typeof hits !== 'undefined' && hits ? parseInt(hits, 10) : 0;
-          setPreviewGroups(data.map((g: any) => g.id));
+          setPreviewGroups(data);
           setPreviewError(false);
           setPageLinks(resp?.getResponseHeader('Link') ?? '');
           setIssueCount(count);
@@ -153,8 +151,6 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
   useEffect(() => {
     return () => {
       debouncedFetchApiData.cancel();
-      // Reset the group store when leaving
-      GroupStore.reset();
     };
   }, [debouncedFetchApiData]);
 
@@ -180,7 +176,7 @@ export function PreviewIssues({members, rule, project}: PreviewIssuesProps) {
       </StyledListItem>
       <ContentIndent>
         <PreviewTable
-          previewGroups={previewGroups}
+          groups={previewGroups}
           members={members}
           pageLinks={pageLinks}
           onCursor={onPreviewCursor}

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {indexMembersByProject} from 'sentry/actionCreators/members';
+import type {AssignableEntity} from 'sentry/components/assigneeSelectorDropdown';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import GroupListHeader from 'sentry/components/issues/groupListHeader';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -20,6 +21,7 @@ type Props = {
   isLoading: boolean;
   issueCount: number;
   members: Member[] | undefined;
+  onAssigneeChange: (groupId: string, newAssignee: AssignableEntity | null) => void;
   onCursor: CursorHandler;
   page: number;
   pageLinks: string;
@@ -30,6 +32,7 @@ function PreviewTable({
   members,
   pageLinks,
   onCursor,
+  onAssigneeChange,
   issueCount,
   page,
   isLoading,
@@ -67,6 +70,7 @@ function PreviewTable({
         canSelect={false}
         showLastTriggered
         withColumns={['assignee', 'event', 'lastTriggered', 'users']}
+        onAssigneeChange={newAssignee => onAssigneeChange(group.id, newAssignee)}
       />
     ));
   };

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -11,23 +11,22 @@ import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import StreamGroup from 'sentry/components/stream/group';
 import {t, tct} from 'sentry/locale';
-import GroupStore from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
 import type {Member} from 'sentry/types/organization';
 
 type Props = {
   error: string | null;
+  groups: Group[];
   isLoading: boolean;
   issueCount: number;
   members: Member[] | undefined;
   onCursor: CursorHandler;
   page: number;
   pageLinks: string;
-  previewGroups: string[];
 };
 
 function PreviewTable({
-  previewGroups,
+  groups,
   members,
   pageLinks,
   onCursor,
@@ -48,7 +47,7 @@ function PreviewTable({
         </EmptyStateWarning>
       );
     }
-    if (issueCount === 0) {
+    if (groups.length === 0) {
       return (
         <EmptyStateWarning>
           <p>{t("We couldn't find any issues that would've triggered your rule")}</p>
@@ -56,31 +55,27 @@ function PreviewTable({
       );
     }
     const memberList = indexMembersByProject(members);
-    return previewGroups.map(id => {
-      const group = GroupStore.get(id) as Group | undefined;
-
-      return (
-        <StreamGroup
-          key={id}
-          id={id}
-          hasGuideAnchor={false}
-          memberList={group?.project ? memberList[group.project.slug] : undefined}
-          displayReprocessingLayout={false}
-          useFilteredStats
-          withChart={false}
-          canSelect={false}
-          showLastTriggered
-          withColumns={['assignee', 'event', 'lastTriggered', 'users']}
-        />
-      );
-    });
+    return groups.map(group => (
+      <StreamGroup
+        key={group.id}
+        group={group}
+        hasGuideAnchor={false}
+        memberList={group.project ? memberList[group.project.slug] : undefined}
+        displayReprocessingLayout={false}
+        useFilteredStats
+        withChart={false}
+        canSelect={false}
+        showLastTriggered
+        withColumns={['assignee', 'event', 'lastTriggered', 'users']}
+      />
+    ));
   };
 
   const renderCaption = () => {
-    if (isLoading || error || !previewGroups) {
+    if (isLoading || error || !groups) {
       return null;
     }
-    const pageIssues = page * 5 + previewGroups.length;
+    const pageIssues = page * 5 + groups.length;
     return tct(`Showing [pageIssues] of [issueCount] issues`, {pageIssues, issueCount});
   };
 

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -331,6 +331,24 @@ describe('Dashboards > Dashboard', () => {
   describe('Issue Widgets', () => {
     beforeEach(() => {
       MemberListStore.init();
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/1/',
+        method: 'GET',
+        body: {
+          annotations: [],
+          id: '1',
+          title: 'Error: Failed',
+          project: {
+            id: '3',
+          },
+          assignedTo: {
+            email: 'test@sentry.io',
+            type: 'user',
+            id: '1',
+            name: 'Test User',
+          },
+        },
+      });
     });
 
     const mount = (dashboard: DashboardDetails) => {

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -18,7 +18,6 @@ import {loadOrganizationTags} from 'sentry/actionCreators/tags';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import {IconResize} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -189,7 +188,6 @@ function Dashboard({
       }
       window.removeEventListener('resize', debouncedHandleResize);
       window.clearTimeout(forceCheckTimeout.current);
-      GroupStore.reset();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
@@ -1,7 +1,6 @@
-import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {useCallback, useMemo, useRef} from 'react';
 
 import type {ApiResult} from 'sentry/api';
-import GroupStore from 'sentry/stores/groupStore';
 import type {Series} from 'sentry/types/echarts';
 import type {Group} from 'sentry/types/group';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
@@ -324,19 +323,6 @@ export function useIssuesTableQuery(
           },
       retryDelay: getRetryDelay,
     })),
-  });
-
-  // Populate GroupStore in effect (outside render phase)
-  // Track by data reference to avoid redundant calls
-  const prevGroupDataRef = useRef<IssuesTableResponse[]>([]);
-  useEffect(() => {
-    queryResults.forEach((q, i) => {
-      const data = q?.data?.[0];
-      if (data && data !== prevGroupDataRef.current[i]) {
-        GroupStore.add(data);
-        prevGroupDataRef.current[i] = data;
-      }
-    });
   });
 
   const transformedData = (() => {

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -21,7 +21,6 @@ import StreamGroup, {
 } from 'sentry/components/stream/group';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
-import GroupStore from 'sentry/stores/groupStore';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
@@ -58,21 +57,6 @@ function useMemberList() {
   }, [api, organization, isMountedRef]);
 
   return memberList;
-}
-
-function useSyncGroupStore(data: Group[] | undefined) {
-  useEffect(() => {
-    GroupStore.loadInitialData([]);
-    return () => {
-      GroupStore.reset();
-    };
-  }, []);
-
-  useEffect(() => {
-    if (data) {
-      GroupStore.add(data);
-    }
-  }, [data]);
 }
 
 export function IssuesWidget() {
@@ -112,9 +96,6 @@ export function IssuesWidget() {
     ],
     {staleTime: 0}
   );
-
-  // We need to sync group store with the data as StreamGroup retrieves data from the store
-  useSyncGroupStore(groups);
 
   const issuesUrl = useMemo(() => {
     return {
@@ -173,15 +154,15 @@ export function IssuesWidget() {
                 <Placeholder height="50px" />
               </GroupPlaceholder>
             ))
-          : groups.map(({id, project}) => {
+          : groups.map(group => {
               return (
                 <StreamGroup
-                  key={id}
-                  id={id}
+                  key={group.id}
+                  group={group}
                   canSelect={false}
                   withChart={breakpoints.xl}
                   withColumns={COLUMNS}
-                  memberList={memberList?.[project.slug]}
+                  memberList={memberList?.[group.project.slug]}
                   useFilteredStats={false}
                   statsPeriod={DEFAULT_STREAM_GROUP_STATS_PERIOD}
                   source="laravel-insights"

--- a/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
+++ b/static/app/views/insights/pages/platform/shared/issuesWidget.tsx
@@ -5,6 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
 import {fetchOrgMembers, indexMembersByProject} from 'sentry/actionCreators/members';
+import type {AssignableEntity} from 'sentry/components/assigneeSelectorDropdown';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import GroupListHeader from 'sentry/components/issues/groupListHeader';
@@ -24,7 +25,7 @@ import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import type {Group} from 'sentry/types/group';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 import {useIsMountedRef} from 'sentry/utils/useIsMountedRef';
@@ -64,6 +65,7 @@ export function IssuesWidget() {
   const organization = useOrganization();
   const memberList = useMemberList();
   const breakpoints = useBreakpoints();
+  const queryClient = useQueryClient();
 
   const {query} = useTransactionNameQuery();
 
@@ -80,22 +82,45 @@ export function IssuesWidget() {
     [datetimeSelection, pageFilters.environments, pageFilters.projects, query]
   );
 
+  const issuesQueryKey = [
+    getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
+      path: {organizationIdOrSlug: organization.slug},
+    }),
+    {
+      query: queryParams,
+    },
+  ] as const;
   const {
     data: groups,
     isPending,
     error,
     refetch,
-  } = useApiQuery<Group[]>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/issues/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {
-        query: queryParams,
-      },
-    ],
-    {staleTime: 0}
-  );
+  } = useApiQuery<Group[]>(issuesQueryKey, {
+    staleTime: 0,
+  });
+
+  const handleAssigneeChange = (
+    groupId: string,
+    newAssignee: AssignableEntity | null
+  ) => {
+    queryClient.setQueryData<Group[]>(issuesQueryKey, previousGroups =>
+      (previousGroups ?? []).map(previousGroup => {
+        if (previousGroup.id !== groupId) {
+          return previousGroup;
+        }
+        return {
+          ...previousGroup,
+          assignedTo: newAssignee
+            ? {
+                id: newAssignee.id,
+                name: newAssignee.assignee.name,
+                type: newAssignee.type,
+              }
+            : null,
+        };
+      })
+    );
+  };
 
   const issuesUrl = useMemo(() => {
     return {
@@ -166,6 +191,9 @@ export function IssuesWidget() {
                   useFilteredStats={false}
                   statsPeriod={DEFAULT_STREAM_GROUP_STATS_PERIOD}
                   source="laravel-insights"
+                  onAssigneeChange={newAssignee =>
+                    handleAssigneeChange(group.id, newAssignee)
+                  }
                 />
               );
             })}

--- a/static/app/views/issueList/groupListBody.tsx
+++ b/static/app/views/issueList/groupListBody.tsx
@@ -147,14 +147,18 @@ function GroupList({
         const hasGuideAnchor = id === topIssue;
         const group = GroupStore.get(id) as Group | undefined;
 
+        if (!group) {
+          return null;
+        }
+
         return (
           <StreamGroup
             key={id}
-            id={id}
+            group={group}
             statsPeriod={groupStatsPeriod}
             query={query}
             hasGuideAnchor={hasGuideAnchor}
-            memberList={group?.project ? memberList[group.project.slug] : undefined}
+            memberList={group.project ? memberList[group.project.slug] : undefined}
             displayReprocessingLayout={displayReprocessingLayout}
             useFilteredStats
             canSelect={!selectDisabled}

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -9,13 +9,14 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import StreamGroup from 'sentry/components/stream/group';
 import TagStore from 'sentry/stores/tagStore';
+import type {Group} from 'sentry/types/group';
 import IssueList from 'sentry/views/issueList/overview';
 
 jest.mock('sentry/views/issueList/filters', () => jest.fn(() => null));
 jest.mock('sentry/components/stream/group', () => ({
   __esModule: true,
-  default: jest.fn(({id}: {id: string}) => <div data-test-id={id} />),
-  LoadingStreamGroup: jest.fn(({id}: {id: string}) => <div data-test-id={id} />),
+  default: jest.fn(({group}: {group: Group}) => <div data-test-id={group.id} />),
+  LoadingStreamGroup: jest.fn(() => <div data-test-id="loading-group" />),
 }));
 
 jest.mock('js-cookie', () => ({


### PR DESCRIPTION
This requires that consumers of StreamGroup pass `group` instead of `id`, so the consumers are now responsible for owning the group data.

Surface area of the change:

- GroupList component (we were already handling assignee and priority changes so no big diff here)
- Dashboard issues widget (needed to add handling for changing the assignee)
- Issue alert preview issues (needed to update local state when changing assignee)

Here is the output from Claude testing with the `validate-changes` skill I've been working on:

```                                                                                        
  Validation Results Summary                                                                                       

  ┌───────┬──────────────────────────────────────────┬────────┐
  │ Group │                   Area                   │ Result │
  ├───────┼──────────────────────────────────────────┼────────┤
  │ 1     │ Issue Stream — Assignee Change           │ PASS   │
  ├───────┼──────────────────────────────────────────┼────────┤
  │ 2     │ Alert Rule Preview — Assignee Change     │ PASS   │
  ├───────┼──────────────────────────────────────────┼────────┤
  │ 3     │ Dashboard Issue Widget — Assignee Change │ PASS   │
  └───────┴──────────────────────────────────────────┴────────┘

  Overall: 3/3 groups passed. All assignee changes reflect immediately in the UI without page reloads. The
  dashboard even showed cross-widget propagation via the query cache, which is a nice bonus from the refactor.
```

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/7b29ff8c-981c-4d77-8dce-471aca36cded" />
