### PR TITLE
fix(integrations): cache empty repo 409 responses to reduce GitHub API calls

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -7,7 +7,7 @@ from typing import Any, NamedTuple
 
 from sentry.integrations.services.integration import RpcOrganizationIntegration
 from sentry.issues.auto_source_code_config.utils.platform import get_supported_extensions
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiConflictError, ApiError, IntegrationError
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -199,7 +199,17 @@ class RepoTreesIntegration(ABC):
         repo_files: list[str] = cache.get(key, [])
         if use_api:
             # Cache miss – fetch from API
-            tree = self.get_client().get_tree(repo_full_name, tree_sha)
+            try:
+                tree = self.get_client().get_tree(repo_full_name, tree_sha)
+            except ApiConflictError:
+                # Empty repos return 409 — cache the empty result so we don't
+                # keep burning API calls on repos we know have no files.
+                logger.info(
+                    "Caching empty files result for repo",
+                    extra={"repo": repo_full_name},
+                )
+                cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
+                return []
             if tree:
                 # Keep files; discard directories
                 repo_files = [node["path"] for node in tree if node["type"] == "blob"]

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -209,7 +209,7 @@ class RepoTreesIntegration(ABC):
                     extra={"repo": repo_full_name},
                 )
                 cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
-                return []
+                tree = None
             if tree:
                 # Keep files; discard directories
                 repo_files = [node["path"] for node in tree if node["type"] == "blob"]


### PR DESCRIPTION
Cache the result when GitHub's Git Trees API returns a 409 ("Git Repository
is empty") instead of re-fetching on every task run.

Previously, when `get_tree` hit a 409 for an empty repo, the exception
propagated without writing to cache. This meant every subsequent
`auto_source_code_config` task run would re-fetch the same empty repos,
wasting API calls and contributing to GitHub rate limiting. For large orgs
with many empty repos, this adds up to thousands of unnecessary API calls
per day.

Now we catch `ApiConflictError` in `get_cached_repo_files`, cache an empty
list with the same TTL as successful results (24h + staggered offset), and
return early. The existing error handling in `_populate_trees` is unaffected
since the exception no longer propagates.

Pairs with #109134 which records these 409s as halts instead of failures
in the interaction event lifecycle.

Refs SENTRY-5K7F