### PR TITLE
feat(preprod): Migrate preprod views to org-scoped endpoints

### DIFF
--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -37,7 +37,6 @@ export function PreprodBuildsDistributionTable({
     const linkUrl =
       getInstallBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       }) ?? '';
     const isInstallable = build.distribution_info?.is_installable ?? false;

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -45,7 +45,6 @@ export function PreprodBuildsSizeTable({
     const linkUrl =
       getSizeBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       }) ?? '';
     return (

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -86,7 +86,6 @@ describe('PreprodBuildsTable', () => {
       'href',
       getInstallBuildPath({
         organizationSlug: organization.slug,
-        projectId: '1',
         baseArtifactId: 'build-1',
       })
     );

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -16,14 +16,13 @@ import {
   useQueryClient,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildCompareHeaderContent';
 import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
@@ -38,41 +37,35 @@ export default function BuildComparison() {
     baseArtifactId?: string;
     headArtifactId?: string;
   }>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
-
   const headBuildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: headArtifactId!,
+              artifactId: headArtifactId!,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!headArtifactId,
+        enabled: !!headArtifactId,
       }
     );
 
-  const compareUrl = getCompareApiUrl({
-    organizationSlug: organization.slug,
-    projectId,
-    headArtifactId: headArtifactId!,
-    baseArtifactId: baseArtifactId!,
-  });
+  const projectId = useResolveProjectFromArtifact(headBuildDetailsQuery.data);
+
+  const compareUrl = projectId
+    ? getCompareApiUrl({
+        organizationSlug: organization.slug,
+        projectId,
+        headArtifactId: headArtifactId!,
+        baseArtifactId: baseArtifactId!,
+      })
+    : null;
 
   const queryClient = useQueryClient();
   const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
@@ -80,7 +73,7 @@ export default function BuildComparison() {
     RequestError
   >({
     mutationFn: () => {
-      return fetchMutation({url: compareUrl, method: 'POST'});
+      return fetchMutation({url: compareUrl!, method: 'POST'});
     },
     onSuccess: response => {
       if (response?.status === 'exists') {
@@ -129,14 +122,27 @@ export default function BuildComparison() {
     );
   }
 
+  if (!projectId) {
+    return (
+      <SentryDocumentTitle title={t('Build comparison')}>
+        <Layout.Page>
+          <Alert variant="danger">{t('Unable to resolve project for this build')}</Alert>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
   let mainContent = null;
   if (baseArtifactId) {
     // Base artifact provided in URL, show comparison state
-    mainContent = <SizeCompareMainContent />;
+    mainContent = <SizeCompareMainContent projectId={projectId} />;
   } else {
     // No base artifact provided in URL, show selection state
     mainContent = (
-      <SizeCompareSelectionContent headBuildDetails={headBuildDetailsQuery.data} />
+      <SizeCompareSelectionContent
+        headBuildDetails={headBuildDetailsQuery.data}
+        projectId={projectId}
+      />
     );
   }
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -16,9 +16,7 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 import parseApiError from 'sentry/utils/parseApiError';
 import {fetchMutation, useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -52,7 +50,11 @@ function getMainComparison(
   );
 }
 
-export function SizeCompareMainContent() {
+interface SizeCompareMainContentProps {
+  projectId: string;
+}
+
+export function SizeCompareMainContent({projectId}: SizeCompareMainContentProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
   const theme = useTheme();
@@ -65,14 +67,6 @@ export function SizeCompareMainContent() {
   const params = useParams();
   const headArtifactId = params.headArtifactId;
   const baseArtifactId = params.baseArtifactId;
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
 
   // These parameters are part of the route and must always be present
   if (headArtifactId === undefined) {
@@ -138,7 +132,6 @@ export function SizeCompareMainContent() {
       navigate(
         getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId,
           baseArtifactId,
         })
@@ -291,11 +284,11 @@ export function SizeCompareMainContent() {
         headBuildDetails={sizeComparisonQuery.data.head_build_details}
         baseBuildDetails={sizeComparisonQuery.data.base_build_details}
         isComparing={false}
+        projectId={projectId}
         onClearBaseBuild={() => {
           navigate(
             getCompareBuildPath({
               organizationSlug: organization.slug,
-              projectId,
               headArtifactId,
             })
           );

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -9,8 +9,6 @@ import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
-import {decodeScalar} from 'sentry/utils/queryString';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
@@ -40,7 +38,6 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
   const buildUrl =
     getSizeBuildPath({
       organizationSlug: organization.slug,
-      projectId: String(projectId),
       baseArtifactId: buildId,
     }) ?? '';
   const platform = buildDetails.app_info?.platform ?? null;
@@ -182,6 +179,7 @@ interface SizeCompareSelectedBuildsProps {
   headBuildDetails: BuildDetailsApiResponse;
   isComparing: boolean;
   onClearBaseBuild: () => void;
+  projectId: string;
   baseBuildDetails?: BuildDetailsApiResponse;
   onTriggerComparison?: () => void;
 }
@@ -192,9 +190,9 @@ export function SizeCompareSelectedBuilds({
   isComparing,
   onClearBaseBuild,
   onTriggerComparison,
+  projectId,
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
-  const {project: projectId} = useLocationQuery({fields: {project: decodeScalar}});
   const platform = headBuildDetails.app_info?.platform ?? null;
   const project = ProjectsStore.getById(projectId);
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -54,6 +54,7 @@ import {SizeCompareSelectedBuilds} from './sizeCompareSelectedBuilds';
 
 interface SizeCompareSelectionContentProps {
   headBuildDetails: BuildDetailsApiResponse;
+  projectId: string;
   baseBuildDetails?: BuildDetailsApiResponse;
   onBaseBuildClear?: () => void;
   onBaseBuildSelect?: () => void;
@@ -61,14 +62,14 @@ interface SizeCompareSelectionContentProps {
 
 export function SizeCompareSelectionContent({
   headBuildDetails,
+  projectId,
   baseBuildDetails,
 }: SizeCompareSelectionContentProps) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
   const navigate = useNavigate();
-  const {project: projectId, cursor} = useLocationQuery({
+  const {cursor} = useLocationQuery({
     fields: {
-      project: decodeScalar,
       cursor: decodeScalar,
     },
   });
@@ -86,7 +87,7 @@ export function SizeCompareSelectionContent({
     build_configuration: headBuildDetails.app_info?.build_configuration,
     ...(cursor && {cursor}),
     ...(searchQuery && {query: searchQuery}),
-    ...(projectId && {project: projectId}),
+    ...(headBuildDetails.project_id && {project: headBuildDetails.project_id}),
   };
 
   const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =
@@ -129,7 +130,6 @@ export function SizeCompareSelectionContent({
       navigate(
         getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId: headBuildDetails.id,
           baseArtifactId: selectedBaseBuild?.id,
         })
@@ -151,6 +151,7 @@ export function SizeCompareSelectionContent({
         isComparing={isComparing}
         headBuildDetails={headBuildDetails}
         baseBuildDetails={selectedBaseBuild}
+        projectId={projectId}
         onClearBaseBuild={() => setSelectedBaseBuild(undefined)}
         onTriggerComparison={() => {
           if (!selectedBaseBuild) {
@@ -179,7 +180,6 @@ export function SizeCompareSelectionContent({
               navigate(
                 getCompareBuildPath({
                   organizationSlug: organization.slug,
-                  projectId,
                   headArtifactId: headBuildDetails.id,
                 }),
                 {replace: true}

--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -24,7 +24,7 @@ describe('BuildDetails', () => {
     route: '/organizations/:orgId/preprod/size/:artifactId/',
   };
 
-  const BUILD_DETAILS_URL = `/projects/org-slug/project-1/preprodartifacts/artifact-1/build-details/`;
+  const BUILD_DETAILS_URL = `/organizations/org-slug/preprodartifacts/artifact-1/build-details/`;
   const SIZE_ANALYSIS_URL = `/projects/org-slug/project-1/files/preprodartifacts/artifact-1/size-analysis/`;
   const QUOTA_STATE_URL = `/organizations/org-slug/preprod/quota/`;
 

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -18,15 +18,14 @@ import {
   useMutation,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
 import {
   isSizeInfoPendingOrProcessing,
@@ -42,31 +41,23 @@ export default function BuildDetails() {
   const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectSlug} = useLocationQuery({fields: {project: decodeScalar}});
-  // Handle project as query param - take first value if array
-  const projectId = Array.isArray(projectSlug) ? projectSlug[0] : projectSlug;
-  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
-    projectId,
-    artifactId,
-  });
 
   const buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: artifactId,
+              artifactId,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!artifactId,
+        enabled: !!artifactId,
         refetchInterval: query => {
           const data = query.state.data;
           const sizeInfo = data?.[0]?.size_info;
@@ -75,39 +66,44 @@ export default function BuildDetails() {
       }
     );
 
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
+    projectId,
+    artifactId,
+  });
+
   const sizeInfo = buildDetailsQuery.data?.size_info;
   const isPendingOrProcessing = isSizeInfoPendingOrProcessing(sizeInfo);
 
+  const appSizeApiUrl = projectId
+    ? getApiUrl(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/preprodartifacts/$headArtifactId/size-analysis/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectId,
+            headArtifactId: artifactId,
+          },
+        }
+      )
+    : ('' as ReturnType<typeof getApiUrl>);
+
   const appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError> =
-    useApiQuery<AppSizeApiResponse>(
-      [
-        getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/preprodartifacts/$headArtifactId/size-analysis/',
-          {
-            path: {
-              organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: artifactId,
-            },
-          }
-        ),
-      ],
-      {
-        staleTime: 0,
-        retry: (failureCount, apiError: RequestError) => {
-          // By default we retry 404s 3 times which causes
-          // latency when loading the page if there is no size-analysis
-          // (which is legitimate if size was not run on this artifact).
-          // Instead don't retry 404s:
-          if (apiError?.status === 404) {
-            return false;
-          }
-          // Keep default behaviour otherwise:
-          return failureCount < 2;
-        },
-        enabled: !!projectId && !!artifactId,
-      }
-    );
+    useApiQuery<AppSizeApiResponse>([appSizeApiUrl], {
+      staleTime: 0,
+      retry: (failureCount, apiError: RequestError) => {
+        // By default we retry 404s 3 times which causes
+        // latency when loading the page if there is no size-analysis
+        // (which is legitimate if size was not run on this artifact).
+        // Instead don't retry 404s:
+        if (apiError?.status === 404) {
+          return false;
+        }
+        // Keep default behaviour otherwise:
+        return failureCount < 2;
+      },
+      enabled: !!projectId && !!artifactId,
+    });
 
   const wasPendingOrProcessingRef = useRef(isPendingOrProcessing);
 
@@ -146,14 +142,7 @@ export default function BuildDetails() {
   const projectType = project?.platform ?? null;
 
   let title = t('Build details');
-  if (
-    version !== undefined &&
-    version !== null &&
-    version !== '' &&
-    buildNumber !== undefined &&
-    buildNumber !== null &&
-    buildNumber !== ''
-  ) {
+  if (version && buildNumber) {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 
@@ -213,7 +202,7 @@ export default function BuildDetails() {
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
                 artifactId={artifactId}
-                projectId={projectId}
+                projectId={projectId ?? null}
               />
             </BuildDetailsSide>
             <BuildDetailsMain>
@@ -224,7 +213,6 @@ export default function BuildDetails() {
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
                 projectType={projectType}
-                projectId={projectId}
               />
             </BuildDetailsMain>
           </UrlParamBatchProvider>

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -44,8 +44,8 @@ import {useBuildDetailsActions} from './useBuildDetailsActions';
 interface BuildDetailsHeaderContentProps {
   artifactId: string;
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
-  projectId: string;
   projectType: string | null;
+  projectId?: string;
 }
 
 export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps) {
@@ -128,7 +128,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     areActionsEnabled || isSizeInfoRetryable(buildDetailsData?.size_info);
 
   const handleCompareClick = () => {
-    if (!areActionsEnabled) {
+    if (!areActionsEnabled || !projectId) {
       return;
     }
     trackAnalytics('preprod.builds.details.compare_build_clicked', {
@@ -141,7 +141,6 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     router.push(
       getCompareBuildPath({
         organizationSlug: organization.slug,
-        projectId,
         headArtifactId: buildDetailsData.id,
       })
     );

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -11,7 +11,7 @@ import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermis
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
-  projectId: string;
+  projectId?: string;
 }
 
 export function useBuildDetailsActions({
@@ -26,6 +26,9 @@ export function useBuildDetailsActions({
     RequestError
   >({
     mutationFn: () => {
+      if (!projectId) {
+        throw new Error('projectId is required to delete an artifact');
+      }
       return fetchMutation({
         url: `/projects/${organization.slug}/${projectId}/preprodartifacts/${artifactId}/delete/`,
         method: 'DELETE',
@@ -37,7 +40,6 @@ export function useBuildDetailsActions({
       navigate(
         getListBuildPath({
           organizationSlug: organization.slug,
-          projectId,
         })
       );
     },
@@ -77,6 +79,10 @@ export function useBuildDetailsActions({
   };
 
   const handleDownloadAction = async () => {
+    if (!projectId) {
+      addErrorMessage(t('Project ID is required to download build'));
+      return;
+    }
     await downloadPreprodArtifact({
       organizationSlug: organization.slug,
       projectSlug: projectId,
@@ -90,6 +96,9 @@ export function useBuildDetailsActions({
     RequestError
   >({
     mutationFn: () => {
+      if (!projectId) {
+        throw new Error('projectId is required to rerun status checks');
+      }
       return fetchMutation({
         url: `/projects/${organization.slug}/${projectId}/preprod-artifact/rerun-status-checks/${artifactId}/`,
         method: 'POST',

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -43,7 +43,6 @@ interface BuildDetailsMainContentProps {
   onRerunAnalysis: () => void;
   buildDetailsData?: BuildDetailsApiResponse | null;
   isBuildDetailsPending?: boolean;
-  projectId?: string;
   projectType?: string | null;
 }
 
@@ -55,7 +54,6 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     buildDetailsData,
     isBuildDetailsPending = false,
     projectType,
-    projectId,
   } = props;
   const {
     data: appSizeData,
@@ -380,7 +378,6 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         baseArtifactId={buildDetailsData?.base_artifact_id ?? null}
         platform={buildDetailsData?.app_info?.platform ?? null}
         projectType={projectType ?? null}
-        projectId={projectId}
         onOpenInsightsSidebar={openInsightsSidebar}
       />
 

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -43,7 +43,6 @@ interface BuildDetailsMetricCardsProps {
   artifactId?: string;
   baseArtifactId?: string | null;
   platform?: Platform | null;
-  projectId?: string;
   projectType?: string | null;
 }
 
@@ -80,7 +79,6 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
     baseArtifactId,
     platform: platformProp,
     projectType,
-    projectId,
     onOpenInsightsSidebar,
   } = props;
 
@@ -119,10 +117,9 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
 
   // Build comparison URL using route params
   const comparisonUrl =
-    baseArtifactId && projectId && artifactId
+    baseArtifactId && artifactId
       ? getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId: artifactId,
           baseArtifactId,
         })

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -250,7 +250,7 @@ describe('BuildDetailsSidebarContent', () => {
       expect(baseBuildLink).not.toHaveAttribute('target', '_blank');
     });
 
-    it('renders Base Build row with dash when projectId is null', async () => {
+    it('renders Base Build row with link even when projectId is null', async () => {
       const buildDetailsData: BuildDetailsApiResponse = {
         ...mockBuildDetailsData,
         vcs_info: {
@@ -279,17 +279,17 @@ describe('BuildDetailsSidebarContent', () => {
         expect(screen.getByText('Build Metadata')).toBeInTheDocument();
       });
 
-      // Base Build row should be present with label
       const baseBuildLabel = screen.getByText('Base Build');
       expect(baseBuildLabel).toBeInTheDocument();
 
-      // Get the parent ContentWrapper and verify the build name is within it
       const contentWrapper = baseBuildLabel.parentElement!;
-      expect(contentWrapper).toBeInTheDocument();
-      expect(contentWrapper).toHaveTextContent('-');
+      expect(contentWrapper).toHaveTextContent('v1.0 (2)');
 
-      // Should NOT have a link (no projectId to build URL)
-      expect(screen.queryByRole('link', {name: 'v1.0 (2)'})).not.toBeInTheDocument();
+      const baseBuildLink = screen.getByRole('link', {name: 'v1.0 (2)'});
+      expect(baseBuildLink).toHaveAttribute(
+        'href',
+        `/organizations/${organization.slug}/preprod/size/base-artifact-id/`
+      );
     });
   });
 });

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -45,7 +45,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
         />
       )}
 
-      <BuildVcsInfo buildDetailsData={buildDetailsData} projectId={projectId} />
+      <BuildVcsInfo buildDetailsData={buildDetailsData} />
     </Flex>
   );
 }

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -23,10 +23,9 @@ import {
 
 interface BuildVcsInfoProps {
   buildDetailsData: BuildDetailsApiResponse;
-  projectId: string | null;
 }
 
-export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
+export function BuildVcsInfo({buildDetailsData}: BuildVcsInfoProps) {
   const organization = useOrganization();
   const vcsInfo = buildDetailsData.vcs_info;
   const hasVcsInfo = [
@@ -84,17 +83,15 @@ export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
                   buildDetailsData.base_build_info.version,
                   buildDetailsData.base_build_info.build_number
                 );
-                const baseBuildUrl =
-                  buildDetailsData.base_artifact_id && projectId
-                    ? getBaseBuildPath(
-                        {
-                          baseArtifactId: buildDetailsData.base_artifact_id,
-                          organizationSlug: organization.slug,
-                          projectId,
-                        },
-                        'size'
-                      )
-                    : null;
+                const baseBuildUrl = buildDetailsData.base_artifact_id
+                  ? getBaseBuildPath(
+                      {
+                        baseArtifactId: buildDetailsData.base_artifact_id,
+                        organizationSlug: organization.slug,
+                      },
+                      'size'
+                    )
+                  : null;
                 if (!baseBuildUrl || !buildName) {
                   return '-';
                 }

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
@@ -1,0 +1,87 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
+import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+const COMPLETED_SIZE_INFO = {
+  state: BuildDetailsSizeAnalysisState.COMPLETED as const,
+  size_metrics: [],
+  base_size_metrics: [],
+};
+
+describe('useResolveProjectFromArtifact', () => {
+  const organization = OrganizationFixture();
+
+  it('returns projectId from URL when project query param is present', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '456'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('456');
+  });
+
+  it('returns project slug from build details data when project query param is missing', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(COMPLETED_SIZE_INFO);
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe(buildDetails.project_slug);
+  });
+
+  it('returns undefined when no project param and no build details data', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('prefers URL project param over build details data', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(COMPLETED_SIZE_INFO);
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '999'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('999');
+  });
+});

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
@@ -1,0 +1,13 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+export function useResolveProjectFromArtifact(
+  buildDetailsData: BuildDetailsApiResponse | undefined
+): string | undefined {
+  const {project: projectFromUrl} = useLocationQuery({
+    fields: {project: decodeScalar},
+  });
+
+  return projectFromUrl || buildDetailsData?.project_slug;
+}

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -1,51 +1,76 @@
+import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildVcsInfo} from 'sentry/views/preprod/components/buildVcsInfo';
 import {InstallDetailsContent} from 'sentry/views/preprod/components/installDetailsContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import {BuildInstallHeader} from 'sentry/views/preprod/install/buildInstallHeader';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function InstallPage() {
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
   const organization = useOrganization();
 
   const buildDetailsQuery = useApiQuery<BuildDetailsApiResponse>(
     [
       getApiUrl(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+        '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
         {
           path: {
             organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: projectId,
-            headArtifactId: artifactId,
+            artifactId,
           },
         }
       ),
     ],
     {
       staleTime: 0,
-      enabled: !!projectId && !!artifactId,
+      enabled: !!artifactId,
     }
   );
+
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+
+  if (buildDetailsQuery.isLoading) {
+    return (
+      <SentryDocumentTitle title="Install">
+        <Layout.Page>
+          <Layout.Body>
+            <Layout.Main>
+              <LoadingIndicator />
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
+  if (buildDetailsQuery.isError || !projectId) {
+    return (
+      <SentryDocumentTitle title="Install">
+        <Layout.Page>
+          <Layout.Body>
+            <Layout.Main>
+              <Alert variant="danger">
+                {buildDetailsQuery.error?.message || t('Failed to load build details')}
+              </Alert>
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
   return (
     <SentryDocumentTitle title="Install">
       <Layout.Page>
@@ -75,10 +100,7 @@ export default function InstallPage() {
                   </Container>
                 </Container>
                 {buildDetailsQuery.data && (
-                  <BuildVcsInfo
-                    buildDetailsData={buildDetailsQuery.data}
-                    projectId={projectId}
-                  />
+                  <BuildVcsInfo buildDetailsData={buildDetailsQuery.data} />
                 )}
               </Flex>
             </Layout.Main>

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -3,7 +3,6 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 interface BuildLinkParams {
   organizationSlug: string;
   baseArtifactId?: string;
-  projectId?: string;
 }
 
 export function getBaseBuildPath(
@@ -31,7 +30,6 @@ export function getCompareBuildPath(params: {
   headArtifactId: string;
   organizationSlug: string;
   baseArtifactId?: string;
-  projectId?: string;
 }): string {
   const {organizationSlug, headArtifactId, baseArtifactId} = params;
 
@@ -42,10 +40,7 @@ export function getCompareBuildPath(params: {
   return `/organizations/${organizationSlug}/preprod/size/compare/${headArtifactId}/`;
 }
 
-export function getListBuildPath(params: {
-  organizationSlug: string;
-  projectId?: string;
-}): string {
+export function getListBuildPath(params: {organizationSlug: string}): string {
   const {organizationSlug} = params;
   return `/organizations/${organizationSlug}/preprod/`;
 }

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -158,7 +158,6 @@ export function MobileBuildsChart({
 
       const path = getSizeBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       });
 


### PR DESCRIPTION
## Summary

- Migrate all preprod view components (build details, install, comparison) to use organization-scoped API endpoints
- Remove `projectId` from all URL path generation call sites
- Views now resolve project context from API responses via `useResolveProjectFromArtifact` hook
- Fully remove the deprecated optional `projectId` parameter from `buildLinkUtils` signatures

## Test plan

- `pnpm run typecheck`
- `CI=true pnpm test static/app/views/preprod/buildDetails/buildDetails.spec.tsx`
- `CI=true pnpm test static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx`
- `CI=true pnpm test static/app/components/preprod/preprodBuildsTable.spec.tsx`