### PR TITLE
fix(code-review): filter pr_closed webhook when no code review triggers configured

### DIFF
--- a/src/sentry/seer/code_review/webhooks/pull_request.py
+++ b/src/sentry/seer/code_review/webhooks/pull_request.py
@@ -142,6 +142,14 @@ def handle_pull_request_event(
         record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
         return
 
+    # If no triggers are configured for this repo, no pr_review was ever sent for it,
+    # so there is nothing for Seer to process on close.
+    if action == PullRequestAction.CLOSED and (
+        org_code_review_settings is None or not org_code_review_settings.triggers
+    ):
+        record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
+        return
+
     # Skip draft check for CLOSED actions to ensure Seer receives cleanup notifications
     # even if the PR was converted to draft before closing
     if action != PullRequestAction.CLOSED and pull_request.get("draft") is True:

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -8,8 +8,9 @@ import pytest
 from fixtures.github import PULL_REQUEST_OPENED_EVENT_EXAMPLE
 from sentry.integrations.github.client import GitHubReaction
 from sentry.integrations.github.webhook_types import GithubWebhookType
-from sentry.models.repositorysettings import CodeReviewTrigger
+from sentry.models.repositorysettings import CodeReviewSettings, CodeReviewTrigger
 from sentry.seer.code_review.models import SeerCodeReviewRequestType, SeerCodeReviewTrigger
+from sentry.seer.code_review.webhooks.pull_request import handle_pull_request_event
 from sentry.testutils.helpers.github import GitHubWebhookCodeReviewTestCase
 
 
@@ -309,7 +310,34 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
 
             self.mock_seer.assert_not_called()
 
-    def test_pull_request_closed_bypasses_trigger_check_post_ga(self) -> None:
+    def test_pull_request_closed_filtered_when_no_triggers_configured_post_ga(self) -> None:
+        """Test that closed action is filtered when no triggers are configured for a seat-based org.
+
+        If no triggers are configured, no pr_review was ever sent for any PR in this repo,
+        so there is nothing for Seer to process on close.
+
+        Note: This test calls handle_pull_request_event directly because the _send_webhook_event
+        helper skips RepositorySettings creation when triggers=[], which would cause the preflight
+        to deny the request before reaching the handler under test.
+        """
+        features = {"organizations:gen-ai-features", "organizations:seat-based-seer-enabled"}
+        with self.feature(features), self.tasks():
+            event = orjson.loads(PULL_REQUEST_OPENED_EVENT_EXAMPLE)
+            event["action"] = "closed"
+
+            handle_pull_request_event(
+                github_event=GithubWebhookType.PULL_REQUEST,
+                event=event,
+                organization=self.organization,
+                repo=self.create_repo(project=self.project, provider="integrations:github"),
+                org_code_review_settings=CodeReviewSettings(enabled=True, triggers=[]),
+                extra={},
+            )
+
+            self.mock_seer.assert_not_called()
+
+    def test_pull_request_closed_not_filtered_when_triggers_configured_post_ga(self) -> None:
+        """Test that closed action reaches Seer when at least one trigger is configured."""
         triggers: list[CodeReviewTrigger] = [CodeReviewTrigger.ON_READY_FOR_REVIEW]
         features = {"organizations:gen-ai-features", "organizations:seat-based-seer-enabled"}
         org_options = {"sentry:enable_pr_review_test_generation": False}

--- a/tests/sentry/seer/code_review/webhooks/test_pull_request.py
+++ b/tests/sentry/seer/code_review/webhooks/test_pull_request.py
@@ -331,7 +331,7 @@ class PullRequestEventWebhookTest(GitHubWebhookCodeReviewTestCase):
                 organization=self.organization,
                 repo=self.create_repo(project=self.project, provider="integrations:github"),
                 org_code_review_settings=CodeReviewSettings(enabled=True, triggers=[]),
-                extra={},
+                tags={},
             )
 
             self.mock_seer.assert_not_called()


### PR DESCRIPTION
When a repo has `enabled_code_review=True` but `code_review_triggers=[]`
(empty — a valid DB state since the field defaults to `list`), `pr_review`
is correctly blocked for all review-triggering actions (`opened`,
`synchronize`, `ready_for_review`) by the existing
`ACTIONS_REQUIRING_TRIGGER_CHECK` gate. But `CLOSED` is absent from that
dict, so `pr_closed` was still firing and enqueuing a `pr_closed_task` in
Seer — even though no `pr_review` had ever been sent for any PR in that
repo. The same applies when `org_code_review_settings is None`.

## Checks gap between `pr_review` and `pr_closed`

The two paths share most gates (GHE skip, AI consent, org feature flag,
repo enablement, billing/quota, Redis dedup). The only differences are:

| Gate | `pr_review` (opened/synchronize/ready_for_review) | `pr_closed` (before this PR) |
|---|---|---|
| Trigger permission check | ✅ filtered if required trigger not in `triggers` | ❌ bypassed — `CLOSED` not in `ACTIONS_REQUIRING_TRIGGER_CHECK` |
| Draft PR check | ✅ filtered if `draft: true` | ❌ intentionally exempted (load-bearing — see below) |

The draft exemption for `CLOSED` is intentional: a PR can be opened
(triggering a review), converted back to draft, then closed. At close time
`draft: true`, but `pr_review` already ran so `pr_closed` must fire for
cleanup. That bypass is load-bearing and unchanged here.

The trigger bypass was unintentional. This PR adds a guard immediately
after the existing trigger check:

```python
# If no triggers are configured for this repo, no pr_review was ever sent for it,
# so there is nothing for Seer to process on close.
if action == PullRequestAction.CLOSED and (
    org_code_review_settings is None or not org_code_review_settings.triggers
):
    record_webhook_filtered(github_event, action_value, WebhookFilteredReason.TRIGGER_DISABLED)
    return
```

This is safe because if `triggers` is empty, the existing gate blocks
every review-triggering action, so no `pr_review` could ever have been
sent for any PR in that repo.

The emitted metric (`github_event_action: closed, reason: trigger_disabled`)
is fully differentiable from the `pr_review` equivalent
(`github_event_action: opened/synchronize/ready_for_review`).

Note: there is a second residual case — a PR opened as a draft and closed
without ever going through `ready_for_review`. That PR still generates a
`pr_closed` call even after this fix. Seer already guards against it via
`_get_all_runs_for_pr()` in `PrClosedStep._invoke()`, so the wasted task
is cheap; a Sentry-side Redis gate for that case is a follow-up if needed.