### PR TITLE
feat(issue-detection): use title-only fingerprinting for LLM-detected issues

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -140,9 +140,7 @@ def create_issue_occurrence_from_detection(
     transaction_name = normalize_description(detected_issue.transaction_name)
     group_for_fingerprint = detected_issue.group_for_fingerprint
 
-    fingerprint = [
-        f"llm-detected-{group_for_fingerprint.strip().lower().replace(' ', '-')}"
-    ]
+    fingerprint = [f"llm-detected-{group_for_fingerprint.strip().lower().replace(' ', '-')}"]
 
     evidence_data = {
         "trace_id": trace_id,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -141,7 +141,7 @@ def create_issue_occurrence_from_detection(
     group_for_fingerprint = detected_issue.group_for_fingerprint
 
     fingerprint = [
-        f"llm-detected-{group_for_fingerprint.strip().lower().replace(' ', '-')}-{transaction_name.lower().replace(' ', '-')}"
+        f"llm-detected-{group_for_fingerprint.strip().lower().replace(' ', '-')}"
     ]
 
     evidence_data = {

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -114,7 +114,7 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.culprit == "test_transaction"
         assert occurrence.level == "warning"
 
-        assert occurrence.fingerprint == ["llm-detected--test_transaction"]
+        assert occurrence.fingerprint == ["llm-detected-"]
 
         assert occurrence.evidence_data["trace_id"] == "abc123xyz"
         assert occurrence.evidence_data["transaction"] == "test_transaction"
@@ -167,7 +167,7 @@ class LLMIssueDetectionTest(TestCase):
             project=self.project,
         )
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
-        assert occurrence.fingerprint == ["llm-detected-seer-group-key-123-get-/api"]
+        assert occurrence.fingerprint == ["llm-detected-seer-group-key-123"]
 
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -82,7 +82,7 @@ class LLMIssueDetectionTest(TestCase):
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
     def test_create_issue_occurrence_from_detection(self, mock_produce_occurrence):
         detected_issue = DetectedIssue(
-            title="Database Connection Pool Exhaustion",
+            title="Slow Database Query",
             explanation="Your application is running out of database connections",
             impact="High - may cause request failures",
             evidence="Connection pool at 95% capacity",
@@ -93,7 +93,7 @@ class LLMIssueDetectionTest(TestCase):
             subcategory="Connection Pool Exhaustion",
             category="Database",
             verification_reason="Problem is correctly identified",
-            group_for_fingerprint="",
+            group_for_fingerprint="Slow Database Query",
         )
 
         create_issue_occurrence_from_detection(
@@ -108,13 +108,13 @@ class LLMIssueDetectionTest(TestCase):
 
         occurrence = call_kwargs["occurrence"]
         assert occurrence.type == LLMDetectedExperimentalGroupType
-        assert occurrence.issue_title == "Database Connection Pool Exhaustion"
+        assert occurrence.issue_title == "Slow Database Query"
         assert occurrence.subtitle == "Your application is running out of database connections"
         assert occurrence.project_id == self.project.id
         assert occurrence.culprit == "test_transaction"
         assert occurrence.level == "warning"
 
-        assert occurrence.fingerprint == ["llm-detected-"]
+        assert occurrence.fingerprint == ["llm-detected-slow-database-query"]
 
         assert occurrence.evidence_data["trace_id"] == "abc123xyz"
         assert occurrence.evidence_data["transaction"] == "test_transaction"
@@ -149,7 +149,7 @@ class LLMIssueDetectionTest(TestCase):
         self, mock_produce_occurrence
     ):
         detected_issue = DetectedIssue(
-            title="N+1 Queries",
+            title="N+1 Database Queries",
             explanation="Multiple queries in loop",
             impact="Medium",
             evidence="5 queries",
@@ -160,14 +160,14 @@ class LLMIssueDetectionTest(TestCase):
             subcategory="N+1",
             category="Performance",
             verification_reason="Verified",
-            group_for_fingerprint="seer-group-key-123",
+            group_for_fingerprint="N+1 Database Queries",
         )
         create_issue_occurrence_from_detection(
             detected_issue=detected_issue,
             project=self.project,
         )
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
-        assert occurrence.fingerprint == ["llm-detected-seer-group-key-123"]
+        assert occurrence.fingerprint == ["llm-detected-n+1-database-queries"]
 
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")


### PR DESCRIPTION
Remove transaction_name from the fingerprint so issues group solely by their title (passed via group_for_fingerprint from seer). This intentionally overgroups to align with the new predefined title list in seer.
