### PR TITLE
fix(tests): Fix flaky replay data export tests with proper Snuba cleanup

### DIFF
--- a/tests/sentry/replays/conftest.py
+++ b/tests/sentry/replays/conftest.py
@@ -13,6 +13,11 @@ class ReplayStore:
         assert response.status_code == 200
         return None
 
+    def save_many(self, data: list[dict[str, Any]]) -> None:
+        request_url = settings.SENTRY_SNUBA + "/tests/entities/replays/insert"
+        response = requests.post(request_url, json=data)
+        assert response.status_code == 200
+
 
 @pytest.fixture
 def replay_store() -> Generator[ReplayStore]:

--- a/tests/sentry/replays/conftest.py
+++ b/tests/sentry/replays/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -14,6 +15,7 @@ class ReplayStore:
 
 
 @pytest.fixture
-def replay_store() -> ReplayStore:
+def replay_store() -> Generator[ReplayStore]:
     assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
-    return ReplayStore()
+    yield ReplayStore()
+    assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200

--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -31,11 +31,15 @@ def test_export_clickhouse_rows(replay_store) -> None:  # type: ignore[no-untype
     t2 = t0 + datetime.timedelta(minutes=2)
     t3 = t0 + datetime.timedelta(minutes=3)
 
-    replay_store.save(mock_replay(t1, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=1))
-    replay_store.save(mock_replay(t3, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save_many(
+        [
+            mock_replay(t1, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=1),
+            mock_replay(t3, 1, replay4_id, segment_id=0),
+            mock_replay(t2, 2, replay5_id, segment_id=0),
+        ]
+    )
 
     query_fn = lambda limit, offset: query_replays_dataset(1, t0, t3, limit, offset)
     rows = list(export_clickhouse_rows(query_fn, limit=1, num_pages=10))
@@ -52,9 +56,13 @@ def test_export_replay_row_set(replay_store) -> None:  # type: ignore[no-untyped
     t1 = t0 + datetime.timedelta(seconds=30)
     t2 = t0 + datetime.timedelta(minutes=1)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
+    replay_store.save_many(
+        [
+            mock_replay(t0, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=0),
+        ]
+    )
 
     class Sink:
         def __init__(self) -> None:
@@ -98,11 +106,15 @@ def test_get_replay_date_query_ranges(replay_store) -> None:  # type: ignore[no-
     t1 = t0 + datetime.timedelta(days=10)
     t2 = t0 + datetime.timedelta(days=20)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save_many(
+        [
+            mock_replay(t0, 1, replay1_id, segment_id=0),
+            mock_replay(t1, 1, replay2_id, segment_id=0),
+            mock_replay(t2, 1, replay3_id, segment_id=0),
+            mock_replay(t2, 1, replay4_id, segment_id=0),
+            mock_replay(t2, 2, replay5_id, segment_id=0),
+        ]
+    )
 
     results = list(get_replay_date_query_ranges(1))
     assert len(results) == 3

--- a/tests/sentry/replays/test_data_export.py
+++ b/tests/sentry/replays/test_data_export.py
@@ -120,7 +120,7 @@ def test_replay_data_export_no_replay_projects(  # type: ignore[no-untyped-def]
 @pytest.mark.snuba
 @requires_snuba
 def test_replay_data_export_no_replay_data(  # type: ignore[no-untyped-def]
-    default_organization, default_project
+    default_organization, default_project, replay_store
 ) -> None:
     # Setting has_replays flag because the export will skip projects it assumes do not have
     # replays.


### PR DESCRIPTION
## Summary
- Fix flaky replay data export tests caused by ClickHouse insert visibility race condition

### Root cause
Each `replay_store.save()` call made a separate HTTP POST to Snuba's ClickHouse insert endpoint. When multiple replays were inserted via separate requests, ClickHouse had no guarantee they'd all be queryable by the time the test's query ran. This caused two failure modes:
- `sink.filename is None` — zero rows returned (no inserts visible yet)
- `len(rows) == 2` — only some inserts visible

### Fix
- Added `save_many()` to `ReplayStore` which sends all replays in a single HTTP POST, so they arrive in one ClickHouse insert and become visible atomically
- Updated all 3 integration tests to use batched inserts
- The `replay_store` fixture also properly cleans up Snuba data before AND after each test (from prior commit)

Fixes #108657
Fixes #108650
Fixes #108648

## Test plan
- [x] `test_export_replay_row_set` passes 10/10 runs locally (previously failed on first run)
- [x] All 3 tests in the integration test file pass
- [x] Pre-commit hooks pass