### PR TITLE
fix(ai-conversations): support multi part messages

### DIFF
--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
@@ -81,6 +81,14 @@ describe('conversationMessages utilities', () => {
       expect(extractTextFromMessage(msg)).toBe('Array message');
     });
 
+    it('joins multiple array content elements with newlines', () => {
+      const msg = {
+        role: 'user',
+        content: [{text: 'First part'}, {text: 'Second part'}],
+      };
+      expect(extractTextFromMessage(msg)).toBe('First part\nSecond part');
+    });
+
     it('extracts text from parts format with content field', () => {
       const msg = {
         role: 'user',

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -260,7 +260,7 @@ export function extractTextFromMessage(msg: RequestMessage): string | null {
   }
 
   if (Array.isArray(msg.content)) {
-    const texts = msg.content.map(p => p.text).filter(Boolean);
+    const texts = msg.content.map(p => p?.text).filter(Boolean);
     return texts.length > 0 ? texts.join('\n') : null;
   }
 

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -260,7 +260,8 @@ export function extractTextFromMessage(msg: RequestMessage): string | null {
   }
 
   if (Array.isArray(msg.content)) {
-    return msg.content[0]?.text ?? null;
+    const texts = msg.content.map(p => p.text).filter(Boolean);
+    return texts.length > 0 ? texts.join('\n') : null;
   }
 
   return null;


### PR DESCRIPTION
closes https://linear.app/getsentry/issue/TET-2003/missing-user-message-part-in-conversation-bubbles