### PR TITLE
perf(issues): Prefetch group.project in update group endpoint

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -354,7 +354,7 @@ def get_group_list(
         return list(
             Group.objects.filter(
                 project__organization_id=organization_id, project__in=projects, id__in=group_ids_int
-            ).select_related("project__organization")
+            ).select_related("project")
         )
     else:
         project_ids = {p.id for p in projects}

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -354,7 +354,7 @@ def get_group_list(
         return list(
             Group.objects.filter(
                 project__organization_id=organization_id, project__in=projects, id__in=group_ids_int
-            )
+            ).select_related("project__organization")
         )
     else:
         project_ids = {p.id for p in projects}


### PR DESCRIPTION
Bulk update paths call get_group_list before update_groups, where group.project are read

[example trace with n+1 ](https://sentry.sentry.io/insights/backend/summary/trace/322165436ab546f2a35c848bdbc35d65/?fov=1%2C99472.42309570312&isDefaultQuery=false&node=span-bbdcbe3e451747a0&project=1&query=http.method%3A%EF%80%8DContains%EF%80%8D%5BPOST%2CPUT%5D&referrer=insights-backend-overview&showTransactions=slow&source=performance_transaction_summary&statsPeriod=7d&timestamp=1771867724&transaction=%2Fapi%2F0%2Forganizations%2F%7Borganization_id_or_slug%7D%2Fissues%2F&transactionCursor=0%3A10%3A0&unselectedSeries=p100%28%29&unselectedSeries=Releases)