### PR TITLE
feat(occurrences): New ingest

### DIFF
--- a/src/sentry/eventstream/item_helpers.py
+++ b/src/sentry/eventstream/item_helpers.py
@@ -1,6 +1,8 @@
-from collections.abc import Mapping
+import ipaddress
+from collections.abc import Callable, Mapping
 from typing import Any
 
+import sentry_sdk
 from google.protobuf.timestamp_pb2 import Timestamp
 from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE
 from sentry_protos.snuba.v1.trace_item_pb2 import (
@@ -15,14 +17,21 @@ from sentry.models.project import Project
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import json
 from sentry.utils.eap import hex_to_item_id
+from sentry.utils.safe import get_path
 
 # Max depth for recursive encoding to protobuf AnyValue.
 _ENCODE_MAX_DEPTH = 6
 
 
 def serialize_event_data_as_item(
-    event: Event | GroupEvent, event_data: Mapping[str, Any], project: Project
+    event: Event | GroupEvent,
+    event_data: Mapping[str, Any],
+    project: Project,
 ) -> TraceItem:
+    """
+    This is the top-level entrypoint for this module. Transforms an Event (with its
+    associated event_data) into a TraceItem.
+    """
     return TraceItem(
         item_id=hex_to_item_id(event_data["event_id"]),
         item_type=TRACE_ITEM_TYPE_OCCURRENCE,
@@ -35,43 +44,355 @@ def serialize_event_data_as_item(
         ),
         retention_days=event_data.get("retention_days", 90),
         attributes=_encode_attributes(
-            event, event_data, ignore_fields={"event_id", "timestamp", "tags", "spans", "'spans'"}
+            event,
+            event_data,
         ),
     )
 
 
 def _encode_attributes(
-    event: Event | GroupEvent, event_data: Mapping[str, Any], ignore_fields: set[str] | None = None
-) -> Mapping[str, AnyValue]:
-    raw_tags = event_data.get("tags") or []
-    tags_dict = {kv[0]: kv[1] for kv in raw_tags if kv is not None and kv[1] is not None}
-
-    all_ignore_fields = (ignore_fields or set()) | {"tags"}
-    attributes = _build_occurrence_attributes(
-        event_data, tags=tags_dict, ignore_fields=all_ignore_fields
-    )
-
-    if event.group_id:
-        attributes["group_id"] = AnyValue(int_value=event.group_id)
-
-    return attributes
-
-
-def _build_occurrence_attributes(
-    data: Mapping[str, Any],
-    tags: Mapping[str, str] | None = None,
+    event: Event | GroupEvent,
+    event_data: Mapping[str, Any],
     ignore_fields: set[str] | None = None,
-) -> dict[str, AnyValue]:
-    ignore_fields = ignore_fields or set()
-    attributes: dict[str, AnyValue] = {
-        k: _encode_value(v) for k, v in data.items() if k not in ignore_fields and v is not None
+) -> Mapping[str, AnyValue]:
+    """
+    This function transforms an Event (with its associated event_data) into a mapping
+    ready to be passed to a TraceItem.
+    """
+    preprocessed = _extract_from_event(event)
+    attribute_data = _gather_attribute_data_from_event_data(event_data, ignore_fields, preprocessed)
+    return _encode_attribute_data(attribute_data)
+
+
+def _gather_attribute_data_from_event_data(
+    event_data: Mapping[str, Any],
+    ignore_fields: set[str] | None = None,
+    preprocessed: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    """
+    Workhorse function that extracts raw attribute data into a standardized mapping.
+    Note that this function's output should NOT include any variant of AnyValue.
+    """
+    encoded_data: dict[str, Any] = {}
+
+    # 1: ALLOWLIST OF DIRECT COPIES
+    simple_allowlist = {
+        "event_id",
+        "type",
+        "version",
+        "platform",
+        "location",
+        "title",
+        "subtitle",
+        "culprit",
+        "level",
+        "resource_id",
+        "message",
+        "release",
+        "transaction",
+    }
+    for key in simple_allowlist:
+        if key in event_data:
+            encoded_data[key] = event_data[key]
+
+    # 2: SIMPLE RENAMES FROM EXISTING DATA
+    renames: tuple[tuple[str, str], ...] = (  # tuple of old, new pairs
+        ("main_exception_id", "exception_main_thread"),
+        ("key_id", "key"),
+        ("project", "project_id"),
+    )
+    for old_key, new_key in renames:
+        if old_key in event_data:
+            encoded_data[new_key] = event_data[old_key]
+
+    # 3: LIST OF PROCESSORS THAT RETURN A DICT
+    processors: tuple[Callable[[Mapping[str, Any]], Mapping[str, Any]], ...] = (
+        # Tags & Contexts ==> Attrs
+        _extract_tags_and_contexts,
+        # IP Address, email, username
+        _extract_from_user,
+        # SDK name & version
+        _extract_from_sdk,
+        # timestamp_ms in addition to timestamp
+        _extract_time_data,
+        # primary_hash from hashes
+        _extract_hashes,
+        # fingerprint from fingerprint (possibly string or list)
+        _extract_fingerprint,
+        _extract_metadata,
+        _extract_http,
+        _extract_modules,
+        _extract_exception,
+    )
+    for processor in processors:
+        try:
+            encoded_data.update(processor(event_data))
+        except Exception as err:
+            sentry_sdk.capture_exception(err)
+
+    # 4: REMOVING EXPLICITLY IGNORED ATTRS
+    for ignored_attr in ignore_fields or []:
+        encoded_data.pop(ignored_attr, None)
+
+    # 5: ADDING ALREADY-HANDLED CASES
+    if preprocessed:
+        encoded_data.update(preprocessed)
+
+    return encoded_data
+
+
+def _encode_attribute_data(attr_data: Mapping[str, Any]) -> Mapping[str, AnyValue]:
+    """
+    Prepares a mapping of attribute data into a form ready to be passed to TraceItem.
+    """
+    return {k: _encode_value(v) for k, v in attr_data.items() if v is not None}
+
+
+def _extract_from_event(event: Event | GroupEvent) -> Mapping[str, float | int]:
+    out: dict[str, float | int] = {}
+    if event.group_id:
+        out["group_id"] = event.group_id
+    if isinstance(event, GroupEvent):
+        out["group_first_seen"] = event.group.first_seen.timestamp()
+    return out
+
+
+def _extract_tags_and_contexts(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool | None]:
+    # These may be overwritten by promoted tags.
+    out = {
+        "release": event_data.get("release"),
+        "environment": event_data.get("environment"),
+        "dist": event_data.get("dist"),
     }
 
-    tag_attrs = {f"tags[{k}]": _encode_value(v) for k, v in (tags or {}).items()}
-    attributes.update(tag_attrs)
-    attributes["tag_keys"] = _encode_value(sorted(tag_attrs.keys()))
+    # From a user's perspective, "attributes" are tags + contexts.
+    # Yes, it's confusing with the general EAP attributes.
+    format_attr_key = lambda key: f"attr[{key}]"
 
-    return attributes
+    attr_keys = set()
+    tags = event_data.get("tags")
+    if tags is not None:
+        for tag in tags:
+            if tag is None:
+                continue
+            key, value = tag
+            if value is None:
+                continue
+            formatted_key = format_attr_key(key)
+            out[formatted_key] = value
+            attr_keys.add(formatted_key)
+
+    contexts = event_data.get("contexts")
+    if isinstance(contexts, dict):
+        context_values = _flatten_attrs(None, contexts)
+        for key, value in context_values.items():
+            formatted_key = format_attr_key(key)
+            out[formatted_key] = value
+            attr_keys.add(formatted_key)
+
+    # Promoted tags
+    promotions = {
+        "sentry:release": "release",
+        "environment": "environment",
+        "sentry:user": "user",
+        "sentry:dist": "dist",
+        "profile.profile_id": "profile_id",
+        "replay.replay_id": "replay_id",
+    }
+    for promo_from, promo_to in promotions.items():
+        promo_key = format_attr_key(promo_from)
+        if promo_key in out:
+            out[promo_to] = out[promo_key]
+
+    out["attr_keys"] = sorted(attr_keys)
+
+    return out
+
+
+def _extract_from_user(event_data: Mapping[str, Any]) -> Mapping[str, str | float | int | bool]:
+    out = {}
+    user_data = event_data.get("user")
+
+    if user_data:
+        ip_address = str(user_data.get("ip_address"))
+        if ip_address:
+            try:
+                parsed_ip_address = ipaddress.ip_address(ip_address)
+                if isinstance(parsed_ip_address, ipaddress.IPv4Address):
+                    out["ip_address_v4"] = ip_address
+                elif isinstance(parsed_ip_address, ipaddress.IPv6Address):
+                    out["ip_address_v6"] = ip_address
+            except ValueError:
+                # Might not be valid IP address due to PII stripping
+                pass
+
+        user_email = user_data.get("email")
+        if user_email is not None:
+            out["user_email"] = user_email
+
+        user_id = user_data.get("user_id", user_data.get("id"))
+        if user_id is not None:
+            out["user_id"] = user_id
+
+        user_name = user_data.get("username")
+        if user_name is not None:
+            out["user_name"] = user_name
+
+    return out
+
+
+def _extract_from_sdk(event_data: Mapping[str, Any]) -> Mapping[str, str | float | int | bool]:
+    out = {}
+    sdk = event_data.get("sdk")
+
+    if sdk:
+        out["sdk_name"] = sdk.get("name")
+        out["sdk_version"] = sdk.get("version")
+        out["sdk_integrations"] = sdk.get("integrations")
+    return out
+
+
+def _extract_time_data(event_data: Mapping[str, Any]) -> Mapping[str, str | float | int | bool]:
+    if "timestamp" not in event_data:
+        return {}
+    return {"timestamp_ms": event_data["timestamp"] * 1000}
+
+
+def _extract_hashes(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool]:
+    hashes = event_data.get("hashes", [])
+    if hashes:
+        return {"primary_hash": hashes[0]}
+    return {}
+
+
+def _extract_fingerprint(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool]:
+    out = {}
+
+    fingerprint = event_data.get("fingerprint", [])
+    if isinstance(fingerprint, str):
+        out["fingerprint"] = fingerprint
+    elif fingerprint:
+        out["fingerprint"] = fingerprint[0]
+
+    grouping_config = event_data.get("grouping_config")
+    if grouping_config:
+        out.update(_flatten_attrs("grouping_config", grouping_config))
+
+    return out
+
+
+def _extract_metadata(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool]:
+    out = {}
+
+    metadata = event_data.get("metadata", {})
+    if metadata:
+        out.update(_flatten_attrs("metadata", metadata))
+
+    return out
+
+
+def _extract_http(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool]:
+    out = {}
+
+    request = event_data.get("request", {})
+    if request:
+        url = request.get("url")
+        if url:
+            out["http_url"] = url
+
+        method = request.get("method")
+        if method:
+            out["http_method"] = method
+
+        headers = request.get("headers", [])
+        for header_name, header_value in headers:
+            if header_name == "Referer" or header_name == "Referrer":
+                out["http_referrer"] = header_value
+
+    return out
+
+
+def _extract_modules(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, str | float | int | bool]:
+    out = {}
+
+    modules = event_data.get("modules", {})
+    if modules:
+        out.update(_flatten_attrs("modules", modules))
+
+    return out
+
+
+def _extract_exception(
+    event_data: Mapping[str, Any],
+) -> Mapping[str, int | list[str | int | bool | None]]:
+    out: dict[str, int | list[Any]] = {}
+
+    exceptions = event_data.get("exception", {}).get("values", [])
+    # So, logically, each exception here is basically a mapping of data.
+    # Most notable in that mapping is frames, which is itself a mapping of frame data.
+    # NOW! EAP currently doesn't support mappings. So what we do here is instead build
+    # consistently-ordered lists.
+    if not exceptions:
+        return out
+
+    out["exception_count"] = len(exceptions)
+
+    stack_types = []
+    stack_values = []
+    stack_mechanism_types = []
+    stack_mechanism_handled = []
+    frame_abs_paths = []
+    frame_filenames = []
+    frame_packages = []
+    frame_modules = []
+    frame_functions = []
+    frame_in_app = []
+    frame_colnos = []
+    frame_linenos = []
+    frame_stack_levels = []
+    for stack_level, stack in enumerate(exceptions):
+        stack_types.append(stack.get("type"))
+        stack_values.append(stack.get("value"))
+        stack_mechanism_types.append(get_path(stack, "mechanism", "type"))
+        stack_mechanism_handled.append(get_path(stack, "mechanism", "handled"))
+        for frame in get_path(stack, "stacktrace", "frames", default=[]):
+            frame_abs_paths.append(frame.get("abs_path"))
+            frame_filenames.append(frame.get("filename"))
+            frame_packages.append(frame.get("package"))
+            frame_modules.append(frame.get("module"))
+            frame_functions.append(frame.get("function"))
+            frame_in_app.append(frame.get("in_app"))
+            frame_colnos.append(frame.get("colno"))
+            frame_linenos.append(frame.get("lineno"))
+            frame_stack_levels.append(stack_level)
+
+    out["stack_types"] = stack_types
+    out["stack_values"] = stack_values
+    out["stack_mechanism_types"] = stack_mechanism_types
+    out["stack_mechanism_handled"] = stack_mechanism_handled
+    out["frame_abs_paths"] = frame_abs_paths
+    out["frame_filenames"] = frame_filenames
+    out["frame_packages"] = frame_packages
+    out["frame_modules"] = frame_modules
+    out["frame_functions"] = frame_functions
+    out["frame_in_app"] = frame_in_app
+    out["frame_colnos"] = frame_colnos
+    out["frame_linenos"] = frame_linenos
+    out["frame_stack_levels"] = frame_stack_levels
+
+    return out
 
 
 def _encode_value(value: Any, _depth: int = 0) -> AnyValue:
@@ -95,9 +416,7 @@ def _encode_value(value: Any, _depth: int = 0) -> AnyValue:
     elif isinstance(value, list) or isinstance(value, tuple):
         # Not yet processed on EAP side
         return AnyValue(
-            array_value=ArrayValue(
-                values=[_encode_value(v, _depth + 1) for v in value if v is not None]
-            )
+            array_value=ArrayValue(values=[_encode_value(v, _depth + 1) for v in value])
         )
     elif isinstance(value, dict):
         # Not yet processed on EAP side
@@ -110,5 +429,20 @@ def _encode_value(value: Any, _depth: int = 0) -> AnyValue:
                 ]
             )
         )
+    elif value is None:
+        return AnyValue(string_value="(No Value)")
     else:
         raise NotImplementedError(f"encode not supported for {type(value)}")
+
+
+def _flatten_attrs(key: str | None, value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for subkey, subvalue in value.items():
+            new_key = subkey if key is None else ".".join([key, subkey])
+            out.update(_flatten_attrs(new_key, subvalue))
+        return out
+
+    else:
+        assert key is not None
+        return {key: value}

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+import sentry_sdk
 import urllib3
 from sentry_protos.snuba.v1.trace_item_pb2 import TraceItem
 from urllib3.fields import RequestField
@@ -216,7 +217,10 @@ class SnubaProtocolEventStream(EventStream):
         )
 
         if in_rollout_group("eventstream.eap_forwarding_rate", event.project_id):
-            self._forward_event_to_items(event, event_data, event_type, project)
+            try:
+                self._forward_event_to_items(event, event_data, event_type, project)
+            except Exception as e:
+                sentry_sdk.capture_exception(e)
 
     def _missing_required_item_fields(self, event_data: Mapping[str, Any]) -> list[str]:
         root_level_fields = ["event_id", "timestamp"]

--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -93,7 +93,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
     ) -> EAPResponse:
         """
         Runs a query with additional selected_columns of all tags in tags.
-        tags should be formatted appropriately - e.g. {tags[foo], tags[bar]}
+        tags should be formatted appropriately - e.g. {attr[foo], attr[bar]}
         """
 
         columns = cls.DEFINITIONS.columns.copy()

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -83,7 +83,8 @@ from sentry.auth.superuser import SUPERUSER_ORG_ID, Superuser
 from sentry.conf.types.kafka_definition import Topic, get_topic_codec
 from sentry.event_manager import EventManager
 from sentry.eventstream.item_helpers import (
-    _build_occurrence_attributes,
+    _encode_attribute_data,
+    _gather_attribute_data_from_event_data,
 )
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.issue_detection.performance_detection import detect_performance_problems
@@ -3592,16 +3593,20 @@ class OccurrenceTestCase(BaseTestCase, TraceItemTestCase):
             "title": title,
             "type": occurrence_type,
         }
+        preprocessed: dict[str, Any] = {}
         if group_id is not None:
-            data["group_id"] = group_id
+            preprocessed["group_id"] = group_id
         if environment is not None:
             data["environment"] = environment
         if transaction is not None:
             data["transaction"] = transaction
         if attributes:
             data.update(attributes)
+        if tags is not None:
+            data["tags"] = tags.items()
 
-        attributes_proto = _build_occurrence_attributes(data, tags=tags)
+        attr_data = _gather_attribute_data_from_event_data(data, preprocessed=preprocessed)
+        attributes_proto = _encode_attribute_data(attr_data)
 
         return TraceItem(
             organization_id=organization.id,

--- a/tests/sentry/eventstream/test_item_helpers.py
+++ b/tests/sentry/eventstream/test_item_helpers.py
@@ -1,18 +1,25 @@
 from typing import Any
 
-from sentry_protos.snuba.v1.request_common_pb2 import TRACE_ITEM_TYPE_OCCURRENCE
-from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue, KeyValue, KeyValueList
+from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, ArrayValue
 
 from sentry.db.models import NodeData
 from sentry.eventstream.item_helpers import (
-    _ENCODE_MAX_DEPTH,
-    _encode_attributes,
-    serialize_event_data_as_item,
+    _encode_value,
+    _extract_exception,
+    _extract_fingerprint,
+    _extract_from_event,
+    _extract_from_sdk,
+    _extract_from_user,
+    _extract_hashes,
+    _extract_http,
+    _extract_metadata,
+    _extract_modules,
+    _extract_tags_and_contexts,
+    _extract_time_data,
+    _flatten_attrs,
 )
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.testutils.cases import TestCase
-from sentry.utils import json
-from sentry.utils.eap import hex_to_item_id, item_id_to_hex
 
 
 class ItemHelpersTest(TestCase):
@@ -28,478 +35,265 @@ class ItemHelpersTest(TestCase):
         )
         return group_event
 
-    def test_encode_attributes_basic(self) -> None:
-        event_data = {
-            "string_field": "test",
-            "int_field": 123,
-            "float_field": 45.67,
-            "bool_field": True,
-            "tags": [],
-        }
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
+    def test_encode_value(self) -> None:
+        assert _encode_value("a") == AnyValue(string_value="a")
+        assert _encode_value(True) == AnyValue(bool_value=True)
+        assert _encode_value(1) == AnyValue(int_value=1)
+        assert _encode_value(3.14) == AnyValue(double_value=3.14)
+        assert _encode_value((1, "a")) == AnyValue(
+            array_value=ArrayValue(values=[AnyValue(int_value=1), AnyValue(string_value="a")])
         )
-        result = _encode_attributes(event, event_data)
-
-        assert result["string_field"] == AnyValue(string_value="test")
-        assert result["int_field"] == AnyValue(int_value=123)
-        assert result["float_field"] == AnyValue(double_value=45.67)
-        assert result["bool_field"] == AnyValue(bool_value=True)
-
-    def test_encode_attributes_with_ignore_fields(self) -> None:
-        event_data = {
-            "keep_field": "value1",
-            "ignore_field": "value2",
-            "another_keep": 42,
-            "tags": [],
-        }
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
+        assert _encode_value([1, "a"]) == AnyValue(
+            array_value=ArrayValue(values=[AnyValue(int_value=1), AnyValue(string_value="a")])
         )
-        result = _encode_attributes(event, event_data, ignore_fields={"ignore_field"})
 
-        assert "keep_field" in result
-        assert "another_keep" in result
-        assert "ignore_field" not in result
+    def test_encode_value_with_long_int(self) -> None:
+        very_big_int = 2**70  # Should trigger ~2**63
+        assert _encode_value(very_big_int) == AnyValue(string_value=str(very_big_int))
 
-    def test_encode_attributes_with_multiple_ignore_fields(self) -> None:
-        event_data = {
-            "field1": "value1",
-            "field2": "value2",
-            "field3": "value3",
-            "tags": [],
+    def test_flatten_attrs(self) -> None:
+        data = {
+            "str": "s",
+            "int": 1,
+            "dict": {
+                "a": "b",
+                "x": 0,
+            },
         }
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-        result = _encode_attributes(event, event_data, ignore_fields={"field1", "field3"})
 
-        assert "field1" not in result
-        assert "field2" in result
-        assert "field3" not in result
+        expected = {
+            "p.str": "s",
+            "p.int": 1,
+            "p.dict.a": "b",
+            "p.dict.x": 0,
+        }
 
-    def test_encode_attributes_with_group_id(self) -> None:
-        event_data = {"field": "value", "tags": []}
+        assert _flatten_attrs("p", data) == expected
 
+    def test_extract_from_event(
+        self,
+    ) -> None:
+        event_data: dict[str, Any] = {}
         event = self.create_group_event(event_data)
-        result = _encode_attributes(event, event_data)
 
-        assert result["group_id"] == AnyValue(int_value=event.group.id)
-        assert result["field"] == AnyValue(string_value="value")
+        out = _extract_from_event(event)
+        assert len(out) == 2
+        assert out["group_id"] == event.group_id
+        assert out["group_first_seen"] == event.group.first_seen.timestamp()
 
-    def test_encode_attributes_without_group_id(self) -> None:
-        event_data = {"field": "value", "tags": []}
-
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        result = _encode_attributes(event, event_data)
-
-        assert "group_id" not in result
-        assert result["field"] == AnyValue(string_value="value")
-
-    def test_encode_attributes_with_tags(self) -> None:
+    def test_extract_tags_and_contexts(
+        self,
+    ) -> None:
+        # Test no promotion
         event_data = {
-            "field": "value",
-            "tags": [
-                ("environment", "production"),
-                ("release", "1.0.0"),
-                ("level", "error"),
-            ],
+            "release": "r",
+            "environment": "e",
+            "dist": "d",
+            "contexts": {"abc": 0, "xyz": 1, "sub": {"abcxyz": 2}},
+        }
+        out = _extract_tags_and_contexts(event_data)
+        assert len(out) == 7
+        assert out == {
+            "attr_keys": ["attr[abc]", "attr[sub.abcxyz]", "attr[xyz]"],
+            "release": "r",
+            "environment": "e",
+            "dist": "d",
+            "attr[abc]": 0,
+            "attr[xyz]": 1,
+            "attr[sub.abcxyz]": 2,
         }
 
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        result = _encode_attributes(event, event_data)
-
-        assert result["tags[environment]"] == AnyValue(string_value="production")
-        assert result["tags[release]"] == AnyValue(string_value="1.0.0")
-        assert result["tags[level]"] == AnyValue(string_value="error")
-        assert result["tag_keys"] == AnyValue(
-            array_value=ArrayValue(
-                values=[
-                    AnyValue(string_value="tags[environment]"),
-                    AnyValue(string_value="tags[level]"),
-                    AnyValue(string_value="tags[release]"),
-                ]
-            )
-        )
-
-    def test_encode_attributes_with_empty_tags(self) -> None:
-        event_data = {"field": "value", "tags": []}
-
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        result = _encode_attributes(event, event_data)
-
-        assert result["field"] == AnyValue(string_value="value")
-        # No tags[] keys should be present
-        assert not any(key.startswith("tags[") for key in result.keys())
-        assert result["tag_keys"] == AnyValue(array_value=ArrayValue(values=[]))
-
-    def test_encode_attributes_with_integer_tag_values(self) -> None:
+        # Test promotion
         event_data = {
-            "field": "value",
-            "tags": [
-                ("numeric_tag", "42"),
-                ("string_tag", "value"),
-            ],
+            "release": "old_r",
+            "environment": "old_e",
+            "dist": "old_d",
+            "contexts": {"sentry:release": "new_r", "environment": "new_e", "sentry:dist": "new_d"},
+        }
+        out = _extract_tags_and_contexts(event_data)
+        assert out["release"] == "new_r"
+        assert out["environment"] == "new_e"
+        assert out["dist"] == "new_d"
+
+    def test_extract_from_user(self) -> None:
+        # Test IPv4
+        event_data = {
+            "user": {"email": "e", "user_id": "i", "username": "n", "ip_address": "1.2.3.4"}
+        }
+        out = _extract_from_user(event_data)
+        assert out == {
+            "ip_address_v4": "1.2.3.4",
+            "user_email": "e",
+            "user_id": "i",
+            "user_name": "n",
         }
 
-        event = self.create_group_event(event_data)
-        result = _encode_attributes(event, event_data)
-
-        assert result["tags[numeric_tag]"] == AnyValue(string_value="42")
-        assert result["tags[string_tag]"] == AnyValue(string_value="value")
-        assert result["group_id"] == AnyValue(int_value=event.group.id)
-
-    def test_encode_attributes_empty_event_data(self) -> None:
-        event_data: dict[str, Any] = {"tags": []}
-
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-        result = _encode_attributes(event, event_data)
-
-        assert len(result) == 1
-        assert "tag_keys" in result
-        assert result["tag_keys"] == AnyValue(array_value=ArrayValue(values=[]))
-
-    def test_encode_attributes_with_complex_types(self) -> None:
+        # Test IPv6
         event_data = {
-            "list_field": [1, 2, 3],
-            "dict_field": {"nested": "value"},
-            "tags": [],
+            "user": {"email": "e", "user_id": "i", "username": "n", "ip_address": "1:2:3:4::"}
+        }
+        out = _extract_from_user(event_data)
+        assert out == {
+            "ip_address_v6": "1:2:3:4::",
+            "user_email": "e",
+            "user_id": "i",
+            "user_name": "n",
         }
 
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        result = _encode_attributes(event, event_data)
-
-        assert result["list_field"] == AnyValue(
-            array_value=ArrayValue(
-                values=[
-                    AnyValue(int_value=1),
-                    AnyValue(int_value=2),
-                    AnyValue(int_value=3),
-                ]
-            )
-        )
-        assert result["dict_field"] == AnyValue(
-            kvlist_value=KeyValueList(
-                values=[
-                    KeyValue(key="nested", value=AnyValue(string_value="value")),
-                ]
-            )
-        )
-
-    def test_encode_attributes_with_none_tags(self) -> None:
-        """Test that _encode_attributes handles None tags gracefully."""
+        # Test invalid IP
         event_data = {
-            "field": "value",
-            "tags": None,
+            "user": {"email": "e", "user_id": "i", "username": "n", "ip_address": "<REDACTED>"}
+        }
+        out = _extract_from_user(event_data)
+        assert out == {
+            "user_email": "e",
+            "user_id": "i",
+            "user_name": "n",
         }
 
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
+    def test_extract_from_sdk(self) -> None:
+        event_data = {"sdk": {"name": "n", "version": "v", "integrations": ["i"]}}
+        out = _extract_from_sdk(event_data)
+        assert out == {"sdk_name": "n", "sdk_version": "v", "sdk_integrations": ["i"]}
 
-        result = _encode_attributes(event, event_data)
+    def test_extract_time_data(self) -> None:
+        event_data = {"timestamp": 123456}
+        out = _extract_time_data(event_data)
+        assert out == {"timestamp_ms": 123456000}
 
-        assert result["field"] == AnyValue(string_value="value")
-        # No tags[] keys should be present when tags is None
-        assert not any(key.startswith("tags[") for key in result.keys())
-        # tag_keys should still be present with an empty array
-        assert result["tag_keys"] == AnyValue(array_value=ArrayValue(values=[]))
+    def test_extract_hashes(
+        self,
+    ) -> None:
+        event_data = {"hashes": ["deadbeef", "13371337"]}
+        out = _extract_hashes(event_data)
+        assert out == {"primary_hash": "deadbeef"}
 
-    def test_encode_attributes_with_none_elements_in_tags(self) -> None:
-        """Test that _encode_attributes handles tags list containing None values."""
+    def test_extract_fingerprint(
+        self,
+    ) -> None:
+        event_data = {"fingerprint": "{{cool}}", "grouping_config": {"a": 0, "b": 1}}
+        out = _extract_fingerprint(event_data)
+        assert out == {"fingerprint": "{{cool}}", "grouping_config.a": 0, "grouping_config.b": 1}
+
+    def test_extract_metadata(
+        self,
+    ) -> None:
+        event_data = {"metadata": {"a": 0, "b": 1}}
+        out = _extract_metadata(event_data)
+        assert out == {"metadata.a": 0, "metadata.b": 1}
+
+    def test_extract_http(
+        self,
+    ) -> None:
         event_data = {
-            "field": "value",
-            "tags": [
-                ("tag1", "value1"),
-                None,
-                ("tag2", None),
-                ("tag3", "value3"),
-            ],
-        }
-
-        event = Event(
-            event_id="a" * 32,
-            data=event_data,
-            project_id=self.project.id,
-        )
-
-        result = _encode_attributes(event, event_data)
-
-        assert result["field"] == AnyValue(string_value="value")
-        assert result["tags[tag1]"] == AnyValue(string_value="value1")
-        assert result["tags[tag3]"] == AnyValue(string_value="value3")
-        # tag2 has None value, so it should be skipped
-        assert "tags[tag2]" not in result
-
-        assert result["tag_keys"] == AnyValue(
-            array_value=ArrayValue(
-                values=[
-                    AnyValue(string_value="tags[tag1]"),
-                    AnyValue(string_value="tags[tag3]"),
-                ]
-            )
-        )
-
-    def test_serialize_event_data_as_item_basic(self) -> None:
-        project = self.create_project()
-
-        event_data = {
-            "event_id": "a" * 32,
-            "timestamp": 1234567890,
-            "contexts": {"trace": {"trace_id": "b" * 32}},
-            "string_field": "test_value",
-            "int_field": 42,
-            "tags": [("environment", "production")],
-        }
-
-        event = self.create_group_event(event_data)
-        result = serialize_event_data_as_item(event, event_data, project)
-
-        assert result.item_id == hex_to_item_id("a" * 32)
-        assert result.item_type == TRACE_ITEM_TYPE_OCCURRENCE
-        assert result.trace_id == "b" * 32
-        assert result.timestamp.seconds == 1234567890
-        assert result.organization_id == project.organization_id
-        assert result.project_id == project.id
-        assert result.retention_days == 90
-        # Check that received field is not set (protobuf optional field)
-        assert not result.HasField("received")
-
-    def test_serialize_event_data_as_item_with_received(self) -> None:
-        project = self.create_project()
-
-        event_data = {
-            "event_id": "c" * 32,
-            "timestamp": 1234567890,
-            "received": 1234567900,
-            "contexts": {"trace": {"trace_id": "d" * 32}},
-            "tags": [],
-        }
-
-        event = Event(
-            event_id="c" * 32,
-            data=event_data,
-            project_id=project.id,
-        )
-        result = serialize_event_data_as_item(event, event_data, project)
-
-        assert result.HasField("received")
-        assert result.received.seconds == 1234567900
-
-    def test_serialize_event_data_as_item_with_custom_retention_days(self) -> None:
-        project = self.create_project()
-
-        event_data = {
-            "event_id": "e" * 32,
-            "timestamp": 1234567890,
-            "contexts": {"trace": {"trace_id": "f" * 32}},
-            "retention_days": 30,
-            "tags": [],
-        }
-
-        event = Event(
-            event_id="e" * 32,
-            data=event_data,
-            project_id=project.id,
-        )
-
-        result = serialize_event_data_as_item(event, event_data, project)
-
-        assert result.retention_days == 30
-
-    def test_serialize_event_data_as_item_ignores_specified_fields(self) -> None:
-        project = self.create_project()
-
-        event_data = {
-            "event_id": "1" * 32,
-            "timestamp": 1234567890,
-            "contexts": {"trace": {"trace_id": "2" * 32}},
-            "other_field": "should_be_included",
-            "tags": [("level", "info")],
-            "empty": None,
-        }
-
-        event = self.create_group_event(event_data)
-        result = serialize_event_data_as_item(event, event_data, project)
-
-        # event_id, timestamp, and tags should be ignored in attributes
-        assert "event_id" not in result.attributes
-        assert "timestamp" not in result.attributes
-        assert "tags" not in result.attributes
-        assert "empty" not in result.attributes
-        # other_field should be present
-        assert result.attributes["other_field"] == AnyValue(string_value="should_be_included")
-        # group_id should be added
-        assert result.attributes["group_id"] == AnyValue(int_value=event.group.id)
-        # tags should be encoded with tags[] prefix
-        assert result.attributes["tags[level]"] == AnyValue(string_value="info")
-
-    def test_serialize_event_data_as_item_with_multiple_attributes(self) -> None:
-        project = self.create_project()
-
-        event_data = {
-            "event_id": "3" * 32,
-            "timestamp": 1234567890,
-            "contexts": {"trace": {"trace_id": "4" * 32}},
-            "level": "error",
-            "logger": "django",
-            "server_name": "web-1",
-            "release": "1.0.0",
-            "environment": "production",
-            "tags": [],
-        }
-
-        event = Event(
-            event_id="3" * 32,
-            data=event_data,
-            project_id=project.id,
-        )
-        result = serialize_event_data_as_item(event, event_data, project)
-
-        assert result.attributes["level"] == AnyValue(string_value="error")
-        assert result.attributes["logger"] == AnyValue(string_value="django")
-        assert result.attributes["server_name"] == AnyValue(string_value="web-1")
-        assert result.attributes["release"] == AnyValue(string_value="1.0.0")
-        assert result.attributes["environment"] == AnyValue(string_value="production")
-
-    def test_event_id_encoding_as_item_id(self) -> None:
-        project = self.create_project()
-
-        test_event_ids = [
-            "0fe53e4887e143549dd0cc65c0370d38",
-            "b87e618e18dc428b9dbd9afc56c9e4cd",
-            "00000000000000000000000000000000",
-            "ffffffffffffffffffffffffffffffff",
-            "0123456789abcdef0123456789abcdef",
-            "fedcba9876543210fedcba9876543210",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            "12345678123456781234567812345678",
-        ]
-
-        for original_event_id in test_event_ids:
-            event_data = {
-                "event_id": original_event_id,
-                "timestamp": 1234567890,
-                "contexts": {"trace": {"trace_id": "b" * 32}},
-                "tags": [],
+            "request": {
+                "url": "sentry.io",
+                "method": "GET",
+                "headers": [["name", "val"], ["Referrer", "bestswetoolsofalltime.com"]],
             }
-            event = Event(
-                event_id=original_event_id,
-                data=event_data,
-                project_id=project.id,
-            )
-            result = serialize_event_data_as_item(event, event_data, project)
-
-            assert len(result.item_id) == 16, (
-                f"item_id must be exactly 16 bytes, got {len(result.item_id)} bytes "
-                f"for event_id {original_event_id}"
-            )
-
-            recovered_event_id = item_id_to_hex(result.item_id)
-            assert recovered_event_id == original_event_id, (
-                f"Encoding scheme failed for event_id {original_event_id}: got {recovered_event_id}"
-            )
-
-    def test_encode_attributes_at_max_depth_boundary(self) -> None:
-        nested: Any = 42
-        for _ in range(_ENCODE_MAX_DEPTH):
-            nested = [nested]
-
-        event_data = {"field": nested, "tags": []}
-        event = Event(event_id="a" * 32, data=event_data, project_id=self.project.id)
-        result = _encode_attributes(event, event_data)
-
-        current = result["field"]
-        for _ in range(_ENCODE_MAX_DEPTH):
-            assert current.HasField("array_value")
-            assert len(current.array_value.values) == 1
-            current = current.array_value.values[0]
-        assert current.HasField("int_value")
-        assert current.int_value == 42
-
-    def test_encode_attributes_deeply_nested_list_stringifies(self) -> None:
-        nested: Any = "leaf"
-        for _ in range(_ENCODE_MAX_DEPTH + 5):
-            nested = [nested]
-
-        event_data = {"field": nested, "tags": []}
-        event = Event(event_id="a" * 32, data=event_data, project_id=self.project.id)
-        result = _encode_attributes(event, event_data)
-
-        # Walk down to the stringification boundary
-        current = result["field"]
-        for _ in range(_ENCODE_MAX_DEPTH + 1):
-            assert current.HasField("array_value")
-            assert len(current.array_value.values) == 1
-            current = current.array_value.values[0]
-        assert current.HasField("string_value")
-        parsed = json.loads(current.string_value)
-        assert isinstance(parsed, list)
-
-    def test_encode_attributes_deeply_nested_dict_stringifies(self) -> None:
-        nested: Any = "leaf"
-        for i in range(_ENCODE_MAX_DEPTH + 3):
-            nested = {f"key_{i}": nested}
-
-        event_data = {"field": nested, "tags": []}
-        event = Event(event_id="a" * 32, data=event_data, project_id=self.project.id)
-        result = _encode_attributes(event, event_data)
-
-        current = result["field"]
-        for _ in range(_ENCODE_MAX_DEPTH + 1):
-            assert current.HasField("kvlist_value")
-            assert len(current.kvlist_value.values) == 1
-            current = current.kvlist_value.values[0].value
-        assert current.HasField("string_value")
-        parsed = json.loads(current.string_value)
-        assert isinstance(parsed, dict)
-
-    def test_serialize_event_data_as_item_deeply_nested(self) -> None:
-        nested: Any = "template_var"
-        for _ in range(51):
-            nested = [nested]
-
-        event_data = {
-            "event_id": "a" * 32,
-            "timestamp": 1234567890,
-            "contexts": {"trace": {"trace_id": "b" * 32}},
-            "template_context": nested,
-            "tags": [],
         }
-        event = self.create_group_event(event_data)
-        project = self.create_project()
+        out = _extract_http(event_data)
+        assert out == {
+            "http_url": "sentry.io",
+            "http_method": "GET",
+            "http_referrer": "bestswetoolsofalltime.com",
+        }
 
-        result = serialize_event_data_as_item(event, event_data, project)
-        assert result.item_type == TRACE_ITEM_TYPE_OCCURRENCE
+    def test_extract_modules(
+        self,
+    ) -> None:
+        event_data = {"modules": {"foo": "1.2", "bar": "2.3"}}
+        out = _extract_modules(event_data)
+        assert out == {"modules.foo": "1.2", "modules.bar": "2.3"}
+
+    def test_extract_exception(
+        self,
+    ) -> None:
+        event_data = {
+            "exception": {
+                "values": [
+                    {
+                        "type": "t0",
+                        "value": "v0",
+                        "mechanism": {
+                            "type": "mt0",
+                            "handled": "mh0",
+                        },
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "fa00",
+                                    "filename": "ff00",
+                                    "package": "fp00",
+                                    "module": "fm00",
+                                    "function": "fu00",
+                                    "in_app": True,
+                                    "colno": 0,
+                                    "lineno": 0,
+                                },
+                                {
+                                    "abs_path": "fa01",
+                                    "filename": "ff01",
+                                    "package": "fp01",
+                                    "module": "fm01",
+                                    "function": "fu01",
+                                    "in_app": True,
+                                    "colno": 1,
+                                    "lineno": 1,
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "type": "t1",
+                        "value": "v1",
+                        "mechanism": {
+                            "type": "mt1",
+                            "handled": "mh1",
+                        },
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "fa10",
+                                    "filename": "ff10",
+                                    "package": "fp10",
+                                    "module": "fm10",
+                                    "function": "fu10",
+                                    "in_app": False,
+                                    "colno": 2,
+                                    "lineno": 2,
+                                },
+                                {
+                                    "abs_path": "fa11",
+                                    "filename": "ff11",
+                                    "package": "fp11",
+                                    "module": "fm11",
+                                    "function": "fu11",
+                                    "in_app": False,
+                                    "colno": 3,
+                                    "lineno": 3,
+                                },
+                            ],
+                        },
+                    },
+                ]
+            }
+        }
+        out = _extract_exception(event_data)
+
+        assert out == {
+            "exception_count": 2,
+            "stack_types": ["t0", "t1"],
+            "stack_values": ["v0", "v1"],
+            "stack_mechanism_types": ["mt0", "mt1"],
+            "stack_mechanism_handled": ["mh0", "mh1"],
+            "frame_abs_paths": ["fa00", "fa01", "fa10", "fa11"],
+            "frame_filenames": ["ff00", "ff01", "ff10", "ff11"],
+            "frame_packages": ["fp00", "fp01", "fp10", "fp11"],
+            "frame_modules": ["fm00", "fm01", "fm10", "fm11"],
+            "frame_functions": ["fu00", "fu01", "fu10", "fu11"],
+            "frame_in_app": [True, True, False, False],
+            "frame_colnos": [0, 1, 2, 3],
+            "frame_linenos": [0, 1, 2, 3],
+            "frame_stack_levels": [0, 0, 1, 1],
+        }


### PR DESCRIPTION
This PR updates the ingest flow for Occurrences on EAP.

CHANGES:
* Moves from a "everything in event_data" model to an allowlist model.
* Unifies tags & contexts into attrs.
* Processes exceptions in a series of related arrays, rather than as a thicket of nested mappings and arrays

SEE ALSO:
* Search issues processor: https://github.com/getsentry/snuba/blob/master/snuba/datasets/processors/search_issues_processor.py
* Errors processor: https://github.com/getsentry/snuba/blob/bc66a617af47de8e0fe573c2ac17c9f378c523c1/rust_snuba/src/processors/errors.rs#L32

I tried to match the existing behavior of those processors as closely as possible.

TEST PLAN:
```
pytest -s tests/snuba/search/test_eap_occurrences.py
```