### PR TITLE
feat(flags): Remove graduated ml-ai feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -56,8 +56,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:anomaly-detection-threshold-data", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.
     manager.add("organizations:auto-enable-codecov", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable GenAI features such as Autofix and Issue Summary
-    manager.add("organizations:autofix-seer-preferences", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enabled for orgs that participated in the code review beta
     manager.add("organizations:code-review-beta", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable A/B testing experiments for code review (org eligibility)
@@ -285,18 +283,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod build distribution
-    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod frontend routes
-    manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable writing preprod size metrics to EAP for querying
-    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable writing preprod build distribution data to EAP for querying
-    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod app size dashboard widget
-    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
@@ -350,8 +338,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:revoke-org-auth-on-slug-rename", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable detecting SDK crashes during event processing
     manager.add("organizations:sdk-crash-detection", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable coding agent integrations for AI-powered code fixes
-    manager.add("organizations:seer-coding-agent-integrations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Config Reminder in the primary nav
     manager.add("organizations:seer-config-reminder", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer panel for AI-powered data exploration
@@ -415,8 +401,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-modules-use-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable access to insights metrics alerts
     manager.add("organizations:insights-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Seer Webhooks to be sent and listened to
-    manager.add("organizations:seer-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable public RPC endpoint for local seer development
     manager.add("organizations:seer-public-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Organizations on the old usage-based (v0) Seer plan

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -283,8 +283,18 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod build distribution
+    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod frontend routes
+    manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable writing preprod size metrics to EAP for querying
+    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable writing preprod build distribution data to EAP for querying
+    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable preprod app size dashboard widget
+    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/integrations/api/endpoints/organization_coding_agents.py
+++ b/src/sentry/integrations/api/endpoints/organization_coding_agents.py
@@ -77,9 +77,6 @@ class OrganizationCodingAgentsEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization) -> Response:
         """Get all available coding agent integrations for the organization."""
-        if not features.has("organizations:seer-coding-agent-integrations", organization):
-            return Response({"detail": "Feature not available"}, status=404)
-
         integrations = integration_service.get_integrations(
             organization_id=organization.id,
             providers=get_coding_agent_providers(),

--- a/src/sentry/integrations/cursor/webhooks/handler.py
+++ b/src/sentry/integrations/cursor/webhooks/handler.py
@@ -12,17 +12,15 @@ from django.http import HttpRequest, HttpResponse
 from django.utils.crypto import constant_time_compare
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from rest_framework.exceptions import MethodNotAllowed, NotFound, ParseError, PermissionDenied
+from rest_framework.exceptions import MethodNotAllowed, ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.services.integration import integration_service
-from sentry.models.organization import Organization
 from sentry.seer.autofix.utils import (
     CodingAgentResult,
     CodingAgentStatus,
@@ -49,10 +47,6 @@ class CursorWebhookEndpoint(Endpoint):
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request: Request, organization_id: int) -> Response:
-        organization = Organization.objects.get(id=organization_id)
-        if not features.has("organizations:seer-coding-agent-integrations", organization):
-            raise NotFound("Coding agent feature not enabled for this organization")
-
         try:
             payload = orjson.loads(request.body)
         except orjson.JSONDecodeError:

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -409,7 +409,7 @@ def launch_coding_agents_for_run(
 
     Raises:
         NotFound: If organization, integration, autofix state, or repos are not found
-        PermissionDenied: If feature is not enabled for the organization
+        PermissionDenied: If GitHub Copilot is not enabled for the organization
         ValidationError: If integration is invalid
         APIException: If there's an error launching agents
     """
@@ -417,9 +417,6 @@ def launch_coding_agents_for_run(
         organization = Organization.objects.get(id=organization_id)
     except Organization.DoesNotExist:
         raise NotFound("Organization not found")
-
-    if not features.has("organizations:seer-coding-agent-integrations", organization):
-        raise PermissionDenied("Feature not available")
 
     integration = None
     installation: CodingAgentIntegration | None = None

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -162,23 +162,22 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                 extra={"event_type": event_type},
             )
 
-        if features.has("organizations:seer-webhooks", organization):
-            try:
-                broadcast_webhooks_for_organization.delay(
-                    resource_name="seer",
-                    event_name=event_name,
-                    organization_id=organization.id,
-                    payload=webhook_payload,
-                )
-            except Exception:
-                logger.exception(
-                    "autofix.on_completion_hook.webhook_failed",
-                    extra={
-                        "run_id": run_id,
-                        "organization_id": organization.id,
-                        "webhook_event": event_name,
-                    },
-                )
+        try:
+            broadcast_webhooks_for_organization.delay(
+                resource_name="seer",
+                event_name=event_name,
+                organization_id=organization.id,
+                payload=webhook_payload,
+            )
+        except Exception:
+            logger.exception(
+                "autofix.on_completion_hook.webhook_failed",
+                extra={
+                    "run_id": run_id,
+                    "organization_id": organization.id,
+                    "webhook_event": event_name,
+                },
+            )
 
     @classmethod
     def _maybe_trigger_supergroups_embedding(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -36,7 +36,6 @@ from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, StrArray
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
@@ -552,9 +551,6 @@ def send_seer_webhook(*, event_name: str, organization_id: int, payload: dict) -
                 "organization_id": organization_id,
             }
         )
-
-    if not features.has("organizations:seer-webhooks", organization):
-        return {"success": False, "error": "Seer webhooks are not enabled for this organization"}
 
     broadcast_webhooks_for_organization.delay(
         resource_name="seer",

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -63,12 +63,9 @@ def launch_coding_agents(
 
     Raises:
         NotFound: If integration not found
-        PermissionDenied: If feature not enabled for the organization
+        PermissionDenied: If GitHub Copilot is not enabled for the organization
         ValidationError: If integration is invalid
     """
-    if not features.has("organizations:seer-coding-agent-integrations", organization):
-        raise PermissionDenied("Feature not available")
-
     integration = None
     installation: CodingAgentIntegration | None = None
     client: CodingAgentClient | None = None

--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -6,7 +6,6 @@ import {ProjectAvatar} from '@sentry/scraps/avatar';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid, type GridProps} from '@sentry/scraps/layout';
 
-import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import AutofixFeedback from 'sentry/components/events/autofix/autofixFeedback';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
@@ -101,16 +100,14 @@ function DrawerNavigator({
       <ButtonWrapper>
         <AutofixFeedback iconOnly />
 
-        <Feature features={['organizations:autofix-seer-preferences']}>
-          <LinkButton
-            external
-            href={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
-            size="xs"
-            tooltipProps={{title: t('Configure Seer settings for this project')}}
-            aria-label={t('Configure Seer settings for this project')}
-            icon={<IconSettings />}
-          />
-        </Feature>
+        <LinkButton
+          external
+          href={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+          size="xs"
+          tooltipProps={{title: t('Configure Seer settings for this project')}}
+          aria-label={t('Configure Seer settings for this project')}
+          icon={<IconSettings />}
+        />
         <Button
           size="xs"
           onClick={onCopyMarkdown}

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -7,7 +7,6 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
-import Feature from 'sentry/components/acl/feature';
 import {AiPrivacyNotice} from 'sentry/components/aiPrivacyTooltip';
 import {Breadcrumbs as NavigationBreadcrumbs} from 'sentry/components/breadcrumbs';
 import {DateTime} from 'sentry/components/dateTime';
@@ -411,16 +410,14 @@ function LegacySeerDrawer({group, project, event, aiConfig}: LegacySeerDrawerPro
         </Flex>
         <ButtonBarWrapper data-test-id="seer-button-bar">
           <Grid flow="column" align="center" gap="md">
-            <Feature features={['organizations:autofix-seer-preferences']}>
-              <LinkButton
-                external
-                href={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
-                size="xs"
-                tooltipProps={{title: t('Project Settings for Seer')}}
-                aria-label={t('Project Settings for Seer')}
-                icon={<IconSettings />}
-              />
-            </Feature>
+            <LinkButton
+              external
+              href={`/settings/${organization.slug}/projects/${project.slug}/seer/`}
+              size="xs"
+              tooltipProps={{title: t('Project Settings for Seer')}}
+              aria-label={t('Project Settings for Seer')}
+              icon={<IconSettings />}
+            />
             {aiConfig.hasAutofix && (
               <Button
                 size="xs"

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -46,9 +46,6 @@ function SubscriptionBox({
     message = t(
       'Your organization does not have access to the error subscription resource.'
     );
-  } else if (resource === 'seer' && !features.includes('seer-webhooks')) {
-    disabled = true;
-    message = t("Your organization can't subscribe to seer events just yet.");
   }
 
   if (webhookDisabled) {

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -36,9 +36,7 @@ describe('ProjectSeer', () => {
 
   beforeEach(() => {
     project = ProjectFixture();
-    organization = OrganizationFixture({
-      features: ['autofix-seer-preferences'],
-    });
+    organization = OrganizationFixture();
 
     // Mock the seer setup check endpoint
     MockApiClient.addMockResponse({
@@ -419,7 +417,7 @@ describe('ProjectSeer', () => {
 
   it('can enable automation handoff to Cursor when Cursor integration is available', async () => {
     const orgWithCursorFeature = OrganizationFixture({
-      features: ['autofix-seer-preferences', 'integrations-cursor'],
+      features: ['integrations-cursor'],
     });
 
     const initialProject: Project = {
@@ -564,7 +562,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['autofix-seer-preferences', 'integrations-cursor'],
+        features: ['integrations-cursor'],
       });
 
       const initialProject: Project = {
@@ -643,7 +641,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['autofix-seer-preferences', 'integrations-cursor'],
+        features: ['integrations-cursor'],
       });
 
       const initialProject: Project = {
@@ -751,7 +749,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['autofix-seer-preferences', 'integrations-cursor'],
+        features: ['integrations-cursor'],
       });
 
       const initialProject: Project = {
@@ -841,7 +839,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['autofix-seer-preferences', 'integrations-cursor'],
+        features: ['integrations-cursor'],
       });
 
       const initialProject: Project = {
@@ -964,7 +962,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithCursorFeature = OrganizationFixture({
-        features: ['autofix-seer-preferences', 'integrations-cursor'],
+        features: ['integrations-cursor'],
       });
 
       const initialProject: Project = {

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -7,7 +7,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
-import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import {CursorIntegrationCta} from 'sentry/components/events/autofix/cursorIntegrationCta';
 import {GithubCopilotIntegrationCta} from 'sentry/components/events/autofix/githubCopilotIntegrationCta';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
@@ -499,17 +498,6 @@ function ProjectSeer({
 export default function ProjectSeerContainer() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-
-  if (!organization.features.includes('autofix-seer-preferences')) {
-    return (
-      <FeatureDisabled
-        features={['organizations:autofix-seer-preferences']}
-        hideHelpToggle
-        message={t('Autofix is not enabled for this organization.')}
-        featureName={t('Autofix')}
-      />
-    );
-  }
 
   return <ProjectSeer organization={organization} project={project} />;
 }

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -4,7 +4,6 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
-import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
@@ -38,19 +37,6 @@ function SeerProjectDetails() {
   const {codeMappingRepos, isPending, preference} = useProjectSeerPreferences(project);
 
   const canWrite = hasEveryAccess(['project:write'], {organization, project});
-
-  if (!organization.features.includes('autofix-seer-preferences')) {
-    return (
-      <AnalyticsArea name="project-details">
-        <FeatureDisabled
-          featureName={t('Autofix')}
-          features={['autofix-seer-preferences']}
-          hideHelpToggle
-          message={t('Autofix is not enabled for this organization.')}
-        />
-      </AnalyticsArea>
-    );
-  }
 
   return (
     <AnalyticsArea name="project-details">

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -249,22 +249,11 @@ class StoreCodingAgentStatesToSeerTest(APITestCase):
 class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
     """Test class for GET endpoint functionality."""
 
-    def test_feature_flag_disabled(self):
-        """Test GET request when feature flag is disabled."""
-        organization = self.create_organization(owner=self.user)
-
-        with self.feature({"organizations:seer-coding-agent-integrations": False}):
-            response = self.get_response(organization.slug)
-
-        assert response.status_code == 404
-        assert response.data["detail"] == "Feature not available"
-
     def test_no_integrations(self):
         """Test GET request with no coding agent integrations."""
         organization = self.create_organization(owner=self.user)
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_response(organization.slug)
+        response = self.get_response(organization.slug)
 
         assert response.status_code == 200
         assert response.data["integrations"] == []
@@ -302,29 +291,27 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_integration.provider = "github"
         mock_get_integrations.return_value = [mock_integration]
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
-            assert "integrations" in response.data
-            integrations = response.data["integrations"]
-            assert len(integrations) == 1
-            integration_data = integrations[0]
+        assert "integrations" in response.data
+        integrations = response.data["integrations"]
+        assert len(integrations) == 1
+        integration_data = integrations[0]
 
-            # The endpoint only returns basic integration data
-            assert integration_data["id"] == str(self.integration.id)
-            assert integration_data["name"] == "GitHub"
-            assert integration_data["provider"] == "github"
+        # The endpoint only returns basic integration data
+        assert integration_data["id"] == str(self.integration.id)
+        assert integration_data["name"] == "GitHub"
+        assert integration_data["provider"] == "github"
 
     @patch("sentry.integrations.services.integration.integration_service.get_integrations")
     def test_handles_integration_processing_error(self, mock_get_integrations):
         """Test GET endpoint handles empty integrations gracefully."""
         mock_get_integrations.return_value = []
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
-            assert "integrations" in response.data
-            assert len(response.data["integrations"]) == 0
+        assert "integrations" in response.data
+        assert len(response.data["integrations"]) == 0
 
     @patch("sentry.integrations.services.integration.integration_service.get_integrations")
     def test_handles_service_error(self, mock_get_integrations):
@@ -332,9 +319,8 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         # Mock service to raise an exception
         mock_get_integrations.side_effect = Exception("Service unavailable")
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_error_response(self.organization.slug, status_code=500)
-            assert response.status_code == 500
+        response = self.get_error_response(self.organization.slug, status_code=500)
+        assert response.status_code == 500
 
     @patch(
         "sentry.integrations.services.integration.integration_service.get_organization_integrations"
@@ -346,12 +332,11 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_get_org_integrations.return_value = [self.rpc_org_integration]
         mock_get_integration.return_value = None
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug)
+        response = self.get_success_response(self.organization.slug)
 
-            # Should skip integrations that can't be found
-            assert "integrations" in response.data
-            assert len(response.data["integrations"]) == 0
+        # Should skip integrations that can't be found
+        assert "integrations" in response.data
+        assert len(response.data["integrations"]) == 0
 
     def test_github_copilot_shown_with_feature_flag(self):
         """Test GET endpoint shows GitHub Copilot when feature flag is enabled."""
@@ -458,58 +443,45 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
 class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCodingAgentsTest):
     """Test class for POST endpoint parameter validation."""
 
-    def test_feature_flag_disabled(self):
-        """Test POST endpoint when feature flag is disabled."""
-        data = {"integration_id": "123", "run_id": 123}
-        response = self.get_error_response(
-            self.organization.slug, method="post", status_code=403, **data
-        )
-        # POST returns plain string for disabled feature (403 PermissionDenied)
-        assert response.data["detail"] == "Feature not available"
-
     def test_missing_integration_id_and_provider(self):
         """Test POST endpoint with missing integration_id and provider."""
         data = {"run_id": 123}
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "non_field_errors" in response.data
-            assert "Either 'integration_id' or 'provider' must be provided" in str(
-                response.data["non_field_errors"]
-            )
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "non_field_errors" in response.data
+        assert "Either 'integration_id' or 'provider' must be provided" in str(
+            response.data["non_field_errors"]
+        )
 
     def test_both_integration_id_and_provider_provided(self):
         """Test POST endpoint with both integration_id and provider provided."""
         data = {"run_id": 123, "integration_id": "123", "provider": "github_copilot"}
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "non_field_errors" in response.data
-            assert "Only one of 'integration_id' or 'provider' should be provided" in str(
-                response.data["non_field_errors"]
-            )
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "non_field_errors" in response.data
+        assert "Only one of 'integration_id' or 'provider' should be provided" in str(
+            response.data["non_field_errors"]
+        )
 
     def test_invalid_integration_id(self):
         """Test POST endpoint with invalid integration_id."""
         data = {"integration_id": "invalid_id", "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "integration_id" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "integration_id" in response.data
 
     def test_invalid_provider(self):
         """Test POST endpoint with invalid provider (not enabled)."""
         data = {"provider": "github_copilot", "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=403, **data
-            )
-            assert "GitHub Copilot is not enabled" in response.data["detail"]
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=403, **data
+        )
+        assert "GitHub Copilot is not enabled" in response.data["detail"]
 
     def test_non_coding_agent_integration(self):
         """Test POST endpoint with non-coding agent integration."""
@@ -523,12 +495,11 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(slack_integration.id), "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            # DRF ValidationError returns a list for non-field errors
-            assert response.data[0] == "Not a coding agent integration"
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        # DRF ValidationError returns a list for non-field errors
+        assert response.data[0] == "Not a coding agent integration"
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -541,11 +512,10 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": "999", "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=404, **data
-            )
-            assert response.data["detail"] == "Integration not found"
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=404, **data
+        )
+        assert response.data["detail"] == "Integration not found"
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -562,11 +532,10 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=404, **data
-            )
-            assert response.data["detail"] == "Integration not found"
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=404, **data
+        )
+        assert response.data["detail"] == "Integration not found"
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -583,11 +552,10 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(self.integration.id), "run_id": ""}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "run_id" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "run_id" in response.data
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -609,11 +577,10 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(self.integration.id), "run_id": None}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "run_id" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "run_id" in response.data
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -632,11 +599,10 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(self.integration.id), "run_id": "not_a_number"}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            assert "run_id" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        assert "run_id" in response.data
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch(
@@ -661,12 +627,11 @@ class OrganizationCodingAgentsPostParameterValidationTest(BaseOrganizationCoding
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature({"organizations:seer-coding-agent-integrations": True}):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            # DRF ValidationError returns a list for non-field errors
-            assert response.data[0] == "Invalid coding agent integration"
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        # DRF ValidationError returns a list for non-field errors
+        assert response.data[0] == "Invalid coding agent integration"
 
 
 class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
@@ -789,12 +754,11 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=404, **data
-            )
-            # POST returns 404 NotFound for this error path
-            assert response.data["detail"] == "Autofix state not found"
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=404, **data
+        )
+        # POST returns 404 NotFound for this error path
+        assert response.data["detail"] == "Autofix state not found"
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1027,22 +991,21 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug, method="post", **data)
-            # All repos failed, so success is False (but HTTP 200 is still returned)
-            assert response.data["success"] is False
-            assert response.data["launched_count"] == 0
-            assert response.data["failed_count"] == 2
-            # Should have failure details
-            assert "failures" in response.data
-            assert len(response.data["failures"]) == 2
-            # Check both repos failed
-            failed_repos = {f["repo_name"] for f in response.data["failures"]}
-            assert failed_repos == {"owner1/repo1", "owner2/repo2"}
-            # Each failure should have an error message
-            for failure in response.data["failures"]:
-                assert "error_message" in failure
-                assert failure["error_message"] != ""
+        response = self.get_success_response(self.organization.slug, method="post", **data)
+        # All repos failed, so success is False (but HTTP 200 is still returned)
+        assert response.data["success"] is False
+        assert response.data["launched_count"] == 0
+        assert response.data["failed_count"] == 2
+        # Should have failure details
+        assert "failures" in response.data
+        assert len(response.data["failures"]) == 2
+        # Check both repos failed
+        failed_repos = {f["repo_name"] for f in response.data["failures"]}
+        assert failed_repos == {"owner1/repo1", "owner2/repo2"}
+        # Each failure should have an error message
+        for failure in response.data["failures"]:
+            assert "error_message" in failure
+            assert failure["error_message"] != ""
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1078,14 +1041,13 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug, method="post", **data)
-            # Should still succeed even if Seer storage fails
-            assert response.data["success"] is True
-            assert response.data["launched_count"] >= 0
-            assert response.data["failed_count"] >= 0
-            # Verify Seer storage was attempted once in batch
-            mock_store_to_seer.assert_called_once()
+        response = self.get_success_response(self.organization.slug, method="post", **data)
+        # Should still succeed even if Seer storage fails
+        assert response.data["success"] is True
+        assert response.data["launched_count"] >= 0
+        assert response.data["failed_count"] >= 0
+        # Verify Seer storage was attempted once in batch
+        mock_store_to_seer.assert_called_once()
 
 
 class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgentsTest):
@@ -1134,12 +1096,11 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug, method="post", **data)
-            assert response.data["success"] is False
-            assert response.data["failed_count"] >= 1
-            failure = response.data["failures"][0]
-            assert failure["failure_type"] == "generic"
+        response = self.get_success_response(self.organization.slug, method="post", **data)
+        assert response.data["success"] is False
+        assert response.data["failed_count"] >= 1
+        failure = response.data["failures"][0]
+        assert failure["failure_type"] == "generic"
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1275,13 +1236,12 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
 
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_success_response(self.organization.slug, method="post", **data)
-            assert response.data["success"] is False
-            assert response.data["failed_count"] >= 1
-            assert "failures" in response.data
-            failure = response.data["failures"][0]
-            assert failure["failure_type"] == "generic"
+        response = self.get_success_response(self.organization.slug, method="post", **data)
+        assert response.data["success"] is False
+        assert response.data["failed_count"] >= 1
+        assert "failures" in response.data
+        failure = response.data["failures"][0]
+        assert failure["failure_type"] == "generic"
 
 
 class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgentsTest):
@@ -1562,12 +1522,11 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
             "trigger_source": "invalid_source",
         }
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            # Serializer field error shape
-            assert "trigger_source" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        # Serializer field error shape
+        assert "trigger_source" in response.data
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
@@ -1844,12 +1803,11 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
             "instruction": too_long_instruction,
         }
 
-        with self.feature("organizations:seer-coding-agent-integrations"):
-            response = self.get_error_response(
-                self.organization.slug, method="post", status_code=400, **data
-            )
-            # Serializer should return field error
-            assert "instruction" in response.data
+        response = self.get_error_response(
+            self.organization.slug, method="post", status_code=400, **data
+        )
+        # Serializer should return field error
+        assert "instruction" in response.data
 
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -268,7 +268,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_integration.provider = "test_provider"
 
         with (
-            self.feature({"organizations:seer-coding-agent-integrations": True}),
             self.mock_integration_service_calls(integrations=[mock_integration]),
         ):
             response = self.get_response(organization.slug)
@@ -341,7 +340,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
     def test_github_copilot_shown_with_feature_flag(self):
         """Test GET endpoint shows GitHub Copilot when feature flag is enabled."""
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             self.mock_integration_service_calls(integrations=[]),
         ):
@@ -363,7 +361,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_identity_service.get_access_token_for_user.return_value = "mock-access-token"
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             self.mock_integration_service_calls(integrations=[]),
         ):
@@ -385,7 +382,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         mock_identity_service.get_access_token_for_user.return_value = None
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             self.mock_integration_service_calls(integrations=[]),
         ):
@@ -412,7 +408,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
         )
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             self.mock_integration_service_calls(integrations=[]),
         ):
@@ -430,7 +425,6 @@ class OrganizationCodingAgentsGetTest(BaseOrganizationCodingAgentsTest):
     def test_github_copilot_not_shown_without_feature_flag(self):
         """Test GET endpoint does not show GitHub Copilot without feature flag."""
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature({"organizations:integrations-github-copilot-agent": False}),
             self.mock_integration_service_calls(integrations=[]),
         ):
@@ -673,7 +667,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -721,7 +714,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -821,7 +813,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -907,7 +898,6 @@ class OrganizationCodingAgentsPostLaunchTest(BaseOrganizationCodingAgentsTest):
         data = {"integration_id": str(self.integration.id), "run_id": 123}
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1140,7 +1130,6 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         data = {"provider": "github_copilot", "run_id": 123}
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
         ):
@@ -1189,7 +1178,6 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         data = {"provider": "github_copilot", "run_id": 123}
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             self.feature("organizations:integrations-github-copilot-agent"),
             patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
         ):
@@ -1283,7 +1271,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1365,7 +1352,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1435,7 +1421,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1482,7 +1467,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1564,7 +1548,6 @@ class OrganizationCodingAgentsPostTriggerSourceTest(BaseOrganizationCodingAgents
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.get_coding_agent_prompt",
                 return_value=None,
@@ -1615,7 +1598,6 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1666,7 +1648,6 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1713,7 +1694,6 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1763,7 +1743,6 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),
@@ -1846,7 +1825,6 @@ class OrganizationCodingAgentsPostInstructionTest(BaseOrganizationCodingAgentsTe
         }
 
         with (
-            self.feature("organizations:seer-coding-agent-integrations"),
             patch(
                 "sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer",
             ),

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -267,25 +267,24 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client.start_run.return_value = 12345
         mock_client.continue_run.return_value = 12345
 
-        with self.feature({"organizations:seer-webhooks": True}):
-            step_to_action = {
-                AutofixStep.ROOT_CAUSE: SeerActionType.ROOT_CAUSE_STARTED,
-                AutofixStep.SOLUTION: SeerActionType.SOLUTION_STARTED,
-                AutofixStep.CODE_CHANGES: SeerActionType.CODING_STARTED,
-                AutofixStep.IMPACT_ASSESSMENT: SeerActionType.IMPACT_ASSESSMENT_STARTED,
-                AutofixStep.TRIAGE: SeerActionType.TRIAGE_STARTED,
-            }
+        step_to_action = {
+            AutofixStep.ROOT_CAUSE: SeerActionType.ROOT_CAUSE_STARTED,
+            AutofixStep.SOLUTION: SeerActionType.SOLUTION_STARTED,
+            AutofixStep.CODE_CHANGES: SeerActionType.CODING_STARTED,
+            AutofixStep.IMPACT_ASSESSMENT: SeerActionType.IMPACT_ASSESSMENT_STARTED,
+            AutofixStep.TRIAGE: SeerActionType.TRIAGE_STARTED,
+        }
 
-            for step, expected_action in step_to_action.items():
-                mock_broadcast.reset_mock()
-                trigger_autofix_explorer(
-                    group=self.group,
-                    step=step,
-                    run_id=None,
-                )
-                mock_broadcast.assert_called_once()
-                call_kwargs = mock_broadcast.call_args.kwargs
-                assert call_kwargs["event_name"] == expected_action.value
+        for step, expected_action in step_to_action.items():
+            mock_broadcast.reset_mock()
+            trigger_autofix_explorer(
+                group=self.group,
+                step=step,
+                run_id=None,
+            )
+            mock_broadcast.assert_called_once()
+            call_kwargs = mock_broadcast.call_args.kwargs
+            assert call_kwargs["event_name"] == expected_action.value
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
@@ -297,19 +296,18 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.continue_run.return_value = 67890
 
-        with self.feature({"organizations:seer-webhooks": True}):
-            result = trigger_autofix_explorer(
-                group=self.group,
-                step=AutofixStep.SOLUTION,
-                run_id=67890,
-            )
+        result = trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.SOLUTION,
+            run_id=67890,
+        )
 
-            assert result == 67890
-            # Verify started webhook was sent with the existing run_id
-            mock_broadcast.assert_called_once()
-            call_kwargs = mock_broadcast.call_args.kwargs
-            assert call_kwargs["event_name"] == SeerActionType.SOLUTION_STARTED.value
-            assert call_kwargs["payload"]["run_id"] == 67890
+        assert result == 67890
+        # Verify started webhook was sent with the existing run_id
+        mock_broadcast.assert_called_once()
+        call_kwargs = mock_broadcast.call_args.kwargs
+        assert call_kwargs["event_name"] == SeerActionType.SOLUTION_STARTED.value
+        assert call_kwargs["payload"]["run_id"] == 67890
 
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -322,43 +322,41 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
             },
         ]
 
-        with self.feature({"organizations:seer-webhooks": True}):
-            for i, test_case in enumerate(test_cases):
-                mock_broadcast.reset_mock()
-                state = run_state(blocks=[test_case["block"]])
-                AutofixOnCompletionHook._send_step_webhook(self.organization, run_id, state)
+        for i, test_case in enumerate(test_cases):
+            mock_broadcast.reset_mock()
+            state = run_state(blocks=[test_case["block"]])
+            AutofixOnCompletionHook._send_step_webhook(self.organization, run_id, state)
 
-                mock_broadcast.assert_called_once()
-                call_kwargs = mock_broadcast.call_args.kwargs
-                if i == 0:  # First test - verify common fields
-                    assert call_kwargs["resource_name"] == "seer"
-                    assert call_kwargs["organization_id"] == self.organization.id
-                    assert call_kwargs["payload"]["run_id"] == run_id
-                assert call_kwargs["event_name"] == test_case["expected_event"].value
-                assert (
-                    call_kwargs["payload"][test_case["expected_payload_key"]]
-                    == test_case["block"].artifacts[0].data
-                )
+            mock_broadcast.assert_called_once()
+            call_kwargs = mock_broadcast.call_args.kwargs
+            if i == 0:  # First test - verify common fields
+                assert call_kwargs["resource_name"] == "seer"
+                assert call_kwargs["organization_id"] == self.organization.id
+                assert call_kwargs["payload"]["run_id"] == run_id
+            assert call_kwargs["event_name"] == test_case["expected_event"].value
+            assert (
+                call_kwargs["payload"][test_case["expected_payload_key"]]
+                == test_case["block"].artifacts[0].data
+            )
 
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
     def test_send_step_webhook_coding(self, mock_broadcast):
         """Sends coding_completed webhook when file patches exist."""
-        with self.feature({"organizations:seer-webhooks": True}):
-            state = run_state(
-                blocks=[
-                    root_cause_memory_block(),
-                    solution_memory_block(),
-                    code_changes_memory_block(),
-                ]
-            )
-            AutofixOnCompletionHook._send_step_webhook(self.organization, 123, state)
+        state = run_state(
+            blocks=[
+                root_cause_memory_block(),
+                solution_memory_block(),
+                code_changes_memory_block(),
+            ]
+        )
+        AutofixOnCompletionHook._send_step_webhook(self.organization, 123, state)
 
-            mock_broadcast.assert_called_once()
-            call_kwargs = mock_broadcast.call_args.kwargs
-            assert call_kwargs["event_name"] == SeerActionType.CODING_COMPLETED.value
-            assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["path"] == "test.py"
-            assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["added"] == 5
-            assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["removed"] == 2
+        mock_broadcast.assert_called_once()
+        call_kwargs = mock_broadcast.call_args.kwargs
+        assert call_kwargs["event_name"] == SeerActionType.CODING_COMPLETED.value
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["path"] == "test.py"
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["added"] == 5
+        assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["removed"] == 2
 
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
     def test_send_step_webhook_no_artifacts_no_webhook(self, mock_broadcast):

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -1,8 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-from rest_framework.exceptions import PermissionDenied
-
 from sentry.seer.explorer.coding_agent_handoff import launch_coding_agents
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
@@ -16,27 +13,10 @@ class TestLaunchCodingAgents(TestCase):
         self.organization = self.create_organization()
         self.run_id = 12345
 
-    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_raises_permission_denied_without_feature(self, mock_features):
-        """Test that PermissionDenied is raised when feature flag is disabled."""
-        mock_features.return_value = False
-
-        with pytest.raises(PermissionDenied, match="Feature not available"):
-            launch_coding_agents(
-                organization=self.organization,
-                integration_id=1,
-                run_id=self.run_id,
-                prompt="Fix the bug",
-                repos=["owner/repo"],
-            )
-
     @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
-    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_successful_launch(self, mock_features, mock_validate, mock_store):
+    def test_successful_launch(self, mock_validate, mock_store):
         """Test successful coding agent launch."""
-        mock_features.return_value = True
-
         mock_integration = MagicMock()
         mock_integration.provider = "cursor"
         mock_installation = MagicMock()
@@ -61,10 +41,8 @@ class TestLaunchCodingAgents(TestCase):
 
     @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
-    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_invalid_repo_format(self, mock_features, mock_validate, mock_store):
+    def test_invalid_repo_format(self, mock_validate, mock_store):
         """Test that invalid repo format is handled as failure."""
-        mock_features.return_value = True
         mock_integration = MagicMock()
         mock_installation = MagicMock()
         mock_validate.return_value = (mock_integration, mock_installation)
@@ -84,12 +62,10 @@ class TestLaunchCodingAgents(TestCase):
 
     @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
-    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_multiple_repos_partial_failure(self, mock_features, mock_validate, mock_store):
+    def test_multiple_repos_partial_failure(self, mock_validate, mock_store):
         """Test handling of partial failures across multiple repos."""
         from requests import HTTPError
 
-        mock_features.return_value = True
         mock_integration = MagicMock()
         mock_integration.provider = "cursor"
         mock_installation = MagicMock()
@@ -115,10 +91,8 @@ class TestLaunchCodingAgents(TestCase):
 
     @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
-    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_branch_name_is_sanitized(self, mock_features, mock_validate, mock_store):
+    def test_branch_name_is_sanitized(self, mock_validate, mock_store):
         """Test that branch name is sanitized before launch."""
-        mock_features.return_value = True
         mock_integration = MagicMock()
         mock_installation = MagicMock()
         mock_installation.launch.return_value = MagicMock(dict=lambda: {"id": "agent-1"})


### PR DESCRIPTION
## Summary
Removes 3 feature flags owned by ml-ai that have been enabled at 100% via flagpole with no conditions:
- `organizations:autofix-seer-preferences`
- `organizations:seer-coding-agent-integrations`
- `organizations:seer-webhooks`

These flags have been fully rolled out and their behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)