### PR TITLE
feat(flags): Remove 5 dead/dead-except-tests flags (batch 12)

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -81,8 +81,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         # Enable usage of external relays, for use with Relay. See
         # https://github.com/getsentry/relay.
         "organizations:relay": True,
-        # Enable core remote-config backend APIs
-        "organizations:remote-config": False,
         # Enable core Session Replay backend APIs
         "organizations:session-replay": False,
         # Measure usage by spans instead of transactions

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -138,16 +138,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dynamic-sampling-minimum-sample-rate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics emission for dynamic sampling rules
     manager.add("organizations:dynamic-sampling-count-biases", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable archive/escalating issue workflow features in v2
-    manager.add("organizations:escalating-issues-v2", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable emiting escalating data to the metrics backend
     manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable returning the migrated discover queries in explore saved queries
     manager.add("organizations:expose-migrated-discover-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI features such as Autofix and Issue Summary
     manager.add("organizations:gen-ai-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable the 'generate me a query' functionality on the explore > traces page
-    manager.add("organizations:gen-ai-explore-traces", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the 'translate' functionality for GenAI on the explore > traces page
     manager.add("organizations:gen-ai-search-agent-translate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
@@ -162,7 +158,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:indexed-spans-extraction", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable integration functionality to work deployment integrations like Vercel
     manager.add("organizations:integrations-deployment", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    manager.add("organizations:integrations-feature-flag-integration", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
@@ -233,8 +228,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:project-creation-games-tab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable mobile performance score calculation for transactions in relay
     manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable deprecate discover widget type
-    manager.add("organizations:deprecate-discover-widget-type", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable UI sending a discover split for widget
     manager.add("organizations:performance-discover-widget-split-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables setting the fetch all custom measurements request time range to match the user selected time range instead of 90 days

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -29,15 +29,3 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["name"] == "Example Server"
-
-    def test_feature_flag_integration(self) -> None:
-        response = self.get_success_response(self.organization.slug)
-        provider = [r for r in response.data["providers"] if r["key"] == "feature_flag_integration"]
-        assert len(provider) == 0
-
-        with self.feature("organizations:integrations-feature-flag-integration"):
-            response = self.get_success_response(self.organization.slug)
-            provider = [
-                r for r in response.data["providers"] if r["key"] == "feature_flag_integration"
-            ]
-            assert len(provider) == 1

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -2435,37 +2435,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 200, response.data
 
-    def test_add_discover_widget_returns_validation_error(self) -> None:
-        data = {
-            "title": "First dashboard",
-            "widgets": [
-                {"id": str(self.widget_1.id)},
-                {
-                    "title": "Issues",
-                    "displayType": "table",
-                    "widgetType": "discover",
-                    "interval": "5m",
-                    "queries": [
-                        {
-                            "name": "",
-                            "fields": ["count()", "total.count"],
-                            "columns": ["total.count"],
-                            "aggregates": ["count()"],
-                            "conditions": "",
-                        }
-                    ],
-                },
-            ],
-        }
-        with self.feature({"organizations:deprecate-discover-widget-type": True}):
-            response = self.do_request("put", self.url(self.dashboard.id), data=data)
-
-        assert response.status_code == 400, response.data
-        assert (
-            "Attribute value `discover` is deprecated. Please use `error-events` or `transaction-like`"
-            in response.content.decode()
-        )
-
     def test_update_dashboard_with_filters(self) -> None:
         project1 = self.create_project(name="foo", organization=self.organization)
         project2 = self.create_project(name="bar", organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
@@ -6,7 +6,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
 
-@with_feature("organizations:gen-ai-explore-traces")
 @with_feature("organizations:gen-ai-features")
 class TraceExplorerAIQueryTest(APITestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Summary
Remove 5 feature flags with no code usage (dead or only referenced in tests):

| Flag | Status | Source | Flagpole |
|------|--------|--------|----------|
| `organizations:remote-config` | dead | permanent.py | no |
| `organizations:deprecate-discover-widget-type` | dead-except-tests | temporary.py | yes |
| `organizations:escalating-issues-v2` | dead-except-tests | temporary.py | no |
| `organizations:gen-ai-explore-traces` | dead-except-tests | temporary.py | yes |
| `organizations:integrations-feature-flag-integration` | dead-except-tests | temporary.py | no |

## Changes
- Remove flag registrations from `permanent.py` and `temporary.py`
- Remove test method `test_add_discover_widget_returns_validation_error` (was only exercised with the dead flag)
- Remove `@with_feature("organizations:gen-ai-explore-traces")` decorator from trace explorer AI test
- Remove test method `test_feature_flag_integration` (tested example integration gating)

## Companion PRs
- **getsentry**: flag-burner/dead/batch-12 (removes `escalating-issues-v2` from ROLLOUT_FEATURES)
- **sentry-options-automator**: flag-burner/dead/batch-12 (removes flagpole entries)

Merge order: automator first → sentry → getsentry