### PR TITLE
fix(ai-conversations): select first message

### DIFF
--- a/static/app/views/insights/pages/conversations/components/conversationDrawer.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationDrawer.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/views/insights/pages/conversations/hooks/useConversation';
 import {useFocusedToolSpan} from 'sentry/views/insights/pages/conversations/hooks/useFocusedToolSpan';
 import {useUrlConversationDrawer} from 'sentry/views/insights/pages/conversations/hooks/useUrlConversationDrawer';
+import {extractMessagesFromNodes} from 'sentry/views/insights/pages/conversations/utils/conversationMessages';
 import {useConversationDrawerQueryState} from 'sentry/views/insights/pages/conversations/utils/urlParams';
 import {DEFAULT_TRACE_VIEW_PREFERENCES} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import {TraceStateProvider} from 'sentry/views/performance/newTraceDetails/traceState/traceStateProvider';
@@ -77,7 +78,11 @@ const ConversationDrawerContent = memo(function ConversationDrawerContent({
     [setConversationDrawerQueryState, organization]
   );
 
-  const defaultNodeId = useMemo(() => getDefaultSelectedNode(nodes)?.id, [nodes]);
+  const defaultNodeId = useMemo(() => {
+    const messages = extractMessagesFromNodes(nodes);
+    const firstAssistant = messages.find(m => m.role === 'assistant');
+    return firstAssistant?.nodeId ?? getDefaultSelectedNode(nodes)?.id;
+  }, [nodes]);
 
   const selectedNode = useMemo(() => {
     return (


### PR DESCRIPTION
closes [TET-2000: First conversation message not selected by default](https://linear.app/getsentry/issue/TET-2000/first-conversation-message-not-selected-by-default)