### PR TITLE
fix(tests): Fix flaky test_update_with_project_write_bulk_enrollment snowflake ID collision

### DIFF
--- a/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_data_forwarding_details.py
@@ -1,9 +1,12 @@
+from datetime import datetime, timedelta, timezone
+
 from django.urls import reverse
 
 from sentry.integrations.models.data_forwarder import DataForwarder
 from sentry.integrations.models.data_forwarder_project import DataForwarderProject
 from sentry.integrations.types import DataForwarderProviderSlug
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import region_silo_test
 
 
@@ -170,6 +173,7 @@ class DataForwardingDetailsPutTest(DataForwardingDetailsEndpointTest):
         )
         assert "invalid project ids" in str(response.data).lower()
 
+    @freeze_time(datetime.now(tz=timezone.utc) - timedelta(hours=1))
     def test_update_with_project_write_bulk_enrollment(self) -> None:
         """Test bulk enrollment of multiple projects by project:write user"""
         data_forwarder = self.create_data_forwarder(


### PR DESCRIPTION
## Summary
- Fix flaky `test_update_with_project_write_bulk_enrollment` which intermittently failed with `MaxSnowflakeRetryError`
- Snowflake IDs use a 4-bit sequence counter per timestamp in Redis; accumulated state from other tests can exhaust available sequences, causing all 5 retries to generate IDs that collide with existing DB entries
- Fix by freezing time to a past timestamp (1 hour ago), ensuring the Redis counters have expired and generated IDs won't collide

Fixes https://github.com/getsentry/sentry/issues/108955

## Test plan
- [x] Test passes 10/10 locally
- [x] Full test class passes