### PR TITLE
fix(workflows): Avoid doing an additional query just to tag the session with a count

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -500,11 +500,14 @@ def process_workflows(
     enqueue_workflows(batch_client, queue_items_by_workflow_id)
 
     actions = filter_recently_fired_workflow_actions(actions_to_trigger, event_data)
-    sentry_sdk.set_tag("workflow_engine.triggered_actions", len(actions))
 
     workflow_evaluation_data.action_groups = actions_to_trigger
     workflow_evaluation_data.triggered_actions = set(actions)
     workflow_evaluation_data.delayed_conditions = queue_items_by_workflow_id
+
+    sentry_sdk.set_tag(
+        "workflow_engine.triggered_actions", len(workflow_evaluation_data.triggered_actions)
+    )
 
     if not actions:
         return WorkflowEvaluation(


### PR DESCRIPTION
`len(actions)` on a QuerySet results in a query, but we later do the same query to populate a set, and we can
just use the size of that set for one fewer query.

Fixes SENTRY-5K4N.
