### PR TITLE
feat(core-ui): Add searchMatcher prop to CompactSelect

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -448,6 +448,80 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('uses custom searchMatcher when provided', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // '_one' matches opt_one by value suffix, opt_two does not match
+      await userEvent.keyboard('_one');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+    });
+
+    it('uses string.includes for default search matching', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // 'ption On' is a mid-string substring of 'Option One' — only includes() catches it
+      await userEvent.keyboard('ption On');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+    });
+
+    it('passes option and search string to searchMatcher', async () => {
+      const searchMatcher = jest.fn().mockReturnValue(true);
+
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={searchMatcher}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('test');
+
+      expect(searchMatcher).toHaveBeenCalledWith(
+        expect.objectContaining({value: 'opt_one', label: 'Option One'}),
+        'test'
+      );
+    });
+
     it('can search with sections', async () => {
       render(
         <CompactSelect
@@ -489,6 +563,46 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(1);
+    });
+
+    it('uses custom searchMatcher with sections', async () => {
+      render(
+        <CompactSelect
+          value={undefined}
+          onChange={jest.fn()}
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {
+              key: 'section-1',
+              label: 'Section 1',
+              options: [
+                {value: 'opt_one', label: 'Option One'},
+                {value: 'opt_two', label: 'Option Two'},
+              ],
+            },
+            {
+              key: 'section-2',
+              label: 'Section 2',
+              options: [
+                {value: 'opt_three', label: 'Option Three'},
+                {value: 'opt_four', label: 'Option Four'},
+              ],
+            },
+          ]}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // 'e' matches opt_one (section 1) and opt_three (section 2) by value suffix
+      await userEvent.keyboard('e');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Four'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async () => {
@@ -835,6 +949,31 @@ describe('CompactSelect', () => {
       await userEvent.keyboard('Two');
 
       // only Option Two should be available, Option One should be filtered out
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+    });
+
+    it('uses custom searchMatcher when provided', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // '_two' matches opt_two by value suffix, opt_one does not match
+      await userEvent.keyboard('_two');
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
     });

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -448,6 +448,71 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('restores full list when search query is cleared', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Two' to filter to one option
+      await userEvent.keyboard('Two');
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // clear the search query — all options should return
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
+    it('resets search query and shows all options when menu is closed and reopened', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      // open the menu and filter results
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('Two');
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // close the menu by clicking outside
+      await userEvent.click(document.body);
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('option', {name: 'Option Two'})
+        ).not.toBeInTheDocument();
+      });
+
+      // reopen the menu — search input should be empty and all options visible
+      await userEvent.click(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
+      });
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
     it('uses custom searchMatcher when provided', async () => {
       render(
         <CompactSelect
@@ -951,6 +1016,71 @@ describe('CompactSelect', () => {
       // only Option Two should be available, Option One should be filtered out
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+    });
+
+    it('restores full list when search query is cleared', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Two' to filter to one option
+      await userEvent.keyboard('Two');
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // clear the search query — all options should return
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+      expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
+    it('resets search query and shows all options when menu is closed and reopened', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      // open the menu and filter results
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('Two');
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // close the menu by clicking outside
+      await userEvent.click(document.body);
+      await waitFor(() => {
+        expect(screen.queryByRole('row', {name: 'Option Two'})).not.toBeInTheDocument();
+      });
+
+      // reopen the menu — search input should be empty and all options visible
+      await userEvent.click(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
+      });
+      expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
     });
 
     it('uses custom searchMatcher when provided', async () => {

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -560,33 +560,6 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
     });
 
-    it('passes option and search string to searchMatcher', async () => {
-      const searchMatcher = jest.fn().mockReturnValue(true);
-
-      render(
-        <CompactSelect
-          searchable
-          searchPlaceholder="Search here…"
-          searchMatcher={searchMatcher}
-          options={[
-            {value: 'opt_one', label: 'Option One'},
-            {value: 'opt_two', label: 'Option Two'},
-          ]}
-          value={undefined}
-          onChange={jest.fn()}
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button'));
-      await userEvent.click(screen.getByPlaceholderText('Search here…'));
-      await userEvent.keyboard('test');
-
-      expect(searchMatcher).toHaveBeenCalledWith(
-        expect.objectContaining({value: 'opt_one', label: 'Option One'}),
-        'test'
-      );
-    });
-
     it('can search with sections', async () => {
       render(
         <CompactSelect
@@ -628,46 +601,6 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(1);
-    });
-
-    it('uses custom searchMatcher with sections', async () => {
-      render(
-        <CompactSelect
-          value={undefined}
-          onChange={jest.fn()}
-          searchable
-          searchPlaceholder="Search here…"
-          searchMatcher={(option, search) => String(option.value).endsWith(search)}
-          options={[
-            {
-              key: 'section-1',
-              label: 'Section 1',
-              options: [
-                {value: 'opt_one', label: 'Option One'},
-                {value: 'opt_two', label: 'Option Two'},
-              ],
-            },
-            {
-              key: 'section-2',
-              label: 'Section 2',
-              options: [
-                {value: 'opt_three', label: 'Option Three'},
-                {value: 'opt_four', label: 'Option Four'},
-              ],
-            },
-          ]}
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button'));
-      await userEvent.click(screen.getByPlaceholderText('Search here…'));
-
-      // 'e' matches opt_one (section 1) and opt_three (section 2) by value suffix
-      await userEvent.keyboard('e');
-      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'Option Four'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async () => {

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -33,7 +33,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import type {SingleListProps} from './list';
-import type {SelectKey, SelectOptionOrSection} from './types';
+import type {SelectKey, SelectOptionOrSection, SelectOptionWithKey} from './types';
 
 // autoFocus react attribute is sync called on render, this causes
 // layout thrashing and is bad for performance. This thin wrapper function
@@ -65,6 +65,10 @@ interface ControlContextValue {
    * selector.
    */
   overlayState?: OverlayTriggerState;
+  /**
+   * Custom function to determine whether an option matches the search query.
+   */
+  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
   size?: FormSize;
 }
 
@@ -174,6 +178,13 @@ export interface ControlProps
    */
   onSearch?: (value: string) => void;
   /**
+   * Custom function to determine whether an option matches the search query (applicable
+   * only when `searchable` is true). Receives the option and the current search string,
+   * and should return true if the option matches. If not provided, defaults to
+   * case-insensitive substring matching on `textValue` or `label`.
+   */
+  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
+  /**
    * The search input's placeholder text (applicable only when `searchable` is true).
    */
   searchPlaceholder?: string;
@@ -231,6 +242,7 @@ export function Control({
   searchPlaceholder = 'Search…',
   disableSearchFilter = false,
   onSearch,
+  searchMatcher,
   clearable = false,
   onClear,
   loading = false,
@@ -466,8 +478,9 @@ export function Control({
       searchable,
       size,
       disabled,
+      searchMatcher,
     };
-  }, [overlayState, overlayIsOpen, search, searchable, size, disabled]);
+  }, [overlayState, overlayIsOpen, search, searchable, size, disabled, searchMatcher]);
 
   const theme = useTheme();
 

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -174,11 +174,12 @@ export function List<Value extends SelectKey>({
   closeOnSelect,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
-  const {overlayState, search, searchable, overlayIsOpen} = useContext(ControlContext);
+  const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
+    useContext(ControlContext);
 
   const hiddenOptions = useMemo(
-    () => getHiddenOptions(items, search, sizeLimit),
-    [items, search, sizeLimit]
+    () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
+    [items, search, sizeLimit, searchMatcher]
   );
 
   /**

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -111,12 +111,16 @@ export function getDisabledOptions<Value extends SelectKey>(
 export function getHiddenOptions<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   search: string,
-  limit = Infinity
+  limit = Infinity,
+  searchMatcher?: (option: SelectOptionWithKey<Value>, search: string) => boolean
 ): Set<SelectKey> {
   //
   // First, filter options using `search` value
   //
-  const filterOption = (opt: SelectOption<Value>) => {
+  const filterOption = (opt: SelectOptionWithKey<Value>) => {
+    if (searchMatcher) {
+      return searchMatcher(opt, search);
+    }
     // Build search string: use textValue if provided, otherwise use label only if it's a string
     const searchableText =
       opt.textValue ?? (typeof opt.label === 'string' ? opt.label : '');


### PR DESCRIPTION
Add a `searchMatcher` prop to `CompactSelect` (and `CompositeSelect`) that lets callers replace the built-in search filtering with a matcher. This will enable us to provide better searching capabilities like fuzzy searching