### PR TITLE
fix(tests): Fix flaky test_sort_by_latest_group non-deterministic ordering

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -255,6 +255,10 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         ]
 
     def test_sort_by_latest_group(self) -> None:
+        # delete the project default detectors as they cause flaky sorting results
+        self.error_detector.delete()
+        self.issue_stream_detector.delete()
+
         detector_1 = self.create_detector(
             project=self.project, name="Detector 1", type=MetricIssue.slug
         )
@@ -277,7 +281,7 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         detector_group_1.date_added = before_now(hours=3)
         detector_group_1.save()
 
-        # detector_2 has the newest grbefore_now
+        # detector_2 has the newest group
         detector_group_2 = DetectorGroup.objects.create(detector=detector_2, group=group_2)
         detector_group_2.date_added = before_now(hours=1)  # Most recent
         detector_group_2.save()
@@ -295,8 +299,6 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             detector_2.name,
             detector_3.name,
             detector_1.name,
-            self.error_detector.name,
-            self.issue_stream_detector.name,
             detector_4.name,  # No groups, should be last
         ]
 
@@ -305,8 +307,6 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
             self.organization.slug, qs_params={"project": self.project.id, "sortBy": "latestGroup"}
         )
         assert [d["name"] for d in response2.data] == [
-            self.error_detector.name,
-            self.issue_stream_detector.name,
             detector_4.name,  # No groups, should be first
             detector_1.name,
             detector_3.name,


### PR DESCRIPTION
## Summary
- Fix flaky `test_sort_by_latest_group` by deleting default detectors (`error_detector`, `issue_stream_detector`) at the start of the test
- Root cause: Default detectors have no associated groups (NULL latest_group), and PostgreSQL ORDER BY with NULLs is non-deterministic without a tiebreaker
- Uses the same pattern already established in `test_sort_by_open_issues` (line 316-319) which also deletes these detectors

Fixes #108837

## Test plan
- [x] Verified fix passes 10/10 runs locally
- [x] Full test class passes