### PR TITLE
fix(tests): Fix flaky detector serializer trigger ordering

### DIFF
--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -28,12 +28,19 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
     def setUp(self) -> None:
         super().setUp()
 
+    @staticmethod
+    def _sort_triggers(data: dict[str, Any]) -> dict[str, Any]:
+        """Sort triggers by id so ordering doesn't affect comparison."""
+        result = data.copy()
+        result["triggers"] = sorted(result.get("triggers", []), key=lambda t: t["id"])
+        return result
+
     def test_simple(self) -> None:
         self.add_warning_trigger()
         serialized_detector = serialize(
             self.detector, self.user, WorkflowEngineDetectorSerializer()
         )
-        assert serialized_detector == self.expected
+        assert self._sort_triggers(serialized_detector) == self._sort_triggers(self.expected)
 
     def test_latest_incident(self) -> None:
         self.add_warning_trigger()
@@ -181,7 +188,7 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
             self.user,
             WorkflowEngineDetectorSerializer(prepare_component_fields=True),
         )
-        assert serialized_detector == sentry_app_expected
+        assert self._sort_triggers(serialized_detector) == self._sort_triggers(sentry_app_expected)
 
     def test_new_models_only(self) -> None:
         # test that we can still serialize if objects do not have lookup table entries


### PR DESCRIPTION
Sort triggers by ID before comparison in TestDetectorSerializer. The
serializer iterates an unordered `DataCondition` queryset, so triggers
can come back in non-deterministic order.

Fixes #108887