### PR TITLE
feat(flags): Remove 2 dead-except-tests flags (batch 13)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -224,8 +224,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit
     manager.add("organizations:ownership-size-limit-xlarge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable games tab in the project creation component
-    manager.add("organizations:project-creation-games-tab", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=True)
     # Enable mobile performance score calculation for transactions in relay
     manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable UI sending a discover split for widget
@@ -452,8 +450,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:tag-key-sample-n", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable dynamic grouping UI (top issues)
     manager.add("organizations:top-issues-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable feature to load new trace view.
-    manager.add("organizations:trace-view-v1", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to load new tracing onboarding ui
     manager.add("organizations:tracing-onboarding-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to expose export csv button in trace explorer

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -91,7 +91,6 @@ class OrganizationSerializerTest(TestCase):
             "invite-members",
             "minute-resolution-sessions",
             "open-membership",
-            "project-creation-games-tab",
             "relay",
             "session-replay-ui",
             "shared-issues",


### PR DESCRIPTION
## Summary
Remove 2 feature flags with no code usage (only referenced in tests):

| Flag | Status | Source | Flagpole |
|------|--------|--------|----------|
| `organizations:project-creation-games-tab` | dead-except-tests | temporary.py | no |
| `organizations:trace-view-v1` | dead-except-tests | temporary.py | yes |

## Changes
- Remove flag registrations from `temporary.py`
- Remove `project-creation-games-tab` from expected features list in `test_organization.py`

## Companion PRs
- **getsentry**: flag-burner/dead/batch-13 (removes TraceViewSTFeatureHandler class)
- **sentry-options-automator**: flag-burner/dead/batch-13 (removes trace-view-v1 flagpole entry)

Merge order: automator first → getsentry → sentry