### PR TITLE
fix(tests): Fix flaky test_snuba_data_transaction timestamp drift

### DIFF
--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -17,7 +17,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import snuba
@@ -279,6 +279,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
         assert not event_from_nodestore.group_id
         assert not event_from_nodestore.group
 
+    @freeze_time()
     def test_snuba_data_transaction(self) -> None:
         self.store_event(
             data={


### PR DESCRIPTION
## Summary
- Fix flaky `test_snuba_data_transaction` by freezing time
- The test compared nodestore and Snuba timestamps, but `before_now()` calls at different real-time moments caused off-by-one second differences
- `freeze_time()` makes all timestamp computations deterministic

Fixes https://github.com/getsentry/sentry/issues/108963

## Test plan
- [x] Test passes 10/10 locally