### PR TITLE
fix(tests): Fix flaky test_query_recent_feedbacks_with_ai_labels

### DIFF
--- a/tests/sentry/feedback/__init__.py
+++ b/tests/sentry/feedback/__init__.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import uuid4
 
 from sentry.utils import json
 
@@ -21,7 +22,7 @@ def mock_feedback_event(
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
             },
         },
-        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "event_id": uuid4().hex,
         "timestamp": dt.timestamp(),
         "received": dt.isoformat(),
         "first_seen": dt.isoformat(),

--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -14,13 +14,13 @@ from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issu
 from sentry.feedback.usecases.label_generation import AI_LABEL_TAG_PREFIX
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.snuba.dataset import Dataset
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.snuba import raw_snql_query
 from tests.sentry.feedback import mock_feedback_event
 
 
-class TestLabelQuery(APITestCase):
+class TestLabelQuery(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()


### PR DESCRIPTION
## Summary
- Fix flaky `test_query_recent_feedbacks_with_ai_labels` caused by ClickHouse data leaking across test methods
- **Root cause**: `TestLabelQuery` only extended `APITestCase` (not `SnubaTestCase`), so the `reset_snuba` fixture never ran — ClickHouse data persisted across tests and parallel xdist workers with overlapping project IDs could contaminate each other's queries
- **Fix 1**: Add `SnubaTestCase` mixin so `reset_snuba` drops all ClickHouse data before each test method
- **Fix 2**: Fix `mock_feedback_event` to use `uuid4().hex` instead of a hardcoded event_id (`56b08cf7852c42cbb95e4a6998c66ad6`), preventing ClickHouse dedup issues when multiple feedbacks share the same event_id

Fixes #108770

## Test plan
- [x] All 4 tests in `TestLabelQuery` pass
- [x] All 34 tests in `test_create_feedback.py` pass (no regression from event_id change)
- [x] `test_save_event_feedback.py` passes
- [x] Target test passes 10/10 consecutive runs