### PR TITLE
feat(preprod): Add analytics events for status check threshold failures and approvals

### DIFF
--- a/src/sentry/preprod/analytics.py
+++ b/src/sentry/preprod/analytics.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from sentry import analytics
 
 
@@ -153,6 +155,23 @@ class PreprodApiPrPageCommentsEvent(analytics.Event):
     pr_number: str
 
 
+# Status check events
+@analytics.eventclass("preprod_status_check.triggered_rule_posted")
+class PreprodStatusCheckTriggeredRulePostedEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    artifact_id: int
+    product: Literal["size", "snapshots"]
+
+
+@analytics.eventclass("preprod_status_check.approval_created")
+class PreprodStatusCheckApprovalCreatedEvent(analytics.Event):
+    organization_id: int
+    project_id: int
+    artifact_id: int
+    product: Literal["size", "snapshots"]
+
+
 analytics.register(PreprodArtifactApiAssembleEvent)
 analytics.register(PreprodArtifactApiUpdateEvent)
 analytics.register(PreprodArtifactApiAssembleGenericEvent)
@@ -174,3 +193,6 @@ analytics.register(PreprodArtifactApiSizeAnalysisCompareDownloadEvent)
 analytics.register(PreprodApiPrPageDetailsEvent)
 analytics.register(PreprodApiPrPageSizeAnalysisDownloadEvent)
 analytics.register(PreprodApiPrPageCommentsEvent)
+# Status check events
+analytics.register(PreprodStatusCheckTriggeredRulePostedEvent)
+analytics.register(PreprodStatusCheckApprovalCreatedEvent)

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from django.db import router, transaction
 
+from sentry import analytics as sentry_analytics
 from sentry.api.event_search import SearchConfig, SearchFilter, parse_search_query
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
@@ -28,6 +29,7 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.project import Project
 from sentry.models.repository import Repository
+from sentry.preprod.analytics import PreprodStatusCheckTriggeredRulePostedEvent
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
@@ -351,6 +353,16 @@ def create_preprod_status_check_task(
     _update_posted_status_check(
         preprod_artifact, check_type="size", success=True, check_id=check_id
     )
+
+    if triggered_rules:
+        sentry_analytics.record(
+            PreprodStatusCheckTriggeredRulePostedEvent(
+                organization_id=preprod_artifact.project.organization_id,
+                project_id=preprod_artifact.project_id,
+                artifact_id=preprod_artifact.id,
+                product="size",
+            )
+        )
 
     logger.info(
         "preprod.status_checks.create.success",


### PR DESCRIPTION
## Summary
- Add two new backend analytics events: `preprod_status_check.triggered_rule_posted` and `preprod_status_check.approval_created`
- Fire the threshold failure event when a size rule violation causes a failed GitHub check run
- Fire the approval event when a user clicks the "Approve" button on a failed check run

## Test plan
- [x] Existing status check size tests pass (94 tests)
- [x] Existing webhook tests pass (12 tests)
- [x] Pre-commit hooks pass on all modified files
