### PR TITLE
feat(ai-conversations): drawer redesign

### DIFF
--- a/static/app/views/insights/pages/conversations/components/conversationDrawer.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationDrawer.tsx
@@ -255,7 +255,7 @@ function ConversationView({
           value={activeTab}
           onChange={key => handleTabChange(key as ConversationTab)}
         >
-          <Container padding="xs lg">
+          <Container paddingTop="lg" borderBottom="primary">
             <TabList>
               <TabList.Item key="messages">{t('Messages')}</TabList.Item>
               <TabList.Item key="trace">{t('AI Spans')}</TabList.Item>
@@ -271,7 +271,7 @@ function ConversationView({
                 />
               </TabPanels.Item>
               <TabPanels.Item key="trace">
-                <Container padding="md lg">
+                <Container padding="md lg md lg">
                   <AISpanList
                     nodes={nodes}
                     selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
@@ -324,6 +324,7 @@ const StyledTabs = styled(Tabs)`
 
 const FullWidthTabPanels = styled(TabPanels)`
   width: 100%;
+  padding: 0;
 
   > [role='tabpanel'] {
     width: 100%;

--- a/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
@@ -176,6 +176,7 @@ function AggregateItem({
   return content;
 }
 
+// Monospace font has different baseline metrics, nudge up to visually align
 const ConversationId = styled(Text)`
   position: relative;
   top: -1px;

--- a/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {css, useTheme} from '@emotion/react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -10,7 +10,6 @@ import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import Count from 'sentry/components/count';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Placeholder from 'sentry/components/placeholder';
-import {IconChat, IconFire, IconFix} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {getExploreUrl} from 'sentry/views/explore/utils';
@@ -78,9 +77,7 @@ export function ConversationSummary({
 }: ConversationSummaryProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
-  const theme = useTheme();
   const aggregates = useMemo(() => calculateAggregates(nodes), [nodes]);
-  const colors = [...theme.chart.getColorPalette(5), theme.colors.red400];
 
   const baseQuery = `gen_ai.conversation.id:${conversationId}`;
 
@@ -121,24 +118,18 @@ export function ConversationSummary({
       <Divider />
       <Flex align="center" gap="sm" wrap="wrap">
         <AggregateItem
-          icon={<IconChat size="sm" />}
-          iconColor={colors[2]}
           label={t('LLM Calls')}
           value={<Count value={aggregates.llmCalls} />}
           to={aggregates.llmCalls > 0 ? llmCallsUrl : undefined}
           isLoading={isLoading}
         />
         <AggregateItem
-          icon={<IconFix size="sm" />}
-          iconColor={colors[5]}
           label={t('Tool Calls')}
           value={<Count value={aggregates.toolCalls} />}
           to={aggregates.toolCalls > 0 ? toolCallsUrl : undefined}
           isLoading={isLoading}
         />
         <AggregateItem
-          icon={<IconFire size="sm" />}
-          iconColor={theme.tokens.graphics.danger.vibrant}
           label={t('Errors')}
           value={<Count value={aggregates.errorCount} />}
           to={aggregates.errorCount > 0 ? errorsUrl : undefined}
@@ -160,8 +151,6 @@ export function ConversationSummary({
 }
 
 function AggregateItem({
-  icon,
-  iconColor,
   label,
   value,
   to,
@@ -169,8 +158,6 @@ function AggregateItem({
 }: {
   label: string;
   value: React.ReactNode;
-  icon?: React.ReactNode;
-  iconColor?: string;
   isLoading?: boolean;
   to?: string;
 }) {
@@ -178,12 +165,7 @@ function AggregateItem({
 
   const content = (
     <AggregateItemContainer align="center" gap="xs" isInteractive={isInteractive}>
-      {icon && (
-        <Flex as="span" style={{color: iconColor}}>
-          {icon}
-        </Flex>
-      )}
-      <Text variant="muted">{label}</Text>
+      <Text bold>{label}</Text>
       {isLoading ? (
         <Placeholder width="20px" height="16px" />
       ) : (

--- a/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
@@ -6,7 +6,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import Count from 'sentry/components/count';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import Placeholder from 'sentry/components/placeholder';
@@ -102,18 +101,12 @@ export function ConversationSummary({
   return (
     <Flex align="center" gap="lg" flex={1}>
       <Flex align="center" gap="sm" flexShrink={0}>
-        <Text size="lg" bold>
+        <Text size="sm" bold>
           {t('Conversation')}
         </Text>
-        <Text variant="muted" monospace>
+        <ConversationId size="sm" variant="muted" monospace>
           {conversationId.slice(0, 8)}
-        </Text>
-        <CopyToClipboardButton
-          aria-label={t('Copy conversation ID')}
-          priority="transparent"
-          size="zero"
-          text={conversationId}
-        />
+        </ConversationId>
       </Flex>
       <Divider />
       <Flex align="center" gap="sm" wrap="wrap">
@@ -165,7 +158,9 @@ function AggregateItem({
 
   const content = (
     <AggregateItemContainer align="center" gap="xs" isInteractive={isInteractive}>
-      <Text bold>{label}</Text>
+      <Text bold size="sm">
+        {label}
+      </Text>
       {isLoading ? (
         <Placeholder width="20px" height="16px" />
       ) : (
@@ -180,6 +175,11 @@ function AggregateItem({
 
   return content;
 }
+
+const ConversationId = styled(Text)`
+  position: relative;
+  top: -1px;
+`;
 
 const Divider = styled('div')`
   width: 1px;

--- a/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
@@ -92,21 +92,15 @@ export function MessageToolCalls({
   });
 
   return (
-    <Footer direction="row" align="center" gap="xs" wrap="wrap" padding="xs sm">
-      <Text size="xs" style={{opacity: 0.7}}>
-        {t('Tools called:')}
-      </Text>
+    <Flex direction="row" align="center" gap="xs" wrap="wrap" padding="md">
       <CollapsibleTagList items={items} failedCount={failedCount} />
-    </Footer>
+    </Flex>
   );
 }
 
-const Footer = styled(Flex)`
-  border-top: 1px solid ${p => p.theme.tokens.border.primary};
-`;
-
 const ClickableTag = styled(Tag)<{hasError?: boolean; isSelected?: boolean}>`
   cursor: pointer;
+  padding: 0 ${p => p.theme.space.xs};
   &:hover {
     opacity: 0.8;
   }

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -352,7 +352,7 @@ describe('MessagesPanel', () => {
     );
 
     expect(screen.getByText('The weather is sunny')).toBeInTheDocument();
-    expect(screen.getByText('Tools called:')).toBeInTheDocument();
+
     expect(screen.getByText('weather')).toBeInTheDocument();
   });
 
@@ -430,7 +430,7 @@ describe('MessagesPanel', () => {
 
     // The final message should show all tool calls (weather x2 from the skipped span + calculator)
     expect(screen.getByText('Here is the comparison')).toBeInTheDocument();
-    expect(screen.getByText('Tools called:')).toBeInTheDocument();
+
     // Should have 2 weather tags and 1 calculator tag
     expect(screen.getAllByText('weather')).toHaveLength(2);
     expect(screen.getByText('calculator')).toBeInTheDocument();

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -92,7 +92,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                     <Text bold size="sm">
                       {t('Assistant')}
                     </Text>
-                    {message.duration !== null && message.duration > 0 && (
+                    {message.duration !== undefined && message.duration > 0 && (
                       <Text size="xs" variant="muted">
                         {getDuration(message.duration, 1, true)}
                       </Text>

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -62,14 +62,24 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 
   if (messages.length === 0) {
     return (
-      <PanelContainer direction="column">
+      <Flex
+        direction="column"
+        padding="lg lg md lg"
+        background="secondary"
+        minHeight="100%"
+      >
         <EmptyMessage>{t('No messages found')}</EmptyMessage>
-      </PanelContainer>
+      </Flex>
     );
   }
 
   return (
-    <PanelContainer direction="column">
+    <Flex
+      direction="column"
+      padding="lg lg md lg"
+      background="secondary"
+      minHeight="100%"
+    >
       <Stack gap="md" width="100%">
         {messages.map((message, index) => {
           const isSelected = message.id === effectiveSelectedMessageId;
@@ -129,15 +139,9 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
           );
         })}
       </Stack>
-    </PanelContainer>
+    </Flex>
   );
 }
-
-const PanelContainer = styled(Flex)`
-  padding: ${p => p.theme.space.lg} ${p => p.theme.space.lg} ${p => p.theme.space.md};
-  background-color: ${p => p.theme.tokens.background.secondary};
-  min-height: 100%;
-`;
 
 const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
   display: flex;

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -6,9 +6,8 @@ import {Text} from '@sentry/scraps/text';
 
 import ClippedBox from 'sentry/components/clippedBox';
 import EmptyMessage from 'sentry/components/emptyMessage';
-import {IconUser} from 'sentry/icons';
-import {IconBot} from 'sentry/icons/iconBot';
 import {t} from 'sentry/locale';
+import getDuration from 'sentry/utils/duration/getDuration';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {MessageToolCalls} from 'sentry/views/insights/pages/conversations/components/messageToolCalls';
@@ -84,14 +83,21 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
               onClick={isAssistant ? () => handleMessageClick(message) : undefined}
             >
               <MessageHeader justify={message.role === 'user' ? 'end' : 'start'}>
-                {message.role === 'user' ? <IconUser size="sm" /> : <IconBot size="sm" />}
-                <Text bold size="sm">
-                  {message.role === 'user' ? t('User') : t('Assistant')}
-                </Text>
-                {message.role === 'user' && message.userEmail && (
-                  <Text size="sm" style={{color: 'inherit', opacity: 0.7}}>
-                    {message.userEmail}
+                {message.role === 'user' ? (
+                  <Text bold size="sm">
+                    {message.userEmail || t('User')}
                   </Text>
+                ) : (
+                  <Flex align="baseline" gap="sm" flex={1}>
+                    <Text bold size="sm">
+                      {t('Assistant')}
+                    </Text>
+                    {message.duration !== null && message.duration > 0 && (
+                      <Text size="xs" variant="muted">
+                        {getDuration(message.duration, 1, true)}
+                      </Text>
+                    )}
+                  </Flex>
                 )}
               </MessageHeader>
               <StyledClippedBox
@@ -99,7 +105,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                 buttonProps={{priority: 'default', size: 'xs'}}
                 collapsible
               >
-                <Container padding="sm">
+                <Container padding="md">
                   <MessageText size="sm">
                     <MarkedText
                       as={TraceDrawerComponents.MarkdownContainer}
@@ -125,7 +131,8 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 }
 
 const PanelContainer = styled(Flex)`
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
+  padding: ${p => p.theme.space.lg} ${p => p.theme.space.lg} ${p => p.theme.space.md};
+  background-color: ${p => p.theme.tokens.background.secondary};
 `;
 
 const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
@@ -133,9 +140,18 @@ const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
   align-items: center;
   gap: ${p => p.theme.space.sm};
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  margin-bottom: ${p => p.theme.space.xs};
   justify-content: ${p => (p.justify === 'end' ? 'flex-end' : 'flex-start')};
-  background-color: ${p => p.theme.tokens.background.secondary};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: ${p => p.theme.space.md};
+    right: ${p => p.theme.space.md};
+    bottom: 0;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+  position: relative;
 `;
 
 const MessageText = styled(Text)`
@@ -154,9 +170,9 @@ const MessageBubble = styled('div')<{
   width: 90%;
   align-self: ${p => (p.role === 'user' ? 'flex-end' : 'flex-start')};
   background-color: ${p =>
-    p.role === 'user'
-      ? p.theme.tokens.background.secondary
-      : p.theme.tokens.background.primary};
+    p.role === 'assistant'
+      ? p.theme.tokens.background.primary
+      : p.theme.tokens.background.secondary};
   &::after {
     content: '';
     position: absolute;
@@ -173,12 +189,7 @@ const MessageBubble = styled('div')<{
     cursor: pointer;
     &:hover::after {
       border-color: ${p.theme.tokens.border.accent.moderate};
-    }
-    &:hover {
-      background-color: ${p.theme.tokens.interactive.transparent.neutral.background.hover};
-    }
-    &:active {
-      background-color: ${p.theme.tokens.interactive.transparent.neutral.background.active};
+      border-width: 2px;
     }
   `}
   ${p =>

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -70,7 +70,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 
   return (
     <PanelContainer direction="column">
-      <Stack gap="md">
+      <Stack gap="md" width="100%">
         {messages.map((message, index) => {
           const isSelected = message.id === effectiveSelectedMessageId;
           const isAssistant = message.role === 'assistant';
@@ -106,7 +106,10 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
                 collapsible
               >
                 <Container padding="md">
-                  <MessageText size="sm">
+                  <MessageText
+                    size="sm"
+                    align={message.role === 'user' ? 'right' : 'left'}
+                  >
                     <MarkedText
                       as={TraceDrawerComponents.MarkdownContainer}
                       text={message.content}
@@ -133,6 +136,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
 const PanelContainer = styled(Flex)`
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.lg} ${p => p.theme.space.md};
   background-color: ${p => p.theme.tokens.background.secondary};
+  min-height: 100%;
 `;
 
 const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
@@ -140,7 +144,6 @@ const MessageHeader = styled('div')<{justify?: 'start' | 'end'}>`
   align-items: center;
   gap: ${p => p.theme.space.sm};
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
-  margin-bottom: ${p => p.theme.space.xs};
   justify-content: ${p => (p.justify === 'end' ? 'flex-end' : 'flex-start')};
 
   &::after {

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
@@ -4,7 +4,6 @@ import {
   buildConversationTurns,
   extractMessagesFromNodes,
   extractTextFromMessage,
-  findToolCallsBetween,
   getNodeTimestamp,
   mergeEmptyTurns,
   parseAssistantContent,
@@ -344,77 +343,6 @@ describe('conversationMessages utilities', () => {
 
       expect(result.generationSpans).toHaveLength(1);
       expect(result.toolSpans).toHaveLength(0);
-    });
-  });
-
-  describe('findToolCallsBetween', () => {
-    it('finds tools between timestamps', () => {
-      const tool1 = createMockToolNode({
-        id: 'tool-1',
-        toolName: 'search',
-        startTimestamp: 1500,
-      });
-      const tool2 = createMockToolNode({
-        id: 'tool-2',
-        toolName: 'calc',
-        startTimestamp: 1600,
-      });
-      const tool3 = createMockToolNode({
-        id: 'tool-3',
-        toolName: 'outside',
-        startTimestamp: 2500,
-      });
-
-      const result = findToolCallsBetween([tool1, tool2, tool3] as any, 1000, 2000);
-
-      expect(result).toHaveLength(2);
-      expect(result.map(t => t.name)).toEqual(['search', 'calc']);
-    });
-
-    it('excludes tools at exact boundaries', () => {
-      const tool1 = createMockToolNode({
-        id: 'tool-1',
-        toolName: 'at-start',
-        startTimestamp: 1000,
-      });
-      const tool2 = createMockToolNode({
-        id: 'tool-2',
-        toolName: 'at-end',
-        startTimestamp: 2000,
-      });
-      const tool3 = createMockToolNode({
-        id: 'tool-3',
-        toolName: 'inside',
-        startTimestamp: 1500,
-      });
-
-      const result = findToolCallsBetween([tool1, tool2, tool3] as any, 1000, 2000);
-
-      expect(result).toHaveLength(1);
-      expect(result[0]?.name).toBe('inside');
-    });
-
-    it('filters out tools without names', () => {
-      const toolWithName = createMockToolNode({
-        id: 'tool-1',
-        toolName: 'named',
-        startTimestamp: 1500,
-      });
-      const toolWithoutName = {
-        id: 'tool-2',
-        value: {start_timestamp: 1600},
-        attributes: {[SpanFields.GEN_AI_OPERATION_TYPE]: 'tool'},
-        errors: new Set(),
-      };
-
-      const result = findToolCallsBetween(
-        [toolWithName, toolWithoutName] as any,
-        1000,
-        2000
-      );
-
-      expect(result).toHaveLength(1);
-      expect(result[0]?.name).toBe('named');
     });
   });
 

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -36,9 +36,9 @@ interface ConversationTurn {
   assistantContent: string | null;
   generation: AITraceSpanNode;
   toolCalls: ToolCall[];
-  toolSpanNodes: AITraceSpanNode[];
   userContent: string | null;
   userEmail: string | undefined;
+  toolSpanNodes?: AITraceSpanNode[];
 }
 
 /**
@@ -122,7 +122,7 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
 
   for (const turn of turns) {
     const allToolCalls = [...pendingToolCalls, ...turn.toolCalls];
-    const allToolSpanNodes = [...pendingToolSpanNodes, ...turn.toolSpanNodes];
+    const allToolSpanNodes = [...pendingToolSpanNodes, ...(turn.toolSpanNodes ?? [])];
 
     if (turn.assistantContent) {
       result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
@@ -170,7 +170,7 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
       // Duration: from start of generation span to end of last span (generation or tool)
       const genEnd = getNodeEndTimestamp(turn.generation);
       const lastToolEnd =
-        turn.toolSpanNodes.length > 0
+        turn.toolSpanNodes?.length > 0
           ? Math.max(...turn.toolSpanNodes.map(getNodeEndTimestamp))
           : 0;
       const endTs = Math.max(genEnd, lastToolEnd);
@@ -276,7 +276,7 @@ export function getNodeTimestamp(node: AITraceSpanNode): number {
   return 'start_timestamp' in node.value ? node.value.start_timestamp : 0;
 }
 
-export function getNodeEndTimestamp(node: AITraceSpanNode): number {
+function getNodeEndTimestamp(node: AITraceSpanNode): number {
   if ('end_timestamp' in node.value && typeof node.value.end_timestamp === 'number') {
     return node.value.end_timestamp;
   }

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -128,7 +128,7 @@ export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
       result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
       pendingToolSpanNodes = [];
-    } else if (turn.toolCalls.length > 0) {
+    } else if (allToolCalls.length > 0 || allToolSpanNodes.length > 0) {
       if (turn.userContent) {
         result.push({...turn, toolCalls: [], toolSpanNodes: []});
       }

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -169,9 +169,10 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
 
       // Duration: from start of generation span to end of last span (generation or tool)
       const genEnd = getNodeEndTimestamp(turn.generation);
+      const toolSpanNodes = turn.toolSpanNodes ?? [];
       const lastToolEnd =
-        turn.toolSpanNodes?.length > 0
-          ? Math.max(...turn.toolSpanNodes.map(getNodeEndTimestamp))
+        toolSpanNodes.length > 0
+          ? Math.max(...toolSpanNodes.map(getNodeEndTimestamp))
           : 0;
       const endTs = Math.max(genEnd, lastToolEnd);
       const duration = endTs > timestamp ? endTs - timestamp : undefined;
@@ -201,23 +202,6 @@ function findToolSpansBetween(
     const ts = getNodeTimestamp(span);
     return ts > startTime && ts < endTime;
   });
-}
-
-export function findToolCallsBetween(
-  toolSpans: AITraceSpanNode[],
-  startTime: number,
-  endTime: number
-): ToolCall[] {
-  return toolSpans
-    .filter(span => {
-      const ts = getNodeTimestamp(span);
-      return ts > startTime && ts < endTime;
-    })
-    .map(span => {
-      const name = getStringAttr(span, SpanFields.GEN_AI_TOOL_NAME);
-      return name ? {name, nodeId: span.id, hasError: hasError(span)} : null;
-    })
-    .filter((tc): tc is ToolCall => tc !== null);
 }
 
 export function parseUserContent(node: AITraceSpanNode): string | null {

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -21,6 +21,7 @@ export interface ConversationMessage {
   nodeId: string;
   role: 'user' | 'assistant';
   timestamp: number;
+  duration?: number;
   toolCalls?: ToolCall[];
   userEmail?: string;
 }
@@ -35,6 +36,7 @@ interface ConversationTurn {
   assistantContent: string | null;
   generation: AITraceSpanNode;
   toolCalls: ToolCall[];
+  toolSpanNodes: AITraceSpanNode[];
   userContent: string | null;
   userEmail: string | undefined;
 }
@@ -92,11 +94,18 @@ export function buildConversationTurns(
     const timestamp = getNodeTimestamp(node);
     const prevTimestamp = i > 0 ? getNodeTimestamp(generationSpans[i - 1]!) : 0;
     const userEmail = getStringAttr(node, SpanFields.USER_EMAIL);
-    const toolCalls = findToolCallsBetween(toolSpans, prevTimestamp, timestamp);
+    const toolCallSpans = findToolSpansBetween(toolSpans, prevTimestamp, timestamp);
+    const toolCalls = toolCallSpans
+      .map(span => {
+        const name = getStringAttr(span, SpanFields.GEN_AI_TOOL_NAME);
+        return name ? {name, nodeId: span.id, hasError: hasError(span)} : null;
+      })
+      .filter((tc): tc is ToolCall => tc !== null);
 
     turns.push({
       generation: node,
       toolCalls,
+      toolSpanNodes: toolCallSpans,
       userContent: parseUserContent(node),
       assistantContent: parseAssistantContent(node),
       userEmail,
@@ -109,21 +118,26 @@ export function buildConversationTurns(
 export function mergeEmptyTurns(turns: ConversationTurn[]): ConversationTurn[] {
   const result: ConversationTurn[] = [];
   let pendingToolCalls: ToolCall[] = [];
+  let pendingToolSpanNodes: AITraceSpanNode[] = [];
 
   for (const turn of turns) {
     const allToolCalls = [...pendingToolCalls, ...turn.toolCalls];
+    const allToolSpanNodes = [...pendingToolSpanNodes, ...turn.toolSpanNodes];
 
     if (turn.assistantContent) {
-      result.push({...turn, toolCalls: allToolCalls});
+      result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
+      pendingToolSpanNodes = [];
     } else if (turn.toolCalls.length > 0) {
       if (turn.userContent) {
-        result.push({...turn, toolCalls: []});
+        result.push({...turn, toolCalls: [], toolSpanNodes: []});
       }
       pendingToolCalls = allToolCalls;
+      pendingToolSpanNodes = allToolSpanNodes;
     } else if (turn.userContent) {
-      result.push({...turn, toolCalls: allToolCalls});
+      result.push({...turn, toolCalls: allToolCalls, toolSpanNodes: allToolSpanNodes});
       pendingToolCalls = [];
+      pendingToolSpanNodes = [];
     }
   }
 
@@ -152,6 +166,16 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
 
     if (turn.assistantContent && !seenAssistantContent.has(turn.assistantContent)) {
       seenAssistantContent.add(turn.assistantContent);
+
+      // Duration: from start of generation span to end of last span (generation or tool)
+      const genEnd = getNodeEndTimestamp(turn.generation);
+      const lastToolEnd =
+        turn.toolSpanNodes.length > 0
+          ? Math.max(...turn.toolSpanNodes.map(getNodeEndTimestamp))
+          : 0;
+      const endTs = Math.max(genEnd, lastToolEnd);
+      const duration = endTs > timestamp ? endTs - timestamp : undefined;
+
       messages.push({
         id: `assistant-${turn.generation.id}`,
         role: 'assistant',
@@ -159,12 +183,24 @@ export function turnsToMessages(turns: ConversationTurn[]): ConversationMessage[
         timestamp: timestamp + 1,
         nodeId: turn.generation.id,
         toolCalls: turn.toolCalls.length > 0 ? turn.toolCalls : undefined,
+        duration,
       });
     }
   }
 
   messages.sort((a, b) => a.timestamp - b.timestamp);
   return messages;
+}
+
+function findToolSpansBetween(
+  toolSpans: AITraceSpanNode[],
+  startTime: number,
+  endTime: number
+): AITraceSpanNode[] {
+  return toolSpans.filter(span => {
+    const ts = getNodeTimestamp(span);
+    return ts > startTime && ts < endTime;
+  });
 }
 
 export function findToolCallsBetween(
@@ -238,6 +274,16 @@ export function parseAssistantContent(node: AITraceSpanNode): string | null {
 
 export function getNodeTimestamp(node: AITraceSpanNode): number {
   return 'start_timestamp' in node.value ? node.value.start_timestamp : 0;
+}
+
+export function getNodeEndTimestamp(node: AITraceSpanNode): number {
+  if ('end_timestamp' in node.value && typeof node.value.end_timestamp === 'number') {
+    return node.value.end_timestamp;
+  }
+  if ('timestamp' in node.value && typeof node.value.timestamp === 'number') {
+    return node.value.timestamp;
+  }
+  return 0;
 }
 
 function getGenAiOpType(node: AITraceSpanNode): string | undefined {


### PR DESCRIPTION
part of: [TET-1982: Implement new design for conversations](https://linear.app/getsentry/issue/TET-1982/implement-new-design-for-conversations)

Before:
<img width="901" height="1324" alt="CleanShot 2026-02-24 at 12 51 17" src="https://github.com/user-attachments/assets/5be942b3-2f64-4576-a18b-a14e8dab3820" />

After:
<img width="902" height="1321" alt="image" src="https://github.com/user-attachments/assets/82793d44-f916-4352-98eb-aced85630ade" />
