### PR TITLE
fix(tests): Fix flaky test_query_single_group empty results

### DIFF
--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -98,6 +98,7 @@ class HistoricGroupCounts(
             "project_id": event.project_id,
         }
 
+    @freeze_time(TIME_YESTERDAY)
     def test_query_single_group(self) -> None:
         event = self._create_events_for_group()
         assert query_groups_past_counts(Group.objects.all()) == [


### PR DESCRIPTION
## Summary
- Fix flaky `test_query_single_group` by adding `@freeze_time(TIME_YESTERDAY)`
- `_create_events_for_group` and `_start_and_end_dates` each call `datetime.now()` independently — these can drift, especially near hour boundaries, causing the event timestamp to fall outside the Snuba query window
- Uses the existing `TIME_YESTERDAY` pattern already used by sibling tests in the same class

Fixes https://github.com/getsentry/sentry/issues/108965

## Test plan
- [x] Test passes 10/10 locally