### PR TITLE
feat(dashboards): Add insights-laravel-overview-dashboard-migration feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -268,6 +268,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:insights-frontend-overview-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Next.js frontend overview dashboard on dashboards platform
     manager.add("organizations:insights-nextjs-frontend-overview-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Laravel overview dashboard on dashboards platform
+    manager.add("organizations:insights-laravel-overview-dashboard-migration", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable all registered prebuilt dashboards to be synced to the database
     manager.add("organizations:dashboards-sync-all-registered-prebuilt-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable sentry convention fields


### PR DESCRIPTION
## Summary
- Adds a new `insights-laravel-overview-dashboard-migration` feature flag to gate the Laravel overview dashboard on the dashboards platform.

## Test plan
- Flag is registered in `temporary.py` with `FLAGPOLE` strategy and `api_expose=True`.