### PR TITLE
fix(tests): Fix flaky test_metrics non-deterministic group ordering

### DIFF
--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -569,7 +569,10 @@ class MergeGroupsTest(TestCase):
                     platform="javascript",
                     metadata={"sdk": {"name_normalized": "sentry.javascript.nextjs"}},
                 ).id,
-                self.create_group(platform="javascript").id,
+                self.create_group(
+                    platform="javascript",
+                    metadata={"sdk": {"name_normalized": "sentry.javascript.nextjs"}},
+                ).id,
             ]
             project = self.project
 


### PR DESCRIPTION
## Summary
- Give both groups the same SDK metadata in `test_metrics` so that regardless of which group is first in the list returned by `get_group_list()`, the metrics `sdk` tag will match the expected value
- `get_group_list()` uses an unordered query, so `group_list[0]` (used by `merge_groups` for the SDK tag) was non-deterministic

Fixes https://github.com/getsentry/sentry/issues/108855