### PR TITLE
perf(issues): Fix N+1 project queries in bulk_transition_group_to_ongoing

### DIFF
--- a/src/sentry/issues/ongoing.py
+++ b/src/sentry/issues/ongoing.py
@@ -24,7 +24,7 @@ def bulk_transition_group_to_ongoing(
         # make sure we don't update the Group when its already updated by conditionally updating the Group
         groups_to_transistion = Group.objects.filter(
             id__in=group_ids, status=from_status, substatus=from_substatus
-        )
+        ).select_related("project")
         span.set_tag("group_ids", group_ids)
         span.set_tag("groups_to_transistion count", len(groups_to_transistion))
 


### PR DESCRIPTION
Add select_related("project") to the Group queryset so that group.project access in the iteration loop doesn't trigger a separate query per group.