### PR TITLE
chore(warden): Disable sentry-javascript-bugs skill

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -33,12 +33,3 @@ ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
 [[skills.triggers]]
 type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
-
-[[skills]]
-name = "sentry-javascript-bugs"
-paths = ["static/**/*.ts", "static/**/*.tsx", "static/**/*.js", "static/**/*.jsx"]
-ignorePaths = ["**/*.spec.*", "**/*.test.*", "**/tests/**", "**/__mocks__/**"]
-
-[[skills.triggers]]
-type = "pull_request"
-actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Disable the sentry-javascript-bugs Warden skill as it's not yet fully
tested and may produce false positives on PRs.

The skill files remain in `.agents/skills/sentry-javascript-bugs/` so
it can be re-enabled once it's more stable.