### PR TITLE
deps(ui): Upgrade to pnpm 10.30.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,5 +316,5 @@
       "current node"
     ]
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.30.2"
 }


### PR DESCRIPTION
I've read that >10.11 should fix dependabot. devenv sync should pull the version based on packageManager