### PR TITLE
bug(infra): Fix test selection bug when files are deleted

### DIFF
--- a/.github/workflows/backend-selective.yml
+++ b/.github/workflows/backend-selective.yml
@@ -191,7 +191,7 @@ jobs:
           python3 .github/workflows/scripts/calculate-backend-test-shards.py
 
   backend-test-selective:
-    if: "(github.event.action != 'labeled' || github.event.label.name == 'Trigger: Override Selective Testing') && needs.files-changed.outputs.backend == 'true' && needs.calculate-shards.outputs.shard-count != '0' && needs.calculate-shards.outputs.shard-count != ''"
+    if: "(github.event.action != 'labeled' || github.event.label.name == 'Trigger: Override Selective Testing') && needs.files-changed.outputs.backend == 'true' && needs.calculate-shards.outputs.shard-count != '0' && needs.calculate-shards.outputs.shard-count != '0' && needs.calculate-shards.outputs.shard-count != ''"
     needs: [files-changed, prepare-selective-tests, calculate-shards]
     name: backend tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -99,7 +99,7 @@ jobs:
           python3 .github/workflows/scripts/calculate-backend-test-shards.py
 
   backend-test:
-    if: needs.files-changed.outputs.backend == 'true'
+    if: needs.files-changed.outputs.backend == 'true' && needs.calculate-shards.outputs.shard-count != '0'
     needs: [files-changed, calculate-shards]
     name: backend test
     runs-on: ubuntu-24.04

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -73,8 +73,8 @@ def collect_test_count() -> int | None:
             return count
 
         if result.returncode == 5:
-            # Exit code 5 means "no tests were collected" (e.g. all selected files
-            # were deleted in this PR). Treat as 0 tests rather than an error.
+            # Exit code 5 indicates no tests collected (https://docs.pytest.org/en/stable/reference/exit-codes.html)
+            # This can stem from files being deleted in a branch/PR.
             print("No tests collected (exit 5)", file=sys.stderr)
             return 0
 

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -72,6 +72,12 @@ def collect_test_count() -> int | None:
             print(f"Collected {count} tests", file=sys.stderr)
             return count
 
+        if result.returncode == 5:
+            # Exit code 5 means "no tests were collected" (e.g. all selected files
+            # were deleted in this PR). Treat as 0 tests rather than an error.
+            print("No tests collected (exit 5)", file=sys.stderr)
+            return 0
+
         if result.returncode != 0:
             print(
                 f"Pytest collection failed (exit {result.returncode})",

--- a/.github/workflows/scripts/calculate-backend-test-shards.py
+++ b/.github/workflows/scripts/calculate-backend-test-shards.py
@@ -99,8 +99,8 @@ def calculate_shards(test_count: int | None) -> int:
         return DEFAULT_SHARDS
 
     if test_count == 0:
-        print(f"No tests to run, using minimum: {MIN_SHARDS}", file=sys.stderr)
-        return MIN_SHARDS
+        print("No tests to run, skipping (0 shards)", file=sys.stderr)
+        return 0
 
     if test_count > MAX_SHARDS * TESTS_PER_SHARD:
         print(


### PR DESCRIPTION
Recently was flagged https://github.com/getsentry/sentry/pull/108184, which caused Selective testing to fail. Upon closer look, I noticed we weren't handling deleted files properly.

This change updates us to now exclude test files that were deleted which should fix this bug. Additionally if 0 tests are selected, we'll skip the job entirely