### PR TITLE
chore(core-ui): Detect and log duplicate option keys for CompactSelect

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -140,6 +140,10 @@ export function CompactSelect<Value extends SelectKey>({
   const controlDisabled = disabled ?? options?.length === 0;
 
   const allItemsWithKey = useMemo(() => getItemsWithKeys(options), [options]);
+  const duplicateOptionKeys = useMemo(
+    () => getDuplicateOptionKeys(allItemsWithKey),
+    [allItemsWithKey]
+  );
   const longestOptionItemsWithKey = useMemo(() => {
     if (needsMeasuring) {
       const longestOption = maxBy(options, option => {
@@ -180,6 +184,7 @@ export function CompactSelect<Value extends SelectKey>({
             trackVirtualizationMetrics(
               allItemsWithKey,
               virtualizeThreshold,
+              duplicateOptionKeys.length,
               typeof controlProps.menuTitle === 'string'
                 ? controlProps.menuTitle
                 : undefined
@@ -239,6 +244,28 @@ export function CompactSelect<Value extends SelectKey>({
   );
 }
 
+function getDuplicateOptionKeys<Value extends SelectKey>(
+  items: Array<SelectOptionOrSectionWithKey<Value>>
+): string[] {
+  const keyCounts = new Map<string, number>();
+
+  const collectOptionKeys = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
+    list.forEach(item => {
+      if ('options' in item) {
+        collectOptionKeys(item.options);
+        return;
+      }
+
+      const key = String(item.key);
+      keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+    });
+  };
+
+  collectOptionKeys(items);
+
+  return [...keyCounts.entries()].filter(([, count]) => count > 1).map(([key]) => key);
+}
+
 function shouldVirtualize<Value extends SelectKey>(
   items: Array<SelectOptionOrSection<Value>>,
   virtualizeThreshold = 150
@@ -254,6 +281,7 @@ function shouldVirtualize<Value extends SelectKey>(
 function trackVirtualizationMetrics<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   virtualizeThreshold = 150,
+  duplicateOptionKeyCount = 0,
   title = 'unknown'
 ) {
   const hasSections = items.some(item => 'options' in item);
@@ -269,6 +297,7 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
         has_sections: hasSections,
         component_title: title,
         count: optionCount,
+        duplicate_option_key_count: duplicateOptionKeyCount,
         threshold,
       },
     });
@@ -278,6 +307,7 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
     attributes: {
       has_sections: hasSections,
       component_title: title,
+      duplicate_option_key_count: duplicateOptionKeyCount,
     },
   });
 }

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useId, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useId, useMemo, useRef, useState} from 'react';
 import {Item, Section} from '@react-stately/collections';
 import * as Sentry from '@sentry/react';
 import maxBy from 'lodash/maxBy';
@@ -140,16 +140,6 @@ export function CompactSelect<Value extends SelectKey>({
   const controlDisabled = disabled ?? options?.length === 0;
   const allItemsWithKey = useMemo(() => getItemsWithKeys(options), [options]);
 
-  const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
-  const duplicateOptionKeys = useMemo(
-    () => getDuplicateOptionKeys(allItemsWithKey),
-    [allItemsWithKey]
-  );
-  const duplicateOptionKeySignature = useMemo(
-    () => duplicateOptionKeys.join(','),
-    [duplicateOptionKeys]
-  );
-
   const longestOptionItemsWithKey = useMemo(() => {
     if (needsMeasuring) {
       const longestOption = maxBy(options, option => {
@@ -170,6 +160,49 @@ export function CompactSelect<Value extends SelectKey>({
   }, [needsMeasuring, options]);
   const itemsWithKey = needsMeasuring ? longestOptionItemsWithKey : allItemsWithKey;
 
+  const componentTitle = useMemo(
+    () =>
+      typeof controlProps.menuTitle === 'string' ? controlProps.menuTitle : 'unknown',
+    [controlProps.menuTitle]
+  );
+  const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
+  const duplicateOptionKeys = useMemo(
+    () => getDuplicateOptionKeys(allItemsWithKey),
+    [allItemsWithKey]
+  );
+  const duplicateOptionKeySignature = useMemo(
+    () => duplicateOptionKeys.join(','),
+    [duplicateOptionKeys]
+  );
+
+  useEffect(() => {
+    if (duplicateOptionKeys.length === 0) {
+      lastLoggedDuplicateKeySignatureRef.current = undefined;
+      return;
+    }
+    if (lastLoggedDuplicateKeySignatureRef.current === duplicateOptionKeySignature) {
+      return;
+    }
+    lastLoggedDuplicateKeySignatureRef.current = duplicateOptionKeySignature;
+
+    Sentry.logger.error('CompactSelect has duplicate option keys', {
+      component_title: componentTitle,
+      duplicate_option_key_count: duplicateOptionKeys.length,
+      duplicate_option_key_signature: duplicateOptionKeySignature,
+      has_sections: allItemsWithKey.some(item => 'options' in item),
+      option_count: allItemsWithKey.reduce((sum, item) => {
+        return 'options' in item ? sum + item.options.length : sum + 1;
+      }, 0),
+      virtualize_threshold: virtualizeThreshold ?? 150,
+    });
+  }, [
+    allItemsWithKey,
+    componentTitle,
+    duplicateOptionKeySignature,
+    duplicateOptionKeys.length,
+    virtualizeThreshold,
+  ]);
+
   return (
     <Control
       {...controlProps}
@@ -187,37 +220,13 @@ export function CompactSelect<Value extends SelectKey>({
         controlProps.onOpenChange?.(newOpenState);
         if (newOpenState) {
           scheduleMicroTask(() => {
-            const componentTitle =
-              typeof controlProps.menuTitle === 'string'
-                ? controlProps.menuTitle
-                : 'unknown';
-
             trackVirtualizationMetrics(
               allItemsWithKey,
               virtualizeThreshold,
               duplicateOptionKeys.length,
+              duplicateOptionKeySignature,
               componentTitle
             );
-
-            if (duplicateOptionKeys.length === 0) {
-              lastLoggedDuplicateKeySignatureRef.current = undefined;
-              return;
-            }
-            if (
-              lastLoggedDuplicateKeySignatureRef.current === duplicateOptionKeySignature
-            ) {
-              return;
-            }
-            lastLoggedDuplicateKeySignatureRef.current = duplicateOptionKeySignature;
-            Sentry.logger.error('CompactSelect has duplicate option keys', {
-              component_title: componentTitle,
-              duplicate_option_key_count: duplicateOptionKeys.length,
-              has_sections: allItemsWithKey.some(item => 'options' in item),
-              option_count: allItemsWithKey.reduce((sum, item) => {
-                return 'options' in item ? sum + item.options.length : sum + 1;
-              }, 0),
-              virtualize_threshold: virtualizeThreshold ?? 150,
-            });
           });
         }
       }}
@@ -289,6 +298,7 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   virtualizeThreshold = 150,
   duplicateOptionKeyCount = 0,
+  duplicateOptionKeySignature = '',
   title = 'unknown'
 ) {
   const hasSections = items.some(item => 'options' in item);
@@ -305,6 +315,7 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
         component_title: title,
         count: optionCount,
         duplicate_option_key_count: duplicateOptionKeyCount,
+        duplicate_option_key_signature: duplicateOptionKeySignature,
         threshold,
       },
     });
@@ -315,6 +326,7 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
       has_sections: hasSections,
       component_title: title,
       duplicate_option_key_count: duplicateOptionKeyCount,
+      duplicate_option_key_signature: duplicateOptionKeySignature,
     },
   });
 }

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useId, useMemo, useState} from 'react';
+import {useCallback, useId, useMemo, useRef, useState} from 'react';
 import {Item, Section} from '@react-stately/collections';
 import * as Sentry from '@sentry/react';
 import maxBy from 'lodash/maxBy';
@@ -138,12 +138,18 @@ export function CompactSelect<Value extends SelectKey>({
   );
 
   const controlDisabled = disabled ?? options?.length === 0;
-
   const allItemsWithKey = useMemo(() => getItemsWithKeys(options), [options]);
+
+  const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
   const duplicateOptionKeys = useMemo(
     () => getDuplicateOptionKeys(allItemsWithKey),
     [allItemsWithKey]
   );
+  const duplicateOptionKeySignature = useMemo(
+    () => duplicateOptionKeys.join(','),
+    [duplicateOptionKeys]
+  );
+
   const longestOptionItemsWithKey = useMemo(() => {
     if (needsMeasuring) {
       const longestOption = maxBy(options, option => {
@@ -181,14 +187,37 @@ export function CompactSelect<Value extends SelectKey>({
         controlProps.onOpenChange?.(newOpenState);
         if (newOpenState) {
           scheduleMicroTask(() => {
+            const componentTitle =
+              typeof controlProps.menuTitle === 'string'
+                ? controlProps.menuTitle
+                : 'unknown';
+
             trackVirtualizationMetrics(
               allItemsWithKey,
               virtualizeThreshold,
               duplicateOptionKeys.length,
-              typeof controlProps.menuTitle === 'string'
-                ? controlProps.menuTitle
-                : undefined
+              componentTitle
             );
+
+            if (duplicateOptionKeys.length === 0) {
+              lastLoggedDuplicateKeySignatureRef.current = undefined;
+              return;
+            }
+            if (
+              lastLoggedDuplicateKeySignatureRef.current === duplicateOptionKeySignature
+            ) {
+              return;
+            }
+            lastLoggedDuplicateKeySignatureRef.current = duplicateOptionKeySignature;
+            Sentry.logger.error('CompactSelect has duplicate option keys', {
+              component_title: componentTitle,
+              duplicate_option_key_count: duplicateOptionKeys.length,
+              has_sections: allItemsWithKey.some(item => 'options' in item),
+              option_count: allItemsWithKey.reduce((sum, item) => {
+                return 'options' in item ? sum + item.options.length : sum + 1;
+              }, 0),
+              virtualize_threshold: virtualizeThreshold ?? 150,
+            });
           });
         }
       }}

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -18,7 +18,7 @@ import type {
   SelectOptionOrSectionWithKey,
   SelectSection,
 } from './types';
-import {getDuplicateOptionKeys, getItemsWithKeys, shouldCloseOnSelect} from './utils';
+import {getDuplicateOptionKeysInfo, getItemsWithKeys, shouldCloseOnSelect} from './utils';
 
 export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
@@ -168,7 +168,8 @@ export function CompactSelect<Value extends SelectKey>({
 
   const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    const duplicateOptionKeys = getDuplicateOptionKeys(allItemsWithKey);
+    const {duplicateOptionKeys, hasSections, optionCount} =
+      getDuplicateOptionKeysInfo(allItemsWithKey);
     if (duplicateOptionKeys.length === 0) {
       lastLoggedDuplicateKeySignatureRef.current = undefined;
       return;
@@ -184,10 +185,8 @@ export function CompactSelect<Value extends SelectKey>({
       component_title: componentTitle,
       duplicate_option_key_count: duplicateOptionKeys.length,
       duplicate_option_key_signature: duplicateOptionKeySignature,
-      has_sections: allItemsWithKey.some(item => 'options' in item),
-      option_count: allItemsWithKey.reduce((sum, item) => {
-        return 'options' in item ? sum + item.options.length : sum + 1;
-      }, 0),
+      has_sections: hasSections,
+      option_count: optionCount,
       virtualize_threshold: virtualizeThreshold ?? 150,
     });
   }, [allItemsWithKey, componentTitle, virtualizeThreshold]);

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -165,21 +165,16 @@ export function CompactSelect<Value extends SelectKey>({
       typeof controlProps.menuTitle === 'string' ? controlProps.menuTitle : 'unknown',
     [controlProps.menuTitle]
   );
-  const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
-  const duplicateOptionKeys = useMemo(
-    () => getDuplicateOptionKeys(allItemsWithKey),
-    [allItemsWithKey]
-  );
-  const duplicateOptionKeySignature = useMemo(
-    () => duplicateOptionKeys.join(','),
-    [duplicateOptionKeys]
-  );
 
+  const lastLoggedDuplicateKeySignatureRef = useRef<string | undefined>(undefined);
   useEffect(() => {
+    const duplicateOptionKeys = getDuplicateOptionKeys(allItemsWithKey);
     if (duplicateOptionKeys.length === 0) {
       lastLoggedDuplicateKeySignatureRef.current = undefined;
       return;
     }
+
+    const duplicateOptionKeySignature = duplicateOptionKeys.join(',');
     if (lastLoggedDuplicateKeySignatureRef.current === duplicateOptionKeySignature) {
       return;
     }
@@ -195,13 +190,7 @@ export function CompactSelect<Value extends SelectKey>({
       }, 0),
       virtualize_threshold: virtualizeThreshold ?? 150,
     });
-  }, [
-    allItemsWithKey,
-    componentTitle,
-    duplicateOptionKeySignature,
-    duplicateOptionKeys.length,
-    virtualizeThreshold,
-  ]);
+  }, [allItemsWithKey, componentTitle, virtualizeThreshold]);
 
   return (
     <Control
@@ -223,8 +212,6 @@ export function CompactSelect<Value extends SelectKey>({
             trackVirtualizationMetrics(
               allItemsWithKey,
               virtualizeThreshold,
-              duplicateOptionKeys.length,
-              duplicateOptionKeySignature,
               componentTitle
             );
           });
@@ -297,8 +284,6 @@ function shouldVirtualize<Value extends SelectKey>(
 function trackVirtualizationMetrics<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   virtualizeThreshold = 150,
-  duplicateOptionKeyCount = 0,
-  duplicateOptionKeySignature = '',
   title = 'unknown'
 ) {
   const hasSections = items.some(item => 'options' in item);
@@ -314,8 +299,6 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
         has_sections: hasSections,
         component_title: title,
         count: optionCount,
-        duplicate_option_key_count: duplicateOptionKeyCount,
-        duplicate_option_key_signature: duplicateOptionKeySignature,
         threshold,
       },
     });
@@ -325,8 +308,6 @@ function trackVirtualizationMetrics<Value extends SelectKey>(
     attributes: {
       has_sections: hasSections,
       component_title: title,
-      duplicate_option_key_count: duplicateOptionKeyCount,
-      duplicate_option_key_signature: duplicateOptionKeySignature,
     },
   });
 }

--- a/static/app/components/core/compactSelect/compactSelect.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.tsx
@@ -18,7 +18,7 @@ import type {
   SelectOptionOrSectionWithKey,
   SelectSection,
 } from './types';
-import {getItemsWithKeys, shouldCloseOnSelect} from './utils';
+import {getDuplicateOptionKeys, getItemsWithKeys, shouldCloseOnSelect} from './utils';
 
 export type {SelectOption, SelectOptionOrSection, SelectSection, SelectKey};
 
@@ -271,28 +271,6 @@ export function CompactSelect<Value extends SelectKey>({
       <EmptyMessage>{emptyMessage ?? t('No options found')}</EmptyMessage>
     </Control>
   );
-}
-
-function getDuplicateOptionKeys<Value extends SelectKey>(
-  items: Array<SelectOptionOrSectionWithKey<Value>>
-): string[] {
-  const keyCounts = new Map<string, number>();
-
-  const collectOptionKeys = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
-    list.forEach(item => {
-      if ('options' in item) {
-        collectOptionKeys(item.options);
-        return;
-      }
-
-      const key = String(item.key);
-      keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
-    });
-  };
-
-  collectOptionKeys(items);
-
-  return [...keyCounts.entries()].filter(([, count]) => count > 1).map(([key]) => key);
 }
 
 function shouldVirtualize<Value extends SelectKey>(

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -354,3 +354,25 @@ export function shouldCloseOnSelect({
   // lists stay open
   return !multiple;
 }
+
+export function getDuplicateOptionKeys<Value extends SelectKey>(
+  items: Array<SelectOptionOrSectionWithKey<Value>>
+): string[] {
+  const keyCounts = new Map<string, number>();
+
+  const collectOptionKeys = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
+    list.forEach(item => {
+      if ('options' in item) {
+        collectOptionKeys(item.options);
+        return;
+      }
+
+      const key = String(item.key);
+      keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
+    });
+  };
+
+  collectOptionKeys(items);
+
+  return [...keyCounts.entries()].filter(([, count]) => count > 1).map(([key]) => key);
+}

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -358,21 +358,27 @@ export function shouldCloseOnSelect({
 export function getDuplicateOptionKeys<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>
 ): string[] {
-  const keyCounts = new Map<string, number>();
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
 
-  const collectOptionKeys = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
-    list.forEach(item => {
+  const collect = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
+    for (const item of list) {
       if ('options' in item) {
-        collectOptionKeys(item.options);
-        return;
+        collect(item.options);
+        continue;
       }
 
       const key = String(item.key);
-      keyCounts.set(key, (keyCounts.get(key) ?? 0) + 1);
-    });
+      if (duplicates.has(key)) continue;
+
+      if (seen.has(key)) {
+        duplicates.add(key);
+      } else {
+        seen.add(key);
+      }
+    }
   };
 
-  collectOptionKeys(items);
-
-  return [...keyCounts.entries()].filter(([, count]) => count > 1).map(([key]) => key);
+  collect(items);
+  return [...duplicates];
 }

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -355,19 +355,23 @@ export function shouldCloseOnSelect({
   return !multiple;
 }
 
-export function getDuplicateOptionKeys<Value extends SelectKey>(
+export function getDuplicateOptionKeysInfo<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>
-): string[] {
+): {duplicateOptionKeys: string[]; hasSections: boolean; optionCount: number} {
   const seen = new Set<string>();
   const duplicates = new Set<string>();
+  let optionCount = 0;
+  let hasSections = false;
 
   const collect = (list: Array<SelectOptionOrSectionWithKey<Value>>) => {
     for (const item of list) {
       if ('options' in item) {
+        hasSections = true;
         collect(item.options);
         continue;
       }
 
+      optionCount += 1;
       const key = String(item.key);
       if (duplicates.has(key)) continue;
 
@@ -380,5 +384,5 @@ export function getDuplicateOptionKeys<Value extends SelectKey>(
   };
 
   collect(items);
-  return [...duplicates];
+  return {duplicateOptionKeys: [...duplicates], hasSections, optionCount};
 }


### PR DESCRIPTION
## Summary

Adds detection and logging of duplicate option keys in `CompactSelect` to help diagnose issues caused by key collisions in selection and virtualization.

### Changes

- Add `getDuplicateOptionKeysInfo` utility that walks the normalized `allItemsWithKey` list (including nested sections) and returns any duplicate keys along with metadata (option count, whether sections are present)
- Add a `useEffect` in `CompactSelect` that runs whenever options change, detects duplicates, and logs them via `Sentry.logger.error` with aggregate metadata (`duplicate_option_key_count`, `option_count`, `has_sections`, `component_title`, `virtualize_threshold`)
- Deduplicate log reports using a ref that tracks the last-seen duplicate key signature, so repeated renders with the same duplicates don't produce redundant logs
- Extract `componentTitle` into a shared `useMemo` to reuse it between the new duplicate-key logging and the existing virtualization metrics path