### PR TITLE
fix(tests): Fix flaky test_cross_db_deletion monitor ID collision

### DIFF
--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -403,11 +403,13 @@ class TestCrossDatabaseTombstoneCascadeBehavior(TestCase):
 
         affected_monitors = [monitor]
 
-        reserve_model_ids(Monitor, 14)
+        all_setup_ids = [monitor.id] + [d["monitor"].id for d in unaffected_data]
+        start_id = max(all_setup_ids) + 2
+        reserve_model_ids(Monitor, start_id + 8)
         affected_monitors.extend(
             [
                 Monitor.objects.create(
-                    id=5 + i * 2,  # Ensure that each monitor is in its own batch
+                    id=start_id + i * 2,  # Ensure that each monitor is in its own batch
                     organization_id=organization.id,
                     project_id=project.id,
                     slug=f"test-monitor-{i}",


### PR DESCRIPTION
## Summary
- Fix flaky `test_cross_db_deletion` caused by PostgreSQL sequence collision with hardcoded monitor IDs

**Root cause:** `setup_cross_db_deletion_data()` creates monitors with auto-incremented IDs. The test then creates additional monitors with hardcoded IDs `5, 7, 9, 11`. When the PostgreSQL sequence (which persists across transaction rollbacks) happens to assign one of these values during setup, the hardcoded `INSERT` fails with `duplicate key value violates unique constraint "sentry_monitor_pkey"`.

**Fix:** Derive hardcoded IDs from the actual auto-generated IDs (`max(setup_ids) + 2 + i*2`), matching the pattern already used correctly in `test_deletion_row_after_tombstone`.

Fixes #108766

## Test plan
- [x] Test passes 10/10 runs locally
- [x] Pre-commit checks pass