### PR TITLE
fix(tests): Fix flaky test_batch_query_percent session timing

### DIFF
--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -499,8 +499,9 @@ class EventFrequencyPercentConditionQueryTest(
 
     @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_batch_query_percent(self) -> None:
-        self._make_sessions(60, self.environment2.name)
-        self._make_sessions(60, self.environment.name)
+        received = self.end.timestamp()
+        self._make_sessions(60, self.environment2.name, received=received)
+        self._make_sessions(60, self.environment.name, received=received)
         batch_query = self.condition_inst.batch_query_hook(
             group_ids=[self.event.group_id, self.event2.group_id, self.perf_event.group_id],
             start=self.start,


### PR DESCRIPTION
## Summary
- Pass explicit `received` time (aligned with `self.end`) to `_make_sessions` so session timestamps consistently fall within the query window
- The timing gap between `timezone.now()` in setUp and `time.time()` in `_make_sessions` caused some sessions to fall outside the query window, changing the session count and resulting in 25% instead of the expected 20%

Fixes https://github.com/getsentry/sentry/issues/108851