### PR TITLE
fix(tests): Fix flaky test_error_handled_alias Snuba data leak

### DIFF
--- a/tests/sentry/snuba/test_errors.py
+++ b/tests/sentry/snuba/test_errors.py
@@ -800,6 +800,11 @@ class ErrorsQueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_error_handled_alias(self) -> None:
         project = self.create_project(organization=self.organization)
+        # Use a dedicated project and a timestamp far in the past (hours=4) to
+        # isolate this test from Snuba data written by concurrent tests. Most
+        # other tests store events with before_now(minutes=N), so placing our
+        # events 4 hours back—combined with a tight query window around that
+        # timestamp—prevents data leakage from other tests polluting results.
         event_time = before_now(hours=4)
         data = load_data("android-ndk", timestamp=event_time)
         events = (

--- a/tests/sentry/snuba/test_errors.py
+++ b/tests/sentry/snuba/test_errors.py
@@ -799,7 +799,9 @@ class ErrorsQueryIntegrationTest(SnubaTestCase, TestCase):
                 assert data[0]["tpm_60"] == 6
 
     def test_error_handled_alias(self) -> None:
-        data = load_data("android-ndk", timestamp=before_now(minutes=10))
+        project = self.create_project(organization=self.organization)
+        event_time = before_now(minutes=10)
+        data = load_data("android-ndk", timestamp=event_time)
         events = (
             ("a" * 32, "not handled", False),
             ("b" * 32, "is handled", True),
@@ -810,7 +812,7 @@ class ErrorsQueryIntegrationTest(SnubaTestCase, TestCase):
             data["logentry"] = {"formatted": event[1]}
             data["exception"]["values"][0]["value"] = event[1]
             data["exception"]["values"][0]["mechanism"]["handled"] = event[2]
-            self.store_event(data=data, project_id=self.project.id)
+            self.store_event(data=data, project_id=project.id)
 
         queries: list[tuple[str, list[int]]] = [
             ("", [0, 1, 1]),
@@ -828,9 +830,9 @@ class ErrorsQueryIntegrationTest(SnubaTestCase, TestCase):
                 query=query,
                 snuba_params=SnubaParams(
                     organization=self.organization,
-                    projects=[self.project],
-                    start=before_now(minutes=12),
-                    end=before_now(minutes=8),
+                    projects=[project],
+                    start=event_time - timedelta(minutes=2),
+                    end=event_time + timedelta(minutes=2),
                 ),
                 referrer="errors",
             )

--- a/tests/sentry/snuba/test_errors.py
+++ b/tests/sentry/snuba/test_errors.py
@@ -800,7 +800,7 @@ class ErrorsQueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_error_handled_alias(self) -> None:
         project = self.create_project(organization=self.organization)
-        event_time = before_now(minutes=10)
+        event_time = before_now(hours=4)
         data = load_data("android-ndk", timestamp=event_time)
         events = (
             ("a" * 32, "not handled", False),


### PR DESCRIPTION
## Summary
- Use a dedicated project and tight time window (±2min around event_time) to isolate from setUp events and any leaked ClickHouse data from other test methods that store events at similar timestamps.

Fixes #108940

## Test plan
- [x] Test passes 10/10 times locally with `--reuse-db`