### PR TITLE
chore: Remove graduated emerge-tools feature flags

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -107,24 +107,9 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsEndpointBase
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
-    feature_flags = [
-        "organizations:ourlogs-enabled",
-        "organizations:visibility-explore-view",
-        "organizations:tracemetrics-enabled",
-    ]
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
-        batch_features = features.batch_has(
-            self.feature_flags, organization=organization, actor=request.user
-        )
-
-        if batch_features is None:
-            return False
-
-        key = f"organization:{organization.id}"
-        org_features = batch_features.get(key, {})
-
-        return any(org_features.get(feature) for feature in self.feature_flags)
+        return True
 
 
 class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -111,7 +111,6 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsEndpointBase
         "organizations:ourlogs-enabled",
         "organizations:visibility-explore-view",
         "organizations:tracemetrics-enabled",
-        "organizations:preprod-frontend-routes",
     ]
 
     def has_feature(self, organization: Organization, request: Request) -> bool:

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -108,9 +108,6 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsEndpointBase
     }
     owner = ApiOwner.DATA_BROWSING
 
-    def has_feature(self, organization: Organization, request: Request) -> bool:
-        return True
-
 
 class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
     itemType = serializers.ChoiceField(
@@ -217,9 +214,6 @@ def as_attribute_key(
 @region_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(organization, request):
-            return Response(status=404)
-
         serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -404,9 +398,6 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 @region_silo_endpoint
 class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization, key: str) -> Response:
-        if not self.has_feature(organization, request):
-            return Response(status=404)
-
         serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -107,6 +107,24 @@ class OrganizationTraceItemAttributesEndpointBase(OrganizationEventsEndpointBase
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DATA_BROWSING
+    feature_flags = [
+        "organizations:ourlogs-enabled",
+        "organizations:visibility-explore-view",
+        "organizations:tracemetrics-enabled",
+    ]
+
+    def has_feature(self, organization: Organization, request: Request) -> bool:
+        batch_features = features.batch_has(
+            self.feature_flags, organization=organization, actor=request.user
+        )
+
+        if batch_features is None:
+            return False
+
+        key = f"organization:{organization.id}"
+        org_features = batch_features.get(key, {})
+
+        return any(org_features.get(feature) for feature in self.feature_flags)
 
 
 class OrganizationTraceItemAttributesEndpointSerializer(serializers.Serializer):
@@ -214,6 +232,9 @@ def as_attribute_key(
 @region_silo_endpoint
 class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
         serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -398,6 +419,9 @@ class OrganizationTraceItemAttributesEndpoint(OrganizationTraceItemAttributesEnd
 @region_silo_endpoint
 class OrganizationTraceItemAttributeValuesEndpoint(OrganizationTraceItemAttributesEndpointBase):
     def get(self, request: Request, organization: Organization, key: str) -> Response:
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
         serializer = OrganizationTraceItemAttributesEndpointSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -293,18 +293,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-spans-suspect-attributes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod build distribution
-    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod frontend routes
-    manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable writing preprod size metrics to EAP for querying
-    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable writing preprod build distribution data to EAP for querying
-    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable preprod app size dashboard widget
-    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -1,7 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -16,8 +15,6 @@ from sentry.preprod.artifact_search import queryset_for_query
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.quotas import get_size_retention_cutoff
 
-ERR_FEATURE_REQUIRED = "Feature {} is not enabled for the organization."
-
 
 @region_silo_endpoint
 class BuildsEndpoint(OrganizationEndpoint):
@@ -27,14 +24,6 @@ class BuildsEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has(
-            "organizations:preprod-frontend-routes", organization, actor=request.user
-        ):
-            return Response(
-                {"detail": ERR_FEATURE_REQUIRED.format("organizations:preprod-frontend-routes")},
-                status=403,
-            )
-
         on_results = lambda artifacts: [
             transform_preprod_artifact_to_build_details(artifact).dict() for artifact in artifacts
         ]

--- a/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_artifact_assemble.py
@@ -5,11 +5,10 @@ from typing import Any
 import jsonschema
 import orjson
 import sentry_sdk
-from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -144,11 +143,6 @@ class ProjectPreprodArtifactAssembleEndpoint(ProjectEndpoint):
                 user_id=request.user.id,
             )
         )
-
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"error": "Feature not enabled"}, status=403)
 
         with sentry_sdk.start_span(op="preprod_artifact.assemble"):
             data, error_message = validate_preprod_artifact_schema(request.body)

--- a/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_list_builds.py
@@ -8,7 +8,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -58,11 +58,6 @@ class OrganizationPreprodListBuildsEndpoint(OrganizationEndpoint):
         :qparam string cursor: (optional) cursor for pagination
         :auth: required
         """
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", organization, actor=request.user
-        ):
-            return Response({"error": "Feature not enabled"}, status=403)
 
         projects = self.get_projects(request, organization)
         if not projects:

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -119,13 +118,12 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
             # Update build distribution data in EAP with new download count
             try:
                 organization = project.organization
-                if features.has("organizations:preprod-build-distribution-eap-write", organization):
-                    produce_preprod_build_distribution_to_eap(
-                        artifact=preprod_artifact,
-                        organization=organization,
-                        organization_id=project.organization_id,
-                        project_id=project.id,
-                    )
+                produce_preprod_build_distribution_to_eap(
+                    artifact=preprod_artifact,
+                    organization=organization,
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                )
             except Exception:
                 logger.exception(
                     "Failed to write preprod build distribution to EAP after download",

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_delete.py
@@ -5,7 +5,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -33,11 +33,6 @@ class ProjectPreprodArtifactDeleteEndpoint(PreprodArtifactEndpoint):
         head_artifact: PreprodArtifact,
     ) -> Response:
         """Delete a preprod artifact and all associated data"""
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"error": "Feature not enabled"}, status=403)
 
         analytics.record(
             PreprodArtifactApiDeleteEvent(

--- a/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_build_details.py
@@ -5,7 +5,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -57,11 +57,6 @@ class ProjectPreprodBuildDetailsEndpoint(PreprodArtifactEndpoint):
                 artifact_id=str(head_artifact_id),
             )
         )
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"error": "Feature not enabled"}, status=403)
 
         cutoff = get_size_retention_cutoff(project.organization)
         if head_artifact.date_added < cutoff:

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -7,7 +7,7 @@ from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -111,11 +111,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
                 base_artifact_id=str(base_artifact_id),
             )
         )
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
 
         cutoff = get_size_retention_cutoff(project.organization)
         if head_artifact.date_added < cutoff or base_artifact.date_added < cutoff:
@@ -301,11 +296,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
                 base_artifact_id=str(base_artifact_id),
             )
         )
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
 
         cutoff = get_size_retention_cutoff(project.organization)
         if head_artifact.date_added < cutoff or base_artifact.date_added < cutoff:

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_download.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare_download.py
@@ -6,7 +6,7 @@ from django.http.response import FileResponse, HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -54,11 +54,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpoint(ProjectEndpoint)
                 base_size_metric_id=str(base_size_metric_id),
             )
         )
-
-        if not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
 
         logger.info(
             "preprod.size_analysis.compare.api.download",

--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_download.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from django.conf import settings
 from django.http.response import HttpResponseBase
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -57,11 +56,6 @@ class ProjectPreprodArtifactSizeAnalysisDownloadEndpoint(PreprodArtifactEndpoint
                 artifact_id=head_artifact_id,
             )
         )
-
-        if not settings.IS_DEV and not features.has(
-            "organizations:preprod-frontend-routes", project.organization, actor=request.user
-        ):
-            return Response({"detail": "Feature not enabled"}, status=403)
 
         cutoff = get_size_retention_cutoff(project.organization)
         if head_artifact.date_added < cutoff:

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -10,7 +10,6 @@ import sentry_sdk
 from django.db import router, transaction
 from django.utils import timezone
 
-from sentry import features
 from sentry.constants import DataCategory
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
@@ -513,23 +512,22 @@ def _assemble_preprod_artifact_size_analysis(
 
         try:
             organization = preprod_artifact.project.organization
-            if features.has("organizations:preprod-size-metrics-eap-write", organization):
-                for size_metric in size_metrics_updated:
-                    produce_preprod_size_metric_to_eap(
-                        size_metric=size_metric,
-                        organization=organization,
-                        organization_id=org_id,
-                        project_id=project.id,
-                    )
-                logger.info(
-                    "Successfully wrote preprod size metrics to EAP",
-                    extra={
-                        "preprod_artifact_id": preprod_artifact.id,
-                        "size_metrics_ids": [m.id for m in size_metrics_updated],
-                        "organization_id": org_id,
-                        "project_id": project.id,
-                    },
+            for size_metric in size_metrics_updated:
+                produce_preprod_size_metric_to_eap(
+                    size_metric=size_metric,
+                    organization=organization,
+                    organization_id=org_id,
+                    project_id=project.id,
                 )
+            logger.info(
+                "Successfully wrote preprod size metrics to EAP",
+                extra={
+                    "preprod_artifact_id": preprod_artifact.id,
+                    "size_metrics_ids": [m.id for m in size_metrics_updated],
+                    "organization_id": org_id,
+                    "project_id": project.id,
+                },
+            )
         except Exception as eap_error:
             logger.exception(
                 "Failed to write preprod size metrics to EAP",
@@ -743,21 +741,20 @@ def _assemble_preprod_artifact_installable_app(
 
     try:
         organization = preprod_artifact.project.organization
-        if features.has("organizations:preprod-build-distribution-eap-write", organization):
-            produce_preprod_build_distribution_to_eap(
-                artifact=preprod_artifact,
-                organization=organization,
-                organization_id=org_id,
-                project_id=project.id,
-            )
-            logger.info(
-                "Successfully wrote preprod build distribution to EAP",
-                extra={
-                    "preprod_artifact_id": preprod_artifact.id,
-                    "organization_id": org_id,
-                    "project_id": project.id,
-                },
-            )
+        produce_preprod_build_distribution_to_eap(
+            artifact=preprod_artifact,
+            organization=organization,
+            organization_id=org_id,
+            project_id=project.id,
+        )
+        logger.info(
+            "Successfully wrote preprod build distribution to EAP",
+            extra={
+                "preprod_artifact_id": preprod_artifact.id,
+                "organization_id": org_id,
+                "project_id": project.id,
+            },
+        )
     except Exception:
         logger.exception(
             "Failed to write preprod build distribution to EAP",

--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -6,7 +6,6 @@ import {MOBILE_BUILDS_ALLOWED_KEYS} from 'sentry/components/preprod/constants';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 
 const displaySelectOptions: Array<SelectOption<PreprodBuildsDisplay>> = [
   {value: PreprodBuildsDisplay.SIZE, label: t('Size')},
@@ -59,11 +58,6 @@ export function PreprodBuildsSearchControls({
   onSearch,
   onDisplayChange,
 }: PreprodBuildsSearchControlsProps) {
-  const organization = useOrganization();
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
-
   return (
     <Flex
       align={{xs: 'stretch', sm: 'center'}}
@@ -80,22 +74,20 @@ export function PreprodBuildsSearchControls({
           projects={projects}
         />
       </Container>
-      {hasDistributionFeature && (
-        <Container maxWidth="200px">
-          <CompactSelect
-            options={displaySelectOptions}
-            value={display}
-            onChange={option => onDisplayChange(option.value)}
-            trigger={triggerProps => (
-              <OverlayTrigger.Button
-                {...triggerProps}
-                prefix={t('Display')}
-                style={{width: '100%', zIndex: 1}}
-              />
-            )}
-          />
-        </Container>
-      )}
+      <Container maxWidth="200px">
+        <CompactSelect
+          options={displaySelectOptions}
+          value={display}
+          onChange={option => onDisplayChange(option.value)}
+          trigger={triggerProps => (
+            <OverlayTrigger.Button
+              {...triggerProps}
+              prefix={t('Display')}
+              style={{width: '100%', zIndex: 1}}
+            />
+          )}
+        />
+      </Container>
     </Flex>
   );
 }

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -8,9 +8,7 @@ import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {getInstallBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
-const organization = OrganizationFixture({
-  features: ['preprod-build-distribution'],
-});
+const organization = OrganizationFixture();
 
 const baseBuild = {
   id: 'build-1',

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -9,7 +9,6 @@ import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import Feature from 'sentry/components/acl/feature';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
@@ -65,34 +64,32 @@ export function PreprodBuildsRowCells({
                   {build.app_info?.name || '--'}
                 </Text>
               </Container>
-              <Feature features="organizations:preprod-build-distribution">
-                {(build.distribution_info?.is_installable ||
-                  showInstallabilityIndicator) && (
-                  <Flex align="center">
-                    {build.distribution_info?.is_installable ? (
-                      <InstallAppButton
-                        projectId={build.project_slug}
-                        artifactId={build.id}
-                        platform={build.app_info.platform ?? null}
-                        source="builds_table"
-                        variant="icon"
-                      />
-                    ) : (
-                      <Tooltip title={t('Not installable')} skipWrapper>
-                        <span>
-                          <Button
-                            aria-label={t('Not installable')}
-                            icon={<IconNot variant="danger" size="xs" />}
-                            priority="transparent"
-                            size="zero"
-                            disabled
-                          />
-                        </span>
-                      </Tooltip>
-                    )}
-                  </Flex>
-                )}
-              </Feature>
+              {(build.distribution_info?.is_installable ||
+                showInstallabilityIndicator) && (
+                <Flex align="center">
+                  {build.distribution_info?.is_installable ? (
+                    <InstallAppButton
+                      projectId={build.project_slug}
+                      artifactId={build.id}
+                      platform={build.app_info.platform ?? null}
+                      source="builds_table"
+                      variant="icon"
+                    />
+                  ) : (
+                    <Tooltip title={t('Not installable')} skipWrapper>
+                      <span>
+                        <Button
+                          aria-label={t('Not installable')}
+                          icon={<IconNot variant="danger" size="xs" />}
+                          priority="transparent"
+                          size="zero"
+                          disabled
+                        />
+                      </span>
+                    </Tooltip>
+                  )}
+                </Flex>
+              )}
             </Flex>
             <Flex align="center" gap="xs">
               <Text size="sm" variant="muted">

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
-import useOrganization from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -68,11 +67,9 @@ export function PreprodSearchBar({
   disallowLogicalOperators,
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
-  const organization = useOrganization();
-
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.PREPROD,
-    enabled: organization.features.includes('preprod-app-size-dashboard'),
+    enabled: true,
   };
 
   // When using allowedKeys, we fetch all attributes then filter to the allowlist.

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -88,13 +88,11 @@ function WidgetBuilderDatasetSelector() {
     details: t('Session data from releases'),
   });
 
-  if (organization.features.includes('preprod-app-size-dashboard')) {
-    datasetOptions.push({
-      value: WidgetType.PREPROD_APP_SIZE,
-      label: t('Mobile Builds'),
-      details: t('Mobile app size metrics'),
-    });
-  }
+  datasetOptions.push({
+    value: WidgetType.PREPROD_APP_SIZE,
+    label: t('Mobile Builds'),
+    details: t('Mobile app size metrics'),
+  });
 
   datasetOptions.push(transactionsOption);
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -95,7 +95,7 @@ function TraceItemAttributeProviderFromDataset({children}: {children: React.Reac
   }
 
   if (state.dataset === WidgetType.PREPROD_APP_SIZE) {
-    enabled = organization.features.includes('preprod-app-size-dashboard');
+    enabled = true;
     traceItemType = TraceItemDataset.PREPROD;
   }
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -5,7 +5,6 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import Feature from 'sentry/components/acl/feature';
 import {Breadcrumbs, type Crumb} from 'sentry/components/breadcrumbs';
 import ConfirmDelete from 'sentry/components/confirmDelete';
 import DropdownButton from 'sentry/components/dropdownButton';
@@ -197,16 +196,14 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
           >
             {t('Compare Build')}
           </Button>
-          <Feature features="organizations:preprod-frontend-routes">
-            {project && (
-              <LinkButton
-                size="sm"
-                icon={<IconSettings />}
-                aria-label={t('Settings')}
-                to={`/settings/${organization.slug}/projects/${project.slug}/mobile-builds/`}
-              />
-            )}
-          </Feature>
+          {project && (
+            <LinkButton
+              size="sm"
+              icon={<IconSettings />}
+              aria-label={t('Settings')}
+              to={`/settings/${organization.slug}/projects/${project.slug}/mobile-builds/`}
+            />
+          )}
           <ConfirmDelete
             message={t(
               'Are you sure you want to delete this build? This action cannot be undone and will permanently remove all associated files and data.'

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -7,7 +7,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import Feature from 'sentry/components/acl/feature';
 import {IconClock, IconFile, IconJson, IconLink, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
@@ -103,23 +102,21 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
             </Text>
           </Flex>
         </Tooltip>
-        <Feature features="organizations:preprod-build-distribution">
-          <Flex gap="2xs" align="center">
-            <InfoIcon>
-              <IconLink />
-            </InfoIcon>
-            <Text>
-              {props.projectId ? (
-                <InstallAppButton
-                  projectId={props.projectId}
-                  artifactId={props.artifactId}
-                  platform={props.appInfo.platform ?? null}
-                  source="build_details_sidebar"
-                />
-              ) : null}
-            </Text>
-          </Flex>
-        </Feature>
+        <Flex gap="2xs" align="center">
+          <InfoIcon>
+            <IconLink />
+          </InfoIcon>
+          <Text>
+            {props.projectId ? (
+              <InstallAppButton
+                projectId={props.projectId}
+                artifactId={props.artifactId}
+                platform={props.appInfo.platform ?? null}
+                source="build_details_sidebar"
+              />
+            ) : null}
+          </Text>
+        </Flex>
         {props.appInfo.build_configuration && (
           <Tooltip title={labels.buildConfiguration}>
             <Flex gap="2xs" align="center">

--- a/static/app/views/preprod/buildList/buildList.tsx
+++ b/static/app/views/preprod/buildList/buildList.tsx
@@ -1,7 +1,6 @@
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
-import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodBuildsTable} from 'sentry/components/preprod/preprodBuildsTable';
@@ -81,14 +80,12 @@ export default function BuildList() {
           <Layout.Title>Builds</Layout.Title>
           <Layout.HeaderActions>
             {singleProject && (
-              <Feature features="organizations:preprod-frontend-routes">
-                <LinkButton
-                  size="sm"
-                  icon={<IconSettings />}
-                  aria-label={t('Settings')}
-                  to={`/settings/${organization.slug}/projects/${singleProject.slug}/mobile-builds/`}
-                />
-              </Feature>
+              <LinkButton
+                size="sm"
+                icon={<IconSettings />}
+                aria-label={t('Settings')}
+                to={`/settings/${organization.slug}/projects/${singleProject.slug}/mobile-builds/`}
+              />
             )}
           </Layout.HeaderActions>
         </Layout.Header>

--- a/static/app/views/preprod/index.tsx
+++ b/static/app/views/preprod/index.tsx
@@ -1,33 +1,14 @@
 import {Outlet} from 'react-router-dom';
 
-import {Alert} from '@sentry/scraps/alert';
-
-import Feature from 'sentry/components/acl/feature';
-import * as Layout from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
-import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 
 export default function PreprodContainer() {
   const organization = useOrganization();
 
   return (
-    <Feature
-      features={['organizations:preprod-frontend-routes']}
-      organization={organization}
-      renderDisabled={() => (
-        <Layout.Page withPadding>
-          <Alert.Container>
-            <Alert variant="warning" showIcon={false}>
-              {t("You don't have access to this feature")}
-            </Alert>
-          </Alert.Container>
-        </Layout.Page>
-      )}
-    >
-      <NoProjectMessage organization={organization}>
-        <Outlet />
-      </NoProjectMessage>
-    </Feature>
+    <NoProjectMessage organization={organization}>
+      <Outlet />
+    </NoProjectMessage>
   );
 }

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -38,12 +38,9 @@ export default function PreprodBuilds() {
   const projectPlatform = releaseContext.project.platform;
   const params = useParams<{release: string}>();
   const location = useLocation();
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, hasDistributionFeature),
-    [hasDistributionFeature, location.query.display]
+    () => getPreprodBuildsDisplay(location.query.display, true),
+    [location.query.display]
   );
 
   const {query: urlSearchQuery, cursor} = useLocationQuery({

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -100,10 +100,7 @@ function ReleaseHeader({
     to: `builds/`,
   };
 
-  if (
-    organization.features?.includes('preprod-frontend-routes') &&
-    (numberOfMobileBuilds || isMobileRelease(project.platform, false))
-  ) {
+  if (numberOfMobileBuilds || isMobileRelease(project.platform, false)) {
     tabs.push(buildsTab);
   }
 

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -541,6 +541,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     render(<ReleasesList />, {
       organization,
       initialRouterConfig: {
@@ -612,6 +616,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     const {router} = render(<ReleasesList />, {
       organization: organizationWithDistribution,
       initialRouterConfig: {
@@ -681,6 +689,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     render(<ReleasesList />, {
       organization,
       initialRouterConfig: {
@@ -753,6 +765,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     const {router} = render(<ReleasesList />, {
       organization,
       initialRouterConfig: {

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -21,7 +21,7 @@ import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOpt
 
 describe('ReleasesList', () => {
   const organization = OrganizationFixture({
-    features: ['search-query-builder-input-flow-changes', 'preprod-frontend-routes'],
+    features: ['search-query-builder-input-flow-changes'],
   });
   const projects = [ProjectFixture({features: ['releases']})];
   const semverVersionInfo = {
@@ -564,7 +564,7 @@ describe('ReleasesList', () => {
   it('toggles display mode in the mobile-builds tab', async () => {
     const organizationWithDistribution = OrganizationFixture({
       slug: organization.slug,
-      features: [...organization.features, 'preprod-build-distribution'],
+      features: [...organization.features],
     });
     const mobileProject = ProjectFixture({
       id: '15',

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -234,10 +234,6 @@ export default function ReleasesList() {
   }, [selection.projects]);
 
   const shouldShowMobileBuildsTab = useMemo(() => {
-    if (!organization.features?.includes('preprod-frontend-routes')) {
-      return false;
-    }
-
     // When "All Projects" is selected (represented by [-1]), check all accessible projects
     // When specific projects are selected, check only those projects
     const isAllProjects =
@@ -254,7 +250,7 @@ export default function ReleasesList() {
       .some(project => project?.platform && isMobileRelease(project.platform, false));
 
     return hasAnyStrictlyMobileProject;
-  }, [organization.features, selectedProjectIds, projects]);
+  }, [selectedProjectIds, projects]);
 
   const selectedTab = useMemo(() => {
     if (!shouldShowMobileBuildsTab) {

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -37,12 +37,9 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
 
   const [searchQuery] = useQueryState('query', parseAsString);
   const [cursor] = useQueryState('cursor', parseAsString);
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, hasDistributionFeature),
-    [hasDistributionFeature, location.query.display]
+    () => getPreprodBuildsDisplay(location.query.display, true),
+    [location.query.display]
   );
 
   const buildsQueryParams = useMemo(() => {

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -15,7 +15,6 @@ import type {Permissions} from 'sentry/types/integrations';
 import type {NewInternalAppApiToken} from 'sentry/types/user';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -35,16 +34,10 @@ export default function ApiNewToken() {
     Distribution: 'no-access',
   });
   const navigate = useNavigate();
-  const organization = useOrganization({allowNull: true});
   const [hasNewToken, setHasnewToken] = useState(false);
   const [preview, setPreview] = useState<string>('');
 
-  const hasPreprodFeature =
-    organization?.features.includes('organizations:preprod-build-distribution') ?? false;
-
-  const displayedPermissions = SENTRY_APP_PERMISSIONS.filter(
-    o => o.resource !== 'Distribution' || hasPreprodFeature
-  );
+  const displayedPermissions = SENTRY_APP_PERMISSIONS;
 
   const getPreview = () => {
     let previewString = '';

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -133,7 +133,7 @@ export default function getConfiguration({
         {
           path: `${pathPrefix}/mobile-builds/`,
           title: t('Mobile Builds'),
-          show: () => !!organization?.features?.includes('preprod-frontend-routes'),
+          show: () => true,
           badge: () => 'new',
           description: t('Size analysis and build distribution configuration.'),
         },

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 
 import {Grid, Stack} from '@sentry/scraps/layout';
 
-import Feature from 'sentry/components/acl/feature';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -27,47 +26,41 @@ const DISTRIBUTION_ENABLED_QUERY_WRITE_KEY = 'preprodDistributionEnabledQuery';
 export default function PreprodSettings() {
   return (
     <Fragment>
-      <Feature features="organizations:preprod-frontend-routes" renderDisabled>
-        <SentryDocumentTitle title={t('Mobile Builds')} />
-        <SettingsPageHeader
-          title={t('Mobile Builds')}
-          action={
-            <Grid flow="column" align="center" gap="lg">
-              <FeedbackButton />
-            </Grid>
-          }
+      <SentryDocumentTitle title={t('Mobile Builds')} />
+      <SettingsPageHeader
+        title={t('Mobile Builds')}
+        action={
+          <Grid flow="column" align="center" gap="lg">
+            <FeedbackButton />
+          </Grid>
+        }
+      />
+      <TextBlock>
+        {t('Configure status checks and thresholds for your mobile build size analysis.')}
+      </TextBlock>
+      <PreprodQuotaAlert />
+      <Stack gap="lg">
+        <StatusCheckRules />
+        <FeatureFilter
+          enabledReadKey={SIZE_ENABLED_READ_KEY}
+          enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
+          queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
+          queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
+          title={t('Size Analysis')}
+          successMessage={t('Size analysis settings updated')}
+          docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
         />
-        <TextBlock>
-          {t(
-            'Configure status checks and thresholds for your mobile build size analysis.'
-          )}
-        </TextBlock>
-        <PreprodQuotaAlert />
-        <Stack gap="lg">
-          <StatusCheckRules />
-          <FeatureFilter
-            enabledReadKey={SIZE_ENABLED_READ_KEY}
-            enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
-            queryReadKey={SIZE_ENABLED_QUERY_READ_KEY}
-            queryWriteKey={SIZE_ENABLED_QUERY_WRITE_KEY}
-            title={t('Size Analysis')}
-            successMessage={t('Size analysis settings updated')}
-            docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
-          />
-          <Feature features="organizations:preprod-build-distribution">
-            <FeatureFilter
-              enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
-              enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
-              queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-              queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-              title={t('Build Distribution')}
-              successMessage={t('Build distribution settings updated')}
-              docsUrl="https://docs.sentry.io/product/build-distribution/"
-              display={PreprodBuildsDisplay.DISTRIBUTION}
-            />
-          </Feature>
-        </Stack>
-      </Feature>
+        <FeatureFilter
+          enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
+          enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
+          queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+          queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+          title={t('Build Distribution')}
+          successMessage={t('Build distribution settings updated')}
+          docsUrl="https://docs.sentry.io/product/build-distribution/"
+          display={PreprodBuildsDisplay.DISTRIBUTION}
+        />
+      </Stack>
     </Fragment>
   );
 }

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -85,7 +84,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             args=[self.organization.slug, self.project.slug, head_artifact_id, base_artifact_id],
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_completed_comparison(self):
         """Test GET endpoint returns successful comparison when comparison exists and is completed"""
         # Create a successful comparison
@@ -122,7 +120,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_code"] is None
         assert comparison_data["error_message"] is None
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_failed_comparison(self):
         """Test GET endpoint returns failed comparison when comparison exists and failed"""
         # Create a failed comparison
@@ -148,7 +145,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_code"] == str(PreprodArtifactSizeComparison.ErrorCode.UNKNOWN)
         assert comparison_data["error_message"] == "Comparison failed due to processing error"
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_pending_comparison(self):
         """Test GET endpoint returns processing state for pending comparison"""
         # Create a pending comparison (which should be shown as PROCESSING to frontend)
@@ -173,7 +169,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_code"] is None
         assert comparison_data["error_message"] is None
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_processing_comparison(self):
         """Test GET endpoint returns processing comparison when comparison is in progress"""
         # Create a processing comparison
@@ -197,7 +192,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_code"] is None
         assert comparison_data["error_message"] is None
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_no_comparison(self):
         """Test GET endpoint returns no comparison when no comparison exists yet"""
         response = self.get_success_response(
@@ -209,7 +203,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         data = response.data
         assert len(data["comparisons"]) == 0
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_success_with_no_matching_base_metric(self):
         """Test GET endpoint handles case where no matching base metric exists"""
         self.create_preprod_artifact_size_comparison(
@@ -249,7 +242,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert watch_comparison["error_code"] == "NO_BASE_METRIC"
         assert watch_comparison["error_message"] == "No matching base artifact size metric found."
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_head_artifact_not_found(self):
         """Test GET endpoint returns 404 when head artifact doesn't exist"""
         response = self.get_error_response(
@@ -261,7 +253,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_base_artifact_not_found(self):
         """Test GET endpoint returns 404 when base artifact doesn't exist"""
         response = self.get_error_response(
@@ -273,7 +264,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_head_artifact_wrong_project(self):
         """Test GET endpoint returns 404 when head artifact belongs to different project"""
         other_project = self.create_project(organization=self.organization)
@@ -294,7 +284,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert response.data["detail"] == "The requested head preprod artifact does not exist"
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_base_artifact_wrong_project(self):
         """Test GET endpoint returns 404 when base artifact belongs to different project"""
         other_project = self.create_project(organization=self.organization)
@@ -315,7 +304,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert response.data["detail"] == "The requested base preprod artifact does not exist"
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_head_artifact_no_size_metrics(self):
         """Test GET endpoint returns 404 when head artifact has no size metrics"""
         # Create artifact without size metrics
@@ -339,7 +327,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             in response.data["detail"]
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_base_artifact_no_size_metrics(self):
         """Test GET endpoint returns 404 when base artifact has no size metrics"""
         # Create artifact without size metrics
@@ -363,19 +350,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             in response.data["detail"]
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
-    def test_get_comparison_feature_disabled(self):
-        """Test GET endpoint returns 403 when feature flag is disabled"""
-        response = self.get_error_response(
-            self.organization.slug,
-            self.project.slug,
-            self.head_artifact.id,
-            self.base_artifact.id,
-            status_code=403,
-        )
-        assert response.data["detail"] == "Feature not enabled"
-
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_get_comparison_multiple_metrics(self):
         """Test GET endpoint handles multiple size metrics correctly"""
         self.create_preprod_artifact_size_comparison(
@@ -439,7 +413,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert watch_comparison_data["base_size_metric_id"] == base_watch_metric.id
         assert watch_comparison_data["comparison_id"] == watch_comparison.id
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
     def test_post_comparison_success(self, mock_apply_async):
         """Test POST endpoint successfully triggers comparison and creates PENDING records"""
@@ -482,7 +455,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison.state == PreprodArtifactSizeComparison.State.PENDING
         assert comparison.organization_id == self.organization.id
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_head_artifact_not_found(self):
         """Test POST endpoint returns 404 when head artifact doesn't exist"""
         response = self.get_error_response(
@@ -495,7 +467,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_base_artifact_not_found(self):
         """Test POST endpoint returns 404 when base artifact doesn't exist"""
         response = self.get_error_response(
@@ -508,7 +479,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert "The requested base preprod artifact does not exist" in response.data["detail"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_head_artifact_no_size_metrics(self):
         """Test POST endpoint returns 404 when head artifact has no size metrics"""
         artifact_no_metrics = self.create_preprod_artifact(
@@ -527,7 +497,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             in response.json()["detail"]
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_base_artifact_no_size_metrics(self):
         """Test POST endpoint returns 404 when base artifact has no size metrics"""
         artifact_no_metrics = self.create_preprod_artifact(
@@ -546,7 +515,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             in response.json()["detail"]
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_head_artifact_processing(self):
         self.head_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.head_size_metric.save()
@@ -558,7 +526,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert data["status"] == "processing"
         assert "not completed size analysis yet" in data["message"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_base_artifact_processing(self):
         self.base_size_metric.state = PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING
         self.base_size_metric.save()
@@ -570,7 +537,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert data["status"] == "processing"
         assert "not completed size analysis yet" in data["message"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_mixed_completed_and_pending_returns_202(self):
         self.create_preprod_artifact_size_metrics(
             self.head_artifact,
@@ -595,7 +561,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert data["status"] == "processing"
         assert "not completed size analysis yet" in data["message"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_existing_comparison(self):
         """Test POST endpoint returns existing comparison when comparison already exists"""
         # Create an existing comparison
@@ -616,7 +581,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert len(data["comparisons"]) == 1
         assert data["comparisons"][0]["comparison_id"] == comparison.id
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_existing_failed_comparison(self):
         """Test POST endpoint returns existing failed comparison when comparison exists and failed"""
         # Create a failed comparison
@@ -640,7 +604,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert comparison_data["error_code"] == str(comparison.error_code)
         assert comparison_data["error_message"] == comparison.error_message
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_cannot_compare_size_metrics(self):
         """Test POST endpoint returns 400 when size metrics cannot be compared"""
         # Create additional head metric to make the lists different lengths
@@ -661,7 +624,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "Head has 2 metric(s)" in detail
         assert "base has 1 metric(s)" in detail
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
     def test_post_comparison_multiple_metrics(self, mock_apply_async):
         """Test POST endpoint handles multiple size metrics correctly and creates PENDING records"""
@@ -718,7 +680,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
             }
         )
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_no_matching_base_metric(self):
         """Test POST endpoint returns 400 when head has more metrics than base"""
         # Create head metric with different identifier that won't match base
@@ -739,7 +700,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert "Head has 2 metric(s)" in detail
         assert "base has 1 metric(s)" in detail
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_mismatched_metric_types(self):
         """Test POST endpoint returns detailed error when comparing mismatched metric types/identifiers"""
         # Replace the default head metric with one that has a different identifier
@@ -768,7 +728,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         # Should mention the identifiers involved
         assert "release" in detail.lower() or "main" in detail.lower()
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_different_build_configurations(self):
         """Test POST endpoint returns 400 when artifacts have different build configurations"""
         # Create a build configuration for the base artifact
@@ -789,7 +748,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert response.data["detail"] == "Head and base build configurations must be the same."
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     @patch(
         "sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare.get_size_retention_cutoff"
     )
@@ -807,7 +765,6 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert response.status_code == 404
         assert response.data["detail"] == "This build's size data has expired."
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     @patch(
         "sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare.get_size_retention_cutoff"
     )

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare_download.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -13,7 +12,6 @@ from sentry.preprod.models import (
 from sentry.testutils.cases import TestCase
 
 
-@override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
 class ProjectPreprodArtifactSizeAnalysisCompareDownloadEndpointTest(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_download.py
@@ -2,18 +2,12 @@ from datetime import timedelta
 from io import BytesIO
 from unittest.mock import patch
 
-from django.test import override_settings
 from django.utils import timezone
 
 from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.testutils.cases import APITestCase
 
 
-@override_settings(
-    SENTRY_FEATURES={
-        "organizations:preprod-frontend-routes": True,
-    }
-)
 class ProjectPreprodArtifactSizeAnalysisDownloadEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-preprod-artifact-size-analysis-download"
 

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -7,7 +7,6 @@ from django.utils.functional import cached_property
 from sentry.preprod.models import PreprodArtifactSizeMetrics
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.testutils.helpers.features import with_feature
 
 
 class BuildsEndpointTest(APITestCase):
@@ -29,13 +28,6 @@ class BuildsEndpointTest(APITestCase):
 
     def _assert_is_successful(self, response):
         assert response.status_code == 200, f"status {response.status_code} body {response.json()}"
-
-    def test_needs_feature(self) -> None:
-        response = self._request({})
-        assert response.status_code == 403
-        assert response.json() == {
-            "detail": "Feature organizations:preprod-frontend-routes is not enabled for the organization."
-        }
 
     def test_invalid_token(self) -> None:
         response = self._request({}, token="Invalid")
@@ -59,13 +51,11 @@ class BuildsEndpointTest(APITestCase):
         assert response.status_code == 403
         assert response.json() == {"detail": "You do not have permission to perform this action."}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_no_builds(self) -> None:
         response = self._request({})
         self._assert_is_successful(response)
         assert response.json() == []
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_one_build(self) -> None:
         self.create_preprod_artifact()
         response = self._request({})
@@ -114,21 +104,18 @@ class BuildsEndpointTest(APITestCase):
             }
         ]
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_bad_project(self) -> None:
         self.create_preprod_artifact()
         response = self._request({"project": [1]})
         assert response.status_code == 403
         assert response.json() == {"detail": "You do not have permission to perform this action."}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_bad_project_slug(self) -> None:
         self.create_preprod_artifact()
         response = self._request({"projectSlug": ["invalid"]})
         assert response.status_code == 403
         assert response.json() == {"detail": "You do not have permission to perform this action."}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_build_in_another_project(self) -> None:
         another_project = self.create_project(name="Baz", slug="baz")
         self.create_preprod_artifact(project=another_project)
@@ -136,7 +123,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert response.json() == []
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_build_in_another_project_slug(self) -> None:
         another_project = self.create_project(name="Baz", slug="baz")
         self.create_preprod_artifact(project=another_project)
@@ -144,21 +130,18 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert response.json() == []
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_build_in_this_project(self) -> None:
         self.create_preprod_artifact()
         response = self._request({"project": [self.project.id]})
         self._assert_is_successful(response)
         assert len(response.json()) == 1
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_build_in_this_project_slug(self) -> None:
         self.create_preprod_artifact()
         response = self._request({"projectSlug": [self.project.slug]})
         self._assert_is_successful(response)
         assert len(response.json()) == 1
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_multiple_projects(self) -> None:
         project_a = self.create_project(name="AAA", slug="aaa")
         self.create_preprod_artifact(project=project_a)
@@ -168,7 +151,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 2
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_multiple_project_slugs(self) -> None:
         project_a = self.create_project(name="AAA", slug="aaa")
         self.create_preprod_artifact(project=project_a)
@@ -178,7 +160,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 2
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_per_page_respected(self) -> None:
         self.create_preprod_artifact()
         self.create_preprod_artifact()
@@ -186,7 +167,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 1
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_start_end_respected(self) -> None:
         self.create_preprod_artifact(date_added=before_now(days=5))
         middle = self.create_preprod_artifact(date_added=before_now(days=3))
@@ -197,14 +177,12 @@ class BuildsEndpointTest(APITestCase):
         assert len(response.json()) == 1
         assert response.json()[0]["id"] == str(middle.id)
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_invalid(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         response = self._request({"query": "no_such_key:foo"})
         assert response.status_code == 400
         assert response.json() == {"detail": "Invalid key for this search: no_such_key"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_app_id_equals(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         self.create_preprod_artifact(app_id="bar")
@@ -213,7 +191,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(response.json()) == 1
         assert response.json()[0]["app_info"]["app_id"] == "foo"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_app_id_not_equals(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         self.create_preprod_artifact(app_id="bar")
@@ -222,7 +199,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(response.json()) == 1
         assert response.json()[0]["app_info"]["app_id"] == "bar"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_app_id_in(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         self.create_preprod_artifact(app_id="bar")
@@ -231,7 +207,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(response.json()) == 1
         assert response.json()[0]["app_info"]["app_id"] == "foo"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_app_id_in_is_list(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         self.create_preprod_artifact(app_id="bar")
@@ -239,7 +214,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 0
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_app_id_not_in(self) -> None:
         self.create_preprod_artifact(app_id="foo")
         self.create_preprod_artifact(app_id="bar")
@@ -249,7 +223,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(response.json()) == 1
         assert response.json()[0]["app_info"]["app_id"] == "baz"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_download_count_for_installable_artifact(self) -> None:
         # Create an installable artifact (has both installable_app_file_id and build_number)
         artifact = self.create_preprod_artifact(
@@ -272,7 +245,6 @@ class BuildsEndpointTest(APITestCase):
         assert data[0]["distribution_info"]["download_count"] == 15
         assert data[0]["distribution_info"]["is_installable"] is True
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_is_installable(self) -> None:
         self.create_preprod_artifact(app_id="not_installable")
         artifact = self.create_preprod_artifact(
@@ -288,7 +260,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "installable"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_is_not_installable(self) -> None:
         self.create_preprod_artifact(app_id="not_installable")
         artifact = self.create_preprod_artifact(
@@ -304,7 +275,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "not_installable"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_download_count_zero_for_non_installable_artifact(self) -> None:
         # Create a non-installable artifact (no installable_app_file_id)
         self.create_preprod_artifact()
@@ -316,7 +286,6 @@ class BuildsEndpointTest(APITestCase):
         assert data[0]["distribution_info"]["download_count"] == 0
         assert data[0]["distribution_info"]["is_installable"] is False
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_download_count_multiple_artifacts(self) -> None:
         # Create multiple installable artifacts with different download counts
         artifact1 = self.create_preprod_artifact(
@@ -354,7 +323,6 @@ class BuildsEndpointTest(APITestCase):
         assert app_one["distribution_info"]["download_count"] == 100
         assert app_two["distribution_info"]["download_count"] == 75
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_install_size(self) -> None:
         # Create artifacts with different install sizes via size metrics
         small_artifact = self.create_preprod_artifact(app_id="small.app")
@@ -377,7 +345,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "small.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_build_configuration_name(self) -> None:
         debug_config = self.create_preprod_build_configuration(name="Debug")
         release_config = self.create_preprod_build_configuration(name="Release")
@@ -391,7 +358,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "debug.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_git_head_ref(self) -> None:
         main_cc = self.create_commit_comparison(organization=self.organization, head_ref="main")
         feature_cc = self.create_commit_comparison(
@@ -407,7 +373,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "main.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_has_git_head_ref(self) -> None:
         cc_with_branch = self.create_commit_comparison(
             organization=self.organization, head_ref="main"
@@ -428,7 +393,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "with_branch.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_not_has_git_head_ref(self) -> None:
         cc_with_branch = self.create_commit_comparison(
             organization=self.organization, head_ref="main"
@@ -450,7 +414,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"without_branch.app", "no_cc.app"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_git_head_sha(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, head_sha="abc123" + "0" * 34
@@ -468,7 +431,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "sha1.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_git_base_sha(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, base_sha="base111" + "1" * 33
@@ -486,7 +448,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "base1.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_git_pr_number(self) -> None:
         cc1 = self.create_commit_comparison(organization=self.organization, pr_number=123)
         cc2 = self.create_commit_comparison(organization=self.organization, pr_number=456)
@@ -500,7 +461,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "pr123.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_platform_name_apple(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
@@ -517,7 +477,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "ios.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_platform_name_android(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
@@ -538,7 +497,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"android.apk", "android.aab"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_platform_name_in(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
@@ -559,7 +517,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"ios.app", "android.apk", "android.aab"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_platform_name_not_in(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
@@ -580,7 +537,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"android.apk", "android.aab"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_greater_than(self) -> None:
         self.create_preprod_artifact(app_id="build100.app", build_number=100)
         self.create_preprod_artifact(app_id="build200.app", build_number=200)
@@ -592,7 +548,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "build300.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_less_than(self) -> None:
         self.create_preprod_artifact(app_id="build100.app", build_number=100)
         self.create_preprod_artifact(app_id="build200.app", build_number=200)
@@ -604,7 +559,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "build100.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_greater_than_or_equal(self) -> None:
         self.create_preprod_artifact(app_id="build100.app", build_number=100)
         self.create_preprod_artifact(app_id="build200.app", build_number=200)
@@ -617,7 +571,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"build200.app", "build300.app"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_less_than_or_equal(self) -> None:
         self.create_preprod_artifact(app_id="build100.app", build_number=100)
         self.create_preprod_artifact(app_id="build200.app", build_number=200)
@@ -630,7 +583,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"build100.app", "build200.app"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_contains(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, head_ref="feature/add-login"
@@ -653,7 +605,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"login.app", "signup.app"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_query_operator_not_contains(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, head_ref="feature/add-login"
@@ -674,7 +625,6 @@ class BuildsEndpointTest(APITestCase):
         data = response.json()
         assert data[0]["app_info"]["app_id"] == "crash.app"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_app_id(self) -> None:
         self.create_preprod_artifact(app_id="com.example.myapp")
         self.create_preprod_artifact(app_id="com.other.app")
@@ -686,7 +636,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "com.example.myapp"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_app_name(self) -> None:
         self.create_preprod_artifact(app_id="com.example.one", app_name="MyAwesomeApp")
         self.create_preprod_artifact(app_id="com.example.two", app_name="OtherApp")
@@ -697,7 +646,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "com.example.one"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_build_version(self) -> None:
         self.create_preprod_artifact(app_id="app1", build_version="1.2.3-beta")
         self.create_preprod_artifact(app_id="app2", build_version="2.0.0-release")
@@ -708,7 +656,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "app1"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_commit_sha(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, head_sha="abc123def456" + "0" * 28
@@ -726,7 +673,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "app1"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_branch(self) -> None:
         cc1 = self.create_commit_comparison(
             organization=self.organization, head_ref="feature/new-login"
@@ -744,7 +690,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "app1"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_pr_number(self) -> None:
         cc1 = self.create_commit_comparison(organization=self.organization, pr_number=12345)
         cc2 = self.create_commit_comparison(organization=self.organization, pr_number=67890)
@@ -758,7 +703,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "app1"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_by_build_id(self) -> None:
         artifact1 = self.create_preprod_artifact(app_id="app1")
         self.create_preprod_artifact(app_id="app2")
@@ -769,7 +713,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["id"] == str(artifact1.id)
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_no_matches(self) -> None:
         self.create_preprod_artifact(app_id="com.example.app")
         self.create_preprod_artifact(app_id="com.other.app")
@@ -779,7 +722,6 @@ class BuildsEndpointTest(APITestCase):
         data = response.json()
         assert len(data) == 0
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_empty_query(self) -> None:
         self.create_preprod_artifact(app_id="app1")
         self.create_preprod_artifact(app_id="app2")
@@ -789,7 +731,6 @@ class BuildsEndpointTest(APITestCase):
         data = response.json()
         assert len(data) == 2
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_whitespace_only(self) -> None:
         self.create_preprod_artifact(app_id="app1")
         self.create_preprod_artifact(app_id="app2")
@@ -799,7 +740,6 @@ class BuildsEndpointTest(APITestCase):
         data = response.json()
         assert len(data) == 2
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_case_insensitive(self) -> None:
         self.create_preprod_artifact(app_id="com.Example.MyApp")
 
@@ -809,7 +749,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "com.Example.MyApp"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_multiple_matches(self) -> None:
         self.create_preprod_artifact(app_id="com.test.one", app_name="TestApp")
         self.create_preprod_artifact(app_id="com.test.two", build_version="1.0-test")
@@ -821,7 +760,6 @@ class BuildsEndpointTest(APITestCase):
         app_ids = {d["app_info"]["app_id"] for d in data}
         assert app_ids == {"com.test.one", "com.test.two"}
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_free_text_search_with_structured_filter(self) -> None:
         from sentry.preprod.models import PreprodArtifact
 
@@ -845,7 +783,6 @@ class BuildsEndpointTest(APITestCase):
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "com.example.android"
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_size_state_filter(self) -> None:
         artifact_not_ran = self.create_preprod_artifact(app_id="not_ran.app")
         self.create_preprod_artifact_size_metrics(
@@ -873,7 +810,6 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 2
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_size_state_filter_mixed_metrics(self) -> None:
         artifact = self.create_preprod_artifact(app_id="mixed.app")
         self.create_preprod_artifact_size_metrics(
@@ -890,13 +826,11 @@ class BuildsEndpointTest(APITestCase):
         self._assert_is_successful(response)
         assert len(response.json()) == 0
 
-    @with_feature("organizations:preprod-frontend-routes")
     def test_size_state_invalid_values(self) -> None:
         self.create_preprod_artifact(app_id="test.app")
         assert self._request({"query": "size_state:bogus"}).status_code == 400
         assert self._request({"query": "size_state:[bogus, completed]"}).status_code == 400
 
-    @with_feature("organizations:preprod-frontend-routes")
     @patch("sentry.preprod.api.endpoints.builds.get_size_retention_cutoff")
     def test_excludes_expired_artifacts(self, mock_cutoff) -> None:
         mock_cutoff.return_value = before_now(days=30)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -19,7 +19,6 @@ from sentry.preprod.tasks import create_preprod_artifact
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import AssembleTask, ChunkFileState, set_assemble_status
 from sentry.testutils.cases import APITestCase, TestCase
-from sentry.testutils.helpers.features import Feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
@@ -352,34 +351,6 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
             "sentry-api-0-assemble-preprod-artifact-files",
             args=[self.organization.slug, self.project.slug],
         )
-
-        self.feature_context = Feature("organizations:preprod-frontend-routes")
-        self.feature_context.__enter__()
-
-    def tearDown(self) -> None:
-        self.feature_context.__exit__(None, None, None)
-        super().tearDown()
-
-    def test_feature_flag_disabled_returns_403(self) -> None:
-        """Test that endpoint returns 404 when feature flag is disabled."""
-        self.feature_context.__exit__(None, None, None)
-
-        try:
-            content = b"test content"
-            total_checksum = sha1(content).hexdigest()
-
-            response = self.client.post(
-                self.url,
-                data={
-                    "checksum": total_checksum,
-                    "chunks": [],
-                },
-                HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
-            )
-            assert response.status_code == 403
-        finally:
-            self.feature_context = Feature("organizations:preprod-frontend-routes")
-            self.feature_context.__enter__()
 
     def test_assemble_json_schema_integration(self) -> None:
         """Integration test for schema validation through the endpoint."""

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_list_builds.py
@@ -105,13 +105,6 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
             app_name="TestApp4",
         )
 
-        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
-        self.feature_context.__enter__()
-
-    def tearDown(self) -> None:
-        self.feature_context.__exit__(None, None, None)
-        super().tearDown()
-
     def _get_url(self):
         return reverse(
             "sentry-api-0-organization-preprod-list-builds",
@@ -211,16 +204,6 @@ class OrganizationPreprodListBuildsEndpointTest(APITestCase):
         )
         assert response.status_code == 200
         assert len(response.json()["builds"]) == 3
-
-    def test_list_builds_feature_flag_disabled(self) -> None:
-        with self.feature({"organizations:preprod-frontend-routes": False}):
-            response = self.client.get(
-                f"{self._get_url()}?project={self.project.id}",
-                format="json",
-                HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}",
-            )
-            assert response.status_code == 403
-            assert response.json()["error"] == "Feature not enabled"
 
     def test_list_builds_invalid_pagination_params(self) -> None:
         response = self.client.get(

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_delete.py
@@ -1,5 +1,3 @@
-from django.test import override_settings
-
 from sentry.models.files.file import File
 from sentry.preprod.models import (
     InstallablePreprodArtifact,
@@ -19,7 +17,6 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
         self.project = self.create_project(organization=self.organization)
         self.login_as(user=self.user)
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_delete_artifact_success(self):
         main_file = self.create_file(name="test_artifact.zip", type="application/zip")
         installable_file = self.create_file(name="test_app.ipa", type="application/octet-stream")
@@ -71,7 +68,6 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
         assert not PreprodArtifactSizeMetrics.objects.filter(id=size_metric.id).exists()
         assert not InstallablePreprodArtifact.objects.filter(id=installable.id).exists()
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_delete_artifact_not_found(self):
         response = self.get_error_response(
             self.organization.slug,
@@ -82,24 +78,6 @@ class ProjectPreprodArtifactDeleteTest(APITestCase):
 
         assert "The requested head preprod artifact does not exist" in response.data["detail"]
 
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": False})
-    def test_delete_artifact_feature_disabled(self):
-        artifact = self.create_preprod_artifact(
-            app_name="test_artifact",
-            app_id="com.test.app",
-            build_version="1.0.0",
-            build_number=1,
-        )
-        response = self.get_error_response(
-            self.organization.slug,
-            self.project.slug,
-            artifact.id,
-            status_code=403,
-        )
-
-        assert response.data["error"] == "Feature not enabled"
-
-    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_delete_artifact_minimal(self):
         """Test deleting an artifact with only the minimum required fields"""
         # Create the preprod artifact without optional files

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_download.py
@@ -70,8 +70,7 @@ class ProjectPreprodArtifactDownloadEndpointTest(TestCase):
 
         headers = self._get_authenticated_request_headers(url)
 
-        with self.feature("organizations:preprod-frontend-routes"):
-            response = self.client.get(url, **headers)
+        response = self.client.get(url, **headers)
 
         assert response.status_code == 404
         assert response.json()["detail"] == "The requested resource does not exist"

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_build_details.py
@@ -48,15 +48,6 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
             build_number=42,
         )
 
-        # Enable the feature flag for all tests by default
-        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
-        self.feature_context.__enter__()
-
-    def tearDown(self) -> None:
-        # Exit the feature flag context manager
-        self.feature_context.__exit__(None, None, None)
-        super().tearDown()
-
     def _get_url(self, artifact_id=None):
         artifact_id = artifact_id or self.preprod_artifact.id
         return reverse(
@@ -108,15 +99,6 @@ class ProjectPreprodBuildDetailsEndpointTest(APITestCase):
         )
         assert response.status_code == 404
         assert "The requested head preprod artifact does not exist" in response.json()["detail"]
-
-    def test_get_build_details_feature_flag_disabled(self) -> None:
-        with self.feature({"organizations:preprod-frontend-routes": False}):
-            url = self._get_url()
-            response = self.client.get(
-                url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
-            )
-            assert response.status_code == 403
-            assert response.json()["error"] == "Feature not enabled"
 
     def test_get_build_details_dates_and_types(self) -> None:
         url = self._get_url()

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_check_for_updates.py
@@ -28,15 +28,6 @@ class ProjectPreprodCheckForUpdatesEndpointTest(APITestCase):
 
         self.file = self.create_file(name="test_artifact.apk", type="application/octet-stream")
 
-        # Enable the feature flag for all tests by default
-        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
-        self.feature_context.__enter__()
-
-    def tearDown(self) -> None:
-        # Exit the feature flag context manager
-        self.feature_context.__exit__(None, None, None)
-        super().tearDown()
-
     def _get_url(self):
         return reverse(
             "sentry-api-0-project-preprod-check-for-updates",

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -950,30 +950,8 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         assert second_analysis_file is not None
         assert main_metrics.analysis_file_id == second_analysis_file.id
 
-    def test_assemble_preprod_artifact_size_analysis_writes_to_eap_when_flag_enabled(self) -> None:
-        """Test that size metrics are written to EAP when feature flag is enabled"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
-                )
-
-                assert status == ChunkFileState.OK
-                assert details is None
-
-                # Verify produce_preprod_size_metric_to_eap was called exactly once
-                # We have other integration tests that verify the EAP write itself works
-                assert mock_eap_write.call_count == 1
-
-                call_args = mock_eap_write.call_args
-                assert call_args is not None
-                size_metric = call_args.kwargs["size_metric"]
-                assert size_metric.preprod_artifact_id == self.preprod_artifact.id
-                assert call_args.kwargs["organization_id"] == self.organization.id
-                assert call_args.kwargs["project_id"] == self.project.id
-
-    def test_assemble_preprod_artifact_size_analysis_skips_eap_when_flag_disabled(self) -> None:
-        """Test that size metrics are NOT written to EAP when feature flag is disabled"""
+    def test_assemble_preprod_artifact_size_analysis_writes_to_eap(self) -> None:
+        """Test that size metrics are written to EAP"""
         with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
             status, details = self._run_task_and_verify_status(
                 b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
@@ -982,49 +960,53 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
             assert status == ChunkFileState.OK
             assert details is None
 
-            # Verify produce_preprod_size_metric_to_eap was NOT called
-            mock_eap_write.assert_not_called()
+            # Verify produce_preprod_size_metric_to_eap was called exactly once
+            # We have other integration tests that verify the EAP write itself works
+            assert mock_eap_write.call_count == 1
+
+            call_args = mock_eap_write.call_args
+            assert call_args is not None
+            size_metric = call_args.kwargs["size_metric"]
+            assert size_metric.preprod_artifact_id == self.preprod_artifact.id
+            assert call_args.kwargs["organization_id"] == self.organization.id
+            assert call_args.kwargs["project_id"] == self.project.id
 
     def test_assemble_preprod_artifact_size_analysis_eap_write_failure_does_not_fail_task(
         self,
     ) -> None:
         """Test that EAP write failures don't cause the main task to fail"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch(
-                "sentry.preprod.tasks.produce_preprod_size_metric_to_eap",
-                side_effect=Exception("EAP write failed"),
-            ):
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
-                )
+        with patch(
+            "sentry.preprod.tasks.produce_preprod_size_metric_to_eap",
+            side_effect=Exception("EAP write failed"),
+        ):
+            status, details = self._run_task_and_verify_status(
+                b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
+            )
 
-                assert status == ChunkFileState.OK
-                assert details is None
+            assert status == ChunkFileState.OK
+            assert details is None
 
-                size_metrics = PreprodArtifactSizeMetrics.objects.filter(
-                    preprod_artifact=self.preprod_artifact
-                )
-                assert len(size_metrics) == 1
-                assert (
-                    size_metrics[0].state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
-                )
+            size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact=self.preprod_artifact
+            )
+            assert len(size_metrics) == 1
+            assert size_metrics[0].state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
 
     def test_assemble_preprod_artifact_size_analysis_writes_multiple_metrics_to_eap(self) -> None:
-        """Test that all size metrics (main + components) are written to EAP when flag is enabled"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 1, "name": "Watch App", "app_id": "com.example.app.watchkitapp", "path": "/Watch", "download_size": 2000, "install_size": 4000}]}'
-                )
+        """Test that all size metrics (main + components) are written to EAP"""
+        with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
+            status, details = self._run_task_and_verify_status(
+                b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 1, "name": "Watch App", "app_id": "com.example.app.watchkitapp", "path": "/Watch", "download_size": 2000, "install_size": 4000}]}'
+            )
 
-                assert status == ChunkFileState.OK
-                assert details is None
+            assert status == ChunkFileState.OK
+            assert details is None
 
-                assert mock_eap_write.call_count == 2
+            assert mock_eap_write.call_count == 2
 
-                for call in mock_eap_write.call_args_list:
-                    assert call.kwargs["organization_id"] == self.organization.id
-                    assert call.kwargs["project_id"] == self.project.id
+            for call in mock_eap_write.call_args_list:
+                assert call.kwargs["organization_id"] == self.organization.id
+                assert call.kwargs["project_id"] == self.project.id
 
 
 class DetectExpiredPreprodArtifactsTest(TestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_preprod_size.py
+++ b/tests/snuba/api/endpoints/test_organization_events_preprod_size.py
@@ -20,7 +20,7 @@ class OrganizationEventsPreprodSizeEndpointTest(OrganizationEventsEndpointTestBa
 
     def _do_request(self, data, features=None):
         if features is None:
-            features = {"organizations:preprod-frontend-routes": True}
+            features = {}
         features.update(self.features)
         url = reverse(
             "sentry-api-0-organization-events",

--- a/tests/snuba/api/endpoints/test_organization_events_stats_preprod_size.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_preprod_size.py
@@ -27,7 +27,7 @@ class OrganizationEventsStatsPreprodSizeEndpointTest(OrganizationEventsEndpointT
 
     def _do_request(self, data, url=None, features=None):
         if features is None:
-            features = {"organizations:preprod-frontend-routes": True}
+            features = {}
         features.update(self.features)
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")


### PR DESCRIPTION
## Summary
- Remove 5 graduated emerge-tools feature flags: `organizations:preprod-app-size-dashboard`, `organizations:preprod-build-distribution`, `organizations:preprod-build-distribution-eap-write`, `organizations:preprod-frontend-routes`, `organizations:preprod-size-metrics-eap-write`
- Remove flag registrations from `temporary.py`, backend feature checks, frontend feature checks, `<Feature>` component wrappers, and test fixtures/decorators
- Remove "feature disabled" test cases that are no longer relevant

## Test plan
- [ ] Verify all preprod pages load correctly without feature flags
- [ ] Verify preprod build distribution features work
- [ ] Verify preprod size metrics EAP write works
- [ ] Verify dashboard widget builder shows Mobile Builds dataset option
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)