### PR TITLE
fix(tests): Fix flaky test_rate_limited by adding indexer_cache fixture

### DIFF
--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -472,7 +472,7 @@ def test_read_when_bulk_record(indexer, use_case_id) -> None:
         )
 
 
-def test_rate_limited(indexer, use_case_id, writes_limiter_option_name) -> None:
+def test_rate_limited(indexer, indexer_cache, use_case_id, writes_limiter_option_name) -> None:
     """
     Assert that rate limits per-org and globally are applied at all.
 


### PR DESCRIPTION
## Summary
- Fix flaky `test_rate_limited[UseCaseID.TRANSACTIONS-PGStringIndexerV2]` in metrics indexer tests
- The test was missing the `indexer_cache` fixture that all other tests in the file use
- Without cache cleanup, stale entries from previous tests cause `CachingIndexer.bulk_record()` to return cached values instead of rate-limiting them
- The fix is a one-line addition of the `indexer_cache` fixture parameter

Fixes #108646

## Test plan
- [x] `pytest tests/sentry/sentry_metrics/test_all_indexers.py::test_rate_limited[UseCaseID.TRANSACTIONS-PGStringIndexerV2]` passes