### PR TITLE
fix(tests): Fix flaky test_unmerge non-deterministic group ordering

### DIFF
--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -261,7 +261,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
         events.setdefault(get_fingerprint(event), []).append(event)
 
-        merge_source, source, destination = list(Group.objects.all())
+        merge_source, source, destination = list(Group.objects.all().order_by("id"))
 
         assert len(events) == 3
         assert sum(len(x) for x in events.values()) == 17


### PR DESCRIPTION
## Summary
- Add explicit `order_by("id")` to `Group.objects.all()` when assigning `merge_source`, `source`, and `destination` groups
- Without ordering, the three groups could be assigned to the wrong variables, causing the merge to operate on wrong groups (e.g., merging group2 into group3 instead of group1 into group2)
- When groups were assigned as `(group2, group3, group1)` instead of `(group1, group2, group3)`, the source ended up with 7 events instead of 6

Fixes https://github.com/getsentry/sentry/issues/108872