### PR TITLE
perf(tasks): Fix N+1 project queries in clear_expired_snoozes

### DIFF
--- a/src/sentry/tasks/clear_expired_snoozes.py
+++ b/src/sentry/tasks/clear_expired_snoozes.py
@@ -26,7 +26,9 @@ def clear_expired_snoozes() -> None:
     groups_with_snoozes = {gs[1]: {"id": gs[0], "until": gs[2]} for gs in groupsnooze_list}
 
     ignored_groups = list(
-        Group.objects.filter(id__in=groups_with_snoozes.keys(), status=GroupStatus.IGNORED)
+        Group.objects.filter(
+            id__in=groups_with_snoozes.keys(), status=GroupStatus.IGNORED
+        ).select_related("project")
     )
 
     GroupSnooze.objects.filter(id__in=group_snooze_ids).delete()


### PR DESCRIPTION
Add select_related("project") to the Group queryset so that group.project access in the loop (signal send and manage_issue_states) doesn't trigger a separate query per group.