### PR TITLE
feat(flags): Remove graduated data-browsing dashboards feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -90,8 +90,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-global-filters", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables favourite and duplicate controls for prebuilt dashboards
     manager.add("organizations:dashboards-prebuilt-controls", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables import/export functionality for dashboards
-    manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable metrics enhanced performance in dashboards
     manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -257,21 +257,19 @@ function Controls({
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
-            <Feature features="dashboards-import">
-              <Tooltip title={t('Export Dashboard')}>
-                <Button
-                  data-test-id="dashboard-export"
-                  aria-label={t('export-dashboard')}
-                  onClick={e => {
-                    e.preventDefault();
-                    exportDashboard();
-                  }}
-                  icon={<IconDownload />}
-                  priority="default"
-                  size="sm"
-                />
-              </Tooltip>
-            </Feature>
+            <Tooltip title={t('Export Dashboard')}>
+              <Button
+                data-test-id="dashboard-export"
+                aria-label={t('export-dashboard')}
+                onClick={e => {
+                  e.preventDefault();
+                  exportDashboard();
+                }}
+                icon={<IconDownload />}
+                priority="default"
+                size="sm"
+              />
+            </Tooltip>
             {dashboard.id !== 'default-overview' && !isPrebuiltDashboard && (
               <EditAccessSelector
                 dashboard={dashboard}

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -614,22 +614,20 @@ function ManageDashboards() {
                           </Button>
                         )}
                       </DashboardCreateLimitWrapper>
-                      <Feature features="dashboards-import">
-                        <Button
-                          onClick={() => {
-                            openImportDashboardFromFileModal({
-                              organization,
-                              api,
-                              location,
-                            });
-                          }}
-                          size="sm"
-                          priority="primary"
-                          icon={<IconAdd />}
-                        >
-                          {t('Import Dashboard from JSON')}
-                        </Button>
-                      </Feature>
+                      <Button
+                        onClick={() => {
+                          openImportDashboardFromFileModal({
+                            organization,
+                            api,
+                            location,
+                          });
+                        }}
+                        size="sm"
+                        priority="primary"
+                        icon={<IconAdd />}
+                      >
+                        {t('Import Dashboard from JSON')}
+                      </Button>
                     </Grid>
                   </Layout.HeaderActions>
                 </Layout.Header>


### PR DESCRIPTION
## Summary
Removes 1 feature flag owned by data-browsing that has been enabled at 100% via flagpole with no conditions:
- `organizations:dashboards-import` — Enables import/export functionality for dashboards (frontend Feature wrapper in controls.tsx and manage/index.tsx)

Note: 3 other flags from this batch had zero code references across all repos and are already fully removed:
- `organizations:dashboards-edit-access`
- `organizations:dashboards-releases-on-charts`
- `organizations:ourlogs-fields-jsonschema`

`organizations:ourlogs-enabled` was excluded from this batch — it has 40+ code references and may not be fully released everywhere.

These flags have been fully rolled out and their behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config