### PR TITLE
fix(workflows): Make workflow limit values options so we can tweak if necessary

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3529,6 +3529,22 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Safe default limit for workflows. Should be high enough to cover almost all orgs,
+# low enough to have no concerns about stability impact.
+register(
+    "workflow_engine.max_workflows_per_org",
+    type=Int,
+    default=1000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Higher opt-in limit for workflows; intended for orgs we know are hitting limits legitimately,
+# generally set to 'as high as we think we can safely handle for a handful of orgs'.
+register(
+    "workflow_engine.max_more_workflows_per_org",
+    type=Int,
+    default=10000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Restrict uptime issue creation for specific host provider identifiers. Items
 # in this list map to the `host_provider_id` column in the UptimeSubscription

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -1,10 +1,9 @@
 from typing import Any, TypeVar
 
-from django.conf import settings
 from django.db import router, transaction
 from rest_framework import serializers
 
-from sentry import audit_log, features
+from sentry import audit_log, features, options
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.db import models
@@ -257,9 +256,9 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         assert isinstance(org, Organization)
         workflow_count = Workflow.objects.filter(organization_id=org.id).count()
         if features.has("organizations:more-workflows", org):
-            max_workflows = settings.MAX_MORE_WORKFLOWS_PER_ORG
+            max_workflows = options.get("workflow_engine.max_more_workflows_per_org")
         else:
-            max_workflows = settings.MAX_WORKFLOWS_PER_ORG
+            max_workflows = options.get("workflow_engine.max_workflows_per_org")
 
         if workflow_count >= max_workflows:
             raise serializers.ValidationError(

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -271,7 +271,7 @@ class TestWorkflowValidatorCreate(TestCase):
 
     def test_create__exceeds_workflow_limit(self) -> None:
         REGULAR_LIMIT = 2
-        with self.settings(MAX_WORKFLOWS_PER_ORG=REGULAR_LIMIT):
+        with self.options({"workflow_engine.max_workflows_per_org": REGULAR_LIMIT}):
             # Create first workflow - should succeed
             validator = WorkflowValidator(data=self.valid_data, context=self.context)
             validator.is_valid(raise_exception=True)
@@ -301,8 +301,11 @@ class TestWorkflowValidatorCreate(TestCase):
     def test_create__exceeds_more_workflow_limit(self) -> None:
         REGULAR_LIMIT = 2
         MORE_LIMIT = 4
-        with self.settings(
-            MAX_WORKFLOWS_PER_ORG=REGULAR_LIMIT, MAX_MORE_WORKFLOWS_PER_ORG=MORE_LIMIT
+        with self.options(
+            {
+                "workflow_engine.max_workflows_per_org": REGULAR_LIMIT,
+                "workflow_engine.max_more_workflows_per_org": MORE_LIMIT,
+            }
         ):
             # First verify regular limit is enforced without the feature flag
             # Create first REGULAR_LIMIT workflows - should succeed


### PR DESCRIPTION
We don't think the current values are likely the real values we'll end up at, and we'd like to be able to adjust them as we encounter issues with opted in orgs if necessary.
