### PR TITLE
chore(warden): Vendor sentry-backend-bugs and sentry-javascript-bugs skills

### DIFF
--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -14,8 +14,6 @@
 /skills/gh-review-requests/
 /skills/iterate-pr/
 /skills/security-review/
-/skills/sentry-backend-bugs/
-/skills/sentry-javascript-bugs/
 /skills/skill-creator/
 /skills/skill-scanner/
 /skills/sred-project-organizer/

--- a/.agents/skills/sentry-backend-bugs/README.md
+++ b/.agents/skills/sentry-backend-bugs/README.md
@@ -1,0 +1,3 @@
+Vendored from https://github.com/getsentry/warden-sentry (.agents/skills/sentry-backend-bugs/).
+
+If this skill needs updating, pull changes from that repository.

--- a/.agents/skills/sentry-backend-bugs/SKILL.md
+++ b/.agents/skills/sentry-backend-bugs/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: sentry-backend-bugs
+description: 'Sentry backend bug pattern review based on real production errors. Use when reviewing Python/Django backend code for common bug patterns. Trigger keywords: "backend bug review", "common errors", "error patterns", "sentry bugs".'
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Sentry Backend Bug Pattern Review
+
+Find bugs in Sentry backend code by checking for the patterns that cause the most production errors.
+
+This skill encodes patterns from 638 real production issues (393 resolved, 220 unresolved, 25 ignored) generating over 27 million error events across 65,000+ affected users. These are not theoretical risks -- they are the actual bugs that ship most often, with known fixes from resolved issues.
+
+## Scope
+
+You receive scoped code chunks from Warden's diff pipeline. Each chunk is a changed hunk (or coalesced group of nearby hunks) with surrounding context.
+
+1. Analyze the chunk against the pattern checks below.
+2. Use `Read` and `Grep` to trace data flow beyond the chunk when needed — follow function calls, check callers, verify types at boundaries.
+3. Report only **HIGH** and **MEDIUM** confidence findings.
+
+| Confidence | Criteria                                                              | Action                       |
+| ---------- | --------------------------------------------------------------------- | ---------------------------- |
+| **HIGH**   | Traced the code path, confirmed the pattern matches a known bug class | Report with fix              |
+| **MEDIUM** | Pattern is present but context may mitigate it                        | Report as needs verification |
+| **LOW**    | Theoretical or mitigated elsewhere                                    | Do not report                |
+
+## Step 1: Classify the Code
+
+Determine what you are reviewing and load the relevant reference.
+
+| Code Type                                                         | Load Reference                                            |
+| ----------------------------------------------------------------- | --------------------------------------------------------- |
+| ORM queries, model lookups, `.objects.get()`, FK access           | `${CLAUDE_SKILL_ROOT}/references/missing-records.md`      |
+| Type conversions, None handling, option reads, serializer returns | `${CLAUDE_SKILL_ROOT}/references/null-and-type-errors.md` |
+| Data input parsing, field lengths, request bodies, decompression  | `${CLAUDE_SKILL_ROOT}/references/data-validation.md`      |
+| `get_or_create`, `save()`, unique constraints, integer overflow   | `${CLAUDE_SKILL_ROOT}/references/database-integrity.md`   |
+| Integration webhooks, external API calls, SentryApp hooks         | `${CLAUDE_SKILL_ROOT}/references/integration-errors.md`   |
+| Dict iteration, shared state, concurrent access                   | `${CLAUDE_SKILL_ROOT}/references/concurrency-bugs.md`     |
+| Snuba queries, metric subscriptions, search filters               | `${CLAUDE_SKILL_ROOT}/references/query-validation.md`     |
+| Redirect URLs, URL construction, routing                          | `${CLAUDE_SKILL_ROOT}/references/url-safety.md`           |
+
+If the code spans multiple categories, load all relevant references.
+
+## Step 2: Check for Top Bug Patterns
+
+These are ordered by combined frequency and impact from real production data.
+
+### Check 1: Metric Subscription Query Errors -- 113 issues, 3,035,640 events
+
+Alert and metric subscriptions referencing tags or functions that do not exist in the target dataset. These fire continuously once created.
+
+**Red flags:**
+
+- Creating Snuba subscriptions with `SubscriptionData` using user-provided query strings without validation
+- Referencing `transaction.duration` in p95/p99 functions on the metrics dataset (it is a string type there)
+- Using custom tag names (e.g., `customerType`) as filter dimensions without checking they exist
+- Calling `resolve_apdex_function` without verifying the dataset supports threshold parameters
+
+**Safe patterns:**
+
+- Validate query fields against dataset schema before subscription creation
+- Wrap `_create_in_snuba` calls with try/except `SubscriptionError` and mark subscription as invalid
+- Use `IncompatibleMetricsQuery` checks before building metric subscription queries
+
+### Check 2: Missing Record / Stale Reference -- 81 issues, 1,403,592 events
+
+Code calls `.get()` on a Django model assuming the record exists, but it has been deleted, merged, or never created.
+
+**Red flags:**
+
+- `Model.objects.get(id=some_id)` without try/except for `DoesNotExist`
+- `Detector.objects.get(id=detector_id)` in workflow engine without handling deletion
+- `Environment.objects.get(name=env_name)` in monitor/cron consumers
+- `Subscription.objects.get(id=sub_id)` in billing tasks
+- Using `Group.objects.get()` with IDs from Snuba query results (groups may be deleted/merged)
+- Chained lookups where second `.get()` fails
+
+**Safe patterns:**
+
+- `Model.objects.filter(...).first()` with a None check
+- try/except `DoesNotExist` that returns a graceful fallback (404, skip, log)
+- Queryset `.exists()` check before `.get()`
+- In API endpoints: return 404 for `DoesNotExist`, 400 for validation errors. Never suggest returning 500 intentionally.
+
+**Not a bug — do not flag:**
+
+- Infrastructure invariants: `.get()` enforcing a deployment precondition (e.g., "default org must exist in single-org mode") should crash — a 500 signals misconfiguration, not a code defect.
+- Already validated by parent: If the endpoint base class validates the object (e.g., `OrganizationEndpoint` resolves the org), don't flag `.get()` on related records unless there's a genuine race or deletion window. Read the endpoint's parent class before reporting.
+- Configuration lookups: Code that loads required config objects (`get_default()`, settings-based lookups) is expected to fail hard if the config is wrong.
+
+### Check 3: Search Query Validation -- 57 issues, 2,001,330 events
+
+InvalidSearchQuery from user-provided or subscription-stored query filters referencing invalid values, deleted issues, or unresolved tags.
+
+**Red flags:**
+
+- `by_qualified_short_id_bulk()` called with short IDs from stored subscriptions that reference deleted/renamed projects
+- `_issue_filter_converter` that calls `Group.objects.get()` on user-provided issue short IDs
+- `resolve_tag_key()` called without checking the tag exists in the target dataset
+- Passing unvalidated `query` strings from alert rule subscriptions to Snuba
+
+**Safe patterns:**
+
+- Validate short IDs before passing to `by_qualified_short_id_bulk()` -- handle `Group.DoesNotExist`
+- Wrap `_issue_filter_converter` in try/except and return empty results for invalid filters
+- Pre-validate tag existence against dataset schema
+
+### Check 4: Value Validation Errors -- 45 issues, 1,000,624 events
+
+ValueError from insufficient input validation: unpacking errors, invalid enum values, missing expected objects, and Pydantic/DRF validation failures.
+
+**Red flags:**
+
+- `SentryAppInstallation.objects.get()` in action builders assuming exactly 1 result exists
+- `AlertRuleWorkflow` lookups by ID without handling `DoesNotExist`
+- Tuple unpacking (`a, b, c = value.split(":")`) on strings that may have fewer separators
+- Integer enum lookups without catching `ValueError` (e.g., `DetectorPriorityLevel(value)`)
+
+**Safe patterns:**
+
+- Validate expected count before `.get()`: use `.filter()` and check `.count()`
+- Wrap tuple unpacking in try/except `ValueError` or validate length first
+- Use `try: EnumClass(value) except ValueError:` for user-facing enum conversions
+- In API endpoints: return 400 for `ValueError` and validation failures.
+
+### Check 5: Type Errors -- 28 issues, 740,106 events
+
+Wrong types passed to functions: iterating over non-iterables, invalid dict keys, None where object expected.
+
+**Red flags:**
+
+- `orjson.dumps(payload)` where payload dict may have non-string keys
+- `list(setting)` where `setting` could be an int (from `project.get_option()`)
+- `result["key"] = value` where `result` could be None
+- Iterating over a value from DB/config that could be int or None instead of list
+
+**Safe patterns:**
+
+- Type-check before iteration: `isinstance(value, (list, str))` before `list(value)`
+- Validate dict keys before JSON serialization: ensure all keys are strings
+- None-guard before subscript assignment: `if result is not None:`
+- Defensive option reads with type checking
+- In API endpoints: return 400 for type mismatches from user input.
+
+### Check 6: Internal API Request Errors -- 71 issues, 829,753 events
+
+ApiError from internal Sentry API calls between services, often caused by stale subscription parameters.
+
+**Red flags:**
+
+- `api.client.get()` calls in metric alert chart rendering without handling 400 responses
+- Internal API calls that forward stale subscription queries (referencing removed tags/metrics)
+- `fetch_metric_alert_events_timeseries()` in `incidents/charts.py` without ApiError handling
+
+**Safe patterns:**
+
+- Wrap internal API calls with try/except `ApiError` and return graceful fallback
+- Validate query parameters before making internal API requests
+- Handle 400/500 responses explicitly in chart/visualization code
+
+### Check 7: Database Constraint Violations -- 22 issues, 2,962,198 events
+
+IntegrityError and DataError from integer overflow, foreign key violations, and unique constraint violations.
+
+**Red flags:**
+
+- Incrementing `times_seen` counter without bounding (integer overflow at ~2.1 billion)
+- Deleting `MonitorCheckIn` records without handling FK constraints from `MonitorIncident`
+- `UPDATE` on `GroupOpenPeriod` date ranges where lower bound can exceed upper bound
+- `save()` on models with unique constraints without handling `IntegrityError`
+
+**Safe patterns:**
+
+- Cap integer fields before update: `min(value, 2_147_483_647)` for 32-bit int columns
+- Use `CASCADE` or handle FK constraints before bulk deletion
+- Validate date range bounds before saving
+- try/except `IntegrityError` with fallback to `get()` or `update_or_create()`
+
+### Check 8: Data Parsing & Deserialization -- 19 issues, 272,812 events
+
+JSONDecodeError and ZstdError from parsing external data or stored compressed data.
+
+**Red flags:**
+
+- `json.loads(response.body)` without catching `JSONDecodeError`
+- `zstd.decompress(data)` without handling corrupt frame descriptors
+- Parsing VSTS/Azure DevOps webhook bodies that may be truncated
+- Assuming API responses are always valid JSON (can be HTML error pages)
+
+**Safe patterns:**
+
+- Always wrap JSON/compression in try/except with graceful fallback
+- Check `content-type` header before parsing
+- Validate response status before parsing body
+
+### Check 9: Missing Key Access (KeyError) -- 25 issues, 155,020 events
+
+Accessing dictionary keys or HTTP headers without existence check.
+
+**Red flags:**
+
+- `request.META["HTTP_X_GITLAB_TOKEN"]` in webhook handlers (header may be absent)
+- `request.META["HTTP_X_EVENT_KEY"]` in Bitbucket webhook handler
+- Dict key lookups with `HANDLERS[event_type]` without checking the event type is registered
+- Tuple unpacking from header values with variable-length splits
+
+**Safe patterns:**
+
+- `request.META.get("HTTP_X_GITLAB_TOKEN")` with None check
+- `HANDLERS.get(event_type)` with fallback for unknown event types
+- Validate required headers at the top of webhook handler before processing
+
+### Check 10: Concurrency and Runtime Bugs -- 23 issues, 38,443 events
+
+Dictionary mutation during iteration, shared mutable state, and unimplemented code paths.
+
+**Red flags:**
+
+- `for key in self._dict:` while another thread modifies it (RuntimeError)
+- Publishing to shared `KafkaPublisher` dict that grows unbounded
+- `dict.pop()` or `dict[key] = value` on a dict being iterated in another thread
+- Missing `NotImplementedError` handlers for new search expression types
+
+**Safe patterns:**
+
+- `dict.copy()` before iteration
+- Use `threading.Lock` for shared mutable state
+- Implement all code paths before enabling features
+- Use `list(dict.keys())` for safe iteration when mutation is needed
+
+### Check 11: Logic Correctness -- not pattern-based
+
+After checking all known patterns above, reason about the changed code itself:
+
+- Does every code path return the correct type?
+- Are all branches of conditionals handled (especially `else` / default cases)?
+- Can any input (None, empty list, 0, empty string) cause unexpected behavior?
+- Are there off-by-one errors in loops, slices, or range checks?
+- If this code runs concurrently, is shared state protected?
+
+Only report if you can trace a specific input that triggers the bug. Do not report theoretical concerns.
+
+**Not a bug — do not flag:**
+
+- `assert` statements enforcing infrastructure invariants — Sentry does not run with `python -O`, so assertions are always active. Crashing on a violated invariant is intentional.
+- Speculative input concerns (e.g., "this URL could be too long", "this header could be malformed") unless you can show the input actually reaches the code path unvalidated. Check for existing validation (host checks, schema validation, DRF serializers) before reporting.
+
+**If no checks produced a potential finding, stop and report zero findings. Do not invent issues to fill the report. An empty result is the correct output when the code has no bugs matching these patterns.**
+
+Each code location should be reported once under the most specific matching pattern. Do not flag the same line under multiple checks.
+
+## Step 3: Report Findings
+
+For each finding, include:
+
+- **Title**: Short description of the bug
+- **Severity**: high, medium, or low
+- **Location**: File path and line number
+- **Description**: Root cause → consequences (2-4 sentences)
+- **Precedent**: A real production issue ID (e.g., "Similar to SENTRY-5D9J: Detector.DoesNotExist, 610K events")
+- **Fix**: A unified diff showing the code fix
+
+Fix suggestions must include actual code. Never suggest a comment or docstring as a fix.
+
+When suggesting fixes in API endpoints, use appropriate HTTP status codes (404 for not found, 400 for bad input, 409 for conflicts). Never suggest returning 500 intentionally.
+
+Do not prescribe your own output format — the review harness controls the response structure.

--- a/.agents/skills/sentry-backend-bugs/references/concurrency-bugs.md
+++ b/.agents/skills/sentry-backend-bugs/references/concurrency-bugs.md
@@ -1,0 +1,197 @@
+# Concurrency and Runtime Bugs
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+**23 issues, 38,443 events, 1,320 affected users.** Shared mutable state accessed from multiple threads without synchronization, unimplemented code paths hit in production, and list/index access without bounds checking. While lower in issue count, these bugs are persistent -- they fire continuously once triggered and are difficult to reproduce in testing.
+
+Three sub-patterns:
+
+1. **Dict mutation during iteration** -- One thread iterates a dict while another thread adds/removes keys (RuntimeError, 14 issues)
+2. **Index out of range** -- List access without bounds checking (IndexError, 5 issues)
+3. **Unimplemented code paths** -- NotImplementedError from search expressions or features not yet handled (4 issues)
+
+## Real Examples
+
+### Example 1: Dictionary changed size during iteration (SENTRY-5BYB) -- unresolved
+
+**28,712 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/utils/pubsub.py -- publish()
+# Called from:
+# sentry/monitors/consumers/monitor_consumer.py -- _process_checkin()
+# sentry/utils/outcomes.py -- track_outcome()
+# RuntimeError: dictionary changed size during iteration
+```
+
+**Root cause:** A `KafkaPublisher` instance has an internal dictionary of futures or topics. The `publish()` method iterates over this dict while another thread concurrently adds new entries. The monitor consumer processes check-ins and calls `track_outcome()` which publishes to Kafka -- in a multi-threaded consumer, multiple check-ins can be processed concurrently.
+
+**Fix:**
+
+```python
+# Snapshot keys before iteration:
+for key in list(self._futures.keys()):
+    future = self._futures.get(key)
+    if future is not None and future.done():
+        self._futures.pop(key, None)
+
+# Or use a lock:
+with self._lock:
+    done = [k for k, v in self._futures.items() if v.done()]
+    for k in done:
+        del self._futures[k]
+```
+
+### Example 2: IndexError in rate limiting (SENTRY-401M) -- resolved
+
+**1,065 events | 353 users**
+
+In-app frames:
+
+```python
+# sentry/ratelimits/redis.py -- is_limited_with_value()
+result = pipeline.execute()
+# ...
+count = result[idx]  # IndexError: list index out of range
+```
+
+Called from:
+
+```python
+# sentry/ratelimits/utils.py -- above_rate_limit_check()
+is_limited, current_count = backend.is_limited_with_value(key, limit, window)
+```
+
+**Root cause:** The Redis pipeline returns fewer results than expected. This can happen if the Redis connection is interrupted mid-pipeline, or if the pipeline commands were partially executed.
+
+**Fix:**
+
+```python
+results = pipeline.execute()
+if len(results) <= idx:
+    logger.warning("ratelimit.pipeline_incomplete", extra={"expected": idx + 1, "got": len(results)})
+    return False, 0  # Default to not rate-limited
+count = results[idx]
+```
+
+**Actual fix:** Resolved -- pipeline results are now validated before access.
+
+### Example 3: Process startup timeout (SENTRY-48Q3) -- unresolved
+
+**2,773 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/spans/consumers/process/flusher.py -- _wait_for_process_to_become_healthy()
+if not process.is_alive():
+    raise RuntimeError(
+        f"process {idx} (shards {shards}) didn't start up in {timeout} seconds"
+    )
+```
+
+**Root cause:** The span processing consumer spawns child processes for sharding. Under load, a child process may take longer than the configured 120-second timeout to start up, causing the parent to raise RuntimeError.
+
+**Fix:**
+
+```python
+# Increase timeout or make it configurable:
+timeout = options.get("spans.process.startup_timeout", 300)
+# Or implement retry logic:
+for attempt in range(max_retries):
+    if process.is_alive():
+        break
+    time.sleep(backoff)
+else:
+    logger.error("process.startup_timeout", extra={"idx": idx, "shards": shards})
+    # Graceful degradation instead of crash
+```
+
+## Root Cause Analysis
+
+| Pattern                           | Frequency | Typical Trigger                                      |
+| --------------------------------- | --------- | ---------------------------------------------------- |
+| Dict mutation during iteration    | Very High | Multi-threaded consumers, publishers                 |
+| List index out of range           | Medium    | Redis pipeline incomplete results, empty collections |
+| Process startup timeout           | Medium    | High-load conditions, resource contention            |
+| Unimplemented search expressions  | Low       | New query syntax not yet handled                     |
+| Shared module-level mutable state | Low       | Global registries without locks                      |
+
+## Fix Patterns
+
+### Pattern A: Copy before iteration
+
+```python
+# Snapshot the dict keys before iterating:
+for key in list(shared_dict.keys()):
+    process(shared_dict.get(key))
+```
+
+### Pattern B: Use threading.Lock for shared state
+
+```python
+import threading
+
+class Publisher:
+    def __init__(self):
+        self._futures = {}
+        self._lock = threading.Lock()
+
+    def publish(self, key, value):
+        with self._lock:
+            self._futures[key] = produce(value)
+
+    def cleanup(self):
+        with self._lock:
+            done = [k for k, v in self._futures.items() if v.done()]
+            for k in done:
+                del self._futures[k]
+```
+
+### Pattern C: Bounds checking before index access
+
+```python
+# Instead of:
+value = results[idx]
+
+# Use:
+if idx < len(results):
+    value = results[idx]
+else:
+    logger.warning("unexpected_result_count", extra={"expected": idx + 1, "got": len(results)})
+    value = default
+```
+
+### Pattern D: Implement all code paths before enabling features
+
+```python
+# Instead of:
+raise NotImplementedError("Haven't handled all search expressions yet")
+
+# Use:
+logger.warning("search.unhandled_expression", extra={"expression": expr})
+return default_result  # Graceful fallback
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `for key in dict:` where the dict is accessible from multiple threads -- is it copied first?
+- [ ] Any module-level or class-level mutable dicts/lists that are modified at runtime
+- [ ] Any `dict.pop()`, `dict[key] = value`, or `del dict[key]` on shared state without a lock
+- [ ] Any list index access `list[idx]` -- is the index bounds-checked?
+- [ ] Any `pipeline.execute()` result access -- is the result list length validated?
+- [ ] Any `raise NotImplementedError` -- is this code reachable in production?
+- [ ] Any KafkaPublisher, PubSub, or similar concurrent producer -- is shared state protected?
+- [ ] Any child process startup -- is the timeout reasonable under load?

--- a/.agents/skills/sentry-backend-bugs/references/data-validation.md
+++ b/.agents/skills/sentry-backend-bugs/references/data-validation.md
@@ -1,0 +1,313 @@
+# Data Validation and Input Handling
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+A broad and impactful category spanning **89 issues across ValueError, KeyError, data parsing, and assertion failures: 1,540,632 events, 10,927 affected users**. External input -- from webhook bodies, user parameters, stored data, and binary blobs -- is not validated before use. Includes field length violations, type coercion failures, missing dict keys, corrupt binary data, and violated invariants.
+
+Sub-categories:
+
+1. **Value validation (45 issues, 1,000,624 events)** -- ValueError from unpacking errors, invalid enum values, missing expected objects
+2. **Data parsing (19 issues, 272,812 events)** -- JSONDecodeError, ZstdError from parsing external or stored data
+3. **Missing key access (25 issues, 155,020 events)** -- KeyError from accessing dict keys or HTTP headers without checking existence
+4. **Assertion failures (15 issues, 112,495 events)** -- AssertionError from bare asserts used as input validation
+
+## Real Examples
+
+### Example 1: Expected 1 sentry app installation (SENTRY-494A) -- resolved
+
+**783,633 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+def get_target_identifier(self, action):
+    installations = SentryAppInstallation.objects.filter(
+        sentry_app__slug=action.target_identifier, ...
+    )
+    if installations.count() != 1:
+        raise ValueError(
+            f"Expected 1 sentry app installation for action type: sentry_app, "
+            f"target_identifier: {action.target_identifier}"
+        )  # CRASHES HERE
+```
+
+**Root cause:** Alert action builder assumes exactly 1 SentryAppInstallation exists for the target identifier. When the app is uninstalled or there are duplicates, this raises ValueError at massive scale because alert rules fire continuously.
+
+**Fix:**
+
+```python
+installation = SentryAppInstallation.objects.filter(
+    sentry_app__slug=action.target_identifier, ...
+).first()
+if installation is None:
+    logger.warning("sentry_app.installation_not_found", ...)
+    return None
+```
+
+**Actual fix:** Resolved -- lookup now handles missing and multiple installations gracefully.
+
+### Example 2: Tuple unpacking failure on GitLab webhook (SENTRY-3VCS) -- ignored
+
+**66,948 events | 64 users**
+
+In-app frames:
+
+```python
+# sentry/integrations/gitlab/webhooks.py -- get_gitlab_external_id()
+secret, group, _url = token.split(":")  # CRASHES: not enough values to unpack
+```
+
+**Root cause:** The GitLab token format is expected to be `secret:group:url`, but some tokens have fewer separators.
+
+**Fix:**
+
+```python
+parts = token.split(":", 2)
+if len(parts) != 3:
+    raise ValueError(f"Invalid GitLab token format: expected 3 parts, got {len(parts)}")
+secret, group, _url = parts
+```
+
+### Example 3: KeyError on GitLab/Bitbucket webhook headers (SENTRY-3VCC, SENTRY-3ZXH)
+
+**65,805 combined events | 357 users**
+
+In-app frames:
+
+```python
+# sentry/integrations/gitlab/webhooks.py
+return request.META["HTTP_X_GITLAB_TOKEN"]  # CRASHES: KeyError
+
+# sentry/integrations/bitbucket/webhook.py
+event = request.META["HTTP_X_EVENT_KEY"]  # CRASHES: KeyError
+```
+
+**Root cause:** Webhook handlers use direct dict key access on `request.META` for HTTP headers. External services can send requests without the expected headers.
+
+**Fix:**
+
+```python
+token = request.META.get("HTTP_X_GITLAB_TOKEN")
+if token is None:
+    return HttpResponse("Missing required header", status=400)
+```
+
+### Example 4: ZstdError on attachment decompression (SENTRY-5C5M) -- unresolved
+
+**75,658 events | 3,834 users**
+
+In-app frames:
+
+```python
+# sentry/api/endpoints/event_attachment_details.py -- stream_attachment()
+data = zstd.decompress(raw_data)  # CRASHES: Unknown frame descriptor
+```
+
+**Root cause:** Stored attachment data is corrupted or was stored uncompressed but marked as compressed.
+
+**Fix:**
+
+```python
+try:
+    data = zstd.decompress(raw_data)
+except zstd.ZstdError:
+    logger.warning("attachment.decompress_failed", extra={"attachment_id": attachment.id})
+    data = raw_data  # Fall back to raw data
+```
+
+### Example 5: JSONDecodeError on VSTS webhook body (SENTRY-5CKF) -- unresolved
+
+**30,593 events | 11 users**
+
+In-app frames:
+
+```python
+# sentry/middleware/integrations/parsers/vsts.py -- get_integration_from_request()
+data = json.loads(request.body)  # CRASHES: unexpected end of data
+```
+
+**Root cause:** Azure DevOps (VSTS) sends webhook bodies that can be truncated. The JSON is valid but incomplete.
+
+**Fix:**
+
+```python
+try:
+    data = json.loads(request.body)
+except (json.JSONDecodeError, ValueError):
+    logger.warning("vsts.webhook.invalid_body", extra={"size": len(request.body)})
+    return HttpResponse(status=400)
+```
+
+### Example 6: AssertionError in auth login (SENTRY-3VFR) -- resolved
+
+**93,882 events | 158 users**
+
+In-app frames:
+
+```python
+# sentry/web/frontend/auth_login.py -- post()
+assert condition  # CRASHES -- assertion used as input validation
+```
+
+**Root cause:** Bare `assert` used for validation in the login flow. Assertions can be disabled with `python -O` and should not be used for input validation in production.
+
+**Fix:**
+
+```python
+if not condition:
+    messages.add_message(request, messages.ERROR, "Invalid request")
+    return self.redirect(get_login_url())
+```
+
+**Actual fix:** Resolved -- assertions replaced with explicit validation.
+
+### Example 7: Rule must belong to Project assertion (SENTRY-5EMS) -- resolved
+
+**8,535 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/digests/notifications.py -- build_digest()
+for rule in rules:
+    assert rule.project_id == project.id, "Rule must belong to Project"  # CRASHES
+```
+
+**Root cause:** Digest notification builder assumes all rules belong to the same project, but cross-project rule references can occur.
+
+**Fix:**
+
+```python
+for rule in rules:
+    if rule.project_id != project.id:
+        logger.warning("digest.rule_project_mismatch", extra={...})
+        continue
+```
+
+**Actual fix:** Resolved -- assertion replaced with graceful skip.
+
+### Example 8: KeyError on unregistered GitLab event type (SENTRY-3ZWW) -- ignored
+
+**45,235 events | 81 users**
+
+In-app frames:
+
+```python
+# sentry/integrations/gitlab/webhooks.py -- post()
+handler = HANDLERS[event_type]  # CRASHES: KeyError: 'Pipeline Hook'
+```
+
+**Root cause:** GitLab sends webhook events for event types (e.g., "Pipeline Hook") that are not in the `HANDLERS` dict. The code uses direct key access without checking existence.
+
+**Fix:**
+
+```python
+handler = HANDLERS.get(event_type)
+if handler is None:
+    logger.info("gitlab.webhook.unhandled_event", extra={"event_type": event_type})
+    return HttpResponse(status=204)  # Acknowledge but don't process
+```
+
+## Root Cause Analysis
+
+| Pattern                                    | Frequency | Typical Source                                |
+| ------------------------------------------ | --------- | --------------------------------------------- |
+| Assuming exactly 1 DB result               | Very High | Deleted or duplicated objects                 |
+| Missing HTTP headers in webhook handlers   | Very High | External services sending incomplete requests |
+| Tuple unpacking on variable-format strings | High      | Token/config formats varying across versions  |
+| Bare assert used as validation             | High      | Development checks left in production         |
+| Corrupt binary data (zstd, zlib)           | High      | Truncated uploads, storage corruption         |
+| JSON parsing without error handling        | High      | Truncated bodies, HTML error pages            |
+| Unregistered dict keys                     | High      | New webhook events not in handler registry    |
+| String exceeds CharField max_length        | Medium    | SDK-submitted data, user input                |
+| Invalid enum/type conversions              | Medium    | User input or config values                   |
+
+## Fix Patterns
+
+### Pattern A: Safe header and dict access
+
+```python
+# Instead of:
+token = request.META["HTTP_X_CUSTOM_HEADER"]
+handler = HANDLERS[event_type]
+
+# Use:
+token = request.META.get("HTTP_X_CUSTOM_HEADER")
+handler = HANDLERS.get(event_type)
+```
+
+### Pattern B: Safe tuple unpacking
+
+```python
+# Instead of:
+a, b, c = value.split(":")
+
+# Use:
+parts = value.split(":", 2)
+if len(parts) != 3:
+    raise ValueError(f"Invalid format: expected 3 parts, got {len(parts)}")
+a, b, c = parts
+```
+
+### Pattern C: Wrap all deserialization
+
+```python
+try:
+    data = json.loads(body)
+except (json.JSONDecodeError, ValueError):
+    return HttpResponse("Invalid JSON", status=400)
+```
+
+### Pattern D: Replace assert with explicit validation
+
+```python
+# Instead of:
+assert rule.project_id == project.id
+
+# Use:
+if rule.project_id != project.id:
+    logger.warning("rule.project_mismatch", extra={"rule_id": rule.id})
+    continue
+```
+
+### Pattern E: Validate binary data
+
+```python
+try:
+    data = zstd.decompress(raw_data)
+except zstd.ZstdError:
+    data = raw_data  # Fall back
+```
+
+### Pattern F: Safe enum conversion
+
+```python
+try:
+    level = DetectorPriorityLevel(value)
+except ValueError:
+    level = DetectorPriorityLevel.DEFAULT
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `request.META["HTTP_X_..."]` -- use `.get()` instead
+- [ ] Any `dict[key]` lookup on handler registries or maps -- use `.get()` with fallback
+- [ ] Any `a, b, c = value.split(...)` -- validate part count first
+- [ ] Any bare `assert` statement -- replace with explicit validation and error handling
+- [ ] Any `json.loads()` or `orjson.loads()` -- wrapped in try/except?
+- [ ] Any `zstd.decompress()` or decompression -- handles corrupt data?
+- [ ] Any `Model.objects.filter(...).count() != 1` followed by a raise -- handle 0 and >1 gracefully?
+- [ ] Any `int()`, `float()`, `EnumClass()` on user input -- wrapped in try/except?
+- [ ] Any webhook handler that accesses `request.body` -- handles empty/truncated bodies?
+- [ ] Any `get_or_create()` -- are field values validated against max_length first?

--- a/.agents/skills/sentry-backend-bugs/references/database-integrity.md
+++ b/.agents/skills/sentry-backend-bugs/references/database-integrity.md
@@ -1,0 +1,265 @@
+# Database Integrity Violations
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+**31 issues (22 constraint violations + 9 duplicate object collisions), 2,972,784 events, 940 affected users.** Race conditions between concurrent requests cause duplicate key violations, foreign key violations during cleanup, integer overflow on counter fields, and `MultipleObjectsReturned` from `get()` calls where uniqueness assumptions are violated.
+
+Three main sub-patterns:
+
+1. **DataError from integer overflow** -- Counter fields like `times_seen` overflow the 32-bit integer range (~2.1 billion)
+2. **IntegrityError from FK violations** -- Bulk deletion of parent records while child records still reference them
+3. **MultipleObjectsReturned** -- `get()` assumes exactly one match, but data has duplicates
+
+## Real Examples
+
+### Example 1: Integer out of range on times_seen counter (SENTRY-4E5F) -- resolved
+
+**1,753,743 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/db/models/query.py -- update()
+# SQL: UPDATE "sentry_groupedmessage" SET "times_seen" = ("sentry_groupedmessage"."times_seen" + 1)
+# DataError: integer out of range
+```
+
+Called from:
+
+```python
+# sentry/buffer/base.py -- process()
+Group.objects.filter(id=group_id).update(times_seen=F("times_seen") + count)
+```
+
+**Root cause:** The `times_seen` field on `Group` is a standard 32-bit integer. For very active groups, the counter exceeds 2,147,483,647 and the Postgres `UPDATE` fails with `DataError: integer out of range`.
+
+**Fix:**
+
+```python
+# Cap the increment to prevent overflow
+from django.db.models import F, Value
+from django.db.models.functions import Least
+
+Group.objects.filter(id=group_id).update(
+    times_seen=Least(F("times_seen") + count, Value(2_147_483_647))
+)
+```
+
+**Actual fix:** Resolved -- either the field was migrated to BigInteger or the increment is now capped.
+
+### Example 2: FK violation during MonitorCheckIn cleanup (SENTRY-5DCR) -- resolved
+
+**187,518 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/utils/query.py -- bulk_delete_objects()
+# IntegrityError: update or delete on table "sentry_monitorcheckin" violates
+# foreign key constraint "sentry_monitorincide_..." on table "sentry_monitorincident"
+```
+
+Called from:
+
+```python
+# sentry/runner/commands/cleanup.py -- multiprocess_worker()
+bulk_delete_objects(MonitorCheckIn, ...)
+```
+
+**Root cause:** The cleanup task bulk-deletes old `MonitorCheckIn` records, but `MonitorIncident` records still reference them via a foreign key. The deletion does not check for or cascade child references.
+
+**Fix:**
+
+```python
+# Delete child references first, or use CASCADE
+MonitorIncident.objects.filter(
+    checkin_id__in=checkin_ids_to_delete
+).update(checkin_id=None)  # Or delete incidents first
+bulk_delete_objects(MonitorCheckIn, ...)
+```
+
+**Actual fix:** Resolved -- cleanup now handles FK constraints before deletion.
+
+### Example 3: Date range lower bound exceeds upper bound (SENTRY-4EDG) -- ignored
+
+**753,527 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/models/groupopenperiod.py -- close_open_period()
+# DataError: range lower bound must be less than or equal to range upper bound
+# SQL: UPDATE "sentry_groupopenperiod" SET ...
+```
+
+**Root cause:** The `GroupOpenPeriod` model uses a date range field. When closing an open period, the end timestamp can be earlier than the start timestamp due to clock skew or race conditions in the event pipeline.
+
+**Fix:**
+
+```python
+def close_open_period(self, end_time):
+    if end_time < self.start_time:
+        end_time = self.start_time  # Clamp to valid range
+    self.date_range = DateTimeTZRange(self.start_time, end_time)
+    self.save()
+```
+
+### Example 4: MultipleObjectsReturned on Repository (SENTRY-3W17) -- unresolved
+
+**2,391 events | 3 users**
+
+In-app frames:
+
+```python
+# sentry_plugins/heroku/plugin.py -- set_refs()
+repo = Repository.objects.get(
+    name=repo_name, organization_id=org_id
+)  # Repository.MultipleObjectsReturned!
+```
+
+**Root cause:** The `(name, organization_id)` combination is not unique at the database level (or became non-unique through a migration gap). The code uses `get()` which raises when more than one match exists.
+
+**Fix:**
+
+```python
+repo = Repository.objects.filter(
+    name=repo_name, organization_id=org_id,
+).order_by("-date_added").first()
+if repo is None:
+    raise Repository.DoesNotExist()
+```
+
+### Example 5: SentryAppInstallation.MultipleObjectsReturned (SENTRY-5HSD) -- resolved
+
+**2,554 events | 305 users**
+
+In-app frames:
+
+```python
+# sentry/sentry_apps/services/app/impl.py -- find_installation_by_proxy_user()
+installation = SentryAppInstallation.objects.get(
+    sentry_app=sentry_app, ...
+)  # MultipleObjectsReturned: get() returned more than one -- it returned 4!
+```
+
+**Root cause:** A SentryApp can have multiple installations (e.g., installed, uninstalled, re-installed) and the query does not filter by status.
+
+**Fix:**
+
+```python
+installation = SentryAppInstallation.objects.filter(
+    sentry_app=sentry_app,
+    status=SentryAppInstallationStatus.INSTALLED,
+    ...
+).first()
+```
+
+**Actual fix:** Resolved -- query now filters by status and uses `.first()`.
+
+### Example 6: ExternalActor.MultipleObjectsReturned in notifications (SENTRY-43YW) -- resolved
+
+**2,250 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/integrations/notifications.py -- _get_channel_and_integration_by_team()
+actor = ExternalActor.objects.get(
+    team_id=team_id, integration_id=integration_id, ...
+)  # MultipleObjectsReturned!
+```
+
+**Root cause:** An ExternalActor (Slack channel mapping for a team) was duplicated, likely through a data migration or re-linking.
+
+**Fix:**
+
+```python
+actor = ExternalActor.objects.filter(
+    team_id=team_id, integration_id=integration_id, ...
+).first()
+```
+
+**Actual fix:** Resolved -- uses `.first()` instead of `.get()`.
+
+## Root Cause Analysis
+
+| Pattern                                | Frequency | Typical Trigger                               |
+| -------------------------------------- | --------- | --------------------------------------------- |
+| Integer field overflow on counters     | Very High | `times_seen` incrementing past 2^31           |
+| FK violation during bulk deletion      | High      | Cleanup tasks deleting parent without cascade |
+| Date range bound inversion             | High      | Clock skew in distributed event pipeline      |
+| get() on non-unique data               | High      | Missing DB unique constraint, data duplicates |
+| Concurrent insert on unique constraint | Medium    | Consumers processing same message             |
+| get_or_create() race                   | Medium    | Two threads call get_or_create simultaneously |
+
+## Fix Patterns
+
+### Pattern A: Cap integer fields before update
+
+```python
+from django.db.models import F, Value
+from django.db.models.functions import Least
+
+Model.objects.filter(id=pk).update(
+    counter=Least(F("counter") + increment, Value(2_147_483_647))
+)
+```
+
+### Pattern B: Handle FK constraints in bulk deletion
+
+```python
+# Delete or nullify child references first
+ChildModel.objects.filter(parent_id__in=ids_to_delete).delete()
+# Then delete parents
+ParentModel.objects.filter(id__in=ids_to_delete).delete()
+```
+
+### Pattern C: Validate range bounds
+
+```python
+if end_time < start_time:
+    end_time = start_time  # or raise ValueError
+```
+
+### Pattern D: filter().first() instead of get()
+
+```python
+# Instead of:
+obj = Model.objects.get(name=name, org=org)
+
+# Use:
+obj = Model.objects.filter(name=name, org=org).order_by("-date_added").first()
+if obj is None:
+    raise Model.DoesNotExist()
+```
+
+### Pattern E: Insert-or-fetch for concurrent inserts
+
+```python
+from django.db import IntegrityError
+
+try:
+    obj = Model.objects.create(**fields)
+except IntegrityError:
+    obj = Model.objects.get(**unique_fields)
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `F("field") + increment` on integer fields -- can the field overflow 2^31?
+- [ ] Any bulk deletion (`bulk_delete_objects`, `queryset.delete()`) -- are there FK constraints on child tables?
+- [ ] Any date range field updates -- can lower bound exceed upper bound?
+- [ ] Any `.get()` call -- is `MultipleObjectsReturned` possible? Check if the filter fields are actually unique at DB level
+- [ ] Any `.save()` on a model with unique constraints -- is `IntegrityError` handled?
+- [ ] Any `get_or_create()` in concurrent context -- wrapped in try/except `IntegrityError`?
+- [ ] Any consumer/worker code processing messages -- can the same message be processed concurrently?

--- a/.agents/skills/sentry-backend-bugs/references/integration-errors.md
+++ b/.agents/skills/sentry-backend-bugs/references/integration-errors.md
@@ -1,0 +1,212 @@
+# Integration and Webhook Handling Errors
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+**96 issues spanning SentryApp webhook errors (25 issues, 6.6M events) and API request errors (71 issues, 830K events), totaling 7,459,209 events, 8,724 affected users.** Integration webhooks, SentryApp callbacks, internal API requests, and external API interactions fail on unexpected payloads, missing state, or stale configuration. This is the highest-volume cluster because a single broken integration can generate millions of events from continuous alert rule firing.
+
+Key sub-patterns:
+
+1. **Missing service hook or installation** -- SentryApp uninstalled but webhooks still fire or alert rules still reference it
+2. **Event not eligible for webhook** -- Webhook delivery attempted for events not in the service hook's event list
+3. **Internal API errors from stale parameters** -- Internal API calls forwarding stale subscription queries that reference removed tags/metrics
+4. **JSON decode on empty or truncated body** -- Integration partner sends empty body, HTML error page, or truncated JSON
+
+## Real Examples
+
+### Example 1: SentryAppSentryError event_not_in_servicehook (SENTRY-414F) -- resolved
+
+**5,419,218 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/sentry_apps/tasks/sentry_apps.py -- send_webhooks()
+# Line 796: SentryAppSentryError: event_not_in_servicehook
+```
+
+**Root cause:** Workflow notification tasks attempt to send webhooks to SentryApps for event types that are not in the service hook's configured event list. The task checks the event type against the service hook's events but raises an error instead of silently skipping. At 5.4M events this is the single highest-volume code bug.
+
+**Fix:**
+
+```python
+def send_webhooks(sentry_app, event, ...):
+    servicehooks = ServiceHook.objects.filter(
+        application_id=sentry_app.application_id,
+    )
+    for hook in servicehooks:
+        if event_type not in hook.events:
+            continue  # Skip -- this hook doesn't subscribe to this event type
+        _deliver_webhook(hook, event, ...)
+```
+
+**Actual fix:** Resolved -- event eligibility check now skips instead of raising.
+
+### Example 2: SentryAppSentryError missing_servicehook (SENTRY-41EN) -- resolved
+
+**391,256 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/sentry_apps/tasks/sentry_apps.py -- send_webhooks()
+# Line 785: SentryAppSentryError: missing_servicehook
+```
+
+**Root cause:** A SentryApp was uninstalled (removing the ServiceHook), but existing alert rules still trigger webhook delivery tasks. The task cannot find the service hook and raises.
+
+**Fix:**
+
+```python
+servicehook = ServiceHook.objects.filter(
+    application_id=sentry_app.application_id,
+    actor_id=sentry_app.proxy_user_id,
+).first()
+if servicehook is None:
+    logger.info("sentry_app.webhook.missing_servicehook", extra={"sentry_app_id": sentry_app.id})
+    return  # App was uninstalled, skip delivery
+```
+
+**Actual fix:** Resolved -- missing hook now results in a skip rather than an error.
+
+### Example 3: Internal API error from stale metric subscription (SENTRY-55BH) -- ignored
+
+**340,371 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/incidents/charts.py -- fetch_metric_alert_events_timeseries()
+response = client.get(url, params=params)  # ApiError: status=400
+# body={'detail': ErrorDetail(string='transaction.duration is not a tag in the metrics dataset')}
+```
+
+Called from metric alert action triggers:
+
+```python
+# sentry/workflow_engine/tasks -- trigger_action()
+chart_data = fetch_metric_alert_events_timeseries(...)  # Crashes
+```
+
+**Root cause:** A metric alert subscription references `transaction.duration` which is not a valid tag in the metrics dataset (it is a string type, not numeric). When the alert fires, the action tries to render a chart by querying the internal API with the same stale parameters. The internal API returns a 400 error that is not caught.
+
+**Fix:**
+
+```python
+try:
+    chart_data = fetch_metric_alert_events_timeseries(
+        subscription_query=subscription.query, ...
+    )
+except ApiError as e:
+    logger.warning(
+        "incidents.charts.fetch_failed",
+        extra={"subscription_id": subscription.id, "error": str(e)},
+    )
+    chart_data = None  # Proceed without chart
+```
+
+### Example 4: Internal API error from apdex threshold incompatibility (SENTRY-54VM) -- resolved
+
+**65,927 events | 0 users**
+
+Same pattern as above but for apdex queries:
+
+```python
+# sentry/incidents/charts.py -- fetch_metric_alert_events_timeseries()
+# ApiError: status=400 body={'detail': 'Cannot query apdex with a threshold parameter on the metrics dataset'}
+```
+
+**Root cause:** Old alert rules created with the events dataset reference `apdex()` with threshold parameters. When these rules fire and the chart render uses the metrics dataset, the query is incompatible.
+
+**Actual fix:** Resolved -- chart rendering now handles API errors gracefully.
+
+## Root Cause Analysis
+
+| Pattern                                | Frequency | Typical Source                                                            |
+| -------------------------------------- | --------- | ------------------------------------------------------------------------- |
+| Event not in service hook event list   | Very High | Workflow tasks sending webhooks for all events regardless of subscription |
+| Missing service hook (app uninstalled) | Very High | Alert rules survive SentryApp uninstallation                              |
+| Stale metric subscription parameters   | Very High | Dataset migration (events->metrics) leaving incompatible queries          |
+| Internal API 400 errors not caught     | High      | Chart rendering in alert action triggers                                  |
+| Empty webhook body                     | High      | MS Teams health pings, provider errors                                    |
+| Truncated JSON payload                 | High      | VSTS large payloads, network timeouts                                     |
+| HTML instead of JSON                   | Medium    | OAuth errors, rate limiting, captchas                                     |
+
+## Fix Patterns
+
+### Pattern A: Check event eligibility before webhook delivery
+
+```python
+def send_webhooks(sentry_app, event_type, ...):
+    hooks = ServiceHook.objects.filter(application_id=sentry_app.application_id)
+    for hook in hooks:
+        if event_type not in hook.events:
+            continue  # Not subscribed to this event type
+        _deliver(hook, ...)
+```
+
+### Pattern B: Handle missing installations gracefully
+
+```python
+hook = ServiceHook.objects.filter(
+    application_id=app.application_id,
+    actor_id=app.proxy_user_id,
+).first()
+if hook is None:
+    return  # App uninstalled
+```
+
+### Pattern C: Catch internal API errors in action triggers
+
+```python
+try:
+    chart_data = fetch_metric_alert_events_timeseries(...)
+except ApiError:
+    chart_data = None  # Send alert without chart attachment
+```
+
+### Pattern D: Validate subscription query compatibility before use
+
+```python
+def validate_subscription_query(subscription):
+    """Check if the subscription query is compatible with the current dataset."""
+    try:
+        build_query(subscription.query, dataset=subscription.dataset)
+    except (IncompatibleMetricsQuery, InvalidSearchQuery):
+        subscription.mark_invalid()
+        return False
+    return True
+```
+
+### Pattern E: Safe JSON parsing for webhooks
+
+```python
+def parse_webhook_body(request):
+    if not request.body:
+        return {}
+    try:
+        return orjson.loads(request.body)
+    except orjson.JSONDecodeError:
+        logger.warning("webhook.invalid_json", extra={"path": request.path})
+        return None
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any SentryApp webhook delivery -- does it check event eligibility against the service hook's event list?
+- [ ] Any ServiceHook or SentryAppInstallation lookup in webhook tasks -- is DoesNotExist handled?
+- [ ] Any internal API call in metric alert action triggers -- is ApiError caught?
+- [ ] Any `fetch_metric_alert_events_timeseries()` call -- does it handle 400 responses?
+- [ ] Any `json.loads()` on `request.body` in webhook handlers -- is JSONDecodeError caught?
+- [ ] Any external API response parsed as JSON -- is the status code and content-type checked?
+- [ ] Any subscription query forwarded to internal API -- has compatibility been validated?
+- [ ] Any alert rule referencing a SentryApp -- what happens when the app is uninstalled?

--- a/.agents/skills/sentry-backend-bugs/references/missing-records.md
+++ b/.agents/skills/sentry-backend-bugs/references/missing-records.md
@@ -1,0 +1,195 @@
+# Missing Records and Stale References
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+The most impactful code-level bug category in the Sentry backend: **81 issues, 1,403,592 events, 10,727 affected users**. The pattern is consistent -- code calls `.get()` on a Django model assuming the record exists, but it has been deleted, merged, or never created.
+
+The most common sources of stale IDs:
+
+1. **Snuba/ClickHouse query results** -- Snuba stores issue IDs, project IDs, and group IDs that may be deleted from Postgres before Snuba data expires
+2. **Workflow engine references** -- Detectors, subscriptions, and alert rules reference objects deleted asynchronously
+3. **Integration state** -- SentryAppInstallation, ServiceHook, or ExternalActor deleted while alert rules still reference them
+4. **Cross-silo references** -- Region silo holds IDs that reference control silo objects (or vice versa) that may be deleted asynchronously
+5. **Cached foreign keys** -- A ProjectKey cached in Redis still references a `project_id` for a deleted project
+6. **Monitor/cron references** -- Environment objects referenced by monitors that may be deleted
+
+## Real Examples
+
+### Example 1: Detector.DoesNotExist in workflow engine (SENTRY-5D9J) -- resolved
+
+**610,142 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/workflow_engine/processors/detector.py -- _get_detector_for_event()
+def _get_detector_for_event(event_data):
+    detector_id = event_data.get("detector_id")
+    try:
+        return Detector.objects.get(id=detector_id)  # CRASHES HERE
+    except Detector.DoesNotExist:
+        raise  # Re-raises without handling
+```
+
+**Root cause:** Workflow events reference detector IDs that have been deleted. The `process_workflows_event` task receives events from a queue with detector IDs, but detectors can be deleted between event creation and processing.
+
+**Fix pattern:**
+
+```python
+detector = Detector.objects.filter(id=detector_id).first()
+if detector is None:
+    logger.warning("detector.not_found", extra={"detector_id": detector_id})
+    return  # Skip processing for deleted detectors
+```
+
+**Actual fix:** Resolved -- detector lookup now handles the DoesNotExist case gracefully.
+
+### Example 2: Environment.DoesNotExist in monitor consumer (SENTRY-3VDX) -- resolved
+
+**146,432 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/monitors/models.py -- get_environment()
+def get_environment(self):
+    return Environment.objects.get(id=self.environment_id)  # CRASHES HERE
+```
+
+Called from:
+
+```python
+# sentry/monitors/logic/incident_occurrence.py -- send_incident_occurrence()
+environment = monitor.get_environment()
+```
+
+**Root cause:** The monitor checkin references an environment that has been deleted. The `Environment.objects.get()` call has no `DoesNotExist` handler.
+
+**Fix pattern:**
+
+```python
+def get_environment(self):
+    try:
+        return Environment.objects.get(id=self.environment_id)
+    except Environment.DoesNotExist:
+        return None
+```
+
+**Actual fix:** Resolved -- environment lookup now returns None for deleted environments.
+
+### Example 3: Subscription.DoesNotExist in billing tasks (SENTRY-4DEQ) -- resolved
+
+**72,700 events | 0 users**
+
+In-app frames:
+
+```python
+# getsentry/billing/tasks/usagebuffer.py -- flush_usage_buffer()
+subscription = Subscription.objects.get(id=subscription_id)  # CRASHES HERE
+```
+
+**Root cause:** Billing usage buffer tasks reference subscription IDs that have been cancelled/deleted between task scheduling and execution.
+
+**Fix pattern:**
+
+```python
+try:
+    subscription = Subscription.objects.get(id=subscription_id)
+except Subscription.DoesNotExist:
+    logger.info("subscription.not_found", extra={"subscription_id": subscription_id})
+    return  # Nothing to flush for a deleted subscription
+```
+
+**Actual fix:** Resolved -- task now handles missing subscriptions gracefully.
+
+## Root Cause Analysis
+
+| Pattern                                         | Frequency | Typical Source                                  |
+| ----------------------------------------------- | --------- | ----------------------------------------------- |
+| Workflow engine detector/rule deleted           | Very High | `Detector.objects.get(id=event.detector_id)`    |
+| Snuba ID references deleted Postgres record     | High      | `Group.objects.get(id=event["issue.id"])`       |
+| Billing/subscription object deleted             | High      | `Subscription.objects.get(id=sub_id)`           |
+| Environment deleted while monitors reference it | High      | `Environment.objects.get(id=monitor.env_id)`    |
+| Integration uninstalled while rules active      | High      | Alert rules referencing deleted SentryApp       |
+| Cached FK target deleted                        | Medium    | `get_from_cache(id=fk_id)` after parent deleted |
+| Cross-silo object deleted asynchronously        | Medium    | Region silo references control silo object      |
+
+## Fix Patterns
+
+### Pattern A: Graceful skip for async task processing
+
+When a celery task or consumer processes an event referencing an object by ID, handle the case where the object was deleted between event creation and processing.
+
+```python
+def process_workflow_event(event_data):
+    detector = Detector.objects.filter(id=event_data["detector_id"]).first()
+    if detector is None:
+        logger.info("detector.deleted", extra={"detector_id": event_data["detector_id"]})
+        return
+    # proceed with detector
+```
+
+### Pattern B: Filter query instead of get
+
+When you need a single object that might not exist, use `.filter().first()` instead of `.get()`.
+
+```python
+# Instead of:
+project = Project.objects.get(id=key.project_id)
+
+# Use:
+project = Project.objects.filter(id=key.project_id).first()
+if project is None:
+    return handle_missing_project()
+```
+
+### Pattern C: Batch lookups with graceful skip
+
+When processing a list of items, prefetch and skip missing records instead of crashing the entire batch.
+
+```python
+# Instead of:
+for event in events:
+    group = Group.objects.get(id=event["issue.id"])  # Crashes on missing
+
+# Use:
+group_ids = [e["issue.id"] for e in events]
+groups = {g.id: g for g in Group.objects.filter(id__in=group_ids)}
+for event in events:
+    group = groups.get(event["issue.id"])
+    if group is None:
+        continue
+    process(group)
+```
+
+### Pattern D: Cascade cleanup on deletion
+
+When deleting a parent object, ensure downstream references are cleaned up.
+
+```python
+# When deleting an environment:
+Environment.objects.filter(id=env_id).delete()
+# Also update monitors that reference this environment
+Monitor.objects.filter(environment_id=env_id).update(environment_id=None)
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `.get()` call on a Django model manager -- does it have a `DoesNotExist` handler?
+- [ ] Any `.get_from_cache()` call -- does it handle the case where the cached FK target is deleted?
+- [ ] Any code that uses IDs from Snuba, Redis, Kafka, or task queues to look up Postgres records
+- [ ] Any code in workflow engine that looks up Detectors, AlertRuleWorkflows, or Subscriptions by ID
+- [ ] Any code in monitor/cron consumers that looks up Environments or MonitorCheckIns
+- [ ] Any code in billing tasks that looks up Subscriptions by ID
+- [ ] Chained lookups: first `.get()` succeeds, second `.get()` on a related object fails
+- [ ] Batch serialization code that calls `.get()` in a loop without try/except

--- a/.agents/skills/sentry-backend-bugs/references/null-and-type-errors.md
+++ b/.agents/skills/sentry-backend-bugs/references/null-and-type-errors.md
@@ -1,0 +1,257 @@
+# Null Reference and Type Errors
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+A high-impact bug category spanning **43 issues across TypeError and AttributeError, 767,662 events, 2,919 affected users**. Code assumes a value has a specific type or is non-None, but runtime data violates that assumption. These are particularly insidious because they often only trigger for specific data shapes in production.
+
+Common shapes:
+
+1. **None where dict expected** -- A serializer or function returns None instead of a dict, then caller does `result["key"] = value`
+2. **Int where iterable expected** -- A project option or config value is stored as an int but code calls `list(value)` or iterates over it
+3. **Missing attribute on request** -- Code accesses `request.auth` on a Django `WSGIRequest` that has not gone through DRF authentication
+4. **Non-string dict keys** -- Payload dicts with integer keys passed to JSON serializers that require string keys
+5. **Wrong return type from option/config** -- `project.get_option()` returns a different type than expected
+6. **Str where object expected** -- Code receives a string ID where it expects a model instance with `.id` attribute
+
+## Real Examples
+
+### Example 1: Dict key must be str in data forwarding (SENTRY-5HY1) -- resolved
+
+**596,437 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/integrations/data_forwarding/amazon_sqs/forwarder.py -- forward_event()
+s3_put_object(
+    Bucket=s3_bucket,
+    Body=orjson.dumps(payload, option=orjson.OPT_UTC_Z).decode(),  # CRASHES HERE
+    Key=key,
+)
+```
+
+**Root cause:** The event payload dict contains non-string keys (likely integer keys from event data). `orjson.dumps()` requires all dict keys to be strings, unlike `json.dumps()` which auto-converts them.
+
+**Fix:**
+
+```python
+# Ensure all keys are strings before serialization
+def _stringify_keys(obj):
+    if isinstance(obj, dict):
+        return {str(k): _stringify_keys(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_stringify_keys(item) for item in obj]
+    return obj
+
+payload = _stringify_keys(payload)
+Body = orjson.dumps(payload, option=orjson.OPT_UTC_Z).decode()
+```
+
+**Actual fix:** Resolved -- payload keys are now converted to strings before serialization.
+
+### Example 2: Int object is not iterable in filter config (SENTRY-5JS8) -- unresolved
+
+**60,654 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/relay/config/__init__.py -- _filter_option_to_config_setting()
+if setting == "1":
+    ret_val["options"] = ["default"]
+else:
+    # new style filter, per legacy browser type handling
+    ret_val["options"] = list(setting)   # CRASHES HERE when setting is an int
+```
+
+**Root cause:** `project.get_option("filters:legacy-browsers")` returned an integer value instead of a string. The code calls `list(setting)` which works for strings (produces a list of characters) but throws `TypeError` for ints. This is a data shape assumption -- the option was stored as an int by an older code path.
+
+**Fix:**
+
+```python
+if setting == "1" or setting == 1:
+    ret_val["options"] = ["default"]
+elif isinstance(setting, str):
+    ret_val["options"] = list(setting)
+elif isinstance(setting, (list, tuple)):
+    ret_val["options"] = list(setting)
+else:
+    ret_val["options"] = ["default"]
+```
+
+### Example 3: NoneType item assignment in event response (SENTRY-3Z3P) -- unresolved
+
+**32,246 events | 158 users**
+
+In-app frames:
+
+```python
+# sentry/issues/endpoints/project_event_details.py -- wrap_event_response()
+event_data["nextEventID"] = next_event_id      # CRASHES HERE
+event_data["previousEventID"] = prev_event_id
+return event_data
+```
+
+**Root cause:** `event_data` is None. The event serializer returned None instead of a dict (likely because the event data was missing or corrupt), but `wrap_event_response` assumes it always gets a dict back.
+
+**Fix:**
+
+```python
+event_data = serialize_event(event, ...)
+if event_data is None:
+    raise NotFound("Event data could not be serialized")
+
+event_data["nextEventID"] = next_event_id
+event_data["previousEventID"] = prev_event_id
+return event_data
+```
+
+### Example 4: WSGIRequest has no attribute 'auth' (SENTRY-3VXH) -- unresolved
+
+**18,241 events | 47 users**
+
+In-app frames:
+
+```python
+# sentry/middleware/__init__.py -- is_frontend_request()
+return bool(request.COOKIES) and request.auth is None   # CRASHES HERE
+```
+
+**Root cause:** `is_frontend_request()` is called from middleware that runs on all requests, including Django views that do not go through DRF authentication. Plain `WSGIRequest` objects do not have an `auth` attribute.
+
+**Fix:**
+
+```python
+def is_frontend_request(request):
+    return bool(request.COOKIES) and getattr(request, 'auth', None) is None
+```
+
+### Example 5: 'str' object has no attribute 'id' in release search (SENTRY-548A / SENTRY-3Z3X)
+
+**5,250 combined events | 283 users** (SENTRY-3Z3X resolved, SENTRY-548A unresolved)
+
+In-app frames:
+
+```python
+# sentry/search/utils.py -- _run_latest_release_query()
+releases = Release.objects.filter(...)
+return [r.id for r in releases]  # Works
+
+# But later in get_latest_release():
+return [r.id for r in results]  # CRASHES when results contains strings
+```
+
+**Root cause:** The `_run_latest_release_query` function can return a list of strings (release version strings) instead of Release objects in certain code paths. Callers then access `.id` on strings.
+
+**Fix:**
+
+```python
+# Ensure consistent return type
+results = _run_latest_release_query(...)
+if results and isinstance(results[0], str):
+    # Convert version strings to Release objects
+    releases = Release.objects.filter(version__in=results, ...)
+    return [r.id for r in releases]
+```
+
+## Root Cause Analysis
+
+| Pattern                                    | Frequency | Trigger                                      |
+| ------------------------------------------ | --------- | -------------------------------------------- |
+| Non-string dict keys in JSON serialization | Very High | Event payloads with integer keys             |
+| Serializer returns None instead of dict    | High      | Corrupt or missing event data                |
+| Project option stored as wrong type        | High      | Legacy data, migration gaps                  |
+| Missing attribute on request object        | Medium    | Non-DRF views hitting DRF-aware middleware   |
+| String where object expected               | Medium    | Inconsistent return types between code paths |
+| NoneType iteration or subscript            | Medium    | Optional values used without guards          |
+| Config value type mismatch                 | Medium    | Options set by old code paths                |
+
+## Fix Patterns
+
+### Pattern A: Guard before subscript assignment
+
+```python
+# Instead of:
+data["key"] = value
+
+# Use:
+if data is not None:
+    data["key"] = value
+# Or raise early:
+if data is None:
+    raise ValueError("Expected dict, got None")
+```
+
+### Pattern B: Type-check before iteration
+
+```python
+# Instead of:
+items = list(value)
+
+# Use:
+if isinstance(value, str):
+    items = list(value)
+elif isinstance(value, (list, tuple)):
+    items = list(value)
+elif isinstance(value, int):
+    items = [str(value)]
+else:
+    items = []
+```
+
+### Pattern C: getattr for optional request attributes
+
+```python
+# Instead of:
+request.auth
+
+# Use:
+getattr(request, 'auth', None)
+```
+
+### Pattern D: Ensure consistent return types
+
+```python
+# If a function can return different types, normalize at the boundary:
+def get_items(query):
+    results = _internal_query(query)
+    if not results:
+        return []
+    # Ensure we always return model instances, not strings
+    if isinstance(results[0], str):
+        return Model.objects.filter(name__in=results)
+    return results
+```
+
+### Pattern E: Stringify dict keys before JSON serialization
+
+```python
+# When using orjson (strict about key types):
+def safe_serialize(data):
+    if isinstance(data, dict):
+        return {str(k): safe_serialize(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [safe_serialize(item) for item in data]
+    return data
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `result["key"] = ...` -- can `result` be None?
+- [ ] Any `list(value)` or `for x in value:` -- can `value` be an int, None, or unexpected type?
+- [ ] Any `request.auth`, `request.user`, or other DRF-specific attributes -- is this code reachable from non-DRF views?
+- [ ] Any `project.get_option()` or `organization.get_option()` return value used without type checking
+- [ ] Any function that returns different types (dict or None, str or object) -- do all callers handle both?
+- [ ] Any `orjson.dumps()` call -- are all dict keys guaranteed to be strings?
+- [ ] Middleware or utility functions called on all request paths -- do they assume DRF request attributes?
+- [ ] Any `.id` attribute access on a variable that could be a string instead of a model instance

--- a/.agents/skills/sentry-backend-bugs/references/query-validation.md
+++ b/.agents/skills/sentry-backend-bugs/references/query-validation.md
@@ -1,0 +1,205 @@
+# Query and Subscription Validation Errors
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+The highest-event-count cluster combining metric subscription errors and search query validation: **170 issues, 5,036,970 events, 2,598 affected users**. Snuba subscriptions and search queries reference tags, fields, or functions that are invalid for the target dataset. These fire continuously -- a single bad subscription generates thousands of events per hour.
+
+Two main sub-patterns:
+
+1. **Metric subscription query errors (113 issues, 3,035,640 events)** -- SubscriptionError when creating or updating alert subscriptions in Snuba with incompatible query parameters
+2. **Search query validation errors (57 issues, 2,001,330 events)** -- InvalidSearchQuery from user-provided or subscription-stored query filters referencing invalid values, deleted issues, or unresolved tags
+
+## Real Examples
+
+### Example 1: SubscriptionError -- tag not in metrics dataset (SENTRY-413P) -- resolved
+
+**531,826 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/search/events/builder/metrics.py -- resolve_tag_key()
+# IncompatibleMetricsQuery: customerType is not a tag in the metrics dataset
+
+# Wrapped and re-raised as:
+# sentry/snuba/tasks.py -- _create_in_snuba()
+# SubscriptionError: customerType is not a tag in the metrics dataset
+```
+
+**Root cause:** A metric alert subscription uses `customerType` as a filter tag, but this tag does not exist in the metrics dataset. The subscription was created when the events dataset was the default, which allowed arbitrary tag names. After migration to the metrics dataset, only known metric tags are valid.
+
+**Fix:**
+
+```python
+def _create_in_snuba(subscription):
+    try:
+        snuba_query = build_snuba_query(subscription)
+        result = _snuba_pool.submit(snuba_query)
+    except (IncompatibleMetricsQuery, InvalidSearchQuery) as e:
+        logger.warning(
+            "subscription.incompatible_query",
+            extra={"subscription_id": subscription.id, "error": str(e)},
+        )
+        subscription.update(status=QuerySubscription.Status.DISABLED.value)
+        return  # Disable instead of crash
+```
+
+**Actual fix:** Resolved -- subscription creation now handles incompatible queries.
+
+### Example 2: SubscriptionError -- invalid function parameter type (SENTRY-4DAA) -- resolved
+
+**294,145 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/search/eap/resolver.py -- resolve_function()
+# InvalidSearchQuery: transaction.duration is invalid for parameter 1 in p95.
+# Its a string type field, but it must be one of: ...
+
+# Re-raised as:
+# sentry/snuba/tasks.py -- _create_in_snuba()
+# SubscriptionError: transaction.duration is invalid for parameter 1 in p95.
+```
+
+**Root cause:** An alert subscription uses `p95(transaction.duration)` on the metrics dataset. In the metrics dataset, `transaction.duration` is stored as a string (tag), not a numeric field, making it incompatible with aggregate functions like `p95()`.
+
+**Fix:** Same as Example 1 -- validate function parameter types against the dataset schema before subscription creation.
+
+**Actual fix:** Resolved -- subscription creation validates field types.
+
+### Example 3: SubscriptionError -- apdex threshold incompatibility (SENTRY-413N) -- resolved
+
+**276,062 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/search/events/datasets/metrics.py -- _resolve_apdex_function()
+# IncompatibleMetricsQuery: Cannot query apdex with a threshold parameter on the metrics dataset
+
+# Re-raised as:
+# sentry/snuba/tasks.py -- _create_in_snuba()
+# SubscriptionError: Cannot query apdex with a threshold parameter on the metrics dataset
+```
+
+**Root cause:** Old alert rules use `apdex()` with a threshold parameter (e.g., `apdex(300)`). The metrics dataset does not support per-query thresholds for apdex -- it uses the project-level threshold instead.
+
+**Actual fix:** Resolved -- apdex function resolution now handles threshold incompatibility.
+
+### Example 4: InvalidSearchQuery -- deleted issue short ID in subscription (SENTRY-3TYF) -- resolved
+
+**1,221,510 events | 0 users**
+
+In-app frames:
+
+```python
+# sentry/search/events/datasets/discover.py -- _issue_filter_converter()
+def _issue_filter_converter(search_filter, ...):
+    # Resolves short IDs like 'PROJ-ABC' to Group IDs
+    groups = Group.objects.by_qualified_short_id_bulk(...)
+    # Group.DoesNotExist raised when short ID references a deleted project
+
+# Re-raised as:
+# InvalidSearchQuery: Invalid value '['PROJ-ABC']' for 'issue:' filter
+```
+
+Called from the subscription consumer:
+
+```python
+# sentry/incidents/utils/process_update_helpers.py -- get_aggregation_value()
+```
+
+**Root cause:** Metric alert subscriptions stored query strings containing issue short IDs (e.g., `issue:PROJ-ABC`). When the referenced project or issue is deleted, the `_issue_filter_converter` tries to resolve the short ID via `by_qualified_short_id_bulk()`, which calls `Group.objects.get()` and raises `DoesNotExist`. This is wrapped as `InvalidSearchQuery`.
+
+This is the single highest-event resolved issue in the search query cluster at 1.2M events -- the subscription fires continuously because the issue is permanently deleted and the query can never succeed.
+
+**Fix:**
+
+```python
+def _issue_filter_converter(search_filter, ...):
+    try:
+        groups = Group.objects.by_qualified_short_id_bulk(org_id, short_ids)
+    except Group.DoesNotExist:
+        # Short ID references a deleted project/issue
+        return Condition(Column("group_id"), Op.IN, [])  # Empty result set
+```
+
+**Actual fix:** Resolved -- issue filter converter now handles deleted short IDs gracefully.
+
+## Root Cause Analysis
+
+| Pattern                                     | Frequency | Typical Trigger                                       |
+| ------------------------------------------- | --------- | ----------------------------------------------------- |
+| Custom tag not in metrics dataset           | Very High | Subscriptions migrated from events to metrics dataset |
+| String field used as numeric in aggregation | Very High | `p95(transaction.duration)` where duration is a tag   |
+| Apdex with threshold on metrics dataset     | High      | Old alert rules with per-query thresholds             |
+| Deleted issue short ID in subscription      | Very High | Subscriptions referencing deleted projects/issues     |
+| Unresolved tag keys in search               | Medium    | Custom tags not registered in the dataset             |
+| Invalid filter values                       | Medium    | User-provided values that don't match expected format |
+
+## Fix Patterns
+
+### Pattern A: Validate subscription queries before creation
+
+```python
+def create_subscription(query, dataset):
+    try:
+        # Dry-run the query to validate it
+        build_snuba_query(query, dataset=dataset)
+    except (IncompatibleMetricsQuery, InvalidSearchQuery) as e:
+        raise ValidationError(f"Invalid subscription query: {e}")
+```
+
+### Pattern B: Handle incompatible queries at subscription processing time
+
+```python
+def process_subscription_update(subscription, update):
+    try:
+        result = execute_query(subscription.query, dataset=subscription.dataset)
+    except (IncompatibleMetricsQuery, InvalidSearchQuery):
+        subscription.update(status=QuerySubscription.Status.DISABLED)
+        logger.warning("subscription.disabled_incompatible_query", ...)
+        return
+```
+
+### Pattern C: Graceful DoesNotExist in filter converters
+
+```python
+def _issue_filter_converter(search_filter, ...):
+    try:
+        groups = Group.objects.by_qualified_short_id_bulk(org_id, short_ids)
+    except Group.DoesNotExist:
+        return Condition(Column("group_id"), Op.IN, [])  # Empty result
+```
+
+### Pattern D: Validate tag existence before query
+
+```python
+def resolve_tag_key(tag_name, dataset):
+    if tag_name not in get_valid_tags(dataset):
+        raise InvalidSearchQuery(
+            f"'{tag_name}' is not a valid tag for the {dataset} dataset"
+        )
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `_create_in_snuba` or subscription creation -- does it validate query compatibility with the target dataset?
+- [ ] Any `resolve_tag_key()` call -- does it handle tags that don't exist in the dataset?
+- [ ] Any `resolve_function()` or `resolve_snql_function()` -- does it validate parameter types?
+- [ ] Any `_issue_filter_converter` or `by_qualified_short_id_bulk()` -- does it handle deleted groups?
+- [ ] Any alert subscription that stores a raw query string -- is the query re-validated on use?
+- [ ] Any `build_snuba_query()` for subscription processing -- does it catch `IncompatibleMetricsQuery`?
+- [ ] Any code that passes user-provided filters to Snuba -- are the filter values validated?
+- [ ] Any subscription update task -- what happens when the subscription query is no longer valid?

--- a/.agents/skills/sentry-backend-bugs/references/url-safety.md
+++ b/.agents/skills/sentry-backend-bugs/references/url-safety.md
@@ -1,0 +1,178 @@
+# URL Safety and Routing Errors
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Real Examples](#real-examples)
+- [Root Cause Analysis](#root-cause-analysis)
+- [Fix Patterns](#fix-patterns)
+- [Detection Checklist](#detection-checklist)
+
+## Overview
+
+**15 issues, 126,318 events, 3,602 affected users.** Redirect URLs that exceed safety limits, missing URL schemes in external URLs, and routing mismatches from URL construction.
+
+Three sub-patterns:
+
+1. **DisallowedRedirect (8 issues, 98,940 events)** -- Redirect URLs exceeding the 2048-character safety limit, all resolved
+2. **MissingSchema (5 issues, 25,548 events)** -- External URLs stored without a scheme (`https://`), causing requests library to fail
+3. **NoReverseMatch (2 issues, 1,830 events)** -- Django URL routing failures from invalid parameters
+
+## Real Examples
+
+### Example 1: Unsafe redirect exceeding 2048 characters (SENTRY-5D1A) -- resolved
+
+**49,799 events | 897 users**
+
+In-app frames:
+
+```python
+# sentry/middleware/access_log.py -- middleware()
+# -> sentry/middleware/subdomain.py -- __call__()
+# DisallowedRedirect: Unsafe redirect exceeding 2048 characters
+```
+
+**Root cause:** Users access Sentry URLs with very long query strings or path segments (often from malformed links, bots, or security scanners). The middleware chain attempts to redirect these requests (e.g., subdomain redirect, customer domain redirect, marketing landing redirect) but the resulting redirect URL exceeds the 2048-character safety limit. The `DisallowedRedirect` exception is thrown by Sentry's redirect safety middleware.
+
+**Fix:**
+
+```python
+def safe_redirect(url, max_length=2048):
+    if len(url) > max_length:
+        # Truncate to base URL without query string
+        parsed = urlparse(url)
+        base_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        if len(base_url) > max_length:
+            return HttpResponseBadRequest("URL too long")
+        return redirect(base_url)
+    return redirect(url)
+```
+
+**Actual fix:** Resolved -- all 8 DisallowedRedirect issues were fixed. The redirect paths now handle overly long URLs gracefully.
+
+### Example 2: Unsafe redirect in customer domain middleware (SENTRY-5D1G) -- resolved
+
+**29,386 events | 81 users**
+
+In-app frames:
+
+```python
+# sentry/middleware/customer_domain.py -- __call__()
+# DisallowedRedirect: Unsafe redirect exceeding 2048 characters
+```
+
+**Root cause:** The customer domain middleware redirects requests from `org.sentry.io` paths to canonical URLs. When the original URL has a very long path or query string, the redirect URL exceeds 2048 characters.
+
+**Actual fix:** Resolved -- middleware now validates redirect URL length.
+
+### Example 3: MissingSchema on empty external URL (SENTRY-5E3V)
+
+**13,965 events | 95 users** (resolved)
+
+```python
+# sentry/net/http.py
+# MissingSchema: Invalid URL '': No scheme supplied. Perhaps you meant https://?
+```
+
+**Root cause:** An integration or webhook configuration stores an empty string as the target URL. When the code attempts to make an HTTP request to this URL, the `requests` library raises `MissingSchema`.
+
+**Fix:**
+
+```python
+if not url or not url.startswith(("http://", "https://")):
+    raise ValueError(f"Invalid URL: {url!r}")
+```
+
+### Example 4: NoReverseMatch in URL construction (SENTRY-5G3B) -- unresolved
+
+**1,280 events | 120 users**
+
+In-app frames:
+
+```python
+# django/urls/resolvers.py
+# NoReverseMatch: Reverse for 'sentry-api-0-organization-group-group-events' with
+# keyword arguments {'organization_id_or_slug': '...', ...} not found
+```
+
+**Root cause:** URL construction uses `reverse()` with keyword arguments that do not match the URL pattern. This can happen when URL patterns are changed but callers are not updated, or when the URL parameter values contain characters that don't match the pattern regex.
+
+**Fix:**
+
+```python
+try:
+    url = reverse("sentry-api-0-organization-group-group-events", kwargs=kwargs)
+except NoReverseMatch:
+    logger.warning("url.reverse_failed", extra={"url_name": url_name, "kwargs": kwargs})
+    url = None  # Or construct manually
+```
+
+## Root Cause Analysis
+
+| Pattern                                 | Frequency | Typical Trigger                                   |
+| --------------------------------------- | --------- | ------------------------------------------------- |
+| Redirect URL too long                   | Very High | Bots, security scanners, malformed inbound links  |
+| Empty URL in integration config         | High      | Unconfigured or partially configured integrations |
+| URL without scheme                      | Medium    | User-provided URLs missing `https://` prefix      |
+| NoReverseMatch from URL pattern changes | Low       | URL refactoring without updating all callers      |
+
+## Fix Patterns
+
+### Pattern A: Validate redirect URL length
+
+```python
+def safe_redirect(request, url, max_length=2048):
+    if len(url) > max_length:
+        # Strip query string first
+        parsed = urlparse(url)
+        url = urlunparse(parsed._replace(query="", fragment=""))
+        if len(url) > max_length:
+            return HttpResponseBadRequest("URL too long")
+    return redirect(url)
+```
+
+### Pattern B: Validate URLs before HTTP requests
+
+```python
+def validate_url(url):
+    if not url:
+        raise ValueError("Empty URL")
+    if not url.startswith(("http://", "https://")):
+        raise ValueError(f"Missing URL scheme: {url!r}")
+    return url
+```
+
+### Pattern C: Safe URL reversal
+
+```python
+try:
+    url = reverse(url_name, kwargs=kwargs)
+except NoReverseMatch:
+    logger.warning("url.no_reverse_match", extra={"name": url_name})
+    url = fallback_url
+```
+
+### Pattern D: Truncate query strings in redirects
+
+```python
+def redirect_with_length_check(url):
+    if len(url) <= 2048:
+        return redirect(url)
+    # Try without query string
+    parsed = urlparse(url)
+    base = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    if len(base) <= 2048:
+        return redirect(base)
+    return HttpResponseBadRequest()
+```
+
+## Detection Checklist
+
+Scan the code for these patterns:
+
+- [ ] Any `redirect()` or `HttpResponseRedirect()` -- is the URL length validated?
+- [ ] Any middleware that constructs redirect URLs from the request path -- can the path be excessively long?
+- [ ] Any HTTP request to a URL stored in the database -- is the URL validated for non-empty and proper scheme?
+- [ ] Any `reverse()` call -- is `NoReverseMatch` handled?
+- [ ] Any URL construction from user input (org slugs, project slugs) -- are invalid characters handled?
+- [ ] Any redirect chain (middleware -> middleware) -- does each step validate the URL?

--- a/.agents/skills/sentry-javascript-bugs/README.md
+++ b/.agents/skills/sentry-javascript-bugs/README.md
@@ -1,0 +1,3 @@
+Vendored from https://github.com/getsentry/warden-sentry (.agents/skills/sentry-javascript-bugs/).
+
+If this skill needs updating, pull changes from that repository.

--- a/.agents/skills/sentry-javascript-bugs/SKILL.md
+++ b/.agents/skills/sentry-javascript-bugs/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: sentry-javascript-bugs
+description: 'Sentry JavaScript frontend bug pattern review based on real production errors. Use when reviewing React/TypeScript frontend code for common bug patterns. Trigger keywords: "javascript bug review", "frontend errors", "react error patterns", "sentry frontend bugs".'
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Sentry JavaScript Frontend Bug Pattern Review
+
+Find bugs in Sentry frontend code by checking for the patterns that cause real production errors.
+
+This skill encodes patterns from 428 real production issues (201 resolved, 130 ignored, 97 unresolved) generating over 524,000 error events across 93,000+ affected users. These are not theoretical risks -- they are the actual bugs that ship most often, with known fixes from resolved issues.
+
+## Scope
+
+You receive scoped code chunks from Warden's diff pipeline. Each chunk is a changed hunk (or coalesced group of nearby hunks) with surrounding context.
+
+1. Analyze the chunk against the pattern checks below.
+2. Use `Read` and `Grep` to trace data flow beyond the chunk when needed — follow component props, hook return values, API response shapes.
+3. Report only **HIGH** and **MEDIUM** confidence findings.
+
+| Confidence | Criteria                                                              | Action                       |
+| ---------- | --------------------------------------------------------------------- | ---------------------------- |
+| **HIGH**   | Traced the code path, confirmed the pattern matches a known bug class | Report with fix              |
+| **MEDIUM** | Pattern is present but context may mitigate it                        | Report as needs verification |
+| **LOW**    | Theoretical or mitigated elsewhere                                    | Do not report                |
+
+## Step 1: Classify the Code
+
+Determine what you are reviewing and load the relevant reference.
+
+| Code Type                                                               | Load Reference                                               |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Null/undefined property access, optional chaining, object destructuring | `${CLAUDE_SKILL_ROOT}/references/null-reference-errors.md`   |
+| Dashboard widgets, chart visualization, widget URL generation           | `${CLAUDE_SKILL_ROOT}/references/dashboard-widget-errors.md` |
+| Trace views, span details, trace tree rendering                         | `${CLAUDE_SKILL_ROOT}/references/trace-view-errors.md`       |
+| API calls, response handling, error states, fetch wrappers              | `${CLAUDE_SKILL_ROOT}/references/api-response-handling.md`   |
+| React hooks, context providers, render loops, component lifecycle       | `${CLAUDE_SKILL_ROOT}/references/react-lifecycle-errors.md`  |
+| AI Insights, LLM prompt parsing, gen_ai span data                       | `${CLAUDE_SKILL_ROOT}/references/ai-insights-parsing.md`     |
+| Array operations, date/time values, numeric formatting                  | `${CLAUDE_SKILL_ROOT}/references/range-and-bounds-errors.md` |
+
+If the code spans multiple categories, load all relevant references.
+
+## Step 2: Check for Top Bug Patterns
+
+These are ordered by combined frequency and impact from real production data.
+
+### Check 1: Null/Undefined Property Access -- 158 issues, 46,337 events
+
+Code accesses a property on a value that may be null or undefined. This is the single most common bug pattern in the Sentry frontend.
+
+**Red flags:**
+
+- Accessing `.id`, `.slug`, `.name`, `.type`, `.match`, `.length`, `.charCodeAt` without null checks
+- Using `object.property` instead of `object?.property` on data from API responses
+- Passing API response data directly to utility functions without null validation
+- Accessing DOM element properties from `querySelector` or `useRef` without checking if the element exists
+- Destructuring objects from hooks/stores that may return null during loading states
+- Calling `.dispatchEvent()` on elements that have been unmounted
+
+**Safe patterns:**
+
+- Optional chaining: `obj?.property?.nested`
+- Default values: `const value = obj?.field ?? defaultValue`
+- Null guards before function calls: `if (data) { parser.parse(data); }`
+- Early returns for null/undefined parameters in utility functions
+
+### Check 2: Dashboard Widget Input Validation -- 6 issues, 90,482 events
+
+Widget visualization components throw when receiving data in unexpected formats.
+
+**Red flags:**
+
+- Rendering chart components without checking if data contains plottable values
+- Calling `getWidgetExploreUrl()` for widget types that do not support multiple queries
+- Passing undefined `field` values to `parseFunction()` or similar field parsers
+- Not handling empty API responses in widget data fetchers
+
+**Safe patterns:**
+
+- Validate data shape before rendering: `if (!hasPlottableValues(data)) return <EmptyState />`
+- Check widget query count before generating explore URLs
+- Guard field parsers: `if (!field) return null`
+
+### Check 3: Trace View Data Integrity -- 12 issues, 328,482 events
+
+The trace tree renderer and trace detail views encounter data that violates structural assumptions.
+
+**Red flags:**
+
+- Building trace trees without cycle detection (or detecting cycles but not handling them gracefully)
+- Looking up projects by ID from span data without checking if the project is accessible
+- Generating trace links without validating `traceSlug` is non-empty
+- Using `captureException` in render paths without deduplication (fires every render cycle)
+
+**Safe patterns:**
+
+- Break cycles by detaching cyclic nodes as orphan roots
+- Validate traceSlug before generating links: `if (!traceSlug) return fallbackLink`
+- Deduplicate error captures using a ref: `if (!capturedRef.current) { captureException(...); capturedRef.current = true; }`
+- Check project access before rendering span details
+
+### Check 4: API Response Shape Assumptions -- 31 issues, 24,019 events
+
+Frontend code assumes API responses have a specific shape but the response is empty, undefined, or has an unexpected status code.
+
+**Red flags:**
+
+- Not handling 200 responses with empty bodies (e.g., `GET /customers/{orgSlug}/` returns 200 with no body)
+- Not handling 402 (Payment Required) status codes in subscription flows
+- Not handling 409 (Conflict) status codes in mutation endpoints
+- Treating `UndefinedResponseBodyError` as unexpected (it indicates the API returned no parseable body)
+- Assuming SelectAsync options will always load successfully
+
+**Safe patterns:**
+
+- Check response body before parsing: `if (!response.body) return null`
+- Handle specific 4xx status codes in catch blocks
+- Provide fallback empty states for failed API fetches instead of throwing
+
+### Check 5: React Lifecycle Violations -- 10 issues, 2,595 events
+
+Components violate React rendering rules, causing infinite loops or crashes.
+
+**Red flags:**
+
+- Setting state unconditionally in `useEffect` without proper dependency arrays
+- Calling `useOrganization()` in components that render before organization context is loaded
+- Using `useContext()` outside the provider boundary
+- Passing objects as React children instead of strings/elements
+- Components that trigger immediate re-render on mount
+
+**Safe patterns:**
+
+- Always provide dependency arrays for `useEffect`
+- Guard context hooks: `const org = useOrganization(); if (!org) return <Loading />`
+- Wrap organization-dependent routes in a provider boundary
+- Validate element types before rendering: `if (typeof Component !== 'function') return null`
+
+### Check 6: AI Insights Data Parsing -- 2 issues, 3,005 events
+
+JSON parsing of AI prompt messages and gen_ai span data fails on non-standard formats.
+
+**Red flags:**
+
+- Calling `JSON.parse()` on `ai.prompt.messages` span attributes without try-catch
+- Assuming all AI model responses produce valid JSON
+- Not handling the "parts" format for multi-modal AI messages
+
+**Safe patterns:**
+
+- Wrap all `JSON.parse` calls on external data in try-catch
+- Check for leading `[` or `{` before parsing
+- Provide raw-text fallback rendering when parsing fails
+
+### Check 7: Array and Bounds Validation -- 15 issues, 3,120 events
+
+Array operations and numeric formatting with values that exceed valid ranges.
+
+**Red flags:**
+
+- Using `result.push(...largeArray)` (crashes when array is too large)
+- Passing unclamped values to `toLocaleString({maximumFractionDigits: n})`
+- Constructing Date objects from unvalidated timestamps
+- Recursive component rendering without depth limits
+
+**Safe patterns:**
+
+- Use `concat` or iterative push for potentially large arrays
+- Clamp numeric format parameters: `Math.min(100, Math.max(0, precision))`
+- Validate dates before constructing: `if (isNaN(new Date(ts).getTime())) return fallback`
+- Use iterative rendering with explicit stacks for deeply nested structures
+
+### Check 8: Logic Correctness -- not pattern-based
+
+After checking all known patterns above, reason about the changed code itself:
+
+- Does every code path return the correct type (or JSX)?
+- Are all branches of conditionals handled (especially missing `else` / default cases in switches)?
+- Can any prop or state value (null, undefined, empty array, empty string) cause unexpected behavior?
+- Are hook dependency arrays correct? Missing deps cause stale closures; extra deps cause infinite loops.
+- If this component unmounts mid-async-operation, is cleanup handled?
+
+Only report if you can trace a specific input that triggers the bug. Do not report theoretical concerns.
+
+**If no checks produced a potential finding, stop and report zero findings. Do not invent issues to fill the report. An empty result is the correct output when the code has no bugs matching these patterns.**
+
+Each code location should be reported once under the most specific matching pattern. Do not flag the same line under multiple checks.
+
+## Step 3: Report Findings
+
+For each finding, include:
+
+- **Title**: Short description of the bug
+- **Severity**: high, medium, or low
+- **Location**: File path and line number
+- **Description**: Root cause → consequences (2-4 sentences)
+- **Precedent**: A real production issue ID (e.g., "Similar to JAVASCRIPT-2NQW: null charCodeAt in SQL parser, 39K events")
+- **Fix**: A unified diff showing the code fix
+
+Fix suggestions must include actual code. Never suggest a comment or docstring as a fix.
+
+Do not prescribe your own output format — the review harness controls the response structure.

--- a/.agents/skills/sentry-javascript-bugs/references/ai-insights-parsing.md
+++ b/.agents/skills/sentry-javascript-bugs/references/ai-insights-parsing.md
@@ -1,0 +1,84 @@
+# AI Insights Parsing Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+AI Insights parsing errors account for 2 issues and 3,005 events, but this cluster is escalating as new AI model formats are introduced. The core problem is that `JSON.parse` is called on AI prompt message data (`ai.prompt.messages` span attribute) that contains invalid JSON — bad escape characters, non-standard serialization, or plain text where JSON is expected.
+
+## Real Examples
+
+### [JAVASCRIPT-34D0]: Error parsing ai.prompt.messages (unresolved, 7 variants merged)
+
+**Sentry**: https://sentry.io/issues/7002181641/
+**Events**: 2,681 | **Users**: 95
+
+**Stacktrace:**
+
+```
+./app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+  parseAIMessages
+    -> JSON.parse(messages)
+
+Underlying: SyntaxError: Bad escaped character in JSON at position 430
+```
+
+**Root cause:** The `parseAIMessages` function calls `JSON.parse` on the `ai.prompt.messages` span attribute. Various LLM providers serialize messages differently and some produce strings with raw newlines, unescaped backslashes, or invalid unicode sequences that are not valid JSON. The function does not catch the parsing error.
+
+**Fix pattern:**
+
+```typescript
+function parseAIMessages(raw: string): AIMessage[] {
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [{role: 'unknown', content: raw}];
+  }
+}
+```
+
+### [JAVASCRIPT-379Y]: Error parsing gen_ai messages with parts format (unresolved, escalating)
+
+**Sentry**: https://sentry.io/issues/7270138341/
+**Events**: 324 | **Users**: 17
+
+**Stacktrace:**
+
+```
+./app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiInput.tsx
+  transformPartsMessages
+    -> JSON.parse(message)
+
+Underlying: SyntaxError: JSON.parse: unexpected character at line 1 column 2
+```
+
+**Root cause:** The "parts" format handler encounters message data that is not valid JSON. Some AI models serialize multi-modal content (text + images) in non-standard formats. The parser assumes all parts-format messages are JSON but some are plain text or use custom serialization.
+
+**Fix pattern:**
+
+```typescript
+function transformPartsMessages(raw: string): TransformedMessage {
+  if (!raw) return {type: 'text', content: ''};
+  if (!raw.startsWith('[') && !raw.startsWith('{')) {
+    return {type: 'text', content: raw};
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {type: 'text', content: raw};
+  }
+}
+```
+
+## Detection Checklist
+
+- [ ] Is `JSON.parse` called on AI/LLM span data without try-catch?
+- [ ] Does the parser handle non-JSON input (plain text, custom formats)?
+- [ ] Is there a fallback rendering path for unparseable messages?
+- [ ] Are new AI model output formats validated before being passed to parsers?
+- [ ] Does the code check for leading `[` or `{` before attempting JSON parse?

--- a/.agents/skills/sentry-javascript-bugs/references/api-response-handling.md
+++ b/.agents/skills/sentry-javascript-bugs/references/api-response-handling.md
@@ -1,0 +1,73 @@
+# API Response Handling Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+API response handling errors account for 31 issues and 24,019 events. The Sentry frontend API client makes assumptions about response shapes that break in edge cases: 200 responses with empty bodies, unexpected 4xx status codes, and undefined response bodies from endpoints that return no content.
+
+Key sub-patterns:
+
+1. **200 treated as error** (12K events): API returns 200 with empty body, client throws
+2. **UndefinedResponseBodyError** (9.5K events): Response has no parseable body
+3. **Unhandled 4xx codes** (1.5K events): 402, 409 not caught in mutation flows
+
+## Real Examples
+
+### [JAVASCRIPT-2M6Q]: 200 treated as error: GET /customers/{orgSlug}/ (ignored)
+
+**Sentry**: https://sentry.io/issues/4290456281/
+**Events**: 12,331 | **Users**: 168
+
+**Root cause:** The API client receives a 200 response from `/customers/{orgSlug}/` but the body is empty or unparseable. The response handler treats this as an error because it expects a JSON body. The endpoint returns 200 with no body when the customer record exists but has no data to return.
+
+**Fix pattern:** Handle empty 200 responses as valid in the API client or response wrapper.
+
+```typescript
+if (response.ok && !response.body) {
+  return null;
+}
+```
+
+### [JAVASCRIPT-2MF5]: UndefinedResponseBodyError: GET /assistant/ 200 (ignored)
+
+**Sentry**: https://sentry.io/issues/4302193574/
+**Events**: 9,017 | **Users**: 706
+
+**Root cause:** Same pattern as above. The `/assistant/` endpoint returns 200 with no body. The `UndefinedResponseBodyError` is thrown by the API client when it cannot parse the response.
+
+**Fix pattern:** The API endpoint should return 204 No Content when there is no data. On the frontend, handle undefined response bodies without throwing.
+
+### [JAVASCRIPT-33RM]: RequestError: PUT subscription 402 (unresolved)
+
+**Sentry**: https://sentry.io/issues/6861277461/
+**Events**: 1,283 | **Users**: 678
+
+**Root cause:** The subscription update endpoint returns 402 (Payment Required) but the frontend does not handle this status code. The error propagates as an unhandled `RequestError`.
+
+**Fix pattern:** Handle 402 specifically in subscription mutation flows.
+
+```typescript
+try {
+  await api.requestPromise(`/customers/${orgSlug}/subscription/`, {method: 'PUT', data});
+} catch (error) {
+  if (error.status === 402) {
+    addErrorMessage(t('Payment is required to make this change.'));
+    return;
+  }
+  throw error;
+}
+```
+
+## Detection Checklist
+
+- [ ] Does the API client handle 200 responses with empty bodies?
+- [ ] Are mutation endpoints (PUT, POST, DELETE) handling 402, 409, 422 status codes?
+- [ ] Is `UndefinedResponseBodyError` caught and handled gracefully?
+- [ ] Do async component data loaders provide error states?
+- [ ] Are gateway timeout (504) and service unavailable (503) errors shown as user-friendly messages?
+- [ ] Do SelectAsync/autocomplete components handle failed option fetches?

--- a/.agents/skills/sentry-javascript-bugs/references/dashboard-widget-errors.md
+++ b/.agents/skills/sentry-javascript-bugs/references/dashboard-widget-errors.md
@@ -1,0 +1,80 @@
+# Dashboard & Widget Error Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+Dashboard widget errors account for 6 issues and 90,482 events. The core problem is widget visualization components that throw exceptions when receiving unexpected data from APIs, rather than rendering graceful empty states. Two dominant patterns:
+
+1. **No plottable values**: Charts throw when all data is null, empty, or non-numeric (38K events, 3.4K users)
+2. **Unsupported widget configurations**: Functions like `getWidgetExploreUrl` throw when called with widget types they do not support (51K events)
+
+## Real Examples
+
+### [JAVASCRIPT-334P]: getWidgetExploreUrl — multiple queries for logs unsupported (unresolved)
+
+**Stacktrace:**
+
+```
+./app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+  actions (line 256)
+    to: getWidgetExploreUrl(widget, dashboardFilters, selection, organization, Mode.SAMPLES),
+
+./app/views/dashboards/utils/getWidgetExploreUrl.tsx
+  getWidgetExploreUrl (line 106)
+    if (widget.queries.length > 1) {
+      if (traceItemDataset === TraceItemDataset.LOGS) {
+        Sentry.captureException(new Error(`getWidgetExploreUrl: multiple queries for logs is unsupported...`));
+      }
+    }
+```
+
+**Root cause:** The widget context menu eagerly computes the "Open in Explore" URL for all widget types. For log widgets with multiple queries, this is unsupported. The function captures an exception every time the menu is rendered.
+
+**Fix pattern:** Check widget configuration before computing the URL. Disable the menu item for unsupported configurations.
+
+```typescript
+const canOpenInExplore = widget.widgetType !== WidgetType.LOGS || widget.queries.length <= 1;
+if (canOpenInExplore) {
+  menuOptions.push({key: 'open-in-explore', to: getWidgetExploreUrl(...)});
+}
+```
+
+### [JAVASCRIPT-34B7]: The data does not contain any plottable values (unresolved, 10 variants merged)
+
+**Stacktrace:**
+
+```
+./app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+  CategoricalSeriesWidgetVisualization
+    throws Error("The data does not contain any plottable values.")
+```
+
+**Root cause:** Widget visualization throws when the API returns data with no numeric values to plot. This happens when widgets are configured with queries that return empty results, all-null columns, or non-numeric data.
+
+**Fix pattern:** Replace the throw with an empty-state render.
+
+```typescript
+if (!hasPlottableValues(data)) {
+  return <EmptyStateWarning>{t('No data available to display.')}</EmptyStateWarning>;
+}
+```
+
+### [JAVASCRIPT-336V]: Unable to fetch releases (resolved)
+
+**Root cause:** Dashboard widget's release data fetch fails and propagates as an unhandled exception instead of showing an error state.
+
+**Fix pattern:** Catch fetch errors and surface them as widget-level error states.
+
+## Detection Checklist
+
+- [ ] Do chart/visualization components handle empty or null data gracefully?
+- [ ] Is widget data validated before being passed to rendering functions?
+- [ ] Do utility functions like `getWidgetExploreUrl` check widget type compatibility?
+- [ ] Are API fetch errors caught and displayed as widget error states?
+- [ ] Do `captureException` calls in render paths have deduplication?
+- [ ] Is `parseFunction()` guarded against undefined field values?

--- a/.agents/skills/sentry-javascript-bugs/references/null-reference-errors.md
+++ b/.agents/skills/sentry-javascript-bugs/references/null-reference-errors.md
@@ -1,0 +1,122 @@
+# Null Reference Error Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+Null/undefined property access is the single most common bug pattern in the Sentry JavaScript frontend, accounting for 158 issues and 46,337 events. These are TypeErrors where code accesses a property (`.id`, `.slug`, `.charCodeAt`, `.match`, `.dispatchEvent`, etc.) on a value that is null or undefined.
+
+The most common sources of null values:
+
+1. **API response fields** that are optional but treated as required
+2. **Store/hook return values** during loading states (before data is hydrated)
+3. **DOM element lookups** (`querySelector`, `useRef`) on unmounted elements
+4. **Function parameters** from callers that pass null/undefined for edge cases
+5. **Destructured objects** where the parent object may be null
+
+## Real Examples
+
+### [JAVASCRIPT-2NQW]: TypeError: null is not an object (evaluating 'e.charCodeAt') (resolved)
+
+**Stacktrace:**
+
+```
+./app/views/insights/common/components/tableCells/spanDescriptionCell.tsx
+  SpanDescriptionCell (line 39)
+    const formatterDescription = useMemo(() => {
+      return formatter.toSimpleMarkup(rawDescription);  // rawDescription is null
+    }, [moduleName, rawDescription, spanAction, system]);
+
+./app/utils/sqlish/SQLishFormatter.tsx
+  SQLishFormatter.toFormat (line 49)
+    tokens = sqlishParser.parse(sql);  // sql is null
+
+./app/utils/sqlish/sqlish.pegjs
+  eI (line 505)
+    if (input.charCodeAt(peg$currPos) === 40) {  // input is null
+```
+
+**Root cause:** `SpanDescriptionCell` passes `rawDescription` to the SQL parser without checking if it is null. Span descriptions can be null for internal spans or spans with redacted data. The null check at line 51 (`if (!rawDescription) return NULL_DESCRIPTION`) executes after the `useMemo`, not inside it.
+
+**Fix pattern:**
+
+```typescript
+const formatterDescription = useMemo(() => {
+  if (!rawDescription) return NULL_DESCRIPTION;
+  if (moduleName !== ModuleName.DB) return rawDescription;
+  return formatter.toSimpleMarkup(rawDescription);
+}, [moduleName, rawDescription, spanAction, system]);
+```
+
+### [JAVASCRIPT-361B]: TypeError: Invalid alert variant, got undefined (resolved)
+
+**Stacktrace:**
+
+```
+./app/components/core/alert/alert.chonk.tsx
+  tokens function
+    throws TypeError("Invalid alert variant, got undefined")
+```
+
+**Root cause:** The Alert component receives an undefined `variant` prop. The chonk token function validates the variant but does not provide a default.
+
+**Fix pattern:**
+
+```typescript
+const resolvedVariant = variant ?? 'info';
+```
+
+### [JAVASCRIPT-36F2]: Cannot read properties of undefined (reading 'match') (resolved)
+
+**Stacktrace:**
+
+```
+./app/utils/discover/fields.tsx
+  parseFunction
+    field.match(AGGREGATE_PATTERN)  // field is undefined
+```
+
+**Root cause:** `parseFunction` is called with an undefined field value from a dashboard widget whose query references a field that no longer exists.
+
+**Fix pattern:**
+
+```typescript
+function parseFunction(field: string): ParsedFunction | null {
+  if (!field) return null;
+  const match = field.match(AGGREGATE_PATTERN);
+  // ...
+}
+```
+
+### [JAVASCRIPT-34ZH]: Cannot read properties of null (reading 'id') (resolved)
+
+**Stacktrace:**
+
+```
+./app/views/issueList/issueViews/useSelectedGroupSeachView.tsx
+  matchingView
+    view.id  // view is null (no matching saved view)
+```
+
+**Root cause:** Hook returns null when no matching saved view exists, but downstream code accesses `.id` without a null check.
+
+**Fix pattern:**
+
+```typescript
+const viewId = matchingView?.id;
+```
+
+## Detection Checklist
+
+- [ ] Does the code access properties on API response data without null checks?
+- [ ] Are function parameters validated before use (especially string methods like `.match()`, `.charCodeAt()`)?
+- [ ] Do `useMemo`/`useCallback` callbacks check for null inputs before processing?
+- [ ] Are DOM element refs checked for null before accessing properties?
+- [ ] Do hook return values have null guards before property access?
+- [ ] Are store values checked during loading/initialization states?
+- [ ] Does destructured data handle the case where the parent object is null?
+- [ ] Are optional props given default values in component signatures?

--- a/.agents/skills/sentry-javascript-bugs/references/range-and-bounds-errors.md
+++ b/.agents/skills/sentry-javascript-bugs/references/range-and-bounds-errors.md
@@ -1,0 +1,101 @@
+# Range & Bounds Error Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+Range and bounds errors account for 15 issues and 3,120 events. These are RangeErrors from array operations with invalid lengths, numeric formatting with out-of-range parameters, invalid Date construction, and stack overflows from deep recursion.
+
+Key sub-patterns:
+
+1. **Invalid array length** (2.9K events): `push(...spread)` on large arrays
+2. **Stack overflow** (99 events): Deep recursion in tree rendering
+3. **Invalid time values** (60 events): Bad timestamps passed to Date constructor
+4. **Numeric formatting** (24 events): `maximumFractionDigits` out of range
+
+## Real Examples
+
+### [JAVASCRIPT-35NH]: RangeError: Invalid array length (resolved)
+
+**Sentry**: https://sentry.io/issues/7121413975/
+**Events**: 911 | **Users**: 674
+
+**Stacktrace:**
+
+```
+Array.push (native)
+```
+
+**Root cause:** Code uses `result.push(...spans)` where `spans` is a very large array. When the combined size exceeds JavaScript's max array length, `push` with spread throws a RangeError. This occurs when processing traces with thousands of spans.
+
+**Fix pattern:**
+
+```typescript
+// Before (crashes on large arrays)
+result.push(...spans);
+
+// After (safe for any size)
+for (const span of spans) {
+  result.push(span);
+}
+// Or: result = result.concat(spans);
+```
+
+**Actual fix:** Resolved (replaced spread with iterative push or concat).
+
+### [JAVASCRIPT-358Q]: RangeError: maximumFractionDigits out of range (resolved)
+
+**Sentry**: https://sentry.io/issues/7130310735/
+**Events**: 24 | **Users**: 4
+
+**Root cause:** `Number.toLocaleString()` receives a `maximumFractionDigits` value outside the valid range (0-100). The precision is dynamically computed (e.g., `Math.ceil(-Math.log10(value))`) and can produce negative values or values exceeding 100 for extreme inputs.
+
+**Fix pattern:**
+
+```typescript
+const precision = Math.min(100, Math.max(0, computedPrecision));
+value.toLocaleString(undefined, {maximumFractionDigits: precision});
+```
+
+**Actual fix:** Resolved (clamped the precision value).
+
+### [JAVASCRIPT-2WVR]: RangeError: Maximum call stack size exceeded (unresolved)
+
+**Sentry**: https://sentry.io/issues/5816316247/
+**Events**: 56 | **Users**: 12
+
+**Root cause:** Stack overflow from deep recursion when rendering deeply nested data structures (trace trees, nested groups). The browser's call stack limit is exceeded.
+
+**Fix pattern:** Convert recursive rendering to iterative with an explicit stack.
+
+```typescript
+// Before (recursive)
+function renderNode(node: TreeNode): JSX.Element {
+  return <div>{node.children.map(child => renderNode(child))}</div>;
+}
+
+// After (iterative)
+function renderTree(root: TreeNode): JSX.Element[] {
+  const result: JSX.Element[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    result.push(<div key={node.id}>{node.label}</div>);
+    stack.push(...node.children);
+  }
+  return result;
+}
+```
+
+## Detection Checklist
+
+- [ ] Is `Array.push(...spread)` used on potentially large arrays?
+- [ ] Are numeric formatting parameters (fraction digits, significant digits) clamped to valid ranges?
+- [ ] Are Date objects constructed from validated timestamps?
+- [ ] Is there recursive rendering of user-controlled data structures?
+- [ ] Are recursive functions guarded with depth limits?
+- [ ] Is `toLocaleString` called with computed precision values?

--- a/.agents/skills/sentry-javascript-bugs/references/react-lifecycle-errors.md
+++ b/.agents/skills/sentry-javascript-bugs/references/react-lifecycle-errors.md
@@ -1,0 +1,94 @@
+# React Lifecycle Error Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+React lifecycle errors account for 10 issues and 2,595 events. These are violations of React's rendering rules that cause infinite loops, crashes, or context errors. Three main sub-patterns:
+
+1. **Infinite re-render loops** (2.3K events): Components set state unconditionally in effects
+2. **Missing context providers** (90 events): Hooks used outside their provider boundary
+3. **Invalid element types** (39 events): Objects or undefined passed as React children/components
+
+## Real Examples
+
+### [JAVASCRIPT-22SP]: InternalError: too much recursion (unresolved)
+
+**Sentry**: https://sentry.io/issues/3573504746/
+**Events**: 2,332 | **Users**: 95
+
+**Root cause:** React's rendering loop enters infinite recursion on the `/issues/` route. A component's render function triggers a state update that triggers another render synchronously, causing stack overflow. This is typically caused by a `useEffect` that sets state without proper dependency arrays or conditions.
+
+**Fix pattern:** Add dependency arrays and conditional guards to effects.
+
+```typescript
+// Before (infinite loop)
+useEffect(() => {
+  setValue(computeValue(data));
+});
+
+// After (conditional, with deps)
+useEffect(() => {
+  const newValue = computeValue(data);
+  if (newValue !== value) {
+    setValue(newValue);
+  }
+}, [data]);
+```
+
+### [JAVASCRIPT-34JC]: useOrganization called but organization is not set (unresolved, 16 variants merged)
+
+**Sentry**: https://sentry.io/issues/7008432988/
+**Events**: 55 | **Users**: 36
+
+**Stacktrace:**
+
+```
+./app/utils/useOrganization.tsx
+  useOrganization
+    throws Error("useOrganization called but organization is not set.")
+```
+
+**Root cause:** `useOrganization` is called in components that render before the organization context has been loaded. 16 variants from different routes were merged, including `/settings/account/`, `/organizations/:orgId/`, and various feature pages.
+
+**Fix pattern:** Return null instead of throwing, or guard with a loading boundary.
+
+```typescript
+// Option 1: Non-throwing hook
+function useOrganization(): Organization | null {
+  const org = useContext(OrganizationContext);
+  return org ?? null;
+}
+
+// Option 2: Guard at route level
+function RequireOrganization({children}: Props) {
+  const org = useOrganization();
+  if (!org) return <LoadingIndicator />;
+  return children;
+}
+```
+
+### [JAVASCRIPT-31AY]: Maximum update depth exceeded (resolved, 16 variants merged)
+
+**Sentry**: https://sentry.io/issues/6688802694/
+**Events**: 38 | **Users**: 1
+
+**Root cause:** React's infinite re-render detection fires. 16 variants on different pages. The common pattern is an effect that unconditionally sets state on every render.
+
+**Fix pattern:** Ensure all `useEffect` hooks have dependency arrays and state setters are conditional.
+
+**Actual fix:** Resolved (specific fix not available, but the pattern is consistent).
+
+## Detection Checklist
+
+- [ ] Do all `useEffect` and `useLayoutEffect` calls have dependency arrays?
+- [ ] Are state setters inside effects conditional (checking if value actually changed)?
+- [ ] Is `useOrganization()` called only within routes that have the organization provider?
+- [ ] Are `useContext()` calls inside their respective providers?
+- [ ] Do dynamic imports and lazy components handle undefined module exports?
+- [ ] Are objects being passed as React children? (Should be strings or elements)
+- [ ] Is state being set during the render phase (outside effects)?

--- a/.agents/skills/sentry-javascript-bugs/references/trace-view-errors.md
+++ b/.agents/skills/sentry-javascript-bugs/references/trace-view-errors.md
@@ -1,0 +1,99 @@
+# Trace View Error Patterns
+
+## Contents
+
+- Overview
+- Real examples
+- Detection checklist
+
+## Overview
+
+Trace view errors account for 12 issues and 328,482 events -- the highest-impact cluster by far. The trace tree renderer and span detail views make structural assumptions about trace data that break when traces contain cycles, reference inaccessible projects, or lack required fields like trace IDs.
+
+Key sub-patterns:
+
+1. **Cycle detection in trace trees** (231K events): Parent-child span relationships form cycles
+2. **Project not found in trace details** (94K events): Span references a project the user cannot access
+3. **Missing trace slug** (347 events): Trace context is absent from events, breaking link generation
+
+## Real Examples
+
+### [JAVASCRIPT-36K9]: Cycle detected in trace tree structure (unresolved)
+
+**Sentry**: https://sentry.io/issues/7219873856/
+**Status**: unresolved | **Events**: 231,413 | **Users**: 79,607
+
+No in-app exception frames (info-level captureMessage on `/explore/traces/trace/:traceSlug/`).
+
+**Root cause:** The trace tree builder detects a cycle in span parent-child relationships (A -> B -> A). This fires for every user who views an affected trace, generating enormous volume.
+
+**Fix pattern:** Handle cycles gracefully by detaching cyclic spans as orphan roots. Rate-limit the diagnostic message per trace ID.
+
+### [JAVASCRIPT-2ZX1]: Project not found in useTraceItemDetails (resolved, 3 variants merged)
+
+**Stacktrace:**
+
+```
+./app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+  EAPSpanNodeDetails (line 349)
+    } = useTraceItemDetails({
+      projectId: node.value.project_id.toString(),
+      ...
+
+./app/views/explore/hooks/useTraceItemDetails.tsx
+  useTraceItemDetails (line 103)
+    if ((props.enabled ?? true) && !project && !fetching) {
+      captureException(
+        new Error(`Project "${props.projectId}" not found in useTraceItemDetails`)
+      );
+    }
+```
+
+**Root cause:** Span data references a project ID that is not in the user's accessible projects. The hook fires `captureException` on every render cycle without deduplication.
+
+**Fix pattern:** Deduplicate the error capture. Return a graceful "project not accessible" state.
+
+```typescript
+const capturedRef = useRef(new Set<string>());
+if (!project && !fetching && !capturedRef.current.has(props.projectId)) {
+  capturedRef.current.add(props.projectId);
+  captureException(new Error(`Project "${props.projectId}" not found`));
+}
+```
+
+### [JAVASCRIPT-3370]: Trace slug is missing (unresolved, 4 variants merged)
+
+**Stacktrace:**
+
+```
+./app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+  makeTransactionNameRow (line 610)
+    const traceSlug = event.contexts?.trace?.trace_id ?? '';
+    const eventDetailsLocation = generateLinkToEventInTraceView({traceSlug, ...});
+
+./app/utils/discover/urls.tsx
+  generateLinkToEventInTraceView (line 82)
+    if (!traceSlug) {
+      Sentry.captureException(new Error('Trace slug is missing'));
+    }
+```
+
+**Root cause:** Events without trace context (no `contexts.trace.trace_id`) produce an empty traceSlug. The link generator detects the problem but generates a broken link anyway.
+
+**Fix pattern:** Check traceSlug before calling the link generator. Show a fallback when trace context is missing.
+
+```typescript
+const traceSlug = event.contexts?.trace?.trace_id;
+if (!traceSlug) {
+  return makeRow(t('Transaction'), event.title);
+}
+```
+
+## Detection Checklist
+
+- [ ] Does trace tree building handle cycles (parent-child loops)?
+- [ ] Are project IDs from span data validated against accessible projects?
+- [ ] Is `traceSlug` checked for emptiness before generating trace links?
+- [ ] Do `captureException` calls in hooks use deduplication (refs, sets)?
+- [ ] Are error captures in render paths guarded against firing every render cycle?
+- [ ] Do trace detail components handle missing/inaccessible spans gracefully?

--- a/agents.toml
+++ b/agents.toml
@@ -9,11 +9,3 @@ allow_all = true
 [[skills]]
 name = "*"
 source = "getsentry/skills"
-
-[[skills]]
-name = "sentry-backend-bugs"
-source = "getsentry/warden-sentry"
-
-[[skills]]
-name = "sentry-javascript-bugs"
-source = "getsentry/warden-sentry"

--- a/warden.toml
+++ b/warden.toml
@@ -27,7 +27,6 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "sentry-backend-bugs"
-remote = "getsentry/warden-sentry"
 paths = ["src/sentry/**/*.py"]
 ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
 
@@ -37,7 +36,6 @@ actions = ["opened", "synchronize", "reopened"]
 
 [[skills]]
 name = "sentry-javascript-bugs"
-remote = "getsentry/warden-sentry"
 paths = ["static/**/*.ts", "static/**/*.tsx", "static/**/*.js", "static/**/*.jsx"]
 ignorePaths = ["**/*.spec.*", "**/*.test.*", "**/tests/**", "**/__mocks__/**"]
 


### PR DESCRIPTION
Vendor the two warden skills from `getsentry/warden-sentry` into this
repo since we can't clone private repos in GitHub Actions.

- Copies `sentry-backend-bugs` and `sentry-javascript-bugs` skill
  directories (SKILL.md + reference files) into `.agents/skills/`
- Removes `remote = "getsentry/warden-sentry"` from `warden.toml`
- Removes the remote source entries from `agents.toml`
- Un-gitignores the two skill directories so they're committed
- Adds a README to each vendored skill noting the source repo