### PR TITLE
fix(tests): Fix flaky test_five_minutes_no_events connection error

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1615,13 +1615,15 @@ class BaseMetricsTestCase(SnubaTestCase):
         for bucket in buckets:
             codec.validate(bucket)
 
-        assert (
-            requests.post(
-                settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity),
-                data=json.dumps(buckets),
-            ).status_code
-            == 200
-        )
+        url = settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity)
+        data = json.dumps(buckets)
+        for attempt in range(3):
+            try:
+                assert requests.post(url, data=data).status_code == 200
+                break
+            except requests.ConnectionError:
+                if attempt == 2:
+                    raise
 
 
 class BaseMetricsLayerTestCase(BaseMetricsTestCase):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1617,6 +1617,8 @@ class BaseMetricsTestCase(SnubaTestCase):
 
         url = settings.SENTRY_SNUBA + cls.snuba_endpoint.format(entity=entity)
         data = json.dumps(buckets)
+        # Retry on transient Snuba connection errors. This benefits all callers
+        # of store_metric, which delegates to this method for HTTP delivery.
         for attempt in range(3):
             try:
                 assert requests.post(url, data=data).status_code == 200


### PR DESCRIPTION
## Summary
- Add retry logic (up to 3 attempts) to `BaseMetricsTestCase.__send_buckets` for transient `ConnectionError` when posting metrics to Snuba
- The test calls `_make_sessions(60)` which generates 120+ individual HTTP POST requests to Snuba (2+ metrics per session). Under CI load, any one of these can fail with `RemoteDisconnected: Remote end closed connection without response`
- The retry only catches `requests.ConnectionError`, so genuine failures still propagate immediately

Fixes https://github.com/getsentry/sentry/issues/108869