### PR TITLE
fix(tests): Fix flaky test_update_widget_title ordering assumption

### DIFF
--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1658,7 +1658,9 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200
 
         widgets = self.get_widgets(self.dashboard.id)
-        self.assert_serialized_widget(data["widgets"][0], widgets[0])
+        assert len(widgets) == 4
+        widget_1 = next(w for w in widgets if w.id == self.widget_1.id)
+        self.assert_serialized_widget(data["widgets"][0], widget_1)
 
     def test_update_widget_add_query(self) -> None:
         data: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- Fix flaky `test_update_widget_title` in dashboard details endpoint tests
- `get_widgets()` orders by the `order` field, which is nullable and not set by `update_widgets`, making widget ordering non-deterministic with 4 widgets
- Look up the target widget by ID instead of relying on index position, consistent with the `assert_serialized_widget` pattern used throughout the file

Fixes #108645

## Test plan
- [x] Test passes locally