### PR TITLE
fix(tests): Fix flaky test_get_dsn settings leak from test_absolute_url

### DIFF
--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -89,6 +89,7 @@ class ProjectKeyTest(TestCase):
 
         assert self.model(project=self.project, status=ProjectKeyStatus.ACTIVE).is_active is True
 
+    @override_settings(JS_SDK_LOADER_CDN_URL="")
     def test_get_dsn(self) -> None:
         with self.options({"system.region-api-url-template": ""}):
             key = self.model(project_id=self.project.id, public_key="abc", secret_key="xyz")

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -438,10 +438,10 @@ class JavaScriptSdkLoaderTest(TestCase):
             reverse("sentry-js-sdk-loader", args=[self.projectkey.public_key, ".min"])
             in self.projectkey.js_sdk_loader_cdn_url
         )
-        settings.JS_SDK_LOADER_CDN_URL = "https://js.sentry-cdn.com/"
-        assert (
-            "https://js.sentry-cdn.com/%s.min.js" % self.projectkey.public_key
-        ) == self.projectkey.js_sdk_loader_cdn_url
+        with self.settings(JS_SDK_LOADER_CDN_URL="https://js.sentry-cdn.com/"):
+            assert (
+                "https://js.sentry-cdn.com/%s.min.js" % self.projectkey.public_key
+            ) == self.projectkey.js_sdk_loader_cdn_url
 
     @mock.patch("sentry.loader.browsersdkversion.load_version_from_file", return_value=["10.0.0"])
     @mock.patch(


### PR DESCRIPTION
## Summary
- `test_absolute_url` in `test_js_sdk_loader.py` directly mutated `settings.JS_SDK_LOADER_CDN_URL` without cleanup, leaking to subsequent tests
- Fixed the leak by using `self.settings()` context manager instead of direct mutation
- Added `@override_settings(JS_SDK_LOADER_CDN_URL="")` to `test_get_dsn` for resilience

Fixes #108824

## Test plan
- [x] `test_get_dsn` passes 10/10 runs
- [x] All tests in `test_projectkey.py` pass
- [x] All 50 tests in `test_js_sdk_loader.py` pass