### PR TITLE
feat(preprod): Migrate buildComparison view to org-scoped endpoint

### DIFF
--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -16,14 +16,13 @@ import {
   useQueryClient,
   type UseApiQueryResult,
 } from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {BuildCompareHeaderContent} from 'sentry/views/preprod/buildComparison/header/buildCompareHeaderContent';
 import {SizeCompareMainContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareMainContent';
 import {SizeCompareSelectionContent} from 'sentry/views/preprod/buildComparison/main/sizeCompareSelectionContent';
+import {useResolveProjectFromArtifact} from 'sentry/views/preprod/hooks/useResolveProjectFromArtifact';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getCompareApiUrl} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {
@@ -38,41 +37,35 @@ export default function BuildComparison() {
     baseArtifactId?: string;
     headArtifactId?: string;
   }>();
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
-
   const headBuildDetailsQuery: UseApiQueryResult<BuildDetailsApiResponse, RequestError> =
     useApiQuery<BuildDetailsApiResponse>(
       [
         getApiUrl(
-          '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/$headArtifactId/build-details/',
+          '/organizations/$organizationIdOrSlug/preprodartifacts/$artifactId/build-details/',
           {
             path: {
               organizationIdOrSlug: organization.slug,
-              projectIdOrSlug: projectId,
-              headArtifactId: headArtifactId!,
+              artifactId: headArtifactId!,
             },
           }
         ),
       ],
       {
         staleTime: 0,
-        enabled: !!projectId && !!headArtifactId,
+        enabled: !!headArtifactId,
       }
     );
 
-  const compareUrl = getCompareApiUrl({
-    organizationSlug: organization.slug,
-    projectId,
-    headArtifactId: headArtifactId!,
-    baseArtifactId: baseArtifactId!,
-  });
+  const projectId = useResolveProjectFromArtifact(headBuildDetailsQuery.data);
+
+  const compareUrl = projectId
+    ? getCompareApiUrl({
+        organizationSlug: organization.slug,
+        projectId,
+        headArtifactId: headArtifactId!,
+        baseArtifactId: baseArtifactId!,
+      })
+    : null;
 
   const queryClient = useQueryClient();
   const {mutate: rerunComparison, isPending: isRerunning} = useMutation<
@@ -80,7 +73,7 @@ export default function BuildComparison() {
     RequestError
   >({
     mutationFn: () => {
-      return fetchMutation({url: compareUrl, method: 'POST'});
+      return fetchMutation({url: compareUrl!, method: 'POST'});
     },
     onSuccess: response => {
       if (response?.status === 'exists') {
@@ -129,14 +122,27 @@ export default function BuildComparison() {
     );
   }
 
+  if (!projectId) {
+    return (
+      <SentryDocumentTitle title={t('Build comparison')}>
+        <Layout.Page>
+          <Alert variant="danger">{t('Unable to resolve project for this build')}</Alert>
+        </Layout.Page>
+      </SentryDocumentTitle>
+    );
+  }
+
   let mainContent = null;
   if (baseArtifactId) {
     // Base artifact provided in URL, show comparison state
-    mainContent = <SizeCompareMainContent />;
+    mainContent = <SizeCompareMainContent projectId={projectId} />;
   } else {
     // No base artifact provided in URL, show selection state
     mainContent = (
-      <SizeCompareSelectionContent headBuildDetails={headBuildDetailsQuery.data} />
+      <SizeCompareSelectionContent
+        headBuildDetails={headBuildDetailsQuery.data}
+        projectId={projectId}
+      />
     );
   }
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -16,9 +16,7 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 import parseApiError from 'sentry/utils/parseApiError';
 import {fetchMutation, useApiQuery, useMutation} from 'sentry/utils/queryClient';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import {decodeList} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -52,7 +50,11 @@ function getMainComparison(
   );
 }
 
-export function SizeCompareMainContent() {
+interface SizeCompareMainContentProps {
+  projectId: string;
+}
+
+export function SizeCompareMainContent({projectId}: SizeCompareMainContentProps) {
   const organization = useOrganization();
   const navigate = useNavigate();
   const theme = useTheme();
@@ -65,14 +67,6 @@ export function SizeCompareMainContent() {
   const params = useParams();
   const headArtifactId = params.headArtifactId;
   const baseArtifactId = params.baseArtifactId;
-  const {project: projectIds} = useLocationQuery({fields: {project: decodeList}});
-  // TODO(EME-735): Remove this once refactoring is complete and we don't need to extract projects from the URL.
-  if (projectIds.length !== 1) {
-    throw new Error(
-      `Expected exactly one project in query string but got ${projectIds.length}`
-    );
-  }
-  const projectId = projectIds[0]!;
 
   // These parameters are part of the route and must always be present
   if (headArtifactId === undefined) {
@@ -138,7 +132,6 @@ export function SizeCompareMainContent() {
       navigate(
         getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId,
           baseArtifactId,
         })
@@ -291,11 +284,11 @@ export function SizeCompareMainContent() {
         headBuildDetails={sizeComparisonQuery.data.head_build_details}
         baseBuildDetails={sizeComparisonQuery.data.base_build_details}
         isComparing={false}
+        projectId={projectId}
         onClearBaseBuild={() => {
           navigate(
             getCompareBuildPath({
               organizationSlug: organization.slug,
-              projectId,
               headArtifactId,
             })
           );

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -194,7 +194,7 @@ export function SizeCompareSelectedBuilds({
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
   const platform = headBuildDetails.app_info?.platform ?? null;
-  const project = ProjectsStore.getById(projectId);
+  const project = ProjectsStore.getBySlug(projectId);
 
   return (
     <ComparisonContainer>

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -9,8 +9,6 @@ import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getFormat, getFormattedDate} from 'sentry/utils/dates';
-import {decodeScalar} from 'sentry/utils/queryString';
-import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {getSizeBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
@@ -40,7 +38,6 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
   const buildUrl =
     getSizeBuildPath({
       organizationSlug: organization.slug,
-      projectId: String(projectId),
       baseArtifactId: buildId,
     }) ?? '';
   const platform = buildDetails.app_info?.platform ?? null;
@@ -182,6 +179,7 @@ interface SizeCompareSelectedBuildsProps {
   headBuildDetails: BuildDetailsApiResponse;
   isComparing: boolean;
   onClearBaseBuild: () => void;
+  projectId: string;
   baseBuildDetails?: BuildDetailsApiResponse;
   onTriggerComparison?: () => void;
 }
@@ -192,9 +190,9 @@ export function SizeCompareSelectedBuilds({
   isComparing,
   onClearBaseBuild,
   onTriggerComparison,
+  projectId,
 }: SizeCompareSelectedBuildsProps) {
   const organization = useOrganization();
-  const {project: projectId} = useLocationQuery({fields: {project: decodeScalar}});
   const platform = headBuildDetails.app_info?.platform ?? null;
   const project = ProjectsStore.getById(projectId);
 

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectionContent.tsx
@@ -54,6 +54,7 @@ import {SizeCompareSelectedBuilds} from './sizeCompareSelectedBuilds';
 
 interface SizeCompareSelectionContentProps {
   headBuildDetails: BuildDetailsApiResponse;
+  projectId: string;
   baseBuildDetails?: BuildDetailsApiResponse;
   onBaseBuildClear?: () => void;
   onBaseBuildSelect?: () => void;
@@ -61,14 +62,14 @@ interface SizeCompareSelectionContentProps {
 
 export function SizeCompareSelectionContent({
   headBuildDetails,
+  projectId,
   baseBuildDetails,
 }: SizeCompareSelectionContentProps) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
   const navigate = useNavigate();
-  const {project: projectId, cursor} = useLocationQuery({
+  const {cursor} = useLocationQuery({
     fields: {
-      project: decodeScalar,
       cursor: decodeScalar,
     },
   });
@@ -86,7 +87,7 @@ export function SizeCompareSelectionContent({
     build_configuration: headBuildDetails.app_info?.build_configuration,
     ...(cursor && {cursor}),
     ...(searchQuery && {query: searchQuery}),
-    ...(projectId && {project: projectId}),
+    ...(headBuildDetails.project_id && {project: headBuildDetails.project_id}),
   };
 
   const buildsQuery: UseApiQueryResult<ListBuildsApiResponse, RequestError> =
@@ -129,7 +130,6 @@ export function SizeCompareSelectionContent({
       navigate(
         getCompareBuildPath({
           organizationSlug: organization.slug,
-          projectId,
           headArtifactId: headBuildDetails.id,
           baseArtifactId: selectedBaseBuild?.id,
         })
@@ -151,6 +151,7 @@ export function SizeCompareSelectionContent({
         isComparing={isComparing}
         headBuildDetails={headBuildDetails}
         baseBuildDetails={selectedBaseBuild}
+        projectId={projectId}
         onClearBaseBuild={() => setSelectedBaseBuild(undefined)}
         onTriggerComparison={() => {
           if (!selectedBaseBuild) {
@@ -179,7 +180,6 @@ export function SizeCompareSelectionContent({
               navigate(
                 getCompareBuildPath({
                   organizationSlug: organization.slug,
-                  projectId,
                   headArtifactId: headBuildDetails.id,
                 }),
                 {replace: true}

--- a/static/app/views/preprod/components/buildVcsInfo.tsx
+++ b/static/app/views/preprod/components/buildVcsInfo.tsx
@@ -23,7 +23,6 @@ import {
 
 interface BuildVcsInfoProps {
   buildDetailsData: BuildDetailsApiResponse;
-  projectId?: string | null;
 }
 
 export function BuildVcsInfo({buildDetailsData}: BuildVcsInfoProps) {

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -3,7 +3,6 @@ import getApiUrl from 'sentry/utils/api/getApiUrl';
 interface BuildLinkParams {
   organizationSlug: string;
   baseArtifactId?: string;
-  projectId?: string;
 }
 
 export function getBaseBuildPath(
@@ -31,7 +30,6 @@ export function getCompareBuildPath(params: {
   headArtifactId: string;
   organizationSlug: string;
   baseArtifactId?: string;
-  projectId?: string;
 }): string {
   const {organizationSlug, headArtifactId, baseArtifactId} = params;
 
@@ -42,10 +40,7 @@ export function getCompareBuildPath(params: {
   return `/organizations/${organizationSlug}/preprod/size/compare/${headArtifactId}/`;
 }
 
-export function getListBuildPath(params: {
-  organizationSlug: string;
-  projectId?: string;
-}): string {
+export function getListBuildPath(params: {organizationSlug: string}): string {
   const {organizationSlug} = params;
   return `/organizations/${organizationSlug}/preprod/`;
 }


### PR DESCRIPTION
## Summary

- Migrates `buildComparison` and all sub-components to use the organization-scoped build-details API endpoint
- Derives `projectId` from API response via `useResolveProjectFromArtifact` hook
- Removes now-unused optional `projectId` from `buildLinkUtils` type signatures and `BuildVcsInfo` props (all callers migrated)

Final PR in the stacked series:
- PR A: URL path utilities refactor
- PR B1 (#109161): Foundation hook + installPage migration
- PR B2 (#109162): buildDetails view migration
- **PR B3 (this PR)**: buildComparison view migration + type cleanup

## Test plan

- [x] `pnpm run typecheck` passes
- [x] All preprod tests pass