### PR TITLE
fix(eap): Use addFilterValue for transaction name in EAP sidebar charts

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapSidebarCharts.tsx
@@ -41,13 +41,16 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
   const theme = useTheme();
   const {selection} = usePageFilters();
 
+  const transactionSearch = new MutableSearch('');
+  transactionSearch.addFilterValue('transaction', transactionName);
+
   const {
     data: failureRateSeriesData,
     isPending: isFailureRateSeriesPending,
     isError: isFailureRateSeriesError,
   } = useFetchSpanTimeSeries(
     {
-      query: new MutableSearch(`transaction:${transactionName}`),
+      query: transactionSearch.copy(),
       yAxis: ['failure_rate()'],
     },
     REFERRER
@@ -59,7 +62,7 @@ function FailureRateWidget({transactionName}: FailureRateWidgetProps) {
     isError: isFailureRateValueError,
   } = useSpans(
     {
-      search: new MutableSearch(`transaction:${transactionName}`),
+      search: transactionSearch.copy(),
       fields: ['failure_rate()'],
       pageFilters: selection,
     },


### PR DESCRIPTION
MutableSearch splits on spaces during parsing, so interpolating
`transactionName` directly into the query string breaks when it contains
spaces (e.g. `GET /api/users`).

Switches to `addFilterValue` which properly quotes such values. Both
`useFetchSpanTimeSeries` and `useSpans` hooks receive independent copies
of the search object via `.copy()` to prevent cross-mutation.