### PR TITLE
fix(tests): Fix flaky test_duration timestamp precision

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -502,11 +502,14 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         )
         self.store_event(data, project_id=self.project.id)
         self.transaction = data.copy()
+        # Compute both timestamps from the same base to get an exact 5000ms duration
+        end_time = before_now(seconds=30)
+        start_time = end_time - timedelta(seconds=5)
         self.transaction.update(
             {
                 "transaction": "/city_by_code/",
-                "timestamp": before_now(seconds=30).isoformat(),
-                "start_timestamp": before_now(seconds=35).isoformat(),
+                "timestamp": end_time.isoformat(),
+                "start_timestamp": start_time.isoformat(),
             }
         )
         self.transaction["contexts"]["trace"].update(


### PR DESCRIPTION
Compute both start and end timestamps from the same base time to get
an exact 5000ms duration. Previously, two separate \`before_now()\` calls
could return slightly different \`now\` values, resulting in a 4999ms
duration instead of 5000ms.

Fixes #108877