### PR TITLE
fix(dashboards): preserve display type when switching display types

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -641,6 +641,13 @@ export const usesTimeSeriesData = (displayType?: DisplayType) => {
   ].includes(displayType);
 };
 
+export function doesDisplayTypeSupportThresholds(displayType?: DisplayType): boolean {
+  if (!displayType) {
+    return false;
+  }
+  return displayType === DisplayType.BIG_NUMBER || usesTimeSeriesData(displayType);
+}
+
 // Custom widgets that fetch their own data (and don't use genericWidgetQueries)
 // handle error state and loading state on their own
 export const widgetFetchesOwnData = (widgetType: DisplayType) => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -35,7 +35,10 @@ import {
   type DashboardFilters,
   type Widget,
 } from 'sentry/views/dashboards/types';
-import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {
+  doesDisplayTypeSupportThresholds,
+  usesTimeSeriesData,
+} from 'sentry/views/dashboards/utils';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
@@ -429,8 +432,7 @@ function WidgetBuilderSlideout({
                         />
                       </Section>
                     )}
-                    {(state.displayType === DisplayType.BIG_NUMBER ||
-                      usesTimeSeriesData(state.displayType)) && (
+                    {doesDisplayTypeSupportThresholds(state.displayType) && (
                       <Section>
                         <ThresholdsSection
                           dataType={thresholdMetaState?.dataType}

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -597,7 +597,7 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.selectedAggregate).toBeUndefined();
     });
 
-    it('resets thresholds when the display type is switched', () => {
+    it('preserves thresholds when the display type is switched', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({
           query: {
@@ -624,7 +624,10 @@ describe('useWidgetBuilderState', () => {
         });
       });
 
-      expect(result.current.state.thresholds).toBeUndefined();
+      expect(result.current.state.thresholds).toEqual({
+        max_values: {max1: 200, max2: 300},
+        unit: 'milliseconds',
+      });
     });
 
     it('sets sort to first available sortable field when switching to release table', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.spec.tsx
@@ -597,7 +597,40 @@ describe('useWidgetBuilderState', () => {
       expect(result.current.state.selectedAggregate).toBeUndefined();
     });
 
-    it('preserves thresholds when the display type is switched', () => {
+    it('preserves thresholds when switching to a display type that supports thresholds', () => {
+      mockedUsedLocation.mockReturnValue(
+        LocationFixture({
+          query: {
+            dataset: WidgetType.ERRORS,
+            displayType: DisplayType.BIG_NUMBER,
+            thresholds: '{"max_values":{"max1":200,"max2":300},"unit":"milliseconds"}',
+          },
+        })
+      );
+
+      const {result} = renderHook(() => useWidgetBuilderState(), {
+        wrapper: WidgetBuilderProvider,
+      });
+
+      expect(result.current.state.thresholds).toEqual({
+        max_values: {max1: 200, max2: 300},
+        unit: 'milliseconds',
+      });
+
+      act(() => {
+        result.current.dispatch({
+          type: BuilderStateAction.SET_DISPLAY_TYPE,
+          payload: DisplayType.LINE,
+        });
+      });
+
+      expect(result.current.state.thresholds).toEqual({
+        max_values: {max1: 200, max2: 300},
+        unit: 'milliseconds',
+      });
+    });
+
+    it('resets thresholds when switching to a display type that does not support thresholds', () => {
       mockedUsedLocation.mockReturnValue(
         LocationFixture({
           query: {
@@ -624,10 +657,7 @@ describe('useWidgetBuilderState', () => {
         });
       });
 
-      expect(result.current.state.thresholds).toEqual({
-        max_values: {max1: 200, max2: 300},
-        unit: 'milliseconds',
-      });
+      expect(result.current.state.thresholds).toBeUndefined();
     });
 
     it('sets sort to first available sortable field when switching to release table', () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -24,7 +24,10 @@ import {
   WidgetType,
   type LinkedDashboard,
 } from 'sentry/views/dashboards/types';
-import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {
+  doesDisplayTypeSupportThresholds,
+  usesTimeSeriesData,
+} from 'sentry/views/dashboards/utils';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds';
 import {
   DISABLED_SORT,
@@ -436,6 +439,9 @@ function useWidgetBuilderState(): {
                 options
               );
             }
+          }
+          if (!doesDisplayTypeSupportThresholds(action.payload)) {
+            setThresholds(undefined, options);
           }
           setSelectedAggregate(undefined, options);
           setLinkedDashboards([], options);

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -437,7 +437,6 @@ function useWidgetBuilderState(): {
               );
             }
           }
-          setThresholds(undefined, options);
           setSelectedAggregate(undefined, options);
           setLinkedDashboards([], options);
           break;


### PR DESCRIPTION
Now that we have more display types with thresholds, we should preserve the thresholds section unless the display type doesn't support it.