### PR TITLE
fix(api): Validate project authorization for qualified short IDs in group updates

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -357,9 +357,12 @@ def get_group_list(
             )
         )
     else:
+        project_ids = {p.id for p in projects}
         for group_id in group_ids:
             if isinstance(group_id, str):
-                groups.append(Group.objects.by_qualified_short_id(organization_id, group_id))
+                group = Group.objects.by_qualified_short_id(organization_id, group_id)
+                if group.project_id in project_ids:
+                    groups.append(group)
 
     return groups
 

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -360,7 +360,10 @@ def get_group_list(
         project_ids = {p.id for p in projects}
         for group_id in group_ids:
             if isinstance(group_id, str):
-                group = Group.objects.by_qualified_short_id(organization_id, group_id)
+                try:
+                    group = Group.objects.by_qualified_short_id(organization_id, group_id)
+                except Group.DoesNotExist:
+                    continue
                 if group.project_id in project_ids:
                     groups.append(group)
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -302,6 +302,19 @@ class UpdateGroupsTest(TestCase):
         assert group.status == GroupStatus.RESOLVED
         assert send_robust.called
 
+    def test_get_group_list_with_short_id_rejects_cross_project(self) -> None:
+        """Qualified short IDs from unauthorized projects must be filtered out."""
+        other_project = self.create_project(organization=self.organization, slug="other-project")
+        other_group = self.create_group(project=other_project, status=GroupStatus.UNRESOLVED)
+
+        # Passing [self.project] as authorized projects, but using other_project's short ID
+        group_list = get_group_list(
+            self.organization.id,
+            [self.project],
+            [other_group.qualified_short_id],
+        )
+        assert group_list == []
+
     def test_unresolve_clears_commit_resolution_links(self) -> None:
         """
         Test that when an issue is unresolved, commit resolution links are deleted

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1633,6 +1633,51 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
         assert Group.objects.filter(id=group1.id).exists()
 
+    def test_update_by_qualified_short_id_rejects_cross_project(self) -> None:
+        """Cannot modify issues in another project via qualified short ID."""
+        other_project = self.create_project(
+            organization=self.project.organization, slug="other-proj"
+        )
+        other_group = self.create_group(project=other_project, status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+        # Use self.path (project A) but pass a qualified short ID from other_project
+        url = f"{self.path}?id={other_group.qualified_short_id}"
+        response = self.client.put(url, data={"status": "resolved"}, format="json")
+
+        assert response.status_code == 204  # "No groups found"
+
+        other_group.refresh_from_db()
+        assert other_group.status == GroupStatus.UNRESOLVED
+
+    def test_update_by_qualified_short_id_rejects_cross_org(self) -> None:
+        """Cannot modify issues in a different organization via qualified short ID."""
+        other_org = self.create_organization(owner=self.create_user())
+        other_project = self.create_project(organization=other_org, slug="cross-org-proj")
+        other_group = self.create_group(project=other_project, status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+        url = f"{self.path}?id={other_group.qualified_short_id}"
+        response = self.client.put(url, data={"status": "resolved"}, format="json")
+
+        assert response.status_code == 204  # "No groups found"
+
+        other_group.refresh_from_db()
+        assert other_group.status == GroupStatus.UNRESOLVED
+
+    def test_update_by_qualified_short_id_allows_same_project(self) -> None:
+        """Can modify issues in the same project via qualified short ID."""
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+        url = f"{self.path}?id={group.qualified_short_id}"
+        response = self.client.put(url, data={"status": "resolved"}, format="json")
+
+        assert response.status_code == 200
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.RESOLVED
+
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     @cached_property


### PR DESCRIPTION
IDOR in `PUT /api/0/projects/{org_slug}/{project_slug}/issues/` — the `get_group_list()` function had two code paths for resolving group IDs:

1. **Numeric IDs** (secure): Filters by `project__in=projects`
2. **Qualified short IDs** (vulnerable): Called `by_qualified_short_id()` which only checks organization membership, completely ignoring the `projects` parameter

This allowed any org member with `event:write` on one project to read/modify issues in other projects within the same org by passing qualified short IDs (e.g. `?id=VICTIM-PROJECT-1`).

The fix adds project authorization to the qualified short ID path — after resolving a group via `by_qualified_short_id()`, we validate `group.project_id` is in the set of authorized project IDs. Unauthorized groups are silently filtered out, consistent with the numeric ID path behavior.