### PR TITLE
chore(ACI): Add render_label method for sentry apps

### DIFF
--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -1,9 +1,12 @@
 from dataclasses import asdict
 from typing import Any
 
+from rest_framework import serializers
+
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.utils.errors import SentryAppError
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
@@ -11,6 +14,8 @@ from sentry.workflow_engine.typings.notification_action import (
     SentryAppDataBlob,
     SentryAppFormConfigDataBlob,
 )
+
+ValidationError = serializers.ValidationError
 
 
 @issue_alert_handler_registry.register(Action.Type.SENTRY_APP)
@@ -83,7 +88,9 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
             filter=dict(uuids=[sentry_app_installation_uuid], organization_id=organization_id)
         )
         if not installations:
-            return ""
+            raise SentryAppError(
+                f"Sentry App installation with UUID {sentry_app_installation_uuid} not found."
+            )
 
         sentry_app = installations[0].sentry_app
         alert_rule_component = None
@@ -93,7 +100,9 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
                 break
 
         if not alert_rule_component:
-            return ""
+            raise ValidationError(
+                f"Alert Actions are not enabled for the {sentry_app.name} integration."
+            )
 
         schema_title = alert_rule_component.app_schema.get("title")
         return schema_title if schema_title is not None else sentry_app.name

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -1,9 +1,11 @@
 from dataclasses import asdict
 from typing import Any
 
+from rest_framework import serializers
+
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
-from sentry.sentry_apps.services.app import app_service
+from sentry.sentry_apps.services.app import RpcSentryAppComponent, app_service
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
@@ -11,6 +13,8 @@ from sentry.workflow_engine.typings.notification_action import (
     SentryAppDataBlob,
     SentryAppFormConfigDataBlob,
 )
+
+ValidationError = serializers.ValidationError
 
 
 @issue_alert_handler_registry.register(Action.Type.SENTRY_APP)
@@ -74,3 +78,30 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
             settings = cls.process_settings(blob.settings)
             return {"settings": settings}
         return {}
+
+    @classmethod
+    def get_alert_rule_component(
+        self, sentry_app_id: int, sentry_app_name: str
+    ) -> RpcSentryAppComponent:
+        components = app_service.find_app_components(app_id=sentry_app_id)
+
+        for component in components:
+            if component.type == "alert-rule-action":
+                return component
+
+        raise ValidationError(
+            f"Alert Actions are not enabled for the {sentry_app_name} integration."
+        )
+
+    @classmethod
+    def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        sentry_app_installation_uuid = blob.get("sentryAppInstallationUuid")
+
+        installations = app_service.get_many(filter=dict(uuids=[sentry_app_installation_uuid]))
+        if not installations:
+            raise ValidationError("Could not identify integration from the installation uuid.")
+
+        sentry_app = installations[0].sentry_app
+        alert_rule_component = cls.get_alert_rule_component(sentry_app.id, sentry_app.name)
+
+        return str(alert_rule_component.app_schema.get("title"))

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -90,6 +90,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         for component in app_service.find_app_components(app_id=sentry_app.id):
             if component.type == "alert-rule-action":
                 alert_rule_component = component
+                break
 
         if not alert_rule_component:
             return ""

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -1,8 +1,6 @@
 from dataclasses import asdict
 from typing import Any
 
-from rest_framework import serializers
-
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
 from sentry.sentry_apps.services.app import RpcSentryAppComponent, app_service
@@ -13,8 +11,6 @@ from sentry.workflow_engine.typings.notification_action import (
     SentryAppDataBlob,
     SentryAppFormConfigDataBlob,
 )
-
-ValidationError = serializers.ValidationError
 
 
 @issue_alert_handler_registry.register(Action.Type.SENTRY_APP)

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -82,6 +82,12 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
+        """
+        blob: {
+            'id': 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction',
+            'sentryAppInstallationUuid': 'str,
+        }
+        """
         sentry_app_installation_uuid = blob.get("sentryAppInstallationUuid")
 
         installations = app_service.get_many(

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -95,4 +95,5 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         if not alert_rule_component:
             return ""
 
-        return str(alert_rule_component.app_schema.get("title", sentry_app.name))
+        schema_title = alert_rule_component.app_schema.get("title")
+        return schema_title if schema_title is not None else sentry_app.name

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -81,7 +81,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
 
     @classmethod
     def get_alert_rule_component(
-        self, sentry_app_id: int, sentry_app_name: str
+        cls, sentry_app_id: int, sentry_app_name: str
     ) -> RpcSentryAppComponent:
         components = app_service.find_app_components(app_id=sentry_app_id)
 
@@ -106,4 +106,4 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         sentry_app = installations[0].sentry_app
         alert_rule_component = cls.get_alert_rule_component(sentry_app.id, sentry_app.name)
 
-        return str(alert_rule_component.app_schema.get("title"))
+        return str(alert_rule_component.app_schema.get("title", sentry_app.name))

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -97,9 +97,11 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
         sentry_app_installation_uuid = blob.get("sentryAppInstallationUuid")
 
-        installations = app_service.get_many(filter=dict(uuids=[sentry_app_installation_uuid]))
+        installations = app_service.get_many(
+            filter=dict(uuids=[sentry_app_installation_uuid], organization_id=organization_id)
+        )
         if not installations:
-            raise ValidationError("Could not identify integration from the installation uuid.")
+            return ""
 
         sentry_app = installations[0].sentry_app
         alert_rule_component = cls.get_alert_rule_component(sentry_app.id, sentry_app.name)

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -82,16 +82,14 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
     @classmethod
     def get_alert_rule_component(
         cls, sentry_app_id: int, sentry_app_name: str
-    ) -> RpcSentryAppComponent:
+    ) -> RpcSentryAppComponent | None:
         components = app_service.find_app_components(app_id=sentry_app_id)
 
         for component in components:
             if component.type == "alert-rule-action":
                 return component
 
-        raise ValidationError(
-            f"Alert Actions are not enabled for the {sentry_app_name} integration."
-        )
+        return None
 
     @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
@@ -105,5 +103,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
 
         sentry_app = installations[0].sentry_app
         alert_rule_component = cls.get_alert_rule_component(sentry_app.id, sentry_app.name)
+        if not alert_rule_component:
+            return ""
 
         return str(alert_rule_component.app_schema.get("title", sentry_app.name))

--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 from sentry.notifications.notification_action.types import BaseIssueAlertHandler
-from sentry.sentry_apps.services.app import RpcSentryAppComponent, app_service
+from sentry.sentry_apps.services.app import app_service
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.typings.notification_action import (
     ActionFieldMapping,
@@ -76,18 +76,6 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
         return {}
 
     @classmethod
-    def get_alert_rule_component(
-        cls, sentry_app_id: int, sentry_app_name: str
-    ) -> RpcSentryAppComponent | None:
-        components = app_service.find_app_components(app_id=sentry_app_id)
-
-        for component in components:
-            if component.type == "alert-rule-action":
-                return component
-
-        return None
-
-    @classmethod
     def render_label(cls, organization_id: int, blob: dict[str, Any]) -> str:
         sentry_app_installation_uuid = blob.get("sentryAppInstallationUuid")
 
@@ -98,7 +86,11 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
             return ""
 
         sentry_app = installations[0].sentry_app
-        alert_rule_component = cls.get_alert_rule_component(sentry_app.id, sentry_app.name)
+        alert_rule_component = None
+        for component in app_service.find_app_components(app_id=sentry_app.id):
+            if component.type == "alert-rule-action":
+                alert_rule_component = component
+
         if not alert_rule_component:
             return ""
 

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -624,6 +624,15 @@ class WorkflowRuleSerializerTest(TestCase):
         action_data["integration"] = integration.id
         action_data.pop("uuid")
 
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        self.assert_equal_serializers(rule)
+
     def test_sentry_app_render_label(self) -> None:
         schema = {"elements": [self.create_alert_rule_action_schema()]}
         sentry_app = self.create_sentry_app(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -620,6 +620,22 @@ class WorkflowRuleSerializerTest(TestCase):
         action_data["integration"] = integration.id
         action_data.pop("uuid")
 
+    def test_sentry_app_render_label(self) -> None:
+        schema = {"elements": [self.create_alert_rule_action_schema()]}
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=schema,
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization
+        )
+
+        action_data = {
+            "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+            "sentryAppInstallationUuid": installation.uuid,
+        }
         rule = self.create_project_rule(
             project=self.project,
             action_data=[action_data],

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,6 +1,8 @@
+import pytest
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
+from rest_framework import serializers
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
@@ -28,6 +30,8 @@ from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.workflow_engine.migration_helpers.issue_alert_migration import IssueAlertMigrator
 from sentry.workflow_engine.models import WorkflowDataConditionGroup, WorkflowFireHistory
 from sentry.workflow_engine.models.data_condition import Condition
+
+ValidationError = serializers.ValidationError
 
 
 @freeze_time()
@@ -643,4 +647,59 @@ class WorkflowRuleSerializerTest(TestCase):
             include_legacy_rule_id=False,
             include_workflow_id=False,
         )
+        self.assert_equal_serializers(rule)
+
+    def test_sentry_app_render_label_no_alert_rule_action_schema(self) -> None:
+        schema = {"elements": [self.create_issue_link_schema()]}
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=schema,
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization
+        )
+
+        action_data = {
+            "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+            "sentryAppInstallationUuid": installation.uuid,
+        }
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        with pytest.raises(ValidationError):
+            self.assert_equal_serializers(rule)
+
+    def test_sentry_app_render_label_no_installation(self) -> None:
+        schema = {"elements": [self.create_alert_rule_action_schema()]}
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=schema,
+        )
+        installation = self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization
+        )
+
+        action_data = {
+            "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+            "sentryAppInstallationUuid": installation.uuid,
+        }
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            installation.delete()
+
+        rule = self.create_project_rule(
+            project=self.project,
+            action_data=[action_data],
+            condition_data=self.conditions,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+        # actions part of response are both []
         self.assert_equal_serializers(rule)


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/108419/ and https://github.com/getsentry/sentry/pull/108795 to add a `render_label` method for sentry app actions to be used by the backwards compatible issue alert serializer.