### PR TITLE
fix(tests): Fix flaky AI conversations tests exceeding span retention

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -616,7 +616,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_first_input_last_output(self) -> None:
         """Test firstInput and lastOutput are correctly populated from ai_client spans"""
-        now = before_now(days=90).replace(microsecond=0)
+        now = before_now(days=11).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -678,7 +678,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_first_input_last_output_no_ai_client_spans(self) -> None:
         """Test firstInput and lastOutput are None when no ai_client spans exist"""
-        now = before_now(days=91).replace(microsecond=0)
+        now = before_now(days=12).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -749,7 +749,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_conversation_with_user_data(self) -> None:
         """Test that user data is extracted from spans and returned in the response"""
-        now = before_now(days=100).replace(microsecond=0)
+        now = before_now(days=13).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -797,7 +797,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_conversation_with_partial_user_data(self) -> None:
         """Test that user is returned even with partial user data"""
-        now = before_now(days=101).replace(microsecond=0)
+        now = before_now(days=14).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -830,7 +830,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_input_output_messages(self) -> None:
         """Test that new format gen_ai.input.messages and gen_ai.output.messages are parsed correctly"""
-        now = before_now(days=102).replace(microsecond=0)
+        now = before_now(days=16).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -877,7 +877,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_with_multiple_text_parts(self) -> None:
         """Test that multiple text parts are concatenated correctly"""
-        now = before_now(days=103).replace(microsecond=0)
+        now = before_now(days=17).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -928,7 +928,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_priority_over_old_format(self) -> None:
         """Test that new format attributes take priority over old format when both exist"""
-        now = before_now(days=104).replace(microsecond=0)
+        now = before_now(days=18).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -983,7 +983,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_new_format_parts_structure(self) -> None:
         """Test that new format with parts structure works correctly"""
-        now = before_now(days=105).replace(microsecond=0)
+        now = before_now(days=19).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1028,7 +1028,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_tool_names_populated(self) -> None:
         """Test that toolNames is populated with distinct tool names from tool spans"""
-        now = before_now(days=106).replace(microsecond=0)
+        now = before_now(days=21).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1087,7 +1087,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_tool_errors_counted(self) -> None:
         """Test that toolErrors counts only failed tool spans"""
-        now = before_now(days=107).replace(microsecond=0)
+        now = before_now(days=22).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1157,7 +1157,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
 
     def test_empty_tool_names_when_no_tool_calls(self) -> None:
         """Test that toolNames is empty when there are no tool calls"""
-        now = before_now(days=108).replace(microsecond=0)
+        now = before_now(days=23).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 
@@ -1200,7 +1200,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         This prevents double counting when both agent spans (invoke_agent) and their
         child ai_client spans have token/cost data.
         """
-        now = before_now(days=109).replace(microsecond=0)
+        now = before_now(days=24).replace(microsecond=0)
         conversation_id = uuid4().hex
         trace_id = uuid4().hex
 


### PR DESCRIPTION
## Summary
- Fix 4+ flaky tests in `test_organization_ai_conversations.py` that intermittently return empty responses
- Root cause: spans stored in ClickHouse have a hard-coded 90-day retention limit (in `span_to_trace_item`), and these tests used `before_now(days=90+)` timestamps (91-109), putting them at or beyond the retention boundary
- Remapped all `before_now` offsets > 90 days to values between 11-24 days, well within the retention window
- Also fixed other tests in the file that were at risk (days=90-109) but hadn't been reported yet

Fixes #108659 #108658 #108653 #108647

## Test plan
- [x] All 24 tests in `OrganizationAIConversationsEndpointTest` pass locally
- [x] The 4 previously-flaky tests (`test_new_format_priority_over_old_format`, `test_new_format_with_multiple_text_parts`, `test_conversation_with_partial_user_data`, `test_tool_errors_counted`) pass