### PR TITLE
feat(tracemetrics): Add deno to available metrics platforms

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -495,6 +495,7 @@ export const limitedMetricsSupportPrefixes: Set<string> = new Set([
   'apple',
   'bun',
   'dart',
+  'deno',
   'dotnet',
   'electron',
   'go',


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/releases/tag/10.40.0#:~:text=feat(deno)%3A%20Export%20metrics%20API%20from%20Deno%20SDK

deno support was released in 10.40.0, adding it to the project platform constant we use to selectively expose the metrics UI