### PR TITLE
feat(uptime): Move suggest assertions button to verification section

### DIFF
--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -458,7 +458,7 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
                       };
                     }}
                     getCurrentAssertion={() =>
-                      formModel.getValue<Assertion | null>('assertion')
+                      formModel.getValue<UptimeAssertion | null>('assertion')
                     }
                     onApplySuggestion={newAssertion => {
                       formModel.setValue('assertion', newAssertion as any);

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -6,7 +6,7 @@ import {Observer} from 'mobx-react-lite';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -248,27 +248,6 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
               <Button priority="danger">{t('Delete Rule')}</Button>
             </Confirm>
           )}
-          {hasRuntimeAssertions && hasAiAssertionSuggestions && (
-            <AssertionSuggestionsButton
-              getFormData={() => {
-                const data = formModel.getTransformedData();
-                return {
-                  url: data.url,
-                  method: data.method ?? DEFAULT_METHOD,
-                  headers: data.headers ?? [],
-                  body: methodHasBody(formModel) ? data.body : null,
-                  timeoutMs: data.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-                };
-              }}
-              getCurrentAssertion={() =>
-                formModel.getValue<UptimeAssertion | null>('assertion')
-              }
-              onApplySuggestion={newAssertion => {
-                // Cast to any to satisfy FormModel's FieldValue type
-                formModel.setValue('assertion', newAssertion as any);
-              }}
-            />
-          )}
           {hasRuntimeAssertions && (
             <TestUptimeMonitorButton
               label={t('Test Rule')}
@@ -455,12 +434,42 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
         </Configuration>
         {hasRuntimeAssertions && (
           <Fragment>
-            <AlertListItem>{t('Verification')}</AlertListItem>
-            <ListItemSubText>
-              {t(
-                'Define conditions that must be met for the check to be considered successful.'
+            <Flex justify="between">
+              <Stack>
+                <AlertListItem>{t('Verification')}</AlertListItem>
+
+                <ListItemSubText>
+                  {t(
+                    'Define conditions that must be met for the check to be considered successful.'
+                  )}
+                </ListItemSubText>
+              </Stack>
+
+              {hasAiAssertionSuggestions && (
+                <Flex alignSelf="end">
+                  <AssertionSuggestionsButton
+                    size="xs"
+                    getFormData={() => {
+                      const data = formModel.getTransformedData();
+                      return {
+                        url: data.url,
+                        method: data.method ?? DEFAULT_METHOD,
+                        headers: data.headers ?? [],
+                        body: methodHasBody(formModel) ? data.body : null,
+                        timeoutMs: data.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+                      };
+                    }}
+                    getCurrentAssertion={() =>
+                      formModel.getValue<Assertion | null>('assertion')
+                    }
+                    onApplySuggestion={newAssertion => {
+                      formModel.setValue('assertion', newAssertion as any);
+                    }}
+                  />
+                </Flex>
               )}
-            </ListItemSubText>
+            </Flex>
+
             <Configuration>
               <ConfigurationPanel>
                 <UptimeAssertionsField

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -434,19 +434,17 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
         </Configuration>
         {hasRuntimeAssertions && (
           <Fragment>
-            <Flex justify="between">
-              <Stack>
-                <AlertListItem>{t('Verification')}</AlertListItem>
-
-                <ListItemSubText>
-                  {t(
-                    'Define conditions that must be met for the check to be considered successful.'
-                  )}
-                </ListItemSubText>
-              </Stack>
-
-              {hasAiAssertionSuggestions && (
-                <Flex alignSelf="end">
+            <AlertListItem>
+              <Flex justify="between" align="end">
+                <Stack>
+                  {t('Verification')}
+                  <ListItemSubText style={{paddingLeft: 0}}>
+                    {t(
+                      'Define conditions that must be met for the check to be considered successful.'
+                    )}
+                  </ListItemSubText>
+                </Stack>
+                {hasAiAssertionSuggestions && (
                   <AssertionSuggestionsButton
                     size="xs"
                     getFormData={() => {
@@ -466,9 +464,9 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
                       formModel.setValue('assertion', newAssertion as any);
                     }}
                   />
-                </Flex>
-              )}
-            </Flex>
+                )}
+              </Flex>
+            </AlertListItem>
 
             <Configuration>
               <ConfigurationPanel>
@@ -581,6 +579,8 @@ const AlertListItem = styled(ListItem)`
 
 const ListItemSubText = styled(Text)`
   padding-left: ${p => p.theme.space['3xl']};
+  font-size: ${p => p.theme.font.size.md};
+  font-weight: ${p => p.theme.font.weight.sans.regular};
   color: ${p => p.theme.tokens.content.secondary};
 `;
 

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -18,7 +17,6 @@ import {useSetAutomaticName} from 'sentry/views/detectors/components/forms/commo
 import type {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
-import {ConnectedAssertionSuggestionsButton} from 'sentry/views/detectors/components/forms/uptime/connectedAssertionSuggestionsButton';
 import {ConnectedTestUptimeMonitorButton} from 'sentry/views/detectors/components/forms/uptime/connectedTestUptimeMonitorButton';
 import {UptimeDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/uptime/detect';
 import {
@@ -77,7 +75,7 @@ export function NewUptimeDetectorForm() {
 }
 
 function NewUptimeDetectorFormContent() {
-  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
+  const {hasRuntimeAssertions} = useUptimeAssertionFeatures();
   const previewCheckResult = usePreviewCheckResult();
 
   return (
@@ -87,12 +85,7 @@ function NewUptimeDetectorFormContent() {
       initialFormData={{}}
       environment={ENVIRONMENT_CONFIG}
       extraFooterButton={
-        hasRuntimeAssertions ? (
-          <Fragment>
-            {hasAiAssertionSuggestions && <ConnectedAssertionSuggestionsButton />}
-            <ConnectedTestUptimeMonitorButton />
-          </Fragment>
-        ) : undefined
+        hasRuntimeAssertions ? <ConnectedTestUptimeMonitorButton /> : undefined
       }
       mapFormErrors={createMapFormErrors(previewCheckResult)}
     >
@@ -110,7 +103,7 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
 }
 
 function EditExistingUptimeDetectorFormContent({detector}: {detector: UptimeDetector}) {
-  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
+  const {hasRuntimeAssertions} = useUptimeAssertionFeatures();
   const previewCheckResult = usePreviewCheckResult();
 
   return (
@@ -120,14 +113,7 @@ function EditExistingUptimeDetectorFormContent({detector}: {detector: UptimeDete
       savedDetectorToFormData={uptimeSavedDetectorToFormData}
       environment={ENVIRONMENT_CONFIG}
       extraFooterButton={
-        hasRuntimeAssertions ? (
-          <Fragment>
-            {hasAiAssertionSuggestions && (
-              <ConnectedAssertionSuggestionsButton size="sm" />
-            )}
-            <ConnectedTestUptimeMonitorButton size="sm" />
-          </Fragment>
-        ) : undefined
+        hasRuntimeAssertions ? <ConnectedTestUptimeMonitorButton size="sm" /> : undefined
       }
       mapFormErrors={createMapFormErrors(previewCheckResult)}
     >

--- a/static/app/views/detectors/components/forms/uptime/verification.tsx
+++ b/static/app/views/detectors/components/forms/uptime/verification.tsx
@@ -3,10 +3,11 @@ import {Section} from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import {UptimeAssertionsField} from 'sentry/views/alerts/rules/uptime/assertions/field';
 import {useUptimeAssertionFeatures} from 'sentry/views/alerts/rules/uptime/useUptimeAssertionFeatures';
+import {ConnectedAssertionSuggestionsButton} from 'sentry/views/detectors/components/forms/uptime/connectedAssertionSuggestionsButton';
 import {UptimeSectionGrid} from 'sentry/views/detectors/components/forms/uptime/styles';
 
 export function UptimeDetectorVerificationSection() {
-  const {hasRuntimeAssertions} = useUptimeAssertionFeatures();
+  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
 
   if (!hasRuntimeAssertions) {
     return null;
@@ -14,7 +15,14 @@ export function UptimeDetectorVerificationSection() {
 
   return (
     <Container>
-      <Section title={t('Verification')}>
+      <Section
+        title={t('Verification')}
+        trailingItems={
+          hasAiAssertionSuggestions ? (
+            <ConnectedAssertionSuggestionsButton size="xs" />
+          ) : undefined
+        }
+      >
         <UptimeSectionGrid>
           <UptimeAssertionsField
             name="assertion"


### PR DESCRIPTION
## Summary
- Moves the "Suggest Assertions" button from the form footer to the verification section for better discoverability
- In the alerts form, the button sits next to the "Verification" heading with the subtext, bottom-aligned
- In the detector form, the button is placed in the Section heading via `trailingItems`
- Removes the button from `extraFooterButton` in both detector form variants

## Screenshots

### Alerts form (`/alerts/new/uptime/`)

| Before | After |
|--------|-------|
|<img width="1400" height="900" alt="suggest-assertions-before-alerts" src="https://github.com/user-attachments/assets/eff93df3-4452-44d4-a26f-db8693809cde" />|<img width="1400" height="900" alt="suggest-assertions-after-alerts" src="https://github.com/user-attachments/assets/c11a1e55-d125-4040-864e-226567a668ac" />|

### Detector form (`/monitors/new/settings/`)

| Before | After |
|--------|-------|
|<img width="1400" height="900" alt="suggest-assertions-before-detector" src="https://github.com/user-attachments/assets/8b70e61c-3d5b-46e6-842f-e49d9e9bec1d" />|<img width="1400" height="900" alt="suggest-assertions-after-detector" src="https://github.com/user-attachments/assets/c7725452-a270-4577-83d6-07e6188092e7" />|

## Test plan
- Verify the "Suggest Assertions" button appears in the verification section (not footer) on both `/alerts/new/uptime/` and `/monitors/create/`
- Verify the numbered list item "3. Verification" retains its number
- Verify the button opens the AI suggestion drawer when clicked
- `CI=true pnpm test static/app/views/alerts/rules/uptime/uptimeAlertForm.spec.tsx`

Fixes NEW-763