### PR TITLE
Fix #108356: Missing binary name in issue stacktrace when identified with

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -519,6 +519,19 @@ def process_native_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
                 merged_frame = dict(raw_frame)
                 platform = merged_frame.get("platform") or data.get("platform") or "native"
                 _merge_frame(merged_frame, complete_frame, platform)
+                # If the frame has no package (binary name), try to resolve it from
+                # the module list using the addr_mode index. This handles the case
+                # where a frame is identified by debug_id but has no code_file.
+                if not merged_frame.get("package"):
+                    addr_mode = merged_frame.get("addr_mode")
+                    if addr_mode and addr_mode.startswith("rel:"):
+                        idx_str = addr_mode[4:]
+                        if idx_str.isdigit():
+                            module_idx = int(idx_str)
+                            if 0 <= module_idx < len(modules):
+                                code_file = modules[module_idx].get("code_file")
+                                if code_file:
+                                    merged_frame["package"] = code_file
                 if merged_frame.get("package"):
                     raw_frame["package"] = merged_frame["package"]
                 new_frames.append(merged_frame)

--- a/tests/sentry/lang/native/test_processing.py
+++ b/tests/sentry/lang/native/test_processing.py
@@ -412,3 +412,87 @@ def test_il2cpp_symbolication(mock_symbolicator, default_project) -> None:
         == "/Users/swatinem/Coding/sentry-unity/samples/unity-of-bugs/Assets/Scripts/BugFarmButtons.cs"
     )
     assert frame["lineno"] == 51
+
+
+@django_db_all
+@mock.patch("sentry.lang.native.processing.Symbolicator")
+def test_package_resolved_from_module_when_missing_code_file(
+    mock_symbolicator, default_project
+) -> None:
+    """
+    When a frame has a debug_id but no code_file/package, the binary name
+    should be resolved from the matched module after symbolication.
+    See: https://github.com/getsentry/sentry/issues/108356
+    """
+    data = {
+        "event_id": "c87700da71534177b92bd912f21a062f",
+        "timestamp": "2022-06-15T10:13:46.963575+00:00",
+        "platform": "native",
+        "project": default_project.id,
+        "exception": {
+            "values": [
+                {
+                    "type": "EXC_CRASH",
+                    "stacktrace": {
+                        "frames": [
+                            {
+                                "instruction_addr": "0x0000000100004000",
+                                "addr_mode": "rel:a9669c0c-72b3-3d2c-952b-d9096f65bc4f",
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        "debug_meta": {
+            "images": [
+                {
+                    "type": "macho",
+                    # No code_file here - this is the scenario from the issue
+                    "image_addr": "0x0000000100000000",
+                    "debug_id": "a9669c0c-72b3-3d2c-952b-d9096f65bc4f",
+                }
+            ]
+        },
+    }
+
+    mock_symbolicator.return_value = mock_symbolicator
+    mock_symbolicator.process_payload.return_value = {
+        "status": "completed",
+        "stacktraces": [
+            {
+                "frames": [
+                    {
+                        "status": "symbolicated",
+                        "original_index": 0,
+                        "instruction_addr": "0x4000",
+                        "addr_mode": "rel:0",
+                        # No package returned by symbolicator either
+                        "function": "my_function",
+                        "symbol": "my_function",
+                        "abs_path": "/path/to/source.c",
+                        "lineno": 42,
+                    }
+                ]
+            }
+        ],
+        "modules": [
+            {
+                "debug_status": "found",
+                "arch": "x86_64",
+                "type": "macho",
+                # Symbolicator resolved the code_file from the dSYM
+                "code_file": "/path/to/MyApp",
+                "debug_id": "a9669c0c-72b3-3d2c-952b-d9096f65bc4f",
+                "image_addr": "0x0000000100000000",
+            }
+        ],
+    }
+
+    process_native_stacktraces(mock_symbolicator, data)
+
+    frame = get_path(data, "exception", "values", 0, "stacktrace", "frames", 0)
+
+    assert frame["function"] == "my_function"
+    # The package should be resolved from the module's code_file
+    assert frame["package"] == "/path/to/MyApp"


### PR DESCRIPTION
Fixes #108356

## Summary
This PR fixes: Missing binary name in issue stacktrace when identified with debug_id

## Changes
```
src/sentry/lang/native/processing.py        | 13 +++++
 tests/sentry/lang/native/test_processing.py | 84 +++++++++++++++++++++++++++++
 2 files changed, 97 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).