### PR TITLE
feat(preprod): Add analytics for status check rule CRUD

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -1,5 +1,6 @@
 import type {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import type {Organization} from 'sentry/types/organization';
+import type {ArtifactType} from 'sentry/views/settings/project/preprod/types';
 
 type BasePreprodBuildEvent = {
   organization: Organization;
@@ -7,6 +8,11 @@ type BasePreprodBuildEvent = {
   platform?: string | null;
   project_slug?: string;
   project_type?: string | null;
+};
+
+type PreprodSettingsEvent = {
+  organization: Organization;
+  project_slug: string;
 };
 
 export type BuildListPageSource =
@@ -60,6 +66,14 @@ export type PreprodBuildEventParameters = {
   'preprod.releases.mobile-builds.tab-clicked': {
     organization: Organization;
   };
+  'preprod.settings.status_check_rule_created': PreprodSettingsEvent;
+  'preprod.settings.status_check_rule_deleted': PreprodSettingsEvent;
+  'preprod.settings.status_check_rule_updated': PreprodSettingsEvent & {
+    artifact_type: ArtifactType;
+    measurement: string;
+    metric: string;
+    value: number;
+  };
 };
 
 type PreprodBuildAnalyticsKey = keyof PreprodBuildEventParameters;
@@ -85,4 +99,10 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.onboarding.docs_clicked': 'Preprod Builds: Onboarding Docs Clicked',
   'preprod.releases.mobile-builds.tab-clicked':
     'Preprod Releases: Mobile Builds Tab Clicked',
+  'preprod.settings.status_check_rule_created':
+    'Preprod Settings: Status Check Rule Created',
+  'preprod.settings.status_check_rule_deleted':
+    'Preprod Settings: Status Check Rule Deleted',
+  'preprod.settings.status_check_rule_updated':
+    'Preprod Settings: Status Check Rule Updated',
 };

--- a/static/app/views/settings/project/preprod/statusCheckRules.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRules.tsx
@@ -13,6 +13,7 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -45,6 +46,10 @@ export function StatusCheckRules() {
   const handleAddRule = () => {
     const newRule = createEmptyRule();
     addRule(newRule);
+    trackAnalytics('preprod.settings.status_check_rule_created', {
+      organization,
+      project_slug: project.slug,
+    });
     setNewRuleId(newRule.id);
     updateExpandedInUrl([...expandedRuleIds, newRule.id]);
   };
@@ -117,11 +122,23 @@ export function StatusCheckRules() {
                         }
                         onSave={updated => {
                           updateRule(rule.id, updated);
+                          trackAnalytics('preprod.settings.status_check_rule_updated', {
+                            organization,
+                            project_slug: project.slug,
+                            metric: updated.metric,
+                            measurement: updated.measurement,
+                            artifact_type: updated.artifactType ?? 'all_artifacts',
+                            value: updated.value,
+                          });
                           if (rule.id === newRuleId) {
                             setNewRuleId(null);
                           }
                         }}
                         onDelete={() => {
+                          trackAnalytics('preprod.settings.status_check_rule_deleted', {
+                            organization,
+                            project_slug: project.slug,
+                          });
                           deleteRule(rule.id);
                           if (rule.id === newRuleId) {
                             setNewRuleId(null);


### PR DESCRIPTION
Add Amplitude analytics events for status check rule create, update, and
delete actions in the project settings UI. This lets us track adoption and
usage patterns for the status checks feature.

Three new events are defined in `preprodBuildAnalyticsEvents.tsx` and fired
from `statusCheckRules.tsx`:
- `preprod.settings.status_check_rule_created` — on rule creation
- `preprod.settings.status_check_rule_updated` — on rule save, includes metric/measurement/artifact_type/value
- `preprod.settings.status_check_rule_deleted` — on rule deletion
