### PR TITLE
fix(tests): Fix flaky test_query_recent_feedbacks_with_ai_labels data leak

### DIFF
--- a/tests/sentry/feedback/__init__.py
+++ b/tests/sentry/feedback/__init__.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import uuid4
 
 from sentry.utils import json
 
@@ -21,7 +22,7 @@ def mock_feedback_event(
                 "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
             },
         },
-        "event_id": "56b08cf7852c42cbb95e4a6998c66ad6",
+        "event_id": uuid4().hex,
         "timestamp": dt.timestamp(),
         "received": dt.isoformat(),
         "first_seen": dt.isoformat(),

--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -15,7 +15,7 @@ from sentry.feedback.usecases.label_generation import AI_LABEL_TAG_PREFIX
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.snuba import raw_snql_query
 from tests.sentry.feedback import mock_feedback_event
 
@@ -109,6 +109,7 @@ class TestLabelQuery(APITestCase):
         assert result[2]["label"] == "Checkout" or result[2]["label"] == "Colors"
         assert result[2]["count"] == 1
 
+    @freeze_time("2025-01-15T00:00:00Z")
     def test_query_recent_feedbacks_with_ai_labels(self) -> None:
         self._create_feedback(
             "The UI is too slow and confusing",
@@ -129,7 +130,7 @@ class TestLabelQuery(APITestCase):
         result = query_recent_feedbacks_with_ai_labels(
             organization_id=self.organization.id,
             project_ids=[self.project.id],
-            start=before_now(days=30),
+            start=before_now(days=4),
             end=before_now(days=0),
             limit=1,
         )

--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -14,13 +14,13 @@ from sentry.feedback.usecases.ingest.create_feedback import create_feedback_issu
 from sentry.feedback.usecases.label_generation import AI_LABEL_TAG_PREFIX
 from sentry.issues.grouptype import FeedbackGroup
 from sentry.snuba.dataset import Dataset
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.utils.snuba import raw_snql_query
 from tests.sentry.feedback import mock_feedback_event
 
 
-class TestLabelQuery(APITestCase):
+class TestLabelQuery(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.project = self.create_project()
@@ -89,14 +89,17 @@ class TestLabelQuery(APITestCase):
         self._create_feedback(
             "UI issue 1",
             ["User Interface", "Performance"],
+            dt=before_now(hours=3),
         )
         self._create_feedback(
             "UI issue 2",
             ["Checkout", "User Interface"],
+            dt=before_now(hours=2),
         )
         self._create_feedback(
             "UI issue 3",
             ["Performance", "User Interface", "Colors"],
+            dt=before_now(hours=1),
         )
 
         result = query_top_ai_labels_by_feedback_count(

--- a/tests/sentry/feedback/lib/test_label_query.py
+++ b/tests/sentry/feedback/lib/test_label_query.py
@@ -37,44 +37,53 @@ class TestLabelQuery(APITestCase):
         create_feedback_issue(event, self.project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     def test_get_ai_labels_from_tags_retrieves_labels_correctly(self) -> None:
-        self._create_feedback(
-            "a",
-            ["Authentication"],
-            dt=before_now(days=2),
-        )
-        self._create_feedback(
-            "b",
-            ["Authentication", "Security"],
-            dt=before_now(days=1),
-        )
+        project = self.create_project()
+        original_project = self.project
+        self.project = project
+        try:
+            self._create_feedback(
+                "a",
+                ["Authentication"],
+                dt=before_now(days=2),
+            )
+            self._create_feedback(
+                "b",
+                ["Authentication", "Security"],
+                dt=before_now(days=1),
+            )
 
-        query = Query(
-            match=Entity(Dataset.IssuePlatform.value),
-            select=[
-                _get_ai_labels_from_tags(alias="labels"),
-            ],
-            where=[
-                Condition(Column("project_id"), Op.EQ, self.project.id),
-                Condition(Column("timestamp"), Op.GTE, before_now(days=30)),
-                Condition(Column("timestamp"), Op.LT, before_now(days=0)),
-                Condition(Column("occurrence_type_id"), Op.EQ, FeedbackGroup.type_id),
-            ],
-            orderby=[OrderBy(Column("timestamp"), Direction.ASC)],
-        )
+            query = Query(
+                match=Entity(Dataset.IssuePlatform.value),
+                select=[
+                    _get_ai_labels_from_tags(alias="labels"),
+                ],
+                where=[
+                    Condition(Column("project_id"), Op.EQ, project.id),
+                    Condition(Column("timestamp"), Op.GTE, before_now(days=30)),
+                    Condition(Column("timestamp"), Op.LT, before_now(days=0)),
+                    Condition(Column("occurrence_type_id"), Op.EQ, FeedbackGroup.type_id),
+                ],
+                orderby=[OrderBy(Column("timestamp"), Direction.ASC)],
+            )
 
-        result = raw_snql_query(
-            Request(
-                dataset=Dataset.IssuePlatform.value,
-                app_id="feedback-backend-web",
-                query=query,
-                tenant_ids={"organization_id": self.organization.id},
-            ),
-            referrer="feedbacks.label_query",
-        )
+            result = raw_snql_query(
+                Request(
+                    dataset=Dataset.IssuePlatform.value,
+                    app_id="feedback-backend-web",
+                    query=query,
+                    tenant_ids={"organization_id": project.organization.id},
+                ),
+                referrer="feedbacks.label_query",
+            )
 
-        assert len(result["data"]) == 2
-        assert {label for label in result["data"][0]["labels"]} == {"Authentication"}
-        assert {label for label in result["data"][1]["labels"]} == {"Authentication", "Security"}
+            assert len(result["data"]) == 2
+            assert {label for label in result["data"][0]["labels"]} == {"Authentication"}
+            assert {label for label in result["data"][1]["labels"]} == {
+                "Authentication",
+                "Security",
+            }
+        finally:
+            self.project = original_project
 
     def test_query_top_ai_labels_by_feedback_count(self) -> None:
         self._create_feedback(


### PR DESCRIPTION
## Summary
- Fix `test_query_recent_feedbacks_with_ai_labels` data leak with `@freeze_time` and narrower date window
- Fix `test_get_ai_labels_from_tags_retrieves_labels_correctly` data leak with project isolation (from #108937)
- Add `SnubaTestCase` mixin and `uuid4` event_id to prevent data leaks (from #108791)
- Add explicit timestamps to `test_query_top_ai_labels_by_feedback_count` (from #108640)

Combines #108937, #108907, #108876, #108791, #108640.