### PR TITLE
Fix #108195: !key:[A,B] should render !key:A and !key:B but currently ren

### DIFF
--- a/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
+++ b/static/app/components/searchQueryBuilder/formattedQuery.spec.tsx
@@ -40,6 +40,14 @@ describe('FormattedQuery', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders negated filters with multiple values using "and"', () => {
+    render(<FormattedQuery {...defaultProps} query="!browser.name:[Firefox,Chrome]" />);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher('browser.name is not Firefox and Chrome'))
+    ).toBeInTheDocument();
+  });
+
   it('renders "is" filter correctly', () => {
     render(<FormattedQuery {...defaultProps} query="is:unresolved" />);
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filter.tsx
@@ -83,7 +83,7 @@ export function FilterValueText({token}: {token: TokenResult<Token.FILTER>}) {
                 {formatFilterValue({token: item.value!})}
               </FilterMultiValueTruncated>
               {index !== items.length - 1 && index < maxItems - 1 ? (
-                <FilterValueOr> or </FilterValueOr>
+                <FilterValueOr>{token.negated ? ' and ' : ' or '}</FilterValueOr>
               ) : null}
             </Fragment>
           ))}


### PR DESCRIPTION
Fixes #108195

## Summary
This PR fixes: !key:[A,B] should render !key:A and !key:B but currently renders !key:A or !key:B

## Changes
```
static/app/components/searchQueryBuilder/formattedQuery.spec.tsx  | 8 ++++++++
 static/app/components/searchQueryBuilder/tokens/filter/filter.tsx | 2 +-
 2 files changed, 9 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).