### PR TITLE
fix(tests): Fix flaky replay data export tests

### DIFF
--- a/tests/sentry/replays/conftest.py
+++ b/tests/sentry/replays/conftest.py
@@ -15,5 +15,4 @@ class ReplayStore:
 
 @pytest.fixture
 def replay_store() -> ReplayStore:
-    assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
     return ReplayStore()

--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+import random
 import uuid
 
 import pytest
@@ -26,18 +27,21 @@ def test_export_clickhouse_rows(replay_store) -> None:  # type: ignore[no-untype
     replay4_id = uuid.uuid4().hex
     replay5_id = uuid.uuid4().hex
 
+    project_id = random.randint(1_000_000, 2_000_000_000)
+    other_project_id = random.randint(1_000_000, 2_000_000_000)
+
     t0 = datetime.datetime.now()
     t1 = t0 + datetime.timedelta(minutes=1)
     t2 = t0 + datetime.timedelta(minutes=2)
     t3 = t0 + datetime.timedelta(minutes=3)
 
-    replay_store.save(mock_replay(t1, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=1))
-    replay_store.save(mock_replay(t3, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay1_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay2_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay3_id, segment_id=1))
+    replay_store.save(mock_replay(t3, project_id, replay4_id, segment_id=0))
+    replay_store.save(mock_replay(t2, other_project_id, replay5_id, segment_id=0))
 
-    query_fn = lambda limit, offset: query_replays_dataset(1, t0, t3, limit, offset)
+    query_fn = lambda limit, offset: query_replays_dataset(project_id, t0, t3, limit, offset)
     rows = list(export_clickhouse_rows(query_fn, limit=1, num_pages=10))
     assert len(rows) == 3
 
@@ -48,13 +52,16 @@ def test_export_replay_row_set(replay_store) -> None:  # type: ignore[no-untyped
     replay1_id = "030c5419-9e0f-46eb-ae18-bfe5fd0331b5"
     replay2_id = "0dbda2b3-9286-4ecc-a409-aa32b241563d"
     replay3_id = "ff08c103-a9a4-47c0-9c29-73b932c2da34"
-    t0 = datetime.datetime(year=2025, month=1, day=1)
+
+    project_id = random.randint(1_000_000, 2_000_000_000)
+
+    t0 = datetime.datetime.now()
     t1 = t0 + datetime.timedelta(seconds=30)
     t2 = t0 + datetime.timedelta(minutes=1)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
+    replay_store.save(mock_replay(t0, project_id, replay1_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay2_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay3_id, segment_id=0))
 
     class Sink:
         def __init__(self) -> None:
@@ -66,7 +73,6 @@ def test_export_replay_row_set(replay_store) -> None:  # type: ignore[no-untyped
             self.contents = contents
 
     sink = Sink()
-    project_id = 1
     initial_offset = 0
     export_replay_row_set(
         project_id, t0, t2, limit=100, initial_offset=initial_offset, write_to_storage=sink
@@ -94,17 +100,20 @@ def test_get_replay_date_query_ranges(replay_store) -> None:  # type: ignore[no-
     replay4_id = str(uuid.uuid4())
     replay5_id = str(uuid.uuid4())
 
+    project_id = random.randint(1_000_000, 2_000_000_000)
+    other_project_id = random.randint(1_000_000, 2_000_000_000)
+
     t0 = datetime.datetime.now()
     t1 = t0 + datetime.timedelta(days=10)
     t2 = t0 + datetime.timedelta(days=20)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 2, replay5_id, segment_id=0))
+    replay_store.save(mock_replay(t0, project_id, replay1_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay2_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay3_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay4_id, segment_id=0))
+    replay_store.save(mock_replay(t2, other_project_id, replay5_id, segment_id=0))
 
-    results = list(get_replay_date_query_ranges(1))
+    results = list(get_replay_date_query_ranges(project_id))
     assert len(results) == 3
     assert results[0][0] == datetime.datetime(year=t0.year, month=t0.month, day=t0.day)
     assert results[0][1] == datetime.datetime(

--- a/tests/sentry/replays/test_data_export.py
+++ b/tests/sentry/replays/test_data_export.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import io
+import random
 import uuid
 from unittest.mock import patch
 
@@ -19,35 +20,42 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 
 
-# This test works and should be deterministic but it flaked in production. I'm not totally sure
-# why. This assert failed: `assert store_rows.called`. Two possibilities I can think of:
-#
-#   1. The mock is somehow flawed.
-#   2. The database query is returning nothing.
-#
-# I'm leaning towards the second option. Is it possible the parallelism of the production test
-# suite is emptying the db as I'm trying to read from it? Seems like we'd encounter a lot more
-# issues than just this test.
-@pytest.mark.skip(reason="Flaked due to 'store_rows' function not being called.")
 @django_db_all
-@pytest.mark.snuba
-@requires_snuba
-def test_replay_data_export(default_organization, default_project, replay_store) -> None:  # type: ignore[no-untyped-def]
-    replay_id = str(uuid.uuid4())
-    t0 = datetime.datetime(year=2025, month=1, day=1)
-    replay_store.save(mock_replay(t0, default_project.id, replay_id, segment_id=0))
+def test_replay_data_export(default_organization, default_project) -> None:
+    """Test the full export_replay_data pipeline without ClickHouse dependency.
 
+    This test verifies the orchestration logic: org/project lookup, blob export scheduling,
+    and database row export task chain. ClickHouse integration is tested separately by
+    test_export_replay_project_async and tests in integration/test_data_export.py.
+
+    The ClickHouse queries are mocked because the insert-then-query pattern is inherently
+    racy with pytest-xdist parallelism (ClickHouse inserts may not be immediately visible).
+    """
     # Setting has_replays flag because the export will skip projects it assumes do not have
     # replays.
     default_project.update(flags=F("flags").bitor(getattr(Project.flags, "has_replays")))
     default_project.flags.has_replays = True
     default_project.save()
 
+    t0 = datetime.datetime.now()
+    day_start = datetime.datetime(t0.year, t0.month, t0.day)
+    day_end = day_start + datetime.timedelta(days=1)
+
     with (
         TaskRunner(),
         patch("sentry.replays.data_export.request_create_transfer_job") as create_job,
         patch("sentry.replays.data_export.save_to_storage") as store_rows,
+        patch("sentry.replays.data_export.get_replay_date_query_ranges") as mock_date_ranges,
+        patch("sentry.replays.data_export.raw_snql_query") as mock_snql,
     ):
+        # Mock the date range discovery to return one day bucket for our project.
+        mock_date_ranges.return_value = iter([(day_start, day_end, 1)])
+        # Mock the ClickHouse row query to return one replay row (then empty for pagination stop).
+        mock_snql.side_effect = [
+            {"data": [{"replay_id": str(uuid.uuid4()), "project_id": default_project.id}]},
+            {"data": []},
+        ]
+
         export_replay_data(
             organization_id=default_organization.id,
             gcp_project_id="1",
@@ -67,7 +75,11 @@ def test_replay_data_export(default_organization, default_project, replay_store)
 def test_replay_data_export_invalid_organization(default_project, replay_store) -> None:  # type: ignore[no-untyped-def]
     replay_id = str(uuid.uuid4())
     t0 = datetime.datetime.now()
-    replay_store.save(mock_replay(t0, default_project.id, replay_id, segment_id=0))
+    # Use a random project_id for the ClickHouse insert to avoid cross-worker data pollution.
+    # The actual project_id doesn't matter here because this test asserts the invalid org path.
+    replay_store.save(
+        mock_replay(t0, random.randint(1_000_000, 2_000_000_000), replay_id, segment_id=0)
+    )
 
     # Setting has_replays flag because the export will skip projects it assumes do not have
     # replays.
@@ -98,7 +110,11 @@ def test_replay_data_export_no_replay_projects(  # type: ignore[no-untyped-def]
 ) -> None:
     replay_id = str(uuid.uuid4())
     t0 = datetime.datetime.now()
-    replay_store.save(mock_replay(t0, default_project.id, replay_id, segment_id=0))
+    # Use a random project_id for the ClickHouse insert to avoid cross-worker data pollution.
+    # The actual project_id doesn't matter here because this test asserts the no-replay-projects path.
+    replay_store.save(
+        mock_replay(t0, random.randint(1_000_000, 2_000_000_000), replay_id, segment_id=0)
+    )
 
     with (
         TaskRunner(),
@@ -153,20 +169,22 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
     replay2_id = "0dbda2b3-9286-4ecc-a409-aa32b241563d"
     replay3_id = "ff08c103-a9a4-47c0-9c29-73b932c2da34"
 
+    project_id = random.randint(1_000_000, 2_000_000_000)
+
     t0 = datetime.datetime.now()
     t1 = t0 + datetime.timedelta(days=1)
     t2 = t0 + datetime.timedelta(days=2)
     t3 = t0 + datetime.timedelta(days=3)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay3_id, segment_id=0))
+    replay_store.save(mock_replay(t0, project_id, replay1_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay2_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay3_id, segment_id=0))
 
     # Assert the number of runs required to export the database given a set of parameters.
     with TaskRunner():
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -178,7 +196,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
 
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -190,7 +208,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
 
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -202,7 +220,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
 
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -214,7 +232,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
 
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -229,7 +247,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
         # We would have exported three but we hit the max call depth.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -243,7 +261,7 @@ def test_export_replay_row_set_async(replay_store) -> None:  # type: ignore[no-u
         # We get more than the max call depth because it was within the bounds of the task.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_row_set_async.delay(
-                project_id=1,
+                project_id=project_id,
                 start=t0,
                 end=t3,
                 destination_bucket="test",
@@ -265,21 +283,23 @@ def test_export_replay_project_async(replay_store) -> None:  # type: ignore[no-u
     replay4_id = str(uuid.uuid4())
     replay5_id = str(uuid.uuid4())
 
+    project_id = random.randint(1_000_000, 2_000_000_000)
+
     t0 = datetime.datetime.now()
     t1 = t0 + datetime.timedelta(days=1)
     t2 = t0 + datetime.timedelta(days=2)
 
-    replay_store.save(mock_replay(t0, 1, replay1_id, segment_id=0))
-    replay_store.save(mock_replay(t0, 1, replay2_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay3_id, segment_id=0))
-    replay_store.save(mock_replay(t1, 1, replay4_id, segment_id=0))
-    replay_store.save(mock_replay(t2, 1, replay5_id, segment_id=0))
+    replay_store.save(mock_replay(t0, project_id, replay1_id, segment_id=0))
+    replay_store.save(mock_replay(t0, project_id, replay2_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay3_id, segment_id=0))
+    replay_store.save(mock_replay(t1, project_id, replay4_id, segment_id=0))
+    replay_store.save(mock_replay(t2, project_id, replay5_id, segment_id=0))
 
     with TaskRunner():
         # Assert we need five runs to export the row set.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_project_async.delay(
-                project_id=1,
+                project_id=project_id,
                 destination_bucket="test",
                 limit=1,
                 num_pages=1,
@@ -289,7 +309,7 @@ def test_export_replay_project_async(replay_store) -> None:  # type: ignore[no-u
         # Assert we can reduce the run count by modifying the limit.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_project_async.delay(
-                project_id=1,
+                project_id=project_id,
                 destination_bucket="test",
                 limit=2,
                 num_pages=1,
@@ -299,7 +319,7 @@ def test_export_replay_project_async(replay_store) -> None:  # type: ignore[no-u
         # Assert we can reduce the run count by modifying the number of pages per run.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_project_async.delay(
-                project_id=1,
+                project_id=project_id,
                 destination_bucket="test",
                 limit=1,
                 num_pages=2,
@@ -309,7 +329,7 @@ def test_export_replay_project_async(replay_store) -> None:  # type: ignore[no-u
         # Assert we need three runs because date bucketing is the limiting factor.
         with patch("sentry.replays.data_export.save_to_storage") as store_rows:
             export_replay_project_async.delay(
-                project_id=1,
+                project_id=project_id,
                 destination_bucket="test",
                 limit=1000,
                 num_pages=1000,

--- a/tests/sentry/replays/test_query.py
+++ b/tests/sentry/replays/test_query.py
@@ -21,7 +21,6 @@ class ReplayStore:
 
 @pytest.fixture
 def replay_store() -> ReplayStore:
-    assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
     return ReplayStore()
 
 


### PR DESCRIPTION
## Summary
- Fix `test_replay_data_export` by mocking the ClickHouse query layer (the insert-then-query pattern is inherently racy with xdist parallelism). The test now verifies the orchestration logic (org/project lookup, blob export, task chain) while ClickHouse integration is covered by `test_export_replay_project_async` and the integration tests.
- Remove global `/tests/replays/drop` from `replay_store` fixtures (both `conftest.py` and `test_query.py`) to prevent cross-worker data destruction under pytest-xdist
- Use random project_ids (1M-2B range) instead of hardcoded `project_id=1` for all ClickHouse-facing tests to avoid cross-worker data pollution
- Use `datetime.now()` instead of hardcoded timestamps to prevent ClickHouse TTL expiry

Fixes #108829
Supersedes #108820

## Test plan
- [x] `test_replay_data_export` passes 10/10 runs
- [x] All 14 replay tests pass together in a single run
- [x] Pre-commit hooks pass