### PR TITLE
feat(flags): Remove graduated issue_detection feature flags

### DIFF
--- a/fixtures/events/issue_detection/uncompressed-assets/uncompressed-script-asset.json
+++ b/fixtures/events/issue_detection/uncompressed-assets/uncompressed-script-asset.json
@@ -66,7 +66,7 @@
       "exclusive_time": 643.100167,
       "description": "https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_components_charts_utils_tsx-app_utils_performance_quickTrace_utils_tsx-app_utils_withPage-3926ec.bc434924850c44d4057f.js",
       "op": "resource.script",
-      "span_id": "b66a5642da1edb52",
+      "span_id": "c77b6753eb2fec63",
       "parent_span_id": "a0c39078d1570b00",
       "trace_id": "0102834d0bf74d388ce0b1e15329f731",
       "data": {

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -52,8 +52,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:alerts-timeseries-comparison", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection feature for EAP spans
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable anomaly detection threshold data endpoint
-    manager.add("organizations:anomaly-detection-threshold-data", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enabled for orgs that participated in the code review beta
@@ -169,13 +167,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Enables streamlined issue details UI for all users of an organization without opt-out
     manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables sorting spans for issue detection
-    manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-generated titles for issue views
     manager.add("organizations:issue-view-ai-title", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable Large HTTP Payload Detector Improvements
-    manager.add("organizations:large-http-payload-detector-improvements", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Migrate Orgs to new Azure DevOps Integration
     manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
@@ -393,8 +386,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-toolbar-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable suspect feature flags endpoint.
     manager.add("organizations:feature-flag-suspect-flags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable suspect commit information in workflow notification emails
-    manager.add("organizations:suspect-commits-in-emails", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
     # Enable suspect feature tags endpoint.
     manager.add("organizations:issues-suspect-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Lets organizations manage grouping configs

--- a/src/sentry/issue_detection/detectors/large_http_payload_detector.py
+++ b/src/sentry/issue_detection/detectors/large_http_payload_detector.py
@@ -4,7 +4,6 @@ import re
 from datetime import timedelta
 from typing import Any
 
-from sentry import features
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
 from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.organization import Organization
@@ -133,12 +132,8 @@ class LargeHTTPPayloadDetector(PerformanceDetector):
         if span_data and span_data.get("http.request.prefetch"):
             return False
 
-        if features.has(
-            "organizations:large-http-payload-detector-improvements",
-            self.organization,
-        ):
-            if any(path in description for path in self.filtered_paths):
-                return False
+        if any(path in description for path in self.filtered_paths):
+            return False
 
         return True
 

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse, urlunparse
 from django.utils.html import format_html
 from django.utils.safestring import SafeString
 
-from sentry import features
 from sentry.db.models import Model
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.helpers import get_reason_context
@@ -140,10 +139,7 @@ class GroupActivityNotification(ActivityNotification, abc.ABC):
             "enhanced_privacy": enhanced_privacy,
         }
 
-        if (
-            features.has("organizations:suspect-commits-in-emails", self.group.organization)
-            and self.group
-        ):
+        if self.group:
             context["commits"] = get_suspect_commits_by_group_id(
                 project=self.project, group_id=self.group.id
             )

--- a/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_anomaly_data.py
@@ -4,7 +4,6 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -112,11 +111,6 @@ class OrganizationDetectorAnomalyDataEndpoint(OrganizationEndpoint):
 
         Pass `legacy_alert=true` query param to treat detector_id as a legacy alert rule ID.
         """
-        if not features.has(
-            "organizations:anomaly-detection-threshold-data", organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
-
         start = request.GET.get("start")
         end = request.GET.get("end")
 

--- a/static/app/views/detectors/components/details/metric/chart.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.spec.tsx
@@ -43,7 +43,7 @@ describe('MetricDetectorDetailsChart', () => {
 
   describe('anomaly threshold cutoff message', () => {
     const organization = OrganizationFixture({
-      features: ['anomaly-detection-threshold-data', 'visibility-explore-view'],
+      features: ['visibility-explore-view'],
     });
 
     const anomalyDetector = MetricDetectorFixture({

--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -624,6 +624,11 @@ describe('DetectorEdit', () => {
         body: mockDetector,
       });
 
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/anomaly-data/`,
+        body: [],
+      });
+
       render(<DetectorEdit />, {
         organization,
         initialRouterConfig,
@@ -673,6 +678,11 @@ describe('DetectorEdit', () => {
         body: dynamicDetector,
       });
 
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${dynamicDetector.id}/anomaly-data/`,
+        body: [],
+      });
+
       render(<DetectorEdit />, {
         organization,
         initialRouterConfig: {
@@ -697,6 +707,11 @@ describe('DetectorEdit', () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
         body: mockDetector,
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/anomaly-data/`,
+        body: [],
       });
 
       // Current data for chart

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.spec.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.spec.tsx
@@ -10,9 +10,7 @@ describe('useMetricDetectorAnomalyThresholds', () => {
   });
 
   it('does not fetch data when detectionType is not dynamic', () => {
-    const organization = OrganizationFixture({
-      features: ['anomaly-detection-threshold-data'],
-    });
+    const organization = OrganizationFixture();
 
     const anomalyDataRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/detectors/123/anomaly-data/`,
@@ -42,9 +40,7 @@ describe('useMetricDetectorAnomalyThresholds', () => {
   });
 
   it('fetches data when detectionType is dynamic', async () => {
-    const organization = OrganizationFixture({
-      features: ['anomaly-detection-threshold-data'],
-    });
+    const organization = OrganizationFixture();
 
     const mockData = [
       {
@@ -86,9 +82,7 @@ describe('useMetricDetectorAnomalyThresholds', () => {
   });
 
   it('does not fetch data when detectionType is undefined', () => {
-    const organization = OrganizationFixture({
-      features: ['anomaly-detection-threshold-data'],
-    });
+    const organization = OrganizationFixture();
 
     const anomalyDataRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/detectors/123/anomaly-data/`,
@@ -118,9 +112,7 @@ describe('useMetricDetectorAnomalyThresholds', () => {
   });
 
   it('includes legacy_alert query param when isLegacyAlert is true', async () => {
-    const organization = OrganizationFixture({
-      features: ['anomaly-detection-threshold-data'],
-    });
+    const organization = OrganizationFixture();
 
     const mockData = [
       {

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalyThresholds.tsx
@@ -54,9 +54,6 @@ export function useMetricDetectorAnomalyThresholds({
   const organization = useOrganization();
   const theme = useTheme();
 
-  const hasAnomalyDataFlag = organization.features.includes(
-    'anomaly-detection-threshold-data'
-  );
   const isAnomalyDetection = detectionType === 'dynamic';
 
   const {
@@ -82,9 +79,7 @@ export function useMetricDetectorAnomalyThresholds({
     {
       staleTime: 0,
       enabled:
-        hasAnomalyDataFlag &&
-        isAnomalyDetection &&
-        Boolean(detectorId && startTimestamp && endTimestamp),
+        isAnomalyDetection && Boolean(detectorId && startTimestamp && endTimestamp),
     }
   );
 

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -805,9 +805,7 @@ function ProjectPerformance() {
               performanceIssueSettings[DetectorConfigAdmin.LARGE_HTTP_PAYLOAD_ENABLED]
             ),
             disabledReason,
-            visible: organization.features.includes(
-              'large-http-payload-detector-improvements'
-            ),
+            visible: true,
           },
         ],
         initiallyCollapsed: issueType !== IssueType.PERFORMANCE_LARGE_HTTP_PAYLOAD,

--- a/tests/sentry/issue_detection/test_large_http_payload_detector.py
+++ b/tests/sentry/issue_detection/test_large_http_payload_detector.py
@@ -13,7 +13,6 @@ from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issues.grouptype import PerformanceLargeHTTPPayloadGroupType
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.issue_detection.event_generators import create_event, create_span
 
 
@@ -308,7 +307,6 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         event = create_event(spans)
         assert len(self.find_problems(event)) == 0
 
-    @with_feature("organizations:large-http-payload-detector-improvements")
     def test_does_not_trigger_detection_for_filtered_paths(self) -> None:
         project = self.create_project()
         ProjectOption.objects.set_value(
@@ -338,7 +336,6 @@ class LargeHTTPPayloadDetectorTest(TestCase):
         run_detector_on_data(detector, event)
         assert len(detector.stored_problems) == 0
 
-    @with_feature("organizations:large-http-payload-detector-improvements")
     def test_does_not_trigger_detection_for_filtered_paths_without_trailing_slash(self) -> None:
         project = self.create_project()
         ProjectOption.objects.set_value(

--- a/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
+++ b/tests/sentry/issue_detection/test_uncompressed_asset_detector.py
@@ -13,6 +13,7 @@ from sentry.issue_detection.performance_detection import (
 )
 from sentry.issue_detection.performance_problem import PerformanceProblem
 from sentry.issues.grouptype import PerformanceUncompressedAssetsGroupType
+from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
 from sentry.testutils.issue_detection.event_generators import PROJECT_ID, create_span, get_event
@@ -402,14 +403,20 @@ class UncompressedAssetsDetectorTest(TestCase):
                 type=PerformanceUncompressedAssetsGroupType,
                 parent_span_ids=[],
                 cause_span_ids=[],
-                offender_span_ids=["b66a5642da1edb52"],
+                offender_span_ids=["c77b6753eb2fec63"],
                 evidence_data={
                     "op": "resource.script",
                     "parent_span_ids": [],
                     "cause_span_ids": [],
-                    "offender_span_ids": ["b66a5642da1edb52"],
+                    "offender_span_ids": ["c77b6753eb2fec63"],
                 },
-                evidence_display=[],
+                evidence_display=[
+                    IssueEvidence(
+                        name="Offending Spans",
+                        value="resource.script - https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_components_charts_utils_tsx-app_utils_performance_quickTrace_utils_tsx-app_utils_withPage-3926ec.bc434924850c44d4057f.js",
+                        important=True,
+                    ),
+                ],
             ),
         ]
 

--- a/tests/sentry/notifications/notifications/test_assigned.py
+++ b/tests/sentry/notifications/notifications/test_assigned.py
@@ -10,7 +10,6 @@ from sentry.models.activity import Activity
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.organization import Organization
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -107,7 +106,6 @@ class AssignedNotificationAPITest(APITestCase):
         assert self.group.title in blocks[1]["text"]["text"]
         assert self.project.slug in blocks[-2]["elements"][0]["text"]
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_sends_assignment_notification_with_suspect_commits(self, mock_post):
         """
         Test that suspect commits are included in assignment notification emails
@@ -162,7 +160,6 @@ class AssignedNotificationAPITest(APITestCase):
         assert "abc123d" in html_content  # shortened commit ID
         assert user.get_display_name() in html_content  # commit author
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_sends_assignment_notification_without_suspect_commits(self, mock_post):
         """
         Test that assignment notifications work normally when no suspect commits exist.
@@ -188,7 +185,6 @@ class AssignedNotificationAPITest(APITestCase):
         # But assignment notification should still work
         assert f"assigned {self.group.qualified_short_id} to themselves" in msg.body
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_enhanced_privacy_hides_suspect_commits_in_emails(self, mock_post):
         user = self.create_user()
         self.setup_user(user, self.team)
@@ -240,7 +236,6 @@ class AssignedNotificationAPITest(APITestCase):
         # assignment notification should still work normally
         assert f"assigned {self.group.qualified_short_id} to themselves" in msg.body
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_enhanced_privacy_default_shows_suspect_commits_in_emails(self, mock_post):
         """
         Test that suspect commits are shown by default in assignment notification emails
@@ -293,7 +288,6 @@ class AssignedNotificationAPITest(APITestCase):
         # assignment notification should still work normally
         assert f"assigned {self.group.qualified_short_id} to themselves" in msg.body
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_sends_assignment_notification_with_multiple_suspect_commits(self, mock_post):
         """
         Test that when multiple suspect commits exist, the most recent one is displayed in notifications.

--- a/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
+++ b/tests/sentry/notifications/notifications/test_suspect_commits_activity.py
@@ -10,7 +10,6 @@ from sentry.notifications.notifications.activity.note import NoteActivityNotific
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
 from sentry.notifications.notifications.activity.unassigned import UnassignedActivityNotification
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.types.activity import ActivityType
 
@@ -57,7 +56,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
             context={"commitId": commit.id},
         )
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_assigned_notification_includes_suspect_commits(self):
         self._create_suspect_commit_owner(self.commit1)
 
@@ -83,7 +81,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert context["commits"][0]["shortId"] == "abc123d"
         assert context["commits"][0]["author"]["name"] == self.user.get_display_name()
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_unassigned_notification_includes_suspect_commits(self):
         # First assign, then unassign
         GroupAssignee.objects.create(
@@ -115,7 +112,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_resolved_notification_includes_suspect_commits(self):
         self._create_suspect_commit_owner(self.commit1)
 
@@ -134,7 +130,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_note_notification_includes_suspect_commits(self):
         self._create_suspect_commit_owner(self.commit1)
 
@@ -153,7 +148,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert len(context["commits"]) == 1
         assert context["commits"][0]["subject"] == "feat: Add new feature"
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_multiple_suspect_commits_in_notification(self):
         """Test that when multiple suspect commits exist, only the most recent one is returned."""
         # Create GroupOwner records for both commits
@@ -185,7 +179,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert commit["subject"] == "fix: Critical bug fix"
         assert commit["id"] == "def456ghi789"
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_notification_without_suspect_commits(self):
         activity = Activity.objects.create(
             project=self.project,
@@ -206,7 +199,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert "commits" in context
         assert context["commits"] == []
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_graceful_handling_of_invalid_commit_ids(self):
         # Create GroupOwner with invalid commit ID
         GroupOwner.objects.create(
@@ -238,7 +230,6 @@ class SuspectCommitsInActivityNotificationsTest(TestCase):
         assert "commits" in context
         assert context["commits"] == []
 
-    @with_feature("organizations:suspect-commits-in-emails")
     def test_enhanced_privacy_hides_suspect_commits(self):
         """Test that suspect commits are hidden when enhanced privacy is enabled."""
         self._create_suspect_commit_owner(self.commit1)


### PR DESCRIPTION
## Summary

Removes 4 feature flags owned by the issue_detection team that have been enabled at 100% via flagpole with no conditions for an extended period:

- `organizations:anomaly-detection-threshold-data` — Anomaly detection threshold data endpoint
- `organizations:issue-detection-sort-spans` — Sorting spans for issue detection
- `organizations:large-http-payload-detector-improvements` — Large HTTP payload detector improvements (path filtering)
- `organizations:suspect-commits-in-emails` — Suspect commit information in workflow notification emails

These flags have been fully rolled out and their behavior is now the default. Owners should consider self-hosted implications — these features will now be available to all self-hosted users as well.

Changes:
- Removed flag registrations from `temporary.py`
- Removed `features.has()` checks, keeping the enabled code paths
- Removed `@with_feature` test decorators and feature-flag-disabled test cases
- Removed frontend feature gate checks
- Cleaned up unused imports

## Test plan
- [ ] Verify pre-commit passes (done locally)
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config