### PR TITLE
feat(flags): Remove graduated dashboards-mep feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -198,8 +198,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         batch_features = self.get_features(organization, request)
 
-        use_metrics = True
-
         try:
             use_on_demand_metrics, on_demand_metrics_type = self.handle_on_demand(request)
         except ValueError:
@@ -264,7 +262,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 use_aggregate_conditions=use_aggregate_conditions,
                 transform_alias_to_input_format=True,
                 # Whether the flag is enabled or not, regardless of the referrer
-                has_metrics=use_metrics,
+                has_metrics=True,
+                use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
                 fallback_to_transactions=True,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -106,7 +106,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
     def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
         feature_names = [
-            "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
             "organizations:performance-use-metrics",
             "organizations:profiling",
@@ -205,7 +204,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 and batch_features.get("organizations:dynamic-sampling", False)
             )
             or batch_features.get("organizations:performance-use-metrics", False)
-            or batch_features.get("organizations:dashboards-mep", False)
+            or True
         )
 
         try:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -263,7 +263,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 transform_alias_to_input_format=True,
                 # Whether the flag is enabled or not, regardless of the referrer
                 has_metrics=True,
-                use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=on_demand_metrics_enabled,
                 on_demand_metrics_type=on_demand_metrics_type,
                 fallback_to_transactions=True,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -198,14 +198,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         batch_features = self.get_features(organization, request)
 
-        use_metrics = (
-            (
-                batch_features.get("organizations:mep-rollout-flag", False)
-                and batch_features.get("organizations:dynamic-sampling", False)
-            )
-            or batch_features.get("organizations:performance-use-metrics", False)
-            or True
-        )
+        use_metrics = True
 
         try:
             use_on_demand_metrics, on_demand_metrics_type = self.handle_on_demand(request)

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -70,8 +70,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
         batch_features = self.get_features(organization, request)
 
-        use_metrics = True
-
         with handle_query_errors():
             if dataset in RPC_DATASETS:
                 result = dataset.run_table_query(
@@ -92,7 +90,8 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                     snuba_params=snuba_params,
                     query=request.query_params.get("query"),
                     referrer=Referrer.API_ORGANIZATION_EVENTS_META.value,
-                    has_metrics=use_metrics,
+                    has_metrics=True,
+                    use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                     # TODO: @athena - add query_source when all datasets support it
                     # query_source=(
                     #     QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -70,14 +70,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
         batch_features = self.get_features(organization, request)
 
-        use_metrics = (
-            (
-                batch_features.get("organizations:mep-rollout-flag", False)
-                and batch_features.get("organizations:dynamic-sampling", False)
-            )
-            or batch_features.get("organizations:performance-use-metrics", False)
-            or True
-        )
+        use_metrics = True
 
         with handle_query_errors():
             if dataset in RPC_DATASETS:

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -5,7 +5,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, options, search
+from sentry import options, search
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
@@ -32,34 +32,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
 
-    def get_features(self, organization: Organization, request: Request) -> dict[str, bool | None]:
-        feature_names = [
-            "organizations:mep-rollout-flag",
-            "organizations:performance-use-metrics",
-            "organizations:profiling",
-            "organizations:dynamic-sampling",
-            "organizations:starfish-view",
-        ]
-        batch_features = features.batch_has(
-            feature_names,
-            organization=organization,
-            actor=request.user,
-        )
-
-        all_features = (
-            batch_features.get(f"organization:{organization.id}", {})
-            if batch_features is not None
-            else {}
-        )
-
-        for feature_name in feature_names:
-            if feature_name not in all_features:
-                all_features[feature_name] = features.has(
-                    feature_name, organization=organization, actor=request.user
-                )
-
-        return all_features
-
     def get(self, request: Request, organization: Organization) -> Response:
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -67,8 +39,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
             return Response({"count": 0})
 
         dataset = self.get_dataset(request)
-
-        batch_features = self.get_features(organization, request)
 
         with handle_query_errors():
             if dataset in RPC_DATASETS:
@@ -91,7 +61,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                     query=request.query_params.get("query"),
                     referrer=Referrer.API_ORGANIZATION_EVENTS_META.value,
                     has_metrics=True,
-                    use_metrics_layer=batch_features.get("organizations:use-metrics-layer", False),
                     # TODO: @athena - add query_source when all datasets support it
                     # query_source=(
                     #     QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -34,7 +34,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
 
     def get_features(self, organization: Organization, request: Request) -> dict[str, bool | None]:
         feature_names = [
-            "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
             "organizations:performance-use-metrics",
             "organizations:profiling",
@@ -77,7 +76,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 and batch_features.get("organizations:dynamic-sampling", False)
             )
             or batch_features.get("organizations:performance-use-metrics", False)
-            or batch_features.get("organizations:dashboards-mep", False)
+            or True
         )
 
         with handle_query_errors():

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -328,11 +328,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 comparison_delta=comparison_delta,
                 allow_metric_aggregates=allow_metric_aggregates,
                 has_metrics=True,
-                # We want to allow people to force use the new metrics layer in the query builder. We decided to go for
-                # this approach so that we can have only a subset of parts of sentry that use the new metrics layer for
-                # their queries since right now the metrics layer has not full feature parity with the query builder.
-                use_metrics_layer=force_metrics_layer
-                or batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=use_on_demand_metrics
                 and (
                     batch_features.get("organizations:on-demand-metrics-extraction", False)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -168,18 +168,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 query_source = QuerySource.SENTRY_BACKEND
 
             batch_features = self.get_features(organization, request)
-            use_metrics = (
-                batch_features.get("organizations:performance-use-metrics", False)
-                or True
-                or (
-                    batch_features.get("organizations:mep-rollout-flag", False)
-                    and features.has(
-                        "organizations:dynamic-sampling",
-                        organization=organization,
-                        actor=request.user,
-                    )
-                )
-            )
+            use_metrics = True
 
             dataset = self.get_dataset(request)
             # Add more here until top events is supported on all the datasets

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -168,7 +168,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 query_source = QuerySource.SENTRY_BACKEND
 
             batch_features = self.get_features(organization, request)
-            use_metrics = True
 
             dataset = self.get_dataset(request)
             # Add more here until top events is supported on all the datasets
@@ -328,7 +327,12 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 zerofill_results=zerofill_results,
                 comparison_delta=comparison_delta,
                 allow_metric_aggregates=allow_metric_aggregates,
-                has_metrics=use_metrics,
+                has_metrics=True,
+                # We want to allow people to force use the new metrics layer in the query builder. We decided to go for
+                # this approach so that we can have only a subset of parts of sentry that use the new metrics layer for
+                # their queries since right now the metrics layer has not full feature parity with the query builder.
+                use_metrics_layer=force_metrics_layer
+                or batch_features.get("organizations:use-metrics-layer", False),
                 on_demand_metrics_enabled=use_on_demand_metrics
                 and (
                     batch_features.get("organizations:on-demand-metrics-extraction", False)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -68,7 +68,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     ) -> Mapping[str, bool | None]:
         feature_names = [
             "organizations:performance-use-metrics",
-            "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
             "organizations:starfish-view",
             "organizations:on-demand-metrics-extraction",
@@ -171,7 +170,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             batch_features = self.get_features(organization, request)
             use_metrics = (
                 batch_features.get("organizations:performance-use-metrics", False)
-                or batch_features.get("organizations:dashboards-mep", False)
+                or True
                 or (
                     batch_features.get("organizations:mep-rollout-flag", False)
                     and features.has(

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -8,7 +7,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.analytics.events.agent_monitoring_events import AgentMonitoringQuery
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -98,29 +97,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             }
         }
     )
-
-    def get_features(
-        self, organization: Organization, request: Request
-    ) -> Mapping[str, bool | None]:
-        feature_names = [
-            "organizations:performance-use-metrics",
-            "organizations:mep-rollout-flag",
-        ]
-        batch_features = features.batch_has(
-            feature_names,
-            organization=organization,
-            actor=request.user,
-        )
-        return (
-            batch_features.get(f"organization:{organization.id}", {})
-            if batch_features is not None
-            else {
-                feature_name: features.has(
-                    feature_name, organization=organization, actor=request.user
-                )
-                for feature_name in feature_names
-            }
-        )
 
     def get_request_querysource(self, request: Request, referrer: str) -> QuerySource:
         if referrer in SENTRY_BACKEND_REFERRERS:
@@ -299,8 +275,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
 
         self._emit_analytics_event(organization, referrer)
 
-        use_metrics = True
-
         if top_events > 0:
             raw_groupby = self.get_field_list(organization, request, param_name="groupBy")
             raw_orderby = self.get_orderby(request)
@@ -366,7 +340,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             zerofill_results=True,
             comparison_delta=comparison_delta,
             allow_metric_aggregates=allow_metric_aggregates,
-            has_metrics=use_metrics,
+            has_metrics=True,
             query_source=query_source,
             fallback_to_transactions=True,
             transform_alias_to_input_format=True,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -299,19 +299,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
 
         self._emit_analytics_event(organization, referrer)
 
-        batch_features = self.get_features(organization, request)
-        use_metrics = (
-            batch_features.get("organizations:performance-use-metrics", False)
-            or True
-            or (
-                batch_features.get("organizations:mep-rollout-flag", False)
-                and features.has(
-                    "organizations:dynamic-sampling",
-                    organization=organization,
-                    actor=request.user,
-                )
-            )
-        )
+        use_metrics = True
 
         if top_events > 0:
             raw_groupby = self.get_field_list(organization, request, param_name="groupBy")

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -104,7 +104,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
     ) -> Mapping[str, bool | None]:
         feature_names = [
             "organizations:performance-use-metrics",
-            "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
         ]
         batch_features = features.batch_has(
@@ -303,7 +302,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         batch_features = self.get_features(organization, request)
         use_metrics = (
             batch_features.get("organizations:performance-use-metrics", False)
-            or batch_features.get("organizations:dashboards-mep", False)
+            or True
             or (
                 batch_features.get("organizations:mep-rollout-flag", False)
                 and features.has(

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -192,7 +192,6 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             "organizations:mep-rollout-flag",
             "organizations:dynamic-sampling",
             "organizations:performance-use-metrics",
-            "organizations:dashboards-mep",
         ]
         batch_features = features.batch_has(
             feature_names,
@@ -273,7 +272,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
                     and batch_features.get("organizations:dynamic-sampling", False)
                 )
                 or batch_features.get("organizations:performance-use-metrics", False)
-                or batch_features.get("organizations:dashboards-mep", False)
+                or True
             )
             # When using the eps/epm functions, they require an interval argument
             # or to provide the start/end so that the interval can be computed.

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -29,7 +29,6 @@ from sentry.models.dashboard_widget import (
     DashboardWidgetTypes,
     DatasetSourcesTypes,
 )
-from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.relay.config.metric_extraction import get_current_widget_specs, widget_exceeds_max_specs
 from sentry.search.events.builder.discover import UnresolvedQuery
@@ -43,7 +42,6 @@ from sentry.tasks.on_demand_metrics import (
     set_or_create_on_demand_state,
 )
 from sentry.tasks.relay import schedule_invalidate_project_config
-from sentry.users.models.user import User
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.strings import oxfordize_list
 
@@ -182,32 +180,6 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
 
     validate_id = validate_id
 
-    def get_metrics_features(
-        self, organization: Organization | None, user: User | None
-    ) -> dict[str, bool | None]:
-        if organization is None or user is None:
-            return {}
-
-        feature_names = [
-            "organizations:mep-rollout-flag",
-            "organizations:dynamic-sampling",
-            "organizations:performance-use-metrics",
-        ]
-        batch_features = features.batch_has(
-            feature_names,
-            organization=organization,
-            actor=user,
-        )
-
-        return (
-            batch_features.get(f"organization:{organization.id}", {})
-            if batch_features is not None
-            else {
-                feature_name: features.has(feature_name, organization=organization, actor=user)
-                for feature_name in feature_names
-            }
-        )
-
     def validate(self, data):
         if not data.get("id"):
             keys = set(data.keys())
@@ -263,7 +235,6 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             data["issue_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}
 
         try:
-            use_metrics = True
             # When using the eps/epm functions, they require an interval argument
             # or to provide the start/end so that the interval can be computed.
             # This uses a hard coded start/end to ensure the validation succeeds
@@ -282,7 +253,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             elif self.context.get("widget_type") == DashboardWidgetTypes.get_type_name(
                 DashboardWidgetTypes.TRANSACTION_LIKE
             ):
-                config.has_metrics = use_metrics
+                config.has_metrics = True
             builder = UnresolvedQuery(
                 dataset=Dataset.Discover,
                 params=params,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -263,17 +263,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer[Dashboard]):
             data["issue_query_error"] = {"conditions": [f"Invalid conditions: {err}"]}
 
         try:
-            batch_features = self.get_metrics_features(
-                self.context.get("organization"), self.context.get("user")
-            )
-            use_metrics = bool(
-                (
-                    batch_features.get("organizations:mep-rollout-flag", False)
-                    and batch_features.get("organizations:dynamic-sampling", False)
-                )
-                or batch_features.get("organizations:performance-use-metrics", False)
-                or True
-            )
+            use_metrics = True
             # When using the eps/epm functions, they require an interval argument
             # or to provide the start/end so that the interval can be computed.
             # This uses a hard coded start/end to ensure the validation succeeds

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -309,16 +309,7 @@ class DataExportEndpoint(OrganizationEndpoint):
         if request.data and hasattr(request.data, "get"):
             limit = request.data.get("limit")
 
-        batch_features = self.get_features(organization, request)
-
-        use_metrics = (
-            (
-                batch_features.get("organizations:mep-rollout-flag", False)
-                and batch_features.get("organizations:dynamic-sampling", False)
-            )
-            or batch_features.get("organizations:performance-use-metrics", False)
-            or True
-        )
+        use_metrics = True
 
         # Validate the data export payload
         serializer = DataExportQuerySerializer(

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -245,34 +245,6 @@ class DataExportEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationDataExportPermission,)
 
-    def get_features(self, organization: Organization, request: Request) -> dict[str, bool | None]:
-        feature_names = [
-            "organizations:mep-rollout-flag",
-            "organizations:performance-use-metrics",
-            "organizations:profiling",
-            "organizations:dynamic-sampling",
-            "organizations:starfish-view",
-        ]
-        batch_features = features.batch_has(
-            feature_names,
-            organization=organization,
-            actor=request.user,
-        )
-
-        all_features = (
-            batch_features.get(f"organization:{organization.id}", {})
-            if batch_features is not None
-            else {}
-        )
-
-        for feature_name in feature_names:
-            if feature_name not in all_features:
-                all_features[feature_name] = features.has(
-                    feature_name, organization=organization, actor=request.user
-                )
-
-        return all_features
-
     def post(self, request: Request, organization: Organization) -> Response:
         """
         Create a new asynchronous file export task, and

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -309,8 +309,6 @@ class DataExportEndpoint(OrganizationEndpoint):
         if request.data and hasattr(request.data, "get"):
             limit = request.data.get("limit")
 
-        use_metrics = True
-
         # Validate the data export payload
         serializer = DataExportQuerySerializer(
             data=request.data,
@@ -320,7 +318,7 @@ class DataExportEndpoint(OrganizationEndpoint):
                     request=request, organization=organization, project_ids=project_query
                 ),
                 "get_projects": lambda: self.get_projects(request, organization),
-                "has_metrics": use_metrics,
+                "has_metrics": True,
             },
         )
         if not serializer.is_valid():

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -247,7 +247,6 @@ class DataExportEndpoint(OrganizationEndpoint):
 
     def get_features(self, organization: Organization, request: Request) -> dict[str, bool | None]:
         feature_names = [
-            "organizations:dashboards-mep",
             "organizations:mep-rollout-flag",
             "organizations:performance-use-metrics",
             "organizations:profiling",
@@ -318,7 +317,7 @@ class DataExportEndpoint(OrganizationEndpoint):
                 and batch_features.get("organizations:dynamic-sampling", False)
             )
             or batch_features.get("organizations:performance-use-metrics", False)
-            or batch_features.get("organizations:dashboards-mep", False)
+            or True
         )
 
         # Validate the data export payload

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from rest_framework.serializers import ListField
 
 import sentry
-from sentry import features
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.discover.arithmetic import ArithmeticError, categorize_columns
 from sentry.discover.models import (
@@ -16,13 +15,11 @@ from sentry.discover.models import (
     TeamKeyTransaction,
 )
 from sentry.exceptions import InvalidSearchQuery
-from sentry.models.organization import Organization
 from sentry.models.team import Team
 from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.errors import PARSER_CONFIG_OVERRIDES as ERROR_PARSER_CONFIG_OVERRIDES
-from sentry.users.models import User
 from sentry.utils.dates import parse_stats_period, validate_interval
 
 
@@ -135,32 +132,6 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
         2: {"groupby", "rollup", "aggregations", "conditions", "limit"},
     }
 
-    def get_metrics_features(
-        self, organization: Organization | None, user: User | None
-    ) -> dict[str, bool | None]:
-        if organization is None or user is None:
-            return {}
-
-        feature_names = [
-            "organizations:mep-rollout-flag",
-            "organizations:dynamic-sampling",
-            "organizations:performance-use-metrics",
-        ]
-        batch_features = features.batch_has(
-            feature_names,
-            organization=organization,
-            actor=user,
-        )
-
-        return (
-            batch_features.get(f"organization:{organization.id}", {})
-            if batch_features is not None
-            else {
-                feature_name: features.has(feature_name, organization=organization, actor=user)
-                for feature_name in feature_names
-            }
-        )
-
     def validate_projects(self, projects):
         from sentry.api.validators import validate_project_ids
 
@@ -242,15 +213,13 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     0,
                 )
             try:
-                use_metrics = True
-
                 equations, columns = categorize_columns(query["fields"])
 
                 config = QueryBuilderConfig()
                 if data.get("queryDataset") == DiscoverSavedQueryTypes.ERROR_EVENTS:
                     config.parser_config_overrides = ERROR_PARSER_CONFIG_OVERRIDES
                 elif data.get("queryDataset") == DiscoverSavedQueryTypes.TRANSACTION_LIKE:
-                    config.has_metrics = use_metrics
+                    config.has_metrics = True
 
                 builder = DiscoverQueryBuilder(
                     dataset=Dataset.Discover,

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -145,7 +145,6 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             "organizations:mep-rollout-flag",
             "organizations:dynamic-sampling",
             "organizations:performance-use-metrics",
-            "organizations:dashboards-mep",
         ]
         batch_features = features.batch_has(
             feature_names,
@@ -252,7 +251,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                         and batch_features.get("organizations:dynamic-sampling", False)
                     )
                     or batch_features.get("organizations:performance-use-metrics", False)
-                    or batch_features.get("organizations:dashboards-mep", False)
+                    or True
                 )
 
                 equations, columns = categorize_columns(query["fields"])

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -242,17 +242,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     0,
                 )
             try:
-                batch_features = self.get_metrics_features(
-                    self.context.get("organization"), self.context.get("user")
-                )
-                use_metrics = bool(
-                    (
-                        batch_features.get("organizations:mep-rollout-flag", False)
-                        and batch_features.get("organizations:dynamic-sampling", False)
-                    )
-                    or batch_features.get("organizations:performance-use-metrics", False)
-                    or True
-                )
+                use_metrics = True
 
                 equations, columns = categorize_columns(query["fields"])
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -92,8 +92,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable interval selection for dashboards
     manager.add("organizations:dashboards-interval-selection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable metrics enhanced performance in dashboards
-    manager.add("organizations:dashboards-mep", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable starred dashboards with reordering

--- a/static/app/utils/useCustomMeasurements.spec.tsx
+++ b/static/app/utils/useCustomMeasurements.spec.tsx
@@ -34,7 +34,7 @@ function mockMeasurementsMeta() {
 describe('useCustomMeasurements', () => {
   it('provides customMeasurements from the custom measurements context', async () => {
     const {organization} = initializeOrg({
-      organization: {features: ['dashboards-mep']},
+      organization: {features: []},
       projects: [],
     });
     const measurementsMetaMock = mockMeasurementsMeta();

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -828,7 +828,7 @@ describe('Dashboards > WidgetCard', () => {
         api={api}
         organization={{
           ...organization,
-          features: [...organization.features, 'dashboards-mep'],
+          features: [...organization.features],
         }}
         widget={multipleQueryWidget}
         selection={selection}

--- a/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.spec.tsx
@@ -737,7 +737,7 @@ describe('Dashboards > WidgetQueries', () => {
       {
         organization: {
           ...organization,
-          features: [...organization.features, 'dashboards-mep'],
+          features: [...organization.features],
         },
       }
     );
@@ -781,7 +781,7 @@ describe('Dashboards > WidgetQueries', () => {
       {
         organization: {
           ...organization,
-          features: [...organization.features, 'dashboards-mep'],
+          features: [...organization.features],
         },
       }
     );

--- a/static/app/views/discover/table/columnEditModal.spec.tsx
+++ b/static/app/views/discover/table/columnEditModal.spec.tsx
@@ -97,7 +97,7 @@ describe('Discover -> ColumnEditModal', () => {
   });
   const initialData = initializeOrg({
     organization: {
-      features: ['performance-view', 'dashboards-mep'],
+      features: ['performance-view'],
     },
   });
   const columns: QueryFieldValue[] = [


### PR DESCRIPTION
## Summary
Removes the `organizations:dashboards-mep` feature flag that has been enabled at 100% via flagpole with no conditions.

This flag has been fully rolled out and its behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)