### PR TITLE
fix(tests): Fix flaky test_epm_function by using exact 2-minute window

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -2430,12 +2430,17 @@ class OrganizationEventsEndpointTest(OrganizationEventsEndpointTestBase, Perform
         data["transaction"] = "/aggregates/2"
         event2 = self.store_event(data, project_id=self.project.id)
 
+        # Derive start/end from the same base timestamp so the window is exactly
+        # 2 minutes, avoiding drift from separate before_now() calls in setUp.
+        start = (self.ten_mins_ago - timedelta(minutes=1)).isoformat()
+        end = (self.ten_mins_ago + timedelta(minutes=1)).isoformat()
+
         query = {
             "field": ["transaction", "epm()"],
             "query": "event.type:transaction",
             "orderby": ["transaction"],
-            "start": self.eleven_mins_ago_iso,
-            "end": self.nine_mins_ago,
+            "start": start,
+            "end": end,
         }
         response = self.do_request(query)
 


### PR DESCRIPTION
## Summary
- Fix flaky `test_epm_function` in organization events endpoint tests
- The EPM assertion fails intermittently because `before_now()` calls in `setUp` happen at slightly different wall-clock times, making the query time range not exactly 2 minutes (e.g., 119s instead of 120s)
- This causes `epm()` to return `0.5042` instead of exactly `0.5`
- Derive `start` and `end` from the same base timestamp (`ten_mins_ago ± 1 minute`) so the window is exactly 2 minutes, allowing an exact `== 0.5` assertion

Fixes #108656 #108651

## Test plan
- [x] Test passes locally with the exact equality assertion