### PR TITLE
fix(dashboards): `storageNamespace` not being applied on prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -111,6 +111,7 @@ export type FiltersBarProps = {
   onSave?: () => Promise<void>;
   prebuiltDashboardId?: PrebuiltDashboardId;
   shouldBusySaveButton?: boolean;
+  storageNamespace?: string;
 };
 
 export default function FiltersBar({
@@ -127,6 +128,7 @@ export default function FiltersBar({
   onSave,
   shouldBusySaveButton,
   prebuiltDashboardId,
+  storageNamespace,
 }: FiltersBarProps) {
   const organization = useOrganization();
   const currentUser = useUser();
@@ -207,6 +209,7 @@ export default function FiltersBar({
         <PageFilterBar condensed>
           <ProjectPageFilter
             disabled={isEditingDashboard}
+            storageNamespace={storageNamespace}
             onChange={() => {
               trackAnalytics('dashboards2.filter.change', {
                 organization,
@@ -216,6 +219,7 @@ export default function FiltersBar({
           />
           <EnvironmentPageFilter
             disabled={isEditingDashboard}
+            storageNamespace={storageNamespace}
             onChange={() => {
               trackAnalytics('dashboards2.filter.change', {
                 organization,

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -13,11 +13,13 @@ import {PREBUILT_DASHBOARDS, type PrebuiltDashboardId} from './utils/prebuiltCon
 type PrebuiltDashboardRendererProps = {
   prebuiltId: PrebuiltDashboardId;
   additionalGlobalFilters?: GlobalFilter[];
+  storageNamespace?: string;
 };
 
 export function PrebuiltDashboardRenderer({
   prebuiltId,
   additionalGlobalFilters,
+  storageNamespace,
 }: PrebuiltDashboardRendererProps) {
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
@@ -71,6 +73,7 @@ export function PrebuiltDashboardRenderer({
         dashboards={[]}
         initialState={DashboardState.EMBEDDED}
         useTimeseriesVisualization
+        storageNamespace={storageNamespace}
       />
     </LoadingContainer>
   );

--- a/static/app/views/insights/pages/frontend/platformizedFrontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/platformizedFrontendOverviewPage.tsx
@@ -1,6 +1,13 @@
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
 export function PlatformizedFrontendOverviewPage() {
-  return <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.FRONTEND_OVERVIEW} />;
+  const {view} = useDomainViewFilters();
+  return (
+    <PrebuiltDashboardRenderer
+      prebuiltId={PrebuiltDashboardId.FRONTEND_OVERVIEW}
+      storageNamespace={view}
+    />
+  );
 }


### PR DESCRIPTION
fixes a bug where `storageNamespace` wasn't being applied with the prebuilt dashboards renderer. We use this in insights to save global selection on a per domain basis. This was causing several other strange issues where page filters would not save global filters. This was fixed with the following changes.

1. When a dashboard is `embeded` we do not wrap it in `PageFiltersContainer`, this was conflicting with the filters container of the parent which applied the storage namespace. I confirmed that embeded is only used on prebuilt dashboards, and i also think it's local that an embeded dashboard doesn't necessarily need to provide its own page filters state.
2. Add a new `storageNamespace` prop to dashboard detail, this is passed through to the dashboard `FiltersBar` and eventually to each filter.