### PR TITLE
fix(tests): Fix flaky dashboard widget reorder and DSN tests

### DIFF
--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -44,6 +44,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         super().setUp()
         self.widget_1 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=0,
             title="Widget 1",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -52,6 +53,7 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         )
         self.widget_2 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=1,
             title="Widget 2",
             display_type=DashboardWidgetDisplayTypes.TABLE,
             widget_type=DashboardWidgetTypes.DISCOVER,
@@ -912,12 +914,14 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         self.create_user_member_role()
         self.widget_3 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=2,
             title="Widget 3",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,
         )
         self.widget_4 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
+            order=3,
             title="Widget 4",
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
             widget_type=DashboardWidgetTypes.DISCOVER,

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -89,6 +89,7 @@ class ProjectKeyTest(TestCase):
 
         assert self.model(project=self.project, status=ProjectKeyStatus.ACTIVE).is_active is True
 
+    @override_settings(JS_SDK_LOADER_CDN_URL="")
     def test_get_dsn(self) -> None:
         with self.options({"system.region-api-url-template": ""}):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -438,10 +438,10 @@ class JavaScriptSdkLoaderTest(TestCase):
             reverse("sentry-js-sdk-loader", args=[self.projectkey.public_key, ".min"])
             in self.projectkey.js_sdk_loader_cdn_url
         )
-        settings.JS_SDK_LOADER_CDN_URL = "https://js.sentry-cdn.com/"
-        assert (
-            "https://js.sentry-cdn.com/%s.min.js" % self.projectkey.public_key
-        ) == self.projectkey.js_sdk_loader_cdn_url
+        with self.settings(JS_SDK_LOADER_CDN_URL="https://js.sentry-cdn.com/"):
+            assert (
+                "https://js.sentry-cdn.com/%s.min.js" % self.projectkey.public_key
+            ) == self.projectkey.js_sdk_loader_cdn_url
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["10.0.0"])
     @mock.patch(


### PR DESCRIPTION
## Summary
- Fix `test_reorder_widgets_has_no_effect` flakiness by setting explicit `order` values on dashboard widgets in setUp, preventing non-deterministic `ORDER BY order` results when all values are NULL
- Fix `test_get_dsn` flakiness by fixing the settings leak in `test_absolute_url` (used `self.settings()` context manager instead of direct mutation) and adding `@override_settings(JS_SDK_LOADER_CDN_URL="")` to `test_get_dsn` for resilience

Fixes #108823
Fixes #108824

## Test plan
- [x] `test_reorder_widgets_has_no_effect` passes 10/10 runs
- [x] `test_get_dsn` passes 10/10 runs
- [x] All 94 tests in `OrganizationDashboardDetailsPutTest` pass
- [x] All 172 tests in `test_organization_dashboard_details.py` pass
- [x] All 50 tests in `test_js_sdk_loader.py` pass
- [x] All tests in `test_projectkey.py` pass