### PR TITLE
fix(tests): Fix flaky test_taskworker_schedule_parameters missing task imports

### DIFF
--- a/tests/sentry/taskworker/test_config.py
+++ b/tests/sentry/taskworker/test_config.py
@@ -53,7 +53,7 @@ def test_taskworker_schedule_type(name: str, config: dict[str, Any], load_tasks)
     )
 
 
-def test_taskworker_schedule_parameters() -> None:
+def test_taskworker_schedule_parameters(load_tasks) -> None:
     for config in settings.TASKWORKER_SCHEDULES.values():
         (namespace, taskname) = config["task"].split(":")
         task = taskregistry.get_task(namespace, taskname)


### PR DESCRIPTION
## Summary
- Add the `load_tasks` fixture to `test_taskworker_schedule_parameters`, matching the pattern in `test_taskworker_schedule_type`. Without this fixture, tasks may not be imported/registered, causing `KeyError` on `sentry.tasks.send_ping`.

Fixes #108901