### PR TITLE
feat(autofix): Support explorer autofix responses for some slack hooks

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -157,8 +157,14 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
             blocks.append(RichTextBlock(elements=[list_element]))
         if data.changes:
             for change in data.changes[:MAX_CHANGES]:
-                change_mrkdwn = f"_In {change['repo_name']}_:\n*{change['title']}*\n{change['description']}\n```\n{change['diff']}```"
-                blocks.append(SectionBlock(text=MarkdownTextObject(text=change_mrkdwn)))
+                change_mrkdwn = [f"_In {change['repo_name']}_:"]
+                if change["title"]:
+                    change_mrkdwn.append(f"*{change['title']}*")
+                if change["description"]:
+                    change_mrkdwn.append(f"{change['description']}")
+                if change["diff"]:
+                    change_mrkdwn.append(f"{change['diff']}")
+                blocks.append(SectionBlock(text=MarkdownTextObject(text="\n".join(change_mrkdwn))))
         if data.pull_requests:
             action_id = encode_action_id(
                 action=SlackAction.SEER_AUTOFIX_VIEW_PR.value,

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -158,12 +158,13 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         if data.changes:
             for change in data.changes[:MAX_CHANGES]:
                 change_mrkdwn = [f"_In {change['repo_name']}_:"]
-                if change["title"]:
+                if change.get("title"):
                     change_mrkdwn.append(f"*{change['title']}*")
-                if change["description"]:
+
+                if change.get("description"):
                     change_mrkdwn.append(f"{change['description']}")
-                if change["diff"]:
-                    change_mrkdwn.append(f"{change['diff']}")
+                if change.get("diff"):
+                    change_mrkdwn.append(f"```{change['diff']}```")
                 blocks.append(SectionBlock(text=MarkdownTextObject(text="\n".join(change_mrkdwn))))
         if data.pull_requests:
             action_id = encode_action_id(

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -198,33 +198,69 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
         match event_type:
             case SentryAppEventType.SEER_ROOT_CAUSE_COMPLETED:
                 root_cause = event_payload.get("root_cause", {})
+
+                if legacy_description := root_cause.get("description"):
+                    summary = legacy_description
+                elif explorer_description := root_cause.get("one_line_description"):
+                    summary = explorer_description
+                else:
+                    summary = ""
+
+                if legacy_steps := root_cause.get("steps", []):
+                    steps = [step.get("title", "") for step in legacy_steps]
+                elif explorer_steps := root_cause.get("reproduction_steps", []):
+                    steps = explorer_steps
+                else:
+                    steps = []
+
                 data_kwargs.update(
                     {
                         "current_point": AutofixStoppingPoint.ROOT_CAUSE,
-                        "summary": root_cause.get("description", ""),
-                        "steps": [step.get("title", "") for step in root_cause.get("steps", [])],
+                        "summary": summary,
+                        "steps": steps,
                     }
                 )
             case SentryAppEventType.SEER_SOLUTION_COMPLETED:
                 solution = event_payload.get("solution", {})
+
+                if legacy_description := solution.get("description"):
+                    summary = legacy_description
+                elif explorer_description := solution.get("one_line_description"):
+                    summary = explorer_description
+                else:
+                    summary = ""
+
+                steps = [step.get("title", "") for step in solution.get("steps", [])]
+
                 data_kwargs.update(
                     {
                         "current_point": AutofixStoppingPoint.SOLUTION,
-                        "summary": solution.get("description", ""),
-                        "steps": [step.get("title", "") for step in solution.get("steps", [])],
+                        "summary": summary,
+                        "steps": steps,
                     }
                 )
             case SentryAppEventType.SEER_CODING_COMPLETED:
-                changes = event_payload.get("changes", [])
-                changes_list = [
-                    {
-                        "repo_name": change.get("repo_name", ""),
-                        "diff": change.get("diff", ""),
-                        "title": change.get("title", ""),
-                        "description": change.get("description", ""),
-                    }
-                    for change in changes
-                ]
+                if legacy_changes := event_payload.get("changes", []):
+                    changes_list = [
+                        {
+                            "repo_name": change.get("repo_name", ""),
+                            "diff": change.get("diff", ""),
+                            "title": change.get("title", ""),
+                            "description": change.get("description", ""),
+                        }
+                        for change in legacy_changes
+                    ]
+                elif explorer_changes := event_payload.get("code_changes", {}):
+                    changes_list = [
+                        {
+                            "repo_name": repo,
+                            "title": change["path"],
+                            # TODO: add the diff to the change list
+                        }
+                        for repo, change in explorer_changes.items()
+                    ]
+                else:
+                    changes_list = []
                 data_kwargs.update(
                     {
                         "current_point": AutofixStoppingPoint.CODE_CHANGES,

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -259,7 +259,8 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                             "description": "",
                             "diff": "",
                         }
-                        for repo, change in explorer_changes.items()
+                        for repo, changes in explorer_changes.items()
+                        for change in changes
                     ]
                 else:
                     changes_list = []

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -256,11 +256,14 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                             "repo_name": repo,
                             "title": change["path"],
                             # TODO: add the diff to the change list
+                            "description": "",
+                            "diff": "",
                         }
                         for repo, change in explorer_changes.items()
                     ]
                 else:
                     changes_list = []
+
                 data_kwargs.update(
                     {
                         "current_point": AutofixStoppingPoint.CODE_CHANGES,


### PR DESCRIPTION
This extracts the payloads for the root cause and solutions steps. It also partially supports the coding step as it's missing getsentry/seer#4965 for better rendering. Support for opening PRs is coming in the near future.