### PR TITLE
refactor(webhooks): Use replica for fetching webhook payloads in parallel drain

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -332,9 +332,11 @@ def _run_parallel_delivery_batch(
     Run one batch of parallel deliveries for the mailbox.
     Returns (delivered_count, request_failed, no_more_messages).
     """
-    query = WebhookPayload.objects.filter(
-        id__gte=payload.id, mailbox_name=payload.mailbox_name
-    ).order_by("id")
+    query = (
+        WebhookPayload.objects.using_replica()
+        .filter(id__gte=payload.id, mailbox_name=payload.mailbox_name)
+        .order_by("id")
+    )
 
     with ThreadPoolExecutor(max_workers=worker_threads) as threadpool:
         futures = {
@@ -377,7 +379,7 @@ def drain_mailbox_parallel(payload_id: int) -> None:
     indicates that we have hit the start of another batch that has been scheduled.
     """
     try:
-        payload = WebhookPayload.objects.get(id=payload_id)
+        payload = WebhookPayload.objects.using_replica().get(id=payload_id)
     except WebhookPayload.DoesNotExist:
         # We could have hit a race condition. Since we've lost already return
         # and let the other process continue, or a future process.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -936,6 +936,42 @@ class DrainMailboxParallelTest(TestCase):
 
         assert len(responses.calls) == 1
 
+    def test_drain_missing_payload_uses_replica(self) -> None:
+        # Calling with a nonexistent ID should use the replica and exit with outcome=race.
+        with patch.object(
+            WebhookPayload.objects,
+            "using_replica",
+            wraps=WebhookPayload.objects.using_replica,
+        ) as mock_replica:
+            drain_mailbox_parallel(99999)
+
+        mock_replica.assert_called()
+
+    @responses.activate
+    @override_regions(region_config)
+    def test_drain_batch_query_uses_replica(self) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook_one = self.create_webhook_payload(
+            mailbox_name="github:123",
+            region_name="us",
+        )
+
+        with patch.object(
+            WebhookPayload.objects,
+            "using_replica",
+            wraps=WebhookPayload.objects.using_replica,
+        ) as mock_replica:
+            drain_mailbox_parallel(webhook_one.id)
+
+        # using_replica() should be called for both the initial payload fetch
+        # and the batch query in _run_parallel_delivery_batch.
+        assert mock_replica.call_count >= 2
+
 
 @control_silo_test
 class SlowDeliveryLoggingTest(TestCase):


### PR DESCRIPTION
## Summary

Routes read queries in `drain_mailbox_parallel` through the read replica instead of the primary DB, reducing unnecessary read load on the control silo primary.

**Changes:**
- `drain_mailbox_parallel`: initial `WebhookPayload.objects.get(id=payload_id)` lookup now uses `.using_replica()`
- `_run_parallel_delivery_batch`: the batch fetch (`WebhookPayload.objects.filter(...)`) now uses `.using_replica()`

These are pure reads — neither query writes anything. The write path (`schedule_next_attempt`, `delete`) continues to use the primary.

## Why

`drain_mailbox_parallel` is called once per active mailbox per drain cycle. At scale, these lookups add meaningful read QPS to the primary DB for data that doesn't require linearizability — if a newly-inserted payload isn't visible on the replica yet, it will be picked up on the next scheduler tick.

## Test plan

- Added `test_drain_missing_payload_uses_replica`: verifies `using_replica()` is called when the payload doesn't exist
- Added `test_drain_batch_query_uses_replica`: verifies `using_replica()` is called at least twice (once for the initial get, once for the batch fetch) on a successful drain
- All existing `DrainMailboxParallelTest` tests pass