### PR TITLE
fix(tests): Fix flaky test_allow_delete_as_superuser_but_no_edit_perms ID collision

### DIFF
--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -766,11 +766,10 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
         assert response.status_code == 204
 
     def test_allow_delete_as_superuser_but_no_edit_perms(self) -> None:
-        self.create_user(id=12333)
+        other_user = self.create_user()
         dashboard = Dashboard.objects.create(
-            id=67,
             title="Dashboard With Dataset Source",
-            created_by_id=12333,
+            created_by_id=other_user.id,
             organization=self.organization,
         )
         DashboardPermissions.objects.create(is_editable_by_everyone=False, dashboard=dashboard)


### PR DESCRIPTION
## Summary
- Remove hardcoded `id=67` for Dashboard and `id=12333` for User in `test_allow_delete_as_superuser_but_no_edit_perms` which can collide with auto-generated IDs in a reused database

Fixes #109000
Fixes #108998

## Test plan
- [x] Test passes 10/10 times locally