### PR TITLE
feat(preprod): Migrate buildDetails view to org-scoped endpoint

### DIFF
--- a/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.spec.tsx
@@ -24,7 +24,7 @@ describe('BuildDetails', () => {
     route: '/organizations/:orgId/preprod/size/:artifactId/',
   };
 
-  const BUILD_DETAILS_URL = `/projects/org-slug/project-1/preprodartifacts/artifact-1/build-details/`;
+  const BUILD_DETAILS_URL = `/organizations/org-slug/preprodartifacts/artifact-1/build-details/`;
   const SIZE_ANALYSIS_URL = `/projects/org-slug/project-1/files/preprodartifacts/artifact-1/size-analysis/`;
   const QUOTA_STATE_URL = `/organizations/org-slug/preprod/quota/`;
 

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -18,15 +18,14 @@ import {
   useMutation,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {PreprodQuotaAlert} from 'sentry/views/preprod/components/preprodQuotaAlert';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {AppSizeApiResponse} from 'sentry/views/preprod/types/appSizeTypes';
 import {
   isSizeInfoPendingOrProcessing,
@@ -42,31 +41,23 @@ export default function BuildDetails() {
   const organization = useOrganization();
   const isSentryEmployee = useIsSentryEmployee();
   const {artifactId} = useParams<{artifactId: string}>();
-  const {project: projectSlug} = useLocationQuery({fields: {project: decodeScalar}});
-  // Handle project as query param - take first value if array
-  const projectId = Array.isArray(projectSlug) ? projectSlug[0] : projectSlug;
-  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
-    projectId,
-    artifactId,
-  });
 
   const buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: artifactId,
+              artifactId,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!artifactId,
+        enabled: !!artifactId,
         refetchInterval: query => {
           const data = query.state.data;
           const sizeInfo = data?.[0]?.size_info;
@@ -75,39 +66,44 @@ export default function BuildDetails() {
       }
     );
 
+  const projectId = useResolveProjectFromArtifact(buildDetailsQuery.data);
+  const {handleDownloadAction, handleRerunAction} = useBuildDetailsActions({
+    projectId,
+    artifactId,
+  });
+
   const sizeInfo = buildDetailsQuery.data?.size_info;
   const isPendingOrProcessing = isSizeInfoPendingOrProcessing(sizeInfo);
 
+  const appSizeApiUrl = projectId
+    ? getApiUrl(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/preprodartifacts/$headArtifactId/size-analysis/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            projectIdOrSlug: projectId,
+            headArtifactId: artifactId,
+          },
+        }
+      )
+    : ('' as ReturnType<typeof getApiUrl>);
+
   const appSizeQuery: UseApiQueryResult<AppSizeApiResponse, RequestError> =
-    useApiQuery<AppSizeApiResponse>(
-      [
-        getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/files/preprodartifacts/$headArtifactId/size-analysis/',
-          {
-            path: {
-              organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: artifactId,
-            },
-          }
-        ),
-      ],
-      {
-        staleTime: 0,
-        retry: (failureCount, apiError: RequestError) => {
-          // By default we retry 404s 3 times which causes
-          // latency when loading the page if there is no size-analysis
-          // (which is legitimate if size was not run on this artifact).
-          // Instead don't retry 404s:
-          if (apiError?.status === 404) {
-            return false;
-          }
-          // Keep default behaviour otherwise:
-          return failureCount < 2;
-        },
-        enabled: !!projectId && !!artifactId,
-      }
-    );
+    useApiQuery<AppSizeApiResponse>([appSizeApiUrl], {
+      staleTime: 0,
+      retry: (failureCount, apiError: RequestError) => {
+        // By default we retry 404s 3 times which causes
+        // latency when loading the page if there is no size-analysis
+        // (which is legitimate if size was not run on this artifact).
+        // Instead don't retry 404s:
+        if (apiError?.status === 404) {
+          return false;
+        }
+        // Keep default behaviour otherwise:
+        return failureCount < 2;
+      },
+      enabled: !!projectId && !!artifactId,
+    });
 
   const wasPendingOrProcessingRef = useRef(isPendingOrProcessing);
 
@@ -146,14 +142,7 @@ export default function BuildDetails() {
   const projectType = project?.platform ?? null;
 
   let title = t('Build details');
-  if (
-    version !== undefined &&
-    version !== null &&
-    version !== '' &&
-    buildNumber !== undefined &&
-    buildNumber !== null &&
-    buildNumber !== ''
-  ) {
+  if (version && buildNumber) {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 
@@ -213,7 +202,7 @@ export default function BuildDetails() {
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
                 artifactId={artifactId}
-                projectId={projectId}
+                projectId={projectId ?? null}
               />
             </BuildDetailsSide>
             <BuildDetailsMain>
@@ -224,7 +213,6 @@ export default function BuildDetails() {
                 buildDetailsData={buildDetailsQuery.data}
                 isBuildDetailsPending={buildDetailsQuery.isLoading}
                 projectType={projectType}
-                projectId={projectId}
               />
             </BuildDetailsMain>
           </UrlParamBatchProvider>

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -108,11 +108,11 @@ export default function BuildDetails() {
   const wasPendingOrProcessingRef = useRef(isPendingOrProcessing);
 
   useEffect(() => {
-    if (wasPendingOrProcessingRef.current && !isPendingOrProcessing) {
+    if (wasPendingOrProcessingRef.current && !isPendingOrProcessing && projectId) {
       appSizeQuery.refetch();
     }
     wasPendingOrProcessingRef.current = isPendingOrProcessing;
-  }, [isPendingOrProcessing, appSizeQuery]);
+  }, [isPendingOrProcessing, appSizeQuery, projectId]);
 
   const {mutate: onRerunAnalysis, isPending: isRerunning} = useMutation<
     void,
@@ -142,7 +142,14 @@ export default function BuildDetails() {
   const projectType = project?.platform ?? null;
 
   let title = t('Build details');
-  if (version && buildNumber) {
+  if (
+    version !== undefined &&
+    version !== null &&
+    version !== '' &&
+    buildNumber !== undefined &&
+    buildNumber !== null &&
+    buildNumber !== ''
+  ) {
     title = t('Build details v%s (%s)', version, buildNumber);
   }
 

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -44,8 +44,8 @@ import {useBuildDetailsActions} from './useBuildDetailsActions';
 interface BuildDetailsHeaderContentProps {
   artifactId: string;
   buildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError>;
-  projectId: string;
   projectType: string | null;
+  projectId?: string;
 }
 
 export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps) {
@@ -128,7 +128,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     areActionsEnabled || isSizeInfoRetryable(buildDetailsData?.size_info);
 
   const handleCompareClick = () => {
-    if (!areActionsEnabled) {
+    if (!areActionsEnabled || !projectId) {
       return;
     }
     trackAnalytics('preprod.builds.details.compare_build_clicked', {
@@ -141,7 +141,6 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
     router.push(
       getCompareBuildPath({
         organizationSlug: organization.slug,
-        projectId,
         headArtifactId: buildDetailsData.id,
       })
     );

--- a/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
+++ b/static/app/views/preprod/buildDetails/header/useBuildDetailsActions.tsx
@@ -11,7 +11,7 @@ import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermis
 
 interface UseBuildDetailsActionsProps {
   artifactId: string;
-  projectId: string;
+  projectId?: string;
 }
 
 export function useBuildDetailsActions({
@@ -26,6 +26,9 @@ export function useBuildDetailsActions({
     RequestError
   >({
     mutationFn: () => {
+      if (!projectId) {
+        throw new Error('projectId is required to delete an artifact');
+      }
       return fetchMutation({
         url: `/projects/${organization.slug}/${projectId}/preprodartifacts/${artifactId}/delete/`,
         method: 'DELETE',
@@ -37,7 +40,6 @@ export function useBuildDetailsActions({
       navigate(
         getListBuildPath({
           organizationSlug: organization.slug,
-          projectId,
         })
       );
     },
@@ -77,6 +79,10 @@ export function useBuildDetailsActions({
   };
 
   const handleDownloadAction = async () => {
+    if (!projectId) {
+      addErrorMessage(t('Project ID is required to download build'));
+      return;
+    }
     await downloadPreprodArtifact({
       organizationSlug: organization.slug,
       projectSlug: projectId,
@@ -90,6 +96,9 @@ export function useBuildDetailsActions({
     RequestError
   >({
     mutationFn: () => {
+      if (!projectId) {
+        throw new Error('projectId is required to rerun status checks');
+      }
       return fetchMutation({
         url: `/projects/${organization.slug}/${projectId}/preprod-artifact/rerun-status-checks/${artifactId}/`,
         method: 'POST',

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -43,7 +43,6 @@ interface BuildDetailsMainContentProps {
   onRerunAnalysis: () => void;
   buildDetailsData?: BuildDetailsApiResponse | null;
   isBuildDetailsPending?: boolean;
-  projectId?: string;
   projectType?: string | null;
 }
 
@@ -55,7 +54,6 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
     buildDetailsData,
     isBuildDetailsPending = false,
     projectType,
-    projectId,
   } = props;
   const {
     data: appSizeData,
@@ -380,7 +378,6 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
         baseArtifactId={buildDetailsData?.base_artifact_id ?? null}
         platform={buildDetailsData?.app_info?.platform ?? null}
         projectType={projectType ?? null}
-        projectId={projectId}
         onOpenInsightsSidebar={openInsightsSidebar}
       />
 

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -43,7 +43,6 @@ interface BuildDetailsMetricCardsProps {
   artifactId?: string;
   baseArtifactId?: string | null;
   platform?: Platform | null;
-  projectId?: string;
   projectType?: string | null;
 }
 
@@ -80,7 +79,6 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
     baseArtifactId,
     platform: platformProp,
     projectType,
-    projectId,
     onOpenInsightsSidebar,
   } = props;
 
@@ -119,10 +117,9 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
 
   // Build comparison URL using route params
   const comparisonUrl =
-    baseArtifactId && projectId && artifactId
+    baseArtifactId && artifactId
       ? getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId: artifactId,
           baseArtifactId,
         })

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarContent.tsx
@@ -45,7 +45,7 @@ export function BuildDetailsSidebarContent(props: BuildDetailsSidebarContentProp
         />
       )}
 
-      <BuildVcsInfo buildDetailsData={buildDetailsData} projectId={projectId} />
+      <BuildVcsInfo buildDetailsData={buildDetailsData} />
     </Flex>
   );
 }


### PR DESCRIPTION
## Summary

- Migrates `buildDetails` and all sub-components to use the organization-scoped build-details API endpoint
- Derives `projectId` from API response via `useResolveProjectFromArtifact` hook instead of URL parameters
- Updates header, main content, metric cards, and sidebar to receive `projectId` as a prop

Stacked on PR B1 (#109161). Part of the preprod org-scoped endpoint migration series.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `buildDetails.spec.tsx` tests pass (20 tests)
- [x] `buildDetailsSidebarContent.spec.tsx` tests pass