### PR TITLE
feat(profiling): More examples on slowest functions widget

### DIFF
--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -99,6 +99,10 @@ export interface DropdownMenuProps
    */
   isDisabled?: boolean;
   /**
+   * Maximum menu width
+   */
+  maxMenuHeight?: number;
+  /**
    * Title for the current menu.
    */
   menuTitle?: React.ReactNode;
@@ -179,6 +183,7 @@ function DropdownMenu({
   flipOptions,
   portalContainerRef,
   shouldApplyMinWidth,
+  maxMenuHeight,
   minMenuWidth,
   // This prop is from popperJS and is an alternative to portals. Use this with components like modals where portalling to document body doesn't work well.
   strategy,
@@ -263,6 +268,7 @@ function DropdownMenu({
           style: {
             ...overlayProps.style,
             minWidth: minMenuWidth ?? overlayProps.style?.minWidth,
+            maxHeight: maxMenuHeight ?? overlayProps.style?.maxHeight,
           },
         }}
         overlayState={overlayState}

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -384,8 +384,7 @@ function SlowestFunctionEntry<F extends BreakdownFunction>({
           };
         });
       })
-      .reverse()
-      .slice(0, 10);
+      .reverse();
   }, [func, stats, organization, project, frame]);
 
   return (
@@ -436,6 +435,7 @@ function SlowestFunctionEntry<F extends BreakdownFunction>({
           }}
           items={examples}
           menuTitle={t('Example Profiles')}
+          maxMenuHeight={300}
         />
       </AccordionItem>
       {isExpanded && (


### PR DESCRIPTION
Instead of limiting to just 10 examples, this renders up to 1 example per point on the timeseries and makes the dropdown scrollable to contain all the examples.