### PR TITLE
feat(span-buffer): OOB storage

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3205,6 +3205,16 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Threshold in bytes for out-of-band storage of large compressed span payloads.
+# Payloads larger than this are stored in separate Redis string keys instead of
+# inline in sets, avoiding expensive SUNIONSTORE memcpy. Set to 0 to disable.
+# Only applies when compression is enabled (compression.level >= 0).
+register(
+    "spans.buffer.oob-threshold-bytes",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Maximum number of subsegments to process in each Redis pipeline. Each
 # subsegment triggers an EVALSHA call which can be slow. Set to 0 for unlimited.
 register(

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -631,16 +631,16 @@ class SpansBuffer:
                 scan_results = p.execute()
 
             for key, (cursor, scan_values) in zip(current_keys, scan_results):
-                dropped = False
+                size_exceeded = False
                 for scan_value in scan_values:
                     if scan_value.startswith(b"span-buf:p:"):
                         oob_refs.append((key, scan_value))
                         oob_keys_by_segment[key].append(scan_value)
                     elif key in payloads:
                         if not _add_spans(key, scan_value):
-                            dropped = True
+                            size_exceeded = True
 
-                if dropped:
+                if size_exceeded:
                     cursors.pop(key, None)
                 elif cursor == 0:
                     del cursors[key]

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -592,12 +592,34 @@ class SpansBuffer:
 
         payloads: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
         cursors = {key: 0 for key in segment_keys}
-        sizes = {key: 0 for key in segment_keys}
+        sizes: dict[SegmentKey, int] = {key: 0 for key in segment_keys}
         self._last_decompress_latency_ms = 0
         decompress_latency_ms = 0.0
 
         oob_refs: list[tuple[SegmentKey, bytes]] = []
         oob_keys_by_segment: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
+
+        def _add_spans(key: SegmentKey, raw_data: bytes) -> bool:
+            """
+            Decompress and add spans to the segment. Returns False if the
+            segment exceeded max_segment_bytes and was dropped.
+            """
+            nonlocal decompress_latency_ms
+
+            decompress_start = time.monotonic()
+            decompressed = self._decompress_batch(raw_data)
+            decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
+
+            sizes[key] = sizes.get(key, 0) + sum(len(span) for span in decompressed)
+            if sizes[key] > max_segment_bytes:
+                metrics.incr("spans.buffer.flush_segments.segment_size_exceeded")
+                logger.warning("Skipping too large segment, byte size %s", sizes[key])
+                payloads.pop(key, None)
+                sizes.pop(key, None)
+                return False
+
+            payloads[key].extend(decompressed)
+            return True
 
         while cursors:
             with self.client.pipeline(transaction=False) as p:
@@ -609,29 +631,18 @@ class SpansBuffer:
                 scan_results = p.execute()
 
             for key, (cursor, scan_values) in zip(current_keys, scan_results):
-                decompressed_spans = []
-
+                dropped = False
                 for scan_value in scan_values:
                     if scan_value.startswith(b"span-buf:p:"):
                         oob_refs.append((key, scan_value))
                         oob_keys_by_segment[key].append(scan_value)
-                    else:
-                        decompress_start = time.monotonic()
-                        decompressed_spans.extend(self._decompress_batch(scan_value))
-                        decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
+                    elif key in payloads:
+                        if not _add_spans(key, scan_value):
+                            dropped = True
 
-                sizes[key] += sum(len(span) for span in decompressed_spans)
-                if sizes[key] > max_segment_bytes:
-                    metrics.incr("spans.buffer.flush_segments.segment_size_exceeded")
-                    logger.warning("Skipping too large segment, byte size %s", sizes[key])
-
-                    del payloads[key]
-                    del cursors[key]
-                    del sizes[key]
-                    continue
-
-                payloads[key].extend(decompressed_spans)
-                if cursor == 0:
+                if dropped:
+                    cursors.pop(key, None)
+                elif cursor == 0:
                     del cursors[key]
                 else:
                     cursors[key] = cursor
@@ -648,22 +659,9 @@ class SpansBuffer:
                     metrics.incr("spans.buffer.oob_key_missing")
                     continue
                 if segment_key not in payloads:
-                    # Segment was already dropped due to size limit
                     continue
 
-                decompress_start = time.monotonic()
-                decompressed = self._decompress_batch(oob_payload)
-                decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
-
-                decompressed_size = sum(len(span) for span in decompressed)
-                sizes[segment_key] = sizes.get(segment_key, 0) + decompressed_size
-                if sizes[segment_key] > max_segment_bytes:
-                    metrics.incr("spans.buffer.flush_segments.segment_size_exceeded")
-                    logger.warning("Skipping too large segment, byte size %s", sizes[segment_key])
-                    del payloads[segment_key]
-                    continue
-
-                payloads[segment_key].extend(decompressed)
+                _add_spans(segment_key, oob_payload)
 
         # Fetch ingested counts for all segments to calculate dropped spans
         with self.client.pipeline(transaction=False) as p:

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -61,6 +61,7 @@ Glossary for types of keys:
     * span-buf:ssr:* -- redirect mappings so that each incoming span ID can be mapped to the right span-buf:s: set.
     * span-buf:ic:* -- ingested count, tracks total number of spans originally ingested for a segment (used to calculate dropped spans for outcome tracking)
     * span-buf:ibc:* -- ingested byte count, tracks total bytes originally ingested for a segment
+    * span-buf:p:* -- out-of-band payload keys, storing large span payloads outside the set to avoid expensive SUNIONSTORE memcpy
 """
 
 from __future__ import annotations
@@ -69,6 +70,7 @@ import itertools
 import logging
 import math
 import time
+import uuid
 from collections.abc import Generator, MutableMapping, Sequence
 from typing import Any, NamedTuple
 
@@ -135,6 +137,7 @@ class OutputSpan(NamedTuple):
 class FlushedSegment(NamedTuple):
     queue_key: QueueKey
     spans: list[OutputSpan]
+    oob_keys: list[bytes] = []
 
 
 class SpansBuffer:
@@ -211,9 +214,13 @@ class SpansBuffer:
             for batch in tree_batches:
                 with self.client.pipeline(transaction=False) as p:
                     for (project_and_trace, parent_span_id), subsegment in batch:
-                        prepared = self._prepare_payloads(subsegment)
+                        set_members, oob_entries = self._prepare_payloads(
+                            subsegment, project_and_trace
+                        )
                         set_key = self._get_span_key(project_and_trace, parent_span_id)
-                        p.sadd(set_key, *prepared.keys())
+                        p.sadd(set_key, *set_members.keys())
+                        for oob_key, payload in oob_entries:
+                            p.set(oob_key, payload, ex=redis_ttl)
 
                     p.execute()
 
@@ -405,9 +412,16 @@ class SpansBuffer:
 
         return trees
 
-    def _prepare_payloads(self, spans: list[Span]) -> dict[str | bytes, float]:
+    def _prepare_payloads(
+        self, spans: list[Span], project_and_trace: str
+    ) -> tuple[dict[str | bytes, float], list[tuple[bytes, bytes]]]:
+        """
+        Prepare span payloads for storage. Returns (set_members, oob_entries) where
+        oob_entries is a list of (oob_key, payload_bytes) for payloads that exceed
+        the OOB threshold and should be stored in separate Redis keys.
+        """
         if self._zstd_compressor is None:
-            return {span.payload: span.end_timestamp for span in spans}
+            return {span.payload: span.end_timestamp for span in spans}, []
 
         combined = b"\x00".join(span.payload for span in spans)
         original_size = len(combined)
@@ -423,7 +437,13 @@ class SpansBuffer:
         metrics.timing("spans.buffer.compression.compression_ratio", compression_ratio)
 
         min_timestamp = min(span.end_timestamp for span in spans)
-        return {compressed: min_timestamp}
+
+        oob_threshold = options.get("spans.buffer.oob-threshold-bytes")
+        if oob_threshold > 0 and compressed_size > oob_threshold:
+            oob_key = f"span-buf:p:{{{project_and_trace}}}:{uuid.uuid4().hex[:16]}".encode("ascii")
+            return {oob_key: min_timestamp}, [(oob_key, compressed)]
+
+        return {compressed: min_timestamp}, []
 
     def _decompress_batch(self, compressed_data: bytes) -> list[bytes]:
         # Check for zstd magic header (0xFD2FB528 in little-endian) --
@@ -483,7 +503,7 @@ class SpansBuffer:
 
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
-            segments = self._load_segment_data([k for _, _, k in segment_keys])
+            segments, oob_keys_by_segment = self._load_segment_data([k for _, _, k in segment_keys])
         load_data_latency_ms = int((time.monotonic() - data_start) * 1000)
 
         return_segments = {}
@@ -522,7 +542,11 @@ class SpansBuffer:
             metrics.incr(
                 "spans.buffer.flush_segments.num_segments_per_shard", tags={"shard_i": shard}
             )
-            return_segments[segment_key] = FlushedSegment(queue_key=queue_key, spans=output_spans)
+            return_segments[segment_key] = FlushedSegment(
+                queue_key=queue_key,
+                spans=output_spans,
+                oob_keys=oob_keys_by_segment.get(segment_key, []),
+            )
             num_has_root_spans += int(has_root_span)
 
             if flusher_logger_enabled and segment:
@@ -550,13 +574,17 @@ class SpansBuffer:
         self.any_shard_at_limit = any_shard_at_limit
         return return_segments
 
-    def _load_segment_data(self, segment_keys: list[SegmentKey]) -> dict[SegmentKey, list[bytes]]:
+    def _load_segment_data(
+        self, segment_keys: list[SegmentKey]
+    ) -> tuple[dict[SegmentKey, list[bytes]], dict[SegmentKey, list[bytes]]]:
         """
         Loads the segments from Redis, given a list of segment keys. Segments
         exceeding a certain size are skipped, and an error is logged.
 
         :param segment_keys: List of segment keys to load.
-        :return: Dictionary mapping segment keys to lists of span payloads.
+        :return: Tuple of (payloads, oob_keys_by_segment). payloads maps segment
+            keys to lists of span payloads. oob_keys_by_segment maps segment keys
+            to lists of OOB Redis keys that should be cleaned up.
         """
 
         page_size = options.get("spans.buffer.segment-page-size")
@@ -567,6 +595,9 @@ class SpansBuffer:
         sizes = {key: 0 for key in segment_keys}
         self._last_decompress_latency_ms = 0
         decompress_latency_ms = 0.0
+
+        oob_refs: list[tuple[SegmentKey, bytes]] = []
+        oob_keys_by_segment: dict[SegmentKey, list[bytes]] = {key: [] for key in segment_keys}
 
         while cursors:
             with self.client.pipeline(transaction=False) as p:
@@ -581,9 +612,13 @@ class SpansBuffer:
                 decompressed_spans = []
 
                 for scan_value in scan_values:
-                    decompress_start = time.monotonic()
-                    decompressed_spans.extend(self._decompress_batch(scan_value))
-                    decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
+                    if scan_value.startswith(b"span-buf:p:"):
+                        oob_refs.append((key, scan_value))
+                        oob_keys_by_segment[key].append(scan_value)
+                    else:
+                        decompress_start = time.monotonic()
+                        decompressed_spans.extend(self._decompress_batch(scan_value))
+                        decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
 
                 sizes[key] += sum(len(span) for span in decompressed_spans)
                 if sizes[key] > max_segment_bytes:
@@ -600,6 +635,35 @@ class SpansBuffer:
                     del cursors[key]
                 else:
                     cursors[key] = cursor
+
+        # Batch-fetch OOB payloads
+        if oob_refs:
+            with self.client.pipeline(transaction=False) as p:
+                for _, oob_key in oob_refs:
+                    p.get(oob_key)
+                oob_results = p.execute()
+
+            for (segment_key, _oob_key), oob_payload in zip(oob_refs, oob_results):
+                if oob_payload is None:
+                    metrics.incr("spans.buffer.oob_key_missing")
+                    continue
+                if segment_key not in payloads:
+                    # Segment was already dropped due to size limit
+                    continue
+
+                decompress_start = time.monotonic()
+                decompressed = self._decompress_batch(oob_payload)
+                decompress_latency_ms += (time.monotonic() - decompress_start) * 1000
+
+                decompressed_size = sum(len(span) for span in decompressed)
+                sizes[segment_key] = sizes.get(segment_key, 0) + decompressed_size
+                if sizes[segment_key] > max_segment_bytes:
+                    metrics.incr("spans.buffer.flush_segments.segment_size_exceeded")
+                    logger.warning("Skipping too large segment, byte size %s", sizes[segment_key])
+                    del payloads[segment_key]
+                    continue
+
+                payloads[segment_key].extend(decompressed)
 
         # Fetch ingested counts for all segments to calculate dropped spans
         with self.client.pipeline(transaction=False) as p:
@@ -662,7 +726,7 @@ class SpansBuffer:
 
         self._last_decompress_latency_ms = int(decompress_latency_ms)
 
-        return payloads
+        return payloads, oob_keys_by_segment
 
     def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
@@ -681,5 +745,8 @@ class SpansBuffer:
                     for span_batch in itertools.batched(flushed_segment.spans, 100):
                         span_ids = [output_span.payload["span_id"] for output_span in span_batch]
                         p.hdel(redirect_map_key, *span_ids)
+
+                    for oob_key in flushed_segment.oob_keys:
+                        p.unlink(oob_key)
 
                 p.execute()

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -137,7 +137,9 @@ class OutputSpan(NamedTuple):
 class FlushedSegment(NamedTuple):
     queue_key: QueueKey
     spans: list[OutputSpan]
-    oob_keys: list[bytes] = []
+    # Since we have a shared mutable default here (for ergonomics), we're using
+    # Sequence to prevent people from mutating the list.
+    oob_keys: Sequence[bytes] = []
 
 
 class SpansBuffer:


### PR DESCRIPTION
We are seeing that SUNIONSTORE sometimes takes forever in prod, and we
speculate that this is due to too large set items (we don't have proof).

To validate this theory, this PR builds OOB storage for too large set
items. A set item is stored in a separate key once it reaches a certain
size, the threshold is configurable via option. The flusher inspects the
first few bytes of the set item to understand how to read it. It's safe
to fiddle with this option repeatedly, there should not be any data loss
at all.

For simplicity, OOB storage only works when compressed payloads are
used. I think we should just make zstd mandatory to simplify the code,
since it's a pure win.

STREAM-742