### PR TITLE
fix(tests): Fix flaky test_disable_alerts_multiple_scopes owner ordering

### DIFF
--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -259,7 +259,10 @@ class GetSendToOwnersTest(_ParticipantsTest):
 
         user_ids = list(self.project.member_set.values_list("user_id", flat=True))
         with assume_test_silo_mode(SiloMode.CONTROL):
-            users = [Owner("user", user.email) for user in User.objects.filter(id__in=user_ids)]
+            users = [
+                Owner("user", user.email)
+                for user in User.objects.filter(id__in=user_ids).order_by("id")
+            ]
         ProjectOwnership.objects.create(
             project_id=self.project.id,
             schema=dump_schema(


### PR DESCRIPTION
## Summary
- Add `order_by("id")` to User query when building the `*.cbl` ownership rule in `GetSendToOwnersTest.setUp()`. `get_owners()` returns only the last owner (`owners[-1:]`) for auto-assignment, so non-deterministic ordering of the User query caused different users to be selected as the sole recipient depending on database row order.

Fixes #108936

## Test plan
- [x] Test passes 10/10 times locally with `--reuse-db`