### PR TITLE
fix(issue-details): Preserve page filters when searching issues by tag value

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -11,6 +11,7 @@ import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import type {TagTreeContent} from 'sentry/components/events/eventTags/eventTagsTree';
 import EventTagsValue from 'sentry/components/events/eventTags/eventTagsValue';
 import {AnnotatedTextErrors} from 'sentry/components/events/meta/annotatedText/annotatedTextErrors';
+import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import Version from 'sentry/components/version';
 import VersionHoverCard from 'sentry/components/versionHoverCard';
 import {IconEllipsis} from 'sentry/icons';
@@ -154,6 +155,7 @@ function EventTagsTreeRowDropdown({
       key: escapeIssueTagKey(originalTag.key),
     }
   );
+  const globalSelectionParams = extractSelectionParameters(location.query);
 
   const isProjectAdmin = hasEveryAccess(['project:admin'], {
     organization,
@@ -178,7 +180,7 @@ function EventTagsTreeRowDropdown({
       hidden: !event.groupID || isFeedback,
       to: {
         pathname: `/organizations/${organization.slug}/issues/${event.groupID}/events/`,
-        query,
+        query: {...globalSelectionParams, ...query},
       },
     },
     {
@@ -187,7 +189,7 @@ function EventTagsTreeRowDropdown({
       hidden: isFeedback,
       to: {
         pathname: `/organizations/${organization.slug}/issues/`,
-        query,
+        query: {...globalSelectionParams, ...query},
       },
     },
     {
@@ -196,7 +198,7 @@ function EventTagsTreeRowDropdown({
       hidden: !isFeedback,
       to: {
         pathname: `/organizations/${organization.slug}/feedback/`,
-        query,
+        query: {...globalSelectionParams, ...query},
       },
     },
     {

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -15,6 +15,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {getContextIcon} from 'sentry/components/events/contexts/utils';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import Pagination from 'sentry/components/pagination';
 import TimeSince from 'sentry/components/timeSince';
 import {IconArrow, IconEllipsis, IconOpen} from 'sentry/icons';
@@ -275,6 +276,7 @@ function TagValueActionsMenu({
   tagValue: TagValue;
 }) {
   const organization = useOrganization();
+  const location = useLocation();
   const {copy} = useCopyToClipboard();
 
   const referrer = 'tag-details-drawer';
@@ -284,6 +286,7 @@ function TagValueActionsMenu({
         query: tagValue.query,
       }
     : generateQueryWithTag({referrer}, {key, value: tagValue.value});
+  const globalSelectionParams = extractSelectionParameters(location.query);
   const eventView = useIssueDetailsEventView({group, queryProps: query});
   const [isVisible, setIsVisible] = useState(false);
 
@@ -314,7 +317,7 @@ function TagValueActionsMenu({
           label: t('View other events with this tag value'),
           to: {
             pathname: `/organizations/${organization.slug}/issues/${group.id}/events/`,
-            query,
+            query: {...globalSelectionParams, ...query},
           },
         },
         {
@@ -322,7 +325,7 @@ function TagValueActionsMenu({
           label: t('Search issues with this tag value'),
           to: {
             pathname: `/organizations/${organization.slug}/issues/`,
-            query,
+            query: {...globalSelectionParams, ...query},
           },
         },
         {


### PR DESCRIPTION
The "Search issues with this tag value" and related navigation links in
the tag details drawer and event tags tree row dropdown were constructing
URLs without carrying over page filter parameters (project, environment,
date range) from the current URL. When a user clicked these links, the
issues list page would fall back to the default or last-saved project
selection instead of staying on the project they were viewing.

This uses `extractSelectionParameters(location.query)` to spread global
page filter params into the navigation query objects in both
`tagDetailsDrawerContent.tsx` and `eventTagsTreeRow.tsx`, matching the
pattern already established in `groupTagValues.tsx` and used widely
across the codebase for cross-page navigation.

Fixes ID-1361
fixes https://github.com/getsentry/sentry/issues/108799