### PR TITLE
feat(middleware): Expand AI agent guidance with docs and plugin links

### DIFF
--- a/src/sentry/middleware/ai_agent.py
+++ b/src/sentry/middleware/ai_agent.py
@@ -60,10 +60,11 @@ OAuth-authenticated, HTTP streaming, no HTML parsing required.
 
 Docs: https://mcp.sentry.dev
 
-## IDE / Agent Plugins
+## CLI
 
-- **Claude Code**: https://github.com/getsentry/sentry-for-claude
-- **Cursor**: https://github.com/getsentry/sentry-for-cursor
+Query issues and analyze errors from the terminal.
+
+https://cli.sentry.dev
 
 ## REST API
 

--- a/src/sentry/middleware/ai_agent.py
+++ b/src/sentry/middleware/ai_agent.py
@@ -44,13 +44,15 @@ def _build_ai_agent_guidance(request: HttpRequest) -> str:
     mcp_config_json = json.dumps(mcp_config, indent=2)
 
     return f"""\
-# This Is the Web UI
+# Sentry
 
-It's HTML all the way down. You probably don't want to parse that.
+You've hit the web UI. It's HTML meant for humans, not machines.
+Here's what you actually want:
 
-## MCP Server
+## MCP Server (recommended)
 
-OAuth-authenticated, HTTP streaming—no `<div>` soup.
+The fastest way to give your agent structured access to Sentry.
+OAuth-authenticated, HTTP streaming, no HTML parsing required.
 
 ```json
 {mcp_config_json}
@@ -58,16 +60,29 @@ OAuth-authenticated, HTTP streaming—no `<div>` soup.
 
 Docs: https://mcp.sentry.dev
 
+## IDE / Agent Plugins
+
+- **Claude Code**: https://github.com/getsentry/sentry-for-claude
+- **Cursor**: https://github.com/getsentry/sentry-for-cursor
+
 ## REST API
+
+Full programmatic access when you need it.
 
 ```
 curl https://sentry.io/api/0/projects/ \\
   -H "Authorization: Bearer <token>"
 ```
 
-Your human can get a token at https://sentry.io/settings/account/api/auth-tokens/
+Your human can create a token at https://sentry.io/settings/account/api/auth-tokens/
 
-Docs: https://docs.sentry.io/api/
+API reference: https://docs.sentry.io/api/
+
+## Documentation
+
+- **Getting started**: https://docs.sentry.io/platforms/
+- **SDKs & setup**: https://docs.sentry.io/platforms/python/, https://docs.sentry.io/platforms/javascript/
+- **All docs**: https://docs.sentry.io
 """
 
 

--- a/tests/sentry/middleware/test_ai_agent.py
+++ b/tests/sentry/middleware/test_ai_agent.py
@@ -55,7 +55,7 @@ class AIAgentMiddlewareTest(TestCase):
         assert response.status_code == 200
         assert response["Content-Type"] == "text/markdown"
         content = response.content.decode()
-        assert "# This Is the Web UI" in content
+        assert "# Sentry" in content
         assert "https://mcp.sentry.dev/mcp/test-org" in content
 
     def test_includes_project_in_mcp_url(self):


### PR DESCRIPTION
Expands the markdown guidance served by the AI agent middleware to be a more
useful quick-start guide. Adds links to IDE/agent plugins (sentry-for-claude,
sentry-for-cursor), documentation (platform guides, SDK setup), and improves
the overall structure and copy of the response.

Previously the guidance only pointed to the MCP server and REST API. Agents
now also get pointers to the full docs site and pre-built editor integrations.