### PR TITLE
fix(explore): Deduplicate group by and visualize select options

### DIFF
--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -1,0 +1,22 @@
+import type {Tag} from 'sentry/types/group';
+import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
+
+export function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
+  return {
+    label: tag.name,
+    value: tag.key,
+    textValue: tag.key,
+    trailingItems: <TypeBadge kind={tag.kind} />,
+    showDetailsInOverlay: true,
+    details: (
+      <AttributeDetails
+        column={tag.key}
+        kind={tag.kind}
+        label={tag.name}
+        traceItemType={traceItemType}
+      />
+    ),
+  };
+}

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -4,10 +4,9 @@ import styled from '@emotion/styled';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {TagCollection} from 'sentry/types/group';
 import {FieldKind, prettifyTagKey} from 'sentry/utils/fields';
-import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
-import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -65,8 +64,8 @@ export function useGroupByFields({
         return true;
       })
       .toSorted((a, b) => {
-        const aLabel = a.label || '';
-        const bLabel = b.label || '';
+        const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
+        const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
         return aLabel.localeCompare(bLabel);
       });
 
@@ -84,24 +83,6 @@ export function useGroupByFields({
       ...options,
     ];
   }, [booleanTags, groupBys, hideEmptyOption, numberTags, stringTags, traceItemType]);
-}
-
-function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
-  return {
-    label: tag.name,
-    value: tag.key,
-    textValue: tag.key,
-    trailingItems: <TypeBadge kind={tag.kind} />,
-    showDetailsInOverlay: true,
-    details: (
-      <AttributeDetails
-        column={tag.key}
-        kind={tag.kind}
-        label={tag.key}
-        traceItemType={traceItemType}
-      />
-    ),
-  };
 }
 
 // Some fields don't make sense to allow users to group by as they create

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -59,6 +59,8 @@ export function useGroupByFields({
         ),
     ]
       .filter(option => {
+        // Filtering by value here, so it's based off of explicit tags i.e. `key`
+        // or `tags[<key>, <boolean | number | string>]
         if (seen.has(option.value)) return false;
         seen.add(option.value);
         return true;

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -33,6 +33,7 @@ export function useGroupByFields({
   hideEmptyOption,
 }: UseGroupByFieldsProps): Array<SelectOption<string>> {
   return useMemo(() => {
+    const seen = new Set<string>();
     const options = [
       ...Object.entries(numberTags)
         .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
@@ -57,13 +58,17 @@ export function useGroupByFields({
             traceItemType
           )
         ),
-    ];
-
-    options.sort((a, b) => {
-      const aLabel = a.label || '';
-      const bLabel = b.label || '';
-      return aLabel.localeCompare(bLabel);
-    });
+    ]
+      .filter(option => {
+        if (seen.has(option.value)) return false;
+        seen.add(option.value);
+        return true;
+      })
+      .toSorted((a, b) => {
+        const aLabel = a.label || '';
+        const bLabel = b.label || '';
+        return aLabel.localeCompare(bLabel);
+      });
 
     return [
       // hard code in an empty option

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
-import type {TagCollection} from 'sentry/types/group';
+import type {Tag, TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {
@@ -45,62 +45,51 @@ export function useVisualizeFields({
   const unknownField = parsedFunction?.arguments[0];
 
   const fieldOptions: Array<SelectOption<string>> = useMemo(() => {
+    const seen = new Set<string>();
     const unknownOptions = [unknownField]
       .filter(defined)
       .filter(option => !tags.hasOwnProperty(option));
 
-    const options = [
+    return [
       ...unknownOptions.map(option => {
         const label = prettifyTagKey(option);
-        return {
-          label,
-          value: option,
-          textValue: option,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={option}
-              label={label}
-              traceItemType={traceItemType}
-            />
-          ),
-        };
+        return optionFromTag({key: option, name: label}, traceItemType);
       }),
       ...Object.values(tags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          textValue: tag.name,
-          trailingItems: <TypeBadge kind={tag.kind} />,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={tag.key}
-              kind={tag.kind}
-              label={tag.name}
-              traceItemType={traceItemType}
-            />
-          ),
-        };
+        return optionFromTag(tag, traceItemType);
       }),
-    ];
-
-    options.sort((a, b) => {
-      if (a.label < b.label) {
-        return -1;
-      }
-
-      if (a.label > b.label) {
-        return 1;
-      }
-
-      return 0;
-    });
-
-    return options;
+    ]
+      .filter(option => {
+        if (seen.has(option.value)) return false;
+        seen.add(option.value);
+        return true;
+      })
+      .toSorted((a, b) => {
+        const aLabel = a.label || '';
+        const bLabel = b.label || '';
+        return aLabel.localeCompare(bLabel);
+      });
   }, [tags, unknownField, traceItemType]);
 
   return fieldOptions;
+}
+
+function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
+  return {
+    label: tag.name,
+    value: tag.key,
+    textValue: tag.key,
+    trailingItems: <TypeBadge kind={tag.kind} />,
+    showDetailsInOverlay: true,
+    details: (
+      <AttributeDetails
+        column={tag.key}
+        kind={tag.kind}
+        label={tag.key}
+        traceItemType={traceItemType}
+      />
+    ),
+  };
 }
 
 function getSupportedAttributes({

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -3,7 +3,7 @@ import {useMemo} from 'react';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
-import type {Tag, TagCollection} from 'sentry/types/group';
+import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
 import {
@@ -12,8 +12,7 @@ import {
   NO_ARGUMENT_SPAN_AGGREGATES,
   prettifyTagKey,
 } from 'sentry/utils/fields';
-import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
-import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -65,31 +64,13 @@ export function useVisualizeFields({
         return true;
       })
       .toSorted((a, b) => {
-        const aLabel = a.label || '';
-        const bLabel = b.label || '';
+        const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
+        const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
         return aLabel.localeCompare(bLabel);
       });
   }, [tags, unknownField, traceItemType]);
 
   return fieldOptions;
-}
-
-function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
-  return {
-    label: tag.name,
-    value: tag.key,
-    textValue: tag.key,
-    trailingItems: <TypeBadge kind={tag.kind} />,
-    showDetailsInOverlay: true,
-    details: (
-      <AttributeDetails
-        column={tag.key}
-        kind={tag.kind}
-        label={tag.name}
-        traceItemType={traceItemType}
-      />
-    ),
-  };
 }
 
 function getSupportedAttributes({

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -85,7 +85,7 @@ function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
       <AttributeDetails
         column={tag.key}
         kind={tag.kind}
-        label={tag.key}
+        label={tag.name}
         traceItemType={traceItemType}
       />
     ),

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -59,6 +59,8 @@ export function useVisualizeFields({
       }),
     ]
       .filter(option => {
+        // Filtering by value here, so it's based off of explicit tags i.e. `key`
+        // or `tags[<key>, <boolean | number | string>]
         if (seen.has(option.value)) return false;
         seen.add(option.value);
         return true;

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -303,6 +303,8 @@ function VisualizeDropdown({
           }),
         ]
           .filter(option => {
+            // Filtering by value here, so it's based off of explicit tags i.e. `key`
+            // or `tags[<key>, <boolean | number | string>]
             if (seen.has(option.value)) return false;
             seen.add(option.value);
             return true;
@@ -406,6 +408,8 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
       }),
     ]
       .filter(option => {
+        // Filtering by value here, so it's based off of explicit tags i.e. `key`
+        // or `tags[<key>, <boolean | number | string>]
         if (seen.has(option.value)) return false;
         seen.add(option.value);
         return true;

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -4,11 +4,10 @@ import styled from '@emotion/styled';
 import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
-import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
-import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
+import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {
   ToolbarFooter,
   ToolbarSection,
@@ -23,7 +22,6 @@ import {
   ToolbarVisualizeDropdown,
   ToolbarVisualizeHeader,
 } from 'sentry/views/explore/components/toolbar/toolbarVisualize';
-import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {
   TraceItemAttributeProvider,
@@ -456,24 +454,6 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
       )}
     </DragNDropContext>
   );
-}
-
-function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
-  return {
-    label: tag.name,
-    value: tag.key,
-    textValue: tag.key,
-    trailingItems: <TypeBadge kind={tag.kind} />,
-    showDetailsInOverlay: true,
-    details: (
-      <AttributeDetails
-        column={tag.key}
-        kind={tag.kind}
-        label={tag.name}
-        traceItemType={traceItemType}
-      />
-    ),
-  };
 }
 
 function updateVisualizeAggregate({

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
+import type {Tag} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {AggregationKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
@@ -281,85 +282,43 @@ function VisualizeDropdown({
     if (aggregateFunction === AggregationKey.COUNT) {
       return [{label: t('logs'), value: OurLogKnownFieldKey.MESSAGE}];
     }
-
+    const seen = new Set<string>();
     return aggregateFunction === AggregationKey.COUNT_UNIQUE
       ? [
           ...sortedNumberKeys.map(key => {
-            const label = prettifyTagKey(key);
-            return {
-              label,
-              value: key,
-              textValue: key,
-              trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
-              showDetailsInOverlay: true,
-              details: (
-                <AttributeDetails
-                  column={key}
-                  kind={FieldKind.MEASUREMENT}
-                  label={label}
-                  traceItemType={TraceItemDataset.LOGS}
-                />
-              ),
-            };
+            return optionFromTag(
+              {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
+              TraceItemDataset.LOGS
+            );
           }),
           ...sortedStringKeys.map(key => {
-            const label = prettifyTagKey(key);
-            return {
-              label,
-              value: key,
-              textValue: key,
-              trailingItems: <TypeBadge kind={FieldKind.TAG} />,
-              showDetailsInOverlay: true,
-              details: (
-                <AttributeDetails
-                  column={key}
-                  kind={FieldKind.TAG}
-                  label={label}
-                  traceItemType={TraceItemDataset.LOGS}
-                />
-              ),
-            };
+            return optionFromTag(
+              {key, name: prettifyTagKey(key), kind: FieldKind.TAG},
+              TraceItemDataset.LOGS
+            );
           }),
           ...sortedBooleanKeys.map(key => {
-            const label = prettifyTagKey(key);
-            return {
-              label,
-              value: key,
-              textValue: key,
-              trailingItems: <TypeBadge kind={FieldKind.BOOLEAN} />,
-              showDetailsInOverlay: true,
-              details: (
-                <AttributeDetails
-                  column={key}
-                  kind={FieldKind.BOOLEAN}
-                  label={label}
-                  traceItemType={TraceItemDataset.LOGS}
-                />
-              ),
-            };
+            return optionFromTag(
+              {key, name: prettifyTagKey(key), kind: FieldKind.BOOLEAN},
+              TraceItemDataset.LOGS
+            );
           }),
-        ].toSorted((a, b) => {
-          const aLabel = prettifyTagKey(a.value);
-          const bLabel = prettifyTagKey(b.value);
-          return aLabel.localeCompare(bLabel);
-        })
+        ]
+          .filter(option => {
+            if (seen.has(option.value)) return false;
+            seen.add(option.value);
+            return true;
+          })
+          .toSorted((a, b) => {
+            const aLabel = prettifyTagKey(a.value);
+            const bLabel = prettifyTagKey(b.value);
+            return aLabel.localeCompare(bLabel);
+          })
       : sortedNumberKeys.map(key => {
-          const label = prettifyTagKey(key);
-          return {
-            label,
-            value: key,
-            textValue: key,
-            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
-            showDetailsInOverlay: true,
-            details: (
-              <AttributeDetails
-                column={key}
-                kind={FieldKind.MEASUREMENT}
-                label={label}
-                traceItemType={TraceItemDataset.LOGS}
-              />
-            ),
-          };
+          return optionFromTag(
+            {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
+            TraceItemDataset.LOGS
+          );
         });
   }, [aggregateFunction, sortedBooleanKeys, sortedNumberKeys, sortedStringKeys]);
 
@@ -421,75 +380,44 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
 
-  const options = useMemo(
-    () =>
-      [
-        {
-          label: '\u2014',
-          value: '',
-          textValue: '\u2014',
-        },
-        ...Object.keys(numberTags ?? {}).map(key => {
-          const label = prettifyTagKey(key);
-          return {
-            label,
-            value: key,
-            textValue: key,
-            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
-            showDetailsInOverlay: true,
-            details: (
-              <AttributeDetails
-                column={key}
-                kind={FieldKind.MEASUREMENT}
-                label={label}
-                traceItemType={TraceItemDataset.LOGS}
-              />
-            ),
-          };
-        }),
-        ...Object.keys(stringTags ?? {}).map(key => {
-          const label = prettifyTagKey(key);
-          return {
-            label,
-            value: key,
-            textValue: key,
-            trailingItems: <TypeBadge kind={FieldKind.TAG} />,
-            showDetailsInOverlay: true,
-            details: (
-              <AttributeDetails
-                column={key}
-                kind={FieldKind.TAG}
-                label={label}
-                traceItemType={TraceItemDataset.LOGS}
-              />
-            ),
-          };
-        }),
-        ...Object.keys(booleanTags ?? {}).map(key => {
-          const label = prettifyTagKey(key);
-          return {
-            label,
-            value: key,
-            textValue: key,
-            trailingItems: <TypeBadge kind={FieldKind.BOOLEAN} />,
-            showDetailsInOverlay: true,
-            details: (
-              <AttributeDetails
-                column={key}
-                kind={FieldKind.BOOLEAN}
-                label={label}
-                traceItemType={TraceItemDataset.LOGS}
-              />
-            ),
-          };
-        }),
-      ].toSorted((a, b) => {
+  const options = useMemo(() => {
+    const seen = new Set<string>();
+    return [
+      {
+        label: '\u2014',
+        value: '',
+        textValue: '\u2014',
+      },
+      ...Object.keys(numberTags ?? {}).map(key => {
+        return optionFromTag(
+          {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
+          TraceItemDataset.LOGS
+        );
+      }),
+      ...Object.keys(stringTags ?? {}).map(key => {
+        return optionFromTag(
+          {key, name: prettifyTagKey(key), kind: FieldKind.TAG},
+          TraceItemDataset.LOGS
+        );
+      }),
+      ...Object.keys(booleanTags ?? {}).map(key => {
+        return optionFromTag(
+          {key, name: prettifyTagKey(key), kind: FieldKind.BOOLEAN},
+          TraceItemDataset.LOGS
+        );
+      }),
+    ]
+      .filter(option => {
+        if (seen.has(option.value)) return false;
+        seen.add(option.value);
+        return true;
+      })
+      .toSorted((a, b) => {
         const aLabel = prettifyTagKey(a.value);
         const bLabel = prettifyTagKey(b.value);
         return aLabel.localeCompare(bLabel);
-      }),
-    [booleanTags, numberTags, stringTags]
-  );
+      });
+  }, [booleanTags, numberTags, stringTags]);
 
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {
@@ -528,6 +456,24 @@ function ToolbarGroupBy({onSearch, onClose}: LogsToolbarProps) {
       )}
     </DragNDropContext>
   );
+}
+
+function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
+  return {
+    label: tag.name,
+    value: tag.key,
+    textValue: tag.key,
+    trailingItems: <TypeBadge kind={tag.kind} />,
+    showDetailsInOverlay: true,
+    details: (
+      <AttributeDetails
+        column={tag.key}
+        kind={tag.kind}
+        label={tag.key}
+        traceItemType={traceItemType}
+      />
+    ),
+  };
 }
 
 function updateVisualizeAggregate({

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -469,7 +469,7 @@ function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
       <AttributeDetails
         column={tag.key}
         kind={tag.kind}
-        label={tag.key}
+        label={tag.name}
         traceItemType={traceItemType}
       />
     ),


### PR DESCRIPTION
When the backend returns the same attribute key under multiple types (e.g. `cache.hit` as both `number` and `boolean`), the options arrays for Group By and Visualize dropdowns ended up with duplicate `value` entries. Since `CompactSelect` derives React keys from option values via `CSS.escape(String(value))`, duplicate keys broke `@tanstack/react-virtual`'s item tracking — causing broken scrolling and duplicate rendered items.

Deduplicates options by key before they reach `CompactSelect`, keeping the first type encountered (number > string > boolean). Also extracts shared `optionFromTag` helpers in `logsToolbar.tsx` and `useVisualizeFields.tsx` to reduce duplication.

Fixes EXP-795