### PR TITLE
chore(seer): Remove unused allowBackgroundAgentDelegation org option - fe

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -51,7 +51,6 @@ export interface Organization extends OrganizationSummary {
   access: Scope[];
   aggregatedDataConsent: boolean;
   alertsMemberWrite: boolean;
-  allowBackgroundAgentDelegation: boolean;
   allowJoinRequests: boolean;
   allowMemberInvite: boolean;
   allowMemberProjectCreation: boolean;

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -28,8 +28,6 @@ export default function SeerAutomationSettings() {
           // Project<->Repo settings:
           defaultAutofixAutomationTuning: organization.defaultAutofixAutomationTuning,
           autoOpenPrs: organization.autoOpenPrs ?? false,
-          allowBackgroundAgentDelegation:
-            organization.allowBackgroundAgentDelegation ?? false,
 
           // Second section
           autoEnableCodeReview: organization.autoEnableCodeReview ?? true,
@@ -109,20 +107,6 @@ export default function SeerAutomationSettings() {
                   disabled: !canWrite || organization.enableSeerCoding === false,
                   setValue: (value: boolean): boolean =>
                     organization.enableSeerCoding === false ? false : value,
-                },
-                {
-                  visible: false, // TODO(ryan953): Disabled until the backend is fully ready
-                  name: 'allowBackgroundAgentDelegation',
-                  label: t('Allow Delegation to External Coding Agents'),
-                  help: tct(
-                    'Enable this to allow projects to use coding agents other than Seer for automation tasks. [docs:Read the docs] to learn more.',
-                    {
-                      docs: (
-                        <ExternalLink href="https://docs.sentry.io/organization/integrations/cursor/" />
-                      ),
-                    }
-                  ),
-                  type: 'boolean',
                 },
               ],
             },

--- a/tests/js/fixtures/organization.ts
+++ b/tests/js/fixtures/organization.ts
@@ -35,7 +35,6 @@ export function OrganizationFixture(params: Partial<Organization> = {}): Organiz
     features: [],
     onboardingTasks: [],
     alertsMemberWrite: false,
-    allowBackgroundAgentDelegation: false,
     allowJoinRequests: false,
     allowMemberInvite: true,
     allowMemberProjectCreation: false,


### PR DESCRIPTION
This option isn't needed. Instead of a global 'disable' for this, we can rely on people just not installing agents to begin with. It's the same permissions to install/uninstall as to check this box.

Related to https://linear.app/getsentry/issue/CW-757/check-allow-background-agent-delegation-before-doing-handoff-to-cloud

Related to https://github.com/getsentry/sentry/pull/109083