### PR TITLE
fix(tests): Fix flaky test_basic_post_with_invalid_integrationId ID collision

### DIFF
--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings.py
@@ -190,13 +190,13 @@ class OrganizationCodeMappingsTest(APITestCase):
         assert len(response.data) == 2
 
     def test_basic_get_with_invalid_integrationId(self) -> None:
-        url_path = f"{self.url}?integrationId=100"
+        url_path = f"{self.url}?integrationId=999999999"
         response = self.client.get(url_path, format="json")
 
         assert response.status_code == 404, response.content
 
     def test_basic_get_with_invalid_projectId(self) -> None:
-        url_path = f"{self.url}?project=100"
+        url_path = f"{self.url}?project=999999999"
         response = self.client.get(url_path, format="json")
 
         assert response.status_code == 403, response.content
@@ -270,7 +270,7 @@ class OrganizationCodeMappingsTest(APITestCase):
         assert response.status_code == 403, response.content
 
     def test_basic_post_with_invalid_integrationId(self) -> None:
-        response = self.make_post({"integrationId": 100})
+        response = self.make_post({"integrationId": 999999999})
         assert response.status_code == 404, response.content
 
     def test_basic_post_with_no_integrationId(self) -> None:


### PR DESCRIPTION
## Summary
- Replace hardcoded ID `100` with `999999999` for "invalid" integration and project IDs in code mappings tests. With `--reuse-db`, auto-incrementing IDs can reach 100 and collide with test expectations of non-existent resources.

Fixes #108942

## Test plan
- [x] Test passes 10/10 times locally with `--reuse-db`