### PR TITLE
fix(grouping): Avoid mutating class-level initial_context in grouping info endpoint

### DIFF
--- a/src/sentry/issues/endpoints/event_grouping_info.py
+++ b/src/sentry/issues/endpoints/event_grouping_info.py
@@ -46,7 +46,12 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
             )
             != StacktraceOrder.MOST_RECENT_LAST
         )
-        grouping_config.initial_context["reverse_stacktraces"] = should_reverse_stacktraces
+        # Create an instance-level copy so we don't mutate the class-level dict,
+        # which is shared across all instances of this config.
+        grouping_config.initial_context = {
+            **grouping_config.initial_context,
+            "reverse_stacktraces": should_reverse_stacktraces,
+        }
 
         grouping_info = get_grouping_info(grouping_config, project, event)
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/getsentry/sentry/issues/108923

Same root cause as #109009. `EventGroupingInfoEndpoint.get()` mutates the class-level `initial_context` dict on `StrategyConfiguration`, causing `reverse_stacktraces` to persist and reverse frame order in subsequent grouping info snapshot tests.

- Create an instance-level copy of `initial_context` before mutating it

## Test plan
- [x] Verified `pytest tests/sentry/issues/endpoints/test_event_grouping_info.py::EventGroupingInfoEndpointTestCase::test_error_event_exception_order tests/sentry/grouping/test_grouping_info.py::test_grouping_info[newstyle:2026_01_20-javascript_xbrowser_edge]` passes