### PR TITLE
fix(aci): Switch organizations:more-workflows to a flagpole feature

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -205,7 +205,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:more-fast-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable higher limit for workflows
-    manager.add("organizations:more-workflows", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
+    manager.add("organizations:more-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Normalize segment names during span enrichment
     manager.add("organizations:normalize_segment_names_in_span_enrichment", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Extract on demand metrics


### PR DESCRIPTION
The flag was marked internally to be consistent with the existing flags for fast and slow options that are managed with in-code getsentry configuration.
It's not clear that this is the right approach, and it limits our ability to be responsive to LA users, so we can make it flagpole-based for now.
