### PR TITLE
fix(tests): Fix flaky test_get_ai_labels_from_tags data leak

### DIFF
--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -55,8 +55,8 @@ class TestLabelQuery(APITestCase):
             ],
             where=[
                 Condition(Column("project_id"), Op.EQ, self.project.id),
-                Condition(Column("timestamp"), Op.GTE, before_now(days=30)),
-                Condition(Column("timestamp"), Op.LT, before_now(days=0)),
+                Condition(Column("timestamp"), Op.GTE, before_now(days=3)),
+                Condition(Column("timestamp"), Op.LT, before_now(hours=12)),
                 Condition(Column("occurrence_type_id"), Op.EQ, FeedbackGroup.type_id),
             ],
             orderby=[OrderBy(Column("timestamp"), Direction.ASC)],


### PR DESCRIPTION
## Summary
- Narrow the Snuba query time range from `[now-30d, now)` to `[now-3d, now-12h)` to exclude feedbacks created by other test methods in the same class
- Other tests create feedbacks at `now-5min` (the default timestamp from `mock_feedback_event`), which leaked into this test's broad 30-day query window
- The test creates its own feedbacks at `now-2d` and `now-1d`, which are well within the narrowed range

Fixes https://github.com/getsentry/sentry/issues/108873