### PR TITLE
chore(billing): Reference startDate when filtering active product trials

### DIFF
--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -941,6 +941,20 @@ describe('getActiveProductTrial', () => {
     expect(replay_pt).toBeNull();
   });
 
+  it('returns null when trial is isStarted but startDate is in the future', () => {
+    const trials: ProductTrial[] = [
+      {
+        category: DataCategory.SPANS,
+        isStarted: true,
+        reasonCode: 4001,
+        startDate: moment().utc().add(5, 'days').format(),
+        endDate: moment().utc().add(35, 'days').format(),
+      },
+    ];
+    const pt = getActiveProductTrial(trials, DataCategory.SPANS);
+    expect(pt).toBeNull();
+  });
+
   it('returns null trial when no trials for category', () => {
     const pt = getProductTrial(TEST_TRIALS, DataCategory.ATTACHMENTS);
     expect(pt).toBeNull();

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -693,7 +693,8 @@ export function getActiveProductTrial(
       pt =>
         pt.category === category &&
         pt.isStarted &&
-        getDaysSinceDate(pt.endDate ?? '') <= 0
+        getDaysSinceDate(pt.endDate ?? '') <= 0 &&
+        getDaysSinceDate(pt.startDate ?? '') >= 0
     )
     .sort((a, b) => b.endDate?.localeCompare(a.endDate ?? '') || 0);
 


### PR DESCRIPTION
required for https://github.com/getsentry/getsentry/pull/19137

Allows us to schedule product trials in the future