### PR TITLE
fix(uptime): fix flaky test by replacing hardcoded date with relative time

### DIFF
--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -237,7 +237,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             recovery_threshold=2,
         )
 
-        base_time = datetime(2025, 10, 29, 13, 30, 0, tzinfo=timezone.utc)
+        base_time = MOCK_DATETIME - timedelta(hours=1)
 
         test_scenarios = [
             # 2 OK checks before incident

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -237,6 +237,10 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             recovery_threshold=2,
         )
 
+        # Use a relative timestamp instead of a hardcoded date. The original
+        # hardcoded date (2025-10-29) gradually drifted past the 90-day EAP
+        # data retention window, causing ClickHouse to silently drop the test
+        # data and return empty results.
         base_time = MOCK_DATETIME - timedelta(hours=1)
 
         test_scenarios = [


### PR DESCRIPTION
## Summary
- The `test_missing_ok_checks_around_downtime` test used a hardcoded date (`datetime(2025, 10, 29, ...)`) that has now exceeded the 90-day `retention_days` set on EAP TraceItems stored in ClickHouse
- ClickHouse can silently drop or filter data beyond retention during background merges, causing the Snuba query to return no results for that subscription_id
- This results in a `KeyError` when the test tries to access the detector's data in the response
- Replaced the hardcoded date with `MOCK_DATETIME - timedelta(hours=1)` to ensure timestamps always remain within retention

Fixes #108635