### PR TITLE
fix(dashboards): use spans dataset in default overview dashboard backend

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -410,13 +410,14 @@ class DashboardLastVisited(DefaultFieldsModel):
 
 def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
     error_events_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
+    is_transactions_deprecation_enabled = features.has(
+        "organizations:discover-saved-queries-deprecation",
+        organization=organization,
+        actor=user,
+    )
     transaction_type = (
         DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.SPANS)
-        if features.has(
-            "organizations:discover-saved-queries-deprecation",
-            organization=organization,
-            actor=user,
-        )
+        if is_transactions_deprecation_enabled
         else DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
     )
 
@@ -570,7 +571,9 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
                             "fields": ["count()", "transaction"],
                             "aggregates": ["count()"],
                             "columns": ["transaction"],
-                            "conditions": "",
+                            "conditions": "is_transaction:true"
+                            if is_transactions_deprecation_enabled
+                            else "",
                             "orderby": "-count()",
                         },
                     ],
@@ -586,7 +589,9 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
                             "fields": ["user_misery(300)"],
                             "aggregates": ["user_misery(300)"],
                             "columns": [],
-                            "conditions": "",
+                            "conditions": "is_transaction:true"
+                            if is_transactions_deprecation_enabled
+                            else "",
                             "orderby": "",
                         },
                     ],
@@ -602,7 +607,9 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
                             "fields": ["transaction", "count()"],
                             "aggregates": ["count()"],
                             "columns": ["transaction"],
-                            "conditions": "",
+                            "conditions": "is_transaction:true"
+                            if is_transactions_deprecation_enabled
+                            else "",
                             "orderby": "-count()",
                         },
                     ],
@@ -634,7 +641,9 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
                             "fields": ["transaction", "user_misery(300)"],
                             "aggregates": ["user_misery(300)"],
                             "columns": ["transaction"],
-                            "conditions": "",
+                            "conditions": "is_transaction:true"
+                            if is_transactions_deprecation_enabled
+                            else "",
                             "orderby": "-user_misery(300)",
                         },
                     ],

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -412,7 +412,11 @@ def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
     error_events_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
     transaction_type = (
         DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.SPANS)
-        if features.has("organizations:discover-saved-queries-deprecation", organization, user)
+        if features.has(
+            "organizations:discover-saved-queries-deprecation",
+            organization=organization,
+            actor=user,
+        )
         else DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
     )
 

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -9,6 +9,7 @@ from django.db.models import CheckConstraint, Q, UniqueConstraint
 from django.db.models.query import QuerySet
 from django.utils import timezone
 
+from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.db.models import FlexibleForeignKey, Model, region_silo_model, sane_repr
@@ -409,7 +410,12 @@ class DashboardLastVisited(DefaultFieldsModel):
 
 def get_prebuilt_dashboards(organization, user) -> list[dict[str, Any]]:
     error_events_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
-    transaction_type = DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
+    transaction_type = (
+        DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.SPANS)
+        if features.has("organizations:discover-saved-queries-deprecation", organization, user)
+        else DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
+    )
+
     return [
         {
             # This should match the general template in static/app/views/dashboardsV2/data.tsx


### PR DESCRIPTION
when we deprecated the spans dataset in the dashboard/widget templates we forgot to do the default overview backend endpoint 🤩 

Closes [DAIN-1197](https://linear.app/getsentry/issue/DAIN-1197/cannot-add-a-widget-to-a-dashboard)