### PR TITLE
fix(tests): Fix flaky test_homepage_query bucket count

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -2,10 +2,16 @@ from datetime import timedelta
 
 from django.urls import reverse
 
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
+# Freeze time to ensure statsPeriod="14d" produces a deterministic number
+# of hourly buckets. Without freezing, the bucket count can vary by ±1
+# depending on when the test runs relative to hour boundaries.
+_FROZEN_TIME = before_now(hours=3).replace(minute=30, second=0, microsecond=0)
 
+
+@freeze_time(_FROZEN_TIME)
 class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-stats"
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -5,13 +5,11 @@ from django.urls import reverse
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
+
 # Freeze time to ensure statsPeriod="14d" produces a deterministic number
 # of hourly buckets. Without freezing, the bucket count can vary by ±1
 # depending on when the test runs relative to hour boundaries.
-_FROZEN_TIME = before_now(hours=3).replace(minute=30, second=0, microsecond=0)
-
-
-@freeze_time(_FROZEN_TIME)
+@freeze_time(before_now(hours=3).replace(minute=30, second=0, microsecond=0))
 class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestBase):
     endpoint = "sentry-api-0-organization-events-stats"
 


### PR DESCRIPTION
## Summary
- Fix flaky `test_homepage_query` which expected exactly 338 hourly buckets from `statsPeriod=14d`
- The bucket count depends on the exact current time relative to hour boundaries, causing ±1 variance
- Fix by applying `@freeze_time` at the class level to make all time computations deterministic
- All other tests in the class continue to pass

Fixes https://github.com/getsentry/sentry/issues/108964

## Test plan
- [x] Test passes 10/10 locally
- [x] All 8 tests in the class pass