### PR TITLE
ref(data-forwarding): Migrate project config to TanStack form in edit view

### DIFF
--- a/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.spec.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.spec.tsx
@@ -1,0 +1,183 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectConfigurationForm} from 'sentry/views/settings/organizationDataForwarding/components/projectConfigurationForm';
+import {
+  DataForwarderProviderSlug,
+  type DataForwarder,
+} from 'sentry/views/settings/organizationDataForwarding/util/types';
+
+const ORG_SLUG = 'test-org';
+const DF_ID = 'df-123';
+const ENDPOINT = `/organizations/${ORG_SLUG}/forwarding/${DF_ID}/`;
+
+function makeDataForwarder(partial: Partial<DataForwarder> = {}): DataForwarder {
+  return {
+    id: DF_ID,
+    provider: DataForwarderProviderSlug.SQS,
+    isEnabled: true,
+    enrollNewProjects: false,
+    enrolledProjects: [],
+    config: {},
+    organizationId: '1',
+    projectConfigs: [],
+    ...partial,
+  };
+}
+
+describe('ProjectConfigurationForm', () => {
+  const organization = OrganizationFixture({slug: ORG_SLUG});
+  const projects = [
+    ProjectFixture({id: 'p1', slug: 'project-one'}),
+    ProjectFixture({id: 'p2', slug: 'project-two'}),
+  ];
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders panel header, field labels, and save button', () => {
+    render(
+      <ProjectConfigurationForm dataForwarder={makeDataForwarder()} projects={projects} />,
+      {organization}
+    );
+
+    expect(screen.getByText('Project Configuration')).toBeInTheDocument();
+    expect(screen.getByText('Auto-enroll new projects')).toBeInTheDocument();
+    expect(screen.getByText('Forwarding projects')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Save Project Configuration'})
+    ).toBeInTheDocument();
+  });
+
+  it('initializes switch as unchecked when enrollNewProjects is false', () => {
+    render(
+      <ProjectConfigurationForm
+        dataForwarder={makeDataForwarder({enrollNewProjects: false})}
+        projects={projects}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByRole('checkbox', {name: 'Auto-enroll new projects'})
+    ).not.toBeChecked();
+  });
+
+  it('initializes switch as checked when enrollNewProjects is true', () => {
+    render(
+      <ProjectConfigurationForm
+        dataForwarder={makeDataForwarder({enrollNewProjects: true})}
+        projects={projects}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByRole('checkbox', {name: 'Auto-enroll new projects'})
+    ).toBeChecked();
+  });
+
+  it('toggles enroll_new_projects and submits to API', async () => {
+    const putMock = MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'PUT',
+      body: makeDataForwarder({enrollNewProjects: true}),
+    });
+
+    render(
+      <ProjectConfigurationForm
+        dataForwarder={makeDataForwarder({enrollNewProjects: false})}
+        projects={projects}
+      />,
+      {organization}
+    );
+
+    const toggle = screen.getByRole('checkbox', {name: 'Auto-enroll new projects'});
+    await userEvent.click(toggle);
+    expect(toggle).toBeChecked();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save Project Configuration'}));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          method: 'PUT',
+          data: expect.objectContaining({
+            enroll_new_projects: true,
+            project_ids: [],
+          }),
+        })
+      );
+    });
+  });
+
+  it('selects a project and submits to API', async () => {
+    const putMock = MockApiClient.addMockResponse({
+      url: ENDPOINT,
+      method: 'PUT',
+      body: makeDataForwarder(),
+    });
+
+    render(
+      <ProjectConfigurationForm dataForwarder={makeDataForwarder()} projects={projects} />,
+      {organization}
+    );
+
+    // Open the multi-select and pick the first project
+    await userEvent.click(screen.getByRole('textbox', {name: 'Forwarding projects'}));
+    await userEvent.click(
+      screen.getByRole('menuitemcheckbox', {name: 'project-one'})
+    );
+    await userEvent.keyboard('{Escape}');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save Project Configuration'}));
+
+    await waitFor(() => {
+      expect(putMock).toHaveBeenCalledWith(
+        ENDPOINT,
+        expect.objectContaining({
+          method: 'PUT',
+          data: expect.objectContaining({
+            enroll_new_projects: false,
+            project_ids: ['p1'],
+          }),
+        })
+      );
+    });
+  });
+
+  it('pre-selects enrolled projects', () => {
+    render(
+      <ProjectConfigurationForm
+        dataForwarder={makeDataForwarder({enrolledProjects: [projects[0]!]})}
+        projects={projects}
+      />,
+      {organization}
+    );
+
+    // The enrolled project's slug should be visible as a selected chip
+    expect(screen.getByText('project-one')).toBeInTheDocument();
+  });
+
+  it('disables switch and save button when disabled prop is true', () => {
+    render(
+      <ProjectConfigurationForm
+        dataForwarder={makeDataForwarder()}
+        projects={projects}
+        disabled
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByRole('checkbox', {name: 'Auto-enroll new projects'})
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', {name: 'Save Project Configuration'})
+    ).toBeDisabled();
+  });
+});

--- a/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.tsx
@@ -4,10 +4,6 @@ import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
 
 import IdBadge from 'sentry/components/idBadge';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelFooter from 'sentry/components/panels/panelFooter';
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -64,9 +60,8 @@ export function ProjectConfigurationForm({dataForwarder, projects, disabled}: Pr
 
   return (
     <form.AppForm>
-      <Panel>
-        <PanelHeader>{t('Project Configuration')}</PanelHeader>
-        <PanelBody>
+      <form.FormWrapper>
+        <form.FieldGroup title={t('Project Configuration')}>
           <form.AppField name="enroll_new_projects">
             {field => (
               <field.Layout.Row
@@ -97,15 +92,13 @@ export function ProjectConfigurationForm({dataForwarder, projects, disabled}: Pr
               </field.Layout.Row>
             )}
           </form.AppField>
-        </PanelBody>
-        <PanelFooter>
-          <Flex justify="end" padding="lg">
+          <Flex justify="end">
             <form.SubmitButton disabled={disabled} priority="primary" size="sm">
               {t('Save Project Configuration')}
             </form.SubmitButton>
           </Flex>
-        </PanelFooter>
-      </Panel>
+        </form.FieldGroup>
+      </form.FormWrapper>
     </form.AppForm>
   );
 }

--- a/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.tsx
+++ b/static/app/views/settings/organizationDataForwarding/components/projectConfigurationForm.tsx
@@ -1,0 +1,111 @@
+import {z} from 'zod';
+
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex} from '@sentry/scraps/layout';
+
+import IdBadge from 'sentry/components/idBadge';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelFooter from 'sentry/components/panels/panelFooter';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useMutateDataForwarder} from 'sentry/views/settings/organizationDataForwarding/util/hooks';
+import type {DataForwarder} from 'sentry/views/settings/organizationDataForwarding/util/types';
+
+const schema = z.object({
+  enroll_new_projects: z.boolean(),
+  project_ids: z.array(z.string()),
+});
+
+interface Props {
+  dataForwarder: DataForwarder;
+  projects: Project[];
+  disabled?: boolean;
+}
+
+export function ProjectConfigurationForm({dataForwarder, projects, disabled}: Props) {
+  const organization = useOrganization();
+
+  const {mutate: updateDataForwarder} = useMutateDataForwarder({
+    params: {orgSlug: organization.slug, dataForwarderId: dataForwarder.id},
+    onSuccess: df => {
+      trackAnalytics('data_forwarding.edit_project_config_complete', {
+        organization,
+        provider: dataForwarder.provider,
+        are_new_projects_enrolled: df?.enrollNewProjects ?? false,
+      });
+    },
+  });
+
+  const projectOptions = projects.map(project => ({
+    value: project.id,
+    label: project.slug,
+    leadingItems: <IdBadge project={project} avatarSize={16} disableLink hideName />,
+  }));
+
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      enroll_new_projects: dataForwarder.enrollNewProjects,
+      project_ids: dataForwarder.enrolledProjects.map(p => p.id),
+    },
+    validators: {onDynamic: schema},
+    onSubmit: ({value}) => {
+      updateDataForwarder({
+        ...dataForwarder,
+        enroll_new_projects: value.enroll_new_projects,
+        project_ids: value.project_ids,
+      } as unknown as DataForwarder);
+    },
+  });
+
+  return (
+    <form.AppForm>
+      <Panel>
+        <PanelHeader>{t('Project Configuration')}</PanelHeader>
+        <PanelBody>
+          <form.AppField name="enroll_new_projects">
+            {field => (
+              <field.Layout.Row
+                label={t('Auto-enroll new projects')}
+                hintText={t('Should new projects automatically forward their data?')}
+              >
+                <field.Switch
+                  checked={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={disabled}
+                />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
+          <form.AppField name="project_ids">
+            {field => (
+              <field.Layout.Row
+                label={t('Forwarding projects')}
+                hintText={t('Select the projects which should forward their data.')}
+              >
+                <field.Select
+                  multiple
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  options={projectOptions}
+                  disabled={disabled}
+                />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
+        </PanelBody>
+        <PanelFooter>
+          <Flex justify="end" padding="lg">
+            <form.SubmitButton disabled={disabled} priority="primary" size="sm">
+              {t('Save Project Configuration')}
+            </form.SubmitButton>
+          </Flex>
+        </PanelFooter>
+      </Panel>
+    </form.AppForm>
+  );
+}

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -24,6 +24,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
 import {DataForwarderDeleteConfirm} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderDeleteConfirm';
+import {ProjectConfigurationForm} from 'sentry/views/settings/organizationDataForwarding/components/projectConfigurationForm';
 import {ProjectOverrideForm} from 'sentry/views/settings/organizationDataForwarding/components/projectOverrideForm';
 import {getDataForwarderFormGroups} from 'sentry/views/settings/organizationDataForwarding/util/forms';
 import {
@@ -83,8 +84,6 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
   >({
     [provider]: {
       is_enabled: dataForwarder.isEnabled,
-      enroll_new_projects: dataForwarder.enrollNewProjects,
-      project_ids: dataForwarder.enrolledProjects.map(project => project.id),
       ...dataForwarder.config,
     },
   });
@@ -186,18 +185,11 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                 submitDisabled={!hasFeature}
                 model={formModel}
                 onSubmit={data => {
-                  const {
-                    enroll_new_projects,
-                    project_ids = [],
-                    is_enabled,
-                    ...config
-                  } = data;
+                  const {is_enabled, ...config} = data;
                   const dataForwardingPayload: Record<string, any> = {
                     provider,
                     config,
                     is_enabled,
-                    enroll_new_projects,
-                    project_ids,
                   };
                   updateDataForwarder({
                     ...dataForwarder,
@@ -225,9 +217,15 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                     provider,
                     projects,
                     dataForwarder,
+                    includeProjectConfig: false,
                   })}
                 />
               </Form>
+              <ProjectConfigurationForm
+                dataForwarder={dataForwarder}
+                projects={projects}
+                disabled={!hasFeature}
+              />
               <Flex align="center" justify="between" gap="2xl">
                 <Flex direction="column" gap="sm">
                   <Flex align="center" gap="lg">

--- a/static/app/views/settings/organizationDataForwarding/util/forms.tsx
+++ b/static/app/views/settings/organizationDataForwarding/util/forms.tsx
@@ -38,15 +38,17 @@ export function getDataForwarderFormGroups({
   provider,
   dataForwarder,
   projects,
+  includeProjectConfig = true,
 }: {
   projects: Project[];
   dataForwarder?: DataForwarder;
+  includeProjectConfig?: boolean;
   provider?: DataForwarderProviderSlug;
 }): JsonFormObject[] {
   return [
     getEnablementForm({dataForwarder}),
     ...getProviderForm({provider}),
-    getProjectConfigurationForm({projects}),
+    ...(includeProjectConfig ? [getProjectConfigurationForm({projects})] : []),
   ];
 }
 


### PR DESCRIPTION
Extracts the \"Project Configuration\" section from the legacy `JsonForm`/`FormModel` in the data forwarder edit page into a standalone `ProjectConfigurationForm` component using the new `useScrapsForm`/TanStack system.

The new component has its own \"Save Project Configuration\" button and submits independently from the main forwarder form (which now only handles enablement + provider config). This is the first step in a phased migration away from the legacy form system in this area.

`setup.tsx` is untouched — it still includes project config as part of the unified `JsonForm` payload sent on initial creation. `getDataForwarderFormGroups` now accepts an optional `includeProjectConfig` flag (defaulting to `true`) so `setup.tsx` requires no changes.