### PR TITLE
feat(uptime): move uptime processing to a task-based model.

### DIFF
--- a/src/sentry/uptime/consumers/results_consumer.py
+++ b/src/sentry/uptime/consumers/results_consumer.py
@@ -48,13 +48,16 @@ from sentry.uptime.subscriptions.tasks import (
 )
 from sentry.uptime.types import UptimeMonitorMode
 from sentry.uptime.utils import (
+    RESULT_DATA_TTL_SECONDS,
     build_backlog_key,
     build_backlog_schedule_lock_key,
     build_backlog_task_scheduled_key,
+    build_incoming_key,
     build_last_interval_change_timestamp_key,
     build_last_update_key,
     generate_scheduled_check_times_ms,
     get_cluster,
+    should_use_task_processing,
 )
 from sentry.utils import json, metrics
 from sentry.utils.locking import UnableToAcquireLock
@@ -476,6 +479,35 @@ class UptimeResultProcessor(ResultProcessor[CheckResult, UptimeSubscription]):
 
     def get_subscription_id(self, result: CheckResult) -> str:
         return result["subscription_id"]
+
+    def __call__(self, identifier: str, result: CheckResult):
+        if should_use_task_processing(result["subscription_id"]):
+            self.enqueue_result_for_task_processing(result)
+            return
+        super().__call__(identifier, result)
+
+    def enqueue_result_for_task_processing(self, result: CheckResult) -> None:
+        """
+        Store result in the incoming sorted set and spawn a processor task.
+
+        The consumer is kept completely thin for the new path — no subscription
+        lookup, no DB access. The full result (including response body) is stored
+        so the task can create response captures.
+        """
+        from sentry.uptime.consumers.tasks import process_subscription
+
+        subscription_id = result["subscription_id"]
+        incoming_key = build_incoming_key(subscription_id)
+        cluster = get_cluster()
+
+        result_json = json.dumps(result)
+        pipeline = cluster.pipeline()
+        pipeline.zadd(incoming_key, {result_json: int(result["scheduled_check_time_ms"])})
+        pipeline.expire(incoming_key, RESULT_DATA_TTL_SECONDS)
+        pipeline.execute()
+
+        process_subscription.delay(subscription_id)
+        metrics.incr("uptime.result_processor.enqueued_for_task", sample_rate=1.0)
 
     def queue_result_for_retry(
         self,

--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -237,24 +237,19 @@ def process_subscription(subscription_id: str):
         CHECKSTATUS_FAILURE,
     )
 
-    cluster = get_cluster()
-    incoming_results = _drain_incoming(cluster, subscription_id)
-    # Annotate incoming results with False (for not being a pending result)
-    incoming_results = [(r[0], r[1], False) for r in incoming_results]
-
     pending_key = build_pending_key(subscription_id)
-    pending_results: list[tuple[bytes, float]] = cluster.zrange(pending_key, 0, -1, withscores=True)
-    # Annotate incoming results with True (for being a pending result)
-    pending_results = [(r[0], r[1], True) for r in pending_results]
 
-    all_results = sorted(incoming_results + pending_results, key=lambda r: r[1])
+    cluster = get_cluster()
+
+    incoming_results = _drain_incoming(cluster, subscription_id)
+    incoming_results = sorted(incoming_results, key=lambda r: r[1])
 
     try:
         subscription: UptimeSubscription = UptimeSubscription.objects.get_from_cache(
             subscription_id=subscription_id
         )
     except UptimeSubscription.DoesNotExist:
-        first_result = json.loads(pending_results[0][0])
+        first_result = json.loads(incoming_results[0][0])
         send_uptime_config_deletion(first_result["region"], subscription_id)
         metrics.incr("uptime.processor.subscription_not_found", sample_rate=1.0)
         return
@@ -283,9 +278,8 @@ def process_subscription(subscription_id: str):
     last_update_ms = 0 if last_update_raw is None else int(last_update_raw)
 
     pending_to_store: list[tuple[bytes, float]] = []
-    pending_to_remove: list[tuple[bytes, float]] = []
 
-    for i, (result_json, score, is_pending) in enumerate(all_results):
+    for i, (result_json, score) in enumerate(incoming_results):
         result = json.loads(result_json)
         metric_tags = {
             "status": result["status"],
@@ -325,34 +319,29 @@ def process_subscription(subscription_id: str):
         if last_update_ms > 0:
             expected_next_ms = last_update_ms + subscription_interval_ms
             if result["scheduled_check_time_ms"] != expected_next_ms:
-                # This is out of expected order.  If this result came from the incoming set,
-                # ready a backfill task, and add it to the pending set
-                if not is_pending:
-                    process_subscription_backfill.apply_async(
-                        args=[subscription_id],
-                        countdown=BACKFILL_DELAY_SECONDS,
-                    )
-                    pending_to_store.append((result_json, score))
-                    metrics.incr(
-                        "uptime.processor.gap_detected",
-                        sample_rate=1.0,
-                        tags=metric_tags,
-                    )
-                    logger.info(
-                        "uptime.processor.gap_detected",
-                        extra={
-                            "subscription_id": subscription_id,
-                            "expected_ms": expected_next_ms,
-                            "found_ms": result["scheduled_check_time_ms"],
-                        },
-                    )
+                # This is out of expected order--add it to the pending set
+                process_subscription_pending.apply_async(
+                    args=[subscription_id],
+                    countdown=BACKFILL_DELAY_SECONDS,
+                )
+                pending_to_store.append((result_json, score))
+                metrics.incr(
+                    "uptime.processor.gap_detected",
+                    sample_rate=1.0,
+                    tags=metric_tags,
+                )
+                logger.info(
+                    "uptime.processor.gap_detected",
+                    extra={
+                        "subscription_id": subscription_id,
+                        "expected_ms": expected_next_ms,
+                        "found_ms": result["scheduled_check_time_ms"],
+                    },
+                )
                 # No matter what, stop processing this check, and move on to the next one.
                 continue
 
         # If we got here, this is a valid and timely check.  Process it.
-
-        if is_pending:
-            pending_to_remove.append((result_json, score))
 
         if result["status"] == CHECKSTATUS_FAILURE and features.has(
             "organizations:uptime-response-capture", organization
@@ -371,15 +360,12 @@ def process_subscription(subscription_id: str):
         # Update local tracking so consecutive results chain correctly
         last_update_ms = result["scheduled_check_time_ms"]
 
-    # Update pending, by removing processed results, and adding newly-pending results
-    if pending_to_store or pending_to_remove:
+    # Update pending, and adding newly-pending results
+    if pending_to_store:
         pipeline = cluster.pipeline()
 
         for result_json, score in pending_to_store:
             pipeline.zadd(pending_key, {result_json: score})
-
-        for result_json, score in pending_to_remove:
-            pipeline.zrem(pending_key, {result_json: score})
 
         pipeline.expire(pending_key, RESULT_DATA_TTL_SECONDS)
 
@@ -387,15 +373,16 @@ def process_subscription(subscription_id: str):
 
 
 @instrumented_task(
-    name="sentry.uptime.consumers.tasks.process_subscription_backfill",
+    name="sentry.uptime.consumers.tasks.process_subscription_pending",
     namespace=uptime_tasks,
     retry=Retry(times=3, delay=1, on=(Exception,)),
 )
-def process_subscription_backfill(subscription_id: str):
+def process_subscription_pending(subscription_id: str):
     from sentry_kafka_schemas.schema_types.uptime_results_v1 import CHECKSTATUS_MISSED_WINDOW
 
     cluster = get_cluster()
     pending_key = build_pending_key(subscription_id)
+    incoming_key = build_incoming_key(subscription_id)
 
     results: list[tuple[bytes, float]] = cluster.zrange(pending_key, 0, -1, withscores=True)
     if not results:
@@ -426,7 +413,9 @@ def process_subscription_backfill(subscription_id: str):
 
     host_provider = get_host_provider_if_valid(subscription)
     now_ms = int(time.time() * 1000)
-    added_backfill = False
+
+    to_add: list[tuple[bytes, float]] = []
+    to_remove: list[tuple[bytes, float]] = []
 
     for result_json, _ in results:
         result = json.loads(result_json)
@@ -437,16 +426,20 @@ def process_subscription_backfill(subscription_id: str):
             continue
 
         expected_next_ms = last_update_ms + subscription_interval_ms
+
         if result["scheduled_check_time_ms"] == expected_next_ms:
-            # No gap here — processor will handle it
+            # We've encountered a now-valid result, move it from pending to incoming,
+            # so that the incoming processor can handle it.
             last_update_ms = expected_next_ms
+            to_add.append((result_json, result["scheduled_check_time_ms"]))
+            to_remove.append((result_json, result["scheduled_check_time_ms"]))
             continue
 
         # There's a gap between last_update_ms and this result.
         check_until_ms = expected_next_ms + (BACKFILL_DELAY_SECONDS * 1000)
 
         if now_ms < check_until_ms:
-            # Gap hasn't expired yet; another backfill task will check this (and any other tasks)
+            # Gap hasn't expired yet; another backfill task will check this
             break
 
         # Gap has expired — create synthetic misses
@@ -462,12 +455,12 @@ def process_subscription_backfill(subscription_id: str):
             ),
         )
         if num_missed > 0:
+            # Add synthetic misses + result to incoming; they can be processed now.
             missed_times = generate_scheduled_check_times_ms(
                 last_update_ms + subscription_interval_ms,
                 subscription_interval_ms,
                 num_missed,
             )
-            pipeline = cluster.pipeline()
             for scheduled_time_ms in missed_times:
                 missed_result = {
                     "guid": uuid.uuid4().hex,
@@ -486,13 +479,15 @@ def process_subscription_backfill(subscription_id: str):
                     "request_info": None,
                     "assertion_failure_data": None,
                 }
-                pipeline.zadd(
-                    pending_key,
-                    {json.dumps(missed_result): scheduled_time_ms},
-                )
-            pipeline.expire(pending_key, RESULT_DATA_TTL_SECONDS)
-            pipeline.execute()
-            added_backfill = True
+                to_add.append((json.dumps(missed_result), scheduled_time_ms))
+
+            # Move the provoking result from pending to incoming, as well
+            to_add.append((result_json, result["scheduled_check_time_ms"]))
+            to_remove.append((result_json, result["scheduled_check_time_ms"]))
+
+            # Because we have generated results, push our last_update_ms forward, in case
+            # we can continue checking results
+            last_update_ms = expected_next_ms
             metrics.incr(
                 "uptime.backfill.misses_created",
                 amount=num_missed,
@@ -500,7 +495,23 @@ def process_subscription_backfill(subscription_id: str):
                 tags=metric_tags,
             )
 
-    if added_backfill:
+    if to_add:
+        incoming_pipeline = cluster.pipeline()
+        for result_json, scheduled_check_time_ms in to_add:
+            incoming_pipeline.zadd(incoming_key, {result_json: scheduled_check_time_ms})
+
+        incoming_pipeline.expire(incoming_key, RESULT_DATA_TTL_SECONDS)
+        incoming_pipeline.execute()
+
+    if to_remove:
+        pending_pipeline = cluster.pipeline()
+        for result_json, scheduled_check_time_ms in to_remove:
+            pending_pipeline.zrem(pending_key, {result_json: scheduled_check_time_ms})
+
+        pending_pipeline.expire(pending_key, RESULT_DATA_TTL_SECONDS)
+        pending_pipeline.execute()
+
+    if to_remove or to_add:
         # Spawn a processor task — it will drain pending and process the
         # synthetic misses followed by the original gap-blocked results.
         process_subscription.delay(subscription_id)

--- a/src/sentry/uptime/consumers/tasks.py
+++ b/src/sentry/uptime/consumers/tasks.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import logging
+import time
+import uuid
 
+from sentry import features
 from sentry.locks import locks
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import uptime_tasks
 from sentry.taskworker.retry import Retry
 from sentry.uptime.consumers.results_consumer import (
     create_backfill_misses,
+    create_uptime_response_capture,
     get_host_provider_if_valid,
+    is_shadow_region_result,
     process_result_internal,
 )
 from sentry.uptime.models import (
@@ -16,17 +21,29 @@ from sentry.uptime.models import (
     get_detector,
     load_regions_for_uptime_subscription,
 )
+from sentry.uptime.subscriptions.subscriptions import (
+    delete_uptime_subscription,
+    disable_uptime_detector,
+)
+from sentry.uptime.subscriptions.tasks import send_uptime_config_deletion
 from sentry.uptime.utils import (
+    BACKFILL_DELAY_SECONDS,
+    RESULT_DATA_TTL_SECONDS,
     build_backlog_key,
     build_backlog_schedule_lock_key,
     build_backlog_task_scheduled_key,
+    build_incoming_key,
     build_last_update_key,
+    build_pending_key,
+    generate_scheduled_check_times_ms,
     get_cluster,
 )
 from sentry.utils import json, metrics
 from sentry.workflow_engine.models.detector import Detector
 
 logger = logging.getLogger(__name__)
+
+MAX_SYNTHETIC_MISSED_CHECKS = 100
 
 # 7 attempts over 180 seconds
 BACKOFF_SCHEDULE = [10, 20, 30, 30, 30, 30, 30, 30, 30, 30, 30]
@@ -190,3 +207,300 @@ def process_uptime_backlog(subscription_id: str, attempt: int = 1):
         process_uptime_backlog.apply_async(
             args=[subscription_id], countdown=next_backoff, kwargs={"attempt": next_attempt}
         )
+
+
+PENDING_RESULT_KEY = "__pending__"
+
+
+def _drain_incoming(cluster, subscription_id: str) -> list[tuple[bytes, float]]:
+    # Atomically drain all results from a subscription's incoming sorted set
+    # using RENAME.
+    incoming_key = build_incoming_key(subscription_id)
+    temp_key = f"{incoming_key}:draining"
+    try:
+        cluster.rename(incoming_key, temp_key)
+    except Exception:
+        return []
+    results: list[tuple[bytes, float]] = cluster.zrange(temp_key, 0, -1, withscores=True)
+    cluster.delete(temp_key)
+    return results
+
+
+@instrumented_task(
+    name="sentry.uptime.consumers.tasks.process_subscription",
+    namespace=uptime_tasks,
+    retry=Retry(times=3, delay=1, on=(Exception,)),
+)
+def process_subscription(subscription_id: str):
+    from sentry_kafka_schemas.schema_types.uptime_results_v1 import (
+        CHECKSTATUS_DISALLOWED_BY_ROBOTS,
+        CHECKSTATUS_FAILURE,
+    )
+
+    cluster = get_cluster()
+    incoming_results = _drain_incoming(cluster, subscription_id)
+    # Annotate incoming results with False (for not being a pending result)
+    incoming_results = [(r[0], r[1], False) for r in incoming_results]
+
+    pending_key = build_pending_key(subscription_id)
+    pending_results: list[tuple[bytes, float]] = cluster.zrange(pending_key, 0, -1, withscores=True)
+    # Annotate incoming results with True (for being a pending result)
+    pending_results = [(r[0], r[1], True) for r in pending_results]
+
+    all_results = sorted(incoming_results + pending_results, key=lambda r: r[1])
+
+    try:
+        subscription: UptimeSubscription = UptimeSubscription.objects.get_from_cache(
+            subscription_id=subscription_id
+        )
+    except UptimeSubscription.DoesNotExist:
+        first_result = json.loads(pending_results[0][0])
+        send_uptime_config_deletion(first_result["region"], subscription_id)
+        metrics.incr("uptime.processor.subscription_not_found", sample_rate=1.0)
+        return
+
+    try:
+        detector = get_detector(subscription, prefetch_workflow_data=True)
+    except Detector.DoesNotExist:
+        delete_uptime_subscription(subscription)
+        metrics.incr("uptime.processor.detector_not_found", sample_rate=1.0)
+        return
+
+    if not detector.enabled:
+        return
+
+    organization = detector.project.organization
+    if not features.has("organizations:uptime", organization):
+        metrics.incr("uptime.processor.dropped_no_feature", sample_rate=1.0)
+        return
+
+    host_provider = get_host_provider_if_valid(subscription)
+    subscription_regions = load_regions_for_uptime_subscription(subscription.id)
+    subscription_interval_ms = subscription.interval_seconds * 1000
+
+    last_update_key = build_last_update_key(detector)
+    last_update_raw: str | None = cluster.get(last_update_key)
+    last_update_ms = 0 if last_update_raw is None else int(last_update_raw)
+
+    pending_to_store: list[tuple[bytes, float]] = []
+    pending_to_remove: list[tuple[bytes, float]] = []
+
+    for i, (result_json, score, is_pending) in enumerate(all_results):
+        result = json.loads(result_json)
+        metric_tags = {
+            "status": result["status"],
+            "uptime_region": result["region"],
+            "host_provider": host_provider,
+        }
+
+        # Handle DISALLOWED_BY_ROBOTS: disable detector, drop everything
+        if result["status"] == CHECKSTATUS_DISALLOWED_BY_ROBOTS:
+            logger.info("uptime.processor.disallowed_by_robots", extra=result)
+            metrics.incr(
+                "uptime.processor.disallowed_by_robots",
+                sample_rate=1.0,
+                tags={"uptime_region": result.get("region", "default")},
+            )
+            disable_uptime_detector(detector)
+            return
+
+        # Skip shadow region results
+        if is_shadow_region_result(result, subscription_regions):
+            metrics.incr(
+                "uptime.processor.dropped_shadow_result",
+                sample_rate=1.0,
+                tags=metric_tags,
+            )
+            continue
+
+        # Dedup: skip if already processed
+        if result["scheduled_check_time_ms"] <= last_update_ms:
+            metrics.incr(
+                "uptime.processor.skipping_already_processed",
+                sample_rate=1.0,
+                tags=metric_tags,
+            )
+            continue
+
+        if last_update_ms > 0:
+            expected_next_ms = last_update_ms + subscription_interval_ms
+            if result["scheduled_check_time_ms"] != expected_next_ms:
+                # This is out of expected order.  If this result came from the incoming set,
+                # ready a backfill task, and add it to the pending set
+                if not is_pending:
+                    process_subscription_backfill.apply_async(
+                        args=[subscription_id],
+                        countdown=BACKFILL_DELAY_SECONDS,
+                    )
+                    pending_to_store.append((result_json, score))
+                    metrics.incr(
+                        "uptime.processor.gap_detected",
+                        sample_rate=1.0,
+                        tags=metric_tags,
+                    )
+                    logger.info(
+                        "uptime.processor.gap_detected",
+                        extra={
+                            "subscription_id": subscription_id,
+                            "expected_ms": expected_next_ms,
+                            "found_ms": result["scheduled_check_time_ms"],
+                        },
+                    )
+                # No matter what, stop processing this check, and move on to the next one.
+                continue
+
+        # If we got here, this is a valid and timely check.  Process it.
+
+        if is_pending:
+            pending_to_remove.append((result_json, score))
+
+        if result["status"] == CHECKSTATUS_FAILURE and features.has(
+            "organizations:uptime-response-capture", organization
+        ):
+            create_uptime_response_capture(subscription, result)
+
+        process_result_internal(
+            detector,
+            subscription,
+            result,
+            metric_tags.copy(),
+            cluster,
+            subscription_regions,
+        )
+
+        # Update local tracking so consecutive results chain correctly
+        last_update_ms = result["scheduled_check_time_ms"]
+
+    # Update pending, by removing processed results, and adding newly-pending results
+    if pending_to_store or pending_to_remove:
+        pipeline = cluster.pipeline()
+
+        for result_json, score in pending_to_store:
+            pipeline.zadd(pending_key, {result_json: score})
+
+        for result_json, score in pending_to_remove:
+            pipeline.zrem(pending_key, {result_json: score})
+
+        pipeline.expire(pending_key, RESULT_DATA_TTL_SECONDS)
+
+        pipeline.execute()
+
+
+@instrumented_task(
+    name="sentry.uptime.consumers.tasks.process_subscription_backfill",
+    namespace=uptime_tasks,
+    retry=Retry(times=3, delay=1, on=(Exception,)),
+)
+def process_subscription_backfill(subscription_id: str):
+    from sentry_kafka_schemas.schema_types.uptime_results_v1 import CHECKSTATUS_MISSED_WINDOW
+
+    cluster = get_cluster()
+    pending_key = build_pending_key(subscription_id)
+
+    results: list[tuple[bytes, float]] = cluster.zrange(pending_key, 0, -1, withscores=True)
+    if not results:
+        return
+
+    try:
+        subscription: UptimeSubscription = UptimeSubscription.objects.get_from_cache(
+            subscription_id=subscription_id
+        )
+        detector = get_detector(subscription, prefetch_workflow_data=True)
+    except (UptimeSubscription.DoesNotExist, Detector.DoesNotExist):
+        cluster.delete(pending_key)
+        return
+
+    if not detector.enabled:
+        return
+
+    organization = detector.project.organization
+    if not features.has("organizations:uptime", organization):
+        return
+
+    last_update_key = build_last_update_key(detector)
+    last_update_raw: str | None = cluster.get(last_update_key)
+    last_update_ms = 0 if last_update_raw is None else int(last_update_raw)
+    if last_update_ms <= 0:
+        return
+    subscription_interval_ms = subscription.interval_seconds * 1000
+
+    host_provider = get_host_provider_if_valid(subscription)
+    now_ms = int(time.time() * 1000)
+    added_backfill = False
+
+    for result_json, _ in results:
+        result = json.loads(result_json)
+
+        # If the result has already been processed, skip (we are racing with the processor,
+        # so this can happen.)
+        if result["scheduled_check_time_ms"] <= last_update_ms:
+            continue
+
+        expected_next_ms = last_update_ms + subscription_interval_ms
+        if result["scheduled_check_time_ms"] == expected_next_ms:
+            # No gap here — processor will handle it
+            last_update_ms = expected_next_ms
+            continue
+
+        # There's a gap between last_update_ms and this result.
+        check_until_ms = expected_next_ms + (BACKFILL_DELAY_SECONDS * 1000)
+
+        if now_ms < check_until_ms:
+            # Gap hasn't expired yet; another backfill task will check this (and any other tasks)
+            break
+
+        # Gap has expired — create synthetic misses
+        metric_tags = {
+            "status": result["status"],
+            "uptime_region": result["region"],
+            "host_provider": host_provider,
+        }
+        num_missed = min(
+            MAX_SYNTHETIC_MISSED_CHECKS,
+            int(
+                (result["scheduled_check_time_ms"] - last_update_ms) / subscription_interval_ms - 1
+            ),
+        )
+        if num_missed > 0:
+            missed_times = generate_scheduled_check_times_ms(
+                last_update_ms + subscription_interval_ms,
+                subscription_interval_ms,
+                num_missed,
+            )
+            pipeline = cluster.pipeline()
+            for scheduled_time_ms in missed_times:
+                missed_result = {
+                    "guid": uuid.uuid4().hex,
+                    "subscription_id": subscription_id,
+                    "status": CHECKSTATUS_MISSED_WINDOW,
+                    "status_reason": {
+                        "type": "miss_backfill",
+                        "description": "Miss was never reported for this scheduled check_time",
+                    },
+                    "trace_id": uuid.uuid4().hex,
+                    "span_id": uuid.uuid4().hex,
+                    "region": result["region"],
+                    "scheduled_check_time_ms": scheduled_time_ms,
+                    "actual_check_time_ms": result["actual_check_time_ms"],
+                    "duration_ms": 0,
+                    "request_info": None,
+                    "assertion_failure_data": None,
+                }
+                pipeline.zadd(
+                    pending_key,
+                    {json.dumps(missed_result): scheduled_time_ms},
+                )
+            pipeline.expire(pending_key, RESULT_DATA_TTL_SECONDS)
+            pipeline.execute()
+            added_backfill = True
+            metrics.incr(
+                "uptime.backfill.misses_created",
+                amount=num_missed,
+                sample_rate=1.0,
+                tags=metric_tags,
+            )
+
+    if added_backfill:
+        # Spawn a processor task — it will drain pending and process the
+        # synthetic misses followed by the original gap-blocked results.
+        process_subscription.delay(subscription_id)

--- a/src/sentry/uptime/utils.py
+++ b/src/sentry/uptime/utils.py
@@ -1,9 +1,14 @@
+import hashlib
+
 from django.conf import settings
 from redis.client import StrictRedis
 from rediscluster import RedisCluster
 
 from sentry.utils import redis
 from sentry.workflow_engine.models.detector import Detector
+
+RESULT_DATA_TTL_SECONDS = 60 * 60
+BACKFILL_DELAY_SECONDS = 180
 
 
 def build_last_update_key(detector: Detector) -> str:
@@ -35,6 +40,29 @@ def build_backlog_task_scheduled_key(subscription_id: str) -> str:
 def build_backlog_schedule_lock_key(subscription_id: str) -> str:
     """Redis lock key for coordinating backlog task scheduling."""
     return f"uptime:backlog_schedule_lock:{subscription_id}"
+
+
+def build_incoming_key(subscription_id: str) -> str:
+    """Redis sorted set key for incoming results (written by consumer, drained by processor)."""
+    return f"uptime:incoming:{subscription_id}"
+
+
+def build_pending_key(subscription_id: str) -> str:
+    """Redis sorted set key for pending results (gap-blocked, waiting for backfill)."""
+    return f"uptime:pending:{subscription_id}"
+
+
+def should_use_task_processing(subscription_id: str) -> bool:
+    """Deterministic check against rollout rate for task-based processing."""
+    from sentry import options
+
+    rate = options.get("uptime.task-processing-rollout")
+    if rate <= 0.0:
+        return False
+    if rate >= 1.0:
+        return True
+    h = int(hashlib.md5(subscription_id.encode()).hexdigest(), 16)
+    return (h % 10000) / 10000.0 < rate
 
 
 def get_cluster() -> RedisCluster | StrictRedis:


### PR DESCRIPTION
This was done with some help from Claude (it tried its best!) Main ideas:
Two tasks, per-subscription: one processes "incoming" results, and one processing "pending" (late) results.  Both "incoming" and "pending" are sorted sets stored in redis, keyed by subscription. A pending task is launched with a 180s (or whatever) delay when a gap is detected during incoming processing.  The task wakes, sees if there is any backfill work to do in the pending set (up to the time it was run.)  If it needs to generate backfill, it does so, adding to the incoming set, and triggering a run of the processing task. A processor task is launched by the consumer for each result it sees, after placing the result in the "incoming" sorted set for that subscription.  The processor will atomically drain the incoming set, and will proceed to process.  Gaps trigger backfill tasks--one per new gap.

Possible improvements/drawbacks: I think it should be straightforward to change the consumer to accept the complete batch of results, and then bucket them into tasks of more than one subscription.  I think it's tricky to do the same for backfills, though, because you do need bookkeeping to get all the timeouts straight, and we'd have to store that in yet-more redis slots, and I'm already a tad worried about increasing redis usage (though my intuition is naive on this, I might be wrong.)

There are inherent benign data races between the running tasks and consumer, but the worst that should happen are some no-op tasks get created.  I have a thought to have a redis slot per subscription task for "is_running", but wondering if that's overkill or not.

Overall, I'd love to have some way to performance-profile this in a real-world setting....

