### PR TITLE
fix(tests): Fix flaky test_gracefully_handles_missing_user ID collision

### DIFF
--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -1430,7 +1430,7 @@ class TestInstallationWebhook(TestCase):
     def test_gracefully_handles_missing_user(self, mock_record: MagicMock) -> None:
         responses.add(responses.POST, "https://example.com/webhook")
 
-        installation_webhook(self.install.id, 999)
+        installation_webhook(self.install.id, 2147483647)
         assert len(responses.calls) == 0
 
         # SLO assertions


### PR DESCRIPTION
## Summary
- Use a large user ID (2147483647) instead of 999 to ensure the user doesn't exist in the test database
- With sequential auto-increment IDs, user ID 999 can be created by other tests running before this one, causing the missing-user code path to be bypassed

Fixes #108980

## Test plan
- [x] Ran test 10 times locally, all passed