### PR TITLE
feat(preprod): Add snapshot image comparison task with odiff

### DIFF
--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -20,6 +20,10 @@ RUN : \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+ARG ODIFF_VERSION=4.3.2
+ARG ODIFF_SHA256_X64=2c17e6bcf92a58e6668f19f17f4a27fa4b1d70840994f31bd837b55bb6b297d7
+ARG ODIFF_SHA256_ARM64=d65f748c463a6aa78fa7bcdd31acd797eaed5160867e7769a3b291cfea42c9a0
+
 WORKDIR /usr/src/sentry
 
 ENV PATH="/.venv/bin:$PATH" UV_PROJECT_ENVIRONMENT=/.venv \
@@ -51,6 +55,14 @@ RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
   && uv sync --frozen --quiet --no-install-project \
+  && case "$(dpkg --print-architecture)" in \
+       amd64) ODIFF_ARCH=x64 ODIFF_SHA256="$ODIFF_SHA256_X64" ;; \
+       arm64) ODIFF_ARCH=arm64 ODIFF_SHA256="$ODIFF_SHA256_ARM64" ;; \
+       *) echo "Unsupported architecture for odiff" && exit 1 ;; \
+     esac \
+  && wget -qO /usr/local/bin/odiff "https://github.com/dmtrKovalenko/odiff/releases/download/v${ODIFF_VERSION}/odiff-linux-${ODIFF_ARCH}" \
+  && echo "${ODIFF_SHA256} /usr/local/bin/odiff" | sha256sum --check --status \
+  && chmod +x /usr/local/bin/odiff \
   && apt-get purge -y --auto-remove $buildDeps \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -887,6 +887,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.notifications.platform.service",
     "sentry.notifications.utils.tasks",
     "sentry.preprod.size_analysis.tasks",
+    "sentry.preprod.snapshots.tasks",
     "sentry.preprod.tasks",
     "sentry.preprod.vcs.status_checks.size.tasks",
     "sentry.profiles.task",

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from PIL import Image
+
+from .odiff import OdiffServer
+from .types import DiffResult
+
+logger = logging.getLogger(__name__)
+
+BASE_THRESHOLD = 0.15
+COLOR_SENSITIVE_THRESHOLD = 0.0225
+DEFAULT_THRESHOLD_SCALE = 25
+
+
+def _to_pil_image(source: bytes | Image.Image) -> Image.Image:
+    if isinstance(source, bytes):
+        return Image.open(io.BytesIO(source))
+    return source
+
+
+def _mask_from_diff_output(output_path: Path) -> Image.Image:
+    alpha = Image.open(output_path).convert("RGBA").split()[3]
+    return alpha.point(lambda px: 255 if px > 0 else 0)
+
+
+def _encode_mask_png_base64(mask: Image.Image) -> str:
+    buf = io.BytesIO()
+    mask.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def compare_images(
+    before: bytes | Image.Image,
+    after: bytes | Image.Image,
+    threshold: int = DEFAULT_THRESHOLD_SCALE,
+) -> DiffResult | None:
+    return compare_images_batch([(before, after)], threshold)[0]
+
+
+def compare_images_batch(
+    pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
+    threshold: int = DEFAULT_THRESHOLD_SCALE,
+    server: OdiffServer | None = None,
+) -> list[DiffResult | None]:
+    scale = threshold / DEFAULT_THRESHOLD_SCALE
+    base_thresh = BASE_THRESHOLD * scale
+    color_thresh = COLOR_SENSITIVE_THRESHOLD * scale
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        if server is not None:
+            return _compare_pairs(pairs, server, tmpdir_path, base_thresh, color_thresh)
+        with OdiffServer() as new_server:
+            return _compare_pairs(pairs, new_server, tmpdir_path, base_thresh, color_thresh)
+
+
+def _compare_pairs(
+    pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
+    server: OdiffServer,
+    tmpdir_path: Path,
+    base_thresh: float,
+    color_thresh: float,
+) -> list[DiffResult | None]:
+    results: list[DiffResult | None] = []
+
+    for idx, (before, after) in enumerate(pairs):
+        try:
+            results.append(
+                _compare_single_pair(
+                    idx, before, after, server, tmpdir_path, base_thresh, color_thresh
+                )
+            )
+        except Exception:
+            logger.exception("Failed to compare image pair %d", idx)
+            results.append(None)
+
+    return results
+
+
+def _compare_single_pair(
+    idx: int,
+    before: bytes | Image.Image,
+    after: bytes | Image.Image,
+    server: OdiffServer,
+    tmpdir_path: Path,
+    base_thresh: float,
+    color_thresh: float,
+) -> DiffResult:
+    before_img = _to_pil_image(before)
+    after_img = _to_pil_image(after)
+
+    bw, bh = before_img.size
+    aw, ah = after_img.size
+    max_w = max(bw, aw)
+    max_h = max(bh, ah)
+
+    before_path = tmpdir_path / f"before_{idx}.png"
+    after_path = tmpdir_path / f"after_{idx}.png"
+    before_img.save(before_path, "PNG")
+    after_img.save(after_path, "PNG")
+
+    base_output = tmpdir_path / f"diff_base_{idx}.png"
+    color_output = tmpdir_path / f"diff_color_{idx}.png"
+
+    base_resp = server.compare(
+        before_path,
+        after_path,
+        base_output,
+        threshold=base_thresh,
+        antialiasing=True,
+        outputDiffMask=True,
+    )
+    color_resp = server.compare(
+        before_path,
+        after_path,
+        color_output,
+        threshold=color_thresh,
+        antialiasing=True,
+        outputDiffMask=True,
+    )
+
+    base_count = base_resp.get("diffCount", 0)
+    color_count = color_resp.get("diffCount", 0)
+    base_pct = base_resp.get("diffPercentage", 0.0)
+    color_pct = color_resp.get("diffPercentage", 0.0)
+
+    if color_pct > base_pct:
+        chosen_output = color_output
+        changed_pixels = color_count
+        diff_pct = color_pct
+    else:
+        chosen_output = base_output
+        changed_pixels = base_count
+        diff_pct = base_pct
+
+    total_pixels = max_w * max_h
+    diff_score = diff_pct / 100.0
+
+    if changed_pixels == 0:
+        diff_mask = Image.new("L", (max_w, max_h), 0)
+    elif not chosen_output.exists():
+        raise RuntimeError(f"odiff did not produce output file: {chosen_output}")
+    else:
+        diff_mask = _mask_from_diff_output(chosen_output)
+        if diff_mask.size != (max_w, max_h):
+            diff_mask = diff_mask.resize((max_w, max_h), Image.NEAREST)
+
+    diff_mask_png = _encode_mask_png_base64(diff_mask)
+
+    return DiffResult(
+        diff_mask_png=diff_mask_png,
+        diff_score=diff_score,
+        changed_pixels=changed_pixels,
+        total_pixels=total_pixels,
+        aligned_height=max_h,
+        width=max_w,
+        before_width=bw,
+        before_height=bh,
+        after_width=aw,
+        after_height=ah,
+    )

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+from sentry.utils import json
+from sentry.utils.json import JSONDecodeError
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("Could not find repository root")
+
+
+_REPO_ROOT = _find_repo_root()
+
+_BINARY_CANDIDATES = [
+    _REPO_ROOT / "node_modules" / ".bin" / "odiff",
+    Path("/usr/local/bin/odiff"),
+]
+
+
+def _find_odiff_binary() -> str:
+    for candidate in _BINARY_CANDIDATES:
+        if candidate.exists():
+            return str(candidate)
+    found = shutil.which("odiff")
+    if found:
+        return found
+    raise FileNotFoundError("odiff binary not found. Run 'pnpm install' to install odiff-bin.")
+
+
+class OdiffServer:
+    def __init__(self) -> None:
+        self._process: subprocess.Popen[bytes] | None = None
+        self._request_id = 0
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> OdiffServer:
+        self._start()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def _read_json(self, line: bytes) -> dict[str, Any]:
+        if not line:
+            stderr = self._process.stderr.read() if self._process and self._process.stderr else b""
+            raise RuntimeError(
+                f"odiff server exited unexpectedly: {stderr.decode(errors='replace')}"
+            )
+        try:
+            return json.loads(line)
+        except JSONDecodeError as e:
+            raise RuntimeError(f"odiff server returned invalid JSON: {line!r}") from e
+
+    def _start(self) -> None:
+        binary = _find_odiff_binary()
+        proc = subprocess.Popen(
+            [binary, "--server"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            line = proc.stdout.readline()  # type: ignore[union-attr]
+            ready = self._read_json(line)
+            if not ready.get("ready"):
+                raise RuntimeError("odiff server failed to start")
+        except BaseException:
+            proc.kill()
+            proc.wait()
+            raise
+        self._process = proc
+
+    def compare(
+        self,
+        base_path: str | Path,
+        compare_path: str | Path,
+        output_path: str | Path,
+        **options: object,
+    ) -> dict[str, Any]:
+        with self._lock:
+            if self._process is None:
+                self._start()
+
+            process = self._process
+            if process is None or process.stdin is None or process.stdout is None:
+                raise RuntimeError("odiff server failed to initialize")
+            self._request_id += 1
+            request: dict[str, object] = {
+                "requestId": self._request_id,
+                "base": str(base_path),
+                "compare": str(compare_path),
+                "output": str(output_path),
+            }
+            if options:
+                request["options"] = options
+
+            try:
+                process.stdin.write(json.dumps(request).encode() + b"\n")
+                process.stdin.flush()
+            except (BrokenPipeError, OSError) as e:
+                process.kill()
+                process.wait()
+                self._process = None
+                raise RuntimeError("odiff process died unexpectedly") from e
+
+            line = process.stdout.readline()
+            try:
+                response = self._read_json(line)
+            except RuntimeError:
+                process.kill()
+                process.wait()
+                self._process = None
+                raise
+
+        if "error" in response:
+            raise RuntimeError(f"odiff error: {response['error']}")
+
+        return response
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._process:
+                return
+            proc = self._process
+            self._process = None
+
+        if proc.stdin:
+            try:
+                proc.stdin.close()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=3)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        proc.kill()
+        proc.wait()
+
+    def __del__(self) -> None:
+        self.close()

--- a/src/sentry/preprod/snapshots/image_diff/types.py
+++ b/src/sentry/preprod/snapshots/image_diff/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DiffResult:
+    diff_mask_png: str
+    diff_score: float
+    changed_pixels: int
+    total_pixels: int
+    aligned_height: int
+    width: int
+    before_width: int
+    before_height: int
+    after_width: int
+    after_height: int

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -1,0 +1,441 @@
+from __future__ import annotations
+
+import base64
+import logging
+from typing import NamedTuple
+
+import orjson
+from django.db import IntegrityError
+
+from sentry.objectstore import get_preprod_session
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.image_diff.compare import compare_images_batch
+from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+MAX_DIFF_PIXELS = 40_000_000
+MAX_PIXELS_PER_BATCH = 40_000_000
+
+
+class _DiffCandidate(NamedTuple):
+    name: str
+    head_hash: str
+    base_hash: str
+    pixel_count: int
+
+
+def _create_pixel_batches(
+    items: list[_DiffCandidate],
+    max_pixels_per_batch: int,
+) -> list[list[_DiffCandidate]]:
+    batches: list[list[_DiffCandidate]] = []
+    current_batch: list[_DiffCandidate] = []
+    current_pixels = 0
+    for item in items:
+        pixels = item.pixel_count
+        if current_pixels + pixels > max_pixels_per_batch and current_batch:
+            batches.append(current_batch)
+            current_batch = [item]
+            current_pixels = pixels
+        else:
+            current_batch.append(item)
+            current_pixels += pixels
+    if current_batch:
+        batches.append(current_batch)
+    return batches
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.compare_snapshots",
+    namespace=preprod_tasks,
+    retry=Retry(times=3),
+    silo_mode=SiloMode.REGION,
+    processing_deadline_duration=300,
+)
+def compare_snapshots(
+    project_id: int,
+    org_id: int,
+    head_artifact_id: int,
+    base_artifact_id: int,
+) -> None:
+    logger.info(
+        "Snapshot comparison kicked off for artifacts",
+        extra={
+            "head_artifact_id": head_artifact_id,
+            "base_artifact_id": base_artifact_id,
+        },
+    )
+
+    try:
+        head_artifact = PreprodArtifact.objects.get(
+            id=head_artifact_id,
+            project__organization_id=org_id,
+            project_id=project_id,
+        )
+        base_artifact = PreprodArtifact.objects.get(
+            id=base_artifact_id,
+            project__organization_id=org_id,
+            project_id=project_id,
+        )
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "Snapshot comparison artifact not found",
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+        return
+
+    try:
+        head_metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=head_artifact)
+        base_metrics = PreprodSnapshotMetrics.objects.get(preprod_artifact=base_artifact)
+    except PreprodSnapshotMetrics.DoesNotExist:
+        logger.exception(
+            "Snapshot comparison metrics not found",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+            },
+        )
+        return
+
+    try:
+        comparison, created = PreprodSnapshotComparison.objects.get_or_create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            defaults={"state": PreprodSnapshotComparison.State.PENDING},
+        )
+    except IntegrityError:
+        comparison = PreprodSnapshotComparison.objects.get(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+        )
+        created = False
+
+    if not created:
+        logger.info(
+            "compare_snapshots: existing comparison found (id=%d, state=%s)",
+            comparison.id,
+            comparison.state,
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+        updated = PreprodSnapshotComparison.objects.filter(
+            id=comparison.id,
+            state=PreprodSnapshotComparison.State.PENDING,
+        ).update(state=PreprodSnapshotComparison.State.PROCESSING)
+        if not updated:
+            logger.info(
+                "compare_snapshots: skipping, comparison not in PENDING state (state=%s)",
+                comparison.state,
+                extra={"head_artifact_id": head_artifact_id, "comparison_id": comparison.id},
+            )
+            return
+        comparison.state = PreprodSnapshotComparison.State.PROCESSING
+    else:
+        # Plain save is safe here: get_or_create's unique constraint guarantees
+        # only one worker gets created=True; others go through the atomic
+        # filter().update() path above.
+        logger.info(
+            "compare_snapshots: created new comparison (id=%d)",
+            comparison.id,
+            extra={"head_artifact_id": head_artifact_id, "base_artifact_id": base_artifact_id},
+        )
+        comparison.state = PreprodSnapshotComparison.State.PROCESSING
+        comparison.save(update_fields=["state"])
+
+    try:
+        session = get_preprod_session(org_id, project_id)
+
+        head_manifest_key = (head_metrics.extras or {}).get("manifest_key")
+        base_manifest_key = (base_metrics.extras or {}).get("manifest_key")
+
+        logger.info(
+            "compare_snapshots: loading manifests",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+                "head_manifest_key": head_manifest_key,
+                "base_manifest_key": base_manifest_key,
+            },
+        )
+
+        if not head_manifest_key or not base_manifest_key:
+            raise ValueError("Missing manifest key")
+
+        head_manifest = orjson.loads(session.get(head_manifest_key).payload.read())
+        base_manifest = orjson.loads(session.get(base_manifest_key).payload.read())
+
+        head_images = head_manifest.get("images", {})
+        base_images = base_manifest.get("images", {})
+
+        head_by_name = {meta.get("image_file_name", h): h for h, meta in head_images.items()}
+        base_by_name = {meta.get("image_file_name", h): h for h, meta in base_images.items()}
+
+        matched = head_by_name.keys() & base_by_name.keys()
+        added = head_by_name.keys() - base_by_name.keys()
+        removed = base_by_name.keys() - head_by_name.keys()
+
+        image_results: dict[str, dict[str, object]] = {}
+        changed_count = 0
+        unchanged_count = 0
+        # TODO (@nico): Decide how to handle skipped or errored snapshots for the frontend
+        skipped_count = 0
+
+        image_key_prefix = f"{org_id}/{project_id}"
+
+        eligible: list[_DiffCandidate] = []
+
+        for name in sorted(matched):
+            head_hash = head_by_name[name]
+            base_hash = base_by_name[name]
+
+            if head_hash == base_hash:
+                unchanged_count += 1
+                image_results[name] = {
+                    "status": "unchanged",
+                    "head_hash": head_hash,
+                    "base_hash": base_hash,
+                }
+                continue
+
+            head_meta = head_images[head_hash]
+            base_meta = base_images[base_hash]
+            head_pixels = head_meta.get("width", 0) * head_meta.get("height", 0)
+            base_pixels = base_meta.get("width", 0) * base_meta.get("height", 0)
+            pixel_count = max(head_pixels, base_pixels)
+
+            if pixel_count > MAX_DIFF_PIXELS:
+                skipped_count += 1
+                logger.warning(
+                    "Skipping oversized image in snapshot comparison",
+                    extra={
+                        "name": name,
+                        "pixel_count": pixel_count,
+                        "max_diff_pixels": MAX_DIFF_PIXELS,
+                        "head_artifact_id": head_artifact_id,
+                        "base_artifact_id": base_artifact_id,
+                    },
+                )
+                image_results[name] = {
+                    "status": "skipped",
+                    "head_hash": head_hash,
+                    "base_hash": base_hash,
+                    "reason": "exceeds_pixel_limit",
+                }
+                continue
+
+            eligible.append(_DiffCandidate(name, head_hash, base_hash, pixel_count))
+
+        logger.info(
+            "compare_snapshots: image matching done",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "matched": len(matched),
+                "added": len(added),
+                "removed": len(removed),
+                "eligible_for_diff": len(eligible),
+                "unchanged_count": unchanged_count,
+                "skipped_count": skipped_count,
+            },
+        )
+
+        batches = _create_pixel_batches(eligible, MAX_PIXELS_PER_BATCH)
+
+        logger.info(
+            "compare_snapshots: starting odiff, %d batches, %d pairs",
+            len(batches),
+            len(eligible),
+            extra={"head_artifact_id": head_artifact_id},
+        )
+
+        # TODO: spawn N OdiffServer workers and distribute pairs across them
+        # via a thread pool to parallelize the odiff comparison step per batch
+        with OdiffServer() as server:
+            for batch in batches:
+                diff_pairs: list[tuple[bytes, bytes]] = []
+                batch_names: list[str] = []
+                batch_hashes: list[tuple[str, str]] = []
+
+                for candidate in batch:
+                    try:
+                        head_data = session.get(
+                            f"{image_key_prefix}/{candidate.head_hash}"
+                        ).payload.read()
+                        base_data = session.get(
+                            f"{image_key_prefix}/{candidate.base_hash}"
+                        ).payload.read()
+                    except Exception:
+                        logger.warning(
+                            "compare_snapshots: failed to fetch images for %s",
+                            candidate.name,
+                            extra={
+                                "head_artifact_id": head_artifact_id,
+                                "head_hash": candidate.head_hash,
+                                "base_hash": candidate.base_hash,
+                            },
+                        )
+                        skipped_count += 1
+                        image_results[candidate.name] = {
+                            "status": "errored",
+                            "head_hash": candidate.head_hash,
+                            "base_hash": candidate.base_hash,
+                            "reason": "image_fetch_failed",
+                        }
+                        continue
+                    diff_pairs.append((base_data, head_data))
+                    batch_names.append(candidate.name)
+                    batch_hashes.append((candidate.head_hash, candidate.base_hash))
+
+                logger.info(
+                    "compare_snapshots: running batch of %d pairs",
+                    len(diff_pairs),
+                    extra={"head_artifact_id": head_artifact_id, "names": batch_names},
+                )
+                diff_results = compare_images_batch(diff_pairs, server=server)
+                logger.info(
+                    "compare_snapshots: batch complete, %d results",
+                    len(diff_results),
+                    extra={"head_artifact_id": head_artifact_id},
+                )
+
+                for name, (head_hash, base_hash), diff_result in zip(
+                    batch_names, batch_hashes, diff_results, strict=True
+                ):
+                    if diff_result is None:
+                        skipped_count += 1
+                        image_results[name] = {
+                            "status": "errored",
+                            "head_hash": head_hash,
+                            "base_hash": base_hash,
+                            "reason": "image_processing_failed",
+                        }
+                        continue
+
+                    safe_name = name.replace("\\", "/").strip("/").replace("/", "_")
+                    stem = safe_name.rsplit(".", 1)[0] if "." in safe_name else safe_name
+                    diff_mask_key = (
+                        f"{image_key_prefix}/{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
+                    )
+                    diff_mask_bytes = base64.b64decode(diff_result.diff_mask_png)
+                    logger.info(
+                        "compare_snapshots: uploading mask for %s (%d bytes, diff=%.4f, changed_px=%d)",
+                        name,
+                        len(diff_mask_bytes),
+                        diff_result.diff_score,
+                        diff_result.changed_pixels,
+                        extra={
+                            "head_artifact_id": head_artifact_id,
+                            "diff_mask_key": diff_mask_key,
+                        },
+                    )
+                    session.put(diff_mask_bytes, key=diff_mask_key, content_type="image/png")
+
+                    is_changed = diff_result.changed_pixels > 0
+                    if is_changed:
+                        changed_count += 1
+                    else:
+                        unchanged_count += 1
+
+                    diff_mask_image_id = f"{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
+
+                    image_results[name] = {
+                        "status": "changed" if is_changed else "unchanged",
+                        "head_hash": head_hash,
+                        "base_hash": base_hash,
+                        "diff_score": diff_result.diff_score,
+                        "changed_pixels": diff_result.changed_pixels,
+                        "total_pixels": diff_result.total_pixels,
+                        "diff_mask_key": diff_mask_key,
+                        "diff_mask_image_id": diff_mask_image_id,
+                        "before_width": diff_result.before_width,
+                        "before_height": diff_result.before_height,
+                        "after_width": diff_result.after_width,
+                        "after_height": diff_result.after_height,
+                        "aligned_height": diff_result.aligned_height,
+                        "width": diff_result.width,
+                    }
+
+        for name in sorted(added):
+            image_results[name] = {"status": "added", "head_hash": head_by_name[name]}
+
+        for name in sorted(removed):
+            base_hash = base_by_name[name]
+            base_meta = base_images.get(base_hash, {})
+            image_results[name] = {
+                "status": "removed",
+                "base_hash": base_hash,
+                "before_width": base_meta.get("width", 0),
+                "before_height": base_meta.get("height", 0),
+            }
+
+        comparison_manifest = {
+            "head_artifact_id": head_artifact_id,
+            "base_artifact_id": base_artifact_id,
+            "summary": {
+                "total": len(matched) + len(added) + len(removed),
+                "changed": changed_count,
+                "unchanged": unchanged_count,
+                "added": len(added),
+                "removed": len(removed),
+                "skipped": skipped_count,
+            },
+            "images": image_results,
+        }
+
+        comparison_key = (
+            f"{org_id}/{project_id}/{head_artifact_id}/{base_artifact_id}/comparison.json"
+        )
+        session.put(
+            orjson.dumps(comparison_manifest),
+            key=comparison_key,
+            content_type="application/json",
+        )
+
+        comparison.state = PreprodSnapshotComparison.State.SUCCESS
+        comparison.images_changed = changed_count
+        comparison.images_unchanged = unchanged_count
+        comparison.images_added = len(added)
+        comparison.images_removed = len(removed)
+        extras = comparison.extras or {}
+        extras["comparison_key"] = comparison_key
+        comparison.extras = extras
+        comparison.save(
+            update_fields=[
+                "state",
+                "images_changed",
+                "images_unchanged",
+                "images_added",
+                "images_removed",
+                "extras",
+            ]
+        )
+
+        logger.info(
+            "Snapshot comparison complete",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+                "changed": changed_count,
+                "unchanged": unchanged_count,
+                "added": len(added),
+                "removed": len(removed),
+                "skipped": skipped_count,
+            },
+        )
+
+    except Exception:
+        logger.exception(
+            "Snapshot comparison failed",
+            extra={
+                "head_artifact_id": head_artifact_id,
+                "base_artifact_id": base_artifact_id,
+            },
+        )
+        comparison.state = PreprodSnapshotComparison.State.FAILED
+        comparison.error_code = PreprodSnapshotComparison.ErrorCode.INTERNAL_ERROR
+        comparison.save(update_fields=["state", "error_code"])
+        raise

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image, ImageDraw
+
+from sentry.preprod.snapshots.image_diff.compare import compare_images, compare_images_batch
+from sentry.preprod.snapshots.image_diff.odiff import _find_odiff_binary
+
+
+def _odiff_available() -> bool:
+    try:
+        _find_odiff_binary()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _odiff_available(), reason="odiff binary not found")
+
+
+def _make_solid_image(width: int, height: int, color: tuple[int, int, int, int]) -> Image.Image:
+    return Image.new("RGBA", (width, height), color)
+
+
+class TestCompareImages:
+    def test_identical_images(self):
+        img = _make_solid_image(100, 100, (128, 128, 128, 255))
+        result = compare_images(img, img.copy())
+        assert result is not None
+        assert result.diff_score == 0.0
+        assert result.changed_pixels == 0
+        assert result.total_pixels == 100 * 100
+
+    def test_completely_different(self):
+        before = _make_solid_image(50, 50, (0, 0, 0, 255))
+        after = _make_solid_image(50, 50, (255, 255, 255, 255))
+        result = compare_images(before, after, threshold=0)
+        assert result is not None
+        assert result.diff_score > 0.5
+        assert result.changed_pixels > 0
+
+    def test_different_sizes(self):
+        small = _make_solid_image(30, 30, (100, 100, 100, 255))
+        large = _make_solid_image(50, 50, (100, 100, 100, 255))
+        result = compare_images(small, large)
+        assert result is not None
+        assert result.width == 50
+        assert result.aligned_height == 50
+
+    def test_modified_block(self):
+        before = _make_solid_image(100, 100, (100, 100, 100, 255))
+        after = _make_solid_image(100, 100, (100, 100, 100, 255))
+        draw = ImageDraw.Draw(after)
+        draw.rectangle((10, 10, 29, 29), fill=(255, 0, 0, 255))
+        result = compare_images(before, after)
+        assert result is not None
+        assert result.changed_pixels > 0
+
+    def test_threshold_sensitivity(self):
+        before = _make_solid_image(50, 50, (100, 100, 100, 255))
+        after = _make_solid_image(50, 50, (110, 110, 110, 255))
+
+        strict = compare_images(before, after, threshold=0)
+        lenient = compare_images(before, after, threshold=50)
+
+        assert strict is not None
+        assert lenient is not None
+        assert strict.diff_score >= lenient.diff_score
+
+    def test_bytes_input(self):
+        img = _make_solid_image(30, 30, (128, 128, 128, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        img_bytes = buf.getvalue()
+
+        result = compare_images(img_bytes, img_bytes)
+        assert result is not None
+        assert result.diff_score == 0.0
+
+
+class TestCompareImagesBatch:
+    def test_batch_returns_correct_count(self):
+        img1 = _make_solid_image(50, 50, (100, 100, 100, 255))
+        img2 = _make_solid_image(50, 50, (200, 200, 200, 255))
+
+        results = compare_images_batch(
+            [
+                (img1, img1.copy()),
+                (img1, img2),
+            ]
+        )
+
+        assert len(results) == 2
+        assert results[0] is not None
+        assert results[1] is not None
+        assert results[0].diff_score == 0.0
+        assert results[1].diff_score > 0.0
+
+    def test_batch_single_pair_matches_single(self):
+        before = _make_solid_image(50, 50, (100, 100, 100, 255))
+        after = _make_solid_image(50, 50, (200, 200, 200, 255))
+
+        single = compare_images(before, after)
+        batch = compare_images_batch([(before, after)])[0]
+
+        assert single is not None
+        assert batch is not None
+        assert single.diff_score == batch.diff_score
+        assert single.changed_pixels == batch.changed_pixels


### PR DESCRIPTION
# Update

Now broken into 3 PRs:

https://github.com/getsentry/sentry/pull/109380
https://github.com/getsentry/sentry/pull/109381
https://github.com/getsentry/sentry/pull/109382

-------

## Summary

Adds visual regression detection for preprod snapshots by comparing images between head and base artifacts using the [odiff](https://github.com/dmtrKovalenko/odiff) binary.

**New modules:**
- `image_diff` — wraps odiff in a persistent server mode for efficient batch comparisons, using a dual-threshold approach (base + color-sensitive) to catch both structural and subtle color changes
- `compare_snapshots` task — async Celery task that fetches manifests from object storage, matches images by filename, and categorizes results as changed/added/removed/unchanged. Diff masks are stored as base64-encoded PNGs in object storage alongside a comparison manifest JSON

**How it works:**
1. When triggered, the task loads head and base snapshot manifests
2. Images present in both are compared — if hashes differ, pixel-level diff is computed via odiff
3. Each comparison runs at two sensitivity thresholds; the one detecting more differences wins
4. Results (diff masks, scores, dimensions) are persisted to object storage and the `PreprodSnapshotComparison` model is updated with summary counts

## Test plan
- [x] Unit tests for `compare_images` and `compare_images_batch` covering identical, different, size-mismatched, and threshold-sensitive inputs
- [x] Tests with real before/after images (skipped if not available)
- [ ] Manual test with uploaded snapshot pairs to verify end-to-end comparison flow