### PR TITLE
feat(preprod): Add App Clip options to size analysis UI

### DIFF
--- a/static/app/views/preprod/types/appSizeTypes.ts
+++ b/static/app/views/preprod/types/appSizeTypes.ts
@@ -248,6 +248,7 @@ export enum MetricsArtifactType {
   MAIN_ARTIFACT = 0,
   WATCH_ARTIFACT = 1,
   ANDROID_DYNAMIC_FEATURE = 2,
+  APP_CLIP_ARTIFACT = 3,
 }
 
 interface SizeMetricDiffItem {

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -11,6 +11,7 @@ export const ALL_ARTIFACT_TYPES = [
   'main_artifact',
   'watch_artifact',
   'android_dynamic_feature_artifact',
+  'app_clip_artifact',
 ] as const;
 
 export type ArtifactType = (typeof ALL_ARTIFACT_TYPES)[number];
@@ -65,6 +66,7 @@ const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
   main_artifact: 'Main App',
   watch_artifact: 'Watch App',
   android_dynamic_feature_artifact: 'Android Dynamic Feature',
+  app_clip_artifact: 'App Clip',
 };
 
 export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> =


### PR DESCRIPTION
Add App Clip support to Sentry preprod frontend surfaces.

This updates the mobile build UI so App Clip metrics are represented consistently with existing component patterns:
- add `APP_CLIP_ARTIFACT = 3` to frontend preprod size metric types
- add App Clip as a selectable artifact type in status-check rule settings
- update build details metric cards to include App Clip in component breakdown tooltips while preserving main metric card values
- rename breakdown naming for clarity (`componentBreakdown`)

Merge/deploy ordering for EME-811:
1) Merge/deploy this frontend PR first
2) Then merge/deploy backend support (PR #108676)
3) Then merge/deploy Launchpad emitter changes

<img width="647" height="276" alt="Screenshot 2026-02-19 at 16 10 50" src="https://github.com/user-attachments/assets/40db1abf-f692-4a91-92f6-b92c489fb171" />

Refs EME-811