### PR TITLE
feat(seer-explorer): add /sentry-conversation slash command for employees

### DIFF
--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -23,6 +23,7 @@ interface ExplorerMenuProps {
     onMaxSize: () => void;
     onMedSize: () => void;
     onNew: () => void;
+    onSentryTrace: () => void;
   };
   textAreaRef: React.RefObject<HTMLTextAreaElement | null>;
   inputAnchorRef?: React.RefObject<HTMLElement | null>;
@@ -347,12 +348,14 @@ function useSlashCommands({
   onNew,
   onFeedback,
   onLangfuse,
+  onSentryTrace,
 }: {
   onFeedback: (() => void) | undefined;
   onLangfuse: () => void;
   onMaxSize: () => void;
   onMedSize: () => void;
   onNew: () => void;
+  onSentryTrace: () => void;
 }): MenuItemProps[] {
   const isSentryEmployee = useIsSentryEmployee();
 
@@ -400,10 +403,16 @@ function useSlashCommands({
               description: 'Open Langfuse to view session details',
               handler: onLangfuse,
             },
+            {
+              title: '/sentry-conversation',
+              key: '/sentry-conversation',
+              description: 'Open Sentry AI trace (conversation view)',
+              handler: onSentryTrace,
+            },
           ]
         : []),
     ],
-    [onNew, onMaxSize, onMedSize, onFeedback, onLangfuse, isSentryEmployee]
+    [onNew, onMaxSize, onMedSize, onFeedback, onLangfuse, onSentryTrace, isSentryEmployee]
   );
 }
 

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -340,6 +340,13 @@ function ExplorerPanel() {
     }
   }, [langfuseUrl]);
 
+  const handleOpenSentryTrace = useCallback(() => {
+    // Command handler. Disabled in slash command menu for non-employees
+    if (conversationsUrl) {
+      window.open(conversationsUrl, '_blank');
+    }
+  }, [conversationsUrl]);
+
   const openFeedbackForm = useFeedbackForm();
 
   // Generic feedback handler
@@ -374,6 +381,7 @@ function ExplorerPanel() {
         onNew: startNewSession,
         onFeedback: openFeedbackForm ? handleFeedback : undefined,
         onLangfuse: handleOpenLangfuse,
+        onSentryTrace: handleOpenSentryTrace,
       },
       onChangeSession: switchToRun,
       menuAnchorRef: sessionHistoryButtonRef,


### PR DESCRIPTION
## Changes

Adds a new employee-only `/sentry-conversation` slash command to the Seer Explorer panel.

- Opens the Sentry conversations URL for the current session in a new tab
- Gated behind `isSentryEmployee` check, same as `/langfuse`
- Mirrors the existing `/langfuse` command pattern end-to-end: handler in `explorerPanel.tsx`, command definition in `explorerMenu.tsx`