### PR TITLE
fix(tests): Fix flaky test_save_event_feedback group_id mismatch

### DIFF
--- a/tests/sentry/feedback/usecases/ingest/test_save_event_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_save_event_feedback.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime
 from unittest import mock
 
@@ -43,9 +44,10 @@ def test_save_event_feedback_with_associated_event(
     default_project, mock_create_feedback_issue, timestamp_format: str
 ):
     environment = Factories.create_environment(default_project, name="production")
+    event_id = uuid.uuid4().hex
     assoc_event = Factories.store_event(
         {
-            "event_id": "ff1c2e3d4b5a6978899abbccddeeff00",
+            "event_id": event_id,
             "environment": environment.name,
         },
         default_project.id,


### PR DESCRIPTION
## Summary
- The parametrized test variants `[number]` and `[iso]` used the same hardcoded event_id (`ff1c2e3d4b5a6978899abbccddeeff00`)
- Since Snuba (ClickHouse) data persists across parametrized variants, the second variant could pick up the first variant's stale group_id, causing `report.group_id != assoc_event.group_id`
- Fixed by using `uuid.uuid4().hex` for a unique event_id per test invocation

Fixes #108705
Fixes #108703