### PR TITLE
fix(tests): Fix flaky test_api_key_request Snuba data leak

### DIFF
--- a/tests/sentry/api/test_organization_events.py
+++ b/tests/sentry/api/test_organization_events.py
@@ -50,7 +50,12 @@ class OrganizationEventsEndpointTest(APITestCase):
         # Project ID cannot be inferred when using an org API key, so that must
         # be passed in the parameters
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
-        query = {"field": ["project.name", "environment"], "project": [self.project.id]}
+        query = {
+            "field": ["project.name", "environment"],
+            "project": [self.project.id],
+            "statsPeriod": "1h",
+            "query": "environment:staging",
+        }
 
         url = self.reverse_url()
         response = self.client_get(


### PR DESCRIPTION
## Summary
- Add `statsPeriod: "1h"` and `query: "environment:staging"` to the test's API query to filter out leaked Snuba events from other tests
- The test was flaky because it had no time range or environment filtering — when run in CI alongside other tests that stored events with the same event_id (`"a"*32`) and project, those leaked events would appear in the query results

## Test plan
- [x] Test passes 10/10 consecutive local runs

Fixes #109059