### PR TITLE
fix(preprod): Update default artifact type and label

### DIFF
--- a/static/app/views/settings/project/preprod/statusCheckRules.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRules.tsx
@@ -21,6 +21,7 @@ import {useRepositories} from 'sentry/utils/useRepositories';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {StatusCheckRuleItem} from './statusCheckRuleItem';
+import {DEFAULT_ARTIFACT_TYPE} from './types';
 import {useStatusCheckRules} from './useStatusCheckRules';
 
 export function StatusCheckRules() {
@@ -127,7 +128,7 @@ export function StatusCheckRules() {
                             project_slug: project.slug,
                             metric: updated.metric,
                             measurement: updated.measurement,
-                            artifact_type: updated.artifactType ?? 'all_artifacts',
+                            artifact_type: updated.artifactType ?? DEFAULT_ARTIFACT_TYPE,
                             value: updated.value,
                           });
                           if (rule.id === newRuleId) {

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -1,3 +1,5 @@
+import {t} from 'sentry/locale';
+
 const ALL_METRIC_TYPES = ['install_size', 'download_size'] as const;
 
 type MetricType = (typeof ALL_METRIC_TYPES)[number];
@@ -36,8 +38,8 @@ export interface StatusCheckRule {
 export const DEFAULT_METRIC_TYPE: MetricType = 'install_size';
 
 const METRIC_LABELS: Record<MetricType, string> = {
-  install_size: 'Install/Uncompressed Size',
-  download_size: 'Download Size',
+  install_size: t('Install/Uncompressed Size'),
+  download_size: t('Download Size'),
 };
 
 export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> =
@@ -49,9 +51,9 @@ export const METRIC_OPTIONS: Array<{label: string; value: MetricType}> =
 export const DEFAULT_MEASUREMENT_TYPE: MeasurementType = 'absolute';
 
 const MEASUREMENT_LABELS: Record<MeasurementType, string> = {
-  absolute: 'Absolute Size',
-  absolute_diff: 'Absolute Diff',
-  relative_diff: 'Relative Diff',
+  absolute: t('Absolute Size'),
+  absolute_diff: t('Absolute Diff'),
+  relative_diff: t('Relative Diff'),
 };
 
 export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}> =
@@ -61,11 +63,11 @@ export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}>
   }));
 
 const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
-  all_artifacts: 'Any Artifact Type',
-  main_artifact: 'Main App',
-  watch_artifact: 'Watch App',
-  android_dynamic_feature_artifact: 'Android Dynamic Feature',
-  app_clip_artifact: 'App Clip',
+  all_artifacts: t('Any Artifact Type'),
+  main_artifact: t('Main App'),
+  watch_artifact: t('Watch App'),
+  android_dynamic_feature_artifact: t('Android Dynamic Feature'),
+  app_clip_artifact: t('App Clip'),
 };
 
 export const ARTIFACT_TYPE_OPTIONS: Array<{label: string; value: ArtifactType}> =

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -17,7 +17,6 @@ export const ALL_ARTIFACT_TYPES = [
 export type ArtifactType = (typeof ALL_ARTIFACT_TYPES)[number];
 
 export const DEFAULT_ARTIFACT_TYPE: ArtifactType = 'main_artifact';
-export const ALL_ARTIFACTS_ARTIFACT_TYPE: ArtifactType = 'all_artifacts';
 
 export interface StatusCheckFilter {
   key: string;

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -61,7 +61,7 @@ export const MEASUREMENT_OPTIONS: Array<{label: string; value: MeasurementType}>
   }));
 
 const ARTIFACT_TYPE_LABELS: Record<ArtifactType, string> = {
-  all_artifacts: 'All Artifact Types',
+  all_artifacts: 'Any Artifact Type',
   main_artifact: 'Main App',
   watch_artifact: 'Watch App',
   android_dynamic_feature_artifact: 'Android Dynamic Feature',

--- a/static/app/views/settings/project/preprod/useStatusCheckRules.ts
+++ b/static/app/views/settings/project/preprod/useStatusCheckRules.ts
@@ -11,7 +11,7 @@ import {uniqueId} from 'sentry/utils/guid';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
 import {
-  ALL_ARTIFACTS_ARTIFACT_TYPE,
+  DEFAULT_ARTIFACT_TYPE,
   DEFAULT_MEASUREMENT_TYPE,
   DEFAULT_METRIC_TYPE,
   toArtifactType,
@@ -141,7 +141,7 @@ export function useStatusCheckRules(project: Project) {
       measurement: DEFAULT_MEASUREMENT,
       value: 0,
       filterQuery: '',
-      artifactType: ALL_ARTIFACTS_ARTIFACT_TYPE,
+      artifactType: DEFAULT_ARTIFACT_TYPE,
     };
   }, []);
 


### PR DESCRIPTION
Change the default artifact type for new status check rules from
`all_artifacts` to `main_artifact` and rename the `all_artifacts`
display label from "All Artifact Types" to "Any Artifact Type" for
clarity.

- New rules now default to `main_artifact` instead of `all_artifacts`
- Removed the unused `ALL_ARTIFACTS_ARTIFACT_TYPE` constant
- Updated the label to better reflect matching semantics

Refs LINEAR-EME-871