### PR TITLE
fix(tests): fix flaky replay data export tests

### DIFF
--- a/tests/sentry/replays/conftest.py
+++ b/tests/sentry/replays/conftest.py
@@ -7,10 +7,12 @@ from django.conf import settings
 
 class ReplayStore:
     def save(self, data: dict[str, Any]) -> None:
+        self.save_all([data])
+
+    def save_all(self, data: list[dict[str, Any]]) -> None:
         request_url = settings.SENTRY_SNUBA + "/tests/entities/replays/insert"
-        response = requests.post(request_url, json=[data])
+        response = requests.post(request_url, json=data)
         assert response.status_code == 200
-        return None
 
 
 @pytest.fixture

--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -31,11 +31,15 @@ def test_export_clickhouse_rows(replay_store) -> None:  # type: ignore[no-untype
     t2 = t0 + datetime.timedelta(minutes=2)
     t3 = t0 + datetime.timedelta(minutes=3)
 
-    replay_store.save(mock_replay(t1, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=1))
-    replay_store.save(mock_replay(t3, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save_all(
+        [
+            mock_replay(t1, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=1),
+            mock_replay(t3, 1, replay4_id, segment_id=0),
+            mock_replay(t2, 2, replay5_id, segment_id=0),
+        ]
+    )
 
     query_fn = lambda limit, offset: query_replays_dataset(1, t0, t3, limit, offset)
     rows = list(export_clickhouse_rows(query_fn, limit=1, num_pages=10))
@@ -52,9 +56,13 @@ def test_export_replay_row_set(replay_store) -> None:  # type: ignore[no-untyped
     t1 = t0 + datetime.timedelta(seconds=30)
     t2 = t0 + datetime.timedelta(minutes=1)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
+    replay_store.save_all(
+        [
+            mock_replay(t0, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=0),
+        ]
+    )
 
     class Sink:
         def __init__(self) -> None:
@@ -98,11 +106,15 @@ def test_get_replay_date_query_ranges(replay_store) -> None:  # type: ignore[no-
     t1 = t0 + datetime.timedelta(days=10)
     t2 = t0 + datetime.timedelta(days=20)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save_all(
+        [
+            mock_replay(t0, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=0),
+            mock_replay(t2, 1, replay4_id, segment_id=0),
+            mock_replay(t2, 2, replay5_id, segment_id=0),
+        ]
+    )
 
     results = list(get_replay_date_query_ranges(1))
     assert len(results) == 3


### PR DESCRIPTION
## Summary
- Batch-store replays in a single insert call instead of individual inserts to avoid ClickHouse eventual consistency issues where not all rows are visible to a subsequent query.
- Adds `save_all` batch method to the `ReplayStore` test fixture and refactors `save` to use it.