### PR TITLE
fix(issues): Persist project id in links to search w/ tag

### DIFF
--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -105,11 +105,18 @@ describe('EventTagsTree', () => {
 
     for (const link of linkDropdowns) {
       await userEvent.click(link);
-      expect(
-        await within(link.parentElement!).findByLabelText(
-          'Search issues with this tag value'
-        )
-      ).toBeInTheDocument();
+      const searchIssuesLink = await within(link.parentElement!).findByLabelText(
+        'Search issues with this tag value'
+      );
+      expect(searchIssuesLink).toBeInTheDocument();
+      expect(searchIssuesLink).toHaveAttribute(
+        'href',
+        expect.stringContaining(`/organizations/${organization.slug}/issues/?`)
+      );
+      expect(searchIssuesLink).toHaveAttribute(
+        'href',
+        expect.stringContaining(`project=${project.id}`)
+      );
       expect(
         await within(link.parentElement!).findByLabelText(
           'View other events with this tag value'

--- a/static/app/components/events/eventTags/eventTagsTree.spec.tsx
+++ b/static/app/components/events/eventTags/eventTagsTree.spec.tsx
@@ -105,18 +105,11 @@ describe('EventTagsTree', () => {
 
     for (const link of linkDropdowns) {
       await userEvent.click(link);
-      const searchIssuesLink = await within(link.parentElement!).findByLabelText(
-        'Search issues with this tag value'
-      );
-      expect(searchIssuesLink).toBeInTheDocument();
-      expect(searchIssuesLink).toHaveAttribute(
-        'href',
-        expect.stringContaining(`/organizations/${organization.slug}/issues/?`)
-      );
-      expect(searchIssuesLink).toHaveAttribute(
-        'href',
-        expect.stringContaining(`project=${project.id}`)
-      );
+      expect(
+        await within(link.parentElement!).findByLabelText(
+          'Search issues with this tag value'
+        )
+      ).toBeInTheDocument();
       expect(
         await within(link.parentElement!).findByLabelText(
           'View other events with this tag value'

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -187,7 +187,10 @@ function EventTagsTreeRowDropdown({
       hidden: isFeedback,
       to: {
         pathname: `/organizations/${organization.slug}/issues/`,
-        query,
+        query: {
+          ...query,
+          project: project.id,
+        },
       },
     },
     {
@@ -196,7 +199,10 @@ function EventTagsTreeRowDropdown({
       hidden: !isFeedback,
       to: {
         pathname: `/organizations/${organization.slug}/feedback/`,
-        query,
+        query: {
+          ...query,
+          project: project.id,
+        },
       },
     },
     {

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.spec.tsx
@@ -125,6 +125,22 @@ describe('TagDetailsDrawerContent', () => {
       'href',
       '/organizations/org-slug/issues/1/events/?query=user.username%3Adavid'
     );
+
+    const searchIssuesMenuItem = screen.getByRole('menuitemradio', {
+      name: 'Search issues with this tag value',
+    });
+    expect(searchIssuesMenuItem).toHaveAttribute(
+      'href',
+      expect.stringContaining('/organizations/org-slug/issues/?')
+    );
+    expect(searchIssuesMenuItem).toHaveAttribute(
+      'href',
+      expect.stringContaining('query=user.username%3Adavid')
+    );
+    expect(searchIssuesMenuItem).toHaveAttribute(
+      'href',
+      expect.stringContaining(`project=${group.project.id}`)
+    );
   });
 
   it('navigates to discover with issue + tag query', async () => {

--- a/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsDrawerContent.tsx
@@ -322,7 +322,10 @@ function TagValueActionsMenu({
           label: t('Search issues with this tag value'),
           to: {
             pathname: `/organizations/${organization.slug}/issues/`,
-            query,
+            query: {
+              ...query,
+              project: group.project.id,
+            },
           },
         },
         {


### PR DESCRIPTION
adds project id when redirecting back to issues search from tags "Search issues with this tag value"

fixes #108799
