### PR TITLE
Teams org context

### DIFF
--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -115,6 +115,11 @@ describe('navigation ActionCreator', () => {
     expect(router.push).toHaveBeenCalledWith('/settings/projects/project-slug/alerts/');
   });
 
+  it('should open modal for teamId', () => {
+    navigateTo('/settings/:orgId/teams/:teamId/settings/', router);
+    expect(openModal).toHaveBeenCalled();
+  });
+
   it('preserves query parameters in path object', () => {
     router.location.query.project = '2';
     navigateTo(

--- a/static/app/actionCreators/navigation.spec.tsx
+++ b/static/app/actionCreators/navigation.spec.tsx
@@ -115,9 +115,18 @@ describe('navigation ActionCreator', () => {
     expect(router.push).toHaveBeenCalledWith('/settings/projects/project-slug/alerts/');
   });
 
-  it('should open modal for teamId', () => {
+  it('should open modal for teamId and require both org and team context', () => {
     navigateTo('/settings/:orgId/teams/:teamId/settings/', router);
     expect(openModal).toHaveBeenCalled();
+
+    const modalFactory = (openModal as jest.Mock).mock.calls[0]?.[0];
+    if (!modalFactory) {
+      throw new Error('Expected openModal to be called with a renderer');
+    }
+
+    const modal = modalFactory({closeModal: jest.fn()} as any);
+    expect(modal.props.needOrg).toBe(true);
+    expect(modal.props.needTeam).toBe(true);
   });
 
   it('preserves query parameters in path object', () => {

--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -23,12 +23,18 @@ export function navigateTo(
   // Check for placeholder params
   const needOrg = pathname.includes(':orgId');
   const needProject = pathname.includes(':projectId') || pathname.includes(':project');
+  const needTeam = pathname.includes(':teamId');
   const comingFromProjectId = router?.location?.query?.project;
   const needProjectId = !comingFromProjectId || Array.isArray(comingFromProjectId);
 
   const projectById = ProjectsStore.getById(comingFromProjectId);
 
-  if (needOrg || (needProject && (needProjectId || !projectById)) || configQueryKey) {
+  if (
+    needOrg ||
+    needTeam ||
+    (needProject && (needProjectId || !projectById)) ||
+    configQueryKey
+  ) {
     openModal(
       modalProps => (
         <ContextPickerModal
@@ -36,6 +42,7 @@ export function navigateTo(
           nextPath={to}
           needOrg={needOrg}
           needProject={needProject}
+          needTeam={needTeam}
           configQueryKey={configQueryKey}
           onFinish={path => {
             modalProps.closeModal();

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -55,7 +55,7 @@ describe('ContextPickerModal', () => {
     props: Partial<React.ComponentProps<typeof ContextPickerModal>> = {}
   ) => (
     <ContextPickerModal
-      Header={() => <div />}
+      Header={headerProps => <div>{headerProps.children}</div>}
       Body={ModalBody}
       nextPath="/test/:orgId/path/"
       needOrg
@@ -389,6 +389,34 @@ describe('ContextPickerModal', () => {
     expect(await screen.findByText('Select a Team to continue')).toBeInTheDocument();
     expect(screen.getByText(`#${team1.slug}`)).toBeInTheDocument();
     expect(screen.getByText(`#${team2.slug}`)).toBeInTheDocument();
+  });
+
+  it('renders org and team header when both are required', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'team-one'});
+    const team2 = TeamFixture({id: '2', slug: 'team-two'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    TeamStore.loadInitialData([team1, team2]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: true,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Select an organization and a team to continue',
+      })
+    ).toBeInTheDocument();
   });
 
   it('selects a team and navigates to the correct path', async () => {

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -17,7 +17,6 @@ import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import TeamStore from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
@@ -33,7 +32,6 @@ describe('ContextPickerModal', () => {
 
   beforeEach(() => {
     ProjectsStore.reset();
-    TeamStore.reset();
     MockApiClient.clearMockResponses();
 
     project = ProjectFixture();
@@ -367,88 +365,10 @@ describe('ContextPickerModal', () => {
     const team2 = TeamFixture({id: '2', slug: 'team-two'});
     OrganizationsStore.load([org]);
     OrganizationStore.onUpdate(org);
-    TeamStore.loadInitialData([team1, team2]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
+    const fetchTeamsForOrg = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [team1, team2],
     });
-
-    render(
-      getComponent({
-        needOrg: false,
-        needProject: false,
-        needTeam: true,
-        nextPath: '/settings/:orgId/teams/:teamId/settings/',
-      })
-    );
-
-    expect(await screen.findByText('Select a Team to continue')).toBeInTheDocument();
-    expect(screen.getByText(`#${team1.slug}`)).toBeInTheDocument();
-    expect(screen.getByText(`#${team2.slug}`)).toBeInTheDocument();
-  });
-
-  it('renders org and team header when both are required', async () => {
-    const team1 = TeamFixture({id: '1', slug: 'team-one'});
-    const team2 = TeamFixture({id: '2', slug: 'team-two'});
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    TeamStore.loadInitialData([team1, team2]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
-    });
-
-    render(
-      getComponent({
-        needOrg: true,
-        needProject: false,
-        needTeam: true,
-        nextPath: '/settings/:orgId/teams/:teamId/settings/',
-      })
-    );
-
-    expect(
-      await screen.findByRole('heading', {
-        name: 'Select an organization and a team to continue',
-      })
-    ).toBeInTheDocument();
-  });
-
-  it('selects a team and navigates to the correct path', async () => {
-    const team1 = TeamFixture({id: '1', slug: 'team-one'});
-    const team2 = TeamFixture({id: '2', slug: 'team-two'});
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    TeamStore.loadInitialData([team1, team2]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/projects/`,
-      body: [],
-    });
-
-    render(
-      getComponent({
-        needOrg: false,
-        needProject: false,
-        needTeam: true,
-        nextPath: '/settings/:orgId/teams/:teamId/settings/',
-      })
-    );
-
-    await selectEvent.select(await screen.findByText(/Select a Team/), `#${team2.slug}`);
-
-    expect(onFinish).toHaveBeenCalledWith(
-      `/settings/${org.slug}/teams/${team2.slug}/settings/`
-    );
-  });
-
-  it('auto-navigates when only one team exists', async () => {
-    const team1 = TeamFixture({id: '1', slug: 'the-only-team'});
-    OrganizationsStore.load([org]);
-    OrganizationStore.onUpdate(org);
-    TeamStore.loadInitialData([team1]);
 
     MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/projects/`,
@@ -465,9 +385,158 @@ describe('ContextPickerModal', () => {
     );
 
     await waitFor(() => {
+      expect(fetchTeamsForOrg).toHaveBeenCalled();
+    });
+    expect(await screen.findByText('Select a Team to continue')).toBeInTheDocument();
+    expect(screen.getByText(`#${team1.slug}`)).toBeInTheDocument();
+    expect(screen.getByText(`#${team2.slug}`)).toBeInTheDocument();
+  });
+
+  it('renders org and team header when both are required', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'team-one'});
+    const team2 = TeamFixture({id: '2', slug: 'team-two'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    const fetchTeamsForOrg = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [team1, team2],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: true,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchTeamsForOrg).toHaveBeenCalled();
+    });
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Select an organization and a team to continue',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('selects a team and navigates to the correct path', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'team-one'});
+    const team2 = TeamFixture({id: '2', slug: 'team-two'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    const fetchTeamsForOrg = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [team1, team2],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchTeamsForOrg).toHaveBeenCalled();
+    });
+    await selectEvent.select(await screen.findByText(/Select a Team/), `#${team2.slug}`);
+
+    expect(onFinish).toHaveBeenCalledWith(
+      `/settings/${org.slug}/teams/${team2.slug}/settings/`
+    );
+  });
+
+  it('auto-navigates when only one team exists', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'the-only-team'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    const fetchTeamsForOrg = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [team1],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchTeamsForOrg).toHaveBeenCalled();
       expect(onFinish).toHaveBeenCalledWith(
         `/settings/${org.slug}/teams/the-only-team/settings/`
       );
     });
+  });
+
+  it('refetches teams when selecting a different organization', async () => {
+    const org1Team = TeamFixture({id: '1', slug: 'org1-team'});
+    const org2Team = TeamFixture({id: '2', slug: 'org2-team'});
+    OrganizationsStore.load([org, org2]);
+    OrganizationStore.onUpdate(org);
+
+    const fetchOrg1Projects = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+    const fetchOrg1Teams = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [org1Team],
+    });
+    const fetchOrg2Projects = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/projects/`,
+      body: [],
+    });
+    const fetchOrg2Teams = MockApiClient.addMockResponse({
+      url: `/organizations/${org2.slug}/teams/`,
+      body: [org2Team],
+    });
+
+    render(
+      getComponent({
+        needOrg: true,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await waitFor(() => {
+      expect(fetchOrg1Projects).toHaveBeenCalled();
+      expect(fetchOrg1Teams).toHaveBeenCalled();
+    });
+    expect(await screen.findByText(`#${org1Team.slug}`)).toBeInTheDocument();
+
+    const [orgSelect] = screen.getAllByRole('textbox');
+    await selectEvent.select(orgSelect, org2.slug);
+
+    await waitFor(() => {
+      expect(fetchOrg2Projects).toHaveBeenCalled();
+      expect(fetchOrg2Teams).toHaveBeenCalled();
+    });
+    expect(await screen.findByText(`#${org2Team.slug}`)).toBeInTheDocument();
+    expect(screen.queryByText(`#${org1Team.slug}`)).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -1,6 +1,7 @@
 import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -16,6 +17,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import TeamStore from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
@@ -31,6 +33,7 @@ describe('ContextPickerModal', () => {
 
   beforeEach(() => {
     ProjectsStore.reset();
+    TeamStore.reset();
     MockApiClient.clearMockResponses();
 
     project = ProjectFixture();
@@ -58,6 +61,7 @@ describe('ContextPickerModal', () => {
       needOrg
       onFinish={onFinish}
       needProject={false}
+      needTeam={false}
       CloseButton={makeCloseButton(() => {})}
       Footer={ModalFooter}
       closeModal={jest.fn()}
@@ -358,6 +362,87 @@ describe('ContextPickerModal', () => {
     expect(onFinish).toHaveBeenLastCalledWith({
       pathname: '/test/org2/path/project2/',
       query: {referrer: 'onboarding_task'},
+    });
+  });
+
+  it('renders team picker when needTeam is true', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'team-one'});
+    const team2 = TeamFixture({id: '2', slug: 'team-two'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    TeamStore.loadInitialData([team1, team2]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    expect(await screen.findByText('Select a Team to continue')).toBeInTheDocument();
+    expect(screen.getByText(`#${team1.slug}`)).toBeInTheDocument();
+    expect(screen.getByText(`#${team2.slug}`)).toBeInTheDocument();
+  });
+
+  it('selects a team and navigates to the correct path', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'team-one'});
+    const team2 = TeamFixture({id: '2', slug: 'team-two'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    TeamStore.loadInitialData([team1, team2]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await selectEvent.select(await screen.findByText(/Select a Team/), `#${team2.slug}`);
+
+    expect(onFinish).toHaveBeenCalledWith(
+      `/settings/${org.slug}/teams/${team2.slug}/settings/`
+    );
+  });
+
+  it('auto-navigates when only one team exists', async () => {
+    const team1 = TeamFixture({id: '1', slug: 'the-only-team'});
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    TeamStore.loadInitialData([team1]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    render(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        needTeam: true,
+        nextPath: '/settings/:orgId/teams/:teamId/settings/',
+      })
+    );
+
+    await waitFor(() => {
+      expect(onFinish).toHaveBeenCalledWith(
+        `/settings/${org.slug}/teams/the-only-team/settings/`
+      );
     });
   });
 });

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -499,7 +499,7 @@ describe('ContextPickerModal', () => {
     OrganizationsStore.load([org, org2]);
     OrganizationStore.onUpdate(org);
 
-    const fetchOrg1Projects = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/projects/`,
       body: [],
     });
@@ -507,7 +507,7 @@ describe('ContextPickerModal', () => {
       url: `/organizations/${org.slug}/teams/`,
       body: [org1Team],
     });
-    const fetchOrg2Projects = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${org2.slug}/projects/`,
       body: [],
     });
@@ -526,9 +526,6 @@ describe('ContextPickerModal', () => {
     );
 
     await waitFor(() => {
-      expect(fetchOrg1Projects).toHaveBeenCalled();
-    });
-    await waitFor(() => {
       expect(fetchOrg1Teams).toHaveBeenCalled();
     });
     expect(await screen.findByText(`#${org1Team.slug}`)).toBeInTheDocument();
@@ -536,9 +533,6 @@ describe('ContextPickerModal', () => {
     const orgSelect = screen.getAllByRole('textbox')[0]!;
     await selectEvent.select(orgSelect, org2.slug);
 
-    await waitFor(() => {
-      expect(fetchOrg2Projects).toHaveBeenCalled();
-    });
     await waitFor(() => {
       expect(fetchOrg2Teams).toHaveBeenCalled();
     });

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -485,6 +485,8 @@ describe('ContextPickerModal', () => {
 
     await waitFor(() => {
       expect(fetchTeamsForOrg).toHaveBeenCalled();
+    });
+    await waitFor(() => {
       expect(onFinish).toHaveBeenCalledWith(
         `/settings/${org.slug}/teams/the-only-team/settings/`
       );
@@ -525,15 +527,19 @@ describe('ContextPickerModal', () => {
 
     await waitFor(() => {
       expect(fetchOrg1Projects).toHaveBeenCalled();
+    });
+    await waitFor(() => {
       expect(fetchOrg1Teams).toHaveBeenCalled();
     });
     expect(await screen.findByText(`#${org1Team.slug}`)).toBeInTheDocument();
 
-    const [orgSelect] = screen.getAllByRole('textbox');
+    const orgSelect = screen.getAllByRole('textbox')[0]!;
     await selectEvent.select(orgSelect, org2.slug);
 
     await waitFor(() => {
       expect(fetchOrg2Projects).toHaveBeenCalled();
+    });
+    await waitFor(() => {
       expect(fetchOrg2Teams).toHaveBeenCalled();
     });
     expect(await screen.findByText(`#${org2Team.slug}`)).toBeInTheDocument();

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -252,7 +252,7 @@ describe('ContextPickerModal', () => {
     }
 
     await selectEvent.select(
-      screen.getByText(/Select a configuration/i),
+      screen.getByRole('textbox'),
       integration.domainName
     );
     expect(onFinish).toHaveBeenCalledWith(

--- a/static/app/components/contextPickerModal.spec.tsx
+++ b/static/app/components/contextPickerModal.spec.tsx
@@ -251,10 +251,7 @@ describe('ContextPickerModal', () => {
       throw new Error('Integration domainName is null');
     }
 
-    await selectEvent.select(
-      screen.getByRole('textbox'),
-      integration.domainName
-    );
+    await selectEvent.select(screen.getByRole('textbox'), integration.domainName);
     expect(onFinish).toHaveBeenCalledWith(
       `/settings/${org.slug}/integrations/github/${integration.id}/`
     );

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -2,7 +2,7 @@ import {Component, Fragment, useState, type Dispatch, type SetStateAction} from 
 import styled from '@emotion/styled';
 import type {Query} from 'history';
 
-import {ProjectAvatar} from '@sentry/scraps/avatar';
+import {ProjectAvatar, TeamAvatar} from '@sentry/scraps/avatar';
 import {Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import type {StylesConfig} from '@sentry/scraps/select';
@@ -19,11 +19,12 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {space} from 'sentry/styles/space';
 import type {Integration} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
+import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import Projects from 'sentry/utils/projects';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+import Teams from 'sentry/utils/teams';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
 
@@ -51,6 +52,11 @@ type SharedProps = ModalRenderProps & {
   onFinish: (path: string | {pathname: string; query?: Query}) => number | void;
 
   allowAllProjectsSelection?: boolean;
+
+  /**
+   * Does modal need to prompt for team
+   */
+  needTeam?: boolean;
 };
 
 type Props = SharedProps & {
@@ -74,9 +80,19 @@ type Props = SharedProps & {
   projects: Project[];
 
   /**
+   * List of available teams
+   */
+  teams: Team[];
+
+  /**
    * Whether projects are still loading
    */
   projectsLoading?: boolean;
+
+  /**
+   * Whether teams are still loading
+   */
+  teamsLoading?: boolean;
 };
 
 function autoFocusReactSelect(reactSelectRef: any) {
@@ -100,7 +116,7 @@ const selectStyles: StylesConfig = {
 
 class ContextPickerModal extends Component<Props> {
   componentDidMount() {
-    const {organization, projects, organizations} = this.props;
+    const {organization, projects, organizations, teams} = this.props;
 
     // Don't make any assumptions if there are multiple organizations
     if (organizations.length !== 1) {
@@ -111,16 +127,23 @@ class ContextPickerModal extends Component<Props> {
     // attempt to see if we need more info from user and redirect otherwise
     if (organization) {
       // This will handle if we can intelligently move the user forward
-      this.navigateIfFinish([{slug: organization}], projects);
+      this.navigateIfFinish([{slug: organization}], projects, teams);
       return;
     }
   }
 
   componentDidUpdate(prevProps: Props) {
-    // Component may be mounted before projects is fetched, check if we can finish when
-    // component is updated with projects
-    if (JSON.stringify(prevProps.projects) !== JSON.stringify(this.props.projects)) {
-      this.navigateIfFinish(this.props.organizations, this.props.projects);
+    // Component may be mounted before projects or teams are fetched, check if we can finish when
+    // component is updated with projects or teams
+    if (
+      JSON.stringify(prevProps.projects) !== JSON.stringify(this.props.projects) ||
+      JSON.stringify(prevProps.teams) !== JSON.stringify(this.props.teams)
+    ) {
+      this.navigateIfFinish(
+        this.props.organizations,
+        this.props.projects,
+        this.props.teams
+      );
     }
   }
 
@@ -136,17 +159,19 @@ class ContextPickerModal extends Component<Props> {
   navigateIfFinish = (
     organizations: Array<{slug: string}>,
     projects: Array<{slug: string}>,
+    teams: Array<{slug: string}> = [],
     latestOrg = this.props.organization
   ) => {
-    const {needProject, onFinish, nextPath, integrationConfigs} = this.props;
+    const {needProject, needTeam, onFinish, nextPath, integrationConfigs} = this.props;
     const {isSuperuser} = ConfigStore.get('user') || {};
 
     // If no project is needed and theres only 1 org OR
     // if we need a project and there's only 1 project
     // then return because we can't navigate anywhere yet
     if (
-      (!needProject && organizations.length !== 1) ||
+      (!needProject && !needTeam && organizations.length !== 1) ||
       (needProject && projects.length !== 1) ||
+      (needTeam && teams.length !== 1) ||
       (integrationConfigs.length && isSuperuser)
     ) {
       return;
@@ -155,8 +180,8 @@ class ContextPickerModal extends Component<Props> {
     window.clearTimeout(this.onFinishTimeout);
     const pathname = typeof nextPath === 'string' ? nextPath : nextPath.pathname;
 
-    // If there is only one org and we don't need a project slug, then call finish callback
-    if (!needProject) {
+    // If there is only one org and we don't need a project or team slug, then call finish callback
+    if (!needProject && !needTeam) {
       const newPathname = replaceRouterParams(pathname, {
         orgId: organizations[0]!.slug,
       });
@@ -177,8 +202,9 @@ class ContextPickerModal extends Component<Props> {
 
     const newPathname = replaceRouterParams(pathname, {
       orgId: org,
-      projectId: projects[0]!.slug,
-      project: this.props.projects.find(p => p.slug === projects[0]!.slug)?.id,
+      projectId: projects[0]?.slug,
+      project: this.props.projects.find(p => p.slug === projects[0]?.slug)?.id,
+      teamId: teams[0]?.slug,
     });
     this.onFinishTimeout =
       onFinish(
@@ -187,10 +213,10 @@ class ContextPickerModal extends Component<Props> {
   };
 
   handleSelectOrganization = ({value}: {value: string}) => {
-    // If we do not need to select a project, we can early return after selecting an org
+    // If we do not need to select a project or team, we can early return after selecting an org
     // No need to fetch org details
-    if (!this.props.needProject) {
-      this.navigateIfFinish([{slug: value}], []);
+    if (!this.props.needProject && !this.props.needTeam) {
+      this.navigateIfFinish([{slug: value}], [], []);
       return;
     }
 
@@ -203,7 +229,17 @@ class ContextPickerModal extends Component<Props> {
       return;
     }
 
-    this.navigateIfFinish([{slug: organization}], [{slug: value}]);
+    this.navigateIfFinish([{slug: organization}], [{slug: value}], []);
+  };
+
+  handleSelectTeam = ({value}: {value: string}) => {
+    const {organization, needProject, projects} = this.props;
+    if (!value || !organization) {
+      return;
+    }
+
+    const projectsArg = needProject ? projects : [];
+    this.navigateIfFinish([{slug: organization}], projectsArg, [{slug: value}]);
   };
 
   handleSelectConfiguration = ({value}: {value: string}) => {
@@ -235,12 +271,15 @@ class ContextPickerModal extends Component<Props> {
   };
 
   get headerText() {
-    const {needOrg, needProject, integrationConfigs} = this.props;
+    const {needOrg, needProject, needTeam, integrationConfigs} = this.props;
     if (needOrg && needProject) {
       return t('Select an organization and a project to continue');
     }
     if (needOrg) {
       return t('Select an organization to continue');
+    }
+    if (needTeam) {
+      return t('Select a team to continue');
     }
     if (needProject) {
       return t('Select a project to continue');
@@ -352,10 +391,46 @@ class ContextPickerModal extends Component<Props> {
     );
   }
 
+  renderTeamSelectOrMessage() {
+    const {teams, teamsLoading} = this.props;
+
+    if (teamsLoading) {
+      return (
+        <Flex justify="center" align="center" minHeight="345px">
+          <LoadingIndicator />
+        </Flex>
+      );
+    }
+
+    if (!teams.length) {
+      return <div>{t('No teams found.')}</div>;
+    }
+
+    const options = teams.map(team => ({
+      value: team.slug,
+      label: `#${team.slug}`,
+      leadingItems: <TeamAvatar team={team} size={20} />,
+    }));
+
+    return (
+      <StyledSelectControl
+        ref={autoFocusReactSelect}
+        placeholder={t('Select a Team to continue')}
+        name="team"
+        options={options}
+        onChange={this.handleSelectTeam}
+        components={{DropdownIndicator: null}}
+        styles={selectStyles}
+        menuIsOpen
+      />
+    );
+  }
+
   render() {
     const {
       needOrg,
       needProject,
+      needTeam,
       organization,
       organizations,
       Header,
@@ -365,6 +440,7 @@ class ContextPickerModal extends Component<Props> {
     const {isSuperuser} = ConfigStore.get('user') || {};
 
     const shouldShowProjectSelector = organization && needProject;
+    const shouldShowTeamSelector = organization && needTeam;
 
     const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;
 
@@ -372,7 +448,8 @@ class ContextPickerModal extends Component<Props> {
       .filter(({status}) => status.id !== 'pending_deletion')
       .map(({slug}) => ({label: slug, value: slug}));
 
-    const shouldShowPicker = needOrg || needProject || shouldShowConfigSelector;
+    const shouldShowPicker =
+      needOrg || needProject || needTeam || shouldShowConfigSelector;
 
     if (!shouldShowPicker) {
       return null;
@@ -399,6 +476,7 @@ class ContextPickerModal extends Component<Props> {
           )}
 
           {shouldShowProjectSelector && this.renderProjectSelectOrMessage()}
+          {shouldShowTeamSelector && this.renderTeamSelectOrMessage()}
           {shouldShowConfigSelector && this.renderIntegrationConfigs()}
         </Body>
       </Fragment>
@@ -436,7 +514,10 @@ export default function ContextPickerModalContainer({
     );
   }
   if (selectedOrgSlug) {
-    return (
+    const needProject = sharedProps.needProject;
+    const needTeam = sharedProps.needTeam;
+
+    const renderWithProjects = (teams: Team[], teamsLoading: boolean) => (
       <Projects
         orgId={selectedOrgSlug}
         allProjects={!projectSlugs?.length}
@@ -445,8 +526,10 @@ export default function ContextPickerModalContainer({
         {({projects, initiallyLoaded}) => (
           <ContextPickerModal
             {...sharedProps}
-            projects={projects as Project[]}
-            projectsLoading={!initiallyLoaded}
+            projects={needProject ? (projects as Project[]) : []}
+            projectsLoading={needProject ? !initiallyLoaded : false}
+            teams={teams}
+            teamsLoading={teamsLoading}
             organizations={organizations}
             organization={selectedOrgSlug}
             onSelectOrganization={setSelectedOrgSlug}
@@ -455,12 +538,23 @@ export default function ContextPickerModalContainer({
         )}
       </Projects>
     );
+
+    if (needTeam) {
+      return (
+        <Teams>
+          {({teams, initiallyLoaded}) => renderWithProjects(teams, !initiallyLoaded)}
+        </Teams>
+      );
+    }
+
+    return renderWithProjects([], false);
   }
 
   return (
     <ContextPickerModal
       {...sharedProps}
       projects={[]}
+      teams={[]}
       organizations={organizations}
       organization={selectedOrgSlug}
       onSelectOrganization={setSelectedOrgSlug}
@@ -497,6 +591,7 @@ function ConfigUrlContainer(
     <ContextPickerModal
       {...sharedProps}
       projects={[]}
+      teams={[]}
       organizations={organizations}
       organization={selectedOrgSlug}
       onSelectOrganization={setSelectedOrgSlug}

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -544,9 +544,9 @@ export default function ContextPickerModalContainer({
 function ContextPickerModalWithOrgSelection(
   props: SharedProps & {
     organizations: Organization[];
-    projectSlugs?: string[];
     selectedOrgSlug: string;
     setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+    projectSlugs?: string[];
   }
 ) {
   const {
@@ -570,7 +570,11 @@ function ContextPickerModalWithOrgSelection(
   });
 
   return (
-    <Projects orgId={selectedOrgSlug} allProjects={!projectSlugs?.length} slugs={projectSlugs}>
+    <Projects
+      orgId={selectedOrgSlug}
+      allProjects={!projectSlugs?.length}
+      slugs={projectSlugs}
+    >
       {({projects, initiallyLoaded}) => (
         <ContextPickerModal
           {...sharedProps}

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -21,10 +21,10 @@ import {space} from 'sentry/styles/space';
 import type {Integration} from 'sentry/types/integrations';
 import type {Organization, Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
 import Projects from 'sentry/utils/projects';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
-import Teams from 'sentry/utils/teams';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
 
@@ -517,40 +517,15 @@ export default function ContextPickerModalContainer({
     );
   }
   if (selectedOrgSlug) {
-    const needProject = sharedProps.needProject;
-    const needTeam = sharedProps.needTeam;
-
-    const renderWithProjects = (teams: Team[], teamsLoading: boolean) => (
-      <Projects
-        orgId={selectedOrgSlug}
-        allProjects={!projectSlugs?.length}
-        slugs={projectSlugs}
-      >
-        {({projects, initiallyLoaded}) => (
-          <ContextPickerModal
-            {...sharedProps}
-            projects={needProject ? (projects as Project[]) : []}
-            projectsLoading={needProject ? !initiallyLoaded : false}
-            teams={teams}
-            teamsLoading={teamsLoading}
-            organizations={organizations}
-            organization={selectedOrgSlug}
-            onSelectOrganization={setSelectedOrgSlug}
-            integrationConfigs={[]}
-          />
-        )}
-      </Projects>
+    return (
+      <ContextPickerModalWithOrgSelection
+        {...sharedProps}
+        organizations={organizations}
+        projectSlugs={projectSlugs}
+        selectedOrgSlug={selectedOrgSlug}
+        setSelectedOrgSlug={setSelectedOrgSlug}
+      />
     );
-
-    if (needTeam) {
-      return (
-        <Teams>
-          {({teams, initiallyLoaded}) => renderWithProjects(teams, !initiallyLoaded)}
-        </Teams>
-      );
-    }
-
-    return renderWithProjects([], false);
   }
 
   return (
@@ -563,6 +538,52 @@ export default function ContextPickerModalContainer({
       onSelectOrganization={setSelectedOrgSlug}
       integrationConfigs={[]}
     />
+  );
+}
+
+function ContextPickerModalWithOrgSelection(
+  props: SharedProps & {
+    organizations: Organization[];
+    projectSlugs?: string[];
+    selectedOrgSlug: string;
+    setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+  }
+) {
+  const {
+    organizations,
+    projectSlugs,
+    selectedOrgSlug,
+    setSelectedOrgSlug,
+    ...sharedProps
+  } = props;
+  const needProject = sharedProps.needProject;
+  const needTeam = sharedProps.needTeam;
+  const teamsQueryKey = [
+    getApiUrl('/organizations/$organizationIdOrSlug/teams/', {
+      path: {organizationIdOrSlug: selectedOrgSlug},
+    }),
+  ] satisfies ApiQueryKey;
+  const {data: teams = [], isPending: teamsLoading} = useApiQuery<Team[]>(teamsQueryKey, {
+    enabled: !!needTeam,
+    staleTime: 0,
+  });
+
+  return (
+    <Projects orgId={selectedOrgSlug} allProjects={!projectSlugs?.length} slugs={projectSlugs}>
+      {({projects, initiallyLoaded}) => (
+        <ContextPickerModal
+          {...sharedProps}
+          projects={needProject ? (projects as Project[]) : []}
+          projectsLoading={needProject ? !initiallyLoaded : false}
+          teams={needTeam ? teams : []}
+          teamsLoading={needTeam ? teamsLoading : false}
+          organizations={organizations}
+          organization={selectedOrgSlug}
+          onSelectOrganization={setSelectedOrgSlug}
+          integrationConfigs={[]}
+        />
+      )}
+    </Projects>
   );
 }
 

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -558,6 +558,7 @@ function ContextPickerModalWithOrgSelection(
   } = props;
   const needProject = sharedProps.needProject;
   const needTeam = sharedProps.needTeam;
+  // Always key team data by selected org so context-picker org changes refetch correctly.
   const teamsQueryKey = [
     getApiUrl('/organizations/$organizationIdOrSlug/teams/', {
       path: {organizationIdOrSlug: selectedOrgSlug},

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -275,6 +275,9 @@ class ContextPickerModal extends Component<Props> {
     if (needOrg && needProject) {
       return t('Select an organization and a project to continue');
     }
+    if (needOrg && needTeam) {
+      return t('Select an organization and a team to continue');
+    }
     if (needOrg) {
       return t('Select an organization to continue');
     }

--- a/static/app/data/forms/teamSettingsFields.tsx
+++ b/static/app/data/forms/teamSettingsFields.tsx
@@ -3,8 +3,7 @@ import {t} from 'sentry/locale';
 import slugify from 'sentry/utils/slugify';
 
 // Export route to make these forms searchable by label/help
-// TODO: :teamId is not a valid route parameter
-// export const route = '/settings/:orgId/teams/:teamId/settings/';
+export const route = '/settings/:orgId/teams/:teamId/settings/';
 
 const formGroups: JsonFormObject[] = [
   {


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fixes an issue where the `<Teams>` component in `ContextPickerModal` did not update when the organization was switched, potentially displaying stale team lists.

The fix involves:
*   Removing the legacy `<Teams>` wrapper.
*   Implementing an explicit `useApiQuery` for teams, keyed by the `selectedOrgSlug`, mirroring how `<Projects>` handles organization context.
*   Adding a regression test to `contextPickerModal.spec.tsx` to verify teams refetch correctly upon organization changes.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<p><a href="https://cursor.com/agents?id=bc-290596b5-0b35-4a2c-a476-ada99db86c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-290596b5-0b35-4a2c-a476-ada99db86c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

