### PR TITLE
fix(globalDrawer): fix horizontal scroll on small screens

### DIFF
--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -187,6 +187,11 @@ const DrawerContainer = styled('div')`
   inset: 0;
   z-index: ${p => p.theme.zIndex.drawer};
   pointer-events: none;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    overflow-x: auto;
+    pointer-events: auto;
+  }
 `;
 
 const DrawerSlidePanel = styled(SlideOverPanel)`
@@ -205,6 +210,17 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
     var(--drawer-width),
     var(--drawer-max-width)
   ) !important;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border: none;
+    box-shadow: none;
+    /* Without this, the base SlideOverPanel's overscroll-behavior: contain blocks horizontal scroll chaining. */
+    overscroll-behavior-x: auto;
+  }
 
   &[data-resizing] {
     /* Hide scrollbars during resize */


### PR DESCRIPTION
**Before**

https://github.com/user-attachments/assets/d59b2d66-0bb6-4f39-8357-a34e0b1d696e



**After**


https://github.com/user-attachments/assets/c405d4b8-f5fe-45d0-857b-d8f34601468f


closes https://linear.app/getsentry/issue/TET-1906/drawer-component-breaks-on-mobile

