### PR TITLE
fix(tests): Fix flaky test_only_issue_alert_rules ordering assumption

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -670,8 +670,9 @@ class CombinedQuerysetPaginator:
             sort_keys = []
             sort_keys.append(self.get_item_key(item))
             if len(self.model_key_map[type(item)]) > 1:
-                for key in self.model_key_map[type(item)][1:]:
-                    sort_keys.append(self._prep_value(item, key, is_prev))
+                # XXX: This doesn't do anything - it just uses a column name as the sort key. It should be pulling the
+                # value of the other keys out instead.
+                sort_keys.extend(iter(self.model_key_map[type(item)][1:]))
             sort_keys.append(type(item).__name__)
             return tuple(sort_keys)
 

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -670,9 +670,8 @@ class CombinedQuerysetPaginator:
             sort_keys = []
             sort_keys.append(self.get_item_key(item))
             if len(self.model_key_map[type(item)]) > 1:
-                # XXX: This doesn't do anything - it just uses a column name as the sort key. It should be pulling the
-                # value of the other keys out instead.
-                sort_keys.extend(iter(self.model_key_map[type(item)][1:]))
+                for key in self.model_key_map[type(item)][1:]:
+                    sort_keys.append(self._prep_value(item, key, is_prev))
             sort_keys.append(type(item).__name__)
             return tuple(sort_keys)
 

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from unittest import TestCase as SimpleTestCase
 
 import pytest
-from django.db.models import DateTimeField, IntegerField, OuterRef, Subquery, Value
+from django.db.models import DateTimeField, F, IntegerField, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
@@ -656,13 +656,16 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         Rule.objects.all().delete()
         rule_ids = []
 
+        base_time = timezone.now()
         for i in range(1, 9):
             rule = self.create_project_rule(name=f"rule{i}")
+            # Set distinct date_added so the paginator has deterministic ordering
+            Rule.objects.filter(id=rule.id).update(date_added=base_time + timedelta(minutes=i))
             rule_ids.append(rule.id)
 
         rules = Rule.objects.all()
-        far_past_date = Value(datetime.min.replace(tzinfo=UTC), output_field=DateTimeField())
-        rules = rules.annotate(date_triggered=far_past_date)
+        # Use each rule's date_added as date_triggered for distinct sort values
+        rules = rules.annotate(date_triggered=F("date_added"))
         incident_status_value = Value(-2, output_field=IntegerField())
         rules = rules.annotate(incident_status=incident_status_value)
 
@@ -677,19 +680,18 @@ class CombinedQuerysetPaginatorTest(APITestCase):
             desc=True,
         )
 
+        # desc=True: rules ordered newest first (rule8, rule7, ..., rule1)
         result = paginator.get_result(limit=5, cursor=None)
         assert len(result) == 5
         page1_results = list(result)
-        page1_ids = {r.id for r in page1_results}
-        assert page1_ids <= set(rule_ids)
+        assert page1_results[0].id == rule_ids[7]
+        assert page1_results[4].id == rule_ids[3]
 
         next_cursor = result.next
         result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 3
-        page2_ids = {r.id for r in page2_results}
-        assert page2_ids <= set(rule_ids)
-        assert page1_ids | page2_ids == set(rule_ids)
+        assert page2_results[-1].id == rule_ids[0]
 
         prev_cursor = result.prev
         result = list(paginator.get_result(limit=5, cursor=prev_cursor))

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime, timedelta
 from unittest import TestCase as SimpleTestCase
 
 import pytest
-from django.db.models import DateTimeField, F, IntegerField, OuterRef, Subquery, Value
+from django.db.models import DateTimeField, IntegerField, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
@@ -656,16 +656,13 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         Rule.objects.all().delete()
         rule_ids = []
 
-        base_time = timezone.now()
         for i in range(1, 9):
             rule = self.create_project_rule(name=f"rule{i}")
-            # Set distinct date_added so the paginator has deterministic ordering
-            Rule.objects.filter(id=rule.id).update(date_added=base_time + timedelta(minutes=i))
             rule_ids.append(rule.id)
 
         rules = Rule.objects.all()
-        # Use each rule's date_added as date_triggered for distinct sort values
-        rules = rules.annotate(date_triggered=F("date_added"))
+        far_past_date = Value(datetime.min.replace(tzinfo=UTC), output_field=DateTimeField())
+        rules = rules.annotate(date_triggered=far_past_date)
         incident_status_value = Value(-2, output_field=IntegerField())
         rules = rules.annotate(incident_status=incident_status_value)
 
@@ -680,23 +677,24 @@ class CombinedQuerysetPaginatorTest(APITestCase):
             desc=True,
         )
 
-        # desc=True: rules ordered newest first (rule8, rule7, ..., rule1)
         result = paginator.get_result(limit=5, cursor=None)
         assert len(result) == 5
         page1_results = list(result)
-        assert page1_results[0].id == rule_ids[7]
-        assert page1_results[4].id == rule_ids[3]
+        page1_ids = {r.id for r in page1_results}
 
         next_cursor = result.next
         result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 3
-        assert page2_results[-1].id == rule_ids[0]
+        page2_ids = {r.id for r in page2_results}
+
+        assert page1_ids & page2_ids == set()
+        assert page1_ids | page2_ids == set(rule_ids)
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        result = paginator.get_result(limit=5, cursor=prev_cursor)
         assert len(result) == 5
-        assert result == page1_results
+        assert {r.id for r in result} == page1_ids
 
     def test_only_metric_alert_rules(self) -> None:
         project = self.project

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -680,14 +680,16 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         result = paginator.get_result(limit=5, cursor=None)
         assert len(result) == 5
         page1_results = list(result)
-        assert page1_results[0].id == rule_ids[0]
-        assert page1_results[4].id == rule_ids[4]
+        page1_ids = {r.id for r in page1_results}
+        assert page1_ids <= set(rule_ids)
 
         next_cursor = result.next
         result = paginator.get_result(limit=5, cursor=next_cursor)
         page2_results = list(result)
         assert len(result) == 3
-        assert page2_results[-1].id == rule_ids[-1]
+        page2_ids = {r.id for r in page2_results}
+        assert page2_ids <= set(rule_ids)
+        assert page1_ids | page2_ids == set(rule_ids)
 
         prev_cursor = result.prev
         result = list(paginator.get_result(limit=5, cursor=prev_cursor))


### PR DESCRIPTION
## Summary
- Use set-based assertions instead of position-based ones for pagination results
- All rules have identical sort keys (`incident_status=-2`, `date_triggered=datetime.min`), so the database returns them in non-deterministic order
- The test now verifies correct pagination behavior (page sizes, complete coverage, cursor navigation) without assuming specific item positions

Fixes #108983

## Test plan
- [x] Ran test 10 times locally, all passed