### PR TITLE
Remove disabled feature flag `data-secrecy-v2`

### DIFF
--- a/src/sentry/data_secrecy/logic.py
+++ b/src/sentry/data_secrecy/logic.py
@@ -44,8 +44,8 @@ def should_allow_superuser_access_v2(
     :param organization_context: The organization context to check.
     :return: True if a superuser session is allowed for the organization, False otherwise.
 
-    Note: This method is not currently used. It will be rolled out when rest of Data Secrecy V2 is ready.
-    It is an in-place replacement for should_allow_superuser_access.
+    This is the v2 replacement for should_allow_superuser_access, adding Break the Glass
+    (data access grant) support.
     """
 
     if settings.SENTRY_SELF_HOSTED:
@@ -56,10 +56,6 @@ def should_allow_superuser_access_v2(
         organization = organization_context.organization
     else:
         organization = organization_context
-
-    # If organization does not have data-secrecy-v2 feature, allow superuser access
-    if not features.has("organizations:data-secrecy-v2", organization):
-        return True
 
     # If organization's prevent_superuser_access bitflag is False, allow superuser access
     if not organization.flags.prevent_superuser_access:

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -112,8 +112,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-text-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Data Secrecy v2 (with Break the Glass feature)
-    manager.add("organizations:data-secrecy-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable default anomaly detection metric monitor for new projects
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables synthesis of device.class in ingest

--- a/tests/sentry/data_secrecy/test_logic.py
+++ b/tests/sentry/data_secrecy/test_logic.py
@@ -87,43 +87,34 @@ class ShouldAllowSuperuserAccessV2Test(TestCase):
             assert should_allow_superuser_access_v2(self.organization) is True
             assert should_allow_superuser_access_v2(self.rpc_context) is True
 
-    def test_feature_flag_disabled(self) -> None:
-        with self.settings(SENTRY_SELF_HOSTED=False):
-            # Feature flag is disabled by default in test setup
-            assert should_allow_superuser_access_v2(self.organization) is True
-            assert should_allow_superuser_access_v2(self.rpc_context) is True
-
     def test_bit_flag_disabled(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                self.organization.flags.prevent_superuser_access = False
-                self.rpc_org.flags.prevent_superuser_access = False
-                assert should_allow_superuser_access_v2(self.organization) is True
-                assert should_allow_superuser_access_v2(self.rpc_context) is True
+            self.organization.flags.prevent_superuser_access = False
+            self.rpc_org.flags.prevent_superuser_access = False
+            assert should_allow_superuser_access_v2(self.organization) is True
+            assert should_allow_superuser_access_v2(self.rpc_context) is True
 
     @patch("sentry.data_secrecy.logic.data_access_grant_exists")
     def test_with_active_grant(self, mock_grant_exists: mock.MagicMock) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                mock_grant_exists.return_value = True
+            mock_grant_exists.return_value = True
 
-                assert should_allow_superuser_access_v2(self.organization) is True
-                assert should_allow_superuser_access_v2(self.rpc_context) is True
+            assert should_allow_superuser_access_v2(self.organization) is True
+            assert should_allow_superuser_access_v2(self.rpc_context) is True
 
-                # Verify the function was called with correct organization ID
-                mock_grant_exists.assert_called_with(self.organization.id)
+            # Verify the function was called with correct organization ID
+            mock_grant_exists.assert_called_with(self.organization.id)
 
     @patch("sentry.data_secrecy.logic.data_access_grant_exists")
     def test_no_active_grant(self, mock_grant_exists: mock.MagicMock) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                mock_grant_exists.return_value = False
+            mock_grant_exists.return_value = False
 
-                assert should_allow_superuser_access_v2(self.organization) is False
-                assert should_allow_superuser_access_v2(self.rpc_context) is False
+            assert should_allow_superuser_access_v2(self.organization) is False
+            assert should_allow_superuser_access_v2(self.rpc_context) is False
 
-                # Verify the function was called with correct organization ID
-                mock_grant_exists.assert_called_with(self.organization.id)
+            # Verify the function was called with correct organization ID
+            mock_grant_exists.assert_called_with(self.organization.id)
 
 
 @all_silo_test(regions=create_test_regions("us"))
@@ -297,119 +288,111 @@ class DataSecrecyE2ETest(TestCase):
 
     def test_superuser_access_granted_with_active_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # Create an active data access grant
-                grant = self.create_data_access_grant(
-                    organization_id=self.organization.id,
-                    grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
-                    grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),  # ends at 4 PM
-                )
+            # Create an active data access grant
+            grant = self.create_data_access_grant(
+                organization_id=self.organization.id,
+                grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),  # ends at 4 PM
+            )
 
-                # Test that superuser access is allowed
-                assert should_allow_superuser_access_v2(self.organization) is True
-                assert should_allow_superuser_access_v2(self.rpc_context) is True
+            # Test that superuser access is allowed
+            assert should_allow_superuser_access_v2(self.organization) is True
+            assert should_allow_superuser_access_v2(self.rpc_context) is True
 
-                # Test that data_access_grant_exists returns True
-                assert data_access_grant_exists(self.organization.id) is True
+            # Test that data_access_grant_exists returns True
+            assert data_access_grant_exists(self.organization.id) is True
 
-                # Verify grant details are what we expect
-                assert grant.organization_id == self.organization.id
-                assert grant.grant_start == datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-                assert grant.grant_end == datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc)
+            # Verify grant details are what we expect
+            assert grant.organization_id == self.organization.id
+            assert grant.grant_start == datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+            assert grant.grant_end == datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc)
 
     def test_superuser_access_denied_without_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # Ensure no grants exist for this organization
-                # (self.create_data_access_grant is not called)
+            # Ensure no grants exist for this organization
+            # (self.create_data_access_grant is not called)
 
-                # Test that superuser access is denied
-                assert should_allow_superuser_access_v2(self.organization) is False
-                assert should_allow_superuser_access_v2(self.rpc_context) is False
+            # Test that superuser access is denied
+            assert should_allow_superuser_access_v2(self.organization) is False
+            assert should_allow_superuser_access_v2(self.rpc_context) is False
 
-                # Test that data_access_grant_exists returns False
-                assert data_access_grant_exists(self.organization.id) is False
+            # Test that data_access_grant_exists returns False
+            assert data_access_grant_exists(self.organization.id) is False
 
     def test_superuser_access_denied_with_expired_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # Create an expired data access grant
-                expired_grant = self.create_data_access_grant(
-                    organization_id=self.organization.id,
-                    grant_start=datetime(2025, 1, 1, 8, 0, 0, tzinfo=timezone.utc),  # 8 AM
-                    grant_end=datetime(
-                        2025, 1, 1, 11, 0, 0, tzinfo=timezone.utc
-                    ),  # 11 AM (expired)
-                )
+            # Create an expired data access grant
+            expired_grant = self.create_data_access_grant(
+                organization_id=self.organization.id,
+                grant_start=datetime(2025, 1, 1, 8, 0, 0, tzinfo=timezone.utc),  # 8 AM
+                grant_end=datetime(2025, 1, 1, 11, 0, 0, tzinfo=timezone.utc),  # 11 AM (expired)
+            )
 
-                # Test that superuser access is denied for expired grant
-                assert should_allow_superuser_access_v2(self.organization) is False
-                assert should_allow_superuser_access_v2(self.rpc_context) is False
+            # Test that superuser access is denied for expired grant
+            assert should_allow_superuser_access_v2(self.organization) is False
+            assert should_allow_superuser_access_v2(self.rpc_context) is False
 
-                # Test that data_access_grant_exists returns False for expired grant
-                assert data_access_grant_exists(self.organization.id) is False
+            # Test that data_access_grant_exists returns False for expired grant
+            assert data_access_grant_exists(self.organization.id) is False
 
-                # Verify grant details
-                assert expired_grant.organization_id == self.organization.id
-                assert expired_grant.grant_end < datetime.now(timezone.utc)  # Confirm it's expired
+            # Verify grant details
+            assert expired_grant.organization_id == self.organization.id
+            assert expired_grant.grant_end < datetime.now(timezone.utc)  # Confirm it's expired
 
     def test_cache_behavior_with_real_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # Create an active grant
-                self.create_data_access_grant(
-                    organization_id=self.organization.id,
-                    grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
-                    grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),
-                )
+            # Create an active grant
+            self.create_data_access_grant(
+                organization_id=self.organization.id,
+                grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),
+            )
 
-                # First call should hit the database and cache the result
-                result1 = data_access_grant_exists(self.organization.id)
-                assert result1 is True
+            # First call should hit the database and cache the result
+            result1 = data_access_grant_exists(self.organization.id)
+            assert result1 is True
 
-                # Second call should use the cache (we can't easily verify this without
-                # mocking, but we can at least verify the result is consistent)
-                result2 = data_access_grant_exists(self.organization.id)
-                assert result2 is True
+            # Second call should use the cache (we can't easily verify this without
+            # mocking, but we can at least verify the result is consistent)
+            result2 = data_access_grant_exists(self.organization.id)
+            assert result2 is True
 
-                # Both calls to should_allow_superuser_access_v2 should return True
-                assert should_allow_superuser_access_v2(self.organization) is True
-                assert should_allow_superuser_access_v2(self.organization) is True
+            # Both calls to should_allow_superuser_access_v2 should return True
+            assert should_allow_superuser_access_v2(self.organization) is True
+            assert should_allow_superuser_access_v2(self.organization) is True
 
     def test_cache_behavior_without_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # No grant created - should result in negative cache
+            # No grant created - should result in negative cache
 
-                # First call should hit the database and cache the negative result
-                result1 = data_access_grant_exists(self.organization.id)
-                assert result1 is False
+            # First call should hit the database and cache the negative result
+            result1 = data_access_grant_exists(self.organization.id)
+            assert result1 is False
 
-                # Second call should use the negative cache
-                result2 = data_access_grant_exists(self.organization.id)
-                assert result2 is False
+            # Second call should use the negative cache
+            result2 = data_access_grant_exists(self.organization.id)
+            assert result2 is False
 
-                # Both calls to should_allow_superuser_access_v2 should return False
-                assert should_allow_superuser_access_v2(self.organization) is False
-                assert should_allow_superuser_access_v2(self.organization) is False
+            # Both calls to should_allow_superuser_access_v2 should return False
+            assert should_allow_superuser_access_v2(self.organization) is False
+            assert should_allow_superuser_access_v2(self.organization) is False
 
     def test_transition_from_no_grant_to_active_grant(self) -> None:
         with self.settings(SENTRY_SELF_HOSTED=False):
-            with self.feature("organizations:data-secrecy-v2"):
-                # Initially no grant exists
-                assert data_access_grant_exists(self.organization.id) is False
-                assert should_allow_superuser_access_v2(self.organization) is False
+            # Initially no grant exists
+            assert data_access_grant_exists(self.organization.id) is False
+            assert should_allow_superuser_access_v2(self.organization) is False
 
-                # Create a grant
-                self.create_data_access_grant(
-                    organization_id=self.organization.id,
-                    grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
-                    grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),
-                )
+            # Create a grant
+            self.create_data_access_grant(
+                organization_id=self.organization.id,
+                grant_start=datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+                grant_end=datetime(2025, 1, 1, 16, 0, 0, tzinfo=timezone.utc),
+            )
 
-                # Clear cache to simulate cache expiration or manual invalidation
-                cache.clear()
+            # Clear cache to simulate cache expiration or manual invalidation
+            cache.clear()
 
-                # Now should have access
-                assert data_access_grant_exists(self.organization.id) is True
-                assert should_allow_superuser_access_v2(self.organization) is True
+            # Now should have access
+            assert data_access_grant_exists(self.organization.id) is True
+            assert should_allow_superuser_access_v2(self.organization) is True


### PR DESCRIPTION
## Summary
- Remove the `organizations:data-secrecy-v2` feature flag which was disabled in flagpole with zero rollout
- Remove the feature gate from `should_allow_superuser_access_v2` in `data_secrecy/logic.py` (function is not yet called in production)
- Remove test wrappers that enabled the flag and the `test_feature_flag_disabled` test

## Merge Order
1. **This PR** (sentry) — remove all code that checks the flag
2. sentry-options-automator — remove flagpole.yaml entry