### PR TITLE
fix(tests): Fix flaky test_get suspect tags group ID collision

### DIFF
--- a/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_suspect_tags.py
@@ -23,6 +23,7 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
             first_seen=today - datetime.timedelta(hours=1),
             last_seen=today + datetime.timedelta(hours=1),
         )
+        other_group = self.create_group()
 
         self._mock_event(
             today,
@@ -35,7 +36,7 @@ class OrganizationGroupSuspectTagsTestCase(APITestCase, SnubaTestCase):
             today,
             hash="a" * 32,
             tags={"key": False, "other": False},
-            group_id=2,
+            group_id=other_group.id,
             project_id=self.project.id,
         )
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `group_id=2` with a dynamically created group for the background event
- When the auto-incremented ID of the target group happens to equal 2, both events end up in the same group, making tag distributions identical and producing a KL divergence score of 0.0 instead of the expected non-zero value

Fixes #108979

## Test plan
- [x] Ran test 10 times locally, all passed