### PR TITLE
feat(flags): Remove graduated coding-workflows feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -171,6 +171,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
+    # Enables streamlined issue details UI for all users of an organization without opt-out
+    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -283,8 +283,18 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod build distribution
+    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable preprod frontend routes
+    manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable writing preprod size metrics to EAP for querying
+    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable writing preprod build distribution data to EAP for querying
+    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable preprod app size dashboard widget
+    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -171,8 +171,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    # Enables streamlined issue details UI for all users of an organization without opt-out
-    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables sorting spans for issue detection
     manager.add("organizations:issue-detection-sort-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Whether to allow issue only search on the issue list
@@ -285,18 +283,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod build distribution
-    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod frontend routes
-    manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable writing preprod size metrics to EAP for querying
-    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable writing preprod build distribution data to EAP for querying
-    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod app size dashboard widget
-    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
@@ -313,8 +301,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:relay-otlp-traces-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables OTLP Log ingestion in Relay for an entire org.
     manager.add("organizations:relay-otel-logs-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables Prevent AI in the Sentry UI
-    manager.add("organizations:prevent-ai", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables recording processing errors to analytics for product validation
     manager.add("organizations:processing-error-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     # Enable profiling

--- a/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
+++ b/static/app/components/commandPalette/useGlobalCommandPaletteActions.tsx
@@ -274,10 +274,7 @@ function useNavigationActions(): CommandPaletteAction[] {
           hidden: !organization.features.includes('prevent-test-analytics'),
         }),
       ],
-      hidden: !(
-        organization.features.includes('prevent-ai') &&
-        organization.features.includes('prevent-test-analytics')
-      ),
+      hidden: !organization.features.includes('prevent-test-analytics'),
     }),
     makeCommandPaletteGroup({
       groupingKey: 'navigate',

--- a/static/app/views/nav/primary/index.tsx
+++ b/static/app/views/nav/primary/index.tsx
@@ -161,22 +161,20 @@ export function PrimaryNavigationItems() {
           </NavTourElement>
         </Feature>
 
-        <Feature features={['prevent-ai']}>
-          {showPreventNav(organization) ? (
-            <Container position="relative" height="100%">
-              <SidebarLink
-                to={`/${prefix}/prevent/tests/`}
-                activeTo={`/${prefix}/prevent/`}
-                analyticsKey="prevent"
-                group={PrimaryNavGroup.PREVENT}
-                {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
-              >
-                <IconPrevent />
-              </SidebarLink>
-              <BetaBadge type="beta" />
-            </Container>
-          ) : null}
-        </Feature>
+        {showPreventNav(organization) ? (
+          <Container position="relative" height="100%">
+            <SidebarLink
+              to={`/${prefix}/prevent/tests/`}
+              activeTo={`/${prefix}/prevent/`}
+              analyticsKey="prevent"
+              group={PrimaryNavGroup.PREVENT}
+              {...makeNavItemProps(PrimaryNavGroup.PREVENT)}
+            >
+              <IconPrevent />
+            </SidebarLink>
+            <BetaBadge type="beta" />
+          </Container>
+        ) : null}
 
         <SeparatorItem />
 

--- a/static/app/views/prevent/index.spec.tsx
+++ b/static/app/views/prevent/index.spec.tsx
@@ -1,11 +1,8 @@
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
-import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import PreventPage from 'sentry/views/prevent';
-
-const PREVENT_FEATURE = 'prevent-ai';
 
 describe('PreventPage', () => {
   const initialRouterConfig = {
@@ -26,27 +23,12 @@ describe('PreventPage', () => {
     });
   });
 
-  describe('when the user has access to the feature', () => {
-    it('renders the passed children', () => {
-      render(<PreventPage />, {
-        organization: OrganizationFixture({features: [PREVENT_FEATURE]}),
-        initialRouterConfig,
-      });
-
-      const testContent = screen.getByText('Test content');
-      expect(testContent).toBeInTheDocument();
+  it('renders the passed children', () => {
+    render(<PreventPage />, {
+      initialRouterConfig,
     });
-  });
 
-  describe('when the user does not have access to the feature', () => {
-    it('renders the NoAccess component', () => {
-      render(<PreventPage />, {
-        organization: OrganizationFixture({features: []}),
-        initialRouterConfig,
-      });
-
-      const noAccessText = screen.getByText("You don't have access to this feature");
-      expect(noAccessText).toBeInTheDocument();
-    });
+    const testContent = screen.getByText('Test content');
+    expect(testContent).toBeInTheDocument();
   });
 });

--- a/static/app/views/prevent/index.tsx
+++ b/static/app/views/prevent/index.tsx
@@ -1,19 +1,5 @@
 import {Outlet} from 'react-router-dom';
 
-import Feature from 'sentry/components/acl/feature';
-import {NoAccess} from 'sentry/components/noAccess';
-import useOrganization from 'sentry/utils/useOrganization';
-
 export default function PreventPage() {
-  const organization = useOrganization();
-
-  return (
-    <Feature
-      features={['prevent-ai']}
-      organization={organization}
-      renderDisabled={NoAccess}
-    >
-      <Outlet />
-    </Feature>
-  );
+  return <Outlet />;
 }


### PR DESCRIPTION
## Summary
Removes 1 feature flag owned by coding-workflows that has been enabled at 100% via flagpole with no conditions:
- `organizations:prevent-ai`

This flag has been fully rolled out and its behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)