### PR TITLE
feat(flags): Remove graduated issue-workflow feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -165,8 +165,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:invite-members", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable rate limits for inviting members.
     manager.add("organizations:invite-members-rate-limits", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
-    # Enables streamlined issue details UI for all users of an organization without opt-out
-    manager.add("organizations:issue-details-streamline-enforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable AI-generated titles for issue views
     manager.add("organizations:issue-view-ai-title", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:mep-use-default-tags", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -542,6 +542,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.is-sentry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.early-adopter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:notification-platform.general-access", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -542,7 +542,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.is-sentry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.early-adopter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:notification-platform.general-access", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -78,7 +78,12 @@ describe('NewIssueExperienceButton', () => {
     act(() =>
       ConfigStore.set(
         'user',
-        UserFixture({options: {prefersIssueDetailsStreamlinedUI: false}})
+        UserFixture({
+          options: {
+            ...UserFixture().options,
+            prefersIssueDetailsStreamlinedUI: false,
+          },
+        })
       )
     );
 
@@ -143,7 +148,12 @@ describe('NewIssueExperienceButton', () => {
     act(() =>
       ConfigStore.set(
         'user',
-        UserFixture({options: {prefersIssueDetailsStreamlinedUI: false}})
+        UserFixture({
+          options: {
+            ...UserFixture().options,
+            prefersIssueDetailsStreamlinedUI: false,
+          },
+        })
       )
     );
 

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -1,6 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {mockTour} from 'sentry/components/tours/testUtils';
 import ConfigStore from 'sentry/stores/configStore';
@@ -73,6 +74,14 @@ describe('NewIssueExperienceButton', () => {
       method: 'PUT',
     });
 
+    // Start with old UI preference so the "Switch to new" button appears
+    act(() =>
+      ConfigStore.set(
+        'user',
+        UserFixture({options: {prefersIssueDetailsStreamlinedUI: false}})
+      )
+    );
+
     render(<NewIssueExperienceButton />, {organization});
 
     const newExperienceButton = screen.getByRole('button', {
@@ -129,6 +138,14 @@ describe('NewIssueExperienceButton', () => {
       url: '/users/me/',
       method: 'PUT',
     });
+
+    // Start with old UI preference so the "Switch to new" button appears
+    act(() =>
+      ConfigStore.set(
+        'user',
+        UserFixture({options: {prefersIssueDetailsStreamlinedUI: false}})
+      )
+    );
 
     render(<NewIssueExperienceButton />, {organization});
     await userEvent.click(

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -19,6 +19,7 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
@@ -123,6 +124,7 @@ function useIssueDetailsPromoModal() {
 
 export function NewIssueExperienceButton() {
   const organization = useOrganization();
+  const user = useUser();
   const isSuperUser = isActiveSuperuser();
   const {
     startTour,
@@ -161,9 +163,14 @@ export function NewIssueExperienceButton() {
     trackAnalytics('issue_details.streamline_ui_toggle', {
       isEnabled: !hasStreamlinedUI,
       organization,
-      enforced_streamline_ui: false,
+      enforced_streamline_ui: user?.options?.prefersIssueDetailsStreamlinedUI === null,
     });
-  }, [mutateUserOptions, organization, hasStreamlinedUI]);
+  }, [
+    mutateUserOptions,
+    organization,
+    hasStreamlinedUI,
+    user?.options?.prefersIssueDetailsStreamlinedUI,
+  ]);
 
   if (!hasStreamlinedUI) {
     return (

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -19,7 +19,6 @@ import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useMutateUserOptions from 'sentry/utils/useMutateUserOptions';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {
   ISSUE_DETAILS_TOUR_GUIDE_KEY,
   useIssueDetailsTour,
@@ -153,8 +152,6 @@ export function NewIssueExperienceButton() {
 
   const hasStreamlinedUI = useHasStreamlinedUI();
   const hasNewUIOnly = Boolean(organization.streamlineOnly);
-  const user = useUser();
-  const userStreamlinePreference = user?.options?.prefersIssueDetailsStreamlinedUI;
 
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
@@ -164,11 +161,9 @@ export function NewIssueExperienceButton() {
     trackAnalytics('issue_details.streamline_ui_toggle', {
       isEnabled: !hasStreamlinedUI,
       organization,
-      enforced_streamline_ui:
-        organization.features.includes('issue-details-streamline-enforce') &&
-        userStreamlinePreference === null,
+      enforced_streamline_ui: false,
     });
-  }, [mutateUserOptions, organization, hasStreamlinedUI, userStreamlinePreference]);
+  }, [mutateUserOptions, organization, hasStreamlinedUI]);
 
   if (!hasStreamlinedUI) {
     return (

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -543,7 +543,7 @@ function useTrackView({
     ref_fallback,
     group_event_type: groupEventType,
     prefers_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI ?? false,
-    enforced_streamlined_ui: false,
+    enforced_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI === null,
     org_streamline_only: organization.streamlineOnly ?? undefined,
     has_streamlined_ui: hasStreamlinedUI,
     has_seer_access: hasAutofixQuota,

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -543,9 +543,7 @@ function useTrackView({
     ref_fallback,
     group_event_type: groupEventType,
     prefers_streamlined_ui: user?.options?.prefersIssueDetailsStreamlinedUI ?? false,
-    enforced_streamlined_ui:
-      organization.features.includes('issue-details-streamline-enforce') &&
-      user?.options?.prefersIssueDetailsStreamlinedUI === null,
+    enforced_streamlined_ui: false,
     org_streamline_only: organization.streamlineOnly ?? undefined,
     has_streamlined_ui: hasStreamlinedUI,
     has_seer_access: hasAutofixQuota,

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -178,7 +178,7 @@ describe('GroupEventAttachments', () => {
         },
         route: `/organizations/:orgId/issues/:groupId/attachments/`,
       },
-      organization: {...organization, features: ['issue-details-streamline-enforce']},
+      organization,
     });
     expect(getAttachmentsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/issues/group-id/attachments/',

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -57,6 +57,18 @@ describe('useHasStreamlinedUI', () => {
     expect(legacyResult.current).toBe(true);
   });
 
+  it('defaults to streamlined UI when user has no preference', () => {
+    ConfigStore.init();
+    const user = UserFixture();
+    user.options.prefersIssueDetailsStreamlinedUI = null;
+    act(() => ConfigStore.set('user', user));
+
+    const {result} = renderHook(useHasStreamlinedUI, {
+      wrapper: contextWrapper(OrganizationFixture({streamlineOnly: null})),
+    });
+    expect(result.current).toBe(true);
+  });
+
   it('ignores the option if unset', () => {
     ConfigStore.init();
     const user = UserFixture();

--- a/static/app/views/issueDetails/utils.spec.tsx
+++ b/static/app/views/issueDetails/utils.spec.tsx
@@ -33,40 +33,6 @@ describe('useHasStreamlinedUI', () => {
     expect(userPrefersLegacy.current).toBe(false);
   });
 
-  it('ignores preferences if enforce flag is set and user has not opted out', () => {
-    const enforceOrg = OrganizationFixture({
-      features: ['issue-details-streamline-enforce'],
-      streamlineOnly: null,
-    });
-
-    ConfigStore.init();
-    const user = UserFixture();
-    user.options.prefersIssueDetailsStreamlinedUI = null;
-    act(() => ConfigStore.set('user', user));
-
-    const {result} = renderHook(useHasStreamlinedUI, {
-      wrapper: contextWrapper(enforceOrg),
-    });
-    expect(result.current).toBe(true);
-  });
-
-  it('respects preferences if enforce flag is set and user has opted out', () => {
-    const enforceOrg = OrganizationFixture({
-      features: ['issue-details-streamline-enforce'],
-      streamlineOnly: null,
-    });
-
-    ConfigStore.init();
-    const user = UserFixture();
-    user.options.prefersIssueDetailsStreamlinedUI = false;
-    act(() => ConfigStore.set('user', user));
-
-    const {result} = renderHook(useHasStreamlinedUI, {
-      wrapper: contextWrapper(enforceOrg),
-    });
-    expect(result.current).toBe(false);
-  });
-
   it('ignores preferences if organization option is set to true', () => {
     const streamlineOrg = OrganizationFixture({streamlineOnly: true});
 

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -287,14 +287,6 @@ export function useHasStreamlinedUI() {
     return true;
   }
 
-  // If the enforce flag is set for the organization, ignore user preferences and enable the UI
-  if (
-    userStreamlinedUIOption !== false &&
-    organization.features.includes('issue-details-streamline-enforce')
-  ) {
-    return true;
-  }
-
   // Apply the UI based on user preferences
   return userStreamlinedUIOption ?? false;
 }

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -287,8 +287,9 @@ export function useHasStreamlinedUI() {
     return true;
   }
 
-  // Apply the UI based on user preferences
-  return userStreamlinedUIOption ?? false;
+  // Apply the UI based on user preferences (default to streamlined UI for users
+  // who haven't explicitly set a preference, matching the previously enforced behavior)
+  return userStreamlinedUIOption ?? true;
 }
 
 export function useIsSampleEvent(): boolean {

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -24,7 +24,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
         UserOption.objects.set_value(
-            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+            user=self.user, key="prefers_issue_details_streamlined_ui", value=False
         )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -5,6 +5,7 @@ from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.silo import no_silo_test
+from sentry.users.models.user_option import UserOption
 from sentry.utils.samples import load_data
 
 now = datetime.now(timezone.utc)
@@ -22,6 +23,9 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
+        UserOption.objects.set_value(
+            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+        )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()
 

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -25,7 +25,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
         UserOption.objects.set_value(
-            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+            user=self.user, key="prefers_issue_details_streamlined_ui", value=False
         )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -9,6 +9,7 @@ from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
+from sentry.users.models.user_option import UserOption
 from sentry.utils.samples import load_data
 
 
@@ -23,6 +24,9 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
+        UserOption.objects.set_value(
+            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+        )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()
 

--- a/tests/acceptance/test_issue_tag_values.py
+++ b/tests/acceptance/test_issue_tag_values.py
@@ -21,7 +21,7 @@ class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
         )
         self.login_as(self.user)
         UserOption.objects.set_value(
-            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+            user=self.user, key="prefers_issue_details_streamlined_ui", value=False
         )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()

--- a/tests/acceptance/test_issue_tag_values.py
+++ b/tests/acceptance/test_issue_tag_values.py
@@ -3,6 +3,7 @@ from sentry.services.eventstore.models import Event
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
+from sentry.users.models.user_option import UserOption
 from sentry.utils.samples import load_data
 
 
@@ -19,6 +20,9 @@ class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
             organization=self.org, teams=[self.team], name="Bengal", date_added=before_now(hours=2)
         )
         self.login_as(self.user)
+        UserOption.objects.set_value(
+            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+        )
         self.page = IssueDetailsPage(self.browser, self.client)
         self.dismiss_assistant()
         self.event = self.create_issue()

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -9,6 +9,7 @@ from fixtures.page_objects.issue_list import IssueListPage
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
+from sentry.users.models.user_option import UserOption
 
 event_time = before_now(days=3)
 
@@ -43,6 +44,9 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.create_environment(name="prod", project=self.project_2)
 
         self.login_as(self.user)
+        UserOption.objects.set_value(
+            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+        )
         self.dismiss_assistant()
 
         self.issues_list = IssueListPage(self.browser, self.client)

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -45,7 +45,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
 
         self.login_as(self.user)
         UserOption.objects.set_value(
-            user=self.user, key="prefers_issue_details_streamlined_ui", value="0"
+            user=self.user, key="prefers_issue_details_streamlined_ui", value=False
         )
         self.dismiss_assistant()
 


### PR DESCRIPTION
## Summary
Removes 1 feature flag owned by issue-workflow that has been enabled at 100% via flagpole with no conditions:
- `organizations:issue-details-streamline-enforce`

This flag has been fully rolled out and its behavior is now the default.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config

🤖 Generated with [Claude Code](https://claude.com/claude-code)