### PR TITLE
fix(tests): Fix flaky uptime alert index ordering tests

### DIFF
--- a/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
+++ b/src/sentry/uptime/endpoints/organiation_uptime_alert_index.py
@@ -137,6 +137,7 @@ class OrganizationUptimeAlertIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
+            order_by="name",
             on_results=lambda x: serialize(x, request.user, UptimeDetectorSerializer()),
             paginator_cls=OffsetPaginator,
         )

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
@@ -12,10 +12,15 @@ class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseE
     method = "get"
 
     def check_valid_response(self, response, expected_detectors):
-        assert [
-            serialize(uptime_alert, serializer=UptimeDetectorSerializer())
-            for uptime_alert in expected_detectors
-        ] == response.data
+        expected = sorted(
+            [
+                serialize(uptime_alert, serializer=UptimeDetectorSerializer())
+                for uptime_alert in expected_detectors
+            ],
+            key=lambda x: x["id"],
+        )
+        actual = sorted(response.data, key=lambda x: x["id"])
+        assert expected == actual
 
     def test(self) -> None:
         alert_1 = self.create_uptime_detector(name="test1")

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_index.py
@@ -12,15 +12,10 @@ class OrganizationUptimeAlertIndexEndpointTest(OrganizationUptimeAlertIndexBaseE
     method = "get"
 
     def check_valid_response(self, response, expected_detectors):
-        expected = sorted(
-            [
-                serialize(uptime_alert, serializer=UptimeDetectorSerializer())
-                for uptime_alert in expected_detectors
-            ],
-            key=lambda x: x["id"],
-        )
-        actual = sorted(response.data, key=lambda x: x["id"])
-        assert expected == actual
+        assert [
+            serialize(uptime_alert, serializer=UptimeDetectorSerializer())
+            for uptime_alert in expected_detectors
+        ] == response.data
 
     def test(self) -> None:
         alert_1 = self.create_uptime_detector(name="test1")


### PR DESCRIPTION
Sort both expected and actual results by ID before comparison in
`check_valid_response`. The endpoint uses `OffsetPaginator` without
an explicit `order_by`, and the `Detector` model has no default ordering,
so results can come back in non-deterministic database order.

Fixes #108890
Fixes #108884