### PR TITLE
chore(eco): Reduces integration related noise for uninteresting errors

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -133,6 +133,8 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
             filepath = filepath.lstrip("/")
             try:
                 client = self.get_client()
+            except IntegrationConfigurationError:
+                return None
             except (Identity.DoesNotExist, IntegrationError):
                 sentry_sdk.capture_exception()
                 return None

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -69,6 +69,7 @@ from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.namespaces import sentryapp_control_tasks, sentryapp_tasks
 from sentry.taskworker.retry import NoRetriesRemainingError, Retry, retry_task
+from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.types.rules import RuleFuture
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -92,6 +93,7 @@ retry_decorator = retry(
         ApiTimeoutError,
         ConnectionError,
         HTTPError,
+        ProcessingDeadlineExceeded,
     ),
     ignore=(
         ClientError,

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -33,6 +33,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.taskworker.retry import NoRetriesRemainingError, Retry
+from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.utils import metrics
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.sdk import set_current_event_project
@@ -50,7 +51,7 @@ logger = logging.getLogger(__name__)
     name="sentry.tasks.process_commit_context",
     namespace=issues_tasks,
     processing_deadline_duration=TASK_DURATION_S,
-    retry=Retry(times=5, delay=5),
+    retry=Retry(times=5, delay=5, on_silent=(ProcessingDeadlineExceeded,)),
     silo_mode=SiloMode.REGION,
 )
 def process_commit_context(

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -25,6 +25,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.taskworker.retry import Retry
+from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
@@ -79,7 +80,7 @@ def handle_invalid_identity(identity, commit_failure=False):
     retry=Retry(times=5, delay=60 * 5),
     silo_mode=SiloMode.REGION,
 )
-@retry(exclude=(Release.DoesNotExist, User.DoesNotExist))
+@retry(on_silent=(ProcessingDeadlineExceeded,), exclude=(Release.DoesNotExist, User.DoesNotExist))
 def fetch_commits(release_id: int, user_id: int, refs, prev_release_id=None, **kwargs):
     # TODO(dcramer): this function could use some cleanup/refactoring as it's a bit unwieldy
     commit_list = []


### PR DESCRIPTION
Our issues channel is clogged with uninteresting, and often unactionable alerts that this PR intends to clear up.

The main classes of errors this addresses are:
- Sentry App task related `ProcessingDeadlineExceeded`
- Suspect commit related `ProcessingDeadlineExceeded`
- `IntegrationConfigurationError` generated by `get_stacktrace_link`

Fixes: SENTRY-5HM4
Fixes: SENTRY-5HKA
Fixes: SENTRY-5K73
Fixes: SENTRY-555Q
