### PR TITLE
fix(ui): Improve layout responsiveness for smaller screens

### DIFF
--- a/static/app/components/core/tabs/tab.tsx
+++ b/static/app/components/core/tabs/tab.tsx
@@ -54,7 +54,6 @@ const StyledTabWrap = styled('li', {
     p.overflowing &&
     css`
       display: none;
-      opacity: 0;
       pointer-events: none;
     `}
 `;

--- a/static/app/components/core/tabs/tab.tsx
+++ b/static/app/components/core/tabs/tab.tsx
@@ -53,6 +53,7 @@ const StyledTabWrap = styled('li', {
   ${p =>
     p.overflowing &&
     css`
+      display: none;
       opacity: 0;
       pointer-events: none;
     `}

--- a/static/app/components/core/tabs/tab.tsx
+++ b/static/app/components/core/tabs/tab.tsx
@@ -46,7 +46,7 @@ const StyledTabWrap = styled('li', {
   }
 
   &[aria-disabled] {
-    opacity: ${p => (p.overflowing ? 0 : 0.6)};
+    opacity: 0.6;
     cursor: default;
   }
 

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -187,6 +187,11 @@ const DrawerContainer = styled('div')`
   inset: 0;
   z-index: ${p => p.theme.zIndex.drawer};
   pointer-events: none;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    overflow-x: auto;
+    pointer-events: auto;
+  }
 `;
 
 const DrawerSlidePanel = styled(SlideOverPanel)`
@@ -205,6 +210,17 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
     var(--drawer-width),
     var(--drawer-max-width)
   ) !important;
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border: none;
+    box-shadow: none;
+    /* Without this, the base SlideOverPanel's overscroll-behavior: contain blocks horizontal scroll chaining. */
+    overscroll-behavior-x: auto;
+  }
 
   &[data-resizing] {
     /* Hide scrollbars during resize */

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -88,6 +88,12 @@ export const HeaderActions = styled('div')`
     width: max-content;
     margin-bottom: ${space(2)};
   }
+
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    width: 100%;
+    min-width: 100%;
+    max-width: 100%;
+  }
 `;
 
 /**

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -107,7 +107,7 @@ export function ExploreTables(props: ExploreTablesProps) {
 
   return (
     <Fragment>
-      <Flex justify="between" marginBottom="md">
+      <Flex justify="between" marginBottom="md" gap="md" wrap="wrap">
         <Tabs value={props.tab} onChange={props.setTab} size="sm">
           <TabList variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -165,6 +165,7 @@ const SupportedBrowsers = styled('div')`
   display: inline-flex;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
+  flex-wrap: wrap;
 `;
 
 const ReferenceLink = styled('div')`

--- a/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
+++ b/static/app/views/insights/browser/webVitals/components/webVitalDescription.tsx
@@ -142,31 +142,26 @@ export function WebVitalDescription({score, value, webVital}: Props) {
           webVital: webVital.toUpperCase(),
         })}
       </Stack>
-      <SupportedBrowsers>
-        {Object.values(Browser).map(browser => (
-          <Flex align="center" gap="md" key={browser}>
-            {vitalSupportedBrowsers[
-              WebVital[webVital.toUpperCase() as Uppercase<typeof webVital>]
-            ]?.includes(browser) ? (
-              <IconCheckmark variant="success" size="sm" />
-            ) : (
-              <IconClose variant="danger" size="sm" />
-            )}
-            {browser}
-          </Flex>
-        ))}
-      </SupportedBrowsers>
-      <ReferenceLink>{link}</ReferenceLink>
+      <Stack gap="xl">
+        <Flex display="inline-flex" wrap="wrap" gap="xl">
+          {Object.values(Browser).map(browser => (
+            <Flex align="center" gap="md" key={browser}>
+              {vitalSupportedBrowsers[
+                WebVital[webVital.toUpperCase() as Uppercase<typeof webVital>]
+              ]?.includes(browser) ? (
+                <IconCheckmark variant="success" size="sm" />
+              ) : (
+                <IconClose variant="danger" size="sm" />
+              )}
+              {browser}
+            </Flex>
+          ))}
+        </Flex>
+        <ReferenceLink>{link}</ReferenceLink>
+      </Stack>
     </div>
   );
 }
-
-const SupportedBrowsers = styled('div')`
-  display: inline-flex;
-  gap: ${space(2)};
-  margin-bottom: ${space(2)};
-  flex-wrap: wrap;
-`;
 
 const ReferenceLink = styled('div')`
   margin-bottom: ${space(2)};

--- a/static/app/views/insights/crons/components/monitorHeaderActions.tsx
+++ b/static/app/views/insights/crons/components/monitorHeaderActions.tsx
@@ -1,5 +1,5 @@
 import {Button, LinkButton, type ButtonProps} from '@sentry/scraps/button';
-import {Grid} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {deleteMonitor, updateMonitor} from 'sentry/actionCreators/monitors';
@@ -82,7 +82,7 @@ function MonitorHeaderActions({monitor, orgSlug, onUpdate}: Props) {
   }
 
   return (
-    <Grid flow="column" align="center" gap="md">
+    <Flex direction="row" align="center" gap="md" wrap="wrap">
       <FeedbackButton />
       <Button
         size="sm"
@@ -131,7 +131,7 @@ function MonitorHeaderActions({monitor, orgSlug, onUpdate}: Props) {
       >
         {t('Edit Monitor')}
       </LinkButton>
-    </Grid>
+    </Flex>
   );
 }
 


### PR DESCRIPTION
Hide overflowing tabs completely, add flex wrapping to explore tables, web vitals browser list, and crons monitor header actions to prevent layout overflow on smaller devices.

