### PR TITLE
chore(flags): Remove 5 GA-graduated data-browsing feature flags (batch 1)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1394,13 +1394,8 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 # Sentry and internal client configuration
 
 SENTRY_EARLY_FEATURES = {
-    "organizations:anr-analyze-frames": "Enable anr frame analysis",
-    "organizations:device-classification": "Enable device.class as a selectable column",
-    "organizations:mobile-cpu-memory-in-transactions": "Display CPU and memory metrics in transactions with profiles",
-    "organizations:performance-metrics-backed-transaction-summary": "Enable metrics-backed transaction summary view",
     "organizations:performance-new-trends": "Enable new trends",
     "organizations:performance-new-widget-designs": "Enable updated landing page widget designs",
-    "organizations:performance-transaction-name-only-search-indexed": "Enable transaction name only search on indexed",
     "organizations:profiling-global-suspect-functions": "Enable global suspect functions in profiling",
 }
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -54,8 +54,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable anomaly detection threshold data endpoint
     manager.add("organizations:anomaly-detection-threshold-data", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable anr frame analysis
-    manager.add("organizations:anr-analyze-frames", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable GenAI features such as Autofix and Issue Summary
@@ -120,8 +118,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:default-anomaly-detector", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables synthesis of device.class in ingest
     manager.add("organizations:device-class-synthesis", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable device.class as a selectable column
-    manager.add("organizations:device-classification", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the 'discover' interface. (might be unused)
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the discover saved queries deprecation warnings
@@ -191,8 +187,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Session Stats down to a minute resolution
     manager.add("organizations:minute-resolution-sessions", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
-    # Display CPU and memory metrics in transactions with profiles
-    manager.add("organizations:mobile-cpu-memory-in-transactions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables higher limit for alert rules
     manager.add("organizations:more-fast-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("organizations:more-slow-alerts", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
@@ -238,8 +232,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Re-enable histograms for Metrics Enhanced Performance Views
     manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable metrics-backed transaction summary view
-    manager.add("organizations:performance-metrics-backed-transaction-summary", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable new trends
     manager.add("organizations:performance-new-trends", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable updated landing page widget designs
@@ -278,8 +270,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-fields-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable transaction name only search
     manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable transaction name only search on indexed
-    manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable the EAP-powered transactions summary view
     manager.add("organizations:performance-transaction-summary-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the new UI for span summary and the spans tab

--- a/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.spec.tsx
@@ -1,5 +1,4 @@
 import {EventFixture} from 'sentry-fixture/event';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
@@ -166,7 +165,6 @@ describe('Frame - Line', () => {
 
   describe('ANR suspect frame', () => {
     it('should render suspect frame', () => {
-      const org = {...OrganizationFixture(), features: ['anr-analyze-frames']};
       const eventWithThreads = EventFixture({
         entries: [
           {
@@ -214,8 +212,7 @@ describe('Frame - Line', () => {
           threadId={13920}
           isANR
           isExpanded
-        />,
-        {organization: org}
+        />
       );
       expect(screen.getByText('Suspect Frame')).toBeInTheDocument();
     });

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -225,7 +225,7 @@ function DeprecatedLine({
           </DefaultLineTitleWrapper>
           <FrameActions>
             <RepeatsIndicator timesRepeated={timesRepeated} />
-            {organization?.features.includes('anr-analyze-frames') && anrCulprit ? (
+            {anrCulprit ? (
               <Tag variant="warning" onClick={scrollToSuspectRootCause}>
                 {t('Suspect Frame')}
               </Tag>

--- a/static/app/components/events/interfaces/performance/anrRootCause.spec.tsx
+++ b/static/app/components/events/interfaces/performance/anrRootCause.spec.tsx
@@ -242,8 +242,7 @@ describe('anrRootCause', () => {
       },
     ]);
     const {organization} = initializeOrg();
-    const org = {...organization, features: ['anr-analyze-frames']};
-    render(<AnrRootCause event={event} organization={org} />, {wrapper});
+    render(<AnrRootCause event={event} organization={organization} />, {wrapper});
 
     expect(
       screen.getByText(

--- a/static/app/components/events/interfaces/performance/anrRootCause.tsx
+++ b/static/app/components/events/interfaces/performance/anrRootCause.tsx
@@ -178,7 +178,7 @@ export function AnrRootCause({event, organization}: Props) {
           </IssueSummary>
         );
       })}
-      {organization.features.includes('anr-analyze-frames') && renderAnrCulprit()}
+      {renderAnrCulprit()}
     </InterimSection>
   );
 }


### PR DESCRIPTION
## Summary

Remove 5 feature flags owned by data-browsing that have been enabled at 100% for all users via flagpole with no conditions for an extended period. These flags are fully graduated and their behavior should be the permanent default.

**Flags removed:**
- `organizations:anr-analyze-frames` — ANR frame analysis (GA since 2024-01-25)
- `organizations:device-classification` — device.class column (GA since 2023-04-12)
- `organizations:mobile-cpu-memory-in-transactions` — CPU/memory in transactions (GA since 2023-05-02)
- `organizations:performance-metrics-backed-transaction-summary` — metrics-backed txn summary (GA since 2023-02-09)
- `organizations:performance-transaction-name-only-search-indexed` — txn name search on indexed (GA since 2022-11-15)

**Changes:**
- Removed flag registrations from `temporary.py`
- Removed default entries from `SENTRY_EARLY_FEATURES` in `conf/server.py`
- Removed feature flag checks in frontend components for `anr-analyze-frames` (ANR root cause analysis is now always active)

**Self-hosted implications:** These features will now always be enabled. Operators should verify this is acceptable for their deployments.

A corresponding PR to remove the flagpole configuration will follow in `sentry-options-automator`.

## Test plan
- [ ] Verify no remaining references to these flag names in the codebase
- [ ] Frontend tests pass with flag checks removed