### PR TITLE
fix(tests): fix flaky substring match in preprod status check test

### DIFF
--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -1442,5 +1442,5 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
                 create_preprod_status_check_task(skipped.id)
 
             kwargs = mock_provider.create_status_check.call_args.kwargs
-            assert str(valid.id) in kwargs["target_url"]
-            assert str(skipped.id) not in kwargs["target_url"]
+            assert f"/size/{valid.id}" in kwargs["target_url"]
+            assert f"/size/{skipped.id}" not in kwargs["target_url"]


### PR DESCRIPTION
## Summary
- Use path-segment match (`/size/{id}`) instead of bare `str(id)` for URL containment checks in `test_skipped_triggering_artifact_uses_sibling_url`, preventing false matches when short numeric IDs appear as substrings of other numbers in the URL.