### PR TITLE
fix(aci): Handle custom zoom stats periods in detector details

### DIFF
--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -14,16 +14,13 @@ describe('buildDetectorZoomQuery', () => {
     });
 
     expect('statsPeriod' in zoomRange).toBe(false);
-    if ('statsPeriod' in zoomRange) {
-      throw new Error('expected absolute zoom range');
-    }
 
     const query = buildDetectorZoomQuery({project: '1', statsPeriod: '14d'}, zoomRange);
 
     expect(query).toEqual({
       project: '1',
-      start: getUtcDateString(zoomRange.start),
-      end: getUtcDateString(zoomRange.end),
+      start: getUtcDateString(Date.parse('2024-12-31T23:50:00Z')), // start -10 * 60 seconds
+      end: getUtcDateString(Date.parse('2025-01-01T01:10:00Z')), // end + 10 * 60 seconds
       statsPeriod: undefined,
     });
   });

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -1,0 +1,73 @@
+import {setMockDate} from 'sentry-test/utils';
+
+import {getUtcDateString} from 'sentry/utils/dates';
+
+import {buildDetectorZoomQuery, computeZoomRangeMs} from './buildDetectorZoomQuery';
+
+describe('buildDetectorZoomQuery', () => {
+  it('uses absolute start/end for historical ranges', () => {
+    setMockDate(Date.parse('2026-02-01T00:00:00Z'));
+    const zoomRange = computeZoomRangeMs({
+      startMs: Date.parse('2025-01-01T00:00:00Z'),
+      endMs: Date.parse('2025-01-01T01:00:00Z'),
+      intervalSeconds: 60,
+    });
+
+    expect('statsPeriod' in zoomRange).toBe(false);
+    if ('statsPeriod' in zoomRange) {
+      throw new Error('expected absolute zoom range');
+    }
+
+    const query = buildDetectorZoomQuery({project: '1', statsPeriod: '14d'}, zoomRange);
+
+    expect(query).toEqual({
+      project: '1',
+      start: getUtcDateString(zoomRange.start),
+      end: getUtcDateString(zoomRange.end),
+      statsPeriod: undefined,
+    });
+  });
+
+  it('uses statsPeriod for ongoing ranges close to now', () => {
+    setMockDate(Date.parse('2026-02-01T12:00:00Z'));
+    const zoomRange = computeZoomRangeMs({
+      startMs: Date.parse('2026-02-01T10:00:00Z'),
+      endMs: Date.parse('2026-02-01T12:05:00Z'),
+      intervalSeconds: 60,
+    });
+
+    expect(zoomRange).toEqual({statsPeriod: '4h'});
+
+    const query = buildDetectorZoomQuery(
+      {project: '1', start: 'old-start', end: 'old-end'},
+      zoomRange
+    );
+
+    expect(query).toEqual({
+      project: '1',
+      start: undefined,
+      end: undefined,
+      statsPeriod: '4h',
+    });
+  });
+
+  it('uses day units when the duration resolves to whole days', () => {
+    setMockDate(Date.parse('2026-02-05T00:00:00Z'));
+    const zoomRange = computeZoomRangeMs({
+      startMs: Date.parse('2026-02-02T00:10:00Z'),
+      endMs: Date.parse('2026-02-04T23:55:00Z'),
+      intervalSeconds: 60,
+    });
+
+    expect(zoomRange).toEqual({statsPeriod: '3d'});
+
+    const query = buildDetectorZoomQuery({project: '1'}, zoomRange);
+
+    expect(query).toEqual({
+      project: '1',
+      start: undefined,
+      end: undefined,
+      statsPeriod: '3d',
+    });
+  });
+});

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -1,14 +1,42 @@
 import {getUtcDateString} from 'sentry/utils/dates';
 
+// If the end time is within 10 minutes of now, we use a relative time range instead of an absolute one
+const NEAR_NOW_THRESHOLD_MS = 10 * 60 * 1000;
+
 interface ComputeZoomRangeOptions {
   endMs: number;
   startMs: number;
   intervalSeconds?: number;
 }
 
-interface ZoomRangeMs {
+interface AbsoluteZoomRangeMs {
   end: number;
   start: number;
+}
+
+interface RelativeZoomRangeMs {
+  statsPeriod: string;
+}
+
+export type ZoomRangeMs = AbsoluteZoomRangeMs | RelativeZoomRangeMs;
+
+function toStatsPeriod(durationMs: number): string {
+  const hourMs = 60 * 60 * 1000;
+  const durationHours = Math.max(Math.ceil(durationMs / hourMs), 4);
+
+  if (durationHours > 24) {
+    return `${Math.ceil(durationHours / 24)}d`;
+  }
+
+  return `${durationHours}h`;
+}
+
+function truncateEndTime(endMs: number): number {
+  if (endMs >= Date.now() - NEAR_NOW_THRESHOLD_MS) {
+    return Date.now();
+  }
+
+  return endMs;
 }
 
 /**
@@ -16,6 +44,7 @@ interface ZoomRangeMs {
  * - Adds ~10 data points of context on each side based on intervalSeconds
  * - Clamps total span to <= 10k points and <= 90 days
  * - Aligns start/end to minute boundaries
+ * - For ranges that are still active/near-now, returns a relative statsPeriod
  */
 export function computeZoomRangeMs({
   startMs,
@@ -26,18 +55,22 @@ export function computeZoomRangeMs({
   const bufferMs = 10 * intervalMs;
 
   const desiredStart = startMs - bufferMs;
-  const desiredEnd = endMs + bufferMs;
+  const desiredEnd = truncateEndTime(endMs + bufferMs);
 
   const MAX_POINTS = 10_000;
   const pointsSpanMs = MAX_POINTS * intervalMs;
   const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
   const maxSpanMs = Math.min(pointsSpanMs, ninetyDaysMs);
 
+  const endIsNearNow = desiredEnd >= Date.now() - NEAR_NOW_THRESHOLD_MS;
   let zoomStartMs = desiredStart;
-  let zoomEndMs = desiredEnd;
+  const zoomEndMs = endIsNearNow ? Date.now() : desiredEnd;
   if (zoomEndMs - zoomStartMs > maxSpanMs) {
-    zoomEndMs = desiredEnd;
     zoomStartMs = zoomEndMs - maxSpanMs;
+  }
+
+  if (endIsNearNow) {
+    return {statsPeriod: toStatsPeriod(Date.now() - zoomStartMs)};
   }
 
   const start = Math.floor(zoomStartMs / 60_000) * 60_000;
@@ -48,17 +81,25 @@ export function computeZoomRangeMs({
 
 /**
  * Build a query object that applies the zoom window to URL params.
- * Clears statsPeriod in favor of absolute start/end.
+ * Uses statsPeriod for ongoing near-now windows and absolute start/end otherwise.
  */
 export function buildDetectorZoomQuery(
   existingQuery: Record<string, any>,
-  zoomStartMs: number,
-  zoomEndMs: number
+  zoomRange: ZoomRangeMs
 ) {
+  if ('statsPeriod' in zoomRange) {
+    return {
+      ...existingQuery,
+      start: undefined,
+      end: undefined,
+      statsPeriod: zoomRange.statsPeriod,
+    };
+  }
+
   return {
     ...existingQuery,
-    start: getUtcDateString(zoomStartMs),
-    end: getUtcDateString(zoomEndMs),
+    start: getUtcDateString(zoomRange.start),
+    end: getUtcDateString(zoomRange.end),
     statsPeriod: undefined,
   };
 }

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -18,7 +18,7 @@ interface RelativeZoomRangeMs {
   statsPeriod: string;
 }
 
-export type ZoomRangeMs = AbsoluteZoomRangeMs | RelativeZoomRangeMs;
+type ZoomRangeMs = AbsoluteZoomRangeMs | RelativeZoomRangeMs;
 
 function toStatsPeriod(durationMs: number): string {
   const hourMs = 60 * 60 * 1000;

--- a/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
+++ b/static/app/views/detectors/components/details/common/openPeriodIssues.tsx
@@ -158,14 +158,14 @@ function LatestGroupWithOpenPeriods({
     (start: Date, end?: Date) => {
       const startMs = start.getTime();
       const endMs = (end ?? new Date()).getTime();
-      const {start: zoomStart, end: zoomEnd} = computeZoomRangeMs({
+      const zoomRange = computeZoomRangeMs({
         startMs,
         endMs,
         intervalSeconds,
       });
       navigate({
         pathname: location.pathname,
-        query: buildDetectorZoomQuery(location.query, zoomStart, zoomEnd),
+        query: buildDetectorZoomQuery(location.query, zoomRange),
       });
     },
     [location.pathname, location.query, navigate, intervalSeconds]

--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -253,14 +253,14 @@ export function useMetricDetectorChart({
       const startMs = context.period.start;
       const endMs = context.period.end ?? Date.now();
       const intervalSeconds = Number(snubaQuery.timeWindow) || 60;
-      const {start: zoomStart, end: zoomEnd} = computeZoomRangeMs({
+      const zoomRange = computeZoomRangeMs({
         startMs,
         endMs,
         intervalSeconds,
       });
       navigate({
         pathname: location.pathname,
-        query: buildDetectorZoomQuery(location.query, zoomStart, zoomEnd),
+        query: buildDetectorZoomQuery(location.query, zoomRange),
       });
     },
   });

--- a/static/app/views/detectors/components/details/metric/timePeriodSelect.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/timePeriodSelect.spec.tsx
@@ -38,4 +38,25 @@ describe('MetricTimePeriodSelect', () => {
     expect(router.location.query.start).toBeUndefined();
     expect(router.location.query.end).toBeUndefined();
   });
+
+  it('displays custom statsPeriod values from the URL', async () => {
+    const {router} = render(
+      <MetricTimePeriodSelect dataset={DetectorDataset.ERRORS} interval={300} />,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/issues/',
+            query: {
+              statsPeriod: '4h',
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByRole('button', {name: /custom time:\s*last 4 hours/i})
+    ).toBeInTheDocument();
+    expect(router.location.query.statsPeriod).toBe('4h');
+  });
 });


### PR DESCRIPTION
Improves some of the zooming behavior on the metric monitor page, something that I also want to use in issue details.

- The current logic does not truncate the end time, so ongoing incidents will show future dates in the chart. This no longer occurs
- If end range of the zoom gets you close to the current time, uses a relative date range instead
- Updates the time range selector to display custom relative date ranges (previously only did so for absolute ones)

Before:

<img width="1002" height="331" alt="CleanShot 2026-02-23 at 15 46 27" src="https://github.com/user-attachments/assets/76fd9c6a-3a61-44ed-80a2-f4c18f58788b" />

After:

<img width="978" height="333" alt="CleanShot 2026-02-23 at 15 46 18" src="https://github.com/user-attachments/assets/5e78092d-b0ce-4026-a3a1-1ed006494524" />
