### PR TITLE
feat(alerts): Consistent logging for cases where users hit alert limits

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1866,6 +1866,18 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
     @with_feature("organizations:incidents")
     @with_feature("organizations:workflow-engine-metric-detector-limit")
+    @patch("sentry.quotas.backend.get_metric_detector_limit")
+    @patch("sentry.incidents.endpoints.organization_alert_rule_index.log_alerting_quota_hit")
+    def test_metric_alert_limit_calls_log(
+        self, mock_log: MagicMock, mock_get_limit: MagicMock
+    ) -> None:
+        mock_get_limit.return_value = 0
+        data = deepcopy(self.alert_rule_dict)
+        self.get_error_response(self.organization.slug, status_code=400, **data)
+        mock_log.assert_called_once()
+
+    @with_feature("organizations:incidents")
+    @with_feature("organizations:workflow-engine-metric-detector-limit")
     def test_metric_alert_limit_unlimited_plan(self) -> None:
         # create orphaned metric alert
         project_to_delete = self.create_project(organization=self.organization)

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -525,6 +525,19 @@ class TestMetricAlertsCreateDetectorValidator(TestMetricAlertsDetectorValidator)
         ):
             validator.save()
 
+    @mock.patch("sentry.quotas.backend.get_metric_detector_limit")
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.log_alerting_quota_hit")
+    @with_feature("organizations:workflow-engine-metric-detector-limit")
+    def test_enforce_quota_calls_log(
+        self, mock_log: mock.MagicMock, mock_get_limit: mock.MagicMock
+    ) -> None:
+        mock_get_limit.return_value = 0
+        validator = MetricIssueDetectorValidator(data=self.valid_data, context=self.context)
+        validator.is_valid()
+        with pytest.raises(ValidationError):
+            validator.save()
+        mock_log.assert_called_once()
+
     @with_feature("organizations:discover-saved-queries-deprecation")
     def test_transaction_dataset_deprecation_transactions(self) -> None:
         data = {

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -298,6 +298,15 @@ class TestWorkflowValidatorCreate(TestCase):
                 )
             ]
 
+    @mock.patch("sentry.workflow_engine.endpoints.validators.base.workflow.log_alerting_quota_hit")
+    def test_create__exceeds_workflow_limit_calls_log(self, mock_log: mock.MagicMock) -> None:
+        with self.options({"workflow_engine.max_workflows_per_org": 0}):
+            validator = WorkflowValidator(data=self.valid_data, context=self.context)
+            validator.is_valid(raise_exception=True)
+            with pytest.raises(ValidationError):
+                validator.create(validator.validated_data)
+        mock_log.assert_called_once()
+
     def test_create__exceeds_more_workflow_limit(self) -> None:
         REGULAR_LIMIT = 2
         MORE_LIMIT = 4


### PR DESCRIPTION
We should be aware of how often users can't create alerting primitives due to limits, and who is encountering these limits.
This logging allows us to monitor generally and check for individual cases.


Fixes ISWF-2117.