### PR TITLE
fix(tests): Use distinct cluster name in buffer fixture to prevent cache pollution

### DIFF
--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -82,13 +82,22 @@ def buffer(request):
     with override_options(test_options):
         if redis_type == "cluster":
             from sentry.testutils.helpers.redis import use_redis_cluster
+            from sentry.utils import redis as redis_utils
 
-            with use_redis_cluster("default"):
+            # Use a distinct cluster name to avoid poisoning the "default"
+            # entry in RedisClusterManager._clusters_bytes, which would
+            # leak a Redis Cluster client into subsequent tests that expect
+            # standalone Redis under "default".
+            with use_redis_cluster(
+                "span-buffer",
+                with_settings={"SENTRY_SPAN_BUFFER_CLUSTER": "span-buffer"},
+            ):
                 buf = SpansBuffer(assigned_shards=list(range(32)))
-                # since we patch the default redis cluster only temporarily, we
-                # need to clean it up ourselves.
                 buf.client.flushall()
                 yield buf
+                # Clean up cached client so it doesn't persist after the
+                # option override is restored.
+                redis_utils.redis_clusters._clusters_bytes.pop("span-buffer", None)
         else:
             buf = SpansBuffer(assigned_shards=list(range(32)))
             buf.client.flushdb()


### PR DESCRIPTION
## Summary
- The `buffer` fixture in `tests/sentry/spans/test_buffer.py` was calling `use_redis_cluster("default")`, which cached a Redis Cluster client under the `"default"` key in `RedisClusterManager._clusters_bytes`.
- After the context manager exited, this cached client persisted and was returned to subsequent tests calling `redis_clusters.get_binary("default")`, causing them to use the Redis Cluster instead of standalone Redis.
- Use a distinct cluster name (`"span-buffer"`) with a matching `SENTRY_SPAN_BUFFER_CLUSTER` setting override to isolate the cache entry.

Fixes https://github.com/getsentry/sentry/issues/108973

## Test plan
- [x] Verified that single-redis buffer tests run correctly alongside `test_delete_count`
- [x] CI should verify the cluster-redis tests still pass (requires Redis Cluster from `devservices up --mode backend-ci`)