### PR TITLE
fix(preprod): fix flaky test by avoiding search field collisions

### DIFF
--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
@@ -28,7 +28,7 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
         commit_comparison = self.create_commit_comparison(
             organization=self.org,
             head_sha="abcdefabcdefabcdefabcdefabcdefabcdefabcd",
-            base_sha="fedcbafedcbafedcbafedcbafedcbafedcbafedcb",
+            base_sha="fedcbafedcbafedcbafedcbafedcbafedcbafedc",
             provider="github",
             head_repo_name="owner/repo",
             base_repo_name="owner/repo",

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
@@ -27,14 +27,14 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
 
         commit_comparison = self.create_commit_comparison(
             organization=self.org,
-            head_sha="1234567890098765432112345678900987654321",
-            base_sha="9876543210012345678998765432100123456789",
+            head_sha="abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+            base_sha="fedcbafedcbafedcbafedcbafedcbafedcbafedcb",
             provider="github",
             head_repo_name="owner/repo",
             base_repo_name="owner/repo",
             head_ref="feature/xyz",
             base_ref="main",
-            pr_number=123,
+            pr_number=99000123,
         )
 
         self.artifact1 = self.create_preprod_artifact(
@@ -331,7 +331,7 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
 
     def test_list_builds_search_by_commit_sha(self) -> None:
         response = self.client.get(
-            f"{self._get_url()}?project={self.project.id}&project={self.project2.id}&query=123456789009876543211234567890",
+            f"{self._get_url()}?project={self.project.id}&project={self.project2.id}&query=abcdefabcdefabcdef",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
         )
@@ -349,7 +349,7 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
 
     def test_list_builds_search_by_pr_number(self) -> None:
         response = self.client.get(
-            f"{self._get_url()}?project={self.project.id}&project={self.project2.id}&query=123",
+            f"{self._get_url()}?project={self.project.id}&project={self.project2.id}&query=99000123",
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
         )


### PR DESCRIPTION
## Summary
- `test_list_builds_search_by_build_id` searches with `query={artifact.id}` and expects 1 result, but the endpoint's search does an OR query across `id`, `pr_number`, and `head_sha` (icontains)
- The old `head_sha` (`"1234567890..."`) contained most small numbers as substrings, causing auto-incremented artifact IDs to accidentally match all 4 artifacts via `head_sha__icontains`
- Additionally, `pr_number=123` could collide with auto-incremented artifact IDs
- Changed `head_sha` to all-letter hex (`"abcdefab..."`) and `pr_number` to `99000123` to eliminate collisions

Fixes #108637