### PR TITLE
fix(tests): Fix flaky test_issue_owners_should_ratelimit

### DIFF
--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -66,7 +66,7 @@ from sentry.tasks.post_process import (
 from sentry.testutils.cases import BaseTestCase, PerformanceIssueTestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.redis import mock_redis_buffer
@@ -1416,6 +1416,7 @@ class AssignmentTestMixin(BasePostProcessGroupMixin):
             not in mock_incr.call_args_list
         )
 
+    @freeze_time()
     @patch("sentry.utils.metrics.incr")
     def test_issue_owners_should_ratelimit(self, mock_incr: MagicMock) -> None:
         cache.set(


### PR DESCRIPTION
## Summary
- Fix flaky `test_issue_owners_should_ratelimit` in post_process tests
- The test uses `datetime.now()` for cache window_start values, and the production code uses `datetime.now()` to calculate cache timeouts via `max(60 - elapsed, 0)`. In slow CI runs, elapsed time can exceed 60s, causing cache entries to expire immediately
- Added `@freeze_time()` to ensure consistent time between cache setup and rate limit checks

Fixes #108655

## Test plan
- [x] `pytest tests/sentry/tasks/test_post_process.py::PostProcessGroupErrorTest::test_issue_owners_should_ratelimit` passes