### PR TITLE
feat(webhooks): Exclude mailboxes from delivery_time_ms metric

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -275,6 +275,11 @@ def _discard_stale_mailbox_payloads(payload: WebhookPayload) -> None:
 
 def _record_delivery_time_metrics(payload: WebhookPayload) -> None:
     """Record delivery time metrics for a successfully delivered webhook payload."""
+    exclude_mailboxes = set(
+        options.get("hybridcloud.deliver_webhooks.delivery_time_exclude_mailboxes") or ()
+    )
+    if payload.mailbox_name in exclude_mailboxes:
+        return
     duration = timezone.now() - payload.date_added
     region_sent_to = (
         payload.region_name

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2407,6 +2407,12 @@ register(
     default=4,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "hybridcloud.deliver_webhooks.delivery_time_exclude_mailboxes",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Break glass controls
 register(

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -1043,3 +1043,68 @@ class DeliveryTimeMetricsTest(TestCase):
         ]
         assert len(incr_calls) == 1
         assert incr_calls[0][1].get("tags", {}).get("outcome") == "ok"
+
+    @responses.activate
+    @override_regions(region_config)
+    @override_options(
+        {"hybridcloud.deliver_webhooks.delivery_time_exclude_mailboxes": ["github:123"]}
+    )
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_delivery_time_metrics_excluded_mailbox_does_not_record(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            region_name="us",
+        )
+        drain_mailbox(webhook.id)
+
+        delivery_time_ms_calls = [
+            c
+            for c in mock_metrics.distribution.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.delivery_time_ms"
+        ]
+        assert len(delivery_time_ms_calls) == 0
+
+        incr_calls = [
+            c
+            for c in mock_metrics.incr.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.delivery"
+        ]
+        assert len(incr_calls) == 1
+        assert incr_calls[0][1].get("tags", {}).get("outcome") == "ok"
+
+    @responses.activate
+    @override_regions(region_config)
+    @override_options(
+        {"hybridcloud.deliver_webhooks.delivery_time_exclude_mailboxes": ["other:mailbox"]}
+    )
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
+    def test_delivery_time_metrics_non_excluded_mailbox_still_records(
+        self, mock_metrics: MagicMock
+    ) -> None:
+        responses.add(
+            responses.POST,
+            "http://us.testserver/extensions/github/webhook/",
+            status=200,
+            body="",
+        )
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            region_name="us",
+        )
+        drain_mailbox(webhook.id)
+
+        delivery_time_ms_calls = [
+            c
+            for c in mock_metrics.distribution.call_args_list
+            if c[0][0] == "hybridcloud.deliver_webhooks.delivery_time_ms"
+        ]
+        assert len(delivery_time_ms_calls) == 1
+        assert delivery_time_ms_calls[0][1].get("tags", {}).get("region_sent_to") == "us"


### PR DESCRIPTION
I want to create a monitor on a specific metric which is currently skewed because of various orgs which are not processing fast enough. Until it can be fixed properly, we're going to exclude those mailboxes to generate the metric. There's also another PR coming to make the metric a true distribution (it needs to be added to a whitelist).

This code is part of the control silo webhook forwarding module.

Adds option `hybridcloud.deliver_webhooks.delivery_time_exclude_mailboxes` so specific mailboxes can be excluded from the `hybridcloud.deliver_webhooks.delivery_time_ms` distribution metric. This avoids skew from a few slow mailboxes while keeping delivery and logging unchanged.

- Register option in `options/defaults.py` (Sequence, default []).
- In `_record_delivery_time_metrics()`, skip `metrics.distribution` when `payload.mailbox_name` is in the exclude set.
- Tests: excluded mailbox does not record; non-excluded mailbox still records.

Made with [Cursor](https://cursor.com)