### PR TITLE
ref(eap): Remove duplicate span.duration filter from SegmentSpansTable

### DIFF
--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -18,7 +18,6 @@ import type EventView from 'sentry/utils/discover/eventView';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -67,7 +66,6 @@ export function SegmentSpansTable({
   const {selected, options} = getEAPSegmentSpansListSort(location, spanCategory);
 
   const p95 = totalValues?.['p95()'] ?? 0;
-  const eventViewQuery = new MutableSearch('');
 
   const {
     data: tableData,
@@ -76,7 +74,7 @@ export function SegmentSpansTable({
     meta,
     error,
   } = useSegmentSpansQuery({
-    query: eventViewQuery.formatString(),
+    query: '',
     sort: selected.sort,
     transactionName,
     p95,

--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -37,7 +37,6 @@ import {
   SEGMENT_SPANS_CURSOR,
 } from 'sentry/views/performance/eap/utils';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
-import {TransactionFilterOptions} from 'sentry/views/performance/transactionSummary/utils';
 
 const LIMIT = 5;
 const PAGINATION_CURSOR_SIZE = 'xs';
@@ -69,9 +68,6 @@ export function SegmentSpansTable({
 
   const p95 = totalValues?.['p95()'] ?? 0;
   const eventViewQuery = new MutableSearch('');
-  if (selected.value === TransactionFilterOptions.SLOW && p95) {
-    eventViewQuery.addFilterValue('span.duration', `<=${p95.toFixed(0)}`);
-  }
 
   const {
     data: tableData,

--- a/static/app/views/performance/eap/useSegmentSpansQuery.tsx
+++ b/static/app/views/performance/eap/useSegmentSpansQuery.tsx
@@ -44,7 +44,10 @@ export function useSegmentSpansQuery({
 }: Options) {
   const location = useLocation();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
-  const selectedOption = decodeScalar(location.query?.showTransactions);
+  const selectedOption = decodeScalar(
+    location.query?.showTransactions,
+    TransactionFilterOptions.SLOW
+  );
 
   const isSingleQueryEnabled =
     selectedOption === TransactionFilterOptions.RECENT || !spanCategoryUrlParam;
@@ -61,6 +64,7 @@ export function useSegmentSpansQuery({
     p95,
     enabled: isSingleQueryEnabled,
     limit,
+    selectedOption,
   });
 
   const isMultipleQueriesEnabled = Boolean(
@@ -79,6 +83,7 @@ export function useSegmentSpansQuery({
     p95,
     enabled: isMultipleQueriesEnabled,
     limit,
+    selectedOption,
   });
 
   if (isSingleQueryEnabled) {
@@ -104,6 +109,7 @@ type UseSingleQueryOptions = {
   limit: number;
   p95: number;
   query: string;
+  selectedOption: string;
   sort: Sort;
   enabled?: boolean;
 };
@@ -112,9 +118,8 @@ type UseSingleQueryOptions = {
 function useSingleQuery(options: UseSingleQueryOptions) {
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[SEGMENT_SPANS_CURSOR_NAME]);
-  const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
-  const {query, sort, p95, enabled, limit} = options;
+  const {query, sort, p95, enabled, limit, selectedOption} = options;
   const newQuery = new MutableSearch(query);
 
   if (selectedOption === TransactionFilterOptions.SLOW && p95) {
@@ -150,16 +155,16 @@ function useSingleQuery(options: UseSingleQueryOptions) {
 type UseMultipleQueriesOptions = {
   limit: number;
   p95: number;
+  selectedOption: string;
   sort: Sort;
   transactionName: string;
   enabled?: boolean;
 };
 
 function useMultipleQueries(options: UseMultipleQueriesOptions) {
-  const {transactionName, sort, p95, enabled, limit} = options;
+  const {transactionName, sort, p95, enabled, limit, selectedOption} = options;
   const location = useLocation();
   const cursor = decodeScalar(location.query?.[SEGMENT_SPANS_CURSOR_NAME]);
-  const selectedOption = decodeScalar(location.query?.showTransactions);
   const {selection} = usePageFilters();
   const spanCategoryUrlParam = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 


### PR DESCRIPTION
Remove a duplicate `span.duration` filter for SLOW transactions from `SegmentSpansTable`. The filter was being applied in both the component and the `useSegmentSpansQuery` hook. The hook is the correct owner of this filtering logic:

- Single-query path: https://github.com/getsentry/sentry/blob/03321757e0e777a4dcabae1d4ca99538e407083a/static/app/views/performance/eap/useSegmentSpansQuery.tsx#L120-L122
- Multi-query path: https://github.com/getsentry/sentry/blob/03321757e0e777a4dcabae1d4ca99538e407083a/static/app/views/performance/eap/useSegmentSpansQuery.tsx#L171-L173