### PR TITLE
fix(tests): Reset flusher isolation scope level to fix test pollution

### DIFF
--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import orjson
 import pytest
+import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.dlq import InvalidMessage
 from arroyo.types import BrokerValue, Message, Partition, Topic
@@ -123,48 +124,54 @@ def test_schema_validator_rejects_none_fields(field_to_set_none: str) -> None:
         commits.append(offsets)
 
     step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
-    with pytest.raises(InvalidMessage):
-        span_data = {
-            "organization_id": 1,
-            "project_id": 12,
-            "span_id": "a" * 16,
-            "trace_id": "b" * 32,
-            "start_timestamp": 1699999999.0,
-            "end_timestamp": 1700000000.0,
-            "retention_days": 90,
-            "received": 1699999999.0,
-            "name": "test-span",
-            "status": "ok",
-            "is_segment": False,
-        }
-        # Set the field to None
-        span_data[field_to_set_none] = None
+    try:
+        with pytest.raises(InvalidMessage):
+            span_data = {
+                "organization_id": 1,
+                "project_id": 12,
+                "span_id": "a" * 16,
+                "trace_id": "b" * 32,
+                "start_timestamp": 1699999999.0,
+                "end_timestamp": 1700000000.0,
+                "retention_days": 90,
+                "received": 1699999999.0,
+                "name": "test-span",
+                "status": "ok",
+                "is_segment": False,
+            }
+            # Set the field to None
+            span_data[field_to_set_none] = None
 
-        step.submit(
-            Message(
-                BrokerValue(
-                    partition=Partition(topic, 0),
-                    offset=1,
-                    payload=KafkaPayload(
-                        None,
-                        orjson.dumps(span_data),
-                        [],
-                    ),
-                    timestamp=datetime.now(),
+            step.submit(
+                Message(
+                    BrokerValue(
+                        partition=Partition(topic, 0),
+                        offset=1,
+                        payload=KafkaPayload(
+                            None,
+                            orjson.dumps(span_data),
+                            [],
+                        ),
+                        timestamp=datetime.now(),
+                    )
                 )
             )
-        )
 
-        step.poll()
-        fac._flusher.current_drift.value = 9000
-
-        for _ in range(20):
             step.poll()
-            real_sleep(0.01)
+            fac._flusher.current_drift.value = 9000
 
-    # The span should be rejected by schema validator, so no messages produced
-    assert len(messages) == 0
-    fac._flusher.join()
+            for _ in range(20):
+                step.poll()
+                real_sleep(0.01)
+
+        # The span should be rejected by schema validator, so no messages produced
+        assert len(messages) == 0
+    finally:
+        fac._flusher.join()
+        # The flusher thread sets scope.level = "warning" on the isolation scope.
+        # In tests, the flusher runs as a thread (not subprocess), so this
+        # modification leaks into subsequent tests.
+        sentry_sdk.get_isolation_scope().level = None
 
 
 @override_options(
@@ -190,46 +197,49 @@ def test_schema_validator_rejects_string_timestamps() -> None:
         commits.append(offsets)
 
     step = fac.create_with_partitions(add_commit, {Partition(topic, 0): 0})
-    with pytest.raises(InvalidMessage):
-        span_data = {
-            "organization_id": 1,
-            "project_id": 12,
-            "span_id": "a" * 16,
-            "trace_id": "b" * 32,
-            "start_timestamp": 1699999999.0,
-            "end_timestamp": "1700000000.0",
-            "retention_days": 90,
-            "received": 1699999999.0,
-            "name": "test-span",
-            "status": "ok",
-            "is_segment": False,
-        }
+    try:
+        with pytest.raises(InvalidMessage):
+            span_data = {
+                "organization_id": 1,
+                "project_id": 12,
+                "span_id": "a" * 16,
+                "trace_id": "b" * 32,
+                "start_timestamp": 1699999999.0,
+                "end_timestamp": "1700000000.0",
+                "retention_days": 90,
+                "received": 1699999999.0,
+                "name": "test-span",
+                "status": "ok",
+                "is_segment": False,
+            }
 
-        step.submit(
-            Message(
-                BrokerValue(
-                    partition=Partition(topic, 0),
-                    offset=1,
-                    payload=KafkaPayload(
-                        None,
-                        orjson.dumps(span_data),
-                        [],
-                    ),
-                    timestamp=datetime.now(),
+            step.submit(
+                Message(
+                    BrokerValue(
+                        partition=Partition(topic, 0),
+                        offset=1,
+                        payload=KafkaPayload(
+                            None,
+                            orjson.dumps(span_data),
+                            [],
+                        ),
+                        timestamp=datetime.now(),
+                    )
                 )
             )
-        )
 
-        step.poll()
-        fac._flusher.current_drift.value = 9000
-
-        for _ in range(20):
             step.poll()
-            real_sleep(0.01)
+            fac._flusher.current_drift.value = 9000
 
-    # The span should be rejected by schema validator, so no messages produced
-    assert len(messages) == 0
-    fac._flusher.join()
+            for _ in range(20):
+                step.poll()
+                real_sleep(0.01)
+
+        # The span should be rejected by schema validator, so no messages produced
+        assert len(messages) == 0
+    finally:
+        fac._flusher.join()
+        sentry_sdk.get_isolation_scope().level = None
 
 
 @override_options(


### PR DESCRIPTION
## Summary
- The span consumer flusher thread sets `scope.level = "warning"` on the sentry_sdk isolation scope. In tests, the flusher runs as a thread (not a subprocess), so this modification leaks into subsequent tests.
- Wrap test body in `try/finally` to ensure flusher cleanup, and reset the isolation scope level after joining the flusher thread.
- Also fix `test_schema_validator_rejects_string_timestamps` which has the same pattern.

Fixes https://github.com/getsentry/sentry/issues/108908

## Test plan
- [x] Verified the previously failing pytest invocation now succeeds:
  ```
  pytest tests/sentry/spans/consumers/process/test_consumer.py::test_schema_validator_rejects_none_fields[span_id] tests/sentry/testutils/thread_leaks/test_pytest.py::TestSentryCapture::test_capture_event_allowlisted
  ```