### PR TITLE
chore(flags): Remove GA-graduated mep-use-default-tags flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -172,7 +172,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable flamegraph visualization for MetricKit hang diagnostic stack traces
     manager.add("organizations:metrickit-flamegraph", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Session Stats down to a minute resolution

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -27,7 +27,6 @@ from snuba_sdk import (
     Request,
 )
 
-from sentry import features
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models.dashboard_widget import DashboardWidgetQueryOnDemand
@@ -119,7 +118,6 @@ class MetricsQueryBuilder(BaseQueryBuilder):
         self.percentiles: list[CurriedFunction] = []
         self.metric_ids: set[int] = set()
         self._indexer_cache: dict[str, int | None] = {}
-        self._use_default_tags: bool | None = None
         self._has_nullable: bool = False
         self._is_spans_metrics_query_cache: bool | None = None
         # always true if this is being called
@@ -158,14 +156,7 @@ class MetricsQueryBuilder(BaseQueryBuilder):
     def use_default_tags(self) -> bool:
         if self.is_spans_metrics_query:
             return False
-        if self._use_default_tags is None:
-            if self.params.organization is not None:
-                self._use_default_tags = features.has(
-                    "organizations:mep-use-default-tags", self.params.organization, actor=None
-                )
-            else:
-                self._use_default_tags = False
-        return self._use_default_tags
+        return True
 
     def are_columns_resolved(self) -> bool:
         # If we have an on demand spec, we want to mark the columns as resolved, since we are not running the

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -2600,20 +2600,19 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         assert spec_map[field]
         assert spec_map[field_two]
 
-        mep_query = TopMetricsQueryBuilder(
-            Dataset.PerformanceMetrics,
-            self.params,
-            3600 * 24,
-            [{"customtag1": "div > text"}, {"customtag2": "red"}],
-            query="",
-            selected_columns=groupbys,
-            timeseries_columns=[field, field_two],
-            config=QueryBuilderConfig(
-                on_demand_metrics_enabled=False,
-            ),
-        )
-
-        assert not mep_query._on_demand_metric_spec_map
+        with pytest.raises(IncompatibleMetricsQuery):
+            TopMetricsQueryBuilder(
+                Dataset.PerformanceMetrics,
+                self.params,
+                3600 * 24,
+                [{"customtag1": "div > text"}, {"customtag2": "red"}],
+                query="",
+                selected_columns=groupbys,
+                timeseries_columns=[field, field_two],
+                config=QueryBuilderConfig(
+                    on_demand_metrics_enabled=False,
+                ),
+            )
         result = query.run_query("test_query")
 
         assert result["data"]

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -3340,18 +3340,17 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         transaction_data["tags"].append(("faketag", "foo"))
         self.store_event(transaction_data, self.project.id)
 
-        with self.feature({"organizations:mep-use-default-tags": True}):
-            response = self.do_request(
-                {
-                    "field": [
-                        "faketag",
-                        "count()",
-                    ],
-                    "query": "event.type:transaction",
-                    "dataset": "metricsEnhanced",
-                    "per_page": 50,
-                }
-            )
+        response = self.do_request(
+            {
+                "field": [
+                    "faketag",
+                    "count()",
+                ],
+                "query": "event.type:transaction",
+                "dataset": "metricsEnhanced",
+                "per_page": 50,
+            }
+        )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         data = response.data["data"]


### PR DESCRIPTION
Remove `mep-use-default-tags` feature flag — enabled at 100% with no conditions.

The `use_default_tags` property in MetricsQueryBuilder now always returns True for non-spans queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)