### PR TITLE
feat(autofix): add modal for GitHub Copilot license required

### DIFF
--- a/static/app/components/events/autofix/autofixGithubCopilotPurchaseModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubCopilotPurchaseModal.tsx
@@ -1,0 +1,44 @@
+import {Fragment} from 'react';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {t, tct} from 'sentry/locale';
+
+const GITHUB_COPILOT_URL = 'https://github.com/features/copilot';
+
+export function AutofixGithubCopilotPurchaseModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+}: ModalRenderProps) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h3">{t('GitHub Copilot License Required')}</Heading>
+      </Header>
+      <Body>
+        <Text as="p">
+          {tct(
+            'Your GitHub account does not have an active GitHub Copilot license. To use Copilot as a coding agent, you will need an active [link:Copilot subscription].',
+            {
+              link: <ExternalLink href={GITHUB_COPILOT_URL} />,
+            }
+          )}
+        </Text>
+      </Body>
+      <Footer>
+        <Grid flow="column" align="center" gap="md">
+          <Button onClick={closeModal}>{t('Remind me later')}</Button>
+          <LinkButton href={GITHUB_COPILOT_URL} external priority="primary">
+            {t('Get GitHub Copilot')}
+          </LinkButton>
+        </Grid>
+      </Footer>
+    </Fragment>
+  );
+}

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -3,6 +3,7 @@ import {useCallback, useMemo, useState} from 'react';
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
 import {
   AutofixStatus,
   AutofixStepType,
@@ -413,8 +414,13 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
         const permissionFailures = data.failures.filter(
           f => f.failure_type === 'github_app_permissions'
         );
+        const copilotLicenseFailures = data.failures.filter(
+          f => f.failure_type === 'github_copilot_not_licensed'
+        );
         const otherFailures = data.failures.filter(
-          f => f.failure_type !== 'github_app_permissions'
+          f =>
+            f.failure_type !== 'github_app_permissions' &&
+            f.failure_type !== 'github_copilot_not_licensed'
         );
 
         if (permissionFailures.length > 0) {
@@ -428,6 +434,10 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
               installationUrl={installationUrl}
             />
           ));
+        }
+
+        if (copilotLicenseFailures.length > 0) {
+          openModal(deps => <AutofixGithubCopilotPurchaseModal {...deps} />);
         }
 
         otherFailures.forEach(failure => {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -3,6 +3,7 @@ import {useCallback, useState} from 'react';
 import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
 import {
   needsGitHubAuth,
   type CodingAgentIntegration,
@@ -473,8 +474,13 @@ export function useExplorerAutofix(
           const permissionFailures = response.failures.filter(
             f => f.failure_type === 'github_app_permissions'
           );
+          const copilotLicenseFailures = response.failures.filter(
+            f => f.failure_type === 'github_copilot_not_licensed'
+          );
           const otherFailures = response.failures.filter(
-            f => f.failure_type !== 'github_app_permissions'
+            f =>
+              f.failure_type !== 'github_app_permissions' &&
+              f.failure_type !== 'github_copilot_not_licensed'
           );
 
           if (permissionFailures.length > 0) {
@@ -488,6 +494,10 @@ export function useExplorerAutofix(
                 installationUrl={installationUrl}
               />
             ));
+          }
+
+          if (copilotLicenseFailures.length > 0) {
+            openModal(deps => <AutofixGithubCopilotPurchaseModal {...deps} />);
           }
 
           otherFailures.forEach(failure => {


### PR DESCRIPTION
Adds a modal that appears when a user tries to launch GitHub Copilot as a coding agent but their GitHub account doesn't have an active Copilot license.

The backend PR (#108782) changed the `failure_type` from `"generic"` to `"github_copilot_not_licensed"` for this case. This PR handles that signal in both `useAutofix` and `useExplorerAutofix`, opening `AutofixGithubCopilotPurchaseModal` instead of falling through to a generic error toast.

The new modal follows the same structure as `AutofixGithubAppPermissionsModal` — close button, explanatory text, a "Remind me later" dismiss button, and a primary "Get GitHub Copilot" link to `https://github.com/features/copilot`.

Depends on #108782.