### PR TITLE
fix(tests): fix flaky tool count in AI conversations tests

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -1032,42 +1032,46 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=4),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            trace_id=trace_id,
-            tool_name="weather_api",
-        )
-
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=3),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            trace_id=trace_id,
-            tool_name="calculator",
-        )
-
-        # Duplicate tool call should not create duplicate entry
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=2),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            trace_id=trace_id,
-            tool_name="weather_api",
-        )
-
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            trace_id=trace_id,
-            tool_name="search",
-        )
+        spans = [
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=4),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                trace_id=trace_id,
+                tool_name="weather_api",
+                store=False,
+            ),
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=3),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                trace_id=trace_id,
+                tool_name="calculator",
+                store=False,
+            ),
+            # Duplicate tool call should not create duplicate entry
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=2),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                trace_id=trace_id,
+                tool_name="weather_api",
+                store=False,
+            ),
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=1),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                trace_id=trace_id,
+                tool_name="search",
+                store=False,
+            ),
+        ]
+        self.store_spans(spans)
 
         query = {
             "project": [self.project.id],
@@ -1091,49 +1095,53 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
-        # Successful tool call
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=4),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            status="ok",
-            trace_id=trace_id,
-            tool_name="weather_api",
-        )
-
-        # Failed tool call
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=3),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            status="internal_error",
-            trace_id=trace_id,
-            tool_name="database_query",
-        )
-
-        # Another failed tool call
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=2),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            status="resource_exhausted",
-            trace_id=trace_id,
-            tool_name="external_api",
-        )
-
-        # Successful tool call
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.execute_tool",
-            operation_type="tool",
-            status="ok",
-            trace_id=trace_id,
-            tool_name="calculator",
-        )
+        spans = [
+            # Successful tool call
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=4),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                status="ok",
+                trace_id=trace_id,
+                tool_name="weather_api",
+                store=False,
+            ),
+            # Failed tool call
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=3),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                status="internal_error",
+                trace_id=trace_id,
+                tool_name="database_query",
+                store=False,
+            ),
+            # Another failed tool call
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=2),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                status="resource_exhausted",
+                trace_id=trace_id,
+                tool_name="external_api",
+                store=False,
+            ),
+            # Successful tool call
+            self.store_ai_span(
+                conversation_id=conversation_id,
+                timestamp=now - timedelta(seconds=1),
+                op="gen_ai.execute_tool",
+                operation_type="tool",
+                status="ok",
+                trace_id=trace_id,
+                tool_name="calculator",
+                store=False,
+            ),
+        ]
+        self.store_spans(spans)
 
         query = {
             "project": [self.project.id],

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations_base.py
@@ -38,6 +38,7 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
         output_messages=None,
         system_instructions=None,
         tool_definitions=None,
+        store=True,
     ):
         """Create and store an AI span with the given attributes.
 
@@ -114,5 +115,6 @@ class BaseAIConversationsTestCase(BaseSpansTestCase, SpanTestCase, APITestCase):
             extra_data,
             start_ts=timestamp,
         )
-        self.store_spans([span])
+        if store:
+            self.store_spans([span])
         return span


### PR DESCRIPTION
## Summary
- Batch-store tool spans in a single `store_spans` call instead of 4 individual inserts in `test_tool_names_populated` and `test_tool_errors_counted`. Multiple separate inserts to ClickHouse can result in not all rows being visible to a subsequent query due to eventual consistency, causing `toolCalls` count to intermittently be 3 instead of 4.
- Add `store` parameter to `store_ai_span` helper (default `True`) so tests can build spans without auto-storing, then batch them.