### PR TITLE
fix(issue search): Route non-error issue message search through Snuba instead of truncated Postgres field

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -253,12 +253,7 @@ def _update_profiling_search_filters(
 
 
 SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
-    GroupCategory.PERFORMANCE.value: lambda search_filters: [
-        # need to remove this search filter, so we don't constrain the returned transactions
-        sf
-        for sf in _update_profiling_search_filters(search_filters)
-        if sf.key.name != "message"
-    ],
+    GroupCategory.PERFORMANCE.value: _update_profiling_search_filters,
     GroupCategory.PROFILE.value: _update_profiling_search_filters,
 }
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -13,7 +13,6 @@ from math import floor
 from typing import Any, TypedDict, cast
 
 import sentry_sdk
-from django.db.models import Q
 from django.utils import timezone
 from snuba_sdk.expressions import Expression
 from snuba_sdk.query import Query
@@ -24,8 +23,7 @@ from sentry.api.paginator import DateTimePaginator, Paginator, SequencePaginator
 from sentry.api.serializers.models.group import SKIP_SNUBA_FIELDS
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.grouping.grouptype import ErrorGroupType
-from sentry.issues.grouptype import GroupCategory, get_group_types_by_category
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.search import (
     SEARCH_FILTER_UPDATERS,
     IntermediateSearchQueryPartial,
@@ -828,21 +826,6 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 .filter(last_seen__gte=start, last_seen__lte=end)
                 .order_by("-last_seen")
             )
-
-            for sf in search_filters or ():
-                # general search query:
-                if "message" == sf.key.name and isinstance(sf.value.raw_value, str):
-                    group_queryset = group_queryset.filter(
-                        Q(type=ErrorGroupType.type_id)
-                        | (
-                            Q(type__in=get_group_types_by_category(GroupCategory.PERFORMANCE.value))
-                            and (
-                                ~Q(message__icontains=sf.value.raw_value)
-                                if sf.is_negation
-                                else Q(message__icontains=sf.value.raw_value)
-                            )
-                        )
-                    )
 
             paginator = DateTimePaginator(group_queryset, "-last_seen", **paginator_options)
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -34,6 +34,7 @@ from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.group import GroupSubStatus, PriorityLevel
+from sentry.utils import snuba
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
@@ -3219,11 +3220,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
             assert list(results) == []
             assert results.hits == 2
 
-    def test_perf_issue_search_message_term_queries_postgres(self) -> None:
-        from django.db.models import Q
-
-        from sentry.utils import snuba
-
+    def test_perf_issue_search_message_term_queries_snuba(self) -> None:
         transaction_name = "im a little tea pot"
 
         with (
@@ -3256,11 +3253,6 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
             assert "tea" in tx.search_message
             created_group = mock_eventstream.call_args[0][2].group
 
-        find_group = Group.objects.filter(
-            Q(type=PerformanceRenderBlockingAssetSpanGroupType.type_id, message__icontains="tea")
-        ).first()
-
-        assert created_group == find_group
         with self.feature(created_group.issue_type.build_visible_feature_name()):
             result = snuba.raw_query(
                 dataset=Dataset.IssuePlatform,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3717,3 +3717,134 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             )
             assert group_info is not None
             assert list(results) == [group_info.group]
+
+    def test_generic_long_message_search(self) -> None:
+        long_message = "A" * 260 + " uniquekeyword123"
+
+        event_id = uuid.uuid4().hex
+        _, group_info = self.process_occurrence(
+            event_id=event_id,
+            project_id=self.project.id,
+            fingerprint=["long-message-group"],
+            issue_title=long_message,
+            event_data={
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "1"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
+        )
+        assert group_info is not None
+
+        # Verify the Postgres Group.message is truncated to 255 chars
+        group = Group.objects.get(id=group_info.group.id)
+        assert "uniquekeyword123" not in group.message
+
+        # Search should still find it via Snuba
+        results = self.make_query(search_filter_query="uniquekeyword123")
+        assert list(results) == [group_info.group]
+
+    def test_feedback_long_message_search(self) -> None:
+        long_message = "This is user feedback. " * 15 + "specificword789"
+
+        with self.feature(
+            [
+                *FeedbackGroup.build_visible_feature_name(),
+                FeedbackGroup.build_ingest_feature_name(),
+            ]
+        ):
+            event_id = uuid.uuid4().hex
+            _, group_info = self.process_occurrence(
+                **{
+                    "project_id": self.project.id,
+                    "event_id": event_id,
+                    "fingerprint": ["feedback-long-msg"],
+                    "issue_title": long_message,
+                    "type": FeedbackGroup.type_id,
+                    "detection_time": datetime.now().timestamp(),
+                    "level": "info",
+                },
+                event_data={
+                    "platform": "python",
+                    "timestamp": before_now(minutes=1).isoformat(),
+                    "received": before_now(minutes=1).isoformat(),
+                },
+            )
+            assert group_info is not None
+
+            # Verify the Postgres Group.message is truncated to 255 chars
+            group = Group.objects.get(id=group_info.group.id)
+            assert "specificword789" not in group.message
+
+            results = self.make_query(
+                search_filter_query="issue.category:feedback specificword789",
+                date_from=self.base_datetime,
+                date_to=self.base_datetime + timedelta(days=10),
+            )
+            assert list(results) == [group_info.group]
+
+    def test_perf_issue_long_message_search(self) -> None:
+        group_type = PerformanceNPlusOneGroupType
+        long_title = "P" * 260 + " perfkeyword456"
+
+        with mock.patch.object(
+            PerformanceNPlusOneGroupType,
+            "noise_config",
+            new=NoiseConfig(0, timedelta(minutes=1)),
+        ):
+            event_id = uuid.uuid4().hex
+            with self.feature(group_type.build_ingest_feature_name()):
+                _, group_info = self.process_occurrence(
+                    event_id=event_id,
+                    project_id=self.project.id,
+                    type=group_type.type_id,
+                    fingerprint=["perf-long-msg"],
+                    issue_title=long_title,
+                    event_data={
+                        "title": "some problem",
+                        "platform": "python",
+                        "tags": {"my_tag": "1"},
+                        "timestamp": before_now(minutes=1).isoformat(),
+                        "received": before_now(minutes=1).isoformat(),
+                    },
+                )
+                assert group_info is not None
+
+            # Verify the Postgres Group.message is truncated to 255 chars
+            group = Group.objects.get(id=group_info.group.id)
+            assert "perfkeyword456" not in group.message
+
+            with self.feature(
+                [
+                    *group_type.build_visible_feature_name(),
+                    "organizations:performance-issues-search",
+                ]
+            ):
+                results = self.make_query(
+                    search_filter_query="issue.category:performance perfkeyword456"
+                )
+                assert list(results) == [group_info.group]
+
+    def test_negated_long_message_search(self) -> None:
+        long_message = "B" * 260 + " excludethis999"
+
+        event_id = uuid.uuid4().hex
+        _, group_info = self.process_occurrence(
+            event_id=event_id,
+            project_id=self.project.id,
+            fingerprint=["negation-test-group"],
+            issue_title=long_message,
+            event_data={
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "1"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "received": before_now(minutes=1).isoformat(),
+            },
+        )
+        assert group_info is not None
+
+        # Negated search for the keyword should NOT return this group
+        results = self.make_query(search_filter_query="!message:excludethis999")
+        assert group_info.group not in set(results)


### PR DESCRIPTION
Fixes [ID-1359](https://linear.app/getsentry/issue/ID-1359/remove-non-error-issue-platform-search-limitation-truncation-at-256).

[Slack thread for context](https://sentry.slack.com/archives/C04KZQBNQ2U/p1771005422114209)

Fixes message search for non-error issues, which can fail when the search keyword(s) appear beyond the first 255 characters of the message, since the `message` field in Postgres is truncated to 255 characters. The Snuba data stores the full message, so we should just search the full text there instead of pre-filtering. This matches the existing behavior for error issues.