### PR TITLE
feat(repositories): Add danger delete button with label to repository row

### DIFF
--- a/static/app/components/repositoryRow.spec.tsx
+++ b/static/app/components/repositoryRow.spec.tsx
@@ -37,7 +37,7 @@ describe('RepositoryRow', () => {
       expect(screen.getByText('github.com/example/repo-name')).toBeInTheDocument();
 
       // Trash button should display enabled
-      expect(screen.getByRole('button', {name: 'delete'})).toBeEnabled();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeEnabled();
 
       // No cancel button
       expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('RepositoryRow', () => {
       });
 
       // Trash button should be disabled
-      expect(screen.getByRole('button', {name: 'delete'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
 
       // Cancel button active
       expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe('RepositoryRow', () => {
       });
 
       // Trash button should be disabled
-      expect(screen.getByRole('button', {name: 'delete'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Delete'})).toBeDisabled();
     });
 
     it('displays disabled cancel', () => {
@@ -126,7 +126,7 @@ describe('RepositoryRow', () => {
         organization,
       });
       renderGlobalModal();
-      await userEvent.click(screen.getByRole('button', {name: 'delete'}));
+      await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
 
       // Confirm modal
       await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -67,14 +67,11 @@ export default function RepositoryRow({
           'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
         )}
       >
-        <StyledButton
-          size="xs"
-          priority="danger"
-          icon={<IconDelete />}
-          disabled={!hasAccess}
-        >
-          {t('Delete')}
-        </StyledButton>
+        <Container paddingLeft="md">
+          <Button size="xs" priority="danger" icon={<IconDelete />} disabled={!hasAccess}>
+            {t('Delete')}
+          </Button>
+        </Container>
       </Confirm>
     </Tooltip>
   );
@@ -88,14 +85,16 @@ export default function RepositoryRow({
               <strong>{repository.name}</strong>
               {!isActive && <small> &mdash; {getRepoStatusLabel(repository)}</small>}
               {repository.status === RepositoryStatus.PENDING_DELETION && (
-                <StyledButton
-                  size="xs"
-                  onClick={cancelDelete}
-                  disabled={!hasAccess}
-                  data-test-id="repo-cancel"
-                >
-                  {t('Cancel')}
-                </StyledButton>
+                <Container paddingLeft="md">
+                  <Button
+                    size="xs"
+                    onClick={cancelDelete}
+                    disabled={!hasAccess}
+                    data-test-id="repo-cancel"
+                  >
+                    {t('Cancel')}
+                  </Button>
+                </Container>
               )}
             </RepositoryTitle>
             <div>
@@ -150,10 +149,6 @@ const StyledPanelItem = styled(PanelItem)<{status: RepositoryStatus}>`
   &:last-child {
     border-bottom: none;
   }
-`;
-
-const StyledButton = styled(Button)`
-  margin-left: ${space(1)};
 `;
 
 const RepositoryTitle = styled('div')`

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -69,10 +69,12 @@ export default function RepositoryRow({
       >
         <StyledButton
           size="xs"
+          priority="danger"
           icon={<IconDelete />}
-          aria-label={t('delete')}
           disabled={!hasAccess}
-        />
+        >
+          {t('Delete')}
+        </StyledButton>
       </Confirm>
     </Tooltip>
   );

--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -51,81 +51,83 @@ export default function RepositoryRow({
       () => {}
     );
 
-  const renderDeleteButton = (hasAccess: boolean) => (
-    <Tooltip
-      title={t(
-        'You must be an organization owner, manager or admin to remove a repository.'
-      )}
-      disabled={hasAccess}
-    >
-      <Confirm
-        disabled={
-          !hasAccess || (!isActive && repository.status !== RepositoryStatus.DISABLED)
-        }
-        onConfirm={deleteRepo}
-        message={t(
-          'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
-        )}
-      >
-        <Container paddingLeft="md">
-          <Button size="xs" priority="danger" icon={<IconDelete />} disabled={!hasAccess}>
-            {t('Delete')}
-          </Button>
-        </Container>
-      </Confirm>
-    </Tooltip>
-  );
-
   return (
     <Access access={['org:integrations']}>
       {({hasAccess}) => (
         <StyledPanelItem status={repository.status}>
-          <Stack>
-            <RepositoryTitle>
-              <strong>{repository.name}</strong>
-              {!isActive && <small> &mdash; {getRepoStatusLabel(repository)}</small>}
-              {repository.status === RepositoryStatus.PENDING_DELETION && (
-                <Container paddingLeft="md">
-                  <Button
-                    size="xs"
-                    onClick={cancelDelete}
-                    disabled={!hasAccess}
-                    data-test-id="repo-cancel"
-                  >
-                    {t('Cancel')}
-                  </Button>
-                </Container>
-              )}
-            </RepositoryTitle>
-            <div>
-              {showProvider && (
-                <Flex as="span" align="center" gap="xs" display="inline-flex">
-                  <small>{repository.provider.name}</small>
-                  {repository.provider.id === 'unknown' && (
-                    <QuestionTooltip
-                      isHoverable
+          <Flex gap="md" justify="between" align="center" flex={1}>
+            <Stack>
+              <RepositoryTitle>
+                <Flex gap="md">
+                  <strong>{repository.name}</strong>
+                  {!isActive && <small> &mdash; {getRepoStatusLabel(repository)}</small>}
+                  {repository.status === RepositoryStatus.PENDING_DELETION && (
+                    <Button
                       size="xs"
-                      title={tct(
-                        'This repository is not linked to a source code management integration. It was detected from your release or stack trace data. [link:Set up an integration].',
-                        {
-                          link: <Link to={`/settings/${orgSlug}/integrations/`} />,
-                        }
-                      )}
-                    />
+                      onClick={cancelDelete}
+                      disabled={!hasAccess}
+                      data-test-id="repo-cancel"
+                    >
+                      {t('Cancel')}
+                    </Button>
                   )}
                 </Flex>
+              </RepositoryTitle>
+              <div>
+                {showProvider && (
+                  <Flex as="span" align="center" gap="xs" display="inline-flex">
+                    <small>{repository.provider.name}</small>
+                    {repository.provider.id === 'unknown' && (
+                      <QuestionTooltip
+                        isHoverable
+                        size="xs"
+                        title={tct(
+                          'This repository is not linked to a source code management integration. It was detected from your release or stack trace data. [link:Set up an integration].',
+                          {
+                            link: <Link to={`/settings/${orgSlug}/integrations/`} />,
+                          }
+                        )}
+                      />
+                    )}
+                  </Flex>
+                )}
+                {showProvider && repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
+                {repository.url && (
+                  <small>
+                    <ExternalLink href={repository.url}>
+                      {repository.url.replace('https://', '')}
+                    </ExternalLink>
+                  </small>
+                )}
+              </div>
+            </Stack>
+            <Tooltip
+              title={t(
+                'You must be an organization owner, manager or admin to remove a repository.'
               )}
-              {showProvider && repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
-              {repository.url && (
-                <small>
-                  <ExternalLink href={repository.url}>
-                    {repository.url.replace('https://', '')}
-                  </ExternalLink>
-                </small>
-              )}
-            </div>
-          </Stack>
-          {renderDeleteButton(hasAccess)}
+              disabled={hasAccess}
+            >
+              <Confirm
+                disabled={
+                  !hasAccess ||
+                  (!isActive && repository.status !== RepositoryStatus.DISABLED)
+                }
+                onConfirm={deleteRepo}
+                message={t(
+                  'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
+                )}
+              >
+                <Button
+                  size="xs"
+                  priority="danger"
+                  icon={<IconDelete />}
+                  disabled={!hasAccess}
+                >
+                  {t('Delete')}
+                </Button>
+              </Confirm>
+            </Tooltip>
+          </Flex>
         </StyledPanelItem>
       )}
     </Access>


### PR DESCRIPTION
This is a destructive action so it should use the appropriate variant and text