### PR TITLE
chore(seer): Remove unused allowBackgroundAgentDelegation org option - be

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -30,7 +30,6 @@ from sentry.auth.access import Access
 from sentry.auth.services.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
-    ALLOW_BACKGROUND_AGENT_DELEGATION,
     ATTACHMENTS_ROLE_DEFAULT,
     AUTO_ENABLE_CODE_REVIEW,
     AUTO_OPEN_PRS_DEFAULT,
@@ -562,7 +561,6 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     enablePrReviewTestGeneration: bool
     enableSeerEnhancedAlerts: bool
     enableSeerCoding: bool
-    allowBackgroundAgentDelegation: bool
     autoEnableCodeReview: bool
     autoOpenPrs: bool
     defaultCodeReviewTriggers: list[str]
@@ -768,12 +766,6 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ),
             "defaultCodeReviewTriggers": obj.get_option(
                 "sentry:default_code_review_triggers", DEFAULT_CODE_REVIEW_TRIGGERS
-            ),
-            "allowBackgroundAgentDelegation": bool(
-                obj.get_option(
-                    "sentry:allow_background_agent_delegation",
-                    ALLOW_BACKGROUND_AGENT_DELEGATION,
-                )
             ),
             "streamlineOnly": obj.get_option("sentry:streamline_ui_only", None),
             "trustedRelays": [

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -304,7 +304,6 @@ class OrganizationExamples:
                 "enableSeerCoding": True,
                 "enableSeerEnhancedAlerts": True,
                 "autoOpenPrs": False,
-                "allowBackgroundAgentDelegation": True,
                 "enablePrReviewTestGeneration": True,
                 "issueAlertsThreadFlag": True,
                 "metricAlertsThreadFlag": True,

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -728,8 +728,6 @@ DEFAULT_CODE_REVIEW_TRIGGERS: list[str] = [
     "on_ready_for_review",
     "on_new_commit",
 ]
-# Org level setting to allow/disallow Projects to delegate Seer scanner automation to other LLMS
-ALLOW_BACKGROUND_AGENT_DELEGATION = True
 ENABLED_CONSOLE_PLATFORMS_DEFAULT: list[str] = []
 CONSOLE_SDK_INVITE_QUOTA_DEFAULT = 0
 ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT = False

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -42,7 +42,6 @@ from sentry.auth.services.auth import auth_service
 from sentry.auth.staff import is_active_staff
 from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
-    ALLOW_BACKGROUND_AGENT_DELEGATION,
     ATTACHMENTS_ROLE_DEFAULT,
     AUTO_ENABLE_CODE_REVIEW,
     AUTO_OPEN_PRS_DEFAULT,
@@ -266,12 +265,6 @@ ORG_OPTIONS = (
         DEFAULT_CODE_REVIEW_TRIGGERS,
     ),
     (
-        "allowBackgroundAgentDelegation",
-        "sentry:allow_background_agent_delegation",
-        bool,
-        ALLOW_BACKGROUND_AGENT_DELEGATION,
-    ),
-    (
         "ingestThroughTrustedRelaysOnly",
         "sentry:ingest-through-trusted-relays-only",
         str,
@@ -372,7 +365,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         allow_empty=True,
         help_text="The default code review triggers for new repositories.",
     )
-    allowBackgroundAgentDelegation = serializers.BooleanField(required=False)
     ingestThroughTrustedRelaysOnly = serializers.ChoiceField(
         choices=[("enabled", "enabled"), ("disabled", "disabled")], required=False
     )
@@ -865,7 +857,6 @@ def create_console_platform_audit_log(
         "autoOpenPrs",
         "autoEnableCodeReview",
         "defaultCodeReviewTriggers",
-        "allowBackgroundAgentDelegation",
         "ingestThroughTrustedRelaysOnly",
         "enabledConsolePlatforms",
         "consoleSdkInviteQuota",


### PR DESCRIPTION
This option isn't needed. Instead of a global 'disable' for this, we can rely on people just not installing agents to begin with. It's the same permissions to install/uninstall as to check this box.

Related to https://linear.app/getsentry/issue/CW-757/check-allow-background-agent-delegation-before-doing-handoff-to-cloud

Depends on https://github.com/getsentry/sentry/pull/109082