### PR TITLE
fix(tests): reduce project count in TestGetActiveOrgs to fix flaky snowflake ID errors

### DIFF
--- a/tests/sentry/dynamic_sampling/tasks/test_common.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_common.py
@@ -22,10 +22,10 @@ MOCK_DATETIME = (timezone.now() - timedelta(days=1)).replace(
 @freeze_time(MOCK_DATETIME)
 class TestGetActiveOrgs(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
     def setUp(self) -> None:
-        # create 10 orgs each with 10 transactions
+        # create 10 orgs each with 3 projects
         for i in range(10):
             org = self.create_organization(f"org-{i}")
-            for i in range(10):
+            for j in range(3):
                 project = self.create_project(organization=org)
                 self.store_performance_metric(
                     name=TransactionMRI.COUNT_PER_ROOT_PROJECT.value,
@@ -53,8 +53,8 @@ class TestGetActiveOrgs(BaseMetricsLayerTestCase, TestCase, SnubaTestCase):
 
     def test_get_active_orgs_with_max_projects(self) -> None:
         total_orgs = 0
-        for orgs in GetActiveOrgs(3, 18):
-            # we ask for max 18 proj (that's 2 org per request since one org has 10 )
+        for orgs in GetActiveOrgs(3, 5):
+            # we ask for max 5 proj (that's 2 orgs per request since each org has 3 projects)
             num_orgs = len(orgs)
             total_orgs += num_orgs
             assert num_orgs == 2  # only 2 orgs since we limit the number of projects


### PR DESCRIPTION
## Summary

Fixes the flaky test `TestGetActiveOrgs::test_get_active_orgs_with_max_projects` that intermittently fails with `MaxSnowflakeRetryError`.

### Root Cause

The test `setUp` creates **100 projects** (10 orgs × 10 projects) under `@freeze_time`. With frozen time, all snowflake ID generation shares the same timestamp, which exhausts the 16-sequence-per-timestamp limit quickly. Combined with potential slug collisions from random name generation (`petname.generate`), the 5-retry limit (`MAX_REDIS_SNOWFLAKE_RETRY_COUNTER`) can be exceeded, causing `MaxSnowflakeRetryError`.

### Changes

- **Reduced projects per org from 10 to 3** — lowers total project creation from 100 to 30, significantly reducing snowflake ID pressure under frozen time
- **Adjusted `max_projects` from 18 to 5** — maintains identical batch semantics (2 orgs per batch, since 2 × 3 = 6 ≥ 5)
- **Fixed variable shadowing** — inner loop variable `i` renamed to `j` to avoid shadowing outer loop variable

### Verification

- All 15 tests in `test_common.py` pass
- The previously flaky test passes consistently across multiple consecutive runs

Fixes #109128