### PR TITLE
fix(events): Handle Snuba errors in group events endpoint gracefully

### DIFF
--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -20,7 +20,7 @@ from sentry.api.helpers.events import get_direct_hit_response, run_group_events_
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 from sentry.api.serializers.models.event import SimpleEventSerializerResponse
-from sentry.api.utils import get_date_range_from_params
+from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
     RESPONSE_FORBIDDEN,
@@ -104,7 +104,8 @@ class GroupEventsEndpoint(GroupEndpoint):
             raise ParseError(detail=str(e))
 
         try:
-            return self._get_events_snuba(request, group, environments, query, start, end)
+            with handle_query_errors():
+                return self._get_events_snuba(request, group, environments, query, start, end)
         except GroupEventsError as exc:
             raise ParseError(detail=str(exc))
 

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
 from rest_framework.response import Response
+from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
@@ -597,9 +598,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         )
 
     @patch("sentry.issues.endpoints.group_events.run_group_events_query")
-    def test_snuba_read_timeout_returns_504(self, mock_query) -> None:
+    def test_snuba_read_timeout_returns_504(self, mock_query: MagicMock) -> None:
         mock_query.side_effect = SnubaError(
-            ReadTimeoutError(pool=None, url="", message="Read timed out")
+            ReadTimeoutError(ConnectionPool("dummy"), "/events/snql", "Read timed out")
         )
         self.login_as(user=self.user)
         event = self.store_event(

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -1,13 +1,16 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 from rest_framework.response import Response
+from urllib3.exceptions import ReadTimeoutError
 
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import APITestCase, PerformanceIssueTestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.utils.snuba import SnubaError
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
 
@@ -592,3 +595,20 @@ class GroupEventsTest(APITestCase, SnubaTestCase, SearchIssueTestMixin, Performa
         assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
+
+    @patch("sentry.issues.endpoints.group_events.run_group_events_query")
+    def test_snuba_read_timeout_returns_504(self, mock_query) -> None:
+        mock_query.side_effect = SnubaError(
+            ReadTimeoutError(pool=None, url="", message="Read timed out")
+        )
+        self.login_as(user=self.user)
+        event = self.store_event(
+            data={
+                "fingerprint": ["group_1"],
+                "timestamp": self.min_ago.isoformat(),
+            },
+            project_id=self.project.id,
+        )
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{event.group.id}/events/"
+        response = self.do_request(url)
+        assert response.status_code == 504


### PR DESCRIPTION
Resolves [SENTRY-5HJX](https://sentry.sentry.io/issues/7222775017?project=1).

Wrap Snuba query in group events endpoint with `handle_query_errors()` so that Snuba timeouts return 504s instead of unhandled 500s.