### PR TITLE
form(search) bailout if label is jsx node and make hintText optional

### DIFF
--- a/static/app/components/core/form/generatedFieldRegistry.ts
+++ b/static/app/components/core/form/generatedFieldRegistry.ts
@@ -91,6 +91,6 @@ export const FORM_FIELD_REGISTRY: Record<string, FormFieldDefinition> = {
     formId: 'password-form',
     route: '/settings/account/security/',
     label: t('Verify New Password'),
-    hintText: t('Verify your new password'),
+    hintText: '',
   },
 };

--- a/static/app/components/core/form/generatedFieldRegistry.ts
+++ b/static/app/components/core/form/generatedFieldRegistry.ts
@@ -91,6 +91,6 @@ export const FORM_FIELD_REGISTRY: Record<string, FormFieldDefinition> = {
     formId: 'password-form',
     route: '/settings/account/security/',
     label: t('Verify New Password'),
-    hintText: '',
+    hintText: t('Verify your new password'),
   },
 };


### PR DESCRIPTION
We cannot serialize JSX nodes here as that would require us to extract entire logic out of components. For now, modify the script to bailout from serializing entries where label is jsx node. If hintText is a JSX node, serialize it as an empty string, so that we can still show the search entry if we have a valid label.

diff for when label is a jsx node
<img width="2004" height="866" alt="CleanShot 2026-02-20 at 08 42 51@2x" src="https://github.com/user-attachments/assets/5e04c1b8-1a53-4add-bc83-00a423b124c1" />

diff for when hintText is a jsx node
<img width="2000" height="762" alt="CleanShot 2026-02-20 at 08 43 15@2x" src="https://github.com/user-attachments/assets/4c4d393a-cecd-4f04-a902-569dd93eb469" />

