### PR TITLE
chore(tasks) Remove the taskregistry global

### DIFF
--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -271,7 +271,3 @@ class TaskRegistry:
         self._namespaces[name] = namespace
 
         return namespace
-
-
-# TODO(mark) replace usage of this with `sentry.taskworker.runtime.app`
-taskregistry = TaskRegistry(application="sentry")

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -2,9 +2,8 @@ from django.conf import settings
 from django.core.cache import cache
 
 from sentry.taskworker.app import TaskworkerApp
-from sentry.taskworker.registry import taskregistry
 
-app = TaskworkerApp(name="sentry", taskregistry=taskregistry)
+app = TaskworkerApp(name="sentry")
 app.set_config(
     {
         "rpc_secret": settings.TASKWORKER_SHARED_SECRET,

--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 import sentry
 from sentry.conf.types.taskworker import crontab
-from sentry.taskworker.registry import taskregistry
+from sentry.taskworker.runtime import app
 
 
 @pytest.fixture
@@ -44,7 +44,7 @@ def test_taskworker_schedule_unique() -> None:
 def test_taskworker_schedule_type(name: str, config: dict[str, Any], load_tasks) -> None:
     assert config["task"], f"schedule {name} is missing a task name"
     (namespace, taskname) = config["task"].split(":")
-    assert taskregistry.get_task(namespace, taskname), f"task for {name} is not registered"
+    assert app.taskregistry.get_task(namespace, taskname), f"task for {name} is not registered"
 
     assert config["schedule"], f"Schedule {name} is missing a schedule"
     schedule = config.get("schedule")
@@ -56,7 +56,7 @@ def test_taskworker_schedule_type(name: str, config: dict[str, Any], load_tasks)
 def test_taskworker_schedule_parameters() -> None:
     for config in settings.TASKWORKER_SCHEDULES.values():
         (namespace, taskname) = config["task"].split(":")
-        task = taskregistry.get_task(namespace, taskname)
+        task = app.taskregistry.get_task(namespace, taskname)
         signature = inspect.signature(task)
 
         for parameter in signature.parameters.values():


### PR DESCRIPTION
Remove usage and creation of the taskregistry global. We can should use `runtime.app` now.

Requires getsentry/getsentry#19403 to be merged

Refs STREAM-716