### PR TITLE
fix(tests): Fix flaky auth channel login redirect test

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -342,6 +342,16 @@ class BaseTestCase(Fixtures):
                 sso_session = SsoSession.create(o)
                 self.session[sso_session.session_key] = sso_session.to_dict()
 
+        # Set the active organization in the session when an organization_id
+        # is provided, so views that check activeorg see the correct value.
+        if organization_id:
+            with assume_test_silo_mode(SiloMode.REGION):
+                try:
+                    org = Organization.objects.get(id=organization_id)
+                    self.session["activeorg"] = org.slug
+                except Organization.DoesNotExist:
+                    pass
+
         # logging in implicitly binds superuser, but for test cases we
         # want that action to be explicit to avoid accidentally testing
         # superuser-only code

--- a/tests/sentry/web/frontend/test_auth_channel_login.py
+++ b/tests/sentry/web/frontend/test_auth_channel_login.py
@@ -28,12 +28,7 @@ class AuthOrganizationChannelLoginTest(TestCase):
         ]
 
     def test_redirect_for_logged_in_user_with_different_active_org(self) -> None:
-        self.login_as(self.user)  # log in to "test org"
-        # Explicitly set the active org in the session so the view sees a
-        # different org than the one being accessed via the channel URL.
-        session = self.client.session
-        session["activeorg"] = self.organization.slug
-        session.save()
+        self.login_as(self.user, organization_id=self.organization.id)
         another_org = self.create_organization(name="another org", owner=self.user)
         self.create_auth_provider("another-fly-org", another_org.id)
         path = reverse("sentry-auth-channel", args=["fly", "another-fly-org"])

--- a/tests/sentry/web/frontend/test_auth_channel_login.py
+++ b/tests/sentry/web/frontend/test_auth_channel_login.py
@@ -29,6 +29,11 @@ class AuthOrganizationChannelLoginTest(TestCase):
 
     def test_redirect_for_logged_in_user_with_different_active_org(self) -> None:
         self.login_as(self.user)  # log in to "test org"
+        # Explicitly set the active org in the session so the view sees a
+        # different org than the one being accessed via the channel URL.
+        session = self.client.session
+        session["activeorg"] = self.organization.slug
+        session.save()
         another_org = self.create_organization(name="another org", owner=self.user)
         self.create_auth_provider("another-fly-org", another_org.id)
         path = reverse("sentry-auth-channel", args=["fly", "another-fly-org"])


### PR DESCRIPTION
Explicitly set the active org in the session before creating a second
org. Without this, `determine_active_organization` picks any of the
user's orgs non-deterministically, sometimes matching the target org
and skipping the expected login redirect.

Fixes #108881
Fixes #108900