### PR TITLE
Fix #108304: Manual refresh on the logs page is disabled.

### DIFF
--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -17,6 +17,7 @@ import {
 } from 'sentry/components/searchQueryBuilder/context';
 import {IconChevron, IconEdit, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {Tooltip} from 'sentry/components/tooltip';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
@@ -414,13 +415,18 @@ export function LogsTabContent({datePageFilterProps}: LogsTabProps) {
             {tableTab === 'logs' && (
               <TableActionsContainer>
                 <AutorefreshToggle averageLogsPerSecond={averageLogsPerSecond} />
-                <Button
-                  size="sm"
-                  icon={<IconRefresh />}
-                  disabled={canManuallyRefresh ? false : true}
-                  onClick={refreshTable}
-                  aria-label={t('Refresh')}
-                />
+                <Tooltip
+                  disabled={canManuallyRefresh}
+                  title={t('Manual refresh is only available for time periods of 1 hour or less.')}
+                >
+                  <Button
+                    size="sm"
+                    icon={<IconRefresh />}
+                    disabled={!canManuallyRefresh}
+                    onClick={refreshTable}
+                    aria-label={t('Refresh')}
+                  />
+                </Tooltip>
                 <TableActionButton
                   mobile={
                     <Button


### PR DESCRIPTION
Fixes #108304

## Summary
This PR fixes: Manual refresh on the logs page is disabled.

## Changes
```
static/app/views/explore/logs/logsTab.tsx | 20 +++++++++++++-------
 1 file changed, 13 insertions(+), 7 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).