### PR TITLE
fix(issues): Fix EventOrdering using wrong column alias for event_id

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -224,15 +224,15 @@ STATUS_UPDATE_CHOICES = {
 
 
 class EventOrdering(Enum):
-    LATEST = ["project_id", "-timestamp", "-event_id"]
-    OLDEST = ["project_id", "timestamp", "event_id"]
+    LATEST = ["project_id", "-timestamp", "-id"]
+    OLDEST = ["project_id", "timestamp", "id"]
     RECOMMENDED = [
         "-replay.id",
         "-trace.sampled",
         "num_processing_errors",
         "-profile.id",
         "-timestamp",
-        "-event_id",
+        "-id",
     ]
 
 


### PR DESCRIPTION
## Summary
- `EventOrdering.RECOMMENDED`, `LATEST`, and `OLDEST` used `-event_id`/`event_id` in their ordering lists
- But `SENTRY_SNUBA_MAP` maps the alias `"id"` (not `"event_id"`) to the Snuba column `event_id`
- The Snuba query builder in `get_events_snql` silently skips unresolved field aliases, so the event_id tiebreaker was never applied to the outer query
- This caused non-deterministic ordering when all other fields (replay_id, trace_sampled, processing_errors, profile_id, timestamp) were equal
- Fix: use the correct column alias `"id"` instead of `"event_id"`

Fixes #108833

## Test plan
- [x] `test_get_helpful_event_id` passes 10/10 times locally
- [x] All 21 tests in `test_group_event_details.py` pass
- [x] All 12 tests in `tests/snuba/models/test_group.py` pass