### PR TITLE
fix(tests): fix flaky widget ordering in dashboard details test

### DIFF
--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -760,11 +760,10 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
         assert response.status_code == 204
 
     def test_allow_delete_as_superuser_but_no_edit_perms(self) -> None:
-        self.create_user(id=12333)
+        other_user = self.create_user()
         dashboard = Dashboard.objects.create(
-            id=67,
             title="Dashboard With Dataset Source",
-            created_by_id=12333,
+            created_by_id=other_user.id,
             organization=self.organization,
         )
         DashboardPermissions.objects.create(is_editable_by_everyone=False, dashboard=dashboard)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -44,6 +44,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         super().setUp()
         self.widget_1 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=0,
             title="Widget 1",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -52,6 +53,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         )
         self.widget_2 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=1,
             title="Widget 2",
             display_type=DashboardWidgetDisplayTypes.TABLE,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -905,12 +907,14 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         self.create_user_member_role()
         self.widget_3 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=2,
             title="Widget 3",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
         )
         self.widget_4 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=3,
             title="Widget 4",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -1657,7 +1661,9 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200
 
         widgets = self.get_widgets(self.dashboard.id)
-        self.assert_serialized_widget(data["widgets"][0], widgets[0])
+        assert len(widgets) == 4
+        widget_1 = next(w for w in widgets if w.id == self.widget_1.id)
+        self.assert_serialized_widget(data["widgets"][0], widget_1)
 
     def test_update_widget_add_query(self) -> None:
         data: dict[str, Any] = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1837,12 +1837,17 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
 
         widgets = self.get_widgets(self.dashboard.id)
         assert len(widgets) == 4
-        # Check ordering
-        assert self.widget_1.id == widgets[0].id
-        assert self.widget_2.id == widgets[1].id
-        assert self.widget_4.id == widgets[2].id
-        # The new widget was added to the end, this is because the order is based on the id
-        self.assert_serialized_widget(data["widgets"][2], widgets[3])
+        widget_ids = {w.id for w in widgets}
+        # Existing widgets 1, 2, 4 are kept; widget 3 was removed
+        assert self.widget_1.id in widget_ids
+        assert self.widget_2.id in widget_ids
+        assert self.widget_4.id in widget_ids
+        # A new widget was created
+        new_widget = [
+            w for w in widgets if w.id not in {self.widget_1.id, self.widget_2.id, self.widget_4.id}
+        ]
+        assert len(new_widget) == 1
+        self.assert_serialized_widget(data["widgets"][2], new_widget[0])
 
     def test_update_widget_invalid_aggregate_parameter(self) -> None:
         data = {

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -2636,16 +2636,15 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 403
 
     def test_all_users_can_edit_dashboard_with_edit_permissions_disabled(self) -> None:
-        self.create_user(id=12333)
+        creator = self.create_user()
         dashboard = Dashboard.objects.create(
-            id=67,
             title="Dashboard With Dataset Source",
-            created_by_id=12333,
+            created_by_id=creator.id,
             organization=self.organization,
         )
         DashboardPermissions.objects.create(is_editable_by_everyone=True, dashboard=dashboard)
 
-        user = self.create_user(id=3456)
+        user = self.create_user()
         self.create_member(user=user, organization=self.organization)
         self.login_as(user)
 


### PR DESCRIPTION
## Summary
- Fix `test_remove_widget_and_add_new`: widgets have `order=NULL` making ordering non-deterministic; replaced positional assertions with set-based checks
- Fix `test_allow_delete_as_superuser_but_no_edit_perms`: remove hardcoded IDs that collide with auto-generated IDs (#109019)
- Fix `test_all_users_can_edit_dashboard_with_edit_permissions_disabled`: same hardcoded ID collision (#108897)
- Set explicit `order=` on widgets in setUp for deterministic ordering (#108827)
- Fix `test_update_widget_title` to look up widget by ID instead of index (#108662)

Combines #109019, #108897, #108827, #108662.
Fixes #109000
Fixes #108998