### PR TITLE
feat(preprod): Add project resolution hook and migrate installPage to org-scoped endpoint

### DIFF
--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -37,7 +37,6 @@ export function PreprodBuildsDistributionTable({
     const linkUrl =
       getInstallBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       }) ?? '';
     const isInstallable = build.distribution_info?.is_installable ?? false;

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -45,7 +45,6 @@ export function PreprodBuildsSizeTable({
     const linkUrl =
       getSizeBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       }) ?? '';
     return (

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -86,7 +86,6 @@ describe('PreprodBuildsTable', () => {
       'href',
       getInstallBuildPath({
         organizationSlug: organization.slug,
-        projectId: '1',
         baseArtifactId: 'build-1',
       })
     );

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.spec.tsx
@@ -250,7 +250,7 @@ describe('BuildDetailsSidebarContent', () => {
       expect(baseBuildLink).not.toHaveAttribute('target', '_blank');
     });
 
-    it('renders Base Build row with dash when projectId is null', async () => {
+    it('renders Base Build row with link even when projectId is null', async () => {
       const buildDetailsData: BuildDetailsApiResponse = {
         ...mockBuildDetailsData,
         vcs_info: {
@@ -279,17 +279,17 @@ describe('BuildDetailsSidebarContent', () => {
         expect(screen.getByText('Build Metadata')).toBeInTheDocument();
       });
 
-      // Base Build row should be present with label
       const baseBuildLabel = screen.getByText('Base Build');
       expect(baseBuildLabel).toBeInTheDocument();
 
-      // Get the parent ContentWrapper and verify the build name is within it
       const contentWrapper = baseBuildLabel.parentElement!;
-      expect(contentWrapper).toBeInTheDocument();
-      expect(contentWrapper).toHaveTextContent('-');
+      expect(contentWrapper).toHaveTextContent('v1.0 (2)');
 
-      // Should NOT have a link (no projectId to build URL)
-      expect(screen.queryByRole('link', {name: 'v1.0 (2)'})).not.toBeInTheDocument();
+      const baseBuildLink = screen.getByRole('link', {name: 'v1.0 (2)'});
+      expect(baseBuildLink).toHaveAttribute(
+        'href',
+        `/organizations/${organization.slug}/preprod/size/base-artifact-id/`
+      );
     });
   });
 });

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -23,10 +23,10 @@ import {
 
 interface BuildVcsInfoProps {
   buildDetailsData: BuildDetailsApiResponse;
-  projectId: string | null;
+  projectId?: string | null;
 }
 
-export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
+export function BuildVcsInfo({buildDetailsData}: BuildVcsInfoProps) {
   const organization = useOrganization();
   const vcsInfo = buildDetailsData.vcs_info;
   const hasVcsInfo = [
@@ -84,17 +84,15 @@ export function BuildVcsInfo({buildDetailsData, projectId}: BuildVcsInfoProps) {
                   buildDetailsData.base_build_info.version,
                   buildDetailsData.base_build_info.build_number
                 );
-                const baseBuildUrl =
-                  buildDetailsData.base_artifact_id && projectId
-                    ? getBaseBuildPath(
-                        {
-                          baseArtifactId: buildDetailsData.base_artifact_id,
-                          organizationSlug: organization.slug,
-                          projectId,
-                        },
-                        'size'
-                      )
-                    : null;
+                const baseBuildUrl = buildDetailsData.base_artifact_id
+                  ? getBaseBuildPath(
+                      {
+                        baseArtifactId: buildDetailsData.base_artifact_id,
+                        organizationSlug: organization.slug,
+                      },
+                      'size'
+                    )
+                  : null;
                 if (!baseBuildUrl || !buildName) {
                   return '-';
                 }

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.spec.tsx
@@ -1,0 +1,87 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PreprodBuildDetailsWithSizeInfoFixture} from 'sentry-fixture/preprod';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
+import {BuildDetailsSizeAnalysisState} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+const COMPLETED_SIZE_INFO = {
+  state: BuildDetailsSizeAnalysisState.COMPLETED as const,
+  size_metrics: [],
+  base_size_metrics: [],
+};
+
+describe('useResolveProjectFromArtifact', () => {
+  const organization = OrganizationFixture();
+
+  it('returns projectId from URL when project query param is present', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '456'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('456');
+  });
+
+  it('returns project slug from build details data when project query param is missing', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(COMPLETED_SIZE_INFO);
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe(buildDetails.project_slug);
+  });
+
+  it('returns undefined when no project param and no build details data', () => {
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(undefined),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('prefers URL project param over build details data', () => {
+    const buildDetails = PreprodBuildDetailsWithSizeInfoFixture(COMPLETED_SIZE_INFO);
+
+    const {result} = renderHookWithProviders(
+      () => useResolveProjectFromArtifact(buildDetails),
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/preprod/size/123/`,
+            query: {project: '999'},
+          },
+        },
+      }
+    );
+
+    expect(result.current).toBe('999');
+  });
+});

--- a/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
+++ b/static/app/views/preprod/hooks/useResolveProjectFromArtifact.ts
@@ -1,0 +1,13 @@
+import {decodeScalar} from 'sentry/utils/queryString';
+import useLocationQuery from 'sentry/utils/url/useLocationQuery';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
+
+export function useResolveProjectFromArtifact(
+  buildDetailsData: BuildDetailsApiResponse | undefined
+): string | undefined {
+  const {project: projectFromUrl} = useLocationQuery({
+    fields: {project: decodeScalar},
+  });
+
+  return projectFromUrl || buildDetailsData?.project_slug;
+}

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -1,51 +1,92 @@
+import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildVcsInfo} from 'sentry/views/preprod/components/buildVcsInfo';
 import {InstallDetailsContent} from 'sentry/views/preprod/components/installDetailsContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import {BuildInstallHeader} from 'sentry/views/preprod/install/buildInstallHeader';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export default function InstallPage() {
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
   const organization = useOrganization();
 
   const buildDetailsQuery = useApiQuery<BuildDetailsApiResponse>(
     [
       getApiUrl(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+        '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
         {
           path: {
             organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: projectId,
-            headArtifactId: artifactId,
+            artifactId,
           },
         }
       ),
     ],
     {
       staleTime: 0,
-      enabled: !!projectId && !!artifactId,
+      enabled: !!artifactId,
     }
   );
+
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+
+  if (buildDetailsQuery.isLoading) {
+    return (
+      <SentryDocumentTitle title="Install">
+        <Layout.Page>
+          <Layout.Body>
+            <Layout.Main>
+              <LoadingIndicator />
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
+  if (buildDetailsQuery.isError) {
+    return (
+      <SentryDocumentTitle title="Install">
+        <Layout.Page>
+          <Layout.Body>
+            <Layout.Main>
+              <Alert variant="danger">
+                {buildDetailsQuery.error?.message || t('Failed to load build details')}
+              </Alert>
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
+  if (!projectId) {
+    return (
+      <SentryDocumentTitle title="Install">
+        <Layout.Page>
+          <Layout.Body>
+            <Layout.Main>
+              <Alert variant="danger">
+                {t('Unable to resolve project for this build')}
+              </Alert>
+            </Layout.Main>
+          </Layout.Body>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
   return (
     <SentryDocumentTitle title="Install">
       <Layout.Page>
@@ -75,10 +116,7 @@ export default function InstallPage() {
                   </Container>
                 </Container>
                 {buildDetailsQuery.data && (
-                  <BuildVcsInfo
-                    buildDetailsData={buildDetailsQuery.data}
-                    projectId={projectId}
-                  />
+                  <BuildVcsInfo buildDetailsData={buildDetailsQuery.data} />
                 )}
               </Flex>
             </Layout.Main>

--- a/static/app/views/releases/list/mobileBuildsChart.tsx
+++ b/static/app/views/releases/list/mobileBuildsChart.tsx
@@ -158,7 +158,6 @@ export function MobileBuildsChart({
 
       const path = getSizeBuildPath({
         organizationSlug,
-        projectId: build.project_id.toString(),
         baseArtifactId: build.id,
       });
 


### PR DESCRIPTION
## Summary

- Introduces `useResolveProjectFromArtifact` hook for deriving `projectId` from API responses instead of URL parameters
- Migrates `installPage` to use the new organization-scoped build-details endpoint
- Updates shared components (`buildVcsInfo`, builds tables, `mobileBuildsChart`) to remove `projectId` parameter from `buildLinkUtils` calls

This is part of a stacked PR series migrating preprod views to org-scoped endpoints:
- PR A: URL path utilities refactor (base)
- **PR B1 (this PR)**: Foundation hook + installPage migration
- PR B2: buildDetails view migration
- PR B3: buildComparison view migration

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `useResolveProjectFromArtifact.spec.tsx` tests pass
- [x] `preprodBuildsTable.spec.tsx` tests pass