### PR TITLE
feat(onboarding): Design adjustments for copy markdown button

### DIFF
--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -6,8 +6,8 @@ import {LinkButton} from '@sentry/scraps/button';
 import OnboardingAdditionalFeatures from 'sentry/components/events/featureFlags/onboarding/onboardingAdditionalFeatures';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -41,6 +41,7 @@ export function FeatureFlagOnboardingLayout({
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const {steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
@@ -101,14 +102,12 @@ export function FeatureFlagOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 ? (
-                    <CopySetupInstructionsGate>
-                      <OnboardingCopyMarkdownButton
-                        borderless
-                        steps={steps}
-                        source="feature_flag_onboarding"
-                      />
-                    </CopySetupInstructionsGate>
+                  index === 0 && copyEnabled ? (
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="feature_flag_onboarding"
+                    />
                   ) : undefined
                 }
               />

--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 
 import OnboardingAdditionalFeatures from 'sentry/components/events/featureFlags/onboarding/onboardingAdditionalFeatures';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
@@ -95,17 +94,24 @@ export function FeatureFlagOnboardingLayout({
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
       <TabSelectionScope>
         <Wrapper>
-          <CopySetupInstructionsGate>
-            <Container paddingBottom="md">
-              <OnboardingCopyMarkdownButton
-                steps={steps}
-                source="feature_flag_onboarding"
-              />
-            </Container>
-          </CopySetupInstructionsGate>
           <Steps>
             {steps.map((step, index) => (
-              <Step key={step.title ?? step.type} stepIndex={index} {...step} />
+              <Step
+                key={step.title ?? step.type}
+                stepIndex={index}
+                {...step}
+                trailingItems={
+                  index === 0 ? (
+                    <CopySetupInstructionsGate>
+                      <OnboardingCopyMarkdownButton
+                        borderless
+                        steps={steps}
+                        source="feature_flag_onboarding"
+                      />
+                    </CopySetupInstructionsGate>
+                  ) : undefined
+                }
+              />
             ))}
             <StyledLinkButton to="/issues/" priority="primary">
               {t('Take me to Issues')}

--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -6,8 +6,8 @@ import {Stack} from '@sentry/scraps/layout';
 import FeedbackConfigToggle from 'sentry/components/feedback/feedbackOnboarding/feedbackConfigToggle';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -41,6 +41,7 @@ export function FeedbackOnboardingLayout({
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const {introduction, steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
 
@@ -160,14 +161,12 @@ export function FeedbackOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 ? (
-                    <CopySetupInstructionsGate>
-                      <OnboardingCopyMarkdownButton
-                        borderless
-                        steps={transformedSteps}
-                        source="feedback_onboarding"
-                      />
-                    </CopySetupInstructionsGate>
+                  index === 0 && copyEnabled ? (
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={transformedSteps}
+                      source="feedback_onboarding"
+                    />
                   ) : undefined
                 }
               />

--- a/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/feedbackOnboardingLayout.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import FeedbackConfigToggle from 'sentry/components/feedback/feedbackOnboarding/feedbackConfigToggle';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
@@ -153,17 +153,24 @@ export function FeedbackOnboardingLayout({
       <TabSelectionScope>
         <Wrapper>
           {introduction && <Stack marginBottom="3xl">{introduction}</Stack>}
-          <CopySetupInstructionsGate>
-            <Container paddingBottom="md">
-              <OnboardingCopyMarkdownButton
-                steps={transformedSteps}
-                source="feedback_onboarding"
-              />
-            </Container>
-          </CopySetupInstructionsGate>
           <Steps>
             {transformedSteps.map((step, index) => (
-              <Step key={step.title ?? step.type} stepIndex={index} {...step} />
+              <Step
+                key={step.title ?? step.type}
+                stepIndex={index}
+                {...step}
+                trailingItems={
+                  index === 0 ? (
+                    <CopySetupInstructionsGate>
+                      <OnboardingCopyMarkdownButton
+                        borderless
+                        steps={transformedSteps}
+                        source="feedback_onboarding"
+                      />
+                    </CopySetupInstructionsGate>
+                  ) : undefined
+                }
+              />
             ))}
           </Steps>
         </Wrapper>

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -179,7 +179,14 @@ function Step(props: StepProps) {
   return (
     <StepWrapper data-test-id={`guided-step-${stepNumber}`}>
       {props.trailingItems ? (
-        <Flex align="center" justify="between" style={{gridArea: 'heading'}}>
+        <Flex
+          direction={{xs: 'column', md: 'row'}}
+          align={{xs: 'start', md: 'center'}}
+          paddingLeft={{xs: 'lg', md: '0'}}
+          justify="between"
+          gap="sm"
+          style={{gridArea: 'heading'}}
+        >
           {headingContent}
           <Flex align="center" onClick={e => e.stopPropagation()}>
             {props.trailingItems}

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -185,7 +185,7 @@ function Step(props: StepProps) {
           paddingLeft={{xs: 'lg', md: '0'}}
           justify="between"
           gap="sm"
-          style={{gridArea: 'heading'}}
+          area="heading"
         >
           {headingContent}
           <Flex align="center" onClick={e => e.stopPropagation()}>

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -159,25 +159,35 @@ function Step(props: StepProps) {
     }
   }, [advanceToNextIncompleteStep, isActive, isCompleted, previousIsCompleted]);
 
+  const headingContent = (
+    <StepButton
+      hasTrailingItems={!!props.trailingItems}
+      disabled={!props.onClick}
+      onClick={props.onClick}
+    >
+      <Flex align="center" gap="lg">
+        <StepNumber isActive={isActive}>{stepNumber}</StepNumber>
+        <StepHeading isActive={isActive}>
+          {props.title}
+          {isCompleted && <StepDoneIcon isActive={isActive} size="sm" />}
+        </StepHeading>
+        {props.onClick ? <InteractionStateLayer /> : null}
+      </Flex>
+    </StepButton>
+  );
+
   return (
     <StepWrapper data-test-id={`guided-step-${stepNumber}`}>
-      <Flex align="center" justify="between" style={{gridArea: 'heading'}}>
-        <StepButton disabled={!props.onClick} onClick={props.onClick}>
-          <Flex align="center" gap="lg">
-            <StepNumber isActive={isActive}>{stepNumber}</StepNumber>
-            <StepHeading isActive={isActive}>
-              {props.title}
-              {isCompleted && <StepDoneIcon isActive={isActive} size="sm" />}
-            </StepHeading>
-            {props.onClick ? <InteractionStateLayer /> : null}
-          </Flex>
-        </StepButton>
-        {props.trailingItems && (
+      {props.trailingItems ? (
+        <Flex align="center" justify="between" style={{gridArea: 'heading'}}>
+          {headingContent}
           <Flex align="center" onClick={e => e.stopPropagation()}>
             {props.trailingItems}
           </Flex>
-        )}
-      </Flex>
+        </Flex>
+      ) : (
+        headingContent
+      )}
 
       <StepDetails>
         {props.optional ? <StepOptionalLabel>Optional</StepOptionalLabel> : null}
@@ -270,13 +280,15 @@ const StepWrapper = styled('div')`
   }
 `;
 
-const StepButton = styled('button')`
-  flex: 1;
-  min-width: 0;
+const StepButton = styled('button')<{hasTrailingItems: boolean}>`
+  ${p =>
+    p.hasTrailingItems
+      ? `flex: 1; min-width: 0; text-align: left;`
+      : `grid-area: heading;`}
+
   position: relative;
   background: none;
   border: none;
-  text-align: left;
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
   margin: -${p => p.theme.space.sm} -${p => p.theme.space.md};
   border-radius: ${p => p.theme.radius.md};

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -43,6 +43,7 @@ interface StepProps {
   isCompleted?: boolean;
   onClick?: () => void;
   optional?: boolean;
+  trailingItems?: React.ReactNode;
 }
 
 type RegisterStepInfo = Pick<StepProps, 'stepKey' | 'isCompleted'>;
@@ -160,16 +161,23 @@ function Step(props: StepProps) {
 
   return (
     <StepWrapper data-test-id={`guided-step-${stepNumber}`}>
-      <StepButton area="heading" disabled={!props.onClick} onClick={props.onClick}>
-        <Flex align="center" gap="lg">
-          <StepNumber isActive={isActive}>{stepNumber}</StepNumber>
-          <StepHeading isActive={isActive}>
-            {props.title}
-            {isCompleted && <StepDoneIcon isActive={isActive} size="sm" />}
-          </StepHeading>
-          {props.onClick ? <InteractionStateLayer /> : null}
-        </Flex>
-      </StepButton>
+      <Flex align="center" justify="between" style={{gridArea: 'heading'}}>
+        <StepButton disabled={!props.onClick} onClick={props.onClick}>
+          <Flex align="center" gap="lg">
+            <StepNumber isActive={isActive}>{stepNumber}</StepNumber>
+            <StepHeading isActive={isActive}>
+              {props.title}
+              {isCompleted && <StepDoneIcon isActive={isActive} size="sm" />}
+            </StepHeading>
+            {props.onClick ? <InteractionStateLayer /> : null}
+          </Flex>
+        </StepButton>
+        {props.trailingItems && (
+          <Flex align="center" onClick={e => e.stopPropagation()}>
+            {props.trailingItems}
+          </Flex>
+        )}
+      </Flex>
 
       <StepDetails>
         {props.optional ? <StepOptionalLabel>Optional</StepOptionalLabel> : null}
@@ -262,12 +270,13 @@ const StepWrapper = styled('div')`
   }
 `;
 
-const StepButton = styled('button')<{area: string}>`
-  grid-area: ${p => p.area};
-
+const StepButton = styled('button')`
+  flex: 1;
+  min-width: 0;
   position: relative;
   background: none;
   border: none;
+  text-align: left;
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
   margin: -${p => p.theme.space.sm} -${p => p.theme.space.md};
   border-radius: ${p => p.theme.radius.md};

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -35,7 +35,7 @@ export function CopyMarkdownButton({
       title={t(
         'Copies all steps and code examples as Markdown, optimized for use with an LLM.'
       )}
-      position="right"
+      position="auto"
     >
       <Button
         priority={borderless ? 'transparent' : undefined}

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -13,6 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 interface CopyMarkdownButtonProps {
   getMarkdown: () => string;
   source: string;
+  borderless?: boolean;
 }
 
 /**
@@ -24,7 +25,11 @@ interface CopyMarkdownButtonProps {
  * surfaces that need tab-selection and auth-token context, use
  * `OnboardingCopyMarkdownButton` instead.
  */
-export function CopyMarkdownButton({getMarkdown, source}: CopyMarkdownButtonProps) {
+export function CopyMarkdownButton({
+  getMarkdown,
+  source,
+  borderless,
+}: CopyMarkdownButtonProps) {
   return (
     <Tooltip
       title={t(
@@ -33,13 +38,14 @@ export function CopyMarkdownButton({getMarkdown, source}: CopyMarkdownButtonProp
       position="right"
     >
       <Button
+        priority={borderless ? 'transparent' : undefined}
         icon={<IconCopy />}
         analyticsEventKey="setup_guide.copy_as_markdown"
         analyticsEventName="Setup Guide: Copy as Markdown"
         analyticsParams={{format: 'markdown', source}}
         onClick={() => copyToClipboard(getMarkdown())}
       >
-        {t('Copy setup instructions')}
+        {t('Copy instructions')}
       </Button>
     </Tooltip>
   );
@@ -48,6 +54,7 @@ export function CopyMarkdownButton({getMarkdown, source}: CopyMarkdownButtonProp
 interface OnboardingCopyMarkdownButtonProps {
   source: string;
   steps: OnboardingStep[];
+  borderless?: boolean;
 }
 
 /**
@@ -57,6 +64,7 @@ interface OnboardingCopyMarkdownButtonProps {
 export function OnboardingCopyMarkdownButton({
   steps,
   source,
+  borderless,
 }: OnboardingCopyMarkdownButtonProps) {
   const authToken = useAuthToken();
   const tabSelectionsMap = useTabSelectionsMap();
@@ -72,7 +80,13 @@ export function OnboardingCopyMarkdownButton({
     }
   };
 
-  return <CopyMarkdownButton getMarkdown={getMarkdown} source={source} />;
+  return (
+    <CopyMarkdownButton
+      getMarkdown={getMarkdown}
+      source={source}
+      borderless={borderless}
+    />
+  );
 }
 
 const FEATURE_FLAG = 'onboarding-copy-setup-instructions';

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -97,9 +97,14 @@ const FEATURE_FLAG = 'onboarding-copy-setup-instructions';
  * `onboarding-copy-setup-instructions` flag is enabled. Includes spacing
  * so callsites don't render an empty Container when the flag is off.
  */
-export function CopySetupInstructionsGate({children}: {children: React.ReactNode}) {
+export function useCopySetupInstructionsEnabled(): boolean {
   const organization = useOrganization();
-  if (!organization.features.includes(FEATURE_FLAG)) {
+  return organization.features.includes(FEATURE_FLAG);
+}
+
+export function CopySetupInstructionsGate({children}: {children: React.ReactNode}) {
+  const enabled = useCopySetupInstructionsEnabled();
+  if (!enabled) {
     return null;
   }
   return children;

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -44,6 +44,7 @@ export function CopyMarkdownButton({
         analyticsEventName="Setup Guide: Copy as Markdown"
         analyticsParams={{format: 'markdown', source}}
         onClick={() => copyToClipboard(getMarkdown())}
+        size="xs"
       >
         {t('Copy instructions')}
       </Button>

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -5,7 +5,6 @@ import HighlightTopRightPattern from 'sentry-images/pattern/highlight-top-right.
 
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -343,17 +342,26 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
       {performanceDocs.introduction && (
         <Introduction>{performanceDocs.introduction(docParams)}</Introduction>
       )}
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton
-            steps={steps}
-            source="performance_sidebar_onboarding"
-          />
-        </Container>
-      </CopySetupInstructionsGate>
       <Steps>
         {steps.map((step, index) => {
-          return <Step key={step.title ?? step.type} stepIndex={index} {...step} />;
+          return (
+            <Step
+              key={step.title ?? step.type}
+              stepIndex={index}
+              {...step}
+              trailingItems={
+                index === 0 ? (
+                  <CopySetupInstructionsGate>
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="performance_sidebar_onboarding"
+                    />
+                  </CopySetupInstructionsGate>
+                ) : undefined
+              }
+            />
+          );
         })}
       </Steps>
       <EventWaiter

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -12,8 +12,8 @@ import useDrawer from 'sentry/components/globalDrawer';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -233,6 +233,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   const api = useApi();
   const organization = useOrganization();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const [received, setReceived] = useState<boolean>(false);
 
   const previousProject = usePrevious(currentProject);
@@ -350,14 +351,12 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
               stepIndex={index}
               {...step}
               trailingItems={
-                index === 0 ? (
-                  <CopySetupInstructionsGate>
-                    <OnboardingCopyMarkdownButton
-                      borderless
-                      steps={steps}
-                      source="performance_sidebar_onboarding"
-                    />
-                  </CopySetupInstructionsGate>
+                index === 0 && copyEnabled ? (
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="performance_sidebar_onboarding"
+                  />
                 ) : undefined
               }
             />

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -12,8 +12,8 @@ import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {DeprecatedPlatformInfo} from 'sentry/components/onboarding/gettingStartedDoc/deprecatedPlatformInfo';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
@@ -276,6 +276,7 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     useSourcePackageRegistries(organization);
 
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   if (isLoading) {
     return <LoadingIndicator />;
@@ -375,14 +376,12 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 ? (
-                    <CopySetupInstructionsGate>
-                      <OnboardingCopyMarkdownButton
-                        borderless
-                        steps={steps}
-                        source="profiling_sidebar_onboarding"
-                      />
-                    </CopySetupInstructionsGate>
+                  index === 0 && copyEnabled ? (
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="profiling_sidebar_onboarding"
+                    />
                   ) : undefined
                 }
               />

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import partition from 'lodash/partition';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import useDrawer from 'sentry/components/globalDrawer';
@@ -367,17 +367,26 @@ function ProfilingOnboardingContent(props: ProfilingOnboardingContentProps) {
     <TabSelectionScope>
       <Wrapper>
         {doc.introduction && <Introduction>{doc.introduction(docParams)}</Introduction>}
-        <CopySetupInstructionsGate>
-          <Container paddingBottom="md">
-            <OnboardingCopyMarkdownButton
-              steps={steps}
-              source="profiling_sidebar_onboarding"
-            />
-          </Container>
-        </CopySetupInstructionsGate>
         <Steps>
           {steps.map((step, index) => {
-            return <Step key={step.title ?? step.type} stepIndex={index} {...step} />;
+            return (
+              <Step
+                key={step.title ?? step.type}
+                stepIndex={index}
+                {...step}
+                trailingItems={
+                  index === 0 ? (
+                    <CopySetupInstructionsGate>
+                      <OnboardingCopyMarkdownButton
+                        borderless
+                        steps={steps}
+                        source="profiling_sidebar_onboarding"
+                      />
+                    </CopySetupInstructionsGate>
+                  ) : undefined
+                }
+              />
+            );
           })}
         </Steps>
       </Wrapper>

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -5,8 +5,8 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import type {OnboardingLayoutProps} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -39,6 +39,7 @@ export function ReplayOnboardingLayout({
   const [mask, setMask] = useState(true);
   const [block, setBlock] = useState(true);
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const {introduction, steps} = useMemo(() => {
     const doc = docsConfig[configType] ?? docsConfig.onboarding;
@@ -151,14 +152,12 @@ export function ReplayOnboardingLayout({
                 stepIndex={index}
                 {...step}
                 trailingItems={
-                  index === 0 ? (
-                    <CopySetupInstructionsGate>
-                      <OnboardingCopyMarkdownButton
-                        borderless
-                        steps={transformedSteps}
-                        source="replay_onboarding"
-                      />
-                    </CopySetupInstructionsGate>
+                  index === 0 && copyEnabled ? (
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={transformedSteps}
+                      source="replay_onboarding"
+                    />
                   ) : undefined
                 }
               />

--- a/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
+++ b/static/app/components/replaysOnboarding/replayOnboardingLayout.tsx
@@ -1,7 +1,7 @@
 import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
@@ -144,17 +144,24 @@ export function ReplayOnboardingLayout({
       <TabSelectionScope>
         <Wrapper>
           {introduction && <Stack margin="0 0 xl 0">{introduction}</Stack>}
-          <CopySetupInstructionsGate>
-            <Container paddingBottom="md">
-              <OnboardingCopyMarkdownButton
-                steps={transformedSteps}
-                source="replay_onboarding"
-              />
-            </Container>
-          </CopySetupInstructionsGate>
           <Stack gap="lg">
             {transformedSteps.map((step, index) => (
-              <Step key={step.title ?? step.type} stepIndex={index} {...step} />
+              <Step
+                key={step.title ?? step.type}
+                stepIndex={index}
+                {...step}
+                trailingItems={
+                  index === 0 ? (
+                    <CopySetupInstructionsGate>
+                      <OnboardingCopyMarkdownButton
+                        borderless
+                        steps={transformedSteps}
+                        source="replay_onboarding"
+                      />
+                    </CopySetupInstructionsGate>
+                  ) : undefined
+                }
+              />
             ))}
           </Stack>
         </Wrapper>

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -11,8 +11,8 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -95,6 +95,7 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
     useSourcePackageRegistries(organization);
 
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatformKey = project?.platform ?? 'other';
   const currentPlatform = platforms.find(
@@ -209,14 +210,12 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
                       stepKey={title}
                       title={title}
                       trailingItems={
-                        index === 0 ? (
-                          <CopySetupInstructionsGate>
-                            <OnboardingCopyMarkdownButton
-                              borderless
-                              steps={steps}
-                              source="issues_onboarding"
-                            />
-                          </CopySetupInstructionsGate>
+                        index === 0 && copyEnabled ? (
+                          <OnboardingCopyMarkdownButton
+                            borderless
+                            steps={steps}
+                            source="issues_onboarding"
+                          />
                         ) : undefined
                       }
                     >

--- a/static/app/components/updatedEmptyState.tsx
+++ b/static/app/components/updatedEmptyState.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import waitingForEventImg from 'sentry-images/spot/waiting-for-event.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
@@ -188,14 +188,6 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
           <Body>
             <Setup>
               <SetupTitle project={project} />
-              <CopySetupInstructionsGate>
-                <Container paddingBottom="md">
-                  <OnboardingCopyMarkdownButton
-                    steps={steps}
-                    source="issues_onboarding"
-                  />
-                </Container>
-              </CopySetupInstructionsGate>
               <GuidedSteps
                 initialStep={decodeInteger(location.query.guidedStep)}
                 onStepChange={step => {
@@ -212,7 +204,22 @@ export default function UpdatedEmptyState({project}: {project?: Project}) {
                   const title = step.title ?? StepTitles[step.type ?? 'install'];
                   const isLastStep = index === steps.length - 1;
                   return (
-                    <GuidedSteps.Step key={index} stepKey={title} title={title}>
+                    <GuidedSteps.Step
+                      key={index}
+                      stepKey={title}
+                      title={title}
+                      trailingItems={
+                        index === 0 ? (
+                          <CopySetupInstructionsGate>
+                            <OnboardingCopyMarkdownButton
+                              borderless
+                              steps={steps}
+                              source="issues_onboarding"
+                            />
+                          </CopySetupInstructionsGate>
+                        ) : undefined
+                      }
+                    >
                       <StepIndexProvider index={index}>
                         <ContentBlocksRenderer
                           contentBlocks={step.content}

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
@@ -194,42 +194,40 @@ export function InstrumentationGuide() {
           <Section
             title={t('Auto-Instrument with %s', platform.label)}
             trailingItems={
-              platform.guides.length > 1 ? (
-                <CompactSelect
-                  size="xs"
-                  trigger={triggerProps => (
-                    <OverlayTrigger.Button
-                      {...triggerProps}
-                      priority="transparent"
-                      size="zero"
-                    />
-                  )}
-                  value={guideKey ?? 'upsert'}
-                  onChange={option => {
-                    setPlatformGuide(platformKey, option.value);
-                  }}
-                  options={platform.guides.map(g => ({
-                    value: g.key as GuideKey,
-                    label: g.title,
-                  }))}
-                />
-              ) : undefined
-            }
-          >
-            <Flex direction="column" gap="lg">
-              <CopySetupInstructionsGate>
-                <Flex justify="end">
+              <Flex align="center" gap="sm">
+                {platform.guides.length > 1 && (
+                  <CompactSelect
+                    size="xs"
+                    trigger={triggerProps => (
+                      <OverlayTrigger.Button
+                        {...triggerProps}
+                        priority="transparent"
+                        size="zero"
+                      />
+                    )}
+                    value={guideKey ?? 'upsert'}
+                    onChange={option => {
+                      setPlatformGuide(platformKey, option.value);
+                    }}
+                    options={platform.guides.map(g => ({
+                      value: g.key as GuideKey,
+                      label: g.title,
+                    }))}
+                  />
+                )}
+                <CopySetupInstructionsGate>
                   <CopyMarkdownButton
                     borderless
                     getMarkdown={getGuideMarkdown}
                     source="crons_detector_guide"
                   />
-                </Flex>
-              </CopySetupInstructionsGate>
-              <div ref={guideContainerRef}>
-                <guide.Guide />
-              </div>
-            </Flex>
+                </CopySetupInstructionsGate>
+              </Flex>
+            }
+          >
+            <div ref={guideContainerRef}>
+              <guide.Guide />
+            </div>
           </Section>
         </WorkflowEngineContainer>
       )}

--- a/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
+++ b/static/app/views/detectors/components/forms/cron/instrumentationGuide.tsx
@@ -5,7 +5,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -218,12 +218,13 @@ export function InstrumentationGuide() {
           >
             <Flex direction="column" gap="lg">
               <CopySetupInstructionsGate>
-                <Container>
+                <Flex justify="end">
                   <CopyMarkdownButton
+                    borderless
                     getMarkdown={getGuideMarkdown}
                     source="crons_detector_guide"
                   />
-                </Container>
+                </Flex>
               </CopySetupInstructionsGate>
               <div ref={guideContainerRef}>
                 <guide.Guide />

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -12,8 +12,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -182,6 +182,7 @@ function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
     : undefined;
@@ -339,14 +340,12 @@ function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 ? (
-                  <CopySetupInstructionsGate>
-                    <OnboardingCopyMarkdownButton
-                      borderless
-                      steps={steps}
-                      source="logs_onboarding"
-                    />
-                  </CopySetupInstructionsGate>
+                index === 0 && copyEnabled ? (
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="logs_onboarding"
+                  />
                 ) : undefined
               }
             >

--- a/static/app/views/explore/logs/logsOnboarding.tsx
+++ b/static/app/views/explore/logs/logsOnboarding.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
@@ -320,11 +319,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton steps={steps} source="logs_onboarding" />
-        </Container>
-      </CopySetupInstructionsGate>
       <GuidedSteps
         initialStep={decodeInteger(location.query.guidedStep)}
         onStepChange={step => {
@@ -340,7 +334,22 @@ function Onboarding({organization, project}: OnboardingProps) {
         {steps.map((step, index) => {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
-            <GuidedSteps.Step key={title} stepKey={title} title={title}>
+            <GuidedSteps.Step
+              key={title}
+              stepKey={title}
+              title={title}
+              trailingItems={
+                index === 0 ? (
+                  <CopySetupInstructionsGate>
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="logs_onboarding"
+                    />
+                  </CopySetupInstructionsGate>
+                ) : undefined
+              }
+            >
               <StepIndexProvider index={index}>
                 <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
               </StepIndexProvider>

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -11,8 +11,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -117,6 +117,7 @@ function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const currentPlatform = project.platform
     ? platforms.find(p => p.id === project.platform)
     : undefined;
@@ -271,14 +272,12 @@ function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 ? (
-                  <CopySetupInstructionsGate>
-                    <OnboardingCopyMarkdownButton
-                      borderless
-                      steps={steps}
-                      source="metrics_onboarding"
-                    />
-                  </CopySetupInstructionsGate>
+                index === 0 && copyEnabled ? (
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="metrics_onboarding"
+                  />
                 ) : undefined
               }
             >

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import connectDotsImg from 'sentry-images/spot/performance-connect-dots.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -252,11 +251,6 @@ function Onboarding({organization, project}: OnboardingProps) {
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton steps={steps} source="metrics_onboarding" />
-        </Container>
-      </CopySetupInstructionsGate>
       <GuidedSteps
         initialStep={decodeInteger(location.query.guidedStep)}
         onStepChange={step => {
@@ -272,7 +266,22 @@ function Onboarding({organization, project}: OnboardingProps) {
         {steps.map((step, index) => {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
-            <GuidedSteps.Step key={title} stepKey={title} title={title}>
+            <GuidedSteps.Step
+              key={title}
+              stepKey={title}
+              title={title}
+              trailingItems={
+                index === 0 ? (
+                  <CopySetupInstructionsGate>
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="metrics_onboarding"
+                    />
+                  </CopySetupInstructionsGate>
+                ) : undefined
+              }
+            >
               <StepIndexProvider index={index}>
                 <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
               </StepIndexProvider>

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -103,7 +103,11 @@ export function CronsLandingPanel() {
         <PanelBody withPadding>
           <h3>{t('Get Started with %s', platform.label)}</h3>
 
-          <Tabs onChange={key => setPlatformGuide(platformKey, key)} value={guideKey}>
+          <Tabs
+            disableOverflow
+            onChange={key => setPlatformGuide(platformKey, key)}
+            value={guideKey}
+          >
             <Flex justify="between" align="center">
               <TabList>
                 {[

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -24,38 +24,19 @@ import {PlatformPickerPanel} from './platformPickerPanel';
 import {useCronsUpsertGuideState} from './useCronsUpsertGuideState';
 
 /**
- * Wrapper that gives each guide tab its own ref for innerHTML-based
- * markdown copying. Without this, a shared ref would always point to
- * the last rendered tab panel instead of the active one.
+ * Wrapper for guide tab content with a ref for innerHTML-based markdown
+ * copying. The ref is passed from the parent so the copy button can live
+ * outside (next to the tab list) while still reading the active guide's HTML.
  */
-function GuideWithCopy({Guide}: {Guide: ComponentType}) {
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  // TODO: Migrate crons guides to the content block system so we can use
-  // structured stepsToMarkdown() instead of innerHTML scraping. The innerHTML
-  // approach may include rendered UI chrome and won't substitute auth tokens.
-  const getMarkdown = () => {
-    if (!containerRef.current) {
-      return '';
-    }
-    try {
-      return simpleHtmlToMarkdown(containerRef.current.innerHTML);
-    } catch {
-      return '';
-    }
-  };
-
+function GuideContent({
+  Guide,
+  containerRef,
+}: {
+  Guide: ComponentType;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}) {
   return (
     <GuideContainer>
-      <CopySetupInstructionsGate>
-        <Flex justify="end">
-          <CopyMarkdownButton
-            borderless
-            getMarkdown={getMarkdown}
-            source="crons_upsert_guide"
-          />
-        </Flex>
-      </CopySetupInstructionsGate>
       <div ref={containerRef}>
         <Guide />
       </div>
@@ -68,6 +49,21 @@ export function CronsLandingPanel() {
 
   const {platformKey, guideKey, platform, setPlatformGuide} = useCronsUpsertGuideState();
   const guideVisibile = platform && guideKey;
+  const guideContainerRef = useRef<HTMLDivElement>(null);
+
+  // TODO: Migrate crons guides to the content block system so we can use
+  // structured stepsToMarkdown() instead of innerHTML scraping. The innerHTML
+  // approach may include rendered UI chrome and won't substitute auth tokens.
+  const getGuideMarkdown = () => {
+    if (!guideContainerRef.current) {
+      return '';
+    }
+    try {
+      return simpleHtmlToMarkdown(guideContainerRef.current.innerHTML);
+    } catch {
+      return '';
+    }
+  };
 
   const OnboardingPanelHook = HookOrDefault({
     hookName: 'component:crons-onboarding-panel',
@@ -108,19 +104,28 @@ export function CronsLandingPanel() {
           <h3>{t('Get Started with %s', platform.label)}</h3>
 
           <Tabs onChange={key => setPlatformGuide(platformKey, key)} value={guideKey}>
-            <TabList>
-              {[
-                ...platform.guides.map(({key, title}) => (
-                  <TabList.Item key={key}>{title}</TabList.Item>
-                )),
-                <TabList.Item key="manual">{t('Manual')}</TabList.Item>,
-              ]}
-            </TabList>
+            <Flex justify="between" align="center">
+              <TabList>
+                {[
+                  ...platform.guides.map(({key, title}) => (
+                    <TabList.Item key={key}>{title}</TabList.Item>
+                  )),
+                  <TabList.Item key="manual">{t('Manual')}</TabList.Item>,
+                ]}
+              </TabList>
+              <CopySetupInstructionsGate>
+                <CopyMarkdownButton
+                  borderless
+                  getMarkdown={getGuideMarkdown}
+                  source="crons_upsert_guide"
+                />
+              </CopySetupInstructionsGate>
+            </Flex>
             <TabPanels>
               {[
                 ...platform.guides.map(({key, Guide}) => (
                   <TabPanels.Item key={key}>
-                    <GuideWithCopy Guide={Guide} />
+                    <GuideContent Guide={Guide} containerRef={guideContainerRef} />
                   </TabPanels.Item>
                 )),
                 <TabPanels.Item key="manual">

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -117,13 +117,15 @@ export function CronsLandingPanel() {
                   <TabList.Item key="manual">{t('Manual')}</TabList.Item>,
                 ]}
               </TabList>
-              <CopySetupInstructionsGate>
-                <CopyMarkdownButton
-                  borderless
-                  getMarkdown={getGuideMarkdown}
-                  source="crons_upsert_guide"
-                />
-              </CopySetupInstructionsGate>
+              {guideKey !== 'manual' && (
+                <CopySetupInstructionsGate>
+                  <CopyMarkdownButton
+                    borderless
+                    getMarkdown={getGuideMarkdown}
+                    source="crons_upsert_guide"
+                  />
+                </CopySetupInstructionsGate>
+              )}
             </Flex>
             <TabPanels>
               {[

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -2,7 +2,7 @@ import {Fragment, useEffect, useRef, type ComponentType} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -48,9 +48,13 @@ function GuideWithCopy({Guide}: {Guide: ComponentType}) {
   return (
     <GuideContainer>
       <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <CopyMarkdownButton getMarkdown={getMarkdown} source="crons_upsert_guide" />
-        </Container>
+        <Flex justify="end">
+          <CopyMarkdownButton
+            borderless
+            getMarkdown={getMarkdown}
+            source="crons_upsert_guide"
+          />
+        </Flex>
       </CopySetupInstructionsGate>
       <div ref={containerRef}>
         <Guide />

--- a/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
+++ b/static/app/views/insights/crons/components/monitorQuickStartGuide.tsx
@@ -3,7 +3,7 @@ import partition from 'lodash/partition';
 import {PlatformIcon} from 'platformicons';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
@@ -277,21 +277,25 @@ export default function MonitorQuickStartGuide({monitorSlug, project}: Props) {
           }
         )}
       </Text>
-      <CompactSelect
-        trigger={triggerProps => (
-          <OverlayTrigger.Button {...triggerProps} prefix={t('Guide')} />
-        )}
-        search
-        options={exampleOptions}
-        value={selectedGuide}
-        onChange={({value}) => setSelectedGuide(value)}
-        size="sm"
-      />
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <CopyMarkdownButton getMarkdown={getGuideMarkdown} source="crons_onboarding" />
-        </Container>
-      </CopySetupInstructionsGate>
+      <Flex justify="between" align="center">
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix={t('Guide')} />
+          )}
+          search
+          options={exampleOptions}
+          value={selectedGuide}
+          onChange={({value}) => setSelectedGuide(value)}
+          size="sm"
+        />
+        <CopySetupInstructionsGate>
+          <CopyMarkdownButton
+            borderless
+            getMarkdown={getGuideMarkdown}
+            source="crons_onboarding"
+          />
+        </CopySetupInstructionsGate>
+      </Flex>
       <div ref={guideContainerRef}>
         <Guide {...guideProps} />
       </div>

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -5,7 +5,6 @@ import {PlatformIcon} from 'platformicons';
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
 import {Button} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
@@ -144,16 +143,19 @@ function StepRenderer({
   step,
   stepIndex,
   isLastStep,
+  trailingItems,
 }: {
   isLastStep: boolean;
   project: Project;
   step: OnboardingStep;
   stepIndex: number;
+  trailingItems?: React.ReactNode;
 }) {
   return (
     <GuidedSteps.Step
       stepKey={step.type || step.title}
       title={step.title || (step.type && StepTitles[step.type])}
+      trailingItems={trailingItems}
     >
       <StepIndexProvider index={stepIndex}>
         <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
@@ -349,14 +351,6 @@ export function Onboarding() {
         <PlatformOptionDropdown platformOptions={integrationOptions} />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton
-            steps={steps}
-            source="agent_monitoring_onboarding"
-          />
-        </Container>
-      </CopySetupInstructionsGate>
       <GuidedSteps
         initialStep={decodeInteger(location.query.guidedStep)}
         onStepChange={step => {
@@ -376,6 +370,17 @@ export function Onboarding() {
             step={step}
             stepIndex={index}
             isLastStep={index === steps.length - 1}
+            trailingItems={
+              index === 0 ? (
+                <CopySetupInstructionsGate>
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="agent_monitoring_onboarding"
+                  />
+                </CopySetupInstructionsGate>
+              ) : undefined
+            }
           />
         ))}
       </GuidedSteps>

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -12,8 +12,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -237,6 +237,7 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -371,14 +372,12 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 ? (
-                <CopySetupInstructionsGate>
-                  <OnboardingCopyMarkdownButton
-                    borderless
-                    steps={steps}
-                    source="agent_monitoring_onboarding"
-                  />
-                </CopySetupInstructionsGate>
+              index === 0 && copyEnabled ? (
+                <OnboardingCopyMarkdownButton
+                  borderless
+                  steps={steps}
+                  source="agent_monitoring_onboarding"
+                />
               ) : undefined
             }
           />

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -11,8 +11,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -216,6 +216,7 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatform = project?.platform
     ? platforms.find(p => p.id === project.platform)
@@ -349,14 +350,12 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 ? (
-                <CopySetupInstructionsGate>
-                  <OnboardingCopyMarkdownButton
-                    borderless
-                    steps={steps}
-                    source="mcp_onboarding"
-                  />
-                </CopySetupInstructionsGate>
+              index === 0 && copyEnabled ? (
+                <OnboardingCopyMarkdownButton
+                  borderless
+                  steps={steps}
+                  source="mcp_onboarding"
+                />
               ) : undefined
             }
           />

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
@@ -339,9 +339,13 @@ export function Onboarding() {
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton steps={steps} source="mcp_onboarding" />
-        </Container>
+        <Flex justify="end">
+          <OnboardingCopyMarkdownButton
+            borderless
+            steps={steps}
+            source="mcp_onboarding"
+          />
+        </Flex>
       </CopySetupInstructionsGate>
       <GuidedSteps>
         {steps.map((step, index) => (

--- a/static/app/views/insights/pages/mcp/onboarding.tsx
+++ b/static/app/views/insights/pages/mcp/onboarding.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
@@ -122,16 +121,19 @@ function StepRenderer({
   step,
   stepIndex,
   isLastStep,
+  trailingItems,
 }: {
   isLastStep: boolean;
   project: Project;
   step: OnboardingStep;
   stepIndex: number;
+  trailingItems?: React.ReactNode;
 }) {
   return (
     <GuidedSteps.Step
       stepKey={step.type || step.title}
       title={step.title || (step.type && StepTitles[step.type])}
+      trailingItems={trailingItems}
     >
       <StepIndexProvider index={stepIndex}>
         <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
@@ -338,15 +340,6 @@ export function Onboarding() {
         <PlatformOptionDropdown platformOptions={integrationOptions} />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
-      <CopySetupInstructionsGate>
-        <Flex justify="end">
-          <OnboardingCopyMarkdownButton
-            borderless
-            steps={steps}
-            source="mcp_onboarding"
-          />
-        </Flex>
-      </CopySetupInstructionsGate>
       <GuidedSteps>
         {steps.map((step, index) => (
           <StepRenderer
@@ -355,6 +348,17 @@ export function Onboarding() {
             step={step}
             stepIndex={index}
             isLastStep={index === steps.length - 1}
+            trailingItems={
+              index === 0 ? (
+                <CopySetupInstructionsGate>
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="mcp_onboarding"
+                  />
+                </CopySetupInstructionsGate>
+              ) : undefined
+            }
           />
         ))}
       </GuidedSteps>

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -10,7 +10,7 @@ import tourMetrics from 'sentry-images/spot/performance-tour-metrics.svg';
 import tourTrace from 'sentry-images/spot/performance-tour-trace.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Container, Grid, type GridProps} from '@sentry/scraps/layout';
+import {Grid, type GridProps} from '@sentry/scraps/layout';
 
 import {
   addErrorMessage,
@@ -587,11 +587,6 @@ export function Onboarding({organization, project}: OnboardingProps) {
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton steps={steps} source="performance_onboarding" />
-        </Container>
-      </CopySetupInstructionsGate>
       <GuidedSteps
         initialStep={decodeInteger(location.query.guidedStep)}
         onStepChange={step => {
@@ -607,7 +602,22 @@ export function Onboarding({organization, project}: OnboardingProps) {
         {steps.map((step, index) => {
           const title = step.title ?? STEP_TITLES[step.type];
           return (
-            <GuidedSteps.Step key={title} stepKey={title} title={title}>
+            <GuidedSteps.Step
+              key={title}
+              stepKey={title}
+              title={title}
+              trailingItems={
+                index === 0 ? (
+                  <CopySetupInstructionsGate>
+                    <OnboardingCopyMarkdownButton
+                      borderless
+                      steps={steps}
+                      source="performance_onboarding"
+                    />
+                  </CopySetupInstructionsGate>
+                ) : undefined
+              }
+            >
               <StepIndexProvider index={index}>
                 <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
               </StepIndexProvider>

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -29,8 +29,8 @@ import FeatureTourModal, {
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -418,6 +418,7 @@ export function Onboarding({organization, project}: OnboardingProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
+  const copyEnabled = useCopySetupInstructionsEnabled();
   const [received, setReceived] = useState<boolean>(false);
   const showNewUi = organization.features.includes('tracing-onboarding-new-ui');
   const isEAPTraceEnabled = organization.features.includes('trace-spans-format');
@@ -607,14 +608,12 @@ export function Onboarding({organization, project}: OnboardingProps) {
               stepKey={title}
               title={title}
               trailingItems={
-                index === 0 ? (
-                  <CopySetupInstructionsGate>
-                    <OnboardingCopyMarkdownButton
-                      borderless
-                      steps={steps}
-                      source="performance_onboarding"
-                    />
-                  </CopySetupInstructionsGate>
+                index === 0 && copyEnabled ? (
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="performance_onboarding"
+                  />
                 ) : undefined
               }
             >

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import emptyTraceImg from 'sentry-images/spot/profiling-empty-state.svg';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Container} from '@sentry/scraps/layout';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -100,18 +99,24 @@ function StepRenderer({
   step,
   stepIndex,
   isLastStep,
+  trailingItems,
 }: {
   isLastStep: boolean;
   project: Project;
   step: OnboardingStep;
   stepIndex: number;
+  trailingItems?: React.ReactNode;
 }) {
   const {type, title} = step;
   const api = useApi();
   const organization = useOrganization();
 
   return (
-    <GuidedSteps.Step stepKey={type || title} title={title || (type && StepTitles[type])}>
+    <GuidedSteps.Step
+      stepKey={type || title}
+      title={title || (type && StepTitles[type])}
+      trailingItems={trailingItems}
+    >
       <StepIndexProvider index={stepIndex}>
         <ContentBlocksRenderer spacing={space(1)} contentBlocks={step.content} />
       </StepIndexProvider>
@@ -309,11 +314,6 @@ export function Onboarding() {
       <SetupTitle project={project} />
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
       <ContinuousProfilingBillingRequirementBanner project={project} />
-      <CopySetupInstructionsGate>
-        <Container paddingBottom="md">
-          <OnboardingCopyMarkdownButton steps={steps} source="profiling_onboarding" />
-        </Container>
-      </CopySetupInstructionsGate>
       <GuidedSteps>
         {steps.map((step, index) => (
           <StepRenderer
@@ -322,6 +322,17 @@ export function Onboarding() {
             step={step}
             stepIndex={index}
             isLastStep={index === steps.length - 1}
+            trailingItems={
+              index === 0 ? (
+                <CopySetupInstructionsGate>
+                  <OnboardingCopyMarkdownButton
+                    borderless
+                    steps={steps}
+                    source="profiling_onboarding"
+                  />
+                </CopySetupInstructionsGate>
+              ) : undefined
+            }
           />
         ))}
       </GuidedSteps>

--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -9,8 +9,8 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {ContentBlocksRenderer} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/renderer';
 import {
-  CopySetupInstructionsGate,
   OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {
   StepIndexProvider,
@@ -208,6 +208,7 @@ export function Onboarding() {
   const {isSelfHosted, urlPrefix} = useLegacyStore(ConfigStore);
   const project = useOnboardingProject();
   const organization = useOrganization();
+  const copyEnabled = useCopySetupInstructionsEnabled();
 
   const currentPlatform = project?.platform
     ? platforms.find(p => p.id === project.platform)
@@ -323,14 +324,12 @@ export function Onboarding() {
             stepIndex={index}
             isLastStep={index === steps.length - 1}
             trailingItems={
-              index === 0 ? (
-                <CopySetupInstructionsGate>
-                  <OnboardingCopyMarkdownButton
-                    borderless
-                    steps={steps}
-                    source="profiling_onboarding"
-                  />
-                </CopySetupInstructionsGate>
+              index === 0 && copyEnabled ? (
+                <OnboardingCopyMarkdownButton
+                  borderless
+                  steps={steps}
+                  source="profiling_onboarding"
+                />
               ) : undefined
             }
           />

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -233,67 +233,66 @@ sentry-cli releases finalize "$VERSION"`;
           )}
         </Text>
 
-        <CompactSelect
-          size="sm"
-          options={apps.map(makeAppOption)}
-          value={selectedApp?.slug}
-          emptyMessage={t('No Integrations')}
-          search
-          disabled={false}
-          menuFooter={({closeOverlay}) => (
-            <Button
-              tooltipProps={{
-                title: canMakeIntegration
-                  ? undefined
-                  : t(
-                      'You must be an organization owner, manager or admin to create an integration.'
-                    ),
-              }}
-              size="xs"
-              priority="transparent"
-              disabled={!canMakeIntegration}
-              onClick={() => {
-                closeOverlay();
-                openCreateReleaseIntegration({
-                  organization,
-                  project,
-                  onCreateSuccess: (app: SentryApp) => {
-                    setApps([app, ...apps]);
-                    setSelectedApp(app);
-                    generateAndSetNewToken(app.slug);
-                    trackQuickstartCreatedIntegration(app);
-                  },
-                  onCancel: trackCreateIntegrationModalClose,
-                });
-              }}
-            >
-              {t('Add New Integration')}
-            </Button>
-          )}
-          trigger={triggerProps => (
-            <OverlayTrigger.Button
-              {...triggerProps}
-              prefix={selectedApp ? t('Token From') : undefined}
-            >
-              {selectedApp ? triggerProps.children : t('Select Integration')}
-            </OverlayTrigger.Button>
-          )}
-          onChange={option => {
-            const app = apps.find(i => i.slug === option.value)!;
-            setSelectedApp(app);
-            generateAndSetNewToken(app.slug);
-          }}
-        />
-
-        <CopySetupInstructionsGate>
-          <Flex justify="end">
+        <Flex justify="between" align="center">
+          <CompactSelect
+            size="sm"
+            options={apps.map(makeAppOption)}
+            value={selectedApp?.slug}
+            emptyMessage={t('No Integrations')}
+            search
+            disabled={false}
+            menuFooter={({closeOverlay}) => (
+              <Button
+                tooltipProps={{
+                  title: canMakeIntegration
+                    ? undefined
+                    : t(
+                        'You must be an organization owner, manager or admin to create an integration.'
+                      ),
+                }}
+                size="xs"
+                priority="transparent"
+                disabled={!canMakeIntegration}
+                onClick={() => {
+                  closeOverlay();
+                  openCreateReleaseIntegration({
+                    organization,
+                    project,
+                    onCreateSuccess: (app: SentryApp) => {
+                      setApps([app, ...apps]);
+                      setSelectedApp(app);
+                      generateAndSetNewToken(app.slug);
+                      trackQuickstartCreatedIntegration(app);
+                    },
+                    onCancel: trackCreateIntegrationModalClose,
+                  });
+                }}
+              >
+                {t('Add New Integration')}
+              </Button>
+            )}
+            trigger={triggerProps => (
+              <OverlayTrigger.Button
+                {...triggerProps}
+                prefix={selectedApp ? t('Token From') : undefined}
+              >
+                {selectedApp ? triggerProps.children : t('Select Integration')}
+              </OverlayTrigger.Button>
+            )}
+            onChange={option => {
+              const app = apps.find(i => i.slug === option.value)!;
+              setSelectedApp(app);
+              generateAndSetNewToken(app.slug);
+            }}
+          />
+          <CopySetupInstructionsGate>
             <CopyMarkdownButton
               borderless
               getMarkdown={getMarkdown}
               source="releases_quickstart"
             />
-          </Flex>
-        </CopySetupInstructionsGate>
+          </CopySetupInstructionsGate>
+        </Flex>
         <div ref={containerRef}>
           <CodeBlock
             dark

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -9,7 +9,7 @@ import {SentryAppAvatar} from '@sentry/scraps/avatar';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {CodeBlock} from '@sentry/scraps/code';
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -233,12 +233,6 @@ sentry-cli releases finalize "$VERSION"`;
           )}
         </Text>
 
-        <CopySetupInstructionsGate>
-          <Container>
-            <CopyMarkdownButton getMarkdown={getMarkdown} source="releases_quickstart" />
-          </Container>
-        </CopySetupInstructionsGate>
-
         <CompactSelect
           size="sm"
           options={apps.map(makeAppOption)}
@@ -291,6 +285,15 @@ sentry-cli releases finalize "$VERSION"`;
           }}
         />
 
+        <CopySetupInstructionsGate>
+          <Flex justify="end">
+            <CopyMarkdownButton
+              borderless
+              getMarkdown={getMarkdown}
+              source="releases_quickstart"
+            />
+          </Flex>
+        </CopySetupInstructionsGate>
         <div ref={containerRef}>
           <CodeBlock
             dark

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -235,6 +235,7 @@ sentry-cli releases finalize "$VERSION"`;
 
         <Flex justify="between" align="center">
           <CompactSelect
+            style={{minWidth: 0}}
             size="sm"
             options={apps.map(makeAppOption)}
             value={selectedApp?.slug}


### PR DESCRIPTION
## Summary
- Shortens button text from "Copy setup instructions" to "Copy instructions" across all onboarding surfaces
- Makes the button borderless (`priority="transparent"`) on sidebar, cron, releases, and MCP surfaces per updated Figma designs
- Repositions the button to be inline with headings/controls instead of standalone above content:
  - **Sidebar surfaces** (feedback, replay, performance, profiling, feature flags): moved into first `Step` heading row via `trailingItems`
  - **Full-page GuidedSteps** (issues, metrics, logs, traces, agents, performance, profiling): moved into first `GuidedSteps.Step` heading via `trailingItems`
  - **MCP**: inline with first `GuidedSteps.Step` heading via `trailingItems` prop on `StepRenderer`
  - **Releases**: right-aligned on same row as "Select Integration" dropdown
  - **Crons**: inline with guide selector/tabs
- Adds `trailingItems` prop to `GuidedSteps.Step`, rendering content in the heading row outside `<StepButton>` to avoid nesting interactive elements

Closes ONB-2

### Before / After

#### Issues onboarding (full-page GuidedSteps pattern — 7 surfaces)
Button moves from standalone bordered button above steps → borderless, inline with "1 Install" step heading.

| Before | After |
|--------|-------|
| ![before-issues](https://files.catbox.moe/tad6az.png) | ![after-issues](https://files.catbox.moe/su1jec.png) |

#### Performance sidebar (drawer pattern — 5 surfaces)
Same repositioning in sidebar/drawer context — button moves into step heading row.

| Before | After |
|--------|-------|
| ![before-sidebar](https://files.catbox.moe/2tuzwo.png) | ![after-sidebar](https://files.catbox.moe/be391a.png) |

#### Releases quickstart
Bordered standalone button above dropdown → borderless, right-aligned on same row as "Select Integration".

| Before | After |
|--------|-------|
| ![before-releases](https://files.catbox.moe/trnvyk.png) | ![after-releases](https://files.catbox.moe/z76x72.png) |

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint/Prettier pass
- [x] GuidedSteps unit tests pass (4/4)
- [x] stepsToMarkdown unit tests pass (55/55)
- [x] instrumentationGuide unit tests pass (11/11)
- [x] Playwright copy-markdown functional tests pass (50/50)
- [x] Playwright tab-persistence tests pass (15/15)
- [x] Visual verification against Figma designs on all 17 surfaces