### PR TITLE
fix(tests): Fix flaky test_api_key_request event data leak

### DIFF
--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -50,7 +50,11 @@ class OrganizationEventsEndpointTest(APITestCase):
         # Project ID cannot be inferred when using an org API key, so that must
         # be passed in the parameters
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
-        query = {"field": ["project.name", "environment"], "project": [self.project.id]}
+        query = {
+            "field": ["project.name", "environment"],
+            "project": [self.project.id],
+            "statsPeriod": "1h",
+        }
 
         url = self.reverse_url()
         response = self.client_get(


### PR DESCRIPTION
## Summary
- Add `statsPeriod` filter to the event query in `test_api_key_request` to prevent stale events from other tests or previous runs from leaking into the results
- The test was querying events without any time bounds, so events stored by other tests in the same project could appear in the results

Fixes https://github.com/getsentry/sentry/issues/108857