### PR TITLE
feat(seer): Add seer-agent-pr-consolidation feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -398,6 +398,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:search-query-builder-input-flow-changes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable search query builder raw search replacement
     manager.add("organizations:search-query-builder-raw-search-replacement", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:seer-agent-pr-consolidation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Seer Autopilot
     manager.add("organizations:seer-autopilot", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable linking from 'new issue' email notifs to the issue replay list


### PR DESCRIPTION
Registers the `organizations:seer-agent-pr-consolidation` FLAGPOLE feature flag.

This will be used by a follow-up PR to consolidate the separate "Seer Agent" and "Coding Agent" settings panels into a single unified "Coding Agent" panel with one PR auto-creation toggle.

Refs https://linear.app/getsentry/issue/AIML-2525/better-coding-agent-configuration