### PR TITLE
feat(seer): add github_copilot_not_licensed failure type

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -330,6 +330,7 @@ def _launch_agents_for_repos(
                 url_part = f" ({e.url})" if e.url else ""
                 if e.code == 403 and client is not None:
                     if e.text and "not licensed" in e.text:
+                        failure_type = "github_copilot_not_licensed"
                         error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
                     else:
                         failure_type = "github_app_permissions"

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -329,7 +329,7 @@ def _launch_agents_for_repos(
             if isinstance(e, ApiError):
                 url_part = f" ({e.url})" if e.url else ""
                 if e.code == 403 and client is not None:
-                    if e.text and "not licensed" in e.text:
+                    if e.text and "not licensed" in e.text.lower():
                         failure_type = "github_copilot_not_licensed"
                         error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
                     else:

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -150,6 +150,7 @@ def launch_coding_agents(
             github_installation_id: str | None = None
             if isinstance(e, ApiError) and e.code == 403 and is_github_copilot:
                 if e.text and "not licensed" in e.text:
+                    failure_type = "github_copilot_not_licensed"
                     error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
                 else:
                     failure_type = "github_app_permissions"

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -149,7 +149,7 @@ def launch_coding_agents(
             error_message = "Failed to launch coding agent"
             github_installation_id: str | None = None
             if isinstance(e, ApiError) and e.code == 403 and is_github_copilot:
-                if e.text and "not licensed" in e.text:
+                if e.text and "not licensed" in e.text.lower():
                     failure_type = "github_copilot_not_licensed"
                     error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
                 else:

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1195,7 +1195,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
     @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
     @patch("sentry.seer.autofix.coding_agent.GithubCopilotAgentClient")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
-    def test_copilot_not_licensed_403_returns_generic_failure_type(
+    def test_copilot_not_licensed_403_returns_github_copilot_not_licensed_failure_type(
         self,
         mock_identity_service,
         mock_copilot_client_class,
@@ -1204,7 +1204,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         mock_get_autofix_state,
         mock_get_providers,
     ):
-        """Test POST endpoint returns failure_type=generic for Copilot 403s with a licensing error.
+        """Test POST endpoint returns failure_type=github_copilot_not_licensed for Copilot 403s with a licensing error.
 
         When GitHub Copilot returns a 403 with "not licensed to use Copilot", the user's
         account lacks an active Copilot subscription. This is distinct from a GitHub App
@@ -1236,11 +1236,8 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
             assert response.data["success"] is False
             assert response.data["failed_count"] >= 1
             failure = response.data["failures"][0]
-            assert failure["failure_type"] == "generic"
-            assert (
-                "not licensed" in failure["error_message"]
-                or "Copilot license" in failure["error_message"]
-            )
+            assert failure["failure_type"] == "github_copilot_not_licensed"
+            assert "Copilot license" in failure["error_message"]
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -141,14 +141,14 @@ class TestLaunchCodingAgents(TestCase):
     @patch("sentry.seer.explorer.coding_agent_handoff.GithubCopilotAgentClient")
     @patch("sentry.seer.explorer.coding_agent_handoff.github_copilot_identity_service")
     @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_copilot_not_licensed_403_returns_generic_failure_type(
+    def test_copilot_not_licensed_403_returns_github_copilot_not_licensed_failure_type(
         self,
         mock_features,
         mock_identity_service,
         mock_copilot_client_class,
         mock_store,
     ):
-        """Test that Copilot 403 'not licensed' errors return generic failure_type.
+        """Test that Copilot 403 'not licensed' errors return github_copilot_not_licensed failure_type.
 
         When GitHub Copilot returns a 403 with "not licensed to use Copilot", the user's
         account lacks an active Copilot subscription. This is distinct from a GitHub App
@@ -176,8 +176,5 @@ class TestLaunchCodingAgents(TestCase):
         assert len(result["successes"]) == 0
         assert len(result["failures"]) == 1
         failure = result["failures"][0]
-        assert failure["failure_type"] == "generic"
-        assert (
-            "not licensed" in failure["error_message"]
-            or "Copilot license" in failure["error_message"]
-        )
+        assert failure["failure_type"] == "github_copilot_not_licensed"
+        assert "Copilot license" in failure["error_message"]


### PR DESCRIPTION
When a user tries to launch GitHub Copilot as a coding agent but their GitHub account doesn't have an active Copilot license, GitHub returns a 403 with "not licensed" in the response text. Previously this produced a `failure_type: "generic"` failure, which surfaced only as a generic error toast on the frontend.

This sets `failure_type` to `"github_copilot_not_licensed"` in both the standard autofix path (`coding_agent.py`) and the explorer handoff path (`coding_agent_handoff.py`), giving the frontend a distinct signal to show a targeted "purchase Copilot" modal instead.

Frontend changes are in a separate PR per Sentry's split-deploy policy.