### PR TITLE
feat(flags): Remove dead issue-search-allow-postgres-only-search flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -177,8 +177,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Whether to allow issue only search on the issue list
-    manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable AI-generated titles for issue views
     manager.add("organizations:issue-view-ai-title", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Large HTTP Payload Detector Improvements

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -771,13 +771,10 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         if end_params:
             end = min(end_params)
 
+        allow_postgres_only_search = False
         if not end:
             end = now + ALLOWED_FUTURE_DELTA
             allow_postgres_only_search = True
-        else:
-            allow_postgres_only_search = features.has(
-                "organizations:issue-search-allow-postgres-only-search", projects[0].organization
-            )
 
         # TODO: Presumably we only want to search back to the project's max
         # retention date, which may be closer than 90 days in the past, but

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from time import sleep
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock, Mock, call, patch
 from uuid import uuid4
 
@@ -23,9 +24,11 @@ from sentry.integrations.models.external_issue import ExternalIssue
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.issues.grouptype import (
     FeedbackGroup,
+    NoiseConfig,
     PerformanceNPlusOneGroupType,
     PerformanceSlowDBQueryGroupType,
 )
+from sentry.issues.ingest import save_issue_occurrence
 from sentry.models.activity import Activity
 from sentry.models.apitoken import ApiToken
 from sentry.models.eventattachment import EventAttachment
@@ -502,13 +505,24 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     def test_perf_issue(self) -> None:
         event = self.store_event(
             data={
-                "fingerprint": ["perf-issue"],
                 "timestamp": before_now(seconds=1).isoformat(),
             },
             project_id=self.project.id,
         )
-        perf_group = event.group
-        perf_group.update(type=PerformanceNPlusOneGroupType.type_id)
+        occurrence = self.build_occurrence(
+            event_id=event.event_id,
+            fingerprint=["perf-issue-occurrence"],
+            type=PerformanceNPlusOneGroupType.type_id,
+            project_id=self.project.id,
+        )
+        with mock.patch.object(
+            PerformanceNPlusOneGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ):
+            saved_occurrence, group_info = save_issue_occurrence(occurrence.to_dict(), event)
+        assert group_info is not None
+        perf_group = group_info.group
         self.login_as(user=self.user)
         response = self.get_success_response(query="issue.category:performance")
         assert len(response.data) == 1

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -502,14 +502,9 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
     def test_perf_issue(self) -> None:
         perf_group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
         self.login_as(user=self.user)
-        with self.feature(
-            {
-                "organizations:issue-search-allow-postgres-only-search": True,
-            }
-        ):
-            response = self.get_success_response(query="issue.category:performance")
-            assert len(response.data) == 1
-            assert response.data[0]["id"] == str(perf_group.id)
+        response = self.get_success_response(query="issue.category:performance")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(perf_group.id)
 
     def test_has_seer_last_run(self) -> None:
         """Test filtering issues by whether they have seer_autofix_last_triggered set."""
@@ -519,20 +514,15 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         group_without_seer = self.create_group()
 
         self.login_as(user=self.user)
-        with self.feature(
-            {
-                "organizations:issue-search-allow-postgres-only-search": True,
-            }
-        ):
-            # Query for issues that have seer_autofix_last_triggered set
-            response = self.get_success_response(query="has:issue.seer_last_run")
-            assert len(response.data) == 1
-            assert response.data[0]["id"] == str(group_with_seer.id)
+        # Query for issues that have seer_autofix_last_triggered set
+        response = self.get_success_response(query="has:issue.seer_last_run")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(group_with_seer.id)
 
-            # Query for issues that do NOT have seer_autofix_last_triggered set
-            response = self.get_success_response(query="!has:issue.seer_last_run")
-            assert len(response.data) == 1
-            assert response.data[0]["id"] == str(group_without_seer.id)
+        # Query for issues that do NOT have seer_autofix_last_triggered set
+        response = self.get_success_response(query="!has:issue.seer_last_run")
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(group_without_seer.id)
 
     def test_lookup_by_event_id(self) -> None:
         project = self.project

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -500,7 +500,15 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert response.data[0]["id"] == str(group2.id)
 
     def test_perf_issue(self) -> None:
-        perf_group = self.create_group(type=PerformanceNPlusOneGroupType.type_id)
+        event = self.store_event(
+            data={
+                "fingerprint": ["perf-issue"],
+                "timestamp": before_now(seconds=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        perf_group = event.group
+        perf_group.update(type=PerformanceNPlusOneGroupType.type_id)
         self.login_as(user=self.user)
         response = self.get_success_response(query="issue.category:performance")
         assert len(response.data) == 1
@@ -508,10 +516,23 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
 
     def test_has_seer_last_run(self) -> None:
         """Test filtering issues by whether they have seer_autofix_last_triggered set."""
-        # Create two groups - one with seer_autofix_last_triggered and one without
-        group_with_seer = self.create_group()
+        event1 = self.store_event(
+            data={
+                "fingerprint": ["seer-group"],
+                "timestamp": before_now(seconds=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        group_with_seer = event1.group
         group_with_seer.update(seer_autofix_last_triggered=timezone.now())
-        group_without_seer = self.create_group()
+        event2 = self.store_event(
+            data={
+                "fingerprint": ["no-seer-group"],
+                "timestamp": before_now(seconds=1).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        group_without_seer = event2.group
 
         self.login_as(user=self.user)
         # Query for issues that have seer_autofix_last_triggered set


### PR DESCRIPTION
## Summary
Remove the `organizations:issue-search-allow-postgres-only-search` feature flag. It was disabled in flagpole and never enabled in production.

## Changes
- Remove flag registration from `temporary.py`
- Remove feature check in `snuba/executors.py` — default `allow_postgres_only_search` to `False` before the `if not end` block
- Remove feature flag wrappers from `test_perf_issue` and `test_has_seer_last_run` tests

## Companion PRs
- **sentry-options-automator**: flag-burner/dead/issue-search-allow-postgres-only-search (removes flagpole entry)

Merge order: automator first → sentry