### PR TITLE
fix(tests): Fix flaky test_get suspect flags group_id collision

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_flags.py
@@ -28,6 +28,7 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
             first_seen=today - datetime.timedelta(hours=1),
             last_seen=today + datetime.timedelta(hours=1),
         )
+        baseline_group = self.create_group()
 
         self._mock_event(
             today,
@@ -46,7 +47,7 @@ class OrganizationGroupSuspectFlagsTestCase(APITestCase, SnubaTestCase):
                 {"flag": "key", "result": False},
                 {"flag": "other", "result": False},
             ],
-            group_id=2,
+            group_id=baseline_group.id,
             project_id=self.project.id,
         )
 


### PR DESCRIPTION
## Summary
- Use a dynamically created group for the baseline event instead of hardcoded `group_id=2`
- When `self.create_group()` returned `id=2`, both events had the same group_id, causing both to be counted as outliers instead of one outlier and one baseline
- This led to wrong distribution values and different flag ordering due to changed scores

Fixes https://github.com/getsentry/sentry/issues/108871