### PR TITLE
fix(ACI): Validate and allow updating project id for detector

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -342,10 +342,6 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         if project.organization.id != organization.id:
             raise ValidationError({"projectId": ["Project not found"]})
 
-        # TODO: Should be in the validator?
-        if not request.access.has_project_access(project):
-            return Response(status=status.HTTP_403_FORBIDDEN)
-
         validator = get_detector_validator(request, project, detector_type)
         if not validator.is_valid():
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -5,6 +5,7 @@ from typing import Any
 from django.db import router, transaction
 from jsonschema import ValidationError as JSONSchemaValidationError
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from sentry import audit_log
 from sentry.api.fields.actor import OwnerActorField
@@ -96,7 +97,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
 
         request = self.context["request"]
         if not request.access.has_project_access(project):
-            raise serializers.ValidationError("User does not have access to this project")
+            raise PermissionDenied("User does not have access to this project")
 
         return project.id
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -90,7 +90,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
     project_id = serializers.CharField(required=False)
 
     def validate_project_id(self, value: str) -> int:
-        project_id = to_valid_int_id("project_id", value)
+        project_id = to_valid_int_id("projectId", value)
 
         organization = self.context.get("organization")
         try:

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -220,6 +220,8 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
 
             if "project_id" in validated_data:
                 instance.project_id = validated_data["project_id"]
+                # invalidate cache of old project
+                Detector.invalidate_project_cache(instance.project_id, instance.type)
 
             instance.save()
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -16,6 +16,7 @@ from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.endpoints.validators.api_docs_help_text import (
     CONDITION_GROUP_HELP_TEXT,
     DATA_SOURCES_HELP_TEXT,
@@ -89,9 +90,11 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
     project_id = serializers.CharField(required=False)
 
     def validate_project_id(self, value: str) -> int:
+        project_id = to_valid_int_id("project_id", value)
+
         organization = self.context.get("organization")
         try:
-            project = Project.objects.get(id=int(value), organization=organization)
+            project = Project.objects.get(id=project_id, organization=organization)
         except Project.DoesNotExist:
             raise serializers.ValidationError("Project not in organization")
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -13,6 +13,7 @@ from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.issues import grouptype
 from sentry.issues.grouptype import GroupType
+from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.validators.api_docs_help_text import (
     CONDITION_GROUP_HELP_TEXT,
@@ -84,6 +85,13 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
     enabled = serializers.BooleanField(
         required=False, help_text="Set to False if you want to disable the monitor."
     )
+    project_id = serializers.CharField(required=False)
+
+    def validate_project_id(self, value: str) -> int:
+        organization = self.context.get("organization")
+        if not Project.objects.filter(id=int(value), organization=organization).exists():
+            raise serializers.ValidationError("Project not in organization")
+        return int(value)
 
     def validate_type(self, value: str) -> builtins.type[GroupType]:
         type = grouptype.registry.get_by_slug(value)
@@ -198,6 +206,9 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
                     instance.enforce_config_schema()
                 except JSONSchemaValidationError as error:
                     raise serializers.ValidationError({"config": [str(error)]})
+
+            if "project_id" in validated_data:
+                instance.project_id = validated_data["project_id"]
 
             instance.save()
 

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -89,8 +89,15 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
 
     def validate_project_id(self, value: str) -> int:
         organization = self.context.get("organization")
-        if not Project.objects.filter(id=int(value), organization=organization).exists():
+        try:
+            project = Project.objects.get(id=int(value), organization=organization)
+        except Project.DoesNotExist:
             raise serializers.ValidationError("Project not in organization")
+
+        request = self.context["request"]
+        if not request.access.has_project_access(project):
+            raise serializers.ValidationError("User does not have access to this project")
+
         return int(value)
 
     def validate_type(self, value: str) -> builtins.type[GroupType]:

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -98,7 +98,7 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
         if not request.access.has_project_access(project):
             raise serializers.ValidationError("User does not have access to this project")
 
-        return int(value)
+        return project.id
 
     def validate_type(self, value: str) -> builtins.type[GroupType]:
         type = grouptype.registry.get_by_slug(value)

--- a/src/sentry/workflow_engine/models/detector.py
+++ b/src/sentry/workflow_engine/models/detector.py
@@ -115,6 +115,11 @@ class Detector(DefaultFieldsModel, OwnerModel, JSONConfigBase):
         return f"detector:by_proj_type:{project_id}:{detector_type}"
 
     @classmethod
+    def invalidate_project_cache(cls, project_id: int, detector_type: str) -> None:
+        cache_key = cls._get_detector_project_type_cache_key(project_id, detector_type)
+        cache.delete(cache_key)
+
+    @classmethod
     def get_default_detector_for_project(cls, project_id: int, detector_type: str) -> Detector:
         cache_key = cls._get_detector_project_type_cache_key(project_id, detector_type)
         detector = cache.get(cache_key)

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -131,10 +131,14 @@ class TestMetricAlertsDetectorValidator(BaseValidatorTest):
         self.environment = Environment.objects.create(
             organization_id=self.project.organization_id, name="production"
         )
+        request = self.make_request()
+        access = mock.MagicMock()
+        access.has_project_access.return_value = True
+        request.access = access
         self.context = {
             "organization": self.project.organization,
             "project": self.project,
-            "request": self.make_request(),
+            "request": request,
         }
         self.valid_data = {
             "name": "Test Detector",

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from django.utils import timezone
+from rest_framework.exceptions import ErrorDetail
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -333,6 +334,38 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             status_code=400,
         )
         assert "projectId" in response.data
+
+        # verify project was not updated
+        self.detector.refresh_from_db()
+        assert self.detector.project == self.project
+
+    def test_update_project_no_access(self) -> None:
+        # Disable Open Membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create a user who is a member of the org but NOT a member of any team
+        user_no_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_no_team, organization=self.organization, role="member", teams=[]
+        )
+        self.login_as(user_no_team)
+
+        project2 = self.create_project(organization=self.organization)
+        data = {"projectId": project2.id}
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=403,
+        )
+        assert response.data == {
+            "detail": ErrorDetail(
+                "You do not have permission to perform this action.",
+                code="permission_denied",
+            ),
+        }
 
         # verify project was not updated
         self.detector.refresh_from_db()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -306,6 +306,38 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         self.assert_snuba_query_updated(snuba_query)
         mock_schedule_update_project_config.assert_called_once_with(detector)
 
+    def test_update_project(self) -> None:
+        project2 = self.create_project(organization=self.organization)
+        data = {"projectId": project2.id}
+
+        with self.tasks():
+            self.get_success_response(
+                self.organization.slug,
+                self.detector.id,
+                **data,
+                status_code=200,
+            )
+
+        self.detector.refresh_from_db()
+        assert self.detector.project == project2
+
+    def test_update_project_other_org(self) -> None:
+        other_organization = self.create_organization()
+        project2 = self.create_project(organization=other_organization)
+        data = {"projectId": project2.id}
+
+        response = self.get_error_response(
+            self.organization.slug,
+            self.detector.id,
+            **data,
+            status_code=400,
+        )
+        assert "projectId" in response.data
+
+        # verify project was not updated
+        self.detector.refresh_from_db()
+        assert self.detector.project == self.project
+
     def test_update_description(self) -> None:
         assert self.detector.description is None
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -881,6 +881,24 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"projectId": ["Project not found"]}
 
+    def test_no_access_project(self) -> None:
+        # Disable Open Membership
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        # Create a user who is a member of the org but NOT a member of any team
+        user_no_team = self.create_user(is_superuser=False)
+        self.create_member(
+            user=user_no_team, organization=self.organization, role="member", teams=[]
+        )
+        self.login_as(user_no_team)
+
+        self.get_error_response(
+            self.organization.slug,
+            **self.valid_data,
+            status_code=403,
+        )
+
     def test_without_feature_flag(self) -> None:
         with self.feature({"organizations:incidents": False}):
             response = self.get_error_response(


### PR DESCRIPTION
Allow for project updates on a detector and validate that the project belongs to the target organization. 

TODO:
- [ ] Add test for invalidating cache
- [ ] Handle updating `Monitor` project for cron detectors
- [ ] Address whatever https://github.com/getsentry/sentry/pull/109135#discussion_r2843096751 is talking about