### PR TITLE
core(styling) drop double serializers

### DIFF
--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react';
-import {css, useTheme, type SerializedStyles} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 
 import type {
   BorderVariant,
@@ -20,7 +20,7 @@ export function rc<T>(
     breakpoint: BreakpointSize | undefined,
     theme: Theme
   ) => string | undefined
-): SerializedStyles | undefined {
+): string | undefined {
   // Most values are unlikely to be responsive, so we can resolve
   // them directly and return early.
   if (!isResponsive(value)) {
@@ -31,39 +31,37 @@ export function rc<T>(
       return undefined;
     }
 
-    return css`
-      ${property}: ${resolvedValue as string};
-    `;
+    return `${property}: ${resolvedValue as string};`;
   }
 
   let first = true;
-  return css`
-    ${BREAKPOINT_ORDER.map(breakpoint => {
-      const v = value[breakpoint];
-      const resolvedValue = resolver ? resolver(v, breakpoint, theme) : v;
+  return BREAKPOINT_ORDER.map(breakpoint => {
+    const v = value[breakpoint];
+    const resolvedValue = resolver ? resolver(v, breakpoint, theme) : v;
 
-      // A resolver can return undefined to indicate that the value should be omitted.
-      if (resolvedValue === undefined) {
-        return undefined;
-      }
+    // A resolver can return undefined to indicate that the value should be omitted.
+    if (resolvedValue === undefined) {
+      return undefined;
+    }
 
-      if (first) {
-        first = false;
-        return css`
+    if (first) {
+      first = false;
+      return `
           @media (min-width: ${theme.breakpoints[breakpoint]}),
             (max-width: ${theme.breakpoints[breakpoint]}) {
             ${property}: ${resolver ? resolver(v, breakpoint, theme) : (v as string)};
-          }
+          };
         `;
-      }
+    }
 
-      return css`
+    return `
         @media (min-width: ${theme.breakpoints[breakpoint]}) {
           ${property}: ${resolver ? resolver(v, breakpoint, theme) : (v as string)};
-        }
+        };
       `;
-    }).filter(Boolean)}
-  `;
+  })
+    .filter(Boolean)
+    .join('');
 }
 
 const BREAKPOINT_ORDER: readonly BreakpointSize[] = [

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -50,14 +50,14 @@ export function rc<T>(
           @media (min-width: ${theme.breakpoints[breakpoint]}),
             (max-width: ${theme.breakpoints[breakpoint]}) {
             ${property}: ${resolver ? resolver(v, breakpoint, theme) : (v as string)};
-          };
+          }
         `;
     }
 
     return `
         @media (min-width: ${theme.breakpoints[breakpoint]}) {
           ${property}: ${resolver ? resolver(v, breakpoint, theme) : (v as string)};
-        };
+        }
       `;
   })
     .filter(Boolean)


### PR DESCRIPTION
We are double parsing when we invoke css inside `rc`, as the final value is parsed anyways when used inside something like a styled component. Since we don't allow style: {{width: rc(...)}}, it means we can bailout and just return the string value.

Since values are not statically analyzable in rc, keeping css here doesn't actually help us with linting and is unlikely to catch anything.
