### PR TITLE
fix(tests): Fix flaky test_issue_owners_should_ratelimit group_id collision

### DIFF
--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -1421,7 +1421,10 @@ class AssignmentTestMixin(BasePostProcessGroupMixin):
     def test_issue_owners_should_ratelimit(self, mock_incr: MagicMock) -> None:
         cache.set(
             f"issue_owner_assignment_ratelimiter:{self.project.id}",
-            (set(range(0, ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT * 10, 10)), datetime.now()),
+            (
+                set(range(1_000_000, 1_000_000 + ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT)),
+                datetime.now(),
+            ),
         )
         event = self.create_event(
             data={
@@ -1467,7 +1470,12 @@ class AssignmentTestMixin(BasePostProcessGroupMixin):
         cache.set(
             f"issue_owner_assignment_ratelimiter:{self.project.id}",
             (
-                set(range(0, HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT * 10, 10)),
+                set(
+                    range(
+                        1_000_000,
+                        1_000_000 + HIGHER_ISSUE_OWNERS_PER_PROJECT_PER_MIN_RATELIMIT,
+                    )
+                ),
                 datetime.now(),
             ),
         )


### PR DESCRIPTION
## Summary
- Fix flaky `test_issue_owners_should_ratelimit` caused by group_id collision in the ratelimit cache

**Root cause:** The test seeds the ratelimit cache with `set(range(0, 50*10, 10))` = `{0, 10, 20, ..., 490}` — exactly 50 group_ids at the ratelimit threshold. When the new event's auto-incremented `group_id` collides with one of these values (e.g., 10, 20, 30...), `groups.add(group_id)` doesn't increase the set size, so `len(groups)` stays at 50 and `50 > 50` is `False` — no ratelimit triggered.

**Fix:** Use group_ids starting at 1,000,000 which can never collide with auto-incremented values.

Fixes #108767

## Test plan
- [x] Test passes 10/10 runs locally
- [x] Pre-commit checks pass