### PR TITLE
feat(preprod): Add org-scoped build-details endpoint and auto-resolve project

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_build_details.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import analytics, features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.preprod.analytics import PreprodArtifactApiGetBuildDetailsEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactResourceDoesNotExist
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.quotas import get_size_retention_cutoff
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationPreprodBuildDetailsEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(self, request: Request, organization: Organization, artifact_id: str) -> Response:
+        analytics.record(
+            PreprodArtifactApiGetBuildDetailsEvent(
+                organization_id=organization.id,
+                project_id=0,
+                user_id=request.user.id,
+                artifact_id=artifact_id,
+            )
+        )
+
+        if not features.has(
+            "organizations:preprod-frontend-routes", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        try:
+            artifact = PreprodArtifact.objects.select_related(
+                "mobile_app_info", "build_configuration", "project", "commit_comparison"
+            ).get(
+                id=int(artifact_id),
+                project__organization_id=organization.id,
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            raise PreprodArtifactResourceDoesNotExist
+
+        cutoff = get_size_retention_cutoff(organization)
+        if artifact.date_added < cutoff:
+            return Response({"detail": "This build's size data has expired."}, status=404)
+
+        if artifact.state == PreprodArtifact.ArtifactState.FAILED:
+            return Response({"detail": artifact.error_message}, status=400)
+
+        build_details = transform_preprod_artifact_to_build_details(artifact)
+        return Response(build_details.dict())

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -17,6 +17,7 @@ from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_do
 )
 
 from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssembleEndpoint
+from .organization_preprod_build_details import OrganizationPreprodBuildDetailsEndpoint
 from .organization_preprod_list_builds import OrganizationPreprodListBuildsEndpoint
 from .organization_preprod_quota import OrganizationPreprodQuotaEndpoint
 from .organization_preprod_retention import OrganizationPreprodRetentionEndpoint
@@ -170,6 +171,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/builds/$",
         BuildsEndpoint.as_view(),
         name="sentry-api-0-organization-builds",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/build-details/$",
+        OrganizationPreprodBuildDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-artifact-build-details",
     ),
 ]
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -472,6 +472,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/pr-comments/$repoName/$prNumber/'
   | '/organizations/$organizationIdOrSlug/preprod/quota/'
   | '/organizations/$organizationIdOrSlug/preprod/retention/'
+  | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/list-builds/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/sync/'

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -16,14 +16,13 @@ import {
   useQueryClient,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildCompareHeaderContent';
 import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
@@ -38,41 +37,35 @@ export default function BuildComparison() {
     baseArtifactId?: string;
     headArtifactId?: string;
   }>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
-
   const headBuildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: headArtifactId!,
+              artifactId: headArtifactId!,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!headArtifactId,
+        enabled: !!headArtifactId,
       }
     );
 
-  const compareUrl = getCompareApiUrl({
-    organizationSlug: organization.slug,
-    projectId,
-    headArtifactId: headArtifactId!,
-    baseArtifactId: baseArtifactId!,
-  });
+  const projectId = useResolveProjectFromArtifact(headBuildDetailsQuery.data);
+
+  const compareUrl = projectId
+    ? getCompareApiUrl({
+        organizationSlug: organization.slug,
+        projectId,
+        headArtifactId: headArtifactId!,
+        baseArtifactId: baseArtifactId!,
+      })
+    : null;
 
   const queryClient = useQueryClient();
   const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
@@ -80,7 +73,7 @@ export default function BuildComparison() {
     RequestError
   >({
     mutationFn: () => {
-      return fetchMutation({url: compareUrl, method: 'POST'});
+      return fetchMutation({url: compareUrl!, method: 'POST'});
     },
     onSuccess: response => {
       if (response?.status === 'exists') {
@@ -127,6 +120,10 @@ export default function BuildComparison() {
         {headBuildDetailsQuery.error?.message || t('Failed to load build details')}
       </Alert>
     );
+  }
+
+  if (!projectId) {
+    return null;
   }
 
   let mainContent = null;

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -24,7 +24,7 @@ describe('BuildDetails', () => {
     route: '/organizations/:orgId/preprod/size/:artifactId/',
   };
 
-  const BUILD_DETAILS_URL = `/projects/org-slug/project-1/preprodartifacts/artifact-1/build-details/`;
+  const BUILD_DETAILS_URL = `/organizations/org-slug/preprodartifacts/artifact-1/build-details/`;
   const SIZE_ANALYSIS_URL = `/projects/org-slug/project-1/files/preprodartifacts/artifact-1/size-analysis/`;
   const QUOTA_STATE_URL = `/organizations/org-slug/preprod/quota/`;
 

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -18,15 +18,14 @@ import {
   useMutation,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
 import {
   isSizeInfoPendingOrProcessing,
@@ -42,31 +41,23 @@ export default function BuildDetails() {
   const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectSlug} = useLocationQuery({fields: {project: decodeScalar}});
-  // Handle project as query param - take first value if array
-  const projectId = Array.isArray(projectSlug) ? projectSlug[0] : projectSlug;
-  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
-    projectId,
-    artifactId,
-  });
 
   const buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: artifactId,
+              artifactId,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!artifactId,
+        enabled: !!artifactId,
         refetchInterval: query => {
           const data = query.state.data;
           const sizeInfo = data?.[0]?.size_info;
@@ -74,6 +65,12 @@ export default function BuildDetails() {
         },
       }
     );
+
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
+    projectId,
+    artifactId,
+  });
 
   const sizeInfo = buildDetailsQuery.data?.size_info;
   const isPendingOrProcessing = isSizeInfoPendingOrProcessing(sizeInfo);

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -44,8 +44,8 @@ import {useBuildDetailsActions} from './useBuildDetailsActions';
 interface BuildDetailsHeaderContentProps {
   artifactId: string;
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
-  projectId: string;
   projectType: string | null;
+  projectId?: string;
 }
 
 export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps) {
@@ -128,7 +128,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     areActionsEnabled || isSizeInfoRetryable(buildDetailsData?.size_info);
 
   const handleCompareClick = () => {
-    if (!areActionsEnabled) {
+    if (!areActionsEnabled || !projectId) {
       return;
     }
     trackAnalytics('preprod.builds.details.compare_build_clicked', {

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -11,7 +11,7 @@ import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermis
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
-  projectId: string;
+  projectId?: string;
 }
 
 export function useBuildDetailsActions({

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
@@ -1,0 +1,80 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
+
+describe('useResolveProjectFromArtifact', () => {
+  const organization = OrganizationFixture();
+
+  it('returns projectId from URL when project query param is present', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '456'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('456');
+  });
+
+  it('returns projectId from build details data when project query param is missing', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture();
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe(String(buildDetails.project_id));
+  });
+
+  it('returns undefined when no project param and no build details data', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('prefers URL project param over build details data', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture();
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '999'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('999');
+  });
+});

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
@@ -1,0 +1,36 @@
+import {useEffect} from 'react';
+
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+export function useResolveProjectFromArtifact(
+  buildDetailsData: BuildDetailsApiResponse | undefined
+): string | undefined {
+  const {project: projectFromUrl} = useLocationQuery({
+    fields: {project: decodeScalar},
+  });
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const projectId = projectFromUrl || buildDetailsData?.project_id?.toString();
+
+  useEffect(() => {
+    if (!projectFromUrl && buildDetailsData?.project_id) {
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            project: String(buildDetailsData.project_id),
+          },
+        },
+        {replace: true}
+      );
+    }
+  }, [projectFromUrl, buildDetailsData?.project_id, navigate, location]);
+
+  return projectId;
+}

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -6,46 +6,43 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildVcsInfo} from 'sentry/views/preprod/components/buildVcsInfo';
 import {InstallDetailsContent} from 'sentry/views/preprod/components/installDetailsContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import {BuildInstallHeader} from 'sentry/views/preprod/install/buildInstallHeader';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function InstallPage() {
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
   const organization = useOrganization();
 
   const buildDetailsQuery = useApiQuery<BuildDetailsApiResponse>(
     [
       getApiUrl(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+        '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
         {
           path: {
             organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: projectId,
-            headArtifactId: artifactId,
+            artifactId,
           },
         }
       ),
     ],
     {
       staleTime: 0,
-      enabled: !!projectId && !!artifactId,
+      enabled: !!artifactId,
     }
   );
+
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+
+  if (!projectId) {
+    return null;
+  }
+
   return (
     <SentryDocumentTitle title="Install">
       <Layout.Page>

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_build_details.py
@@ -1,0 +1,134 @@
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry.preprod.models import PreprodArtifact
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationPreprodBuildDetailsEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = self.create_user(email="test@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.api_token = self.create_user_auth_token(
+            user=self.user, scope_list=["org:admin", "project:admin"]
+        )
+
+        self.file = self.create_file(name="test_artifact.apk", type="application/octet-stream")
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.org,
+            head_sha="1234567890098765432112345678900987654321",
+            base_sha="9876543210012345678998765432100123456789",
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/xyz",
+            base_ref="main",
+            pr_number=123,
+        )
+
+        self.preprod_artifact = self.create_preprod_artifact(
+            project=self.project,
+            file_id=self.file.id,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+            app_id="com.example.app",
+            build_configuration=None,
+            installable_app_file_id=1234,
+            commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version="1.0.0",
+            build_number=42,
+        )
+
+        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
+        self.feature_context.__enter__()
+
+    def tearDown(self) -> None:
+        self.feature_context.__exit__(None, None, None)
+        super().tearDown()
+
+    def _get_url(self, artifact_id=None):
+        artifact_id = artifact_id or self.preprod_artifact.id
+        return reverse(
+            "sentry-api-0-organization-preprod-artifact-build-details",
+            args=[self.org.slug, artifact_id],
+        )
+
+    def test_get_build_details_success(self) -> None:
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["state"] == self.preprod_artifact.state
+        assert resp_data["app_info"]["app_id"] == self.preprod_artifact.app_id
+        assert resp_data["app_info"]["name"] == self.mobile_app_info.app_name
+        assert resp_data["app_info"]["version"] == self.mobile_app_info.build_version
+        assert resp_data["app_info"]["build_number"] == self.mobile_app_info.build_number
+        assert resp_data["project_id"] == self.project.id
+        assert resp_data["project_slug"] == self.project.slug
+
+    def test_get_build_details_not_found(self) -> None:
+        url = self._get_url(artifact_id=999999)
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+
+    def test_get_build_details_different_org(self) -> None:
+        other_org = self.create_organization(owner=self.user)
+        url = reverse(
+            "sentry-api-0-organization-preprod-artifact-build-details",
+            args=[other_org.slug, self.preprod_artifact.id],
+        )
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+
+    def test_get_build_details_feature_flag_disabled(self) -> None:
+        self.feature_context.__exit__(None, None, None)
+        with self.feature({"organizations:preprod-frontend-routes": False}):
+            url = self._get_url()
+            response = self.client.get(
+                url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+            )
+            assert response.status_code == 403
+        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
+        self.feature_context.__enter__()
+
+    def test_returns_404_for_expired_artifact(self) -> None:
+        self.preprod_artifact.date_added = timezone.now() - timedelta(days=365)
+        self.preprod_artifact.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "This build's size data has expired."
+
+    def test_returns_400_for_failed_artifact(self) -> None:
+        self.preprod_artifact.state = PreprodArtifact.ArtifactState.FAILED
+        self.preprod_artifact.error_message = "Processing failed"
+        self.preprod_artifact.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Processing failed"


### PR DESCRIPTION
Add a new organization-scoped build-details API endpoint at
`/organizations/{org}/preprodartifacts/{artifactId}/build-details/`
that returns build details including `project_id` and `project_slug`
without requiring the project slug in the URL path.

This enables preprod URLs like `/preprod/size/12345/` to work without
requiring `?project=` upfront, improving UX for shared links. When a
user opens a link without the project query param, the frontend fetches
build details from the org-scoped endpoint, extracts the project ID
from the response, and automatically adds it to the URL via a
`useResolveProjectFromArtifact` hook.

**Backend:**
- New `OrganizationPreprodBuildDetailsEndpoint` with IDOR protection
  (scopes artifact lookup by `project__organization_id`)
- Includes retention cutoff validation and failed artifact handling
- 6 backend test cases covering success, 404, IDOR, feature flag, expiry, and failure

**Frontend:**
- New `useResolveProjectFromArtifact` hook with URL param precedence
  over API response data, plus automatic URL update via `navigate({replace: true})`
- Refactored `buildDetails`, `buildComparison`, and `installPage` to
  use the org-scoped endpoint and defer project-scoped API calls until
  project is resolved
- Made `projectId` optional in header components with runtime guards
- 4 frontend hook tests validating the resolution fallback chain