### PR TITLE
Fix #108113: MS Teams Integration for self-hosted Sentry

### DIFF
--- a/src/sentry/integrations/msteams/parsing.py
+++ b/src/sentry/integrations/msteams/parsing.py
@@ -83,13 +83,26 @@ def is_new_integration_installation_event(data: Mapping[str, Any]) -> bool:
     try:
         raw_event_type = data["type"]
         event_type = MsTeamsEvents.get_from_value(value=raw_event_type)
-        if event_type != MsTeamsEvents.INSTALLATION_UPDATE:
-            return False
 
-        action = data.get("action", None)
-        if action is None or action != "add":
-            return False
+        if event_type == MsTeamsEvents.INSTALLATION_UPDATE:
+            action = data.get("action", None)
+            return action is not None and action == "add"
 
-        return True
+        if event_type == MsTeamsEvents.CONVERSATION_UPDATE:
+            # A conversationUpdate with teamMemberAdded is the older mechanism
+            # by which MS Teams notifies a bot that it has been added to a team.
+            # There is no integration record yet, so we must handle this in the
+            # control silo just like an installationUpdate "add" event.
+            channel_data = data.get("channelData", {})
+            if channel_data.get("eventType") == "teamMemberAdded":
+                return True
+
+            # A personal (1:1) installation also arrives as a conversationUpdate
+            # with a membersAdded list and conversationType "personal".
+            conversation = data.get("conversation", {})
+            if data.get("membersAdded") and conversation.get("conversationType") == "personal":
+                return True
+
+        return False
     except Exception:
         return False

--- a/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_parsing.py
+++ b/tests/sentry/integrations/msteams/webhook/test_ms_teams_webhook_parsing.py
@@ -35,3 +35,43 @@ class TestIsNewIntegrationInstallationEvent:
     def test_invalid_action(self) -> None:
         data: dict[str, Any] = {"type": "installationUpdate", "action": "remove"}
         assert is_new_integration_installation_event(data) is False
+
+    def test_conversation_update_team_member_added(self) -> None:
+        # MS Teams sends a conversationUpdate + teamMemberAdded when a bot is first
+        # added to a team (older bot mechanism).  There is no integration record yet,
+        # so this must be treated as a new-installation event.
+        data: dict[str, Any] = {
+            "type": "conversationUpdate",
+            "channelData": {
+                "eventType": "teamMemberAdded",
+                "team": {"id": "team_id", "name": "My Team"},
+                "tenant": {"id": "tenant_id"},
+            },
+        }
+        assert is_new_integration_installation_event(data) is True
+
+    def test_conversation_update_team_member_removed(self) -> None:
+        data: dict[str, Any] = {
+            "type": "conversationUpdate",
+            "channelData": {"eventType": "teamMemberRemoved"},
+        }
+        assert is_new_integration_installation_event(data) is False
+
+    def test_conversation_update_personal_member_added(self) -> None:
+        # Personal (1:1) installations arrive as a conversationUpdate with membersAdded
+        # in a personal conversation.
+        data: dict[str, Any] = {
+            "type": "conversationUpdate",
+            "conversation": {"conversationType": "personal"},
+            "membersAdded": [{"id": "bot_id"}],
+            "channelData": {"tenant": {"id": "tenant_id"}},
+        }
+        assert is_new_integration_installation_event(data) is True
+
+    def test_conversation_update_personal_no_members_added(self) -> None:
+        data: dict[str, Any] = {
+            "type": "conversationUpdate",
+            "conversation": {"conversationType": "personal"},
+            "channelData": {"tenant": {"id": "tenant_id"}},
+        }
+        assert is_new_integration_installation_event(data) is False

--- a/tests/sentry/middleware/integrations/parsers/test_msteams.py
+++ b/tests/sentry/middleware/integrations/parsers/test_msteams.py
@@ -199,3 +199,20 @@ class MsTeamsRequestParserTest(TestCase):
             assert response.content == b"passthrough"
             assert len(responses.calls) == 0
             assert_no_webhook_payloads()
+
+    def test_team_member_added_routed_to_control_silo(self) -> None:
+        # A conversationUpdate + teamMemberAdded event (the older bot-installation
+        # mechanism) must be forwarded to the control silo even when a matching
+        # integration already exists, because the same event fires for a *new*
+        # installation where no integration record has been created yet.
+        request = self.factory.post(
+            self.path,
+            json=EXAMPLE_TEAM_MEMBER_ADDED,
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN}",
+        )
+        parser = MsTeamsRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.content == b"passthrough"
+        assert_no_webhook_payloads()


### PR DESCRIPTION
Fixes #108113

## Summary
This PR fixes: MS Teams Integration for self-hosted Sentry

## Changes
```
src/sentry/integrations/msteams/parsing.py         | 25 ++++++++++----
 .../webhook/test_ms_teams_webhook_parsing.py       | 40 ++++++++++++++++++++++
 .../integrations/parsers/test_msteams.py           | 17 +++++++++
 3 files changed, 76 insertions(+), 6 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).