### PR TITLE
fix(tests): Fix flaky test_get_projects_by_slugs_all project ordering

### DIFF
--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -585,13 +585,13 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             self.org,
         )
 
-        mock__filter_projects_by_permissions.assert_called_with(
-            projects=[self.project_1, self.project_2],
-            request=request,
-            filter_by_membership=False,
-            force_global_perms=False,
-            include_all_accessible=True,
-        )
+        mock__filter_projects_by_permissions.assert_called_once()
+        call_kwargs = mock__filter_projects_by_permissions.call_args.kwargs
+        assert set(call_kwargs["projects"]) == {self.project_1, self.project_2}
+        assert call_kwargs["request"] == request
+        assert call_kwargs["filter_by_membership"] is False
+        assert call_kwargs["force_global_perms"] is False
+        assert call_kwargs["include_all_accessible"] is True
         assert len(response) == 2
         assert self.project_1 in response
         assert self.project_2 in response


### PR DESCRIPTION
## Summary
- Fix flaky `test_get_projects_by_slugs_all` by checking `projects` as a set instead of an ordered list
- The test used `assert_called_with(projects=[p1, p2], ...)` but the DB query doesn't guarantee ordering
- Now uses `assert_called_once()` and verifies kwargs individually, comparing projects as a set

Fixes https://github.com/getsentry/sentry/issues/108954
Also fixes duplicate https://github.com/getsentry/sentry/issues/108950

## Test plan
- [x] Test passes 10/10 locally