### PR TITLE
feat(seer-explorer): enable copy button without completed status, fall back to status string when no blocks

### DIFF
--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -102,12 +102,10 @@ function ExplorerPanel() {
     createPR,
   } = useSeerExplorer();
 
-  const copySessionEnabled = Boolean(
-    sessionData?.status === 'completed' && !!runId && !!organization?.slug
-  );
-
+  const copySessionEnabled = Boolean(runId && organization?.slug);
   const {copySessionToClipboard} = useCopySessionDataToClipboard({
-    blocks: sessionData?.blocks || [],
+    blocks: sessionData?.blocks,
+    status: sessionData?.status,
     organization,
     projects,
     enabled: copySessionEnabled,

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -788,26 +788,29 @@ export function usePageReferrer(): {getPageReferrer: () => string} {
 
 export function useCopySessionDataToClipboard({
   blocks,
+  status,
   organization,
   projects,
   enabled,
 }: {
-  blocks: Block[];
+  blocks: Block[] | undefined;
   enabled: boolean;
   organization: Organization | null;
+  status: string | undefined;
   projects?: Array<{id: string; slug: string}>;
 }) {
   const [isError, setIsError] = useState(false);
 
   const copySessionToClipboard = useCallback(async () => {
-    if (!enabled || !organization || !blocks) {
+    if (!enabled || !organization) {
       return;
     }
     setIsError(false);
     try {
-      await navigator.clipboard.writeText(
-        formatSessionData(blocks, organization.slug, projects)
-      );
+      const text = blocks
+        ? formatSessionData(blocks, organization.slug, projects)
+        : `No data available. Status: ${status ?? 'unknown'}`;
+      await navigator.clipboard.writeText(text);
       addSuccessMessage('Copied conversation to clipboard');
     } catch (err) {
       setIsError(true);
@@ -815,7 +818,7 @@ export function useCopySessionDataToClipboard({
     }
 
     trackAnalytics('seer.explorer.session_copied_to_clipboard', {organization});
-  }, [enabled, blocks, organization, projects]);
+  }, [enabled, blocks, status, organization, projects]);
 
   return {copySessionToClipboard, isError};
 }


### PR DESCRIPTION
## Changes

- **`copySessionEnabled`** no longer requires `sessionData.status === 'completed'`; the copy button is now enabled whenever `runId` and `organization.slug` are present.
- **`useCopySessionDataToClipboard`** accepts a new `status` parameter. When no block data is available, it copies `No data available. Status: <status>` to the clipboard instead of formatted session data.