### PR TITLE
fix(tests): Fix flaky ProjectUserDetailsTest Snuba data leak

### DIFF
--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -1,13 +1,13 @@
 from django.urls import reverse
 
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
 
 
-class ProjectUserDetailsTest(APITestCase):
+class ProjectUserDetailsTest(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()


### PR DESCRIPTION
## Summary
- Add `SnubaTestCase` to `ProjectUserDetailsTest` so the `reset_snuba` fixture drops ClickHouse data between test runs, preventing stale user data from inflating the distinct user count (3 instead of expected 2).

Fixes #108943

## Test plan
- [x] Test passes 10/10 times locally with `--reuse-db`