### PR TITLE
feat(auth): Add structured logging for AuthIdentity updates and deletes

### DIFF
--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Collection
 from typing import Any
 
@@ -14,6 +15,10 @@ from sentry.db.models import FlexibleForeignKey, control_silo_model, sane_repr
 from sentry.hybridcloud.outbox.base import ReplicatedControlModel
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.types.region import find_regions_for_orgs
+
+logger = logging.getLogger("sentry.auth.identity")
+
+_MEANINGFUL_UPDATE_FIELDS = frozenset({"user", "user_id", "ident", "data"})
 
 
 @control_silo_model
@@ -52,6 +57,32 @@ class AuthIdentity(ReplicatedControlModel):
 
         sanitizer.set_json(json, SanitizableField(model_name, "data"), {})
         sanitizer.set_string(json, SanitizableField(model_name, "ident"))
+
+    def update(self, *args: Any, **kwds: Any) -> int:
+        changed_fields = _MEANINGFUL_UPDATE_FIELDS.intersection(kwds)
+        result = super().update(*args, **kwds)
+        if changed_fields:
+            logger.info(
+                "auth_identity.update",
+                extra={
+                    "auth_identity_id": self.id,
+                    "auth_provider_id": self.auth_provider_id,
+                    "user_id": self.user_id,
+                    "changed_fields": sorted(changed_fields),
+                },
+            )
+        return result
+
+    def delete(self, *args: Any, **kwds: Any) -> tuple[int, dict[str, Any]]:
+        logger.info(
+            "auth_identity.delete",
+            extra={
+                "auth_identity_id": self.id,
+                "auth_provider_id": self.auth_provider_id,
+                "user_id": self.user_id,
+            },
+        )
+        return super().delete(*args, **kwds)
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/authidentity.py
+++ b/src/sentry/models/authidentity.py
@@ -60,17 +60,18 @@ class AuthIdentity(ReplicatedControlModel):
 
     def update(self, *args: Any, **kwds: Any) -> int:
         changed_fields = _MEANINGFUL_UPDATE_FIELDS.intersection(kwds)
+        old_user_id = self.user_id
         result = super().update(*args, **kwds)
         if changed_fields:
-            logger.info(
-                "auth_identity.update",
-                extra={
-                    "auth_identity_id": self.id,
-                    "auth_provider_id": self.auth_provider_id,
-                    "user_id": self.user_id,
-                    "changed_fields": sorted(changed_fields),
-                },
-            )
+            extra: dict[str, Any] = {
+                "auth_identity_id": self.id,
+                "auth_provider_id": self.auth_provider_id,
+                "user_id": old_user_id,
+                "changed_fields": sorted(changed_fields),
+            }
+            if self.user_id != old_user_id:
+                extra["new_user_id"] = self.user_id
+            logger.info("auth_identity.update", extra=extra)
         return result
 
     def delete(self, *args: Any, **kwds: Any) -> tuple[int, dict[str, Any]]:

--- a/tests/sentry/models/test_authidentity.py
+++ b/tests/sentry/models/test_authidentity.py
@@ -53,7 +53,8 @@ class AuthIdentityUpdateLoggingTest(TestCase):
         )
 
     @patch("sentry.models.authidentity.logger")
-    def test_update_user_id_logs(self, mock_logger):
+    def test_update_user_id_logs_old_and_new(self, mock_logger):
+        old_user_id = self.user.id
         new_user = self.create_user()
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.auth_identity.update(user_id=new_user.id)
@@ -63,7 +64,8 @@ class AuthIdentityUpdateLoggingTest(TestCase):
             extra={
                 "auth_identity_id": self.auth_identity.id,
                 "auth_provider_id": self.auth_provider.id,
-                "user_id": new_user.id,
+                "user_id": old_user_id,
+                "new_user_id": new_user.id,
                 "changed_fields": ["user_id"],
             },
         )

--- a/tests/sentry/models/test_authidentity.py
+++ b/tests/sentry/models/test_authidentity.py
@@ -1,0 +1,117 @@
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from sentry.models.authidentity import AuthIdentity
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+
+
+@control_silo_test
+class AuthIdentityUpdateLoggingTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.auth_provider = self.create_auth_provider(
+            organization_id=self.organization.id, provider="dummy"
+        )
+        self.auth_identity = self.create_auth_identity(
+            auth_provider=self.auth_provider,
+            user=self.user,
+            ident="test-ident",
+            data={"old": "value"},
+        )
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_data_logs(self, mock_logger):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.update(data={"new": "value"})
+
+        mock_logger.info.assert_called_once_with(
+            "auth_identity.update",
+            extra={
+                "auth_identity_id": self.auth_identity.id,
+                "auth_provider_id": self.auth_provider.id,
+                "user_id": self.user.id,
+                "changed_fields": ["data"],
+            },
+        )
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_ident_logs(self, mock_logger):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.update(ident="new-ident")
+
+        mock_logger.info.assert_called_once_with(
+            "auth_identity.update",
+            extra={
+                "auth_identity_id": self.auth_identity.id,
+                "auth_provider_id": self.auth_provider.id,
+                "user_id": self.user.id,
+                "changed_fields": ["ident"],
+            },
+        )
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_user_id_logs(self, mock_logger):
+        new_user = self.create_user()
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.update(user_id=new_user.id)
+
+        mock_logger.info.assert_called_once_with(
+            "auth_identity.update",
+            extra={
+                "auth_identity_id": self.auth_identity.id,
+                "auth_provider_id": self.auth_provider.id,
+                "user_id": new_user.id,
+                "changed_fields": ["user_id"],
+            },
+        )
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_timestamp_only_does_not_log(self, mock_logger):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.update(last_synced=timezone.now())
+
+        mock_logger.info.assert_not_called()
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_mixed_meaningful_and_timestamp_logs(self, mock_logger):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.update(data={"refreshed": True}, last_synced=timezone.now())
+
+        mock_logger.info.assert_called_once_with(
+            "auth_identity.update",
+            extra={
+                "auth_identity_id": self.auth_identity.id,
+                "auth_provider_id": self.auth_provider.id,
+                "user_id": self.user.id,
+                "changed_fields": ["data"],
+            },
+        )
+
+    @patch("sentry.models.authidentity.logger")
+    def test_update_returns_affected_count(self, mock_logger):
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            result = self.auth_identity.update(data={"new": "value"})
+
+        assert result == 1
+
+    @patch("sentry.models.authidentity.logger")
+    def test_delete_logs(self, mock_logger):
+        identity_id = self.auth_identity.id
+        provider_id = self.auth_provider.id
+        user_id = self.user.id
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.auth_identity.delete()
+
+        mock_logger.info.assert_called_once_with(
+            "auth_identity.delete",
+            extra={
+                "auth_identity_id": identity_id,
+                "auth_provider_id": provider_id,
+                "user_id": user_id,
+            },
+        )
+        assert not AuthIdentity.objects.filter(id=identity_id).exists()


### PR DESCRIPTION
Security-relevant changes to SSO identities (user reassignment, ident changes, data updates, deletions) were happening silently. Override `update()` and `delete()` on `AuthIdentity` to emit `logger.info` for meaningful field changes, filtering out timestamp-only updates.

I'm a bit unsure if this will be too noisy, but I suspect that identity changes aren't common(?)
