### PR TITLE
chore: remove graduated feature flags (data-browsing batch 6)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -453,8 +453,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:top-issues-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to load new tracing onboarding ui
     manager.add("organizations:tracing-onboarding-new-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable feature to expose export csv button in trace explorer
-    manager.add("organizations:tracing-export-csv", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to load quota exceeded banner in new trace view.
     manager.add("organizations:trace-view-quota-exceeded-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature to use span only trace endpoint.
@@ -542,18 +540,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:service-hooks-outbox", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable alerting on trace metrics
     manager.add("organizations:tracemetrics-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable trace metrics in dashboards UI
-    manager.add("organizations:tracemetrics-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product (known internally as tracemetrics) in UI and backend
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product to be ingested via Relay
     manager.add("organizations:tracemetrics-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics in overlaying charts
     manager.add("organizations:tracemetrics-overlay-charts-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable trace metrics saved queries
-    manager.add("organizations:tracemetrics-saved-queries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable trace metrics stats to be displayed in the UI
-    manager.add("organizations:tracemetrics-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics units in trace view UI
     manager.add("organizations:tracemetrics-units-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable traces page cross event querying

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -27,7 +27,6 @@ import {
   transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {combineBaseFieldsWithTags} from 'sentry/views/dashboards/datasetConfig/utils/combineBaseFieldsWithEapTags';
-import {useHasTraceMetricsDashboards} from 'sentry/views/dashboards/hooks/useHasTraceMetricsDashboards';
 import {DisplayType, type WidgetQuery} from 'sentry/views/dashboards/types';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {
@@ -78,14 +77,13 @@ function TraceMetricsSearchBar({
   const {
     selection: {projects},
   } = usePageFilters();
-  const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
   const {state: widgetBuilderState} = useWidgetBuilderContext();
 
   const traceMetric = widgetBuilderState.traceMetric ?? {name: '', type: ''};
 
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.TRACEMETRICS,
-    enabled: hasTraceMetricsDashboards,
+    enabled: true,
     query: createTraceMetricFilter(traceMetric),
   };
 
@@ -134,14 +132,13 @@ function useTraceMetricsSearchBarDataProvider(
   props: SearchBarDataProviderProps
 ): SearchBarData {
   const {pageFilters, widgetQuery} = props;
-  const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
   const {state: widgetBuilderState} = useWidgetBuilderContext();
 
   const traceMetric = widgetBuilderState.traceMetric ?? {name: '', type: ''};
 
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.TRACEMETRICS,
-    enabled: hasTraceMetricsDashboards,
+    enabled: true,
     query: createTraceMetricFilter(traceMetric),
   };
 

--- a/static/app/views/dashboards/hooks/useHasTraceMetricsDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useHasTraceMetricsDashboards.tsx
@@ -1,3 +1,0 @@
-export function useHasTraceMetricsDashboards() {
-  return true;
-}

--- a/static/app/views/dashboards/hooks/useHasTraceMetricsDashboards.tsx
+++ b/static/app/views/dashboards/hooks/useHasTraceMetricsDashboards.tsx
@@ -1,6 +1,3 @@
-import useOrganization from 'sentry/utils/useOrganization';
-
 export function useHasTraceMetricsDashboards() {
-  const organization = useOrganization();
-  return organization.features.includes('tracemetrics-dashboards');
+  return true;
 }

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -10,7 +10,6 @@ import {space} from 'sentry/styles/space';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useHasTraceMetricsDashboards} from 'sentry/views/dashboards/hooks/useHasTraceMetricsDashboards';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
@@ -25,8 +24,6 @@ function WidgetBuilderDatasetSelector() {
   const source = useDashboardWidgetSource();
   const isEditing = useIsEditingWidget();
   const {cacheBuilderState, restoreOrSetBuilderState} = useCacheBuilderState();
-
-  const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
 
   const datasetOptions = [];
   datasetOptions.push({
@@ -66,10 +63,7 @@ function WidgetBuilderDatasetSelector() {
     });
   }
 
-  if (
-    organization.features.includes('tracemetrics-enabled') &&
-    hasTraceMetricsDashboards
-  ) {
+  if (organization.features.includes('tracemetrics-enabled')) {
     datasetOptions.push({
       value: WidgetType.TRACEMETRICS,
       label: t('Metrics'),

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -20,7 +20,6 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useHasTraceMetricsDashboards} from 'sentry/views/dashboards/hooks/useHasTraceMetricsDashboards';
 import {
   DisplayType,
   WidgetType,
@@ -72,7 +71,6 @@ type WidgetBuilderV2Props = {
 function TraceItemAttributeProviderFromDataset({children}: {children: React.ReactNode}) {
   const {state} = useWidgetBuilderContext();
   const organization = useOrganization();
-  const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
 
   let enabled = false;
   let traceItemType = TraceItemDataset.SPANS;
@@ -89,7 +87,7 @@ function TraceItemAttributeProviderFromDataset({children}: {children: React.Reac
   }
 
   if (state.dataset === WidgetType.TRACEMETRICS && state.traceMetric) {
-    enabled = hasTraceMetricsDashboards;
+    enabled = true;
     traceItemType = TraceItemDataset.TRACEMETRICS;
     query = createTraceMetricFilter(state.traceMetric);
   }

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -8,16 +8,11 @@ export const canUseMetricsUI = (organization: Organization) => {
 };
 
 export const canUseMetricsStatsUI = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) && organization.features.includes('tracemetrics-stats')
-  );
+  return canUseMetricsUI(organization);
 };
 
 export const canUseMetricsSavedQueriesUI = (organization: Organization) => {
-  return (
-    canUseMetricsUI(organization) &&
-    organization.features.includes('tracemetrics-saved-queries')
-  );
+  return canUseMetricsUI(organization);
 };
 
 export const canUseMetricsAlertsUI = (organization: Organization) => {

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -24,7 +24,7 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled', 'tracemetrics-saved-queries'],
+    features: ['tracemetrics-enabled'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
@@ -152,32 +152,5 @@ describe('useSaveAsMetricItems', () => {
 
     expect(saveAsItems.some(item => item.key === 'update-query')).toBe(false);
     expect(saveAsItems.some(item => item.key === 'save-query')).toBe(true);
-  });
-
-  it('should return empty array when metrics saved queries UI is not enabled', () => {
-    const orgWithoutFeature = OrganizationFixture({
-      features: [],
-    });
-
-    const {result} = renderHook(
-      () =>
-        useSaveAsMetricItems({
-          interval: '5m',
-        }),
-      {
-        wrapper: function ({children}: {children?: React.ReactNode}) {
-          return (
-            <OrganizationContext.Provider value={orgWithoutFeature}>
-              <QueryClientProvider client={queryClient}>
-                <MockMetricQueryParamsContext>{children}</MockMetricQueryParamsContext>
-              </QueryClientProvider>
-            </OrganizationContext.Provider>
-          );
-        },
-      }
-    );
-
-    const saveAsItems = result.current;
-    expect(saveAsItems).toEqual([]);
   });
 });

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -13,7 +13,6 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {formatTraceMetricsFunction} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
-import {useHasTraceMetricsDashboards} from 'sentry/views/dashboards/hooks/useHasTraceMetricsDashboards';
 import {getIdFromLocation} from 'sentry/views/explore/contexts/pageParamsContext/id';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {useAddMetricToDashboard} from 'sentry/views/explore/metrics/hooks/useAddMetricToDashboard';
@@ -37,7 +36,6 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
   const {data: savedQuery} = useGetSavedQuery(id);
 
   const metricQueries = useMultiMetricsQueryParams();
-  const hasTraceMetricsDashboards = useHasTraceMetricsDashboards();
   const {addToDashboard} = useAddMetricToDashboard();
 
   const saveAsItems = useMemo(() => {
@@ -96,10 +94,8 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
   // TODO: Implement alert functionality when organizations:tracemetrics-alerts flag is enabled
 
   const addToDashboardItems = useMemo(() => {
-    const items = [];
-
-    if (hasTraceMetricsDashboards) {
-      items.push({
+    return [
+      {
         key: 'add-to-dashboard',
         label: t('Dashboard widget'),
         textValue: t('Dashboard widget'),
@@ -131,11 +127,9 @@ export function useSaveAsMetricItems(_options: UseSaveAsMetricItemsOptions) {
             };
           }),
         ],
-      });
-    }
-
-    return items;
-  }, [hasTraceMetricsDashboards, addToDashboard, metricQueries]);
+      },
+    ];
+  }, [addToDashboard, metricQueries]);
 
   return useMemo(() => {
     return [...saveAsItems, ...addToDashboardItems];

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -6,7 +6,6 @@ import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
-import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -316,12 +315,10 @@ function SpanTabContentSection({
           {controlSectionExpanded ? null : t('Advanced')}
         </ChevronButton>
         <Flex gap="xs">
-          <Feature features="organizations:tracing-export-csv">
-            <SpansExport
-              aggregatesTableResult={aggregatesTableResult}
-              spansTableResult={spansTableResult}
-            />
-          </Feature>
+          <SpansExport
+            aggregatesTableResult={aggregatesTableResult}
+            spansTableResult={spansTableResult}
+          />
           <SettingsDropdown />
         </Flex>
       </OverChartButtonGroup>

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -560,9 +560,9 @@ describe('OrganizationStats', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Metrics category when tracemetrics-stats feature flag is enabled', async () => {
+  it('shows Metrics category when tracemetrics-enabled feature flag is enabled', async () => {
     const newOrg = OrganizationFixture({
-      features: ['team-insights', 'tracemetrics-enabled', 'tracemetrics-stats'],
+      features: ['team-insights', 'tracemetrics-enabled'],
     });
 
     render(<OrganizationStats />, {
@@ -571,19 +571,6 @@ describe('OrganizationStats', () => {
 
     await userEvent.click(await screen.findByText('Category'));
     expect(screen.getByRole('option', {name: 'Metrics'})).toBeInTheDocument();
-  });
-
-  it('does not show Metrics category when tracemetrics-stats feature flag is disabled', async () => {
-    const newOrg = OrganizationFixture({
-      features: ['team-insights'],
-    });
-
-    render(<OrganizationStats />, {
-      organization: newOrg,
-    });
-
-    await userEvent.click(await screen.findByText('Category'));
-    expect(screen.queryByRole('option', {name: 'Metrics'})).not.toBeInTheDocument();
   });
 
   it('denies access on no projects', async () => {


### PR DESCRIPTION
## Summary
Removes 4 feature flags owned by data-browsing that have been enabled at 100% via flagpole with no conditions:
- `organizations:tracemetrics-dashboards`
- `organizations:tracemetrics-saved-queries`
- `organizations:tracemetrics-stats`
- `organizations:tracing-export-csv`

These flags have been fully rolled out and their behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)