### PR TITLE
fix(tests): Fix flaky test_get discover saved queries project ordering

### DIFF
--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -49,7 +49,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["name"] == "Test query"
-        assert response.data[0]["projects"] == self.project_ids
+        assert sorted(response.data[0]["projects"]) == sorted(self.project_ids)
         assert response.data[0]["fields"] == ["test"]
         assert response.data[0]["conditions"] == []
         assert response.data[0]["limit"] == 10


### PR DESCRIPTION
## Summary
- Sort both sides of the project IDs comparison in `test_get` since the API may return project IDs in a different order than they were created
- The `DiscoverSavedQuery.set_projects` stores project IDs but the serializer doesn't guarantee ordering

Fixes #108912