### PR TITLE
fix(tests): Fix flaky test_link_all_repos non-deterministic ordering

### DIFF
--- a/tests/sentry/integrations/github/tasks/test_link_all_repos.py
+++ b/tests/sentry/integrations/github/tasks/test_link_all_repos.py
@@ -71,7 +71,7 @@ class LinkAllReposTestCase(IntegrationTestCase):
         )
 
         with assume_test_silo_mode(SiloMode.REGION):
-            repos = Repository.objects.all()
+            repos = Repository.objects.all().order_by("name")
         assert len(repos) == 2
 
         for repo in repos:


### PR DESCRIPTION
## Summary
- Add explicit `order_by("name")` to `Repository.objects.all()` query so positional assertions on repo names are deterministic.

Fixes #108941

## Test plan
- [x] Test passes 10/10 times locally with `--reuse-db`