### PR TITLE
fix(tests): Fix flaky test_snuba_data timestamp precision mismatch

### DIFF
--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -17,7 +17,7 @@ from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import PerformanceIssueTestCase, TestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.skips import requires_snuba
 from sentry.utils import snuba
@@ -279,6 +279,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
         assert not event_from_nodestore.group_id
         assert not event_from_nodestore.group
 
+    @freeze_time()
     def test_snuba_data_transaction(self) -> None:
         self.store_event(
             data={
@@ -690,6 +691,7 @@ class EventNodeStoreTest(TestCase):
         event = self.store_event(data={}, project_id=self.project.id)
         assert event.data.get_ref(event) == event.project.id
 
+    @freeze_time()
     def test_datetime_uses_timestamp_ms_from_snuba(self) -> None:
         second_before_now = before_now(seconds=1)
         second_before_now_str = second_before_now.isoformat()

--- a/tests/sentry/services/eventstore/test_models.py
+++ b/tests/sentry/services/eventstore/test_models.py
@@ -212,7 +212,7 @@ class EventTest(TestCase, PerformanceIssueTestCase):
                 "message": "Hello World!",
                 "tags": {"logger": "foobar", "site": "foo", "server_name": "bar"},
                 "user": {"id": "test", "email": "test@test.com"},
-                "timestamp": before_now(seconds=1).isoformat(),
+                "timestamp": before_now(seconds=1).replace(microsecond=0).isoformat(),
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
## Summary
- Fix `test_snuba_data` timestamp precision mismatch by stripping microseconds
- Fix `test_snuba_data_transaction` timestamp drift with `@freeze_time()` (from #108972)
- Fix `test_datetime_uses_timestamp_ms_from_snuba` precision with `@freeze_time()` (from #108974)
- #108905 was a duplicate of this PR

Combines #108972, #108974, #108905.