### PR TITLE
fix(models): fix flaky test_without_snowflake sequence assertion

### DIFF
--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -61,21 +61,14 @@ class TeamTest(TestCase):
     def test_without_snowflake(self) -> None:
         user = self.create_user()
         org = self.create_organization(owner=user)
-
-        with connection.cursor() as cursor:
-            cursor.execute("SELECT last_value FROM sentry_team_id_seq")
-            id_before = cursor.fetchone()[0]
-
         team = self.create_team(organization=org)
 
+        # When snowflake is disabled, the ID should come from the PostgreSQL sequence
         with connection.cursor() as cursor:
             cursor.execute("SELECT last_value FROM sentry_team_id_seq")
-            id_after = cursor.fetchone()[0]
+            seq_value = cursor.fetchone()[0]
 
-        # When snowflake is disabled, the ID should advance by exactly 1
-        # (Tests that we used regular auto-increment, not snowflake generation)
-        assert id_after == id_before + 1
-        assert team.id == id_after
+        assert team.id == seq_value
         assert Team.objects.filter(id=team.id).exists()
 
 


### PR DESCRIPTION
## Summary
- `test_without_snowflake` asserted `id_after == id_before + 1` by reading the PostgreSQL sequence's `last_value` before and after creating a team
- This fails when the sequence has never been used (`is_called=false`), because PostgreSQL's first `nextval()` returns the start value (1) without advancing `last_value` — both reads return 1, so `1 != 1 + 1`
- Simplified the assertion to verify that the team's ID matches the sequence's `last_value` after creation, which correctly validates that the sequence was used regardless of its prior state

Fixes #108636