### PR TITLE
feat(compactSelect): Extract MenuComponents as shared slot primitives

### DIFF
--- a/static/app/components/core/compactSelect/compactSelect.mdx
+++ b/static/app/components/core/compactSelect/compactSelect.mdx
@@ -14,6 +14,8 @@ resources:
 
 import {useState} from 'react';
 
+import {t} from 'sentry/locale';
+
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
@@ -157,6 +159,8 @@ export function SectionsDemo() {
   <Storybook.Grid>
     <CompactSelect
       size="md"
+      menuTitle={t('Size')}
+      searchable
       trigger={props => <OverlayTrigger.Button {...props} prefix="Size" />}
       options={[
         {value: '1', label: 'Medium (default)'},
@@ -165,6 +169,8 @@ export function SectionsDemo() {
     />
     <CompactSelect
       size="sm"
+      menuTitle={t('Size')}
+      searchable
       trigger={props => <OverlayTrigger.Button {...props} prefix="Size" />}
       options={[
         {value: '1', label: 'Small'},
@@ -173,6 +179,8 @@ export function SectionsDemo() {
     />
     <CompactSelect
       size="xs"
+      menuTitle={t('Size')}
+      searchable
       trigger={props => <OverlayTrigger.Button {...props} prefix="Size" />}
       options={[
         {value: '1', label: 'Extra Small'},

--- a/static/app/components/core/compactSelect/index.tsx
+++ b/static/app/components/core/compactSelect/index.tsx
@@ -13,6 +13,8 @@ export {CompositeSelect, type CompositeSelectProps} from './composite';
 
 export {ControlContext} from './control';
 
+export {MenuComponents} from './menuComponents';
+
 export {
   LeadWrap,
   SectionSeparator,

--- a/static/app/components/core/compactSelect/menuComponents.tsx
+++ b/static/app/components/core/compactSelect/menuComponents.tsx
@@ -1,0 +1,175 @@
+import {useContext} from 'react';
+import styled from '@emotion/styled';
+import type {DistributedOmit} from 'type-fest';
+
+import {Alert, type AlertProps} from '@sentry/scraps/alert';
+import {
+  Button,
+  LinkButton,
+  type ButtonProps,
+  type LinkButtonProps,
+} from '@sentry/scraps/button';
+
+import {t} from 'sentry/locale';
+
+import {ControlContext} from './control';
+
+export const MenuComponents = {
+  /**
+   * A link button sized and styled to sit in `menuHeaderTrailingItems`. Inherits
+   * the header's font size and renders in secondary text color so it blends with
+   * the title rather than competing with it.
+   *
+   * Use this for navigation actions in the header — e.g. a "View all" link that
+   * opens a related page. For non-navigation actions (no `to`/`href`) use
+   * `HeaderButton` instead.
+   *
+   * `priority` and `size` are locked to keep the header visually consistent.
+   */
+  LinkButton(props: DistributedOmit<LinkButtonProps, 'priority' | 'size'>) {
+    return <HeaderLinkButton size="zero" priority="transparent" {...props} />;
+  },
+
+  /**
+   * A button sized and styled to sit in `menuHeaderTrailingItems`. Inherits the
+   * header's font size and renders in secondary text color so it blends with the
+   * title rather than competing with it.
+   *
+   * Use this for lightweight, immediate actions in the header — e.g. "Reset",
+   * "Clear", "Invite Member", or "Sync". These actions typically take effect
+   * immediately and close the menu. For navigation actions use `LinkButton`
+   * instead. For prominent footer actions use `CTAButton`.
+   *
+   * `priority` and `size` are locked to keep the header visually consistent.
+   */
+  HeaderButton(props: DistributedOmit<ButtonProps, 'priority' | 'size'>) {
+    return <HeaderButton size="zero" priority="transparent" {...props} />;
+  },
+
+  /**
+   * A link button sized for `menuFooter` call-to-action slots. Larger and more
+   * visually prominent than `LinkButton`, making it suitable for primary footer
+   * actions that navigate to another page — e.g. "Create Project" or "Add Team".
+   *
+   * Use this in `menuFooter` when the action navigates somewhere (`to`/`href`).
+   * For in-place footer actions without navigation use `CTAButton` instead.
+   *
+   * `priority` and `size` are locked to keep footer actions visually consistent.
+   */
+  CTALinkButton(props: DistributedOmit<LinkButtonProps, 'priority' | 'size'>) {
+    return <LinkButton size="xs" {...props} />;
+  },
+
+  /**
+   * A button sized for `menuFooter` call-to-action slots. Larger and more
+   * visually prominent than `HeaderButton`, making it suitable for primary footer
+   * actions that don't navigate — e.g. "Invite Member" or "Create".
+   *
+   * Use this in `menuFooter` for standalone actions that aren't part of a staged
+   * selection workflow. For staged selection (deferred apply/cancel) use
+   * `ApplyButton` and `CancelButton` instead. For navigation actions use
+   * `CTALinkButton`.
+   *
+   * `priority` and `size` are locked to keep footer actions visually consistent.
+   */
+  CTAButton(props: DistributedOmit<ButtonProps, 'priority' | 'size'>) {
+    return <Button size="xs" {...props} />;
+  },
+
+  /**
+   * A primary "Apply" button for use in `menuFooter` in staged selection
+   * workflows, where changes are held locally and only committed when the user
+   * explicitly confirms. Automatically closes the menu after the `onClick`
+   * handler runs.
+   *
+   * Always pair with `CancelButton`. The typical pattern is:
+   *
+   * ```tsx
+   * menuFooter={
+   *   stagedSelect.hasStagedChanges ? (
+   *     <Flex gap="md" justify="end">
+   *       <MenuComponents.CancelButton onClick={() => stagedSelect.removeStagedChanges()} />
+   *       <MenuComponents.ApplyButton onClick={() => stagedSelect.commit(stagedSelect.stagedValue)} />
+   *     </Flex>
+   *   ) : null
+   * }
+   * ```
+   *
+   * `priority` (`primary`) and `size` are locked to keep staged selection UIs consistent.
+   */
+  ApplyButton(props: DistributedOmit<ButtonProps, 'priority' | 'size'>) {
+    const controlContext = useContext(ControlContext);
+    return (
+      <Button
+        size="xs"
+        priority="primary"
+        {...props}
+        onClick={e => {
+          props.onClick?.(e);
+          controlContext.overlayState?.close();
+        }}
+      >
+        {t('Apply')}
+      </Button>
+    );
+  },
+
+  /**
+   * A "Cancel" button for use in `menuFooter` in staged selection workflows,
+   * where changes are held locally and discarded when the user cancels.
+   * Automatically closes the menu after the `onClick` handler runs.
+   *
+   * Always pair with `ApplyButton`. See `ApplyButton` for the full usage pattern.
+   *
+   * `priority` and `size` are locked to keep staged selection UIs consistent.
+   */
+  CancelButton(props: DistributedOmit<ButtonProps, 'priority' | 'size'>) {
+    const controlContext = useContext(ControlContext);
+    return (
+      <Button
+        size="xs"
+        priority="transparent"
+        {...props}
+        onClick={e => {
+          props.onClick?.(e);
+          controlContext.overlayState?.close();
+        }}
+      >
+        {t('Cancel')}
+      </Button>
+    );
+  },
+
+  /**
+   * A condensed alert for use in `menuFooter` to surface contextual warnings or
+   * information without leaving the menu — e.g. "You've reached the selection
+   * limit" or "Some items are unavailable".
+   *
+   * Accepts all Alert `variant` values (`warning`, `info`, `error`, `success`).
+   * `system` is locked to `false` to prevent the full-bleed layout from
+   * breaking the menu's padding, and `showIcon` is locked to `false` to keep
+   * the alert compact.
+   */
+  Alert(props: DistributedOmit<AlertProps, 'system' | 'showIcon'>) {
+    return <StyledAlert {...props} system={false} showIcon={false} />;
+  },
+};
+
+const StyledAlert = styled(Alert)`
+  padding: ${p => p.theme.space.xs} ${p => p.theme.space.lg};
+  text-wrap: balance;
+`;
+
+const HeaderButton = styled(Button)`
+  font-size: inherit; /* Inherit font size from MenuHeader */
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  color: ${p => p.theme.tokens.content.secondary};
+  padding: 0 ${p => p.theme.space.xs};
+`;
+
+const HeaderLinkButton = styled(LinkButton)`
+  font-size: inherit; /* Inherit font size from MenuHeader */
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  color: ${p => p.theme.tokens.content.secondary};
+  padding: 0 ${p => p.theme.space.xs};
+`;

--- a/static/app/components/pageFilters/environment/environmentPageFilter.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilter.tsx
@@ -255,9 +255,7 @@ export function EnvironmentPageFilter({
       menuWidth={menuWidth ?? defaultMenuWidth}
       menuHeaderTrailingItems={
         stagedSelect.shouldShowReset ? (
-          <HybridFilterComponents.ResetButton
-            onClick={() => stagedSelect.handleReset()}
-          />
+          <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
         ) : null
       }
       menuFooter={
@@ -265,7 +263,7 @@ export function EnvironmentPageFilter({
           <Flex gap="md" align="center" justify="end">
             <HybridFilterComponents.CancelButton
               disabled={!stagedSelect.hasStagedChanges}
-              onClick={() => stagedSelect.removeStagedChanges()}
+              onClick={stagedSelect.removeStagedChanges}
             />
             <HybridFilterComponents.ApplyButton
               onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}

--- a/static/app/components/pageFilters/hybridFilter.spec.tsx
+++ b/static/app/components/pageFilters/hybridFilter.spec.tsx
@@ -76,9 +76,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -86,7 +84,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -130,9 +128,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -140,7 +136,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -194,9 +190,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -204,7 +198,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -267,9 +261,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -277,7 +269,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -333,9 +325,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -343,7 +333,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -399,9 +389,7 @@ describe('HybridFilter', () => {
           stagedSelect={stagedSelect}
           menuHeaderTrailingItems={
             stagedSelect.shouldShowReset ? (
-              <HybridFilterComponents.ResetButton
-                onClick={() => stagedSelect.handleReset()}
-              />
+              <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
             ) : null
           }
           menuFooter={
@@ -409,7 +397,7 @@ describe('HybridFilter', () => {
               <div>
                 <HybridFilterComponents.CancelButton
                   disabled={!stagedSelect.hasStagedChanges}
-                  onClick={() => stagedSelect.removeStagedChanges()}
+                  onClick={stagedSelect.removeStagedChanges}
                 />
                 <HybridFilterComponents.ApplyButton
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
@@ -479,7 +467,7 @@ describe('HybridFilter', () => {
               stagedSelect.hasStagedChanges ? (
                 <div>
                   <HybridFilterComponents.CancelButton
-                    onClick={() => stagedSelect.removeStagedChanges()}
+                    onClick={stagedSelect.removeStagedChanges}
                   />
                   <HybridFilterComponents.ApplyButton
                     onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}

--- a/static/app/components/pageFilters/hybridFilter.tsx
+++ b/static/app/components/pageFilters/hybridFilter.tsx
@@ -7,17 +7,12 @@ import {
   useRef,
   useState,
 } from 'react';
-import styled from '@emotion/styled';
 import {isAppleDevice, isMac} from '@react-aria/utils';
 import xor from 'lodash/xor';
 import type {DistributedOmit} from 'type-fest';
 
-import {
-  Button,
-  LinkButton,
-  type ButtonProps,
-  type LinkButtonProps,
-} from '@sentry/scraps/button';
+import {type AlertProps} from '@sentry/scraps/alert';
+import {type ButtonProps, type LinkButtonProps} from '@sentry/scraps/button';
 import {Checkbox, type CheckboxProps} from '@sentry/scraps/checkbox';
 import type {
   MultipleSelectProps,
@@ -26,7 +21,11 @@ import type {
   SelectOptionOrSection,
   SelectSection,
 } from '@sentry/scraps/compactSelect';
-import {CompactSelect, ControlContext} from '@sentry/scraps/compactSelect';
+import {
+  CompactSelect,
+  ControlContext,
+  MenuComponents,
+} from '@sentry/scraps/compactSelect';
 import {Grid} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
@@ -480,25 +479,43 @@ export function HybridFilter<Value extends SelectKey>({
 }
 
 export const HybridFilterComponents = {
-  LinkButton(props: DistributedOmit<LinkButtonProps, 'priority' | 'size'>) {
-    return <LinkButton size="xs" {...props} />;
+  CTALinkButton(props: DistributedOmit<LinkButtonProps, 'priority' | 'size'>) {
+    return <MenuComponents.CTALinkButton {...props} />;
+  },
+
+  CTAButton(props: DistributedOmit<ButtonProps, 'priority' | 'size'>) {
+    return <MenuComponents.CTAButton {...props} />;
   },
 
   ResetButton(props: DistributedOmit<ButtonProps, 'children' | 'priority' | 'size'>) {
     const controlContext = useContext(ControlContext);
 
     return (
-      <ResetButton
+      <MenuComponents.HeaderButton
         {...props}
-        priority="transparent"
-        size="zero"
         onClick={e => {
           props.onClick?.(e);
           controlContext.overlayState?.close();
         }}
       >
         {t('Reset')}
-      </ResetButton>
+      </MenuComponents.HeaderButton>
+    );
+  },
+
+  ClearButton(props: DistributedOmit<ButtonProps, 'children' | 'priority' | 'size'>) {
+    const controlContext = useContext(ControlContext);
+
+    return (
+      <MenuComponents.HeaderButton
+        {...props}
+        onClick={e => {
+          props.onClick?.(e);
+          controlContext.overlayState?.close();
+        }}
+      >
+        {t('Clear')}
+      </MenuComponents.HeaderButton>
     );
   },
 
@@ -506,10 +523,8 @@ export const HybridFilterComponents = {
     const controlContext = useContext(ControlContext);
 
     return (
-      <Button
+      <MenuComponents.ApplyButton
         {...props}
-        size="xs"
-        priority="primary"
         disabled={props.disabled}
         onClick={e => {
           props.onClick?.(e);
@@ -517,7 +532,7 @@ export const HybridFilterComponents = {
         }}
       >
         {t('Apply')}
-      </Button>
+      </MenuComponents.ApplyButton>
     );
   },
 
@@ -525,29 +540,23 @@ export const HybridFilterComponents = {
     const controlContext = useContext(ControlContext);
 
     return (
-      <Button
+      <MenuComponents.CancelButton
         {...props}
-        size="xs"
-        priority="transparent"
         onClick={e => {
           props.onClick?.(e);
           controlContext.overlayState?.close();
         }}
       >
         {t('Cancel')}
-      </Button>
+      </MenuComponents.CancelButton>
     );
   },
 
   Checkbox(props: CheckboxProps) {
     return <Checkbox {...props} />;
   },
-};
 
-const ResetButton = styled(Button)`
-  font-size: inherit; /* Inherit font size from MenuHeader */
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  color: ${p => p.theme.tokens.content.secondary};
-  padding: 0 ${p => p.theme.space.xs};
-  margin: -${p => p.theme.space.xs} -${p => p.theme.space.xs};
-`;
+  Alert(props: DistributedOmit<AlertProps, 'system' | 'showIcon'>) {
+    return <MenuComponents.Alert {...props} />;
+  },
+};

--- a/static/app/components/pageFilters/project/projectPageFilter.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.tsx
@@ -45,24 +45,8 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import {useUser} from 'sentry/utils/useUser';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
-export interface ProjectPageFilterProps extends Partial<
-  Omit<
-    HybridFilterProps<number>,
-    | 'searchable'
-    | 'multiple'
-    | 'options'
-    | 'value'
-    | 'defaultValue'
-    | 'onReplace'
-    | 'onReset'
-    | 'onToggle'
-    | 'menuBody'
-    | 'menuFooter'
-    | 'shouldCloseOnInteractOutside'
-    | 'sizeLimitMessage'
-    | 'stagedSelect'
-  >
-> {
+export interface ProjectPageFilterProps {
+  disabled?: HybridFilterProps<number>['disabled'];
   /**
    * Called when the selection changes
    */
@@ -104,12 +88,6 @@ const SELECTION_COUNT_LIMIT = 50;
 export function ProjectPageFilter({
   onChange,
   onReset,
-  disabled,
-  sizeLimit,
-  emptyMessage,
-  menuTitle,
-  menuWidth,
-  trigger,
   resetParamsOnChange,
   storageNamespace,
   ...selectProps
@@ -452,30 +430,28 @@ export function ProjectPageFilter({
       ref={hybridFilterRef}
       searchMatcher={projectSearchMatcher}
       {...selectProps}
+      disabled={selectProps.disabled ?? (!projectsLoaded || !pageFilterIsReady)}
       stagedSelect={stagedSelect}
       searchable
       options={options}
-      disabled={disabled ?? (!projectsLoaded || !pageFilterIsReady)}
-      sizeLimit={sizeLimit ?? 25}
-      emptyMessage={emptyMessage ?? t('No projects found')}
+      sizeLimit={25}
+      emptyMessage={t('No projects found')}
       menuTitle={
-        menuTitle ?? (
-          <Flex gap="xs" align="center">
-            <Text>{t('Filter Projects')}</Text>
-            <InfoTip
-              size="xs"
-              title={tct(
-                '[rangeModifier] + click to select a range of projects or [multiModifier] + click to select multiple projects at once.',
-                {
-                  rangeModifier: t('Shift'),
-                  multiModifier: isAppleDevice() ? t('Cmd') : t('Ctrl'),
-                }
-              )}
-            />
-          </Flex>
-        )
+        <Flex gap="xs" align="center">
+          <Text>{t('Filter Projects')}</Text>
+          <InfoTip
+            size="xs"
+            title={tct(
+              '[rangeModifier] + click to select a range of projects or [multiModifier] + click to select multiple projects at once.',
+              {
+                rangeModifier: t('Shift'),
+                multiModifier: isAppleDevice() ? t('Cmd') : t('Ctrl'),
+              }
+            )}
+          />
+        </Flex>
       }
-      menuWidth={menuWidth ?? defaultMenuWidth}
+      menuWidth={defaultMenuWidth}
       onOpenChange={() => {
         bookmarkedSnapshotRef.current = new Set(optimisticallyBookmarkedProjects);
       }}
@@ -527,18 +503,15 @@ export function ProjectPageFilter({
           </Stack>
         ) : null
       }
-      trigger={
-        trigger ??
-        (triggerProps => (
-          <ProjectPageFilterTrigger
-            {...triggerProps}
-            value={value}
-            memberProjects={memberProjects}
-            nonMemberProjects={nonMemberProjects}
-            ready={projectsLoaded && pageFilterIsReady}
-          />
-        ))
-      }
+      trigger={triggerProps => (
+        <ProjectPageFilterTrigger
+          {...triggerProps}
+          value={value}
+          memberProjects={memberProjects}
+          nonMemberProjects={nonMemberProjects}
+          ready={projectsLoaded && pageFilterIsReady}
+        />
+      )}
       shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
     />
   );

--- a/static/app/components/pageFilters/project/projectPageFilter.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.tsx
@@ -1,11 +1,9 @@
 import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
-import styled from '@emotion/styled';
 import {isAppleDevice} from '@react-aria/utils';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
 import sortBy from 'lodash/sortBy';
 
-import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import type {
   SelectKey,
@@ -13,6 +11,7 @@ import type {
   SelectOptionOrSection,
   SelectOptionWithKey,
 } from '@sentry/scraps/compactSelect';
+import {MenuComponents} from '@sentry/scraps/compactSelect';
 import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -457,16 +456,14 @@ export function ProjectPageFilter({
       }}
       menuHeaderTrailingItems={
         stagedSelect.shouldShowReset ? (
-          <HybridFilterComponents.ResetButton
-            onClick={() => stagedSelect.handleReset()}
-          />
+          <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
         ) : null
       }
       menuFooter={
         selectionLimitExceeded || hasProjectWrite || stagedSelect.hasStagedChanges ? (
           <Stack gap="md" direction="column">
             {selectionLimitExceeded && (
-              <CondensedAlert variant="warning" showIcon={false}>
+              <HybridFilterComponents.Alert variant="warning">
                 <Text size="sm">
                   {tct(
                     `You've selected [count] projects, but only up to [limit] can be selected at a time. Clear your selection to view all projects.`,
@@ -476,17 +473,17 @@ export function ProjectPageFilter({
                     }
                   )}
                 </Text>
-              </CondensedAlert>
+              </HybridFilterComponents.Alert>
             )}
             <Flex gap="md" align="center" justify={hasProjectWrite ? 'between' : 'end'}>
               {hasProjectWrite ? (
-                <HybridFilterComponents.LinkButton
+                <MenuComponents.CTALinkButton
                   icon={<IconAdd />}
                   to={makeProjectsPathname({path: '/new/', organization})}
                   onClick={() => stagedSelect.commit(stagedSelect.stagedValue)}
                 >
                   {t('Create Project')}
-                </HybridFilterComponents.LinkButton>
+                </MenuComponents.CTALinkButton>
               ) : undefined}
               {stagedSelect.hasStagedChanges ? (
                 <Flex gap="md" align="center" justify="end">
@@ -516,11 +513,6 @@ export function ProjectPageFilter({
     />
   );
 }
-
-const CondensedAlert = styled(Alert)`
-  padding: ${p => p.theme.space.xs} ${p => p.theme.space.lg};
-  text-wrap: balance;
-`;
 
 function shouldCloseOnInteractOutside(target: Element) {
   // Don't close select menu when clicking on power hovercard ("Requires Business Plan") or disabled feature hovercard

--- a/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
+++ b/static/app/components/prevent/testSuiteDropdown/testSuiteDropdown.tsx
@@ -112,9 +112,7 @@ export function TestSuiteDropdown() {
       menuTitle={t('Filter Test Suites')}
       menuHeaderTrailingItems={
         stagedSelect.shouldShowReset ? (
-          <HybridFilterComponents.ResetButton
-            onClick={() => stagedSelect.handleReset()}
-          />
+          <HybridFilterComponents.ResetButton onClick={stagedSelect.handleReset} />
         ) : null
       }
       menuFooter={

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -135,7 +135,7 @@ function TableHeader() {
 
   return (
     <Flex gap="xl">
-      <ProjectPageFilter size="md" />
+      <ProjectPageFilter />
       <div style={{flexGrow: 1}}>
         <AutomationSearch initialQuery={initialQuery} onSearch={onSearch} />
       </div>


### PR DESCRIPTION
Introduces `MenuComponents` as a single source of truth for the buttons and alerts used in CompactSelect's `menuHeaderTrailingItems` and `menuFooter` slots. Previously each consumer defined its own inline styled components — a `ResetButton` here, a `CondensedAlert` there — which diverged in size, color, and spacing. This centralises them.

## What changed

**`menuComponents.tsx`** — new file exporting a `MenuComponents` object with purpose-built slot primitives:
- `HeaderButton` / `LinkButton` — sized and styled for `menuHeaderTrailingItems` (inherits header font size, renders in secondary colour so it blends with the title)
- `CTAButton` / `CTALinkButton` — sized for `menuFooter` standalone actions
- `ApplyButton` / `CancelButton` — staged-selection pair; both auto-close the menu after their `onClick` runs
- `Alert` — condensed alert for in-menu warnings; locks `system=false` and `showIcon=false` to prevent layout breakage

**`HybridFilterComponents`** (hybridFilter.tsx) — now delegates to `MenuComponents` instead of reimplementing the same buttons. Adds `ClearButton`, `CTAButton`, and `Alert` to cover previously missing cases. Renames `LinkButton` → `CTALinkButton` to distinguish footer CTAs from header navigation links.

**Consumers** (`projectPageFilter`, `environmentPageFilter`, `testSuiteDropdown`) — updated to use the canonical components directly, removing local `CondensedAlert` styled components.

## Why

The scattered implementations were drifting apart. `menuHeaderTrailingItems` and `menuFooter` are styled containers with specific visual expectations; having one place to define the components that live there makes the contract explicit and makes future visual changes a one-line edit.

A companion ESLint rule (`restrict-jsx-slot-children`) in #109169 enforces that only `MenuComponents.*` and layout primitives are used in these slots.