### PR TITLE
fix(dashboards): side nav updates on dashboard deletion

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -213,13 +213,12 @@ export function updateDashboard(
 
 export function deleteDashboard(
   api: Client,
-  orgId: string,
   dashboardId: string,
   queryClient: QueryClient,
   organization: Organization
 ): Promise<undefined> {
   const promise: Promise<undefined> = api.requestPromise(
-    `/organizations/${orgId}/dashboards/${dashboardId}/`,
+    `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
     {
       method: 'DELETE',
     }

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -214,7 +214,9 @@ export function updateDashboard(
 export function deleteDashboard(
   api: Client,
   orgId: string,
-  dashboardId: string
+  dashboardId: string,
+  queryClient: QueryClient,
+  organization: Organization
 ): Promise<undefined> {
   const promise: Promise<undefined> = api.requestPromise(
     `/organizations/${orgId}/dashboards/${dashboardId}/`,
@@ -222,6 +224,12 @@ export function deleteDashboard(
       method: 'DELETE',
     }
   );
+
+  promise.then(() => {
+    queryClient.invalidateQueries({
+      queryKey: getQueryKey(organization),
+    });
+  });
 
   promise.catch(response => {
     const errorResponse = response?.responseJSON ?? null;

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1396,6 +1396,7 @@ interface DashboardDetailWithInjectedPropsProps extends Omit<
   | 'location'
   | 'params'
   | 'router'
+  | 'queryClient'
 > {}
 
 export default function DashboardDetailWithInjectedProps(

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -458,7 +458,7 @@ class DashboardDetail extends Component<Props, State> {
     const previousDashboardState = this.state.dashboardState;
 
     this.setState({dashboardState: DashboardState.PENDING_DELETE}, () => {
-      deleteDashboard(api, organization.slug, dashboard.id, queryClient, organization)
+      deleteDashboard(api, dashboard.id, queryClient, organization)
         .then(() => {
           addSuccessMessage(t('Dashboard deleted'));
           trackAnalytics('dashboards2.delete', {organization});

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -46,6 +46,7 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MetricsResultsMetaProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OnDemandControlProvider} from 'sentry/utils/performance/contexts/onDemandControl';
+import {QueryClient, useQueryClient} from 'sentry/utils/queryClient';
 import {decodeBoolean} from 'sentry/utils/queryString';
 import {OnRouteLeave} from 'sentry/utils/reactRouter6Compat/onRouteLeave';
 import {scheduleMicroTask} from 'sentry/utils/scheduleMicroTask';
@@ -138,6 +139,7 @@ type Props = {
   organization: Organization;
   params: RouteParams;
   projects: Project[];
+  queryClient: QueryClient;
   router: InjectedRouter;
   theme: Theme;
   children?: React.ReactNode;
@@ -448,7 +450,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onDelete = (dashboard: State['modifiedDashboard']) => () => {
-    const {api, organization, location} = this.props;
+    const {api, organization, location, queryClient} = this.props;
     if (!dashboard?.id) {
       return;
     }
@@ -456,7 +458,7 @@ class DashboardDetail extends Component<Props, State> {
     const previousDashboardState = this.state.dashboardState;
 
     this.setState({dashboardState: DashboardState.PENDING_DELETE}, () => {
-      deleteDashboard(api, organization.slug, dashboard.id)
+      deleteDashboard(api, organization.slug, dashboard.id, queryClient, organization)
         .then(() => {
           addSuccessMessage(t('Dashboard deleted'));
           trackAnalytics('dashboards2.delete', {organization});
@@ -1408,7 +1410,7 @@ export default function DashboardDetailWithInjectedProps(
   const params = useParams<RouteParams>();
   const router = useRouter();
   const [chartInterval] = useChartInterval();
-
+  const queryClient = useQueryClient();
   // Always use the validated chart interval so the UI dropdown and widget
   // requests stay in sync. chartInterval is validated against the current page
   // filter period (e.g. won't return 1m for a 30d range) and always has a value.
@@ -1428,6 +1430,7 @@ export default function DashboardDetailWithInjectedProps(
       params={params}
       router={router}
       widgetInterval={widgetInterval}
+      queryClient={queryClient}
     />
   );
 }

--- a/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
@@ -20,13 +20,7 @@ export function useDeleteDashboard({onSuccess}: UseDeleteDashboardProps) {
 
   const deleteDashboard = useCallback(
     (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
-      deleteDashboardAction(
-        api,
-        organization.slug,
-        dashboard.id,
-        queryClient,
-        organization
-      )
+      deleteDashboardAction(api, dashboard.id, queryClient, organization)
         .then(() => {
           trackAnalytics('dashboards_manage.delete', {
             organization,

--- a/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
+++ b/static/app/views/dashboards/hooks/useDeleteDashboard.tsx
@@ -4,6 +4,7 @@ import {deleteDashboard as deleteDashboardAction} from 'sentry/actionCreators/da
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {DashboardListItem} from 'sentry/views/dashboards/types';
@@ -15,10 +16,17 @@ interface UseDeleteDashboardProps {
 export function useDeleteDashboard({onSuccess}: UseDeleteDashboardProps) {
   const api = useApi();
   const organization = useOrganization();
+  const queryClient = useQueryClient();
 
   const deleteDashboard = useCallback(
     (dashboard: DashboardListItem, viewType: 'table' | 'grid') => {
-      deleteDashboardAction(api, organization.slug, dashboard.id)
+      deleteDashboardAction(
+        api,
+        organization.slug,
+        dashboard.id,
+        queryClient,
+        organization
+      )
         .then(() => {
           trackAnalytics('dashboards_manage.delete', {
             organization,
@@ -32,7 +40,7 @@ export function useDeleteDashboard({onSuccess}: UseDeleteDashboardProps) {
           addErrorMessage(t('Error deleting Dashboard'));
         });
     },
-    [api, organization, onSuccess]
+    [api, organization, queryClient, onSuccess]
   );
 
   return deleteDashboard;


### PR DESCRIPTION
fixes a bug where deleting a dashboard from the dashboards landing page would not reflect in the side nav; you needed to refresh the page to see the changes. Note this is specifically noticed when deleting a starred dashboard. Now this works as expected.