### PR TITLE
feat(flags): Remove graduated team-replay user-feedback AI flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -463,16 +463,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:uptime-response-capture", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable runtime assertions for uptime monitors
     manager.add("organizations:uptime-runtime-assertions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable endpoint and frontend for AI-powered UF summaries
-    manager.add("organizations:user-feedback-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable org-level caching for user feedback summaries and categorization
-    manager.add("organizations:user-feedback-ai-summaries-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE)
-    # Enable label generation at ingest time for user feedbacks
-    manager.add("organizations:user-feedback-ai-categorization", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable the backend endpoint and frontend for categorizing user feedbacks
-    manager.add("organizations:user-feedback-ai-categorization-features", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable AI-powered title generation for user feedback
-    manager.add("organizations:user-feedback-ai-titles", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable auto spam classification at User Feedback ingest time
     manager.add("organizations:user-feedback-spam-ingest", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable view hierarchies options

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 import jsonschema
 
-from sentry import features, options
+from sentry import options
 from sentry.constants import DataCategory
 from sentry.feedback.lib.utils import UNREAL_FEEDBACK_UNATTENDED_MESSAGE, FeedbackCreationSource
 from sentry.feedback.usecases.label_generation import (
@@ -298,9 +298,7 @@ def create_feedback_issue(
     )
     issue_fingerprint = [uuid4().hex]
 
-    use_ai_title = should_query_seer and features.has(
-        "organizations:user-feedback-ai-titles", project.organization
-    )
+    use_ai_title = should_query_seer
     title = truncate_feedback_title(
         get_feedback_title(feedback_message, project.organization_id, use_ai_title)
     )
@@ -335,9 +333,7 @@ def create_feedback_issue(
     )
 
     # Generating labels using Seer, which will later be used to categorize feedbacks
-    if should_query_seer and features.has(
-        "organizations:user-feedback-ai-categorization", project.organization
-    ):
+    if should_query_seer:
         try:
             labels = generate_labels(feedback_message, project.organization_id)
             # This will rarely happen unless the user writes a really long feedback message

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -148,7 +148,7 @@ describe('FeedbackItemUsername', () => {
 
       render(<FeedbackItemUsername feedbackIssue={issue} />, {
         organization: {
-          features: ['user-feedback-ai-titles', 'gen-ai-features'],
+          features: ['gen-ai-features'],
         },
       });
 
@@ -168,17 +168,12 @@ describe('FeedbackItemUsername', () => {
     it.each([
       {
         description: 'AI features are disabled',
-        features: ['user-feedback-ai-titles'],
-        summary: 'Login issue with payment flow',
-      },
-      {
-        description: 'user feedback AI titles are disabled',
-        features: ['gen-ai-features'],
+        features: [] as string[],
         summary: 'Login issue with payment flow',
       },
       {
         description: 'AI features enabled but summary is null',
-        features: ['user-feedback-ai-titles', 'gen-ai-features'],
+        features: ['gen-ai-features'],
         summary: null,
       },
     ])(

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -32,8 +32,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const user = name && email && !isSameNameAndEmail ? `${name} <${email}>` : nameOrEmail;
 
   const summary = feedbackIssue.metadata.summary;
-  const isAiSummaryEnabled =
-    areAiFeaturesAllowed && organization.features.includes('user-feedback-ai-titles');
+  const isAiSummaryEnabled = areAiFeaturesAllowed;
 
   const userNodeId = useId();
 

--- a/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
+++ b/static/app/components/feedback/summaryCategories/feedbackSummaryCategories.tsx
@@ -10,12 +10,9 @@ import FeedbackSummary from 'sentry/components/feedback/summaryCategories/feedba
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
 export default function FeedbackSummaryCategories() {
-  const organization = useOrganization();
-
   const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
 
   const [isExpanded, setIsExpanded] = useSyncedLocalStorageState(
@@ -23,12 +20,7 @@ export default function FeedbackSummaryCategories() {
     true
   );
 
-  const showSummaryCategories =
-    (organization.features.includes('user-feedback-ai-summaries') ||
-      organization.features.includes('user-feedback-ai-categorization-features')) &&
-    areAiFeaturesAllowed;
-
-  if (!showSummaryCategories) {
+  if (!areAiFeaturesAllowed) {
     return null;
   }
 
@@ -78,12 +70,8 @@ export default function FeedbackSummaryCategories() {
         </Disclosure.Title>
         <Disclosure.Content>
           <Stack gap="md" width="100%">
-            {organization.features.includes('user-feedback-ai-summaries') && (
-              <FeedbackSummary />
-            )}
-            {organization.features.includes(
-              'user-feedback-ai-categorization-features'
-            ) && <FeedbackCategories />}
+            <FeedbackSummary />
+            <FeedbackCategories />
           </Stack>
         </Disclosure.Content>
       </Disclosure>

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_categories.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_categories.py
@@ -22,9 +22,6 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
         self.org = self.organization
         self.project1 = self.project
         self.project2 = self.create_project(teams=[self.team])
-        self.features = {
-            "organizations:user-feedback-ai-categorization-features": True,
-        }
         self.url = reverse(
             self.endpoint,
             kwargs={"organization_id_or_slug": self.org.slug},
@@ -74,15 +71,10 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
         )
         create_feedback_issue(event, project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
-    def test_get_feedback_categories_without_feature_flag(self) -> None:
-        response = self.get_error_response(self.org.slug)
-        assert response.status_code == 403
-
     def test_get_feedback_categories_without_seer_access(self) -> None:
         self.mock_has_seer_access.return_value = False
-        with self.feature(self.features):
-            response = self.get_error_response(self.org.slug)
-            assert response.status_code == 403
+        response = self.get_error_response(self.org.slug)
+        assert response.status_code == 403
 
     def test_get_feedback_categories_basic(self) -> None:
         self._create_feedback("a", ["User Interface", "Speed"], self.project1)
@@ -105,8 +97,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
             },
         )
 
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug)
+        response = self.get_success_response(self.org.slug)
 
         assert response.data["success"] is True
         assert response.data["numFeedbacksContext"] == 4
@@ -148,8 +139,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
             },
         )
 
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug, project=[self.project1.id])
+        response = self.get_success_response(self.org.slug, project=[self.project1.id])
 
         assert response.data["success"] is True
         assert response.data["numFeedbacksContext"] == 2
@@ -189,8 +179,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
             },
         )
 
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug)
+        response = self.get_success_response(self.org.slug)
 
         assert response.data["success"] is True
         categories = response.data["categories"]
@@ -221,8 +210,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
             },
         )
 
-        with self.feature(self.features):
-            response = self.get_success_response(self.org.slug)
+        response = self.get_success_response(self.org.slug)
 
         assert response.data["success"] is True
         categories = response.data["categories"]
@@ -235,8 +223,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
         self._create_feedback("a", ["User Interface", "Issues UI"], self.project1)
         self.mock_make_signed_seer_api_request.side_effect = Exception("seer failed")
 
-        with self.feature(self.features):
-            response = self.get_error_response(self.org.slug)
+        response = self.get_error_response(self.org.slug)
 
         assert response.status_code == 500
         assert response.data["detail"] == "Failed to generate user feedback label groups"
@@ -248,8 +235,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
                 status=status, json_data={"detail": "seer failed"}
             )
 
-            with self.feature(self.features):
-                response = self.get_error_response(self.org.slug)
+            response = self.get_error_response(self.org.slug)
 
             assert response.status_code == 500
             assert response.data["detail"] == "Failed to generate user feedback label groups"
@@ -263,8 +249,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
         ):
             self._create_feedback("a", ["User Interface", "Usability"], self.project1)
 
-            with self.feature(self.features):
-                response = self.get_success_response(self.org.slug)
+            response = self.get_success_response(self.org.slug)
 
             assert self.mock_make_signed_seer_api_request.call_count == 0
 


### PR DESCRIPTION
## Summary
Removes 5 user-feedback AI feature flags owned by team-replay that have been enabled at 100% via flagpole with no conditions:
- `organizations:user-feedback-ai-categorization`
- `organizations:user-feedback-ai-categorization-features`
- `organizations:user-feedback-ai-summaries`
- `organizations:user-feedback-ai-summaries-cache`
- `organizations:user-feedback-ai-titles`

These flags have been fully rolled out and their behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)