### PR TITLE
fix(tests): Fix flaky test_issue_multiple_status_changes batch timing

### DIFF
--- a/tests/sentry/issues/test_run.py
+++ b/tests/sentry/issues/test_run.py
@@ -465,7 +465,9 @@ class TestBatchedOccurrenceConsumer(
         strategy = OccurrenceStrategyFactory(
             mode="batched-parallel",
             max_batch_size=6,
-            max_batch_time=sys.maxsize,
+            # Use a large batch timeout to prevent time-based flushes during the test,
+            # ensuring all events are processed in a single batch.
+            max_batch_time=300,
         ).create_with_partitions(
             commit=mock_commit,
             partitions={},

--- a/tests/sentry/issues/test_run.py
+++ b/tests/sentry/issues/test_run.py
@@ -465,7 +465,7 @@ class TestBatchedOccurrenceConsumer(
         strategy = OccurrenceStrategyFactory(
             mode="batched-parallel",
             max_batch_size=6,
-            max_batch_time=1,
+            max_batch_time=sys.maxsize,
         ).create_with_partitions(
             commit=mock_commit,
             partitions={},


### PR DESCRIPTION
## Summary
- Change `max_batch_time` from `1` to `sys.maxsize` to prevent time-based batch flushing from splitting messages into multiple batches on slow CI, matching the pattern used by `test_issue_occurrence_status_change_mix`

Fixes #108997

## Test plan
- [x] Test passes 10/10 times locally