### PR TITLE
Add missing audit events on some code paths

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -163,9 +163,17 @@ class ApiInviteHelper:
     def handle_invite_not_approved(self) -> None:
         if not self.invite_approved:
             assert self.invite_context.member
+            member = self.invite_context.member
             organization_service.delete_organization_member(
-                organization_member_id=self.invite_context.member.id,
+                organization_member_id=member.id,
                 organization_id=self.invite_context.organization.id,
+            )
+            create_audit_entry(
+                self.request,
+                organization_id=self.invite_context.organization.id,
+                target_object=member.id,
+                event=audit_log.get_event_id("INVITE_REQUEST_REMOVE"),
+                data={"email": member.email},
             )
 
     @property

--- a/src/sentry/core/endpoints/organization_member_details.py
+++ b/src/sentry/core/endpoints/organization_member_details.py
@@ -316,23 +316,23 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
         else:
             diff = save_team_assignments(member, teams)
 
-        for team in diff.added:
+        for change in diff.added:
             self.create_audit_entry(
                 request=request,
                 organization=organization,
-                target_object=member.id,
+                target_object=change.omt_id,
                 target_user_id=member.user_id,
                 event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
-                data={"email": member.get_email(), "team_slug": team.slug},
+                data={"email": member.get_email(), "team_slug": change.team.slug},
             )
-        for team in diff.removed:
+        for change in diff.removed:
             self.create_audit_entry(
                 request=request,
                 organization=organization,
-                target_object=member.id,
+                target_object=change.omt_id,
                 target_user_id=member.user_id,
                 event=audit_log.get_event_id("MEMBER_LEAVE_TEAM"),
-                data={"email": member.get_email(), "team_slug": team.slug},
+                data={"email": member.get_email(), "team_slug": change.team.slug},
             )
 
         is_update_org_role = assigned_org_role and assigned_org_role != member.role

--- a/src/sentry/core/endpoints/organization_member_details.py
+++ b/src/sentry/core/endpoints/organization_member_details.py
@@ -312,9 +312,28 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 )
 
         if team_roles:
-            save_team_assignments(member, None, team_roles)
+            diff = save_team_assignments(member, None, team_roles)
         else:
-            save_team_assignments(member, teams)
+            diff = save_team_assignments(member, teams)
+
+        for team in diff.added:
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=member.id,
+                target_user_id=member.user_id,
+                event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
+                data={"email": member.get_email(), "team_slug": team.slug},
+            )
+        for team in diff.removed:
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=member.id,
+                target_user_id=member.user_id,
+                event=audit_log.get_event_id("MEMBER_LEAVE_TEAM"),
+                data={"email": member.get_email(), "team_slug": team.slug},
+            )
 
         is_update_org_role = assigned_org_role and assigned_org_role != member.role
 

--- a/src/sentry/core/endpoints/organization_member_requests_join.py
+++ b/src/sentry/core/endpoints/organization_member_requests_join.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from django.db import IntegrityError
 from django.db.models import Q
-from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,7 +12,6 @@ from sentry import ratelimits as ratelimiter
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.services.auth import auth_service
 from sentry.demo_mode.utils import is_demo_user
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -25,6 +23,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.parsers.email import AllowedEmailField
+from sentry.utils.audit import create_system_audit_entry
 
 logger = logging.getLogger(__name__)
 
@@ -111,16 +110,12 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         member = create_organization_join_request(organization, email, ip_address)
 
         if member:
-            log_service.record_audit_log(
-                event=AuditLogEvent(
-                    organization_id=organization.id,
-                    date_added=timezone.now(),
-                    event_id=audit_log.get_event_id("INVITE_REQUEST_ADD"),
-                    actor_label=f"{email} (join request)",
-                    ip_address=ip_address,
-                    target_object_id=member.id,
-                    data={"email": email},
-                )
+            create_system_audit_entry(
+                organization=organization,
+                target_object=member.id,
+                event=audit_log.get_event_id("INVITE_REQUEST_ADD"),
+                ip_address=ip_address,
+                data={"email": email},
             )
             async_send_notification(JoinRequestNotification, member, request.user)
             # legacy analytics

--- a/src/sentry/core/endpoints/organization_member_requests_join.py
+++ b/src/sentry/core/endpoints/organization_member_requests_join.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.db import IntegrityError
 from django.db.models import Q
+from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -12,6 +13,7 @@ from sentry import ratelimits as ratelimiter
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.services.auth import auth_service
 from sentry.demo_mode.utils import is_demo_user
 from sentry.hybridcloud.models.outbox import outbox_context
@@ -23,7 +25,6 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.parsers.email import AllowedEmailField
-from sentry.utils.audit import create_system_audit_entry
 
 logger = logging.getLogger(__name__)
 
@@ -110,13 +111,16 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         member = create_organization_join_request(organization, email, ip_address)
 
         if member:
-            create_system_audit_entry(
-                organization=organization,
-                target_object=member.id,
-                event=audit_log.get_event_id("INVITE_REQUEST_ADD"),
-                actor_label=f"{email} (join request)",
-                ip_address=ip_address,
-                data={"email": email},
+            log_service.record_audit_log(
+                event=AuditLogEvent(
+                    organization_id=organization.id,
+                    date_added=timezone.now(),
+                    event_id=audit_log.get_event_id("INVITE_REQUEST_ADD"),
+                    actor_label=f"{email} (join request)",
+                    ip_address=ip_address,
+                    target_object_id=member.id,
+                    data={"email": email},
+                )
             )
             async_send_notification(JoinRequestNotification, member, request.user)
             # legacy analytics

--- a/src/sentry/core/endpoints/organization_member_requests_join.py
+++ b/src/sentry/core/endpoints/organization_member_requests_join.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import audit_log
 from sentry import ratelimits as ratelimiter
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -22,6 +23,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.signals import join_request_created
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.api.parsers.email import AllowedEmailField
+from sentry.utils.audit import create_system_audit_entry
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +110,14 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         member = create_organization_join_request(organization, email, ip_address)
 
         if member:
+            create_system_audit_entry(
+                organization=organization,
+                target_object=member.id,
+                event=audit_log.get_event_id("INVITE_REQUEST_ADD"),
+                actor_label=f"{email} (join request)",
+                ip_address=ip_address,
+                data={"email": email},
+            )
             async_send_notification(JoinRequestNotification, member, request.user)
             # legacy analytics
             join_request_created.send_robust(sender=self, member=member)

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -422,6 +422,20 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationMemberEndpoint):
 
             self._change_team_member_role(omt, new_role)
 
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=omt.id,
+                target_user_id=member.user_id,
+                event=audit_log.get_event_id("MEMBER_EDIT"),
+                data={
+                    "email": member.get_email(),
+                    "role": member.role,
+                    "team_slug": team.slug,
+                    "team_role": new_role_id,
+                },
+            )
+
         return Response(
             serialize(omt, request.user, OrganizationMemberTeamDetailsSerializer()), status=200
         )

--- a/src/sentry/core/endpoints/organization_member_utils.py
+++ b/src/sentry/core/endpoints/organization_member_utils.py
@@ -80,11 +80,17 @@ class RelaxedMemberPermission(OrganizationPermission):
         return False
 
 
+class TeamAssignmentDiff:
+    def __init__(self, added: list[Team], removed: list[Team]) -> None:
+        self.added = added
+        self.removed = removed
+
+
 def save_team_assignments(
     organization_member: OrganizationMember,
     teams: list[Team] | None,
     teams_with_roles: list[tuple[Team, str]] | None = None,
-) -> None:
+) -> TeamAssignmentDiff:
     # https://github.com/getsentry/sentry/pull/6054/files/8edbdb181cf898146eda76d46523a21d69ab0ec7#r145798271
     lock = locks.get(
         f"org:member:{organization_member.id}", duration=5, name="save_team_assignment"
@@ -105,6 +111,9 @@ def save_team_assignments(
 
         with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
             existing = OrganizationMemberTeam.objects.filter(organizationmember=organization_member)
+            old_team_ids = set(existing.values_list("team_id", flat=True))
+            new_team_ids = {team.id for team in target_teams}
+
             OrganizationMemberTeam.objects.bulk_delete(existing)
             OrganizationMemberTeam.objects.bulk_create(
                 [
@@ -114,6 +123,13 @@ def save_team_assignments(
                     for team, role in new_assignments
                 ]
             )
+
+        added_ids = new_team_ids - old_team_ids
+        removed_ids = old_team_ids - new_team_ids
+        teams_by_id = {team.id: team for team in target_teams}
+        added = [teams_by_id[tid] for tid in added_ids if tid in teams_by_id]
+        removed_teams = list(Team.objects.filter(id__in=removed_ids)) if removed_ids else []
+        return TeamAssignmentDiff(added=added, removed=removed_teams)
 
 
 def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:

--- a/src/sentry/core/endpoints/organization_member_utils.py
+++ b/src/sentry/core/endpoints/organization_member_utils.py
@@ -80,8 +80,16 @@ class RelaxedMemberPermission(OrganizationPermission):
         return False
 
 
+class TeamAssignmentChange:
+    def __init__(self, team: Team, omt_id: int) -> None:
+        self.team = team
+        self.omt_id = omt_id
+
+
 class TeamAssignmentDiff:
-    def __init__(self, added: list[Team], removed: list[Team]) -> None:
+    def __init__(
+        self, added: list[TeamAssignmentChange], removed: list[TeamAssignmentChange]
+    ) -> None:
         self.added = added
         self.removed = removed
 
@@ -111,8 +119,16 @@ def save_team_assignments(
 
         with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
             existing = OrganizationMemberTeam.objects.filter(organizationmember=organization_member)
-            old_team_ids = set(existing.values_list("team_id", flat=True))
+            old_omt_by_team = {omt.team_id: omt for omt in existing}
+            old_team_ids = set(old_omt_by_team.keys())
             new_team_ids = {team.id for team in target_teams}
+
+            removed_ids = old_team_ids - new_team_ids
+            teams_by_id = {team.id: team for team in target_teams}
+            removed_teams = list(Team.objects.filter(id__in=removed_ids)) if removed_ids else []
+            removed_changes = [
+                TeamAssignmentChange(team=t, omt_id=old_omt_by_team[t.id].id) for t in removed_teams
+            ]
 
             OrganizationMemberTeam.objects.bulk_delete(existing)
             OrganizationMemberTeam.objects.bulk_create(
@@ -125,11 +141,16 @@ def save_team_assignments(
             )
 
         added_ids = new_team_ids - old_team_ids
-        removed_ids = old_team_ids - new_team_ids
-        teams_by_id = {team.id: team for team in target_teams}
-        added = [teams_by_id[tid] for tid in added_ids if tid in teams_by_id]
-        removed_teams = list(Team.objects.filter(id__in=removed_ids)) if removed_ids else []
-        return TeamAssignmentDiff(added=added, removed=removed_teams)
+        new_omts = OrganizationMemberTeam.objects.filter(
+            organizationmember=organization_member, team_id__in=added_ids
+        )
+        new_omt_by_team = {omt.team_id: omt for omt in new_omts}
+        added_changes = [
+            TeamAssignmentChange(team=teams_by_id[tid], omt_id=new_omt_by_team[tid].id)
+            for tid in added_ids
+            if tid in teams_by_id and tid in new_omt_by_team
+        ]
+        return TeamAssignmentDiff(added=added_changes, removed=removed_changes)
 
 
 def can_set_team_role(request: Request, team: Team, new_role: TeamRole) -> bool:

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -214,11 +214,13 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                 except OrganizationMember.DoesNotExist:
                     pass
                 else:
-                    OrganizationMemberTeam.objects.create(team=team, organizationmember=member)
+                    omt = OrganizationMemberTeam.objects.create(
+                        team=team, organizationmember=member
+                    )
                     self.create_audit_entry(
                         request=request,
                         organization=organization,
-                        target_object=member.id,
+                        target_object=omt.id,
                         target_user_id=member.user_id,
                         event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
                         data={"email": member.get_email(), "team_slug": team.slug},

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -215,6 +215,14 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                     pass
                 else:
                     OrganizationMemberTeam.objects.create(team=team, organizationmember=member)
+                    self.create_audit_entry(
+                        request=request,
+                        organization=organization,
+                        target_object=member.id,
+                        target_user_id=member.user_id,
+                        event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
+                        data={"email": member.get_email(), "team_slug": team.slug},
+                    )
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -437,6 +437,16 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         member.flags["idp:provisioned"] = True
         member.save()
 
+        if previous_role != member.role:
+            self.create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=member.id,
+                target_user_id=member.user_id,
+                event=audit_log.get_event_id("MEMBER_EDIT"),
+                data={"role": member.role, "email": member.get_email()},
+            )
+
         # only update metric if the role changed
         if (
             previous_role != organization.default_role

--- a/tests/sentry/core/endpoints/scim/test_scim_user_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_user_details.py
@@ -14,6 +14,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase, SCIMAzureTestCase, SCIMTestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 from sentry.users.services.user.model import RpcUser
 
@@ -238,13 +239,14 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         assert self.unrestricted_default_role_member.flags["idp:role-restricted"]
 
         # current Unrestricted custom role + default sentryOrgRole -> restricted default role
-        resp = self.get_success_response(
-            self.organization.slug,
-            self.unrestricted_custom_role_member.id,
-            **generate_put_data(
-                self.unrestricted_custom_role_member, role=self.organization.default_role
-            ),
-        )
+        with outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug,
+                self.unrestricted_custom_role_member.id,
+                **generate_put_data(
+                    self.unrestricted_custom_role_member, role=self.organization.default_role
+                ),
+            )
         self.unrestricted_custom_role_member.refresh_from_db()
         assert resp.data["sentryOrgRole"] == self.organization.default_role
         assert self.unrestricted_custom_role_member.role == self.organization.default_role
@@ -252,7 +254,6 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         assert_org_audit_log_exists(
             organization=self.organization,
             event=audit_log.get_event_id("MEMBER_EDIT"),
-            target_object=self.unrestricted_custom_role_member.id,
         )
 
         # current restricted default role + default sentryOrgRole -> restricted default role (no change)

--- a/tests/sentry/core/endpoints/scim/test_scim_user_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_user_details.py
@@ -5,12 +5,14 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 
+from sentry import audit_log
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.core.endpoints.scim.utils import SCIMFilterError, parse_filter_conditions
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.organizationmember import OrganizationMember
 from sentry.silo.base import SiloMode
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase, SCIMAzureTestCase, SCIMTestCase
 from sentry.testutils.silo import assume_test_silo_mode, no_silo_test
 from sentry.users.services.user.model import RpcUser
@@ -247,6 +249,11 @@ class SCIMMemberRoleUpdateTests(SCIMTestCase):
         assert resp.data["sentryOrgRole"] == self.organization.default_role
         assert self.unrestricted_custom_role_member.role == self.organization.default_role
         assert self.unrestricted_custom_role_member.flags["idp:role-restricted"]
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MEMBER_EDIT"),
+            target_object=self.unrestricted_custom_role_member.id,
+        )
 
         # current restricted default role + default sentryOrgRole -> restricted default role (no change)
         resp = self.get_success_response(

--- a/tests/sentry/core/endpoints/test_organization_member_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_details.py
@@ -517,7 +517,10 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         member_om = self.create_member(
             organization=self.organization, user=member, role="member", teams=[]
         )
-        self.get_success_response(self.organization.slug, member_om.id, teams=[foo.slug, bar.slug])
+        with outbox_runner():
+            self.get_success_response(
+                self.organization.slug, member_om.id, teams=[foo.slug, bar.slug]
+            )
 
         member_teams = OrganizationMemberTeam.objects.filter(organizationmember=member_om)
         team_ids = list(map(lambda x: x.team_id, member_teams))
@@ -533,7 +536,6 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         assert_org_audit_log_exists(
             organization=self.organization,
             event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
-            target_user_id=member.id,
         )
 
     @with_feature("organizations:team-roles")

--- a/tests/sentry/core/endpoints/test_organization_member_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_details.py
@@ -530,6 +530,12 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase, HybridCloudTestMi
         assert foo.slug in teams
         assert bar.slug in teams
 
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
+            target_user_id=member.id,
+        )
+
     @with_feature("organizations:team-roles")
     def test_can_update_teams_with_feature_flag(self) -> None:
         self.test_can_update_teams()

--- a/tests/sentry/core/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_team_details.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from rest_framework import status
 
+from sentry import audit_log
 from sentry.auth import access
 from sentry.core.endpoints.organization_member_team_details import ERR_INSUFFICIENT_ROLE
 from sentry.models.groupassignee import GroupAssignee
@@ -14,6 +15,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.roles import organization_roles
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -862,6 +864,11 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
             team=self.team, organizationmember=self.member_on_team
         )
         assert updated_omt.role == "admin"
+        assert_org_audit_log_exists(
+            organization=self.org,
+            event=audit_log.get_event_id("MEMBER_EDIT"),
+            target_user_id=self.member_on_team.user_id,
+        )
 
     @with_feature("organizations:team-roles")
     def test_team_admin_can_promote_member(self) -> None:

--- a/tests/sentry/core/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/core/endpoints/test_organization_member_team_details.py
@@ -19,6 +19,7 @@ from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.outbox import outbox_runner
 from tests.sentry.core.endpoints.test_organization_member_index import (
     mock_organization_roles_get_factory,
 )
@@ -855,9 +856,10 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
     def test_owner_can_promote_member(self) -> None:
         self.login_as(self.owner)
 
-        resp = self.get_response(
-            self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
-        )
+        with outbox_runner():
+            resp = self.get_response(
+                self.org.slug, self.member_on_team.id, self.team.slug, teamRole="admin"
+            )
         assert resp.status_code == 200
 
         updated_omt = OrganizationMemberTeam.objects.get(
@@ -867,7 +869,6 @@ class UpdateOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert_org_audit_log_exists(
             organization=self.org,
             event=audit_log.get_event_id("MEMBER_EDIT"),
-            target_user_id=self.member_on_team.user_id,
         )
 
     @with_feature("organizations:team-roles")

--- a/tests/sentry/core/endpoints/test_organization_teams.py
+++ b/tests/sentry/core/endpoints/test_organization_teams.py
@@ -1,8 +1,10 @@
+from sentry import audit_log
 from sentry.integrations.utils.providers import get_provider_string
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 
@@ -198,6 +200,11 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert OrganizationMemberTeam.objects.filter(
             organizationmember=member, team=team, is_active=True
         ).exists()
+        assert_org_audit_log_exists(
+            organization=self.organization,
+            event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
+            target_user_id=self.user.id,
+        )
 
     def test_without_slug(self) -> None:
         resp = self.get_success_response(

--- a/tests/sentry/core/endpoints/test_organization_teams.py
+++ b/tests/sentry/core/endpoints/test_organization_teams.py
@@ -6,6 +6,7 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.outbox import outbox_runner
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 
 
@@ -183,9 +184,10 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert b"Name or slug is required" in resp.content
 
     def test_valid_params(self) -> None:
-        resp = self.get_success_response(
-            self.organization.slug, name="hello world", slug="foobar", status_code=201
-        )
+        with outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug, name="hello world", slug="foobar", status_code=201
+            )
 
         team = Team.objects.get(id=resp.data["id"])
         assert team.name == "hello world"
@@ -203,7 +205,6 @@ class OrganizationTeamsCreateTest(APITestCase):
         assert_org_audit_log_exists(
             organization=self.organization,
             event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
-            target_user_id=self.user.id,
         )
 
     def test_without_slug(self) -> None:

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -4,9 +4,11 @@ from unittest.mock import MagicMock, patch
 from django.test import override_settings
 from pytest import fixture
 
+from sentry import audit_log
 from sentry.conf.types.sentry_config import SentryMode
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
 from sentry.interfaces.stacktrace import StacktraceOrder
+from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.deletedorganization import DeletedOrganization
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmember import OrganizationMember
@@ -875,6 +877,14 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
             # should NOT delete `not_owned_org`
             assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
             assert DeletedOrganization.objects.count() == 1
+
+            member_remove_entries = AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("MEMBER_REMOVE"),
+                target_user_id=self.user.id,
+            )
+            removed_org_ids = {e.organization_id for e in member_remove_entries}
+            assert org_with_other_owner.id in removed_org_ids
+            assert org_as_other_owner.id in removed_org_ids
 
         user = User.objects.get(id=self.user.id)
         assert not user.is_active

--- a/tests/sentry/users/api/endpoints/test_user_details.py
+++ b/tests/sentry/users/api/endpoints/test_user_details.py
@@ -878,13 +878,13 @@ class UserDetailsDeleteTest(UserDetailsTest, HybridCloudTestMixin):
             assert Organization.objects.get(id=not_owned_org.id).status == OrganizationStatus.ACTIVE
             assert DeletedOrganization.objects.count() == 1
 
-            member_remove_entries = AuditLogEntry.objects.filter(
-                event=audit_log.get_event_id("MEMBER_REMOVE"),
-                target_user_id=self.user.id,
-            )
-            removed_org_ids = {e.organization_id for e in member_remove_entries}
-            assert org_with_other_owner.id in removed_org_ids
-            assert org_as_other_owner.id in removed_org_ids
+        member_remove_entries = AuditLogEntry.objects.filter(
+            event=audit_log.get_event_id("MEMBER_REMOVE"),
+            target_user_id=self.user.id,
+        )
+        removed_org_ids = {e.organization_id for e in member_remove_entries}
+        assert org_with_other_owner.id in removed_org_ids
+        assert org_as_other_owner.id in removed_org_ids
 
         user = User.objects.get(id=self.user.id)
         assert not user.is_active


### PR DESCRIPTION
During some customer support and incident work I spotted a pair of missing audit event creations on org member code paths that needed fixing. Did a wider review of all %MEMBER% org audit log events and associated endpoints and found a few more. Added some fixes and tests for the following: 
- MEMBER_REMOVE on user account deletion
- INVITE_REQUEST_REMOVE on unapproved invite cleanup
- MEMBER_EDIT on SCIM and team role updates
- MEMBER_JOIN_TEAM/MEMBER_LEAVE_TEAM on bulk team changes and team creation
- INVITE_REQUEST_ADD on join requests

Had to wrap some of the tests with the outbox_runner cause of region silo fun times.