### PR TITLE
fix(core-ui): Apply sizeLimit after score sorting to keep most relevant options visible

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -448,6 +448,80 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('uses custom searchMatcher when provided', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // '_one' matches opt_one by value suffix, opt_two does not match
+      await userEvent.keyboard('_one');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+    });
+
+    it('uses string.includes for default search matching', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // 'ption On' is a mid-string substring of 'Option One' — only includes() catches it
+      await userEvent.keyboard('ption On');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+    });
+
+    it('passes option and search string to searchMatcher', async () => {
+      const searchMatcher = jest.fn().mockReturnValue(true);
+
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={searchMatcher}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('test');
+
+      expect(searchMatcher).toHaveBeenCalledWith(
+        expect.objectContaining({value: 'opt_one', label: 'Option One'}),
+        'test'
+      );
+    });
+
     it('can search with sections', async () => {
       render(
         <CompactSelect
@@ -489,6 +563,46 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(1);
+    });
+
+    it('uses custom searchMatcher with sections', async () => {
+      render(
+        <CompactSelect
+          value={undefined}
+          onChange={jest.fn()}
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {
+              key: 'section-1',
+              label: 'Section 1',
+              options: [
+                {value: 'opt_one', label: 'Option One'},
+                {value: 'opt_two', label: 'Option Two'},
+              ],
+            },
+            {
+              key: 'section-2',
+              label: 'Section 2',
+              options: [
+                {value: 'opt_three', label: 'Option Three'},
+                {value: 'opt_four', label: 'Option Four'},
+              ],
+            },
+          ]}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // 'e' matches opt_one (section 1) and opt_three (section 2) by value suffix
+      await userEvent.keyboard('e');
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option Four'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async () => {
@@ -835,6 +949,31 @@ describe('CompactSelect', () => {
       await userEvent.keyboard('Two');
 
       // only Option Two should be available, Option One should be filtered out
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+    });
+
+    it('uses custom searchMatcher when provided', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // '_two' matches opt_two by value suffix, opt_one does not match
+      await userEvent.keyboard('_two');
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
     });

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -560,6 +560,90 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
     });
 
+    it('sorts options by score when searchMatcher returns SearchMatchResult', async () => {
+      // Assign scores so the natural order (One, Two, Three) is reversed: Three > Two > One
+      const scores: Record<string, number> = {opt_one: 1, opt_two: 2, opt_three: 3};
+
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={option => ({score: scores[String(option.value)] ?? 0})}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('opt');
+
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveTextContent('Option Three'); // score 3
+      expect(options[1]).toHaveTextContent('Option Two'); // score 2
+      expect(options[2]).toHaveTextContent('Option One'); // score 1
+    });
+
+    it('options without a score maintain original order relative to each other', async () => {
+      // Only opt_two gets a score; opt_one and opt_three have no score and should keep
+      // their original relative order (One before Three)
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={option => (option.value === 'opt_two' ? {score: 10} : true)}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('opt');
+
+      const options = screen.getAllByRole('option');
+      expect(options[0]).toHaveTextContent('Option Two'); // score 10
+      expect(options[1]).toHaveTextContent('Option One'); // no score, original order
+      expect(options[2]).toHaveTextContent('Option Three'); // no score, original order
+    });
+
+    it('passes option and search string to searchMatcher', async () => {
+      const searchMatcher = jest.fn().mockReturnValue(true);
+
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={searchMatcher}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('test');
+
+      expect(searchMatcher).toHaveBeenCalledWith(
+        expect.objectContaining({value: 'opt_one', label: 'Option One'}),
+        'test'
+      );
+    });
+
     it('can search with sections', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -646,6 +646,39 @@ describe('CompactSelect', () => {
       expect(options[2]).toHaveTextContent('Option Three'); // no score, original order
     });
 
+    it('sizeLimit keeps highest-scored options visible, not first-in-order options', async () => {
+      // Natural order: One (score 1), Two (score 3), Three (score 2).
+      // sizeLimit=2 should keep the two highest-scored items: Two (3) and Three (2),
+      // not the first two in original order: One (1) and Two (3).
+      const scores: Record<string, number> = {opt_one: 1, opt_two: 3, opt_three: 2};
+
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          sizeLimit={2}
+          searchMatcher={option => ({score: scores[String(option.value)] ?? 0})}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+            {value: 'opt_three', label: 'Option Three'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('opt');
+
+      const options = screen.getAllByRole('option');
+      expect(options).toHaveLength(2);
+      expect(options[0]).toHaveTextContent('Option Two'); // score 3, visible
+      expect(options[1]).toHaveTextContent('Option Three'); // score 2, visible
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument(); // score 1, hidden
+    });
+
     it('passes option and search string to searchMatcher', async () => {
       const searchMatcher = jest.fn().mockReturnValue({score: 1});
 

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -448,6 +448,71 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
     });
 
+    it('restores full list when search query is cleared', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Two' to filter to one option
+      await userEvent.keyboard('Two');
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // clear the search query — all options should return
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
+    it('resets search query and shows all options when menu is closed and reopened', async () => {
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      // open the menu and filter results
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('Two');
+      expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // close the menu by clicking outside
+      await userEvent.click(document.body);
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('option', {name: 'Option Two'})
+        ).not.toBeInTheDocument();
+      });
+
+      // reopen the menu — search input should be empty and all options visible
+      await userEvent.click(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
+      });
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
     it('uses custom searchMatcher when provided', async () => {
       render(
         <CompactSelect
@@ -951,6 +1016,71 @@ describe('CompactSelect', () => {
       // only Option Two should be available, Option One should be filtered out
       expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+    });
+
+    it('restores full list when search query is cleared', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+
+      // type 'Two' to filter to one option
+      await userEvent.keyboard('Two');
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // clear the search query — all options should return
+      await userEvent.clear(screen.getByPlaceholderText('Search here…'));
+      expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
+    it('resets search query and shows all options when menu is closed and reopened', async () => {
+      render(
+        <CompactSelect
+          grid
+          searchable
+          searchPlaceholder="Search here…"
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      // open the menu and filter results
+      await userEvent.click(screen.getByRole('button'));
+      await userEvent.click(screen.getByPlaceholderText('Search here…'));
+      await userEvent.keyboard('Two');
+      expect(screen.queryByRole('row', {name: 'Option One'})).not.toBeInTheDocument();
+
+      // close the menu by clicking outside
+      await userEvent.click(document.body);
+      await waitFor(() => {
+        expect(screen.queryByRole('row', {name: 'Option Two'})).not.toBeInTheDocument();
+      });
+
+      // reopen the menu — search input should be empty and all options visible
+      await userEvent.click(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search here…')).toHaveValue('');
+      });
+      expect(screen.getByRole('row', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('row', {name: 'Option Two'})).toBeInTheDocument();
     });
 
     it('uses custom searchMatcher when provided', async () => {

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -539,6 +539,33 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
     });
 
+    it('does not call searchMatcher when search is empty, showing all options', async () => {
+      // A matcher that returns score 0 for any empty query would hide all options if
+      // called during the initial render (before the user types anything).
+      render(
+        <CompactSelect
+          searchable
+          searchPlaceholder="Search here…"
+          searchMatcher={(option, search) => ({
+            // Return 0 for empty search — real-world matchers may do this
+            score: search === '' ? 0 : String(option.value).includes(search) ? 1 : 0,
+          })}
+          options={[
+            {value: 'opt_one', label: 'Option One'},
+            {value: 'opt_two', label: 'Option Two'},
+          ]}
+          value={undefined}
+          onChange={jest.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button'));
+
+      // All options should be visible even though the matcher returns 0 for ''
+      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
+    });
+
     it('uses string.includes for default search matching', async () => {
       render(
         <CompactSelect

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -560,33 +560,6 @@ describe('CompactSelect', () => {
       expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
     });
 
-    it('passes option and search string to searchMatcher', async () => {
-      const searchMatcher = jest.fn().mockReturnValue(true);
-
-      render(
-        <CompactSelect
-          searchable
-          searchPlaceholder="Search here…"
-          searchMatcher={searchMatcher}
-          options={[
-            {value: 'opt_one', label: 'Option One'},
-            {value: 'opt_two', label: 'Option Two'},
-          ]}
-          value={undefined}
-          onChange={jest.fn()}
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button'));
-      await userEvent.click(screen.getByPlaceholderText('Search here…'));
-      await userEvent.keyboard('test');
-
-      expect(searchMatcher).toHaveBeenCalledWith(
-        expect.objectContaining({value: 'opt_one', label: 'Option One'}),
-        'test'
-      );
-    });
-
     it('can search with sections', async () => {
       render(
         <CompactSelect
@@ -628,46 +601,6 @@ describe('CompactSelect', () => {
       expect(screen.getByRole('option', {name: 'Option Two'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
       expect(screen.getAllByRole('option')).toHaveLength(1);
-    });
-
-    it('uses custom searchMatcher with sections', async () => {
-      render(
-        <CompactSelect
-          value={undefined}
-          onChange={jest.fn()}
-          searchable
-          searchPlaceholder="Search here…"
-          searchMatcher={(option, search) => String(option.value).endsWith(search)}
-          options={[
-            {
-              key: 'section-1',
-              label: 'Section 1',
-              options: [
-                {value: 'opt_one', label: 'Option One'},
-                {value: 'opt_two', label: 'Option Two'},
-              ],
-            },
-            {
-              key: 'section-2',
-              label: 'Section 2',
-              options: [
-                {value: 'opt_three', label: 'Option Three'},
-                {value: 'opt_four', label: 'Option Four'},
-              ],
-            },
-          ]}
-        />
-      );
-
-      await userEvent.click(screen.getByRole('button'));
-      await userEvent.click(screen.getByPlaceholderText('Search here…'));
-
-      // 'e' matches opt_one (section 1) and opt_three (section 2) by value suffix
-      await userEvent.keyboard('e');
-      expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'Option Two'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'Option Three'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'Option Four'})).not.toBeInTheDocument();
     });
 
     it('can limit the number of options', async () => {

--- a/static/app/components/core/compactSelect/compactSelect.spec.tsx
+++ b/static/app/components/core/compactSelect/compactSelect.spec.tsx
@@ -518,7 +518,9 @@ describe('CompactSelect', () => {
         <CompactSelect
           searchable
           searchPlaceholder="Search here…"
-          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          searchMatcher={(option, search) => ({
+            score: String(option.value).endsWith(search) ? 1 : 0,
+          })}
           options={[
             {value: 'opt_one', label: 'Option One'},
             {value: 'opt_two', label: 'Option Two'},
@@ -589,14 +591,14 @@ describe('CompactSelect', () => {
       expect(options[2]).toHaveTextContent('Option One'); // score 1
     });
 
-    it('options without a score maintain original order relative to each other', async () => {
-      // Only opt_two gets a score; opt_one and opt_three have no score and should keep
-      // their original relative order (One before Three)
+    it('options with equal scores maintain their original relative order', async () => {
+      // opt_two gets a higher score; opt_one and opt_three share the same low score
+      // and should keep their original relative order (One before Three)
       render(
         <CompactSelect
           searchable
           searchPlaceholder="Search here…"
-          searchMatcher={option => (option.value === 'opt_two' ? {score: 10} : true)}
+          searchMatcher={option => ({score: option.value === 'opt_two' ? 10 : 1})}
           options={[
             {value: 'opt_one', label: 'Option One'},
             {value: 'opt_two', label: 'Option Two'},
@@ -618,7 +620,7 @@ describe('CompactSelect', () => {
     });
 
     it('passes option and search string to searchMatcher', async () => {
-      const searchMatcher = jest.fn().mockReturnValue(true);
+      const searchMatcher = jest.fn().mockReturnValue({score: 1});
 
       render(
         <CompactSelect
@@ -1106,7 +1108,9 @@ describe('CompactSelect', () => {
           grid
           searchable
           searchPlaceholder="Search here…"
-          searchMatcher={(option, search) => String(option.value).endsWith(search)}
+          searchMatcher={(option, search) => ({
+            score: String(option.value).endsWith(search) ? 1 : 0,
+          })}
           options={[
             {value: 'opt_one', label: 'Option One'},
             {value: 'opt_two', label: 'Option Two'},

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -33,7 +33,7 @@ import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import type {SingleListProps} from './list';
-import type {SelectKey, SelectOptionOrSection} from './types';
+import type {SelectKey, SelectOptionOrSection, SelectOptionWithKey} from './types';
 
 // autoFocus react attribute is sync called on render, this causes
 // layout thrashing and is bad for performance. This thin wrapper function
@@ -65,6 +65,10 @@ interface ControlContextValue {
    * selector.
    */
   overlayState?: OverlayTriggerState;
+  /**
+   * Custom function to determine whether an option matches the search query.
+   */
+  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
   size?: FormSize;
 }
 
@@ -174,6 +178,13 @@ export interface ControlProps
    */
   onSearch?: (value: string) => void;
   /**
+   * Custom function to determine whether an option matches the search query (applicable
+   * only when `searchable` is true). Receives the option and the current search string,
+   * and should return true if the option matches. If not provided, defaults to
+   * case-insensitive substring matching on `textValue` or `label`.
+   */
+  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
+  /**
    * The search input's placeholder text (applicable only when `searchable` is true).
    */
   searchPlaceholder?: string;
@@ -231,6 +242,7 @@ export function Control({
   searchPlaceholder = 'Search…',
   disableSearchFilter = false,
   onSearch,
+  searchMatcher,
   clearable = false,
   onClear,
   loading = false,
@@ -466,8 +478,9 @@ export function Control({
       searchable,
       size,
       disabled,
+      searchMatcher,
     };
-  }, [overlayState, overlayIsOpen, search, searchable, size, disabled]);
+  }, [overlayState, overlayIsOpen, search, searchable, size, disabled, searchMatcher]);
 
   const theme = useTheme();
 

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -33,7 +33,12 @@ import useOverlay from 'sentry/utils/useOverlay';
 import usePrevious from 'sentry/utils/usePrevious';
 
 import type {SingleListProps} from './list';
-import type {SelectKey, SelectOptionOrSection, SelectOptionWithKey} from './types';
+import type {
+  SearchMatchResult,
+  SelectKey,
+  SelectOptionOrSection,
+  SelectOptionWithKey,
+} from './types';
 
 // autoFocus react attribute is sync called on render, this causes
 // layout thrashing and is bad for performance. This thin wrapper function
@@ -68,7 +73,10 @@ interface ControlContextValue {
   /**
    * Custom function to determine whether an option matches the search query.
    */
-  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
+  searchMatcher?: (
+    option: SelectOptionWithKey<SelectKey>,
+    search: string
+  ) => boolean | SearchMatchResult;
   size?: FormSize;
 }
 
@@ -183,7 +191,10 @@ export interface ControlProps
    * and should return true if the option matches. If not provided, defaults to
    * case-insensitive substring matching on `textValue` or `label`.
    */
-  searchMatcher?: (option: SelectOptionWithKey<SelectKey>, search: string) => boolean;
+  searchMatcher?: (
+    option: SelectOptionWithKey<SelectKey>,
+    search: string
+  ) => boolean | SearchMatchResult;
   /**
    * The search input's placeholder text (applicable only when `searchable` is true).
    */

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -76,7 +76,7 @@ interface ControlContextValue {
   searchMatcher?: (
     option: SelectOptionWithKey<SelectKey>,
     search: string
-  ) => boolean | SearchMatchResult;
+  ) => SearchMatchResult;
   size?: FormSize;
 }
 
@@ -188,13 +188,15 @@ export interface ControlProps
   /**
    * Custom function to determine whether an option matches the search query (applicable
    * only when `searchable` is true). Receives the option and the current search string,
-   * and should return true if the option matches. If not provided, defaults to
-   * case-insensitive substring matching on `textValue` or `label`.
+   * and must return a `SearchMatchResult`. A score greater than 0 means the option
+   * matches; options with higher scores are sorted first. If not provided, defaults to
+   * case-insensitive substring matching on `textValue` or `label` with a static score
+   * of 1.
    */
   searchMatcher?: (
     option: SelectOptionWithKey<SelectKey>,
     search: string
-  ) => boolean | SearchMatchResult;
+  ) => SearchMatchResult;
   /**
    * The search input's placeholder text (applicable only when `searchable` is true).
    */

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -27,6 +27,7 @@ export {
 } from './styles';
 
 export type {
+  SearchMatchResult,
   SelectOptionOrSectionWithKey,
   SelectOptionWithKey,
   SelectSectionWithKey,
@@ -36,6 +37,7 @@ export {
   getItemsWithKeys,
   getDisabledOptions,
   getHiddenOptions,
+  getSortedItems,
   itemIsSectionWithKey,
   SectionToggle,
   getEscapedKey,

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -27,7 +27,6 @@ export {
 } from './styles';
 
 export type {
-  SearchMatchResult,
   SelectOptionOrSectionWithKey,
   SelectOptionWithKey,
   SelectSectionWithKey,
@@ -37,7 +36,6 @@ export {
   getItemsWithKeys,
   getDisabledOptions,
   getHiddenOptions,
-  getSortedItems,
   itemIsSectionWithKey,
   SectionToggle,
   getEscapedKey,

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -174,11 +174,12 @@ export function List<Value extends SelectKey>({
   closeOnSelect,
   ...props
 }: SingleListProps<Value> | MultipleListProps<Value>) {
-  const {overlayState, search, searchable, overlayIsOpen} = useContext(ControlContext);
+  const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
+    useContext(ControlContext);
 
   const hiddenOptions = useMemo(
-    () => getHiddenOptions(items, search, sizeLimit),
-    [items, search, sizeLimit]
+    () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
+    [items, search, sizeLimit, searchMatcher]
   );
 
   /**

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -184,8 +184,8 @@ export function List<Value extends SelectKey>({
   );
 
   const sortedItems = useMemo(
-    () => (scores.size > 0 ? getSortedItems(items, scores) : items),
-    [items, scores]
+    () => (searchMatcher && scores.size > 0 ? getSortedItems(items, scores) : items),
+    [items, scores, searchMatcher]
   );
 
   /**

--- a/static/app/components/core/compactSelect/list.tsx
+++ b/static/app/components/core/compactSelect/list.tsx
@@ -23,6 +23,7 @@ import {
   getEscapedKey,
   getHiddenOptions,
   getSelectedOptions,
+  getSortedItems,
   HiddenSectionToggle,
   shouldCloseOnSelect,
 } from './utils';
@@ -177,9 +178,14 @@ export function List<Value extends SelectKey>({
   const {overlayState, search, searchable, overlayIsOpen, searchMatcher} =
     useContext(ControlContext);
 
-  const hiddenOptions = useMemo(
+  const {hidden: hiddenOptions, scores} = useMemo(
     () => getHiddenOptions(items, search, sizeLimit, searchMatcher),
     [items, search, sizeLimit, searchMatcher]
+  );
+
+  const sortedItems = useMemo(
+    () => (scores.size > 0 ? getSortedItems(items, scores) : items),
+    [items, scores]
   );
 
   /**
@@ -250,7 +256,7 @@ export function List<Value extends SelectKey>({
   const listState = useListState({
     ...props,
     ...listStateProps,
-    items,
+    items: sortedItems,
   });
 
   // In composite selects, focus should seamlessly move from one region (list) to

--- a/static/app/components/core/compactSelect/types.tsx
+++ b/static/app/components/core/compactSelect/types.tsx
@@ -38,6 +38,20 @@ export type SelectOptionOrSection<Value extends SelectKey> =
   | SelectOption<Value>
   | SelectSection<Value>;
 
+/**
+ * The result of a custom `searchMatcher` function. Returning this (instead of a plain
+ * boolean) allows callers to influence how matching options are sorted: options with a
+ * higher `score` are shown first. To hide an option, return `false` instead.
+ */
+export interface SearchMatchResult {
+  /**
+   * Match quality score. Higher values cause the option to appear earlier in the list.
+   * Options that match but return no score maintain their original order relative to
+   * each other.
+   */
+  score: number;
+}
+
 export interface SelectOptionWithKey<
   Value extends SelectKey,
 > extends SelectOption<Value> {

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -111,12 +111,16 @@ export function getDisabledOptions<Value extends SelectKey>(
 export function getHiddenOptions<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   search: string,
-  limit = Infinity
+  limit = Infinity,
+  searchMatcher?: (option: SelectOptionWithKey<Value>, search: string) => boolean
 ): Set<SelectKey> {
   //
   // First, filter options using `search` value
   //
-  const filterOption = (opt: SelectOption<Value>) => {
+  const filterOption = (opt: SelectOptionWithKey<Value>) => {
+    if (searchMatcher) {
+      return searchMatcher(opt, search);
+    }
     // Build search string: use textValue if provided, otherwise use label only if it's a string
     const searchableText =
       opt.textValue ?? (typeof opt.label === 'string' ? opt.label : '');

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -141,6 +141,12 @@ export function getHiddenOptions<Value extends SelectKey>(
   // First, filter options using `search` value
   //
   const filterOption = (opt: SelectOptionWithKey<Value>) => {
+    // When there is no active search query, all options match. Do not call the
+    // searchMatcher — a custom matcher may return score 0 for an empty query,
+    // which would incorrectly hide all options.
+    if (!search) {
+      return true;
+    }
     const result = matcher(opt, search);
     if (result.score > 0) {
       if (searchMatcher) {

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -187,14 +187,21 @@ export function getHiddenOptions<Value extends SelectKey>(
     .filter((item): item is SelectOptionOrSectionWithKey<Value> => !!item);
 
   //
+  // Sort remaining items by score before applying the size limit, so that higher-scored
+  // (more relevant) items are kept visible when the limit is reached.
+  //
+  const orderedRemainingItems =
+    scores.size > 0 ? getSortedItems(remainingItems, scores) : remainingItems;
+
+  //
   // Then, limit the number of remaining options to `limit`
   //
   let threshold = [Infinity, Infinity];
   let accumulator = 0;
   let currentIndex = 0;
 
-  while (currentIndex < remainingItems.length) {
-    const item = remainingItems[currentIndex]!;
+  while (currentIndex < orderedRemainingItems.length) {
+    const item = orderedRemainingItems[currentIndex]!;
     const delta = 'options' in item ? item.options.length : 1;
 
     if (accumulator + delta > limit) {
@@ -206,8 +213,8 @@ export function getHiddenOptions<Value extends SelectKey>(
     currentIndex += 1;
   }
 
-  for (let i = threshold[0]!; i < remainingItems.length; i++) {
-    const item = remainingItems[i]!;
+  for (let i = threshold[0]!; i < orderedRemainingItems.length; i++) {
+    const item = orderedRemainingItems[i]!;
     if ('options' in item) {
       const startingIndex = i === threshold[0] ? threshold[1]! : 0;
       for (let j = startingIndex; j < item.options.length; j++) {

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -105,14 +105,25 @@ export function getDisabledOptions<Value extends SelectKey>(
   }, []);
 }
 
+function defaultSearchMatcher<Value extends SelectKey>(
+  opt: SelectOptionWithKey<Value>,
+  search: string
+): SearchMatchResult {
+  const searchableText =
+    opt.textValue ?? (typeof opt.label === 'string' ? opt.label : '');
+  return {score: searchableText.toLowerCase().includes(search.toLowerCase()) ? 1 : 0};
+}
+
 /**
  * Recursively finds the option(s) that don't match the designated search string or are
- * outside the list box's count limit. Also collects match scores from a custom
- * `searchMatcher` that returns a `SearchMatchResult`.
+ * outside the list box's count limit. Also collects match scores for use in sorting.
+ *
+ * An option is considered a match when its score is greater than 0. The default matcher
+ * returns score 1 for a substring match and 0 otherwise. Custom matchers can return any
+ * positive score to influence sort order — higher scores appear first.
  *
  * Returns both the set of hidden option keys and a map of key → score for matched
- * options that provided a score. The scores map is empty when the default matcher is
- * used or when the custom matcher only returns booleans.
+ * options. The scores map only contains entries when a custom searchMatcher is provided.
  */
 export function getHiddenOptions<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
@@ -121,26 +132,25 @@ export function getHiddenOptions<Value extends SelectKey>(
   searchMatcher?: (
     option: SelectOptionWithKey<Value>,
     search: string
-  ) => boolean | SearchMatchResult
+  ) => SearchMatchResult
 ): {hidden: Set<SelectKey>; scores: Map<SelectKey, number>} {
   const scores = new Map<SelectKey, number>();
+  const matcher = searchMatcher ?? defaultSearchMatcher;
 
   //
   // First, filter options using `search` value
   //
   const filterOption = (opt: SelectOptionWithKey<Value>) => {
-    if (searchMatcher) {
-      const result = searchMatcher(opt, search);
-      if (typeof result === 'object') {
+    const result = matcher(opt, search);
+    if (result.score > 0) {
+      if (searchMatcher) {
+        // Only track scores when a custom matcher is provided — default scores are
+        // always 1 and would trigger unnecessary sorting.
         scores.set(opt.key, result.score);
-        return true;
       }
-      return result;
+      return true;
     }
-    // Build search string: use textValue if provided, otherwise use label only if it's a string
-    const searchableText =
-      opt.textValue ?? (typeof opt.label === 'string' ? opt.label : '');
-    return searchableText.toLowerCase().includes(search.toLowerCase());
+    return false;
   };
 
   const hiddenOptionsSet = new Set<SelectKey>();
@@ -202,7 +212,6 @@ export function getHiddenOptions<Value extends SelectKey>(
     }
   }
 
-  // Return the hidden option keys and any scores collected during filtering.
   return {hidden: hiddenOptionsSet, scores};
 }
 

--- a/static/app/components/core/compactSelect/utils.tsx
+++ b/static/app/components/core/compactSelect/utils.tsx
@@ -11,6 +11,7 @@ import {defined} from 'sentry/utils';
 import type {SelectProps} from './compactSelect';
 import {SectionToggleButton} from './styles';
 import type {
+  SearchMatchResult,
   SelectKey,
   SelectOption,
   SelectOptionOrSection,
@@ -106,20 +107,35 @@ export function getDisabledOptions<Value extends SelectKey>(
 
 /**
  * Recursively finds the option(s) that don't match the designated search string or are
- * outside the list box's count limit.
+ * outside the list box's count limit. Also collects match scores from a custom
+ * `searchMatcher` that returns a `SearchMatchResult`.
+ *
+ * Returns both the set of hidden option keys and a map of key → score for matched
+ * options that provided a score. The scores map is empty when the default matcher is
+ * used or when the custom matcher only returns booleans.
  */
 export function getHiddenOptions<Value extends SelectKey>(
   items: Array<SelectOptionOrSectionWithKey<Value>>,
   search: string,
   limit = Infinity,
-  searchMatcher?: (option: SelectOptionWithKey<Value>, search: string) => boolean
-): Set<SelectKey> {
+  searchMatcher?: (
+    option: SelectOptionWithKey<Value>,
+    search: string
+  ) => boolean | SearchMatchResult
+): {hidden: Set<SelectKey>; scores: Map<SelectKey, number>} {
+  const scores = new Map<SelectKey, number>();
+
   //
   // First, filter options using `search` value
   //
   const filterOption = (opt: SelectOptionWithKey<Value>) => {
     if (searchMatcher) {
-      return searchMatcher(opt, search);
+      const result = searchMatcher(opt, search);
+      if (typeof result === 'object') {
+        scores.set(opt.key, result.score);
+        return true;
+      }
+      return result;
     }
     // Build search string: use textValue if provided, otherwise use label only if it's a string
     const searchableText =
@@ -186,8 +202,42 @@ export function getHiddenOptions<Value extends SelectKey>(
     }
   }
 
-  // Return the values of options that were removed.
-  return hiddenOptionsSet;
+  // Return the hidden option keys and any scores collected during filtering.
+  return {hidden: hiddenOptionsSet, scores};
+}
+
+/**
+ * Sorts items by their match scores (descending). Options with higher scores appear
+ * first. Options without a score entry maintain their original relative order.
+ *
+ * For sectioned lists, options are sorted within each section. For flat lists, all
+ * options are sorted globally.
+ */
+export function getSortedItems<Value extends SelectKey>(
+  items: Array<SelectOptionOrSectionWithKey<Value>>,
+  scores: Map<SelectKey, number>
+): Array<SelectOptionOrSectionWithKey<Value>> {
+  const hasSections = items.some(item => 'options' in item);
+
+  if (hasSections) {
+    return items.map(item => {
+      if ('options' in item) {
+        return {
+          ...item,
+          options: [...item.options].sort(
+            (a, b) => (scores.get(b.key) ?? 0) - (scores.get(a.key) ?? 0)
+          ),
+        };
+      }
+      return item;
+    });
+  }
+
+  return [...items].sort(
+    (a, b) =>
+      (scores.get((b as SelectOptionWithKey<Value>).key) ?? 0) -
+      (scores.get((a as SelectOptionWithKey<Value>).key) ?? 0)
+  );
 }
 
 /**

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -193,17 +193,17 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
   shouldFilterResults?: boolean;
 }) {
   const hiddenOptions: Set<SelectKey> = useMemo(() => {
-    const options = getHiddenOptions(
+    const {hidden} = getHiddenOptions(
       items,
       shouldFilterResults ? filterValue : '',
       maxOptions
     );
 
     if (showAskSeerOption) {
-      options.add(ASK_SEER_ITEM_KEY);
+      hidden.add(ASK_SEER_ITEM_KEY);
     }
 
-    return options;
+    return hidden;
   }, [filterValue, items, maxOptions, shouldFilterResults, showAskSeerOption]);
 
   const disabledKeys = useMemo(() => {

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -73,7 +73,12 @@ function useHiddenItems<T extends SelectOptionOrSectionWithKey<string>>({
   shouldFilterResults?: boolean;
 }) {
   const hiddenOptions: Set<SelectKey> = useMemo(() => {
-    return getHiddenOptions(items, shouldFilterResults ? filterValue : '', maxOptions);
+    const {hidden} = getHiddenOptions(
+      items,
+      shouldFilterResults ? filterValue : '',
+      maxOptions
+    );
+    return hidden;
   }, [items, shouldFilterResults, filterValue, maxOptions]);
 
   const disabledKeys = useMemo(


### PR DESCRIPTION
When both `sizeLimit` and a custom `searchMatcher` with varying scores are active, `getHiddenOptions` was applying the size limit based on original item order, then `getSortedItems` would reorder by score. This meant lower-scored items that happened to appear first in the original list stayed visible, while higher-scored (more relevant) items beyond the limit were hidden — defeating the purpose of score-based ranking.

The fix sorts remaining (search-matched) items by score inside `getHiddenOptions` before applying the size limit, so the limit always keeps the most relevant results visible.

A regression test was added covering the exact failure case: three options with scores `[1, 3, 2]` in original order and `sizeLimit=2` — the two highest-scored options (3 and 2) should be visible, not the first two in original order (1 and 3).