### PR TITLE
fix(eap): Add transaction filters to SegmentSpansTable query

### DIFF
--- a/static/app/views/performance/eap/overviewSpansTable.tsx
+++ b/static/app/views/performance/eap/overviewSpansTable.tsx
@@ -90,7 +90,6 @@ export function OverviewSpansTable({eventView, totalValues, transactionName}: Pr
       field: 'span.duration',
       kind: 'desc',
     },
-    transactionName,
     p95,
     limit: LIMIT,
   });

--- a/static/app/views/performance/eap/segmentSpansTable.spec.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.spec.tsx
@@ -1,0 +1,126 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import EventView from 'sentry/utils/discover/eventView';
+import {SegmentSpansTable} from 'sentry/views/performance/eap/segmentSpansTable';
+
+describe('SegmentSpansTable', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({id: '1'});
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [Number(project.id)]})
+    );
+    ProjectsStore.loadInitialData([project]);
+  });
+
+  afterEach(() => {
+    ProjectsStore.reset();
+  });
+
+  it('renders column headers and data rows', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {
+            span_id: 'abc123def456',
+            'user.email': 'test@example.com',
+            'user.username': '',
+            'user.id': '',
+            'user.ip': '',
+            'span.duration': 250,
+            trace: 'trace-abc123',
+            timestamp: '2025-01-01T00:00:00+00:00',
+            replayId: '',
+            'profile.id': '',
+            'profiler.id': '',
+            'thread.id': '',
+            'precise.start_ts': 1735689600,
+            'precise.finish_ts': 1735689600.25,
+          },
+        ],
+        meta: {
+          fields: {
+            span_id: 'string',
+            'user.email': 'string',
+            'user.username': 'string',
+            'user.id': 'string',
+            'user.ip': 'string',
+            'span.duration': 'duration',
+            trace: 'string',
+            timestamp: 'date',
+            replayId: 'string',
+            'profile.id': 'string',
+            'profiler.id': 'string',
+            'thread.id': 'string',
+            'precise.start_ts': 'number',
+            'precise.finish_ts': 'number',
+          },
+          units: {'span.duration': 'millisecond'},
+        },
+      },
+    });
+
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: 'test',
+        fields: ['span_id', 'span.duration', 'trace', 'timestamp'],
+        projects: [Number(project.id)],
+        query: '',
+        orderby: '-span.duration',
+      },
+      {
+        pathname: '/performance/summary/',
+        query: {transaction: '/api/test', project: project.id},
+        search: '',
+        hash: '',
+        state: undefined,
+        action: 'POP',
+        key: '',
+      }
+    );
+
+    render(
+      <SegmentSpansTable
+        eventView={eventView}
+        handleDropdownChange={jest.fn()}
+        totalValues={{'p95()': 500}}
+        transactionName="/api/test"
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/performance/summary/',
+            query: {transaction: '/api/test', project: project.id},
+          },
+        },
+      }
+    );
+
+    // Verify column headers
+    expect(await screen.findByText('Trace ID')).toBeInTheDocument();
+    expect(screen.getByText('Span ID')).toBeInTheDocument();
+    expect(screen.getByText('Total Duration')).toBeInTheDocument();
+    expect(screen.getByText('Timestamp')).toBeInTheDocument();
+    expect(screen.getByText('Replay')).toBeInTheDocument();
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+
+    // Verify the Filter dropdown trigger is present
+    expect(screen.getByText('Filter')).toBeInTheDocument();
+
+    // Verify data from the mock response appears
+    expect(await screen.findByText('abc123def456')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -47,6 +47,7 @@ type Props = {
   handleDropdownChange: (k: string) => void;
   totalValues: Record<string, number> | null;
   transactionName: string;
+  query?: string;
   showViewSampledEventsButton?: boolean;
 };
 
@@ -55,6 +56,7 @@ export function SegmentSpansTable({
   handleDropdownChange,
   totalValues,
   transactionName,
+  query = '',
   showViewSampledEventsButton,
 }: Props) {
   const theme = useTheme();
@@ -68,7 +70,9 @@ export function SegmentSpansTable({
   const {selected, options} = getEAPSegmentSpansListSort(location, spanCategory);
 
   const p95 = totalValues?.['p95()'] ?? 0;
-  const eventViewQuery = new MutableSearch('');
+  const eventViewQuery = new MutableSearch(
+    `is_transaction:true transaction:${transactionName} ${query}`
+  );
   if (selected.value === TransactionFilterOptions.SLOW && p95) {
     eventViewQuery.addFilterValue('span.duration', `<=${p95.toFixed(0)}`);
   }
@@ -96,10 +100,10 @@ export function SegmentSpansTable({
     };
   });
 
-  const handleCursor: CursorHandler = (_cursor, pathname, query) => {
+  const handleCursor: CursorHandler = (_cursor, pathname, cursorQuery) => {
     navigate({
       pathname,
-      query: {...query, [SEGMENT_SPANS_CURSOR]: _cursor},
+      query: {...cursorQuery, [SEGMENT_SPANS_CURSOR]: _cursor},
     });
   };
 

--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -70,9 +70,9 @@ export function SegmentSpansTable({
   const {selected, options} = getEAPSegmentSpansListSort(location, spanCategory);
 
   const p95 = totalValues?.['p95()'] ?? 0;
-  const eventViewQuery = new MutableSearch(
-    `is_transaction:true transaction:${transactionName} ${query}`
-  );
+  const eventViewQuery = new MutableSearch(query);
+  eventViewQuery.addFilterValue('is_transaction', 'true');
+  eventViewQuery.addFilterValue('transaction', transactionName);
   if (selected.value === TransactionFilterOptions.SLOW && p95) {
     eventViewQuery.addFilterValue('span.duration', `<=${p95.toFixed(0)}`);
   }

--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -86,7 +86,6 @@ export function SegmentSpansTable({
   } = useSegmentSpansQuery({
     query: eventViewQuery.formatString(),
     sort: selected.sort,
-    transactionName,
     p95,
     limit: LIMIT,
   });

--- a/static/app/views/performance/eap/useSegmentSpansQuery.tsx
+++ b/static/app/views/performance/eap/useSegmentSpansQuery.tsx
@@ -12,7 +12,6 @@ type Options = {
   p95: number;
   query: string;
   sort: Sort;
-  transactionName: string;
   limit?: number;
 };
 
@@ -35,13 +34,7 @@ const FIELDS: SpanProperty[] = [
   'precise.finish_ts',
 ];
 
-export function useSegmentSpansQuery({
-  query,
-  transactionName,
-  sort,
-  p95,
-  limit = DEFAULT_LIMIT,
-}: Options) {
+export function useSegmentSpansQuery({query, sort, p95, limit = DEFAULT_LIMIT}: Options) {
   const location = useLocation();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
@@ -75,7 +68,6 @@ export function useSegmentSpansQuery({
     meta: multipleQueriesMeta,
   } = useMultipleQueries({
     query,
-    transactionName,
     sort,
     p95,
     enabled: isMultipleQueriesEnabled,
@@ -153,7 +145,6 @@ type UseMultipleQueriesOptions = {
   p95: number;
   query: string;
   sort: Sort;
-  transactionName: string;
   enabled?: boolean;
 };
 

--- a/static/app/views/performance/eap/useSegmentSpansQuery.tsx
+++ b/static/app/views/performance/eap/useSegmentSpansQuery.tsx
@@ -74,6 +74,7 @@ export function useSegmentSpansQuery({
     pageLinks: multipleQueriesPageLinks,
     meta: multipleQueriesMeta,
   } = useMultipleQueries({
+    query,
     transactionName,
     sort,
     p95,
@@ -150,22 +151,22 @@ function useSingleQuery(options: UseSingleQueryOptions) {
 type UseMultipleQueriesOptions = {
   limit: number;
   p95: number;
+  query: string;
   sort: Sort;
   transactionName: string;
   enabled?: boolean;
 };
 
 function useMultipleQueries(options: UseMultipleQueriesOptions) {
-  const {transactionName, sort, p95, enabled, limit} = options;
+  const {query, sort, p95, enabled, limit} = options;
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[SEGMENT_SPANS_CURSOR_NAME]);
   const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
-  const categorizedSpansQuery = new MutableSearch(
-    `transaction:${transactionName} span.category:${spanCategoryUrlParam}`
-  );
+  const categorizedSpansQuery = new MutableSearch(query);
+  categorizedSpansQuery.addFilterValue('span.category', spanCategoryUrlParam ?? '');
 
   // The slow (p95) option is the only one that requires an explicit duration filter
   if (selectedOption === TransactionFilterOptions.SLOW && p95) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -270,6 +270,7 @@ function EAPSummaryContentInner({
             handleDropdownChange={handleTransactionsListSortChange}
             totalValues={totalValues}
             transactionName={transactionName}
+            query={query}
             showViewSampledEventsButton
           />
         </PerformanceAtScaleContextProvider>


### PR DESCRIPTION
The SegmentSpansTable component was constructing an empty MutableSearch query, causing it to fetch all spans instead of only transaction-level spans for the selected transaction. This PR:

Adds is_transaction:true and transaction:<name> filters to the query
Forwards the parent's search query prop so the table respects user-applied filters
Adds a smoke test for this component
Closes DAIN-1227