### PR TITLE
feat(flags): Remove graduated alerts-notifications feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -586,7 +586,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:notification-platform.internal-testing", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.is-sentry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:notification-platform.early-adopter", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:notification-platform.general-access", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # NOTE: Don't add features down here! Add them to their specific group and sort
     #       them alphabetically! The order features are registered is not important.

--- a/src/sentry/notifications/platform/rollout.py
+++ b/src/sentry/notifications/platform/rollout.py
@@ -36,9 +36,6 @@ class NotificationRolloutService:
         early_adopter = features.has(
             "organizations:notification-platform.early-adopter", self.organization
         )
-        general_access = features.has(
-            "organizations:notification-platform.general-access", self.organization
-        )
 
         option_key = None
         if internal_testing:
@@ -47,7 +44,7 @@ class NotificationRolloutService:
             option_key = "notifications.platform-rollout.is-sentry"
         elif early_adopter:
             option_key = "notifications.platform-rollout.early-adopter"
-        elif general_access:
+        else:
             option_key = "notifications.platform-rollout.general-access"
 
         return option_key

--- a/tests/sentry/notifications/platform/test_rollout.py
+++ b/tests/sentry/notifications/platform/test_rollout.py
@@ -78,9 +78,9 @@ class NotificationRolloutServiceTest(TestCase):
         service = NotificationRolloutService(organization=self.organization)
         assert service.should_notify(NotificationSource.DATA_EXPORT_SUCCESS)
 
-    def test_has_feature_flag_access_returns_none_when_no_flags(self) -> None:
+    def test_has_feature_flag_access_returns_general_access_when_no_flags(self) -> None:
         service = NotificationRolloutService(organization=self.organization)
-        assert service.has_feature_flag_access() is None
+        assert service.has_feature_flag_access() == "notifications.platform-rollout.general-access"
 
     @with_feature("organizations:notification-platform.internal-testing")
     def test_has_feature_flag_access_returns_internal_testing_key(self) -> None:
@@ -89,7 +89,6 @@ class NotificationRolloutServiceTest(TestCase):
             service.has_feature_flag_access() == "notifications.platform-rollout.internal-testing"
         )
 
-    @with_feature("organizations:notification-platform.general-access")
     @with_feature("organizations:notification-platform.is-sentry")
     def test_has_feature_flag_access_gets_most_specific_key(self) -> None:
         service = NotificationRolloutService(organization=self.organization)


### PR DESCRIPTION
## Summary
Removes 1 feature flag owned by alerts-notifications that has been enabled at 100% via flagpole with no conditions:
- `organizations:notification-platform.general-access` — Notification platform general access rollout tier

This flag is part of a tiered cascade system (internal-testing → is-sentry → early-adopter → general-access). Since general-access was at 100% rollout with no conditions, it has been graduated to be the default behavior. The cascade logic now falls through to general-access for any org not matching a higher-priority tier.

The other three notification-platform flags (internal-testing, is-sentry, early-adopter) are NOT removed - they still have targeted conditions.

## Test plan
- [ ] CI passes
- [ ] Corresponding sentry-options-automator PR to remove flagpole config