### PR TITLE
fix(objectstore): Change scopes type from dict to list of tuples

### DIFF
--- a/src/sentry/objectstore/types.py
+++ b/src/sentry/objectstore/types.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import TypedDict
 
 
 class ObjectstoreUploadOptions(TypedDict):
     url: str
-    scopes: dict[str, Any]
+    scopes: list[tuple[str, str]]
     # TODO: add authToken
     expirationPolicy: str

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -47,10 +47,10 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
 
         options = ObjectstoreUploadOptions(
             url=url,
-            scopes={
-                "org": str(organization.id),
-                "project": str(project.id),
-            },
+            scopes=[
+                ("org", str(organization.id)),
+                ("project", str(project.id)),
+            ],
             expirationPolicy=format_expiration(
                 TimeToLive(timedelta(days=396))
             ),  # Hardcoded for now

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_upload_options.py
@@ -25,8 +25,7 @@ class ProjectPreprodUploadOptionsTest(APITestCase):
 
         assert f"/api/0/organizations/{self.org.id}/objectstore/" in data["url"]
 
-        assert data["scopes"]["org"] == str(self.org.id)
-        assert data["scopes"]["project"] == str(self.project.id)
+        assert data["scopes"] == [("org", str(self.org.id)), ("project", str(self.project.id))]
 
         assert data["expirationPolicy"] == "ttl:396 days"
 


### PR DESCRIPTION
It's better for CLI if we have a specific type here rather than `Any`, so let's just use `str`.
Additionally, order matters for Objectstore scopes, so we should really use a list instead of an object for that purpose.