### PR TITLE
chore: remove graduated feature flags (dashboards batch 4)

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -669,13 +669,6 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardDetailsResponse:
         page_filters, tag_filters = self.get_filters(obj)
 
-        if "globalFilter" in tag_filters and not features.has(
-            "organizations:dashboards-global-filters",
-            organization=obj.organization,
-            actor=user,
-        ):
-            tag_filters["globalFilter"] = []
-
         data: DashboardDetailsResponse = {
             "id": str(obj.id),
             "title": obj.title,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -726,12 +726,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer[Dashboard]):
         page_filter_keys = ["environment", "period", "start", "end", "utc"]
         dashboard_filter_keys = ["release", "release_id"]
 
-        if features.has(
-            "organizations:dashboards-global-filters",
-            organization=self.context["organization"],
-            actor=self.context["request"].user,
-        ):
-            dashboard_filter_keys.append("global_filter")
+        dashboard_filter_keys.append("global_filter")
 
         filters = {}
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -80,8 +80,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-categorical-bar-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables custom editable dashboards
     manager.add("organizations:dashboards-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
-    # Enables global filters for dashboards
-    manager.add("organizations:dashboards-global-filters", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables favourite and duplicate controls for prebuilt dashboards
     manager.add("organizations:dashboards-prebuilt-controls", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables import/export functionality for dashboards
@@ -96,8 +94,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-drilldown-flow", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable prebuilt dashboards for insights modules
     manager.add("organizations:dashboards-prebuilt-insights-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable new timeseries visualization for dashboard widgets
-    manager.add("organizations:dashboards-widget-timeseries-visualization", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Replaces insights ui with prebuilt dashboards
     manager.add("organizations:insights-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the details widget for dashboards

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -506,7 +506,6 @@ describe('Dashboards > Dashboard', () => {
             widgetLimitReached={false}
             widgetLegendState={widgetLegendState}
             widgetInterval={widgetInterval}
-            useTimeseriesVisualization
           />
         </MEPSettingProvider>
       );

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -89,7 +89,6 @@ type Props = {
   onEditWidget?: (widget: Widget) => void;
   onNewWidgetScrollComplete?: () => void;
   onSetNewWidget?: () => void;
-  useTimeseriesVisualization?: boolean;
   widgetInterval?: string;
 };
 
@@ -114,7 +113,6 @@ function Dashboard({
   onEditWidget,
   onNewWidgetScrollComplete,
   onSetNewWidget,
-  useTimeseriesVisualization,
   widgetInterval,
 }: Props) {
   const theme = useTheme();
@@ -441,7 +439,6 @@ function Dashboard({
               index={String(index)}
               newlyAddedWidget={newlyAddedWidget}
               onNewWidgetScrollComplete={onNewWidgetScrollComplete}
-              useTimeseriesVisualization={useTimeseriesVisualization}
               widgetInterval={widgetInterval}
             />
           </div>

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -141,7 +141,6 @@ type Props = {
   children?: React.ReactNode;
   onDashboardUpdate?: (updatedDashboard: DashboardDetails) => void;
   storageNamespace?: string;
-  useTimeseriesVisualization?: boolean;
   widgetInterval?: string;
 };
 
@@ -1042,7 +1041,6 @@ class DashboardDetail extends Component<Props, State> {
       location,
       onDashboardUpdate,
       projects,
-      useTimeseriesVisualization,
     } = this.props;
     const {
       modifiedDashboard,
@@ -1242,7 +1240,6 @@ class DashboardDetail extends Component<Props, State> {
                                 onNewWidgetScrollComplete={
                                   this.handleScrollToNewWidgetComplete
                                 }
-                                useTimeseriesVisualization={useTimeseriesVisualization}
                                 widgetInterval={this.props.widgetInterval}
                               />
                             </WidgetQueryQueueProvider>

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -29,7 +29,7 @@ describe('FiltersBar', () => {
     mockNetworkRequests();
 
     organization = OrganizationFixture({
-      features: ['dashboards-basic', 'dashboards-edit', 'dashboards-global-filters'],
+      features: ['dashboards-basic', 'dashboards-edit'],
     });
   });
 

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import {createParser, useQueryState} from 'nuqs';
@@ -283,52 +283,48 @@ export default function FiltersBar({
           }}
           onSortChange={setReleaseSort}
         />
-        {organization.features.includes('dashboards-global-filters') && (
-          <Fragment>
-            {activeGlobalFilters.map(filter => (
-              <GenericFilterSelector
-                disableRemoveFilter={
-                  isPrebuiltDashboard &&
-                  prebuiltDashboardFilters.some(
-                    prebuiltFilter =>
-                      prebuiltFilter.tag.key === filter.tag.key &&
-                      prebuiltFilter.dataset === filter.dataset
-                  )
-                }
-                key={filter.tag.key + filter.value}
-                globalFilter={filter}
-                searchBarData={getSearchBarData(filter.dataset)}
-                onUpdateFilter={updatedFilter => {
-                  updateGlobalFilters(
-                    activeGlobalFilters.map(f =>
-                      globalFilterKeysAreEqual(f, updatedFilter) ? updatedFilter : f
-                    )
-                  );
-                }}
-                onRemoveFilter={removedFilter => {
-                  updateGlobalFilters(
-                    activeGlobalFilters.filter(
-                      f => !globalFilterKeysAreEqual(f, removedFilter)
-                    )
-                  );
-                  trackAnalytics('dashboards2.global_filter.remove', {
-                    organization,
-                  });
-                }}
-              />
-            ))}
-            <AddFilter
-              globalFilters={activeGlobalFilters}
-              getSearchBarData={getSearchBarData}
-              onAddFilter={newFilter => {
-                updateGlobalFilters([...activeGlobalFilters, newFilter]);
-                trackAnalytics('dashboards2.global_filter.add', {
-                  organization,
-                });
-              }}
-            />
-          </Fragment>
-        )}
+        {activeGlobalFilters.map(filter => (
+          <GenericFilterSelector
+            disableRemoveFilter={
+              isPrebuiltDashboard &&
+              prebuiltDashboardFilters.some(
+                prebuiltFilter =>
+                  prebuiltFilter.tag.key === filter.tag.key &&
+                  prebuiltFilter.dataset === filter.dataset
+              )
+            }
+            key={filter.tag.key + filter.value}
+            globalFilter={filter}
+            searchBarData={getSearchBarData(filter.dataset)}
+            onUpdateFilter={updatedFilter => {
+              updateGlobalFilters(
+                activeGlobalFilters.map(f =>
+                  globalFilterKeysAreEqual(f, updatedFilter) ? updatedFilter : f
+                )
+              );
+            }}
+            onRemoveFilter={removedFilter => {
+              updateGlobalFilters(
+                activeGlobalFilters.filter(
+                  f => !globalFilterKeysAreEqual(f, removedFilter)
+                )
+              );
+              trackAnalytics('dashboards2.global_filter.remove', {
+                organization,
+              });
+            }}
+          />
+        ))}
+        <AddFilter
+          globalFilters={activeGlobalFilters}
+          getSearchBarData={getSearchBarData}
+          onAddFilter={newFilter => {
+            updateGlobalFilters([...activeGlobalFilters, newFilter]);
+            trackAnalytics('dashboards2.global_filter.add', {
+              organization,
+            });
+          }}
+        />
         {!hasTemporaryFilters &&
           hasUnsavedChanges &&
           !isEditingDashboard &&

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -97,7 +97,6 @@ export function PrebuiltDashboardRenderer({
         dashboard={dashboard}
         dashboards={[]}
         initialState={DashboardState.EMBEDDED}
-        useTimeseriesVisualization
         storageNamespace={storageNamespace}
       />
     </LoadingContainer>

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -49,7 +49,6 @@ type Props = {
   isPreview?: boolean;
   newlyAddedWidget?: Widget;
   onNewWidgetScrollComplete?: () => void;
-  useTimeseriesVisualization?: boolean;
   widgetInterval?: string;
   windowWidth?: number;
 };
@@ -79,7 +78,6 @@ function SortableWidget(props: Props) {
     dashboardCreator,
     newlyAddedWidget,
     onNewWidgetScrollComplete,
-    useTimeseriesVisualization,
     isPrebuiltDashboard = false,
   } = props;
 
@@ -155,7 +153,6 @@ function SortableWidget(props: Props) {
         : (widget.limit ?? TABLE_ITEM_LIMIT),
     onWidgetTableSort,
     onWidgetTableResizeColumn,
-    useTimeseriesVisualization,
     widgetInterval: props.widgetInterval,
   };
 

--- a/static/app/views/dashboards/utils/useTimeseriesVisualizationEnabled.tsx
+++ b/static/app/views/dashboards/utils/useTimeseriesVisualizationEnabled.tsx
@@ -1,6 +1,0 @@
-import useOrganization from 'sentry/utils/useOrganization';
-
-export const useTimeseriesVisualizationEnabled = () => {
-  const organization = useOrganization();
-  return organization.features.includes('dashboards-widget-timeseries-visualization');
-};

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -15,7 +15,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {DashboardState, type DashboardDetails} from 'sentry/views/dashboards/types';
-import {useTimeseriesVisualizationEnabled} from 'sentry/views/dashboards/utils/useTimeseriesVisualizationEnabled';
 
 import DashboardDetail from './detail';
 import OrgDashboards from './orgDashboards';
@@ -33,8 +32,6 @@ export default function ViewEditDashboard() {
       updateDashboardVisit(api, orgSlug, dashboardId);
     }
   }, [api, orgSlug, dashboardId]);
-
-  const useTimeseriesVisualization = useTimeseriesVisualizationEnabled();
 
   // Get optimistic dashboard from location.state if available (e.g., after adding a widget)
   const optimisticDashboard = (location.state as {dashboard?: DashboardDetails} | null)
@@ -54,7 +51,6 @@ export default function ViewEditDashboard() {
                 dashboard={dashboard}
                 dashboards={dashboards}
                 onDashboardUpdate={onDashboardUpdate}
-                useTimeseriesVisualization={useTimeseriesVisualization}
               />
             </ErrorBoundary>
           ) : (

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -14,7 +14,6 @@ import {
   type DashboardFilters,
 } from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
-import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertBuilderStateToWidget} from 'sentry/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget';
@@ -93,8 +92,6 @@ function WidgetPreview({
     setTableWidths(widths);
   }
 
-  const useTimeseriesVisualization = widgetCanUseTimeSeriesVisualization(widget);
-
   return (
     <WidgetCard
       disableFullscreen
@@ -140,7 +137,6 @@ function WidgetPreview({
       onWidgetTableSort={handleWidgetTableSort}
       onWidgetTableResizeColumn={handleWidgetTableResizeColumn}
       disableTableActions
-      useTimeseriesVisualization={useTimeseriesVisualization}
     />
   );
 }

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -118,7 +118,6 @@ type Props = WithRouterProps & {
   showLoadingText?: boolean;
   showStoredAlert?: boolean;
   tableItemLimit?: number;
-  useTimeseriesVisualization?: boolean;
   widgetInterval?: string;
   windowWidth?: number;
 };
@@ -185,7 +184,6 @@ function WidgetCard(props: Props) {
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     disableTableActions,
-    useTimeseriesVisualization,
     widgetInterval,
   } = props;
 
@@ -298,7 +296,7 @@ function WidgetCard(props: Props) {
     : undefined;
 
   const canUseTimeseriesVisualization = widgetCanUseTimeSeriesVisualization(widget);
-  if (canUseTimeseriesVisualization && useTimeseriesVisualization) {
+  if (canUseTimeseriesVisualization) {
     return (
       <ErrorBoundary
         customComponent={() => <ErrorCard>{t('Error loading widget data')}</ErrorCard>}


### PR DESCRIPTION
## Summary
Removes 2 feature flags owned by data-browsing that have been enabled at 100% via flagpole with no conditions:
- `organizations:dashboards-global-filters`
- `organizations:dashboards-widget-timeseries-visualization`

These flags have been fully rolled out and their behavior is now the default.
