### PR TITLE
[WIP] feat(tests): disallow branching around asserts in tests

### DIFF
--- a/tests/sentry/objectstore/test_objectstore.py
+++ b/tests/sentry/objectstore/test_objectstore.py
@@ -16,6 +16,11 @@ def test_object_url() -> None:
     server = Testserver()
     client = ClientBuilder(server.url, "test").for_project(123, 456)
 
+    foo = 3
+    bar = 4
+    if foo > bar:
+        assert False
+
     assert (
         client.object_url("foo")
         == "http://localhost:8888/v1/foo?usecase=test&scope=org.123%2Fproj.456"

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -249,10 +249,17 @@ def test_example() -> None:
     if result:
         assert result.value == 5
 """
-    # Should error in test files
     errors = _run(src, filename="tests/test_example.py")
     assert errors == ["t.py:4:8: S015 Tests should not use branching logic around asserts."]
 
+
+def test_S015_only_in_test_files() -> None:
+    src = """\
+def test_example() -> None:
+    result = get_result()
+    if result:
+        assert result.value == 5
+"""
     # Should not error in non-test files
     assert _run(src, filename="src/sentry/example.py") == []
 

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -251,10 +251,7 @@ def test_example() -> None:
 """
     # Should error in test files
     errors = _run(src, filename="tests/test_example.py")
-    assert errors == [
-        "t.py:4:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches."
-    ]
+    assert errors == ["t.py:4:8: S015 Tests should not use branching logic around asserts."]
 
     # Should not error in non-test files
     assert _run(src, filename="src/sentry/example.py") == []
@@ -273,53 +270,41 @@ def test_example() -> None:
 """
     errors = _run(src, filename="tests/test_example.py")
     assert errors == [
-        "t.py:4:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches.",
-        "t.py:6:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches.",
-        "t.py:8:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches.",
-    ]
-
-
-def test_S015_for_loop() -> None:
-    src = """\
-def test_example() -> None:
-    for item in items:
-        assert item.valid
-"""
-    errors = _run(src, filename="tests/test_example.py")
-    assert errors == [
-        "t.py:3:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches."
-    ]
-
-
-def test_S015_while_loop() -> None:
-    src = """\
-def test_example() -> None:
-    while condition:
-        assert something
-"""
-    errors = _run(src, filename="tests/test_example.py")
-    assert errors == [
-        "t.py:3:8: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches."
+        "t.py:4:8: S015 Tests should not use branching logic around asserts.",
+        "t.py:6:8: S015 Tests should not use branching logic around asserts.",
+        "t.py:8:8: S015 Tests should not use branching logic around asserts.",
     ]
 
 
 def test_S015_nested_branching() -> None:
     src = """\
 def test_example() -> None:
-    if condition:
-        for item in items:
-            assert item.valid
+    if condition1:
+        if condition2:
+            assert something
 """
     errors = _run(src, filename="tests/test_example.py")
-    assert errors == [
-        "t.py:4:12: S015 Tests should not use branching logic around asserts. "
-        "Asserts may not run in all branches."
-    ]
+    assert errors == ["t.py:4:12: S015 Tests should not use branching logic around asserts."]
+
+
+def test_S015_ok_for_loop() -> None:
+    src = """\
+def test_example() -> None:
+    for item in items:
+        assert item.valid
+"""
+    # Should not error - for loops are not branching logic
+    assert _run(src, filename="tests/test_example.py") == []
+
+
+def test_S015_ok_while_loop() -> None:
+    src = """\
+def test_example() -> None:
+    while condition:
+        assert something
+"""
+    # Should not error - while loops are not branching logic
+    assert _run(src, filename="tests/test_example.py") == []
 
 
 def test_S015_ok_no_branching() -> None:

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -40,9 +40,7 @@ S013_msg = "S013 Use `django.contrib.postgres.fields.array.ArrayField` instead"
 
 S014_msg = "S014 Use `unittest.mock` instead"
 
-S015_msg = (
-    "S015 Tests should not use branching logic around asserts. Asserts may not run in all branches."
-)
+S015_msg = "S015 Tests should not use branching logic around asserts."
 
 
 class SentryVisitor(ast.NodeVisitor):

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -173,26 +173,6 @@ class SentryVisitor(ast.NodeVisitor):
         else:
             self.generic_visit(node)
 
-    def visit_For(self, node: ast.For) -> None:
-        if "tests/" in self.filename or "testutils/" in self.filename:
-            self._branching_depth += 1
-            try:
-                self.generic_visit(node)
-            finally:
-                self._branching_depth -= 1
-        else:
-            self.generic_visit(node)
-
-    def visit_While(self, node: ast.While) -> None:
-        if "tests/" in self.filename or "testutils/" in self.filename:
-            self._branching_depth += 1
-            try:
-                self.generic_visit(node)
-            finally:
-                self._branching_depth -= 1
-        else:
-            self.generic_visit(node)
-
     def visit_Assert(self, node: ast.Assert) -> None:
         if (
             "tests/" in self.filename or "testutils/" in self.filename

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -164,14 +164,14 @@ class SentryVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_If(self, node: ast.If) -> None:
-        if "tests/" in self.filename or "testutils/" in self.filename:
+        is_test_file = "tests/" in self.filename or "testutils/" in self.filename
+        if is_test_file:
             self._branching_depth += 1
-            try:
-                self.generic_visit(node)
-            finally:
-                self._branching_depth -= 1
-        else:
-            self.generic_visit(node)
+
+        self.generic_visit(node)
+
+        if is_test_file:
+            self._branching_depth -= 1
 
     def visit_Assert(self, node: ast.Assert) -> None:
         if (


### PR DESCRIPTION
For some reason LLMs love to add conditional branching around assertions when writing tests. This is a bad practice since it's very easy for the conditional to not be true, in which case no assertion runs at all!