### PR TITLE
Remove disabled feature flag `performance-trace-explorer`

### DIFF
--- a/src/sentry/api/endpoints/organization_spans_fields.py
+++ b/src/sentry/api/endpoints/organization_spans_fields.py
@@ -72,15 +72,9 @@ class OrganizationSpansFieldsEndpointSerializer(serializers.Serializer):
 @region_silo_endpoint
 class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
-        performance_trace_explorer = features.has(
-            "organizations:performance-trace-explorer", organization, actor=request.user
-        )
-
-        visibility_explore_view = features.has(
+        if not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user
-        )
-
-        if not performance_trace_explorer and not visibility_explore_view:
+        ):
             return Response(status=404)
 
         try:
@@ -153,15 +147,9 @@ class OrganizationSpansFieldsEndpoint(OrganizationSpansFieldsEndpointBase):
 @region_silo_endpoint
 class OrganizationSpansFieldValuesEndpoint(OrganizationSpansFieldsEndpointBase):
     def get(self, request: Request, organization: Organization, key: str) -> Response:
-        performance_trace_explorer = features.has(
-            "organizations:performance-trace-explorer", organization, actor=request.user
-        )
-
-        visibility_explore_view = features.has(
+        if not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user
-        )
-
-        if not performance_trace_explorer and not visibility_explore_view:
+        ):
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/organization_traces.py
+++ b/src/sentry/api/endpoints/organization_traces.py
@@ -150,8 +150,6 @@ class OrganizationTracesEndpointBase(OrganizationEventsEndpointBase):
 class OrganizationTracesEndpoint(OrganizationTracesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
         if not features.has(
-            "organizations:performance-trace-explorer", organization, actor=request.user
-        ) and not features.has(
             "organizations:visibility-explore-view", organization, actor=request.user
         ):
             return Response(status=404)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -220,8 +220,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-queries-mongodb-extraction", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable removing the fallback for metrics compatibility
     manager.add("organizations:performance-remove-metrics-compatibility-fallback", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable trace explorer features
-    manager.add("organizations:performance-trace-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable session health overview to dashboard platform migration
     manager.add("organizations:performance-session-health-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable queries module dashboard on dashboards platform

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -423,10 +423,7 @@ export function viewSamplesTarget({
 }
 
 export function getDefaultExploreRoute(organization: Organization) {
-  if (
-    organization.features.includes('performance-trace-explorer') ||
-    organization.features.includes('visibility-explore-view')
-  ) {
+  if (organization.features.includes('visibility-explore-view')) {
     return 'traces';
   }
 

--- a/static/app/views/nav/index.spec.tsx
+++ b/static/app/views/nav/index.spec.tsx
@@ -35,7 +35,6 @@ const ALL_AVAILABLE_FEATURES = [
   'session-replay-ui',
   'ourlogs-enabled',
   'performance-view',
-  'performance-trace-explorer',
   'profiling',
   'visibility-explore-view',
 ];

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.spec.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.spec.tsx
@@ -7,11 +7,7 @@ import {NavContextProvider} from 'sentry/views/nav/context';
 describe('ExploreSecondaryNav', () => {
   const {organization} = initializeOrg({
     organization: {
-      features: [
-        'performance-trace-explorer',
-        'performance-view',
-        'visibility-explore-view',
-      ],
+      features: ['performance-view', 'visibility-explore-view'],
     },
   });
 

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -76,10 +76,7 @@ export function ExploreSecondaryNav() {
       <SecondaryNav.Body>
         <SecondaryNav.Section id="explore-main">
           <Feature features={['performance-view']}>
-            <Feature
-              features={['performance-trace-explorer', 'visibility-explore-view']}
-              requireAll={false}
-            >
+            <Feature features={['visibility-explore-view']}>
               <SecondaryNav.Item
                 to={`${baseUrl}/traces/`}
                 analyticsItemName="explore_traces"

--- a/static/app/views/traces/index.tsx
+++ b/static/app/views/traces/index.tsx
@@ -21,8 +21,7 @@ export default function TracesPage() {
 
   return (
     <Feature
-      features={['performance-trace-explorer', 'visibility-explore-view']}
-      requireAll={false}
+      features={['visibility-explore-view']}
       organization={organization}
       renderDisabled={NoAccess}
     >

--- a/tests/sentry/api/endpoints/test_organization_spans_fields.py
+++ b/tests/sentry/api/endpoints/test_organization_spans_fields.py
@@ -18,7 +18,7 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
 
     def do_request(self, query=None, features=None, **kwargs):
         if features is None:
-            features = ["organizations:performance-trace-explorer"]
+            features = ["organizations:visibility-explore-view"]
 
         if query is None:
             query = {}
@@ -64,7 +64,7 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
 
         for features in [
             None,  # use the default features
-            ["organizations:performance-trace-explorer"],
+            ["organizations:visibility-explore-view"],
         ]:
             response = self.do_request(
                 features=features,
@@ -113,7 +113,7 @@ class OrganizationSpansTagsEndpointTest(BaseSpansTestCase, SpanTestCase, APITest
 
         for features in [
             None,  # use the default features
-            ["organizations:performance-trace-explorer"],
+            ["organizations:visibility-explore-view"],
         ]:
             response = self.do_request(
                 features=features,
@@ -173,7 +173,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
 
     def do_request(self, key: str, query=None, features=None, **kwargs):
         if features is None:
-            features = ["organizations:performance-trace-explorer"]
+            features = ["organizations:visibility-explore-view"]
 
         if query is None:
             query = {}
@@ -549,7 +549,7 @@ class OrganizationSpansTagKeyValuesEndpointTest(BaseSpansTestCase, APITestCase):
         self.create_project(id=base_id + 399, name="baz")
 
         features = [
-            "organizations:performance-trace-explorer",
+            "organizations:visibility-explore-view",
         ]
 
         for key in ["project", "project.name"]:

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -790,7 +790,6 @@ class TestTraceTableQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
         self.project = self.create_project(organization=self.organization)
         self.login_as(user=self.user)
         self.features = {
-            "organizations:performance-trace-explorer": True,
             "organizations:visibility-explore-view": True,
         }
 


### PR DESCRIPTION
## Summary
- Remove the `organizations:performance-trace-explorer` feature flag which was disabled in flagpole with zero rollout
- This flag was always ORd with `visibility-explore-view` — simplify to only check `visibility-explore-view`
- Remove from 3 backend endpoints, 5 frontend files, and associated tests

## Merge Order
1. getsentry [#19411](https://github.com/getsentry/getsentry/pull/19411) — remove handler and option registrations
2. **This PR** (sentry) — remove all code that checks the flag
3. sentry-options-automator — remove flagpole config and region configs: https://github.com/getsentry/sentry-options-automator/pull/6544/