### PR TITLE
Fix #108390: Unable to Select Organization when setting up GitHub Auth

### DIFF
--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -30,13 +30,16 @@ class GitHubClient:
     ) -> None:
         self.http.close()
 
-    def _request(self, path: str) -> dict[str, Any] | list[dict[str, Any]]:
+    def _request(
+        self, path: str, params: dict[str, Any] | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
         headers = {"Authorization": f"token {self.access_token}"}
 
         try:
             req = self.http.get(
                 f"https://{API_DOMAIN}/{path.lstrip('/')}",
                 headers=headers,
+                params=params,
             )
         except RequestException as e:
             raise GitHubApiError(f"{e}", status=getattr(e, "status_code", 0))
@@ -45,10 +48,23 @@ class GitHubClient:
         return orjson.loads(req.content)
 
     def get_org_list(self) -> list[dict[str, Any]]:
-        res = self._request("/user/orgs")
-        if not isinstance(res, list):
-            return [res]
-        return res
+        # GitHub paginates /user/orgs (default 30 per page, max 100).
+        # Fetch all pages so the full list of organizations is returned.
+        results: list[dict[str, Any]] = []
+        page = 1
+        per_page = 100
+        while True:
+            res = self._request("/user/orgs", params={"per_page": per_page, "page": page})
+            if not isinstance(res, list):
+                results.append(res)
+                break
+            if not res:
+                break
+            results.extend(res)
+            if len(res) < per_page:
+                break
+            page += 1
+        return results
 
     def get_user(self) -> dict[str, Any] | list[dict[str, Any]]:
         return self._request("/user")

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -21,10 +21,53 @@ def test_request_sends_access_token(client) -> None:
     assert responses.calls[0].request.headers["Authorization"] == "token accessToken"
 
 
-@mock.patch.object(GitHubClient, "_request")
-def test_get_org_list(mock_request, client) -> None:
-    client.get_org_list()
-    mock_request.assert_called_once_with("/user/orgs")
+@responses.activate
+def test_get_org_list_single_page(client) -> None:
+    orgs = [{"id": i, "login": f"org{i}"} for i in range(5)]
+    responses.add(
+        responses.GET,
+        f"https://{API_DOMAIN}/user/orgs",
+        json=orgs,
+        status=200,
+    )
+    result = client.get_org_list()
+    assert result == orgs
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.params["per_page"] == "100"
+    assert responses.calls[0].request.params["page"] == "1"
+
+
+@responses.activate
+def test_get_org_list_multiple_pages(client) -> None:
+    page1 = [{"id": i, "login": f"org{i}"} for i in range(100)]
+    page2 = [{"id": i + 100, "login": f"org{i + 100}"} for i in range(3)]
+    responses.add(
+        responses.GET,
+        f"https://{API_DOMAIN}/user/orgs",
+        json=page1,
+        status=200,
+    )
+    responses.add(
+        responses.GET,
+        f"https://{API_DOMAIN}/user/orgs",
+        json=page2,
+        status=200,
+    )
+    result = client.get_org_list()
+    assert result == page1 + page2
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_get_org_list_empty(client) -> None:
+    responses.add(
+        responses.GET,
+        f"https://{API_DOMAIN}/user/orgs",
+        json=[],
+        status=200,
+    )
+    result = client.get_org_list()
+    assert result == []
 
 
 @mock.patch.object(GitHubClient, "_request")


### PR DESCRIPTION
Fixes #108390

## Summary
This PR fixes: Unable to Select Organization when setting up GitHub Auth

## Changes
```
src/sentry/auth/providers/github/client.py        | 26 +++++++++---
 tests/sentry/auth/providers/github/test_client.py | 51 +++++++++++++++++++++--
 2 files changed, 68 insertions(+), 9 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).