### PR TITLE
fix(tests): Fix flaky test_datetime_uses_timestamp_ms_from_snuba precision

### DIFF
--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -17,7 +17,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import snuba
@@ -690,6 +690,7 @@ class EventNodeStoreTest(TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.data.get_ref(event) == event.project.id
 
+    @freeze_time()
     def test_datetime_uses_timestamp_ms_from_snuba(self) -> None:
         second_before_now = before_now(seconds=1)
         second_before_now_str = second_before_now.isoformat()


### PR DESCRIPTION
## Summary
- Fix flaky `test_datetime_uses_timestamp_ms_from_snuba` by freezing time
- `before_now(seconds=1)` produces non-deterministic microseconds; Snuba's `timestamp_ms` column doesn't consistently preserve microsecond precision
- `freeze_time()` ensures `before_now()` always returns the same value, eliminating precision mismatches

Fixes https://github.com/getsentry/sentry/issues/108969

## Test plan
- [x] Test passes 10/10 locally
- [x] Full EventNodeStoreTest class passes