### PR TITLE
fix(tests): Fix flaky test_get explore saved queries project ordering

### DIFF
--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -88,7 +88,7 @@ class ExploreSavedQueriesTest(APITestCase):
 
         # User saved query
         assert response.data[3]["name"] == "Test query"
-        assert response.data[3]["projects"] == self.project_ids
+        assert sorted(response.data[3]["projects"]) == sorted(self.project_ids)
         assert response.data[3]["range"] == "24h"
         assert response.data[3]["query"] == [{"fields": ["span.op"], "mode": "samples"}]
         assert "createdBy" in response.data[3]


### PR DESCRIPTION
## Summary
- Sort project IDs before comparing since the API response may return them in non-deterministic order

Fixes #108995

## Test plan
- [x] Test passes 10/10 times locally