### PR TITLE
fix(uptime-trace): Enabling linking to timing nodes on re-load

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.spec.tsx
@@ -43,6 +43,7 @@ describe('UptimeCheckNode', () => {
       // All children should be UptimeCheckTimingNode instances
       node.children.forEach(child => {
         expect(child).toBeInstanceOf(UptimeCheckTimingNode);
+        expect(child.id).toBe(`uptime-check-1-${child.op}`);
         expect(child.parent).toBe(node);
       });
     });

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/uptimeCheckNode.tsx
@@ -2,7 +2,6 @@ import type {Theme} from '@emotion/react';
 
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {t} from 'sentry/locale';
-import {uniqueId} from 'sentry/utils/guid';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {UptimeNodeDetails} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/uptime';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
@@ -89,7 +88,7 @@ export class UptimeCheckNode extends BaseNode<TraceTree.UptimeCheck> {
 
       const fakeSpan: TraceTree.UptimeCheckTiming = {
         event_type: 'uptime_check_timing',
-        event_id: uniqueId(),
+        event_id: `${uptimeCheck.event_id}-${phase.op}`,
         start_timestamp: startTimestamp,
         end_timestamp: startTimestamp + duration,
         duration,


### PR DESCRIPTION
- Uptime check timing nodes like `dns.lookup.duration` are syntheti
- Assigning a consistent id, to be able to highlight uptime check timing nodes on trace view re-load
<img width="1381" height="541" alt="Screenshot 2026-02-20 at 11 35 42 AM" src="https://github.com/user-attachments/assets/5ce3613b-cc9c-4405-8255-1338b8d3111c" />
