### PR TITLE
fix(tests): Fix flaky test_snuba_data timestamp mismatch

### DIFF
--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -17,7 +17,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import snuba
@@ -206,16 +206,17 @@ class EventTest(TestCase, PerformanceIssueTestCase):
         assert event.culprit == "app/components/events/eventEntries in map"
 
     def test_snuba_data(self) -> None:
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "message": "Hello World!",
-                "tags": {"logger": "foobar", "site": "foo", "server_name": "bar"},
-                "user": {"id": "test", "email": "test@test.com"},
-                "timestamp": before_now(seconds=1).isoformat(),
-            },
-            project_id=self.project.id,
-        )
+        with freeze_time():
+            self.store_event(
+                data={
+                    "event_id": "a" * 32,
+                    "message": "Hello World!",
+                    "tags": {"logger": "foobar", "site": "foo", "server_name": "bar"},
+                    "user": {"id": "test", "email": "test@test.com"},
+                    "timestamp": before_now(seconds=1).isoformat(),
+                },
+                project_id=self.project.id,
+            )
 
         event_from_nodestore = Event(project_id=self.project.id, event_id="a" * 32)
 


### PR DESCRIPTION
## Summary
- Fix flaky `test_snuba_data` by wrapping `store_event` call in `freeze_time()` to ensure deterministic timestamps
- Root cause: `before_now(seconds=1)` uses `datetime.now()` which can differ between nodestore and Snuba storage paths when the pipeline takes non-trivial time
- With `freeze_time()`, both paths see the same wall clock, eliminating the timestamp mismatch

Fixes #108838

## Test plan
- [x] Verified fix passes 10/10 runs locally