### PR TITLE
feat(replay): add DOM inspect element mode for Seer Explorer

### DIFF
--- a/static/app/components/replays/domInspector/inspectElementModal.tsx
+++ b/static/app/components/replays/domInspector/inspectElementModal.tsx
@@ -1,0 +1,229 @@
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
+import {closeModal, openModal} from 'sentry/actionCreators/modal';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import {extractDomTree} from 'sentry/utils/replays/extractDomTree';
+
+interface Props {
+  element: HTMLElement;
+  onClose: () => void;
+  onSend: (message: string) => void;
+  promptContext: {
+    currentTimestampMs: number;
+    currentUrl: string;
+    replayId?: string;
+  };
+}
+
+function getElementPreview(element: HTMLElement): string {
+  const tag = element.tagName.toLowerCase();
+  const id = element.id ? `#${element.id}` : '';
+  const classes = Array.from(element.classList)
+    .filter(cls => !cls.startsWith('rr-') && !cls.startsWith('rr_'))
+    .slice(0, 3)
+    .map(cls => `.${cls}`)
+    .join('');
+  const component = element.getAttribute('data-sentry-component');
+
+  if (component) {
+    return `<${component}> (${tag}${id}${classes})`;
+  }
+  return `<${tag}${id}${classes}>`;
+}
+
+function getHtmlSnippet(element: HTMLElement): string {
+  let html = element.outerHTML;
+  if (html.length > 200) {
+    html = html.substring(0, 200) + '...';
+  }
+  return html;
+}
+
+function InspectElementModalContent({
+  element,
+  Header,
+  Body,
+  Footer,
+  closeModal: closeModalProp,
+  onClose,
+  onSend,
+  promptContext: {replayId, currentTimestampMs, currentUrl},
+}: ModalRenderProps & Props) {
+  const [prompt, setPrompt] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    // Auto-focus the textarea
+    textareaRef.current?.focus();
+  }, []);
+
+  const handleSend = useCallback(() => {
+    setIsSending(true);
+
+    const domTree = extractDomTree(element);
+    const trimmedPrompt = prompt.trim();
+    const message = `I'm viewing a replay with id: ${replayId}
+Replay is at timestamp (ms): ${currentTimestampMs}
+Replay is on URL: ${currentUrl}
+
+I have specifically selected the below DOM snippet where you should focus your attention on:
+${domTree}
+
+${trimmedPrompt || 'Analyze this element from a session replay'}`;
+
+    closeModalProp();
+    onSend(message);
+  }, [element, prompt, replayId, currentTimestampMs, currentUrl, closeModalProp, onSend]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  const preview = getElementPreview(element);
+  const snippet = getHtmlSnippet(element);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('Inspect Element')}</h4>
+      </Header>
+      <Body>
+        <Flex direction="column" gap="md">
+          <ElementPreview>
+            <PreviewLabel>{preview}</PreviewLabel>
+            <CodeSnippet>{snippet}</CodeSnippet>
+          </ElementPreview>
+          <Textarea
+            ref={textareaRef}
+            placeholder={t(
+              'What would you like to investigate about this element? (optional)'
+            )}
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={3}
+          />
+        </Flex>
+      </Body>
+      <Footer>
+        <Flex justify="end" gap="md">
+          <Button
+            onClick={() => {
+              closeModalProp();
+              onClose();
+            }}
+          >
+            {t('Cancel')}
+          </Button>
+          <Button priority="primary" onClick={handleSend} disabled={isSending}>
+            {t('Send to Seer')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+/**
+ * Renders nothing visually — triggers an openModal() call when mounted,
+ * and calls onClose when the modal is dismissed.
+ */
+export default function InspectElementModal({
+  element,
+  promptContext,
+  onClose,
+  onSend,
+}: Props) {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const onSendRef = useRef(onSend);
+  onSendRef.current = onSend;
+  const promptContextRef = useRef(promptContext);
+  promptContextRef.current = promptContext;
+
+  useEffect(() => {
+    openModal(
+      deps => (
+        <InspectElementModalContent
+          {...deps}
+          element={element}
+          promptContext={promptContextRef.current}
+          onClose={() => onCloseRef.current()}
+          onSend={(message: string) => onSendRef.current(message)}
+        />
+      ),
+      {
+        modalCss: modalStyles,
+        onClose: () => onCloseRef.current(),
+      }
+    );
+
+    return () => {
+      closeModal();
+    };
+  }, [element]);
+
+  return null;
+}
+
+const modalStyles = css`
+  max-width: 560px;
+`;
+
+const ElementPreview = styled('div')`
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${space(1.5)};
+  overflow: hidden;
+`;
+
+const PreviewLabel = styled('div')`
+  font-family: ${p => p.theme.font.family.mono};
+  font-size: ${p => p.theme.font.size.md};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  margin-bottom: ${space(1)};
+  color: ${p => p.theme.tokens.content.primary};
+`;
+
+const CodeSnippet = styled('pre')`
+  font-family: ${p => p.theme.font.family.mono};
+  font-size: ${p => p.theme.font.size.sm};
+  color: ${p => p.theme.tokens.content.secondary};
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+  max-height: 120px;
+  overflow-y: auto;
+`;
+
+const Textarea = styled('textarea')`
+  width: 100%;
+  resize: vertical;
+  font-family: ${p => p.theme.font.family.sans};
+  font-size: ${p => p.theme.font.size.md};
+  padding: ${space(1)};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  background: ${p => p.theme.tokens.background.primary};
+  color: ${p => p.theme.tokens.content.primary};
+
+  &:focus {
+    outline: none;
+    border-color: ${p => p.theme.tokens.focus.default};
+    box-shadow: ${p => p.theme.tokens.focus.default} 0 0 0 1px;
+  }
+`;

--- a/static/app/components/replays/domInspector/inspectModeToggle.tsx
+++ b/static/app/components/replays/domInspector/inspectModeToggle.tsx
@@ -1,0 +1,94 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {IconFocus} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
+import {useReplayReader} from 'sentry/utils/replays/playback/providers/replayReaderProvider';
+import useOrganization from 'sentry/utils/useOrganization';
+import {openSeerExplorer} from 'sentry/views/seerExplorer/openSeerExplorer';
+import {useExplorerPanel} from 'sentry/views/seerExplorer/useExplorerPanel';
+import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
+
+import InspectElementModal from './inspectElementModal';
+import useInspectMode from './useInspectMode';
+
+interface Props {
+  isLoading?: boolean;
+}
+
+export default function InspectModeToggle({isLoading}: Props) {
+  const organization = useOrganization();
+  const replay = useReplayReader();
+  const {isVideoReplay, currentTime} = useReplayContext();
+  const {openExplorerPanel} = useExplorerPanel();
+
+  const {
+    isInspecting,
+    selectedElement,
+    enableInspect,
+    disableInspect,
+    clearSelectedElement,
+  } = useInspectMode();
+
+  const handleSend = useCallback(
+    (message: string) => {
+      disableInspect();
+
+      // openSeerExplorer stores the pending message options via a DOM event.
+      // Normally it also tries to open the panel via a simulated keyboard shortcut,
+      // but that shortcut is disabled while a modal is open. Instead, we call
+      // openExplorerPanel() directly from context to open the panel. The panel's
+      // useExternalOpen visibility effect will pick up the pending options and
+      // process the message once the panel is visible.
+      openSeerExplorer({
+        startNewRun: true,
+        initialMessage: message,
+      });
+      openExplorerPanel();
+    },
+    [disableInspect, openExplorerPanel]
+  );
+
+  // Hide for video replays or when Seer Explorer is not enabled
+  if (isVideoReplay || !isSeerExplorerEnabled(organization)) {
+    return null;
+  }
+
+  return (
+    <span>
+      <Button
+        size="sm"
+        tooltipProps={{
+          title: isInspecting
+            ? t('Exit element inspector')
+            : t('Inspect element & ask Seer'),
+        }}
+        icon={<IconFocus size="sm" />}
+        aria-pressed={isInspecting}
+        priority={isInspecting ? 'primary' : 'default'}
+        onClick={() => (isInspecting ? disableInspect() : enableInspect())}
+        aria-label={t('Inspect element')}
+        disabled={isLoading}
+      />
+      {selectedElement ? (
+        <InspectElementModal
+          element={selectedElement}
+          promptContext={{
+            replayId: replay?.getReplay().id,
+            currentTimestampMs: currentTime,
+            currentUrl: getCurrentUrl(
+              replay?.getReplay(),
+              replay?.getNavigationFrames(),
+              currentTime
+            ),
+          }}
+          onClose={clearSelectedElement}
+          onSend={handleSend}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/static/app/components/replays/domInspector/useInspectMode.tsx
+++ b/static/app/components/replays/domInspector/useInspectMode.tsx
@@ -1,0 +1,258 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+
+const HIGHLIGHT_COLOR = 'rgba(130, 180, 255, 0.45)';
+const HIGHLIGHT_BORDER_COLOR = 'rgba(80, 140, 240, 0.9)';
+
+interface UseInspectModeReturn {
+  /**
+   * Clear the selected element (e.g., when the modal is closed).
+   */
+  clearSelectedElement: () => void;
+  /**
+   * Disable inspect mode: remove listeners, clear highlight, optionally resume playback.
+   */
+  disableInspect: () => void;
+  /**
+   * Enable inspect mode: pause replay, attach iframe listeners, show hover highlight.
+   */
+  enableInspect: () => void;
+  /**
+   * The element the user hovered over (for preview purposes).
+   */
+  hoveredElement: HTMLElement | null;
+  /**
+   * Whether inspect mode is currently active.
+   */
+  isInspecting: boolean;
+  /**
+   * The element the user clicked on. When non-null, the modal should be shown.
+   */
+  selectedElement: HTMLElement | null;
+}
+
+export default function useInspectMode(): UseInspectModeReturn {
+  const {getIframe, isPlaying, togglePlayPause, isVideoReplay} = useReplayContext();
+
+  const [isInspecting, setIsInspecting] = useState(false);
+  const [hoveredElement, setHoveredElement] = useState<HTMLElement | null>(null);
+  const [selectedElement, setSelectedElement] = useState<HTMLElement | null>(null);
+
+  // Track whether replay was playing before entering inspect mode, so we can resume
+  const wasPlayingRef = useRef(false);
+
+  // Single reusable canvas for hover highlight (avoids create/destroy per hover)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // RAF handle for throttled highlight updates
+  const rafRef = useRef<number | null>(null);
+
+  // Track the current hovered element for RAF callback
+  const pendingTargetRef = useRef<HTMLElement | null>(null);
+
+  const drawHighlight = useCallback(
+    (element: HTMLElement | null) => {
+      const iframe = getIframe();
+      if (!iframe) {
+        return;
+      }
+
+      let canvas = canvasRef.current;
+      const wrapper = iframe.parentElement;
+
+      if (!element) {
+        // Clear the highlight
+        if (canvas && wrapper?.contains(canvas)) {
+          wrapper.removeChild(canvas);
+        }
+        canvasRef.current = null;
+        return;
+      }
+
+      // Create canvas if needed
+      if (!canvas) {
+        canvas = document.createElement('canvas');
+        canvas.setAttribute(
+          'style',
+          'position:absolute; pointer-events:none; z-index:1;'
+        );
+        canvasRef.current = canvas;
+      }
+
+      // Size canvas to match iframe
+      canvas.width = Number(iframe.width) || iframe.clientWidth;
+      canvas.height = Number(iframe.height) || iframe.clientHeight;
+
+      // Draw the highlight
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // Fill
+      ctx.fillStyle = HIGHLIGHT_COLOR;
+      ctx.fillRect(rect.left, rect.top, rect.width, rect.height);
+
+      // Border
+      ctx.strokeStyle = HIGHLIGHT_BORDER_COLOR;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(rect.left, rect.top, rect.width, rect.height);
+
+      // Tooltip showing tag name
+      const label =
+        element.getAttribute('data-sentry-component') ||
+        `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ''}`;
+      ctx.font = '12px monospace';
+      const textMetrics = ctx.measureText(label);
+      const textPadding = 4;
+      const textHeight = 16;
+      const tooltipX = rect.left;
+      const tooltipY =
+        rect.top > textHeight + textPadding * 2
+          ? rect.top - textHeight - textPadding * 2
+          : rect.bottom;
+
+      ctx.fillStyle = 'rgba(30, 30, 30, 0.85)';
+      ctx.fillRect(
+        tooltipX,
+        tooltipY,
+        textMetrics.width + textPadding * 2,
+        textHeight + textPadding
+      );
+      ctx.fillStyle = 'white';
+      ctx.fillText(label, tooltipX + textPadding, tooltipY + textHeight);
+
+      // Insert canvas into wrapper (before iframe, same as existing highlight system)
+      if (wrapper && !wrapper.contains(canvas)) {
+        wrapper.insertBefore(canvas, iframe);
+      }
+    },
+    [getIframe]
+  );
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target || target.tagName === 'HTML' || target.tagName === 'BODY') {
+        pendingTargetRef.current = null;
+        setHoveredElement(null);
+        drawHighlight(null);
+        return;
+      }
+
+      pendingTargetRef.current = target;
+
+      // Throttle redraws with RAF
+      if (rafRef.current === null) {
+        rafRef.current = requestAnimationFrame(() => {
+          rafRef.current = null;
+          const pendingTarget = pendingTargetRef.current;
+          setHoveredElement(pendingTarget);
+          drawHighlight(pendingTarget);
+        });
+      }
+    },
+    [drawHighlight]
+  );
+
+  const handleClick = useCallback((event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const target = event.target as HTMLElement | null;
+    if (!target || target.tagName === 'HTML' || target.tagName === 'BODY') {
+      return;
+    }
+
+    setSelectedElement(target);
+  }, []);
+
+  const cleanup = useCallback(() => {
+    // Remove event listeners from iframe
+    const iframe = getIframe();
+    const doc = iframe?.contentDocument;
+    if (doc) {
+      doc.removeEventListener('mousemove', handleMouseMove);
+      doc.removeEventListener('click', handleClick, true);
+    }
+
+    // Cancel pending RAF
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+
+    // Remove highlight canvas
+    drawHighlight(null);
+
+    setHoveredElement(null);
+  }, [getIframe, handleMouseMove, handleClick, drawHighlight]);
+
+  const enableInspect = useCallback(() => {
+    if (isVideoReplay) {
+      return; // Inspect mode not supported for video replays
+    }
+
+    const iframe = getIframe();
+    const doc = iframe?.contentDocument;
+    if (!doc) {
+      return;
+    }
+
+    // Pause replay if playing
+    wasPlayingRef.current = isPlaying;
+    if (isPlaying) {
+      togglePlayPause(false);
+    }
+
+    // Attach listeners to iframe's contentDocument
+    doc.addEventListener('mousemove', handleMouseMove);
+    doc.addEventListener('click', handleClick, true); // capture phase to beat rrweb
+
+    setIsInspecting(true);
+  }, [
+    getIframe,
+    isPlaying,
+    isVideoReplay,
+    togglePlayPause,
+    handleMouseMove,
+    handleClick,
+  ]);
+
+  const disableInspect = useCallback(() => {
+    cleanup();
+    setIsInspecting(false);
+    setSelectedElement(null);
+
+    // Resume playback if it was playing before inspect mode
+    if (wasPlayingRef.current) {
+      togglePlayPause(true);
+      wasPlayingRef.current = false;
+    }
+  }, [cleanup, togglePlayPause]);
+
+  const clearSelectedElement = useCallback(() => {
+    setSelectedElement(null);
+  }, []);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      cleanup();
+    };
+  }, [cleanup]);
+
+  return {
+    isInspecting,
+    hoveredElement,
+    selectedElement,
+    enableInspect,
+    disableInspect,
+    clearSelectedElement,
+  };
+}

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -54,6 +54,12 @@ interface ReplayPlayerContextProps extends HighlightCallbacks {
   fastForwardSpeed: number;
 
   /**
+   * Returns the rrweb replay iframe element.
+   * Useful for attaching event listeners directly to the iframe's contentDocument.
+   */
+  getIframe: () => HTMLIFrameElement | null;
+
+  /**
    * Returns the replay DOM mirror
    */
   getMirror: () => Mirror | null;
@@ -132,6 +138,7 @@ const ReplayPlayerContext = createContext<ReplayPlayerContextProps>({
   isFinished: false,
   isPlaying: false,
   isVideoReplay: false,
+  getIframe: () => null,
   removeHighlight: () => {},
   restart: () => {},
   setCurrentTime: () => {},
@@ -621,6 +628,7 @@ export function Provider({
           restart,
           setCurrentTime,
           togglePlayPause,
+          getIframe: () => replayerRef.current?.iframe ?? null,
           getMirror: () => replayerRef.current?.getMirror() ?? null,
           ...value,
         }}

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -9,6 +9,7 @@ import NegativeSpaceContainer from 'sentry/components/container/negativeSpaceCon
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import QuestionTooltip from 'sentry/components/questionTooltip';
 import {CanvasSupportNotice} from 'sentry/components/replays/canvasSupportNotice';
+import InspectModeToggle from 'sentry/components/replays/domInspector/inspectModeToggle';
 import {
   JetpackComposePiiNotice,
   useNeedsJetpackComposePiiNotice,
@@ -87,6 +88,7 @@ export default function ReplayView({toggleFullscreen, isLoading}: Props) {
               <ReplayCurrentUrl />
             )}
 
+            <InspectModeToggle isLoading={isLoading} />
             <ErrorBoundary customComponent={FatalIconTooltip}>
               <BrowserOSIcons showBrowser={!isVideoReplay} isLoading={isLoading} />
             </ErrorBoundary>

--- a/static/app/utils/replays/extractDomTree.spec.tsx
+++ b/static/app/utils/replays/extractDomTree.spec.tsx
@@ -1,0 +1,235 @@
+import {extractDomTree} from 'sentry/utils/replays/extractDomTree';
+
+function createElement(
+  tag: string,
+  attrs: Record<string, string> = {},
+  children: Array<HTMLElement | string> = []
+): HTMLElement {
+  const el = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    el.setAttribute(key, value);
+  }
+  for (const child of children) {
+    if (typeof child === 'string') {
+      el.appendChild(document.createTextNode(child));
+    } else {
+      el.appendChild(child);
+    }
+  }
+  return el;
+}
+
+// Helper to build a DOM tree with body > ... > target so ancestor path is testable
+function buildWithAncestors(target: HTMLElement): HTMLElement {
+  const body = document.createElement('body');
+  const app = createElement('div', {id: 'app'});
+  const main = createElement('main', {class: 'dashboard'});
+  body.appendChild(app);
+  app.appendChild(main);
+  main.appendChild(target);
+  return target;
+}
+
+describe('extractDomTree', () => {
+  describe('small subtrees', () => {
+    it('includes full HTML for elements with few descendants', () => {
+      const el = createElement(
+        'div',
+        {class: 'error-card', 'data-sentry-component': 'ErrorCard'},
+        [
+          createElement('h3', {class: 'title'}, ['Something went wrong']),
+          createElement('span', {class: 'timestamp'}, ['2 hours ago']),
+        ]
+      );
+
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('error-card');
+      expect(result).toContain('Something went wrong');
+      expect(result).toContain('2 hours ago');
+      expect(result).toContain('<!-- Ancestor path:');
+      expect(result).toContain('<!-- CSS Selector:');
+    });
+
+    it('includes ancestor path from body', () => {
+      const el = createElement('span', {}, ['hello']);
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('body > div#app > main.dashboard');
+    });
+  });
+
+  describe('CSS selector generation', () => {
+    it('generates selector with data-sentry-component', () => {
+      const el = createElement('div', {
+        'data-sentry-component': 'ErrorCard',
+        id: 'my-card',
+      });
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('CSS Selector:');
+      expect(result).toContain('ErrorCard');
+    });
+
+    it('generates selector with tag and classes when no component name', () => {
+      const el = createElement('div', {class: 'foo bar'});
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('CSS Selector:');
+      expect(result).toContain('div');
+    });
+  });
+
+  describe('rrweb artifact cleanup', () => {
+    it('removes data-rr-* attributes', () => {
+      const el = createElement('div', {
+        'data-rr-is-shadow-host': 'true',
+        'data-rr-id': '42',
+        class: 'real-class',
+      });
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).not.toContain('data-rr-is-shadow-host');
+      expect(result).not.toContain('data-rr-id');
+      expect(result).toContain('real-class');
+    });
+
+    it('removes rr- prefixed class names', () => {
+      const el = createElement('div', {class: 'rr-block my-class rr_mirror'});
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('my-class');
+      expect(result).not.toMatch(/rr-block/);
+      expect(result).not.toMatch(/rr_mirror/);
+    });
+  });
+
+  describe('depth limiting for large subtrees', () => {
+    it('truncates children beyond depth limit', () => {
+      // Build a tree with > 50 elements to trigger depth limiting
+      const children: HTMLElement[] = [];
+      for (let i = 0; i < 20; i++) {
+        children.push(
+          createElement('div', {class: `item-${i}`}, [
+            createElement('span', {}, ['text']),
+            createElement('div', {}, [
+              createElement('a', {}, [createElement('strong', {}, ['link'])]),
+              createElement('em', {}, ['emphasis']),
+            ]),
+          ])
+        );
+      }
+      const el = createElement('div', {class: 'large-container'}, children);
+      buildWithAncestors(el);
+
+      // depthLimit: 1 means children at depth 1 or deeper get truncated
+      const result = extractDomTree(el, {depthLimit: 1});
+
+      // Items have child elements, so they should get truncated
+      expect(result).toContain('more children');
+    });
+
+    it('collapses style elements regardless of depth', () => {
+      const el = createElement('div', {}, [
+        createElement('style', {}, ['.foo { color: red; } .bar { color: blue; }']),
+      ]);
+      buildWithAncestors(el);
+      const result = extractDomTree(el);
+
+      expect(result).toContain('/* styles */');
+      expect(result).not.toContain('color: red');
+    });
+
+    it('collapses SVG elements regardless of depth', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+      circle.setAttribute('cx', '10');
+      circle.setAttribute('cy', '10');
+      circle.setAttribute('r', '5');
+      svg.appendChild(circle);
+
+      const el = createElement('div', {});
+      el.appendChild(svg);
+      buildWithAncestors(el);
+
+      const result = extractDomTree(el);
+
+      expect(result).toContain('<!-- SVG -->');
+      // Should not contain the circle's attributes
+      expect(result).not.toContain('cx="10"');
+    });
+  });
+
+  describe('token budget enforcement', () => {
+    it('truncates output when exceeding character budget', () => {
+      // Build a tree that will produce a large output
+      const children: HTMLElement[] = [];
+      for (let i = 0; i < 100; i++) {
+        children.push(
+          createElement('div', {class: `long-class-name-${i}-extra-padding-text`}, [
+            createElement('span', {class: `nested-${i}`}, [
+              `Long text content number ${i} that adds to the overall size of the output`,
+            ]),
+          ])
+        );
+      }
+      const el = createElement('div', {class: 'container'}, children);
+      buildWithAncestors(el);
+
+      const result = extractDomTree(el, {charBudget: 500});
+
+      expect(result.length).toBeLessThanOrEqual(500);
+      // Should have a truncation marker
+      expect(result).toContain('total elements');
+    });
+
+    it('stays within budget for small elements without truncation', () => {
+      const el = createElement('div', {class: 'small'}, [
+        createElement('span', {}, ['hello']),
+      ]);
+      buildWithAncestors(el);
+
+      const result = extractDomTree(el, {charBudget: 8000});
+
+      // Should not be truncated
+      expect(result).not.toContain('Truncated');
+      expect(result).toContain('hello');
+    });
+  });
+
+  describe('element description in ancestor path', () => {
+    it('includes data-sentry-component in ancestor descriptions', () => {
+      const body = document.createElement('body');
+      const wrapper = createElement('div', {'data-sentry-component': 'PageLayout'});
+      const target = createElement('span', {}, ['target']);
+      body.appendChild(wrapper);
+      wrapper.appendChild(target);
+
+      const result = extractDomTree(target);
+
+      expect(result).toContain('data-sentry-component="PageLayout"');
+    });
+
+    it('skips very long class names in ancestor descriptions', () => {
+      const body = document.createElement('body');
+      const wrapper = createElement('div', {
+        class:
+          'short-cls a-very-long-hash-like-class-name-that-exceeds-forty-characters-in-length',
+      });
+      const target = createElement('span', {}, ['target']);
+      body.appendChild(wrapper);
+      wrapper.appendChild(target);
+
+      const result = extractDomTree(target);
+
+      // The short class should appear in ancestor path
+      expect(result).toContain('short-cls');
+    });
+  });
+});

--- a/static/app/utils/replays/extractDomTree.tsx
+++ b/static/app/utils/replays/extractDomTree.tsx
@@ -1,0 +1,226 @@
+import constructSelector from 'sentry/views/replays/selectors/constructSelector';
+
+const MAX_CHAR_BUDGET = 8000;
+const SMALL_SUBTREE_THRESHOLD = 50;
+const DEFAULT_DEPTH_LIMIT = 3;
+
+interface ExtractDomTreeOptions {
+  /**
+   * Maximum character budget for the output (~2 chars per token).
+   */
+  charBudget?: number;
+  /**
+   * Maximum depth for subtree serialization.
+   * Only applies if the subtree exceeds SMALL_SUBTREE_THRESHOLD elements.
+   */
+  depthLimit?: number;
+}
+
+/**
+ * Extracts a structured DOM tree representation from an element inside an rrweb replay iframe.
+ * Designed to produce concise, LLM-friendly output for Seer Explore.
+ *
+ * The output includes:
+ * - An ancestor path from <body> to the element's parent
+ * - A CSS selector for the element
+ * - The element's subtree HTML, depth-limited and cleaned of rrweb artifacts
+ */
+export function extractDomTree(
+  element: HTMLElement,
+  options: ExtractDomTreeOptions = {}
+): string {
+  const {charBudget = MAX_CHAR_BUDGET, depthLimit = DEFAULT_DEPTH_LIMIT} = options;
+
+  const ancestorPath = buildAncestorPath(element);
+  const selector = buildElementSelector(element);
+  const subtreeSize = countDescendantElements(element);
+
+  // Always serialize with depth limiting to ensure style/SVG cleanup.
+  // For small subtrees, use a very high depth to preserve full structure.
+  let html: string;
+  const effectiveDepth = subtreeSize < SMALL_SUBTREE_THRESHOLD ? Infinity : depthLimit;
+  html = serializeWithDepthLimit(element, effectiveDepth);
+
+  // Clean rrweb artifacts from the HTML
+  html = cleanRrwebArtifacts(html);
+
+  // Assemble the output
+  let output = '';
+  if (ancestorPath) {
+    output += `<!-- Ancestor path: ${ancestorPath} -->\n`;
+  }
+  if (selector) {
+    output += `<!-- CSS Selector: ${selector} -->\n`;
+  }
+  output += html;
+
+  // Enforce token budget — progressively reduce depth if too large
+  if (output.length > charBudget) {
+    for (let depth = depthLimit - 1; depth >= 1; depth--) {
+      html = cleanRrwebArtifacts(serializeWithDepthLimit(element, depth));
+      output = '';
+      if (ancestorPath) {
+        output += `<!-- Ancestor path: ${ancestorPath} -->\n`;
+      }
+      if (selector) {
+        output += `<!-- CSS Selector: ${selector} -->\n`;
+      }
+      output += html;
+
+      if (output.length <= charBudget) {
+        break;
+      }
+    }
+
+    // If still too large after depth=1, hard truncate
+    if (output.length > charBudget) {
+      output =
+        output.substring(0, charBudget - 50) +
+        `\n<!-- Truncated: ${subtreeSize} total elements -->`;
+    }
+  }
+
+  return output;
+}
+
+/**
+ * Builds a human-readable ancestor path from <body> down to the element's parent.
+ * Example: "body > div#app > main.dashboard > section.error-list"
+ */
+function buildAncestorPath(element: HTMLElement): string {
+  const ancestors: string[] = [];
+  let current = element.parentElement;
+
+  while (current && current.tagName !== 'HTML') {
+    ancestors.unshift(describeElement(current));
+    current = current.parentElement;
+  }
+
+  return ancestors.join(' > ');
+}
+
+/**
+ * Produces a short descriptor for an element: tag + id + key classes + data-sentry-component.
+ */
+function describeElement(el: HTMLElement): string {
+  let desc = el.tagName.toLowerCase();
+
+  if (el.id) {
+    desc += `#${el.id}`;
+  }
+
+  const classes = getSignificantClasses(el);
+  if (classes.length > 0) {
+    desc += `.${classes.join('.')}`;
+  }
+
+  const sentryComponent = el.getAttribute('data-sentry-component');
+  if (sentryComponent) {
+    desc += `[data-sentry-component="${sentryComponent}"]`;
+  }
+
+  return desc;
+}
+
+/**
+ * Gets the first few non-rrweb, non-generated class names from an element.
+ */
+function getSignificantClasses(el: HTMLElement, max = 2): string[] {
+  const classes: string[] = [];
+  for (const cls of el.classList) {
+    // Skip rrweb-injected and very long/hash-like class names
+    if (cls.startsWith('rr-') || cls.startsWith('rr_') || cls.length > 40) {
+      continue;
+    }
+    classes.push(cls);
+    if (classes.length >= max) {
+      break;
+    }
+  }
+  return classes;
+}
+
+/**
+ * Builds a CSS selector for the element using the same constructSelector utility
+ * used elsewhere in the replay system.
+ */
+function buildElementSelector(element: HTMLElement): string {
+  const classes = (element.getAttribute('class')?.split(' ') ?? []).filter(
+    cls => cls && !cls.startsWith('rr-') && !cls.startsWith('rr_')
+  );
+  return constructSelector({
+    alt: element.getAttribute('alt') ?? '',
+    aria_label: element.getAttribute('aria-label') ?? '',
+    class: classes,
+    component_name: element.getAttribute('data-sentry-component') ?? '',
+    id: element.id,
+    role: element.getAttribute('role') ?? '',
+    tag: element.tagName.toLowerCase(),
+    testid: element.getAttribute('data-test-id') ?? '',
+    title: element.getAttribute('title') ?? '',
+  }).selector;
+}
+
+/**
+ * Counts all descendant elements (not text nodes) of an element.
+ */
+function countDescendantElements(element: HTMLElement): number {
+  return element.querySelectorAll('*').length;
+}
+
+/**
+ * Serializes an element's outerHTML with a depth limit.
+ * Children beyond the depth limit are replaced with placeholder comments.
+ */
+function serializeWithDepthLimit(element: HTMLElement, maxDepth: number): string {
+  // Clone so we don't mutate the replay DOM
+  const clone = element.cloneNode(true) as HTMLElement;
+  truncateAtDepth(clone, maxDepth, 0);
+  return clone.outerHTML;
+}
+
+function truncateAtDepth(el: HTMLElement, maxDepth: number, currentDepth: number) {
+  for (const child of Array.from(el.children)) {
+    const htmlChild = child as HTMLElement;
+
+    // Always collapse style and SVG content regardless of depth
+    if (child.tagName === 'STYLE') {
+      child.textContent = '/* styles */';
+      continue;
+    }
+    if (child.tagName.toLowerCase() === 'svg') {
+      child.innerHTML = '<!-- SVG -->';
+      continue;
+    }
+
+    if (currentDepth >= maxDepth) {
+      if (child.childElementCount > 0) {
+        child.innerHTML = `<!-- ${child.childElementCount} more children -->`;
+      }
+    } else {
+      truncateAtDepth(htmlChild, maxDepth, currentDepth + 1);
+    }
+  }
+}
+
+/**
+ * Cleans rrweb-specific artifacts from serialized HTML that would confuse an LLM.
+ * - Removes data-rr-* attributes
+ * - Removes rr-block class references
+ */
+function cleanRrwebArtifacts(html: string): string {
+  // Remove data-rr-* attributes (e.g. data-rr-is-shadow-host, data-rr-id)
+  let cleaned = html.replace(/\s+data-rr-[a-z-]+="[^"]*"/g, '');
+  // Remove rr_ prefixed class names from class attributes
+  cleaned = cleaned.replace(/class="([^"]*)"/g, (_match, classes: string) => {
+    const filtered = classes
+      .split(' ')
+      .filter((cls: string) => !cls.startsWith('rr-') && !cls.startsWith('rr_'))
+      .join(' ')
+      .trim();
+    return filtered ? `class="${filtered}"` : '';
+  });
+  // Clean up any leftover empty class attributes
+  cleaned = cleaned.replace(/\s+class=""\s*/g, ' ');
+  return cleaned;
+}


### PR DESCRIPTION
## Summary

Adds an **Inspect Element** button to the replay viewer toolbar that enables users to hover over and click on DOM elements within the replay iframe. When an element is selected, a modal opens showing an element preview and HTML snippet, with an option to compose a prompt and send it—along with the DOM context—to **Seer Explorer** for analysis.

## New Components

- **`InspectModeToggle`** — Toolbar button (crosshair icon) that toggles inspect mode on/off
- **`InspectElementModal`** — Modal showing selected element details (tag, classes, component name, HTML snippet) with a textarea to compose a Seer prompt
- **`useInspectMode`** — Hook managing inspect state: hover highlighting via canvas overlay, click handling in the iframe's contentDocument, and replay pause/resume
- **`extractDomTree`** — Utility to extract a focused DOM subtree from a selected element for inclusion in the Seer prompt
- **`getIframe()`** added to `ReplayContext` — Exposes the rrweb replay iframe for direct event listener attachment

## How it Works

1. User clicks the inspect button in the replay toolbar (next to the browser/OS icons)
2. Replay pauses, and hover highlighting activates inside the replay iframe
3. User clicks an element → a modal appears with the element preview
4. User optionally types a question, then clicks "Send to Seer"
5. The DOM context + prompt is sent to Seer Explorer for analysis
6. Replay resumes when inspect mode is exited

## Screenshots

### Replay viewer with new Inspect Element button in toolbar
The crosshair icon button appears between the URL copy button and browser/OS icons:

