### PR TITLE
fix(tests): Fix flaky test_get suspect tags group_id collision

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
@@ -23,6 +23,7 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
             first_seen=today - datetime.timedelta(hours=1),
             last_seen=today + datetime.timedelta(hours=1),
         )
+        other_group = self.create_group()
 
         self._mock_event(
             today,
@@ -35,7 +36,7 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
             today,
             hash="a" * 32,
             tags={"key": False, "other": False},
-            group_id=2,
+            group_id=other_group.id,
             project_id=self.project.id,
         )
 


### PR DESCRIPTION
## Summary
- The test hardcoded `group_id=2` for the baseline event
- When `self.create_group()` returned `id=2`, both events belonged to the same group, making tag distributions identical and producing `score=0.0` instead of the expected `2.762`
- Create a proper second group via `self.create_group()` to guarantee distinct group IDs

Fixes #108738

## Test plan
- [x] Test passes locally 10/10 times