### PR TITLE
perf(incidents): Eliminate redundant COUNT query in auto_resolve_snapshot_incidents

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -121,14 +121,15 @@ def auto_resolve_snapshot_incidents(alert_rule_id: int, **kwargs: Any) -> None:
         return
 
     batch_size = 50
-    incidents = Incident.objects.filter(alert_rule=alert_rule).exclude(
-        status=IncidentStatus.CLOSED.value
-    )[: batch_size + 1]
-    has_more = incidents.count() > batch_size
+    incidents = list(
+        Incident.objects.filter(alert_rule=alert_rule).exclude(status=IncidentStatus.CLOSED.value)[
+            : batch_size + 1
+        ]
+    )
+    has_more = len(incidents) > batch_size
     if incidents:
-        incidents = incidents[:batch_size]
         with transaction.atomic(router.db_for_write(Incident)):
-            for incident in incidents:
+            for incident in incidents[:batch_size]:
                 update_incident_status(
                     incident,
                     IncidentStatus.CLOSED,

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from sentry.incidents.models.alert_rule import AlertRule, AlertRuleStatus
+from sentry.incidents.models.incident import IncidentStatus
+from sentry.incidents.tasks import auto_resolve_snapshot_incidents
+from sentry.testutils.cases import TestCase
+
+
+class AutoResolveSnapshotIncidentsTest(TestCase):
+    def test_resolves_open_incidents(self):
+        alert_rule = self.create_alert_rule()
+        AlertRule.objects.filter(id=alert_rule.id).update(status=AlertRuleStatus.SNAPSHOT.value)
+        incident = self.create_incident(alert_rule=alert_rule, status=IncidentStatus.OPEN.value)
+
+        auto_resolve_snapshot_incidents(alert_rule_id=alert_rule.id)
+
+        incident.refresh_from_db()
+        assert incident.status == IncidentStatus.CLOSED.value
+
+    @patch("sentry.incidents.tasks.auto_resolve_snapshot_incidents.apply_async")
+    def test_reenqueues_when_more_than_batch_size(self, mock_apply_async):
+        alert_rule = self.create_alert_rule()
+        AlertRule.objects.filter(id=alert_rule.id).update(status=AlertRuleStatus.SNAPSHOT.value)
+        for _ in range(55):
+            self.create_incident(alert_rule=alert_rule, status=IncidentStatus.OPEN.value)
+
+        auto_resolve_snapshot_incidents(alert_rule_id=alert_rule.id)
+
+        mock_apply_async.assert_called_once_with(kwargs={"alert_rule_id": alert_rule.id})


### PR DESCRIPTION
Materialize the queryset with list() and use len() instead of .count() to check for remaining batches. The fetch-N+1 pattern already exists but was defeated by a separate COUNT round-trip.