### PR TITLE
fix(devserver): improve HMR and liveReload for reverse proxy

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -655,13 +655,18 @@ if (
       watch: true,
     },
     host: SENTRY_WEBPACK_PROXY_HOST,
-    hot: SHOULD_HOT_MODULE_RELOAD,
+    hot: SHOULD_HOT_MODULE_RELOAD ? 'only' : false,
+    liveReload: !SENTRY_DEVSERVER_NGROK,
     port: Number(SENTRY_WEBPACK_PROXY_PORT),
     devMiddleware: {
       stats: 'errors-only',
     },
     client: {
       overlay: false,
+      // When behind a reverse proxy (ngrok/Coder), the WebSocket client must
+      // derive its URL from window.location instead of the dev server's host.
+      // Without this, HMR tries ws://127.0.0.1:8000/ws which is unreachable.
+      ...(SENTRY_DEVSERVER_NGROK && {webSocketURL: 'auto://0.0.0.0:0/ws'}),
     },
   };
 


### PR DESCRIPTION
## Summary
Three changes to the rspack dev server config for better reverse proxy compatibility (ngrok, Coder, etc.):

- **`hot: 'only'`** instead of `hot: true` when HMR is enabled — prevents failed HMR updates from falling back to full page reload (which causes flickering)
- **`liveReload: !SENTRY_DEVSERVER_NGROK`** — disables WebSocket-based live reload through reverse proxies (prevents a rapid page refresh loop at ~5.6/sec)
- **`webSocketURL: 'auto://0.0.0.0:0/ws'`** when behind a proxy — tells the HMR WebSocket client to derive its URL from `window.location` instead of the dev server's host. Without this, HMR tries `ws://127.0.0.1:8000/ws` which is unreachable from the browser through the proxy.

These changes only affect behavior when using `SENTRY_UI_HOT_RELOAD=1` (for hot) and `SENTRY_DEVSERVER_NGROK` (for liveReload and webSocketURL). Local development without these env vars is completely unaffected.

### `hot: 'only'`
With plain `hot: true`, failed HMR updates call `window.location.reload()` as a fallback. With `'only'`, the update is silently dropped — the developer can manually refresh when needed. This prevents flickering when HMR can't apply a change (e.g., non-React module changes).

### `liveReload: !SENTRY_DEVSERVER_NGROK`
rspack's dev server liveReload uses a WebSocket connection to trigger full page reloads when files change. Through reverse proxies, this WebSocket connection is unstable and causes rapid reload loops. Disabling it when behind a proxy (detected via `SENTRY_DEVSERVER_NGROK`) fixes this. Local development retains the default `liveReload: true`.

### `webSocketURL: 'auto://0.0.0.0:0/ws'`
By default, the rspack HMR client connects to `ws://{devServerHost}:{devServerPort}/ws` — which resolves to `ws://127.0.0.1:8000/ws`. This is unreachable when the browser accesses the devserver through a reverse proxy. The `auto://0.0.0.0:0/ws` format tells the client to derive protocol, hostname, and port from `window.location`, so it connects to `wss://sentry-dev--workspace--owner.coder.sentry.dev/ws` instead.

`SENTRY_DEVSERVER_NGROK` is already read in this file (line 78) and used for `allowedHosts` (line 651).

## Test plan
- [ ] Verify local `sentry devserver` still works normally (no env vars set)
- [ ] Verify `SENTRY_UI_HOT_RELOAD=1 sentry devserver` enables HMR without reload fallback
- [ ] Verify `SENTRY_DEVSERVER_NGROK=example.ngrok.io sentry devserver` disables liveReload and configures webSocketURL
- [ ] Verify HMR WebSocket connects via proxy URL (not localhost) when NGROK is set