### PR TITLE
refactor: remove redundant isAiSummaryEnabled variable

### DIFF
--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -32,7 +32,6 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   const user = name && email && !isSameNameAndEmail ? `${name} <${email}>` : nameOrEmail;
 
   const summary = feedbackIssue.metadata.summary;
-  const isAiSummaryEnabled = areAiFeaturesAllowed;
 
   const userNodeId = useId();
 
@@ -52,7 +51,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   }
 
   const emailSubject =
-    isAiSummaryEnabled && summary
+    areAiFeaturesAllowed && summary
       ? `Following up from ${organization.name}: ${summary}`
       : `Following up from ${organization.name}`;
 
@@ -66,7 +65,7 @@ export default function FeedbackItemUsername({className, feedbackIssue, style}: 
   return (
     <Flex align="center" gap="md" className={className} style={style}>
       <Flex align="center" wrap="wrap" gap="xs">
-        {isAiSummaryEnabled && summary && (
+        {areAiFeaturesAllowed && summary && (
           <Fragment>
             <AiPrivacyTooltip>
               <strong>{summary}</strong>


### PR DESCRIPTION
## Summary
- Follow-up to #108811 (merged) per review comment from @billyvg
- After the `user-feedback-ai-titles` flag removal, `isAiSummaryEnabled` became a redundant alias for `areAiFeaturesAllowed`
- Removes the variable and uses `areAiFeaturesAllowed` directly

## Test plan
- [x] `feedbackItemUsername.spec.tsx` passes (9/9 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)