### PR TITLE
fix(monitors): Fix flaky test_rate_limit time bucket race condition

### DIFF
--- a/tests/sentry/monitors/consumers/test_monitor_consumer.py
+++ b/tests/sentry/monitors/consumers/test_monitor_consumer.py
@@ -33,6 +33,7 @@ from sentry.monitors.types import CheckinItem
 from sentry.monitors.utils import get_detector_for_monitor
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.utils import json
@@ -737,6 +738,7 @@ class MonitorConsumerTest(TestCase):
         assert closed_checkin.status == CheckInStatus.OK
         assert closed_checkin.guid != uuid.UUID(int=0)
 
+    @freeze_time()
     def test_rate_limit(self) -> None:
         now = datetime.now()
         monitor = self._create_monitor(slug="my-monitor")


### PR DESCRIPTION
## Summary
- Add `@freeze_time()` decorator to the test to prevent a Redis time bucket boundary race condition
- The monitor consumer rate limiter uses `time.time()` to compute a 60-second Redis key bucket. When the two `send_checkin` calls straddled a minute boundary (e.g., `XX:59.999` and `XX+1:00.001`), they used different Redis keys, so the second check-in was never rate limited
- With frozen time, both calls always compute the same Redis bucket, so the rate limit counter properly triggers

## Test plan
- [x] Test passes 10/10 consecutive local runs

Fixes #109063