### PR TITLE
feat(preprod): Add org-scoped build-details endpoint and auto-resolve project

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_build_details.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_build_details.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import analytics, features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.models.organization import Organization
+from sentry.preprod.analytics import PreprodArtifactApiGetBuildDetailsEvent
+from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactResourceDoesNotExist
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    transform_preprod_artifact_to_build_details,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.quotas import get_size_retention_cutoff
+
+
+@region_silo_endpoint
+class OrganizationPreprodBuildDetailsEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+
+    def get(self, request: Request, organization: Organization, artifact_id: str) -> Response:
+        if not features.has(
+            "organizations:preprod-frontend-routes", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        try:
+            artifact = PreprodArtifact.objects.select_related(
+                "mobile_app_info", "build_configuration", "project", "commit_comparison"
+            ).get(
+                id=int(artifact_id),
+                project__organization_id=organization.id,
+            )
+        except (PreprodArtifact.DoesNotExist, ValueError):
+            raise PreprodArtifactResourceDoesNotExist
+
+        analytics.record(
+            PreprodArtifactApiGetBuildDetailsEvent(
+                organization_id=organization.id,
+                project_id=artifact.project_id,
+                user_id=request.user.id,
+                artifact_id=artifact_id,
+            )
+        )
+
+        cutoff = get_size_retention_cutoff(organization)
+        if artifact.date_added < cutoff:
+            return Response({"detail": "This build's size data has expired."}, status=404)
+
+        if artifact.state == PreprodArtifact.ArtifactState.FAILED:
+            return Response({"detail": artifact.error_message}, status=400)
+
+        build_details = transform_preprod_artifact_to_build_details(artifact)
+        return Response(build_details.dict())

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -17,6 +17,7 @@ from sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_do
 )
 
 from .organization_preprod_artifact_assemble import ProjectPreprodArtifactAssembleEndpoint
+from .organization_preprod_build_details import OrganizationPreprodBuildDetailsEndpoint
 from .organization_preprod_list_builds import OrganizationPreprodListBuildsEndpoint
 from .organization_preprod_quota import OrganizationPreprodQuotaEndpoint
 from .organization_preprod_retention import OrganizationPreprodRetentionEndpoint
@@ -170,6 +171,11 @@ preprod_organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/builds/$",
         BuildsEndpoint.as_view(),
         name="sentry-api-0-organization-builds",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/preprodartifacts/(?P<artifact_id>[^/]+)/build-details/$",
+        OrganizationPreprodBuildDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-preprod-artifact-build-details",
     ),
 ]
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -472,6 +472,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/pr-comments/$repoName/$prNumber/'
   | '/organizations/$organizationIdOrSlug/preprod/quota/'
   | '/organizations/$organizationIdOrSlug/preprod/retention/'
+  | '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/'
   | '/organizations/$organizationIdOrSlug/preprodartifacts/list-builds/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/'
   | '/organizations/$organizationIdOrSlug/prevent/owner/$owner/repositories/sync/'

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_build_details.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_build_details.py
@@ -1,0 +1,134 @@
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry.preprod.models import PreprodArtifact
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationPreprodBuildDetailsEndpointTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.user = self.create_user(email="test@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.api_token = self.create_user_auth_token(
+            user=self.user, scope_list=["org:admin", "project:admin"]
+        )
+
+        self.file = self.create_file(name="test_artifact.apk", type="application/octet-stream")
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.org,
+            head_sha="1234567890098765432112345678900987654321",
+            base_sha="9876543210012345678998765432100123456789",
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/xyz",
+            base_ref="main",
+            pr_number=123,
+        )
+
+        self.preprod_artifact = self.create_preprod_artifact(
+            project=self.project,
+            file_id=self.file.id,
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+            app_id="com.example.app",
+            build_configuration=None,
+            installable_app_file_id=1234,
+            commit_comparison=commit_comparison,
+        )
+        self.mobile_app_info = self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=self.preprod_artifact,
+            build_version="1.0.0",
+            build_number=42,
+        )
+
+        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
+        self.feature_context.__enter__()
+
+    def tearDown(self) -> None:
+        self.feature_context.__exit__(None, None, None)
+        super().tearDown()
+
+    def _get_url(self, artifact_id=None):
+        artifact_id = artifact_id or self.preprod_artifact.id
+        return reverse(
+            "sentry-api-0-organization-preprod-artifact-build-details",
+            args=[self.org.slug, artifact_id],
+        )
+
+    def test_get_build_details_success(self) -> None:
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 200
+        resp_data = response.json()
+        assert resp_data["state"] == self.preprod_artifact.state
+        assert resp_data["app_info"]["app_id"] == self.preprod_artifact.app_id
+        assert resp_data["app_info"]["name"] == self.mobile_app_info.app_name
+        assert resp_data["app_info"]["version"] == self.mobile_app_info.build_version
+        assert resp_data["app_info"]["build_number"] == self.mobile_app_info.build_number
+        assert resp_data["project_id"] == self.project.id
+        assert resp_data["project_slug"] == self.project.slug
+
+    def test_get_build_details_not_found(self) -> None:
+        url = self._get_url(artifact_id=999999)
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+
+    def test_get_build_details_different_org(self) -> None:
+        other_org = self.create_organization(owner=self.user)
+        url = reverse(
+            "sentry-api-0-organization-preprod-artifact-build-details",
+            args=[other_org.slug, self.preprod_artifact.id],
+        )
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+
+    def test_get_build_details_feature_flag_disabled(self) -> None:
+        self.feature_context.__exit__(None, None, None)
+        with self.feature({"organizations:preprod-frontend-routes": False}):
+            url = self._get_url()
+            response = self.client.get(
+                url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+            )
+            assert response.status_code == 403
+        self.feature_context = self.feature({"organizations:preprod-frontend-routes": True})
+        self.feature_context.__enter__()
+
+    def test_returns_404_for_expired_artifact(self) -> None:
+        self.preprod_artifact.date_added = timezone.now() - timedelta(days=365)
+        self.preprod_artifact.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "This build's size data has expired."
+
+    def test_returns_400_for_failed_artifact(self) -> None:
+        self.preprod_artifact.state = PreprodArtifact.ArtifactState.FAILED
+        self.preprod_artifact.error_message = "Processing failed"
+        self.preprod_artifact.save()
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Processing failed"


### PR DESCRIPTION
Add a new organization-scoped build-details API endpoint at
`/organizations/{org}/preprodartifacts/{artifactId}/build-details/`
that returns build details including `project_id` and `project_slug`
without requiring the project slug in the URL path.

This enables preprod URLs like `/preprod/size/12345/` to work without
requiring `?project=` upfront, improving UX for shared links. When a
user opens a link without the project query param, the frontend fetches
build details from the org-scoped endpoint, extracts the project ID
from the response, and automatically adds it to the URL via a
`useResolveProjectFromArtifact` hook.


- New `OrganizationPreprodBuildDetailsEndpoint` with IDOR protection
  (scopes artifact lookup by `project__organization_id`)
