### PR TITLE
Perf/parallel-drain-use-replica

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -332,9 +332,11 @@ def _run_parallel_delivery_batch(
     Run one batch of parallel deliveries for the mailbox.
     Returns (delivered_count, request_failed, no_more_messages).
     """
-    query = WebhookPayload.objects.filter(
-        id__gte=payload.id, mailbox_name=payload.mailbox_name
-    ).order_by("id")
+    query = (
+        WebhookPayload.objects.using_replica()
+        .filter(id__gte=payload.id, mailbox_name=payload.mailbox_name)
+        .order_by("id")
+    )
 
     with ThreadPoolExecutor(max_workers=worker_threads) as threadpool:
         futures = {
@@ -377,7 +379,7 @@ def drain_mailbox_parallel(payload_id: int) -> None:
     indicates that we have hit the start of another batch that has been scheduled.
     """
     try:
-        payload = WebhookPayload.objects.get(id=payload_id)
+        payload = WebhookPayload.objects.using_replica().get(id=payload_id)
     except WebhookPayload.DoesNotExist:
         # We could have hit a race condition. Since we've lost already return
         # and let the other process continue, or a future process.

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -653,13 +653,10 @@ class Release(Model):
 
         set_commits(self, commit_list)
 
-    def safe_delete(self):
-        """Deletes a release if possible or raises a `UnsafeReleaseDeletion`
-        exception.
-        """
+    def validate_safe_to_delete(self) -> None:
+        """Raises UnsafeReleaseDeletion if this release cannot be deleted."""
         from sentry import release_health
         from sentry.models.group import Group
-        from sentry.models.releasefile import ReleaseFile
 
         # we don't want to remove the first_release metadata on the Group, and
         # while people might want to kill a release (maybe to remove files),
@@ -676,14 +673,6 @@ class Release(Model):
             [(p[0], self.version) for p in project_ids]
         ):
             raise UnsafeReleaseDeletion(ERR_RELEASE_HEALTH_DATA)
-
-        # TODO(dcramer): this needs to happen in the queue as it could be a long
-        # and expensive operation
-        file_list = ReleaseFile.objects.filter(release_id=self.id).select_related("file")
-        for releasefile in file_list:
-            releasefile.file.delete()
-            releasefile.delete()
-        self.delete()
 
     def count_artifacts(self):
         """Sum the artifact_counts of all release files.

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -25,14 +25,15 @@ from sentry.api.serializers.rest_framework import (
 )
 from sentry.api.serializers.types import ReleaseSerializerResponse
 from sentry.apidocs.constants import (
+    RESPONSE_ACCEPTED,
     RESPONSE_FORBIDDEN,
-    RESPONSE_NO_CONTENT,
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams, ReleaseParams, VisibilityParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -542,7 +543,7 @@ class OrganizationReleaseDetailsEndpoint(
             ReleaseParams.VERSION,
         ],
         responses={
-            204: RESPONSE_NO_CONTENT,
+            202: RESPONSE_ACCEPTED,
             401: RESPONSE_UNAUTHORIZED,
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
@@ -562,8 +563,9 @@ class OrganizationReleaseDetailsEndpoint(
             raise ResourceDoesNotExist
 
         try:
-            release.safe_delete()
+            release.validate_safe_to_delete()
         except UnsafeReleaseDeletion as e:
             return Response({"detail": str(e)}, status=400)
 
-        return Response(status=204)
+        RegionScheduledDeletion.schedule(release, days=0, actor=request.user)
+        return Response(status=202)

--- a/src/sentry/releases/endpoints/project_release_details.py
+++ b/src/sentry/releases/endpoints/project_release_details.py
@@ -11,6 +11,7 @@ from sentry.api.endpoints.organization_releases import get_stats_period_detail
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ReleaseSerializer
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.activity import Activity
 from sentry.models.release import Release
 from sentry.models.releases.exceptions import UnsafeReleaseDeletion
@@ -175,8 +176,9 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             raise ResourceDoesNotExist
 
         try:
-            release.safe_delete()
+            release.validate_safe_to_delete()
         except UnsafeReleaseDeletion as e:
             return Response({"detail": str(e)}, status=400)
 
-        return Response(status=204)
+        RegionScheduledDeletion.schedule(release, days=0, actor=request.user)
+        return Response(status=202)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -936,6 +936,42 @@ class DrainMailboxParallelTest(TestCase):
 
         assert len(responses.calls) == 1
 
+    def test_drain_missing_payload_uses_replica(self) -> None:
+        # Calling with a nonexistent ID should use the replica and exit with outcome=race.
+        with patch.object(
+            WebhookPayload.objects,
+            "using_replica",
+            wraps=WebhookPayload.objects.using_replica,
+        ) as mock_replica:
+            drain_mailbox_parallel(99999)
+
+        mock_replica.assert_called()
+
+    @responses.activate
+    @override_regions(region_config)
+    def test_drain_batch_query_uses_replica(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook_one = self.create_webhook_payload(
+            mailbox_name="github:123",
+            region_name="us",
+        )
+
+        with patch.object(
+            WebhookPayload.objects,
+            "using_replica",
+            wraps=WebhookPayload.objects.using_replica,
+        ) as mock_replica:
+            drain_mailbox_parallel(webhook_one.id)
+
+        # using_replica() should be called for both the initial payload fetch
+        # and the batch query in _run_parallel_delivery_batch.
+        assert mock_replica.call_count >= 2
+
 
 @control_silo_test
 class SlowDeliveryLoggingTest(TestCase):

--- a/tests/sentry/releases/endpoints/test_organization_release_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_details.py
@@ -6,6 +6,7 @@ import pytest
 from django.urls import reverse
 
 from sentry.constants import MAX_VERSION_LENGTH
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.locks import locks
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
@@ -1176,10 +1177,13 @@ class ReleaseDeleteTest(APITestCase):
         )
         response = self.client.delete(url)
 
-        assert response.status_code == 204, response.content
+        assert response.status_code == 202, response.content
 
-        assert not Release.objects.filter(id=release.id).exists()
-        assert not ReleaseFile.objects.filter(id=release_file.id).exists()
+        assert Release.objects.filter(id=release.id).exists()
+        assert ReleaseFile.objects.filter(id=release_file.id).exists()
+        assert RegionScheduledDeletion.objects.filter(
+            model_name="Release", object_id=release.id
+        ).exists()
 
     def test_existing_group(self) -> None:
         user = self.create_user(is_staff=False, is_superuser=False)

--- a/tests/sentry/releases/endpoints/test_project_release_details.py
+++ b/tests/sentry/releases/endpoints/test_project_release_details.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from sentry.api.serializers.rest_framework.release import ReleaseSerializer
 from sentry.constants import MAX_VERSION_LENGTH
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.models.activity import Activity
 from sentry.models.files.file import File
 from sentry.models.release import Release
@@ -231,9 +232,12 @@ class ReleaseDeleteTest(APITestCase):
         )
         response = self.client.delete(url)
 
-        assert response.status_code == 204, response.content
+        assert response.status_code == 202, response.content
 
-        assert not Release.objects.filter(id=release.id).exists()
+        assert Release.objects.filter(id=release.id).exists()
+        assert RegionScheduledDeletion.objects.filter(
+            model_name="Release", object_id=release.id
+        ).exists()
 
     def test_existing_group(self) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
- Updated the delivery tasks to utilize the database replica for fetching webhook payloads in both  and  functions.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
