### PR TITLE
fix(ai-monitoring): fix error icon bg bleed in ai trace span list

### DIFF
--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -239,11 +239,7 @@ const TraceListItem = memo(function TraceListItem({
       onClick={onClick}
       indent={indent}
     >
-      <Flex
-        align="center"
-        position="relative"
-        style={{color, background: 'var(--row-bg)'}}
-      >
+      <Flex align="center" position="relative" style={{color}}>
         {icon}
         {hasErrors && (
           <Tooltip delay={300} title={t('This span encountered an error')} skipWrapper>

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -239,14 +239,18 @@ const TraceListItem = memo(function TraceListItem({
       onClick={onClick}
       indent={indent}
     >
-      <Flex align="center" position="relative" style={{color, background: 'inherit'}}>
+      <Flex
+        align="center"
+        position="relative"
+        style={{color, background: 'var(--row-bg)'}}
+      >
         {icon}
         {hasErrors && (
           <Tooltip delay={300} title={t('This span encountered an error')} skipWrapper>
             <Container
               position="absolute"
               radius="full"
-              style={{bottom: -6, right: -6, padding: 1, background: 'inherit'}}
+              style={{bottom: -6, right: -6, padding: 1, background: 'var(--row-bg)'}}
             >
               <IconFire display="block" size="xs" variant="danger" />
             </Container>
@@ -533,10 +537,11 @@ const ListItemContainer = styled('div')<{
   padding-left: ${p => (p.indent ? p.indent * 16 : 4)}px;
   border-radius: ${p => p.theme.radius.md};
   cursor: pointer;
-  background-color: ${p =>
+  --row-bg: ${p =>
     p.isSelected
       ? p.theme.tokens.background.secondary
       : p.theme.tokens.background.primary};
+  background-color: var(--row-bg);
   outline: ${p =>
     p.isSelected
       ? p.hasErrors


### PR DESCRIPTION
Use a CSS custom property (--row-bg) to propagate the row background color to the error icon badge. Previously, `background: inherit` resolved incorrectly in certain stacking contexts, causing the icon badge to show the wrong background on hover/selection state transitions.

**Before**

https://github.com/user-attachments/assets/44465ca4-cae0-4ef9-9d17-a742363077ea




**After**

https://github.com/user-attachments/assets/c3ad1de4-c786-4a00-b8ca-9d4108ef3c53




closes https://linear.app/getsentry/issue/TET-1966/ai-trace-triple-nested-hover-background
