### PR TITLE
feat(flags): Remove disabled unlimited-auto-triggered-autofix-runs flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -468,8 +468,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:transaction-widget-deprecation-explore-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Normalize URL transaction names during ingestion.
     manager.add("organizations:transaction-name-normalize", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    # Enables unlimited auto-triggered autofix runs
-    manager.add("organizations:unlimited-auto-triggered-autofix-runs", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables view hierarchy attachment scrubbing
     manager.add("organizations:view-hierarchy-scrubbing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable AI-powered assertion suggestions for uptime monitors

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -430,7 +430,7 @@ def is_group_triggering_automation(group: Group) -> bool:
     if not has_budget:
         return False
 
-    is_rate_limited = is_seer_autotriggered_autofix_rate_limited(group.project, group.organization)
+    is_rate_limited = is_seer_autotriggered_autofix_rate_limited(group.project)
     if is_rate_limited:
         return False
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -558,9 +558,7 @@ def _get_autofix_rate_limit_config(project: Project) -> AutoTriggerRateLimitConf
     return AutoTriggerRateLimitConfig(limit=limit, key="autofix.auto_triggered", window=60 * 60)
 
 
-def is_seer_autotriggered_autofix_rate_limited(
-    project: Project, organization: Organization
-) -> bool:
+def is_seer_autotriggered_autofix_rate_limited(project: Project) -> bool:
     """
     Read-only check of whether the autofix rate limit has been reached.
     Does NOT increment the counter. Safe to call from non-triggering code paths.

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -430,9 +430,6 @@ def is_seer_scanner_rate_limited(project: Project, organization: Organization) -
     Returns:
         bool: Whether the seer scanner is rate limited.
     """
-    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
-        return False
-
     limit = options.get("seer.max_num_scanner_autotriggered_per_ten_seconds", 15)
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(
         project=project,
@@ -568,9 +565,6 @@ def is_seer_autotriggered_autofix_rate_limited(
     Read-only check of whether the autofix rate limit has been reached.
     Does NOT increment the counter. Safe to call from non-triggering code paths.
     """
-    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
-        return False
-
     config = _get_autofix_rate_limit_config(project)
     current = ratelimits.backend.current_value(
         key=config["key"],
@@ -595,9 +589,6 @@ def is_seer_autotriggered_autofix_rate_limited_and_increment(
     Returns:
         bool: Whether Autofix is rate limited.
     """
-    if features.has("organizations:unlimited-auto-triggered-autofix-runs", organization):
-        return False
-
     config = _get_autofix_rate_limit_config(project)
 
     is_rate_limited, current, _ = ratelimits.backend.is_limited_with_value(

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -269,8 +269,6 @@ class TestAutomationRateLimiting(TestCase):
         assert is_rate_limited is True
         mock_track_outcome.assert_called_once()
 
-        mock_track_outcome.assert_not_called()
-
     @patch("sentry.seer.autofix.utils.ratelimits.backend.is_limited_with_value")
     @patch("sentry.seer.autofix.utils.track_outcome")
     def test_autofix_rate_limited_logic(

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -19,7 +19,6 @@ from sentry.seer.autofix.utils import (
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
@@ -253,18 +252,6 @@ class TestGetAutofixState(TestCase):
 
 
 class TestAutomationRateLimiting(TestCase):
-    @with_feature("organizations:unlimited-auto-triggered-autofix-runs")
-    @patch("sentry.seer.autofix.utils.track_outcome")
-    def test_scanner_rate_limited_with_unlimited_flag(self, mock_track_outcome: MagicMock) -> None:
-        """Test scanner rate limiting bypassed with unlimited feature flag"""
-        project = self.create_project()
-        organization = project.organization
-
-        is_rate_limited = is_seer_scanner_rate_limited(project, organization)
-
-        assert is_rate_limited is False
-        mock_track_outcome.assert_not_called()
-
     @patch("sentry.seer.autofix.utils.ratelimits.backend.is_limited_with_value")
     @patch("sentry.seer.autofix.utils.track_outcome")
     def test_scanner_rate_limited_logic(
@@ -282,18 +269,6 @@ class TestAutomationRateLimiting(TestCase):
         assert is_rate_limited is True
         mock_track_outcome.assert_called_once()
 
-    @with_feature("organizations:unlimited-auto-triggered-autofix-runs")
-    @patch("sentry.seer.autofix.utils.track_outcome")
-    def test_autofix_rate_limited_with_unlimited_flag(self, mock_track_outcome: MagicMock) -> None:
-        """Test autofix rate limiting bypassed with unlimited feature flag"""
-        project = self.create_project()
-        organization = project.organization
-
-        is_rate_limited = is_seer_autotriggered_autofix_rate_limited_and_increment(
-            project, organization
-        )
-
-        assert is_rate_limited is False
         mock_track_outcome.assert_not_called()
 
     @patch("sentry.seer.autofix.utils.ratelimits.backend.is_limited_with_value")

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -319,7 +319,7 @@ class TestAutomationRateLimiting(TestCase):
 
         # Check a few times to be safe
         for _ in range(5):
-            is_seer_autotriggered_autofix_rate_limited(project, organization)
+            is_seer_autotriggered_autofix_rate_limited(project)
         current = ratelimits.backend.current_value(
             key=config["key"], project=project, window=config["window"]
         )


### PR DESCRIPTION
## Summary
Remove the `organizations:unlimited-auto-triggered-autofix-runs` feature flag. It was disabled in flagpole — the rate limiting bypass for auto-triggered autofix/scanner runs never fired in production.

## Changes
- Remove flag registration from `temporary.py`
- Remove 3 bypass checks in `seer/autofix/utils.py` (rate limiting now always applies)
- Remove 2 test methods that verified the bypass behavior
- Remove unused `with_feature` import

## Companion PRs
- **sentry-options-automator**: flag-burner/dead/unlimited-auto-triggered-autofix-runs

Merge order: automator first → sentry