### PR TITLE
fix(performance): Remap request.method for EAP related issues table

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -698,4 +698,36 @@ describe('utils/tokenizeSearch', () => {
       it(`${name}`, () => expect(object.formatString()).toEqual(string));
     }
   });
+
+  describe('renameFilter', () => {
+    it('renames a simple filter key', () => {
+      const search = new MutableSearch('request.method:GET');
+      search.renameFilter('request.method', 'http.method');
+      expect(search.formatString()).toBe('http.method:GET');
+    });
+
+    it('renames negated filter keys', () => {
+      const search = new MutableSearch('!request.method:GET');
+      search.renameFilter('request.method', 'http.method');
+      expect(search.formatString()).toBe('!http.method:GET');
+    });
+
+    it('preserves OR grouping', () => {
+      const search = new MutableSearch('(request.method:GET OR request.method:POST)');
+      search.renameFilter('request.method', 'http.method');
+      expect(search.formatString()).toBe('( http.method:GET OR http.method:POST )');
+    });
+
+    it('does not rename unrelated keys', () => {
+      const search = new MutableSearch('request.method:GET browser:Chrome');
+      search.renameFilter('request.method', 'http.method');
+      expect(search.formatString()).toBe('http.method:GET browser:Chrome');
+    });
+
+    it('is a no-op when key is not present', () => {
+      const search = new MutableSearch('browser:Chrome');
+      search.renameFilter('request.method', 'http.method');
+      expect(search.formatString()).toBe('browser:Chrome');
+    });
+  });
 });

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -419,6 +419,21 @@ export class MutableSearch {
     return this.getFilterValues(key).length > 0;
   }
 
+  /**
+   * Renames all filter tokens matching `oldKey` to `newKey` in-place,
+   * preserving operators, negation, position, and filter type.
+   */
+  renameFilter(oldKey: string, newKey: string) {
+    for (const token of this.tokens) {
+      if (token.key === oldKey) {
+        token.key = newKey;
+      } else if (token.key === `!${oldKey}`) {
+        token.key = `!${newKey}`;
+      }
+    }
+    return this;
+  }
+
   removeFilter(key: string) {
     const removeErroneousAndOrOps = () => {
       let toRemove = -1;

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -55,10 +55,14 @@ function RelatedIssues({
       // Issues and EAP spans disagree on what to call the HTTP request method
       // parameter, and it's commonly present in the query since the Insights
       // landing pages add it for HTTP transactions.
-      const requestMethods = currentFilter.getFilterValues('request.method');
-      currentFilter
-        .removeFilter('request.method')
-        .addFilterValues('http.method', requestMethods);
+      // Mutate tokens in-place to preserve operators, negation, and position.
+      for (const token of currentFilter.tokens) {
+        if (token.key === 'request.method') {
+          token.key = 'http.method';
+        } else if (token.key === '!request.method') {
+          token.key = '!http.method';
+        }
+      }
     }
     removeTracingKeysFromSearch(currentFilter);
     currentFilter

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -55,14 +55,7 @@ function RelatedIssues({
       // Issues and EAP spans disagree on what to call the HTTP request method
       // parameter, and it's commonly present in the query since the Insights
       // landing pages add it for HTTP transactions.
-      // Mutate tokens in-place to preserve operators, negation, and position.
-      for (const token of currentFilter.tokens) {
-        if (token.key === 'request.method') {
-          token.key = 'http.method';
-        } else if (token.key === '!request.method') {
-          token.key = '!http.method';
-        }
-      }
+      currentFilter.renameFilter('request.method', 'http.method');
     }
     removeTracingKeysFromSearch(currentFilter);
     currentFilter

--- a/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/relatedIssues.tsx
@@ -19,6 +19,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useTransactionSummaryEAP} from 'sentry/views/performance/eap/useTransactionSummaryEAP';
 import {removeTracingKeysFromSearch} from 'sentry/views/performance/utils';
 
 type Props = {
@@ -38,6 +39,8 @@ function RelatedIssues({
   end,
   statsPeriod,
 }: Props) {
+  const isEAP = useTransactionSummaryEAP();
+
   const getIssuesEndpointQueryParams = () => {
     const queryParams = {
       start,
@@ -48,6 +51,15 @@ function RelatedIssues({
       ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
     };
     const currentFilter = new MutableSearch(decodeScalar(location.query.query, ''));
+    if (isEAP) {
+      // Issues and EAP spans disagree on what to call the HTTP request method
+      // parameter, and it's commonly present in the query since the Insights
+      // landing pages add it for HTTP transactions.
+      const requestMethods = currentFilter.getFilterValues('request.method');
+      currentFilter
+        .removeFilter('request.method')
+        .addFilterValues('http.method', requestMethods);
+    }
     removeTracingKeysFromSearch(currentFilter);
     currentFilter
       .addFreeText('is:unresolved')


### PR DESCRIPTION
EAP spans use a different parameter name for HTTP request method than issues. Remap `request.method` to `http.method` in the related issues query when using the EAP version of transaction summary. (The Insights landing pages add request.method to the query for HTTP transactions, so this is a frequent problem).

Since renaming a filter is a little subtle (see e.g. [this comment](https://github.com/getsentry/sentry/pull/109196#discussion_r2848923096)), added a`renameFilter` method to `MutableSearch` to handle this in this case and any other future similar renames.

Fixes DAIN-1229