### PR TITLE
fix(tests): Fix flaky test_snuba_data timestamp mismatch

### DIFF
--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -212,7 +212,9 @@ class EventTest(TestCase, PerformanceIssueTestCase):
                 "message": "Hello World!",
                 "tags": {"logger": "foobar", "site": "foo", "server_name": "bar"},
                 "user": {"id": "test", "email": "test@test.com"},
-                "timestamp": before_now(seconds=1).isoformat(),
+                # Use a timestamp well in the past and at second precision to avoid
+                # flakiness from EventDict re-normalization adjusting timestamps near now()
+                "timestamp": before_now(minutes=1).replace(microsecond=0).isoformat(),
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
## Summary
- Fixes flaky `test_snuba_data` by changing the event timestamp from `before_now(seconds=1)` to `before_now(minutes=1).replace(microsecond=0)`
- The root cause is that when event data is loaded from nodestore, `EventDict` re-normalizes it via `StoreNormalizer(is_renormalize=True)`. For timestamps very close to `now()`, this re-normalization can adjust the timestamp, causing a mismatch with the original timestamp stored in Snuba
- This matches the pattern already used by the sibling `test_snuba_data_transaction` test

Fixes #108852

## Test plan
- [x] `test_snuba_data` passes consistently (verified 5 consecutive runs locally)
- [x] All 14 tests in `EventTest` pass