### PR TITLE
fix(warden): Add remote source for dotagents-managed skills

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -27,6 +27,7 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "sentry-backend-bugs"
+remote = "getsentry/warden-sentry"
 paths = ["src/sentry/**/*.py"]
 ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
 
@@ -36,6 +37,7 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "sentry-javascript-bugs"
+remote = "getsentry/warden-sentry"
 paths = ["static/**/*.ts", "static/**/*.tsx", "static/**/*.js", "static/**/*.jsx"]
 ignorePaths = ["**/*.spec.*", "**/*.test.*", "**/tests/**", "**/__mocks__/**"]
 


### PR DESCRIPTION
The `sentry-backend-bugs` and `sentry-javascript-bugs` skills are installed locally by dotagents and gitignored, so the Warden GitHub Action can't find them at runtime and fails with "Skill not found".

Adds `remote = "getsentry/warden-sentry"` to these two skill entries so the action can fetch them. The `sentry-security` skill is already committed to the repo and doesn't need a remote.