### PR TITLE
fix(tests): Fix flaky test_update_workflows_add_workflow ordering

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -521,7 +521,9 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
                 status_code=200,
             )
 
-        assert response.data["workflowIds"] == [str(workflow1.id), str(workflow2.id)]
+        assert sorted(response.data["workflowIds"]) == sorted(
+            [str(workflow1.id), str(workflow2.id)]
+        )
 
         detector_workflows = DetectorWorkflow.objects.filter(detector=self.detector)
         assert detector_workflows.count() == 2


### PR DESCRIPTION
## Summary
- The response `workflowIds` list has no guaranteed ordering, so the assertion was failing intermittently when IDs came back in a different order
- Changed to sorted comparison

Fixes #108717