### PR TITLE
chore(flags): Remove GA-graduated dynamic-sampling-count-biases flag

### DIFF
--- a/src/sentry/dynamic_sampling/rules/base.py
+++ b/src/sentry/dynamic_sampling/rules/base.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import sentry_sdk
 
-from sentry import features, quotas
+from sentry import quotas
 from sentry.constants import TARGET_SAMPLE_RATE_DEFAULT
 from sentry.db.models import Model
 from sentry.dynamic_sampling.rules.biases.base import Bias
@@ -112,9 +112,7 @@ def _get_rules_of_enabled_biases(
             try:
                 generated_rules = bias.generate_rules(project, base_sample_rate)
                 rules += generated_rules
-                if generated_rules and features.has(
-                    "organizations:dynamic-sampling-count-biases", project.organization
-                ):
+                if generated_rules:
                     metrics.incr(
                         "dynamic_sampling.rule_emitted",
                         tags={"bias": bias.__class__.__name__},

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -136,8 +136,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dynamic-sampling-custom", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dynamic sampling minimum sample rate
     manager.add("organizations:dynamic-sampling-minimum-sample-rate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable metrics emission for dynamic sampling rules
-    manager.add("organizations:dynamic-sampling-count-biases", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable emiting escalating data to the metrics backend
     manager.add("organizations:escalating-metrics-backend", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable returning the migrated discover queries in explore saved queries


### PR DESCRIPTION
## Summary

Remove the `organizations:dynamic-sampling-count-biases` feature flag owned by telemetry-experience. This flag has been enabled at 100% for all users via flagpole since 2026-01-20 with no conditions.

The flag gated a `metrics.incr` call for tracking dynamic sampling rule emissions. With the flag removed, the metric is now always emitted — this is the intended long-term behavior.

**Self-hosted implications:** The `dynamic_sampling.rule_emitted` metric will now always be emitted. This is purely observability and has no functional impact.

A corresponding PR to remove the flagpole configuration will follow in `sentry-options-automator`.

## Test plan
- [ ] Verify no remaining references to this flag name
- [ ] Dynamic sampling continues to function normally