### PR TITLE
feat(flags): Remove graduated mep-rollout-flag feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -106,7 +106,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
     def get_features(self, organization: Organization, request: Request) -> Mapping[str, bool]:
         feature_names = [
-            "organizations:mep-rollout-flag",
             "organizations:performance-use-metrics",
             "organizations:profiling",
             "organizations:dynamic-sampling",

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -68,7 +68,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     ) -> Mapping[str, bool | None]:
         feature_names = [
             "organizations:performance-use-metrics",
-            "organizations:mep-rollout-flag",
             "organizations:starfish-view",
             "organizations:on-demand-metrics-extraction",
             "organizations:on-demand-metrics-extraction-widgets",

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -399,10 +399,6 @@ class OrganizationSerializer(Serializer):
             feature_set.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):
             feature_set.add("shared-issues")
-        if "dynamic-sampling" not in feature_set and "mep-rollout-flag" in feature_set:
-            feature_set.remove("mep-rollout-flag")
-        if options.get("performance.hide-metrics-ui") and "mep-rollout-flag" in feature_set:
-            feature_set.remove("mep-rollout-flag")
 
         return sorted(feature_set)
 

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -179,7 +179,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-view-ai-title", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Large HTTP Payload Detector Improvements
     manager.add("organizations:large-http-payload-detector-improvements", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:mep-rollout-flag", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Migrate Orgs to new Azure DevOps Integration
     manager.add("organizations:migrate-azure-devops-integration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -296,19 +296,6 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
                 % sorted(dataset.name.lower() for dataset in valid_datasets)
             )
 
-        if (
-            not features.has(
-                "organizations:mep-rollout-flag",
-                self.context["organization"],
-                actor=self.context.get("user", None),
-            )
-            and dataset == Dataset.PerformanceMetrics
-            and query_type == SnubaQuery.Type.PERFORMANCE
-        ):
-            raise serializers.ValidationError(
-                "This project does not have access to the `generic_metrics` dataset"
-            )
-
         projects = data.get("projects")
         if not projects:
             # We just need a valid project id from the org so that we can verify
@@ -403,10 +390,7 @@ class SnubaQueryValidator(BaseDataSourceValidator[QuerySubscription]):
         has_dynamic_sampling = features.has(
             "organizations:dynamic-sampling", self.context["organization"]
         )
-        has_performance_metrics_flag = features.has(
-            "organizations:mep-rollout-flag", self.context["organization"]
-        )
-        has_performance_metrics = has_dynamic_sampling and has_performance_metrics_flag
+        has_performance_metrics = has_dynamic_sampling
 
         has_on_demand_metrics = features.has(
             "organizations:on-demand-metrics-extraction",

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -59,9 +59,7 @@ export function canUseMetricsData(organization: Organization) {
   const isInternalViewOn = organization.features.includes(
     'performance-transaction-name-only-search'
   );
-  const samplingFeatureFlag = organization.features.includes('dynamic-sampling'); // Exists on AM2 plans only.
-  const isRollingOut =
-    samplingFeatureFlag && organization.features.includes('mep-rollout-flag');
+  const isRollingOut = organization.features.includes('dynamic-sampling'); // Exists on AM2 plans only.
 
   // For plans transitioning from AM2 to AM3, we still want to show metrics
   // until 90d after 100% transaction ingestion to avoid spikes in charts

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.tsx
@@ -258,7 +258,6 @@ describe('Incident Rules Form', () => {
     });
 
     it('creates a rule with generic_metrics dataset', async () => {
-      organization.features = [...organization.features, 'mep-rollout-flag'];
       const rule = MetricRuleFixture();
       createWrapper({
         rule: {
@@ -583,11 +582,7 @@ describe('Incident Rules Form', () => {
     });
 
     it('creates a metrics Apdex rule without satisfaction parameter', async () => {
-      organization.features = [
-        ...organization.features,
-        'performance-view',
-        'mep-rollout-flag',
-      ];
+      organization.features = [...organization.features, 'performance-view'];
 
       const rule = MetricRuleFixture();
       createWrapper({

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1047,12 +1047,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
   handleMEPAlertDataset = (data: EventsStats | MultiSeriesEventsStats | null) => {
     const {isMetricsData} = data ?? {};
-    const {organization} = this.props;
 
-    if (
-      isMetricsData === undefined ||
-      !organization.features.includes('mep-rollout-flag')
-    ) {
+    if (isMetricsData === undefined) {
       return;
     }
 
@@ -1213,12 +1209,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     // TODO: once all alerts are migrated to MEP, we can set the default to GENERIC_METRICS and remove this as well as
     // logic in handleMEPDataset, handleTimeSeriesDataFetched and checkOnDemandMetricsDataset
     const {dataset} = this.state;
-    const {organization} = this.props;
-    const hasMetricsFeatureFlags =
-      organization.features.includes('mep-rollout-flag') ||
-      hasOnDemandMetricAlertFeature(organization);
-
-    if (hasMetricsFeatureFlags && dataset === Dataset.TRANSACTIONS) {
+    if (dataset === Dataset.TRANSACTIONS) {
       return Dataset.GENERIC_METRICS;
     }
     return dataset;

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -57,7 +57,6 @@ export function getMetricDatasetQueryExtras({
 
   const hasMetricDataset =
     hasOnDemandMetricAlertFeature(organization) ||
-    organization.features.includes('mep-rollout-flag') ||
     organization.features.includes('dashboards-metrics-transition');
   const disableMetricDataset =
     decodeScalar(location?.query?.disableMetricDataset) === 'true';

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -2,7 +2,6 @@ import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {
   Dataset,

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -2,6 +2,7 @@ import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {
   Dataset,

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -87,7 +87,6 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
 
       const hasMetricDataset =
         hasOnDemandMetricAlertFeature(options.organization) ||
-        options.organization.features.includes('mep-rollout-flag') ||
         options.organization.features.includes('dashboards-metrics-transition');
       const isOnDemandQuery =
         options.dataset === Dataset.GENERIC_METRICS &&

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -5,7 +5,6 @@ import type {EventsStats, Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {isOnDemandAggregate, isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
-import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {TransactionsConfig} from 'sentry/views/dashboards/datasetConfig/transactions';
 import {TraceSearchBar} from 'sentry/views/detectors/datasetConfig/components/traceSearchBar';

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -5,6 +5,7 @@ import type {EventsStats, Organization} from 'sentry/types/organization';
 import type {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {isOnDemandAggregate, isOnDemandQueryString} from 'sentry/utils/onDemandMetrics';
+import {hasOnDemandMetricAlertFeature} from 'sentry/utils/onDemandMetrics/features';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {TransactionsConfig} from 'sentry/views/dashboards/datasetConfig/transactions';
 import {TraceSearchBar} from 'sentry/views/detectors/datasetConfig/components/traceSearchBar';

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -1019,7 +1019,7 @@ describe('Performance > TransactionSummary', () => {
     it('uses MEP dataset for stats query', async () => {
       const data = initializeData({
         query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
-        features: ['dynamic-sampling', 'mep-rollout-flag'],
+        features: ['dynamic-sampling'],
       });
 
       renderWithLayout(data);
@@ -1065,7 +1065,7 @@ describe('Performance > TransactionSummary', () => {
       });
       const data = initializeData({
         query: {query: 'transaction.op:pageload'}, // transaction.op is covered by the metrics dataset
-        features: ['dynamic-sampling', 'mep-rollout-flag'],
+        features: ['dynamic-sampling'],
       });
 
       renderWithLayout(data);
@@ -1138,7 +1138,7 @@ describe('Performance > TransactionSummary', () => {
       });
       const data = initializeData({
         query: {query: 'transaction.op:pageload has:not-compatible'}, // Adds incompatible w/ metrics tag
-        features: ['dynamic-sampling', 'mep-rollout-flag'],
+        features: ['dynamic-sampling'],
       });
 
       renderWithLayout(data);

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -66,7 +66,7 @@ from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule impo
     assert_dual_written_resolution_threshold_equals,
 )
 
-pytestmark = [requires_snuba]
+pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 
 
 class AlertRuleDetailsBase(AlertRuleBase):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -931,7 +931,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:mep-rollout-flag",
                     "organizations:dynamic-sampling",
                 ]
             ),
@@ -987,7 +986,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:mep-rollout-flag",
                     "organizations:dynamic-sampling",
                 ]
             ),
@@ -1720,7 +1718,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             [
                 "organizations:incidents",
                 "organizations:performance-view",
-                "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
             ]
         ):
@@ -1754,7 +1751,6 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             [
                 "organizations:incidents",
                 "organizations:performance-view",
-                "organizations:mep-rollout-flag",
                 "organizations:dynamic-sampling",
             ]
         ):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -219,29 +219,16 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
                 ]
             },
         )
-        self.run_fail_validation_test(
-            {
-                "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": Dataset.PerformanceMetrics.value,
-            },
-            {
-                "nonFieldErrors": [
-                    "This project does not have access to the `generic_metrics` dataset"
-                ]
-            },
-        )
-
-        with self.feature("organizations:mep-rollout-flag"):
-            base_params = self.valid_params.copy()
-            base_params["queryType"] = SnubaQuery.Type.PERFORMANCE.value
-            base_params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-            base_params["dataset"] = Dataset.PerformanceMetrics.value
-            base_params["query"] = ""
-            serializer = AlertRuleSerializer(context=self.context, data=base_params)
-            assert serializer.is_valid(), serializer.errors
-            alert_rule = serializer.save()
-            assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
-            assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
+        base_params = self.valid_params.copy()
+        base_params["queryType"] = SnubaQuery.Type.PERFORMANCE.value
+        base_params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
+        base_params["dataset"] = Dataset.PerformanceMetrics.value
+        base_params["query"] = ""
+        serializer = AlertRuleSerializer(context=self.context, data=base_params)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+        assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
+        assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
     def test_aggregate(self) -> None:
         self.run_fail_validation_test(
@@ -863,30 +850,28 @@ class TestAlertRuleSerializer(TestAlertRuleSerializerBase):
         assert alert_rule.snuba_query.query == "status:unresolved"
 
     def test_http_response_rate(self) -> None:
-        with self.feature("organizations:mep-rollout-flag"):
-            params = self.valid_params.copy()
-            params["query"] = "span.module:http span.op:http.client"
-            params["aggregate"] = "http_response_rate(3)"
-            params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-            params["dataset"] = Dataset.PerformanceMetrics.value
-            serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-            assert serializer.is_valid(), serializer.errors
-            alert_rule = serializer.save()
-            assert alert_rule.snuba_query.query == "span.module:http span.op:http.client"
-            assert alert_rule.snuba_query.aggregate == "http_response_rate(3)"
+        params = self.valid_params.copy()
+        params["query"] = "span.module:http span.op:http.client"
+        params["aggregate"] = "http_response_rate(3)"
+        params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
+        params["dataset"] = Dataset.PerformanceMetrics.value
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+        assert alert_rule.snuba_query.query == "span.module:http span.op:http.client"
+        assert alert_rule.snuba_query.aggregate == "http_response_rate(3)"
 
     def test_performance_score(self) -> None:
-        with self.feature("organizations:mep-rollout-flag"):
-            params = self.valid_params.copy()
-            params["query"] = "has:measurements.score.total"
-            params["aggregate"] = "performance_score(measurements.score.lcp)"
-            params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-            params["dataset"] = Dataset.PerformanceMetrics.value
-            serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-            assert serializer.is_valid(), serializer.errors
-            alert_rule = serializer.save()
-            assert alert_rule.snuba_query.query == "has:measurements.score.total"
-            assert alert_rule.snuba_query.aggregate == "performance_score(measurements.score.lcp)"
+        params = self.valid_params.copy()
+        params["query"] = "has:measurements.score.total"
+        params["aggregate"] = "performance_score(measurements.score.lcp)"
+        params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
+        params["dataset"] = Dataset.PerformanceMetrics.value
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert serializer.is_valid(), serializer.errors
+        alert_rule = serializer.save()
+        assert alert_rule.snuba_query.query == "has:measurements.score.total"
+        assert alert_rule.snuba_query.aggregate == "performance_score(measurements.score.lcp)"
 
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_count_aggregate_gets_converted_to_upsampled_count_for_upsampled_projects(

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -563,7 +563,6 @@ class TestMetricAlertsCreateDetectorValidator(TestMetricAlertsDetectorValidator)
             validator.save()
 
     @with_feature("organizations:discover-saved-queries-deprecation")
-    @with_feature("organizations:mep-rollout-flag")
     def test_transaction_dataset_deprecation_generic_metrics(self) -> None:
         data = {
             **self.valid_data,
@@ -1407,7 +1406,6 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         updated_detector = update_validator.save()
         assert updated_detector.name == "Updated Detector Name"
 
-    @with_feature("organizations:mep-rollout-flag")
     def test_transaction_dataset_deprecation_generic_metrics_update(self) -> None:
         data = {
             **self.valid_data,
@@ -1453,7 +1451,6 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         ):
             update_validator.save()
 
-    @with_feature("organizations:mep-rollout-flag")
     def test_transaction_dataset_deprecation_update_to_transactions(self) -> None:
         data = {
             **self.valid_data,


### PR DESCRIPTION
## Summary
Removes the `organizations:mep-rollout-flag` feature flag that has been enabled at 100% via flagpole with no conditions.

This flag has been fully rolled out and its behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)