### PR TITLE
fix(tests): Fix flaky test_homepage_query bucket count assertion

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -96,7 +96,9 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
             },
         )
         assert response.status_code == 200, response.content
-        assert [attrs for time, attrs in response.data["data"]] == [[{"count": 0}]] * 338
+        data = [attrs for time, attrs in response.data["data"]]
+        assert len(data) > 0
+        assert all(bucket == [{"count": 0}] for bucket in data)
 
     def test_top_events(self) -> None:
         event_counts = [6, 0, 6, 3, 0, 3]


### PR DESCRIPTION
## Summary
- The test uses `statsPeriod=14d` which produces a variable number of hourly buckets (337-339) depending on the exact time of day relative to hour boundaries
- Replace the hardcoded count of 338 with assertions that verify all buckets are zero-filled without relying on an exact count

Fixes #108747

## Test plan
- [x] Test passes locally 10/10 times