### PR TITLE
fix(tests): Fix flaky test_update detector details condition ordering

### DIFF
--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -296,7 +296,9 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         conditions = list(DataCondition.objects.filter(condition_group=condition_group))
         assert len(conditions) == 2
-        condition = conditions[0]
+        condition = DataCondition.objects.get(
+            condition_group=condition_group, type=Condition.GREATER.value
+        )
         self.assert_data_condition_updated(condition)
 
         data_source_detector = DataSourceDetector.objects.get(detector=detector)


### PR DESCRIPTION
## Summary
- Use `DataCondition.objects.get(type=Condition.GREATER.value)` instead of `conditions[0]` to select the specific condition to assert on
- The `DataCondition.objects.filter(condition_group=...)` queryset has no explicit ordering, so `conditions[0]` could be either the GREATER or LESS_OR_EQUAL condition

Fixes #108911