### PR TITLE
fix(feedback): fix flaky test by adding explicit timestamps to feedbacks

### DIFF
--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -80,14 +80,17 @@ class TestLabelQuery(APITestCase):
         self._create_feedback(
             "UI issue 1",
             ["User Interface", "Performance"],
+            dt=before_now(hours=3),
         )
         self._create_feedback(
             "UI issue 2",
             ["Checkout", "User Interface"],
+            dt=before_now(hours=2),
         )
         self._create_feedback(
             "UI issue 3",
             ["Performance", "User Interface", "Colors"],
+            dt=before_now(hours=1),
         )
 
         result = query_top_ai_labels_by_feedback_count(


### PR DESCRIPTION
## Summary
- `test_query_top_ai_labels_by_feedback_count` created feedbacks without explicit timestamps, causing all three to share the same default timestamp (`now() - 5min`)
- With Snuba eventual consistency, partial data ingestion could result in tied label counts (e.g., "User Interface"=2 vs "Performance"=2 instead of 3 vs 2) and non-deterministic ordering
- Added distinct timestamps (`before_now(hours=3/2/1)`) to each feedback to ensure reliable ingestion and deterministic count results

Fixes #108638