### PR TITLE
feat(preprod): Add snapshot image comparison task and endpoint logic

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -27,8 +27,13 @@ from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import 
 )
 from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
-from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.comparison_categorizer import (
+    CategorizedComparison,
+    categorize_comparison_images,
+)
+from sentry.preprod.snapshots.manifest import ComparisonManifest, ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
@@ -132,16 +137,61 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
 
         # Build VCS info from commit_comparison
         commit_comparison = artifact.commit_comparison
-        vcs_info = BuildDetailsVcsInfo(
-            head_sha=commit_comparison.head_sha if commit_comparison else None,
-            base_sha=commit_comparison.base_sha if commit_comparison else None,
-            provider=commit_comparison.provider if commit_comparison else None,
-            head_repo_name=commit_comparison.head_repo_name if commit_comparison else None,
-            base_repo_name=commit_comparison.base_repo_name if commit_comparison else None,
-            head_ref=commit_comparison.head_ref if commit_comparison else None,
-            base_ref=commit_comparison.base_ref if commit_comparison else None,
-            pr_number=commit_comparison.pr_number if commit_comparison else None,
+        if commit_comparison:
+            vcs_info = BuildDetailsVcsInfo(
+                head_sha=commit_comparison.head_sha,
+                base_sha=commit_comparison.base_sha,
+                provider=commit_comparison.provider,
+                head_repo_name=commit_comparison.head_repo_name,
+                base_repo_name=commit_comparison.base_repo_name,
+                head_ref=commit_comparison.head_ref,
+                base_ref=commit_comparison.base_ref,
+                pr_number=commit_comparison.pr_number,
+            )
+        else:
+            vcs_info = BuildDetailsVcsInfo()
+
+        comparison_manifest: ComparisonManifest | None = None
+        base_manifest: SnapshotManifest | None = None
+        comparison = (
+            PreprodSnapshotComparison.objects.select_related(
+                "base_snapshot_metrics",
+            )
+            .filter(
+                head_snapshot_metrics=snapshot_metrics,
+                state=PreprodSnapshotComparison.State.SUCCESS,
+            )
+            .order_by("-id")
+            .first()
         )
+        if comparison:
+            comparison_key = (comparison.extras or {}).get("comparison_key")
+            if comparison_key:
+                try:
+                    comparison_manifest = ComparisonManifest(
+                        **orjson.loads(session.get(comparison_key).payload.read())
+                    )
+                except Exception:
+                    comparison_manifest = None
+                    logger.exception(
+                        "Failed to fetch comparison manifest",
+                        extra={
+                            "preprod_artifact_id": artifact.id,
+                        },
+                    )
+
+        if comparison_manifest is not None:
+            base_manifest_key = (comparison.base_snapshot_metrics.extras or {}).get("manifest_key")
+            if base_manifest_key:
+                try:
+                    base_manifest = SnapshotManifest(
+                        **orjson.loads(session.get(base_manifest_key).payload.read())
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to fetch base manifest",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
 
         analytics.record(
             PreprodArtifactApiGetSnapshotDetailsEvent(
@@ -163,14 +213,68 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             for key, metadata in sorted(manifest.images.items())
         ]
 
+        images_by_file_name: dict[str, SnapshotImageResponse] = {
+            img.image_file_name: img for img in image_list
+        }
+
+        base_artifact_id: str | None = None
+        comparison_state: str | None = None
+
+        if comparison_manifest is not None:
+            base_artifact_id = str(comparison_manifest.base_artifact_id)
+            categorized = categorize_comparison_images(
+                comparison_manifest, images_by_file_name, base_manifest
+            )
+        else:
+            categorized = CategorizedComparison()
+            pending_or_failed_state = (
+                PreprodSnapshotComparison.objects.filter(
+                    head_snapshot_metrics=snapshot_metrics,
+                    state__in=[
+                        PreprodSnapshotComparison.State.PENDING,
+                        PreprodSnapshotComparison.State.PROCESSING,
+                        PreprodSnapshotComparison.State.FAILED,
+                    ],
+                )
+                .values_list("state", flat=True)
+                .order_by("-id")
+                .first()
+            )
+            if pending_or_failed_state is not None:
+                comparison_state = PreprodSnapshotComparison.State(
+                    pending_or_failed_state
+                ).name.lower()
+
+        comparison_type = "diff" if comparison_manifest is not None else "solo"
+
         def on_results(images: list[SnapshotImageResponse]) -> dict[str, Any]:
-            return SnapshotDetailsApiResponse(
+            response = SnapshotDetailsApiResponse(
                 head_artifact_id=str(artifact.id),
+                base_artifact_id=base_artifact_id,
                 state=artifact.state,
                 vcs_info=vcs_info,
                 images=images,
                 image_count=snapshot_metrics.image_count,
-            ).dict()
+                changed=categorized.changed,
+                changed_count=len(categorized.changed),
+                added=categorized.added,
+                added_count=len(categorized.added),
+                removed=categorized.removed,
+                removed_count=len(categorized.removed),
+                unchanged=categorized.unchanged,
+                unchanged_count=len(categorized.unchanged),
+                errored=categorized.errored,
+                errored_count=len(categorized.errored),
+            )
+
+            result = response.dict()
+            result["org_id"] = str(project.organization_id)
+            result["project_id"] = str(project.id)
+            result["comparison_type"] = comparison_type
+            if comparison_state is not None:
+                result["comparison_state"] = comparison_state
+
+            return result
 
         return self.paginate(
             request=request,
@@ -267,6 +371,60 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "image_count": len(images),
             },
         )
+
+        if base_sha and base_repo_name:
+            try:
+                base_artifact = (
+                    PreprodArtifact.objects.filter(
+                        commit_comparison__organization_id=project.organization_id,
+                        commit_comparison__head_sha=base_sha,
+                        commit_comparison__head_repo_name=base_repo_name,
+                        project=project,
+                        preprodsnapshotmetrics__isnull=False,
+                        app_id=artifact.app_id,
+                        artifact_type=artifact.artifact_type,
+                        build_configuration=artifact.build_configuration,
+                    )
+                    .order_by("-date_added")
+                    .first()
+                )
+                if base_artifact:
+                    logger.info(
+                        "Found matching base artifact, triggering snapshot comparison",
+                        extra={
+                            "head_artifact_id": artifact.id,
+                            "base_artifact_id": base_artifact.id,
+                            "base_sha": base_sha,
+                        },
+                    )
+
+                    compare_snapshots.apply_async(
+                        kwargs={
+                            "project_id": project.id,
+                            "org_id": project.organization_id,
+                            "head_artifact_id": artifact.id,
+                            "base_artifact_id": base_artifact.id,
+                        },
+                    )
+
+                else:
+                    logger.info(
+                        "No matching base artifact found for snapshot comparison",
+                        extra={
+                            "head_artifact_id": artifact.id,
+                            "base_sha": base_sha,
+                            "base_repo_name": base_repo_name,
+                            "base_ref": base_ref,
+                        },
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to trigger snapshot comparison",
+                    extra={
+                        "head_artifact_id": artifact.id,
+                        "base_sha": base_sha,
+                    },
+                )
 
         return Response(
             {

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -180,7 +180,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                         },
                     )
 
-        if comparison_manifest is not None:
+        if comparison_manifest is not None and comparison is not None:
             base_manifest_key = (comparison.base_snapshot_metrics.extras or {}).get("manifest_key")
             if base_manifest_key:
                 try:

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
+    SnapshotDiffPair,
+    SnapshotImageResponse,
+)
+from sentry.preprod.snapshots.manifest import (
+    ComparisonImageResult,
+    ComparisonManifest,
+    ImageMetadata,
+    SnapshotManifest,
+)
+
+
+class CategorizedComparison(BaseModel):
+    changed: list[SnapshotDiffPair] = []
+    added: list[SnapshotImageResponse] = []
+    removed: list[SnapshotImageResponse] = []
+    unchanged: list[SnapshotImageResponse] = []
+    errored: list[SnapshotDiffPair] = []
+
+
+def _base_image_from_comparison(name: str, img: ComparisonImageResult) -> SnapshotImageResponse:
+    return SnapshotImageResponse(
+        key=img.base_hash or "",
+        display_name=name,
+        image_file_name=name,
+        width=img.before_width or 0,
+        height=img.before_height or 0,
+    )
+
+
+def _build_base_images(
+    base_images: dict[str, ImageMetadata],
+) -> dict[str, SnapshotImageResponse]:
+    result: dict[str, SnapshotImageResponse] = {}
+    for key, meta in base_images.items():
+        result[meta.image_file_name] = SnapshotImageResponse(
+            key=key,
+            display_name=meta.display_name,
+            image_file_name=meta.image_file_name,
+            width=meta.width,
+            height=meta.height,
+        )
+    return result
+
+
+def categorize_comparison_images(
+    comparison_data: ComparisonManifest,
+    head_images_by_file_name: dict[str, SnapshotImageResponse],
+    base_manifest: SnapshotManifest | None,
+) -> CategorizedComparison:
+    result = CategorizedComparison()
+
+    base_images_by_file_name = _build_base_images(base_manifest.images) if base_manifest else {}
+
+    for name, img in sorted(comparison_data.images.items()):
+        head_img = head_images_by_file_name.get(name)
+        base_img = base_images_by_file_name.get(name)
+
+        if img.status == "changed":
+            if head_img:
+                result.changed.append(
+                    SnapshotDiffPair(
+                        base_image=base_img or _base_image_from_comparison(name, img),
+                        head_image=head_img,
+                        diff_image_key=img.diff_mask_image_id,
+                        diff=img.changed_pixels / img.total_pixels if img.total_pixels else None,
+                    )
+                )
+        elif img.status == "added":
+            if head_img:
+                result.added.append(head_img)
+        elif img.status == "removed":
+            result.removed.append(base_img or _base_image_from_comparison(name, img))
+        elif img.status == "unchanged":
+            if head_img:
+                result.unchanged.append(head_img)
+        elif img.status == "errored":
+            head = head_img or SnapshotImageResponse(
+                key=img.head_hash or img.base_hash or "",
+                display_name=name,
+                image_file_name=name,
+                width=img.after_width or img.before_width or 0,
+                height=img.after_height or img.before_height or 0,
+            )
+            result.errored.append(
+                SnapshotDiffPair(
+                    base_image=base_img or _base_image_from_comparison(name, img),
+                    head_image=head,
+                )
+            )
+
+    result.changed.sort(key=lambda p: p.diff or 0, reverse=True)
+    return result

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -67,7 +67,9 @@ def categorize_comparison_images(
                         base_image=base_img or _base_image_from_comparison(name, img),
                         head_image=head_img,
                         diff_image_key=img.diff_mask_image_id,
-                        diff=img.changed_pixels / img.total_pixels if img.total_pixels else None,
+                        diff=img.changed_pixels / img.total_pixels
+                        if img.changed_pixels is not None and img.total_pixels
+                        else None,
                     )
                 )
         elif img.status == "added":

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -114,10 +114,7 @@ def _compare_single_pair(
             failOnLayoutDiff=False,
         )
         changed_pixels = resp.diffCount or 0
-        diff_pct = resp.diffPercentage or 0.0
-
         total_pixels = max_w * max_h
-        diff_score = diff_pct / 100.0
 
         if changed_pixels == 0:
             diff_mask = Image.new("L", (max_w, max_h), 0)
@@ -134,11 +131,9 @@ def _compare_single_pair(
 
         return DiffResult(
             diff_mask_png=diff_mask_png,
-            diff_score=diff_score,
             changed_pixels=changed_pixels,
             total_pixels=total_pixels,
             aligned_height=max_h,
-            width=max_w,
             before_width=bw,
             before_height=bh,
             after_width=aw,

--- a/src/sentry/preprod/snapshots/image_diff/types.py
+++ b/src/sentry/preprod/snapshots/image_diff/types.py
@@ -7,11 +7,9 @@ class DiffResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     diff_mask_png: str
-    diff_score: float
     changed_pixels: int
     total_pixels: int
     aligned_height: int
-    width: int
     before_width: int
     before_height: int
     after_width: int

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -15,3 +17,35 @@ class ImageMetadata(BaseModel):
 
 class SnapshotManifest(BaseModel):
     images: dict[str, ImageMetadata]
+
+
+class ComparisonImageResult(BaseModel):
+    status: Literal["added", "removed", "changed", "unchanged", "errored"]
+    head_hash: str | None = None
+    base_hash: str | None = None
+    changed_pixels: int | None = None
+    total_pixels: int | None = None
+    diff_mask_key: str | None = None
+    diff_mask_image_id: str | None = None
+    before_width: int | None = None
+    before_height: int | None = None
+    after_width: int | None = None
+    after_height: int | None = None
+    aligned_height: int | None = None
+    reason: str | None = None
+
+
+class ComparisonSummary(BaseModel):
+    total: int
+    changed: int
+    unchanged: int
+    added: int
+    removed: int
+    errored: int
+
+
+class ComparisonManifest(BaseModel):
+    head_artifact_id: int
+    base_artifact_id: int
+    summary: ComparisonSummary
+    images: dict[str, ComparisonImageResult]

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -16,7 +16,6 @@ class TestCompareImages:
         img = _make_solid_image(100, 100, (128, 128, 128, 255))
         result = compare_images(img, img.copy())
         assert result is not None
-        assert result.diff_score == 0.0
         assert result.changed_pixels == 0
         assert result.total_pixels == 100 * 100
 
@@ -25,7 +24,7 @@ class TestCompareImages:
         large = _make_solid_image(50, 50, (100, 100, 100, 255))
         result = compare_images(small, large)
         assert result is not None
-        assert result.width == 50
+        assert result.after_width == 50
         assert result.aligned_height == 50
         assert result.before_width == 30
         assert result.before_height == 30
@@ -49,7 +48,7 @@ class TestCompareImages:
 
         result = compare_images(img_bytes, img_bytes)
         assert result is not None
-        assert result.diff_score == 0.0
+        assert result.changed_pixels == 0
 
 
 class TestCompareImagesBatch:
@@ -67,8 +66,8 @@ class TestCompareImagesBatch:
         assert len(results) == 2
         assert results[0] is not None
         assert results[1] is not None
-        assert results[0].diff_score == 0.0
-        assert results[1].diff_score > 0.0
+        assert results[0].changed_pixels == 0
+        assert results[1].changed_pixels > 0
 
     def test_batch_single_pair_matches_single(self):
         before = _make_solid_image(50, 50, (100, 100, 100, 255))
@@ -79,5 +78,5 @@ class TestCompareImagesBatch:
 
         assert single is not None
         assert batch is not None
-        assert single.diff_score == batch.diff_score
         assert single.changed_pixels == batch.changed_pixels
+        assert single.total_pixels == batch.total_pixels

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -24,7 +24,8 @@ class TestCompareImages:
         large = _make_solid_image(50, 50, (100, 100, 100, 255))
         result = compare_images(small, large)
         assert result is not None
-        assert result.after_width == 50
+        assert result.changed_pixels == 0
+        assert result.total_pixels == 50 * 50
         assert result.aligned_height == 50
         assert result.before_width == 30
         assert result.before_height == 30
@@ -39,6 +40,7 @@ class TestCompareImages:
         result = compare_images(before, after)
         assert result is not None
         assert result.changed_pixels > 0
+        assert result.total_pixels == 100 * 100
 
     def test_bytes_input(self):
         img = _make_solid_image(30, 30, (128, 128, 128, 255))
@@ -49,6 +51,7 @@ class TestCompareImages:
         result = compare_images(img_bytes, img_bytes)
         assert result is not None
         assert result.changed_pixels == 0
+        assert result.total_pixels == 30 * 30
 
 
 class TestCompareImagesBatch:
@@ -67,7 +70,7 @@ class TestCompareImagesBatch:
         assert results[0] is not None
         assert results[1] is not None
         assert results[0].changed_pixels == 0
-        assert results[1].changed_pixels > 0
+        assert results[1].changed_pixels == results[1].total_pixels
 
     def test_batch_single_pair_matches_single(self):
         before = _make_solid_image(50, 50, (100, 100, 100, 255))


### PR DESCRIPTION
Adds the ability to automatically compare snapshot images between two preprod builds using pixel-level diffing.

When a snapshot is uploaded with VCS info (base_sha, base_repo_name, base_ref), the endpoint now looks for a matching base artifact and triggers a `compare_snapshots` Celery task. This task:
- Fetches manifests for both head and base artifacts
- Matches images by file name across the two builds
- Runs pixel-level comparison using odiff (via a new `image_diff` module)
- Stores diff masks and a comparison manifest in object storage
- Records results in a `PreprodSnapshotComparison` model

The GET endpoint is updated to return categorized image lists (changed, added, removed, unchanged) along with diff metadata when comparison data is available.

New modules:
- `sentry.preprod.snapshots.image_diff` — wraps the odiff binary in server mode for efficient batch image comparison
- `sentry.preprod.snapshots.tasks` — Celery task for async snapshot comparison
- `snapshot-diff` internal endpoint registered in URL patterns

Also adds `odiff-bin` as a dependency for the image diffing binary.