### PR TITLE
chore: add eslint-plugin-regexp's straightforward recommended rules

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -37,6 +37,7 @@ import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need-an-effect';
+import regexp from 'eslint-plugin-regexp';
 // @ts-expect-error TS(7016): Could not find a declaration file
 import sentry from 'eslint-plugin-sentry';
 import testingLibrary from 'eslint-plugin-testing-library';
@@ -832,6 +833,20 @@ export default typescript.config([
     files: ['**/*.spec.{ts,js,tsx,jsx}', 'tests/js/**/*.{ts,js,tsx,jsx}'],
     // https://github.com/testing-library/eslint-plugin-jest-dom/tree/main?tab=readme-ov-file#supported-rules
     ...jestDom.configs['flat/recommended'],
+  },
+  {
+    extends: [regexp.configs.recommended],
+    name: 'plugin/regexp',
+    rules: {
+      'prefer-regex-literals': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/no-misleading-capturing-group': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/no-obscure-range': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/no-super-linear-backtracking': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/no-unused-capturing-group': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/optimal-quantifier-concatenation': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/strict': 'off', // TODO(JoshuaKGoldberg): do we want this?
+      'regexp/use-ignore-case': 'off', // TODO(JoshuaKGoldberg): do we want this?
+    },
   },
   {
     name: 'plugin/testing-library',

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "eslint-plugin-no-relative-import-paths": "^1.6.1",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "6.1.0",
+    "eslint-plugin-regexp": "^3.0.0",
     "eslint-plugin-react-you-might-not-need-an-effect": "0.5.3",
     "eslint-plugin-sentry": "^2.10.0",
     "eslint-plugin-testing-library": "^7.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,6 +652,9 @@ importers:
       eslint-plugin-react-you-might-not-need-an-effect:
         specifier: 0.5.3
         version: 0.5.3(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-regexp:
+        specifier: ^3.0.0
+        version: 3.0.0(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-sentry:
         specifier: ^2.10.0
         version: 2.10.0
@@ -4975,6 +4978,10 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
+  comment-parser@1.4.5:
+    resolution: {integrity: sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==}
+    engines: {node: '>= 12.0.0'}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -5746,6 +5753,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-regexp@3.0.0:
+    resolution: {integrity: sha512-iW7hgAV8NOG6E2dz+VeKpq67YLQ9jaajOKYpoOSic2/q8y9BMdXBKkSR9gcMtbqEhNQzdW41E3wWzvhp8ExYwQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: '>=9.38.0'
 
   eslint-plugin-sentry@2.10.0:
     resolution: {integrity: sha512-QuCUr2B78Onr2GdXM4ncPlS2IBAB+lL5QwSPNvX5LcAoBtV7iFuhEY7DS4WqwgmJcRnI6g3/dKARpFuOILR35A==}
@@ -6996,6 +7009,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@7.1.1:
+    resolution: {integrity: sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==}
+    engines: {node: '>=20.0.0'}
 
   jsdom@24.1.3:
     resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
@@ -8297,6 +8314,10 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   reflect.getprototypeof@1.0.9:
     resolution: {integrity: sha512-r0Ay04Snci87djAsI4U+WNRcSw5S4pOH7qFjd/veA5gC7TbqESR3tcj28ia95L/fYUDw11JKP7uqUKUAfVvV5Q==}
     engines: {node: '>= 0.4'}
@@ -8328,6 +8349,10 @@ packages:
 
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -8523,6 +8548,10 @@ packages:
 
   scroll-to-element@2.0.3:
     resolution: {integrity: sha512-5herPcm9jMfQgRwu94lH5mei+2YhipR4RQ2nAvnBxJb2tG+P7O0ctOKAaAZBXbBejnn+MImh3wrAUA5EcLnjEQ==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   select-hose@2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
@@ -14842,6 +14871,8 @@ snapshots:
 
   commander@8.3.0: {}
 
+  comment-parser@1.4.5: {}
+
   compare-versions@6.1.1: {}
 
   compressible@2.0.18:
@@ -15772,6 +15803,17 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-regexp@3.0.0(eslint@9.34.0(jiti@2.6.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.34.0(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.1
+      comment-parser: 1.4.5
+      eslint: 9.34.0(jiti@2.6.1)
+      jsdoc-type-pratt-parser: 7.1.1
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+      scslre: 0.3.0
 
   eslint-plugin-sentry@2.10.0:
     dependencies:
@@ -17443,6 +17485,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@7.1.1: {}
+
   jsdom@24.1.3:
     dependencies:
       cssstyle: 4.4.0
@@ -19107,6 +19151,10 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+
   reflect.getprototypeof@1.0.9:
     dependencies:
       call-bind: 1.0.8
@@ -19147,6 +19195,11 @@ snapshots:
   regex@6.0.1:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
 
   regexp-tree@0.1.27: {}
 
@@ -19396,6 +19449,12 @@ snapshots:
   scroll-to-element@2.0.3:
     dependencies:
       raf: 3.4.1
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   select-hose@2.0.0: {}
 

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -724,8 +724,7 @@ if (IS_UI_DEV_ONLY) {
   // XXX: If you change this also change its sibiling in:
   // - static/index.ejs
   // - static/app/utils/extractSlug.tsx
-  const KNOWN_DOMAINS =
-    /(?:\.?)((?:localhost|dev\.getsentry\.net|sentry\.dev)(?::\d*)?)$/;
+  const KNOWN_DOMAINS = /\.?((?:localhost|dev\.getsentry\.net|sentry\.dev)(?::\d*)?)$/;
 
   const extractSlug = (hostname: string) => {
     const match = hostname.match(KNOWN_DOMAINS);

--- a/static/app/actionCreators/tags.tsx
+++ b/static/app/actionCreators/tags.tsx
@@ -190,7 +190,7 @@ export function fetchFeatureFlagValues({
   sort?: '-last_seen' | '-count';
 }): Promise<TagValue[]> {
   // Search syntax may wrap with flags[] or flags[""], but this endpoint doesn't support it.
-  const strippedKey = tagKey.replace(/^flags\[(?:"?)(.*?)(?:"?)\]$/, '$1');
+  const strippedKey = tagKey.replace(/^flags\["?(.*?)"?\]$/, '$1');
 
   const url = `/organizations/${organization.slug}/tags/${strippedKey}/values/`;
 

--- a/static/app/components/customResolutionModal.spec.tsx
+++ b/static/app/components/customResolutionModal.spec.tsx
@@ -41,7 +41,7 @@ describe('CustomResolutionModal', () => {
 
     const trigger = screen.getByRole('button', {name: /version/i});
     await userEvent.click(trigger);
-    const option = await screen.findByRole('option', {name: /1\.2\.0/i});
+    const option = await screen.findByRole('option', {name: /1\.2\.0/});
     await userEvent.click(option);
 
     await userEvent.click(screen.getByText('Resolve'));
@@ -145,7 +145,7 @@ describe('CustomResolutionModal', () => {
     // selecting clears the error
     const trigger = screen.getByRole('button', {name: /version/i});
     await userEvent.click(trigger);
-    const option = await screen.findByRole('option', {name: /1\.2\.0/i});
+    const option = await screen.findByRole('option', {name: /1\.2\.0/});
     await userEvent.click(option);
     expect(screen.queryByText('Please select a release.')).not.toBeInTheDocument();
   });

--- a/static/app/components/events/interfaces/analyzeFrames.spec.tsx
+++ b/static/app/components/events/interfaces/analyzeFrames.spec.tsx
@@ -143,7 +143,7 @@ describe('analyzeAnrFrames', () => {
       'SharedPreferences.apply will save data on background thread only if it happens before the activity/service finishes. Switch to SharedPreferences.commit and move commit to a background thread.'
     );
     expect(rootCause?.culprit).toBe(
-      '/^android\\.app\\.SharedPreferencesImpl\\$EditorImpl\\$[0-9]/'
+      '/^android\\.app\\.SharedPreferencesImpl\\$EditorImpl\\$\\d/'
     );
   });
 
@@ -219,7 +219,7 @@ describe('analyzeAnrFrames', () => {
       'SharedPreferences.apply will save data on background thread only if it happens before the activity/service finishes. Switch to SharedPreferences.commit and move commit to a background thread.'
     );
     expect(rootCause?.culprit).toBe(
-      '/^android\\.app\\.SharedPreferencesImpl\\$EditorImpl\\$[0-9]/'
+      '/^android\\.app\\.SharedPreferencesImpl\\$EditorImpl\\$\\d/'
     );
   });
 

--- a/static/app/components/events/interfaces/analyzeFrames.tsx
+++ b/static/app/components/events/interfaces/analyzeFrames.tsx
@@ -74,7 +74,7 @@ const CULPRIT_FRAMES: SuspectFrame[] = [
     ),
   },
   {
-    module: /^android\.app\.SharedPreferencesImpl\$EditorImpl\$[0-9]/,
+    module: /^android\.app\.SharedPreferencesImpl\$EditorImpl\$\d/,
     functions: ['run'],
     offendingThreadStates: [
       ThreadStates.WAITING,

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -31,7 +31,7 @@ export const renderLinksInText = ({
   //    The "i" modifier makes the regex match both upper and lower case characters
 
   const urlRegex =
-    /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9]{1,6}(?:[-a-zA-Z0-9@:%_+~#?&/=,[\].]*[-a-zA-Z0-9@:%_+~#?&/=,[\]])?/gi;
+    /https?:\/\/(?:www\.)?[-\w@:%.+~#=]{1,256}\.[a-z0-9]{1,6}(?:[-\w@:%+~#?&/=,[\].]*[-\w@:%+~#?&/=,[\]])?/gi;
 
   const parts = exceptionText.split(urlRegex);
   const urls = exceptionText.match(urlRegex) || [];

--- a/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.tsx
+++ b/static/app/components/events/interfaces/frame/usePrismTokensSourceContext.tsx
@@ -39,7 +39,7 @@ const BLOCK_COMMENT_SYNTAX_BY_LANGUAGE: Record<string, BlockCommentSyntax[]> = {
   haskell: [{start: '{-', end: '-}'}],
   julia: [{start: '#=', end: '=#'}],
   lua: [{start: '--[[', end: ']]'}],
-  perl: [{start: {example: '=comment', search: /^\s*?=\S+/m}, end: '=cut'}],
+  perl: [{start: {example: '=comment', search: /^\s*=\S+/m}, end: '=cut'}],
   powershell: [{start: '<#', end: '#>'}],
   python: [
     {start: '"""', end: '"""'},

--- a/static/app/components/events/interfaces/threads/threadSelector/filterThreadInfo.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/filterThreadInfo.tsx
@@ -16,7 +16,7 @@ export type ThreadInfo = {
 };
 
 function trimFilename(filename: string) {
-  const pieces = filename.split(/\//g);
+  const pieces = filename.split(/\//);
   return pieces[pieces.length - 1];
 }
 

--- a/static/app/components/modals/widgetViewerModal/utils.tsx
+++ b/static/app/components/modals/widgetViewerModal/utils.tsx
@@ -11,5 +11,5 @@ export enum WidgetViewerQueryField {
 }
 
 export function isWidgetViewerPath(pathname: string) {
-  return pathname.match(/\/widget\/[0-9]+\/$/);
+  return pathname.match(/\/widget\/\d+\/$/);
 }

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -41,7 +41,7 @@ const selectablePlatforms = platforms.filter(platform =>
 );
 
 function startsWithPunctuation(name: string) {
-  return /^[\p{P}]/u.test(name);
+  return /^\p{P}/u.test(name);
 }
 
 export type Category = (typeof categoryList)[number]['id'];

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -29,7 +29,7 @@ const shouldSearchEventIds = (query?: string) =>
   typeof query === 'string' && query.length === 32;
 
 // STRING-HEXVAL
-const shouldSearchShortIds = (query: string) => /[\w\d]+-[\w\d]+/.test(query);
+const shouldSearchShortIds = (query: string) => /\w+-\w+/.test(query);
 
 async function createProjectResults(
   projectsPromise: Promise<Project[]>,

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/utils.ts
@@ -54,7 +54,7 @@ function formatToken(token: string): string {
 
 export function formatQueryToNaturalLanguage(query: string): string {
   if (!query.trim()) return '';
-  const tokens = query.match(/(?:[^\s"]+|"[^"]*")+/g) || [];
+  const tokens = query.match(/(?:[^\s"]|"[^"]*")+/g) || [];
   const formattedTokens = tokens.map(formatToken);
 
   const formattedQuery = formattedTokens.reduce((result, token, index) => {

--- a/static/app/components/searchQueryBuilder/index.stories.tsx
+++ b/static/app/components/searchQueryBuilder/index.stories.tsx
@@ -779,7 +779,7 @@ export default Storybook.story('SearchQueryBuilder', story => {
           filterKeys={FILTER_KEYS}
           getTagValues={getTagValues}
           searchSource="storybook"
-          matchKeySuggestions={[{key: 'id', valuePattern: /^[0-9]{3}$/}]}
+          matchKeySuggestions={[{key: 'id', valuePattern: /^\d{3}$/}]}
         />
         <p>
           You can also pass multiple values in the prop to show suggestions for multiple
@@ -792,8 +792,8 @@ export default Storybook.story('SearchQueryBuilder', story => {
           getTagValues={getTagValues}
           searchSource="storybook"
           matchKeySuggestions={[
-            {key: 'test-1.id', valuePattern: /^[0-9]{3}$/},
-            {key: 'test-2.id', valuePattern: /^[0-9]{3}$/},
+            {key: 'test-1.id', valuePattern: /^\d{3}$/},
+            {key: 'test-2.id', valuePattern: /^\d{3}$/},
           ]}
         />
       </Fragment>

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -471,7 +471,7 @@ export function SearchQueryBuilderCombobox<
         if (
           e.key === 'ArrowDown' ||
           e.key === 'ArrowUp' ||
-          /^\w$/i.test(e.key) ||
+          /^\w$/.test(e.key) ||
           e.key === ','
         ) {
           if (isOpen || isCtrlKeyPressed(e)) return;

--- a/static/app/components/searchSyntax/mutableSearch.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.tsx
@@ -14,7 +14,7 @@ const EMPTY_OPTION_VALUE = '(empty)';
 
 // Hoisted regular expressions to avoid recompilation in hot paths
 const TRIMMABLE_ENDS_RE = /^["(]+|[")]+$/g;
-const WILDCARD_ESCAPE_RE = /([*])/g;
+const WILDCARD_ESCAPE_RE = /(\*)/g;
 const NEEDS_QUOTING_RE = /[\s(),\\"]/;
 const VALUE_IS_LIST_RE = /^\[.*\]$/;
 const VALUE_IS_QUOTED_RE = /^".*"$/;

--- a/static/app/components/timeRangeSelector/utils.tsx
+++ b/static/app/components/timeRangeSelector/utils.tsx
@@ -29,7 +29,7 @@ type RelativeUnitsMapping = Record<
 
 const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
-const STATS_PERIOD_REGEX = /^(\d+)([mhdw]{1})$/;
+const STATS_PERIOD_REGEX = /^(\d+)([mhdw])$/;
 
 const SUPPORTED_RELATIVE_PERIOD_UNITS: RelativeUnitsMapping = {
   m: {

--- a/static/app/debug/notifications/hooks/useRouteSource.tsx
+++ b/static/app/debug/notifications/hooks/useRouteSource.tsx
@@ -14,7 +14,7 @@ export function useRouteSource() {
       ? // Removes the last route segment. This is to ensure `/debug/notifications/` and
         // `/organizations/:slug/debug/notifications/` are valid as base routes
         // It does mean we'll have to change this if we add change the routes but works for now
-        location.pathname.replace(/[\w-]+\/{0,1}$/, '')
+        location.pathname.replace(/[\w-]+\/?$/, '')
       : location.pathname,
   };
 }

--- a/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-log4j2/onboarding.spec.tsx
@@ -50,7 +50,7 @@ describe('getting started with log4j2', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/java-logback/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-logback/onboarding.spec.tsx
@@ -50,7 +50,7 @@ describe('getting started with logback', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-spring-boot/onboarding.spec.tsx
@@ -50,7 +50,7 @@ describe('java-spring-boot onboarding docs', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/java-spring/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java-spring/onboarding.spec.tsx
@@ -52,7 +52,7 @@ describe('GettingStartedWithSpring', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/java/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/java/onboarding.spec.tsx
@@ -49,7 +49,7 @@ describe('java-spring-boot onboarding docs', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe('java-spring-boot onboarding docs', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /libraryDependencies \+= "io\.sentry" % "sentry" % "4\.99\.9"/m
+          /libraryDependencies \+= "io\.sentry" % "sentry" % "4\.99\.9"/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/kotlin/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/kotlin/onboarding.spec.tsx
@@ -49,7 +49,7 @@ describe('GettingStartedWithKotlin', () => {
     expect(
       await screen.findByText(
         textWithMarkupMatcher(
-          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/m
+          /<artifactId>sentry-maven-plugin<\/artifactId>\s*<version>3\.99\.9<\/version>/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/stories/colorReference.tsx
+++ b/static/app/stories/colorReference.tsx
@@ -132,7 +132,7 @@ function ColorToken({
 function formatSnippet({token, scale}: {scale: string; token: string}) {
   const parts = token.split('.');
   const accessor = parts
-    .map(part => (/^[0-9]/.test(part) ? `["${part}"]` : `.${part}`))
+    .map(part => (/^\d/.test(part) ? `["${part}"]` : `.${part}`))
     .join('');
   return `\${p => p.theme.tokens.${scale}${accessor}}`;
 }

--- a/static/app/stories/tokenReference.tsx
+++ b/static/app/stories/tokenReference.tsx
@@ -75,7 +75,7 @@ function Token({
 }
 
 function formatSnippet({token, scale}: {scale: string; token: string}) {
-  const accessor = /^[0-9]/.test(token) ? `["${token}"]` : `.${token}`;
+  const accessor = /^\d/.test(token) ? `["${token}"]` : `.${token}`;
   return `\${p => p.theme.tokens.${scale}${accessor}}`;
 }
 

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -19,7 +19,7 @@ export function defined<T>(item: T): item is Exclude<T, null | undefined> {
 }
 
 export function nl2br(str: string): string {
-  return str.replace(/(?:\r\n|\r|\n)/g, '<br />');
+  return str.replace(/\r\n|\r|\n/g, '<br />');
 }
 
 export function escape(str: string): string {

--- a/static/app/utils/api/getApiUrl.ts
+++ b/static/app/utils/api/getApiUrl.ts
@@ -27,7 +27,7 @@ type PathParamOptions<TApiPath extends string> =
 export type OptionalPathParams<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never ? never[] : [PathParamOptions<TApiPath>];
 
-const paramRegex = /\$([a-zA-Z0-9_-]+)/g;
+const paramRegex = /\$([\w-]+)/g;
 
 type ApiUrl = string & {__apiUrl: true};
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -894,8 +894,8 @@ export const TRANSACTIONS_AGGREGATION_FUNCTIONS = [
 // This list contains fields/functions that are available with profiling feature.
 export const PROFILING_FIELDS: string[] = [FieldKey.PROFILE_ID];
 
-const MEASUREMENT_PATTERN = /^measurements\.([a-zA-Z0-9-_.]+)$/;
-const SPAN_OP_BREAKDOWN_PATTERN = /^spans\.([a-zA-Z0-9-_.]+)$/;
+const MEASUREMENT_PATTERN = /^measurements\.([\w-.]+)$/;
+const SPAN_OP_BREAKDOWN_PATTERN = /^spans\.([\w-.]+)$/;
 
 export function isMeasurement(field: string): boolean {
   return MEASUREMENT_PATTERN.test(field);
@@ -918,9 +918,9 @@ export function getMeasurementSlug(field: string): string | null {
   return null;
 }
 
-const AGGREGATE_PATTERN = /^(\w+)\((.*)?\)$/;
+const AGGREGATE_PATTERN = /^(\w+)\((.*)\)$/;
 // Identical to AGGREGATE_PATTERN, but without the $ for newline, or ^ for start of line
-export const AGGREGATE_BASE = /(\w+)\((.*)?\)/g;
+export const AGGREGATE_BASE = /(\w+)\((.*)\)/g;
 
 export function getAggregateArg(field: string): string | null {
   // only returns the first argument if field is an aggregate
@@ -1167,7 +1167,7 @@ export function getAggregateAlias(field: string): string {
     alias += '_' + result.arguments.join('_');
   }
 
-  return alias.replace(/[^\w]/g, '_').replace(/^_+/g, '').replace(/_+$/, '');
+  return alias.replace(/\W/g, '_').replace(/^_+/g, '').replace(/_+$/, '');
 }
 
 /**

--- a/static/app/utils/duration/getPeriod.tsx
+++ b/static/app/utils/duration/getPeriod.tsx
@@ -46,7 +46,7 @@ export function getPeriod(
     if (!shouldDoublePeriod) {
       return {statsPeriod: period};
     }
-    const [, periodNumber, periodLength] = period.match(/([0-9]+)([mhdw])/)!;
+    const [, periodNumber, periodLength] = period.match(/(\d+)([mhdw])/)!;
 
     return {statsPeriod: `${parseInt(periodNumber!, 10) * 2}${periodLength}`};
   }

--- a/static/app/utils/duration/intervalToMilliseconds.tsx
+++ b/static/app/utils/duration/intervalToMilliseconds.tsx
@@ -8,7 +8,7 @@
  */
 
 export function intervalToMilliseconds(interval: string): number {
-  const pattern = /^(\d+)(w|d|h|m)$/;
+  const pattern = /^(\d+)([wdhm])$/;
   const matches = pattern.exec(interval);
   if (!matches) {
     return 0;

--- a/static/app/utils/extractSlug.tsx
+++ b/static/app/utils/extractSlug.tsx
@@ -6,7 +6,7 @@ type ExtractedSlug = {
 // XXX: If you change this also change its sibiling in:
 // - static/index.ejs
 // - rspack.config.ts
-const KNOWN_DOMAINS = /(?:\.?)((?:localhost|dev\.getsentry\.net|sentry\.dev)(?::\d*)?)$/;
+const KNOWN_DOMAINS = /\.?((?:localhost|dev\.getsentry\.net|sentry\.dev)(?::\d*)?)$/;
 
 /**
  * Extract a slug from a known local development host.

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3588,7 +3588,7 @@ export function isDeviceClass(key: any): boolean {
 
 export const DEVICE_CLASS_TAG_VALUES = ['high', 'medium', 'low'];
 
-const TYPED_TAG_KEY_RE = /tags\[([^\s]*),([^\s]*)\]/;
+const TYPED_TAG_KEY_RE = /tags\[(\S*),(\S*)\]/;
 
 export function classifyTagKey(key: string): FieldKind {
   const result = key.match(TYPED_TAG_KEY_RE);

--- a/static/app/utils/isValidOrgSlug.tsx
+++ b/static/app/utils/isValidOrgSlug.tsx
@@ -4,7 +4,7 @@
 // See: https://bugs.webkit.org/show_bug.cgi?id=174931
 //
 // The ^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ regex should almost match the above regex.
-const ORG_SLUG_REGEX = new RegExp('^(?![0-9]+$)[a-zA-Z0-9][a-zA-Z0-9-]*$');
+const ORG_SLUG_REGEX = new RegExp('^(?!\\d+$)[a-zA-Z0-9][a-zA-Z0-9-]*$');
 
 export function isValidOrgSlug(orgSlug: string): boolean {
   return (

--- a/static/app/utils/middleEllipsis.spec.tsx
+++ b/static/app/utils/middleEllipsis.spec.tsx
@@ -22,7 +22,7 @@ describe('middleEllipsis', () => {
       middleEllipsis(
         'visual collector.console-running on_cloud.technology-task.with_luck',
         50,
-        / |\.|-|_|\s/
+        /[.\-_\s]/
       )
     ).toBe('visual collector.console…technology-task.with_luck');
   });

--- a/static/app/utils/parseLinkHeader.tsx
+++ b/static/app/utils/parseLinkHeader.tsx
@@ -15,9 +15,7 @@ export function parseLinkHeader(header: string | null): Result {
 
   headerValues.forEach(val => {
     const match =
-      /<([^>]+)>; rel="([^"]+)"(?:; results="([^"]+)")?(?:; cursor="([^"]+)")?/g.exec(
-        val
-      );
+      /<([^>]+)>; rel="([^"]+)"(?:; results="([^"]+)")?(?:; cursor="([^"]+)")?/.exec(val);
     if (!match) {
       return;
     }

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -47,7 +47,11 @@ export function appendTagCondition(
 
   if (
     typeof value === 'string' &&
-    new RegExp(TAG_VALUE_ESCAPE_PATTERN, 'g').test(value)
+    // TODO(JoshuaKGoldberg):
+    //   Unnecessary escape character: \(  regexp/no-useless-escape
+    //   Unnecessary escape character: \)  regexp/no-useless-escape
+    // eslint-disable-next-line regexp/no-useless-escape
+    new RegExp(TAG_VALUE_ESCAPE_PATTERN).test(value)
   ) {
     value = `"${escapeDoubleQuotes(value)}"`;
   }
@@ -72,7 +76,7 @@ export function appendExcludeTagValuesCondition(
       : '';
   const filteredValuesCondition = `[${values
     .map(value => {
-      if (typeof value === 'string' && /[\s"]/g.test(value)) {
+      if (typeof value === 'string' && /[\s"]/.test(value)) {
         value = `"${escapeDoubleQuotes(value)}"`;
       }
       return value;

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -72,7 +72,7 @@ function isProperlyQuoted(value: string): boolean {
 }
 
 function requiresQuotes(value: string): boolean {
-  return /[\s()\\"]/g.test(value);
+  return /[\s()\\"]/.test(value);
 }
 
 function generateFilterValue(token: Token, operator: string): string {
@@ -710,5 +710,5 @@ export function escapeFilterValue(value: string) {
   // Need to dig deeper to see where exactly it's wrong.
   //
   // astericks (*) is used for wildcard searches
-  return typeof value === 'string' ? value.replace(/([*])/g, '\\$1') : value;
+  return typeof value === 'string' ? value.replace(/(\*)/g, '\\$1') : value;
 }

--- a/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.spec.tsx
@@ -133,7 +133,7 @@ describe('RuleNode', () => {
   };
 
   const labelReplacer = (label: string, values: any) => {
-    return label.replace(/{\w+}/gm, placeholder => values[placeholder]);
+    return label.replace(/{\w+}/g, placeholder => values[placeholder]);
   };
 
   afterEach(() => {

--- a/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/thresholdControl.tsx
@@ -34,7 +34,7 @@ class ThresholdControl extends Component<Props, State> {
 
   handleThresholdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     // Only allow number and partial number inputs
-    if (!/^[0-9]*\.?[0-9]*$/.test(event.target.value)) {
+    if (!/^\d*\.?\d*$/.test(event.target.value)) {
       return;
     }
 

--- a/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
@@ -15,7 +15,7 @@ import {uniqueId} from 'sentry/utils/guid';
 /**
  * Matches characters that are not valid in a header name.
  */
-const INVALID_NAME_HEADER_REGEX = new RegExp(/[^a-zA-Z0-9_-]+/g);
+const INVALID_NAME_HEADER_REGEX = new RegExp(/[^\w-]+/g);
 
 type HeaderEntry = [id: string, name: string, value: string];
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -303,7 +303,7 @@ class DashboardDetail extends Component<Props, State> {
             const query = omit(location.query, Object.values(WidgetViewerQueryField));
             navigate(
               {
-                pathname: location.pathname.replace(/widget\/[0-9]+\/$/, ''),
+                pathname: location.pathname.replace(/widget\/\d+\/$/, ''),
                 query,
               },
               {preventScrollReset: true}

--- a/static/app/views/dashboards/manage/tableView/table.spec.tsx
+++ b/static/app/views/dashboards/manage/tableView/table.spec.tsx
@@ -104,7 +104,7 @@ describe('DashboardTable', () => {
     // matches the format of the "0ms ago" text more robustly in
     // case the timestamp does not exactly match
     const lastVisitedContent = lastVisitedCell.textContent;
-    expect(lastVisitedContent).toMatch(/[\d\w]+s ago$/);
+    expect(lastVisitedContent).toMatch(/\w+s ago$/);
   });
 
   it('renders release filters', () => {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -283,6 +283,9 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   const {start, end, period, utc} = selection.datetime;
   const {projects, environments} = selection;
 
+  // TODO(JoshuaKGoldberg):
+  //   Unexpected unnecessary non-capturing group. This group can be removed without changing the behaviour of the regex  regexp/no-useless-non-capturing-group
+  // eslint-disable-next-line regexp/no-useless-non-capturing-group
   const otherRegex = new RegExp(`(?:.* : ${OTHER}$)|^${OTHER}$`);
   const shouldColorOther = timeseriesResults?.some(({seriesName}) =>
     seriesName?.match(otherRegex)

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -45,7 +45,7 @@ export function WidgetCardConfidenceFooter({
   const selection = selectionProp ?? pageFilterSelection;
   const rawCounts = useWidgetRawCounts({selection, widget});
   const hasOtherSeries = timeseriesResults?.some(({seriesName}) =>
-    seriesName?.match(/(?:.* : Other)$|^Other$/)
+    seriesName?.match(/.* : Other$|^Other$/)
   );
 
   const topEventsCountExcludingOther =

--- a/static/app/views/detectors/components/forms/uptime/detect/uptimeHeadersField.tsx
+++ b/static/app/views/detectors/components/forms/uptime/detect/uptimeHeadersField.tsx
@@ -15,7 +15,7 @@ import {uniqueId} from 'sentry/utils/guid';
 /**
  * Matches characters that are not valid in a header name.
  */
-const INVALID_NAME_HEADER_REGEX = new RegExp(/[^a-zA-Z0-9_-]+/g);
+const INVALID_NAME_HEADER_REGEX = new RegExp(/[^\w-]+/g);
 
 type HeaderEntry = [id: string, name: string, value: string];
 

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.spec.tsx
@@ -126,7 +126,7 @@ describe('Quick Context', () => {
       await userEvent.hover(screen.getByText('Text from Child'));
 
       expect(await screen.findByText(/Release/i)).toBeInTheDocument();
-      expect(screen.getByText(/22.10.0/i)).toBeInTheDocument();
+      expect(screen.getByText(/22.10.0/)).toBeInTheDocument();
       expect(screen.getByText(/(aaf33944f93d)/i)).toBeInTheDocument();
       expect(
         screen.getByTestId('quick-context-hover-header-copy-button')

--- a/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.spec.tsx
@@ -53,7 +53,7 @@ describe('Quick Context Content Release Column', () => {
     expect(screen.getByText(/Last Event/i)).toBeInTheDocument();
     expect(screen.getByText(/6 years ago/i)).toBeInTheDocument();
     expect(screen.getByText(/New Issues/i)).toBeInTheDocument();
-    expect(screen.getByText(/21/i)).toBeInTheDocument();
+    expect(screen.getByText(/21/)).toBeInTheDocument();
   });
 
   it('Renders Last Commit', async () => {
@@ -70,9 +70,9 @@ describe('Quick Context Content Release Column', () => {
       await screen.findByTestId('quick-context-release-author-header')
     );
 
-    expect(authorsSectionHeader.getByText(/4/i)).toBeInTheDocument();
+    expect(authorsSectionHeader.getByText(/4/)).toBeInTheDocument();
     expect(authorsSectionHeader.getByText(/commits by/i)).toBeInTheDocument();
-    expect(authorsSectionHeader.getByText(/2/i)).toBeInTheDocument();
+    expect(authorsSectionHeader.getByText(/2/)).toBeInTheDocument();
     expect(authorsSectionHeader.getByText(/authors/i)).toBeInTheDocument();
     expect(screen.getByText(/KN/i)).toBeInTheDocument();
     expect(screen.getByText(/VN/i)).toBeInTheDocument();
@@ -82,7 +82,7 @@ describe('Quick Context Content Release Column', () => {
     ConfigStore.loadInitialData(ConfigFixture({user: mockedUser1}));
     renderReleaseContext();
 
-    expect(await screen.findByText(/4/i)).toBeInTheDocument();
+    expect(await screen.findByText(/4/)).toBeInTheDocument();
     expect(screen.getByText(/commits by you and 1 other/i)).toBeInTheDocument();
     expect(screen.getByText(/KN/i)).toBeInTheDocument();
     expect(screen.getByText(/VN/i)).toBeInTheDocument();

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -368,7 +368,7 @@ function generateAdditionalConditions(
       const shouldQuote =
         value === null || value === undefined
           ? false
-          : /[\s()\\"]/g.test(String(value).trim());
+          : /[\s()\\"]/.test(String(value).trim());
       const nextValue =
         value === null || value === undefined
           ? ''

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -334,7 +334,7 @@ export function usePreprodItemAttributes(
 }
 
 const TAGS_REGEX =
-  /^tags\[(?<tagKey>[a-zA-Z0-9_.:-]+),(?<attributeType>boolean|number|string)\]$/;
+  /^tags\[(?<tagKey>[\w.:-]+),(?<attributeType>boolean|number|string)\]$/;
 
 /**
  * Extracts the base key from a tag key, handling both plain keys and

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeKeys.tsx
@@ -114,8 +114,8 @@ function getTraceItemTagCollection(
     // EAP spans contain tags with illegal characters
     // SnQL forbids `-` but is allowed in RPC. So add it back later
     if (
-      !/^[a-zA-Z0-9_.:-]+$/.test(attribute.key) &&
-      !/^tags\[[a-zA-Z0-9_.:-]+,(number|boolean)\]$/.test(attribute.key)
+      !/^[\w.:-]+$/.test(attribute.key) &&
+      !/^tags\[[\w.:-]+,(number|boolean)\]$/.test(attribute.key)
     ) {
       continue;
     }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.ts
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentDetection.ts
@@ -56,7 +56,7 @@ export function tryParsePythonDict(text: string): Record<PropertyKey, unknown> |
  */
 export function parseXmlTagSegments(text: string): ContentSegment[] {
   const segments: ContentSegment[] = [];
-  const xmlTagRegex = /<([a-zA-Z][\w-]*?)>([\s\S]*?)<\/\1>/g;
+  const xmlTagRegex = /<([a-zA-Z][\w-]*)>([\s\S]*?)<\/\1>/g;
   let lastIndex = 0;
 
   for (const match of text.matchAll(xmlTagRegex)) {
@@ -78,7 +78,7 @@ export function parseXmlTagSegments(text: string): ContentSegment[] {
   return segments;
 }
 
-const XML_TAG_REGEX = /<([a-zA-Z][\w-]*?)>[\s\S]*?<\/\1>/;
+const XML_TAG_REGEX = /<([a-zA-Z][\w-]*)>[\s\S]*?<\/\1>/;
 
 const MARKDOWN_INDICATORS = [
   /^#{1,6}\s/m, // headings

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -410,7 +410,7 @@ function linkifyIssueShortIds(text: string): string {
   // Pattern matches: PROJECT_SLUG-SHORT_ID (uppercase only, case-sensitive)
   // Requires at least 2 chars before hyphen and 1+ chars after
   // First segment must contain at least one uppercase letter (all letters must be uppercase)
-  const shortIdPattern = /\b((?:[A-Z][A-Z0-9_]{1,}|[0-9_]+[A-Z][A-Z0-9_]*)-[A-Z0-9]+)\b/g;
+  const shortIdPattern = /\b((?:[A-Z][A-Z0-9_]+|[0-9_]+[A-Z][A-Z0-9_]*)-[A-Z0-9]+)\b/g;
 
   // Track positions that should be excluded (inside code blocks, links, or URLs)
   const excludedRanges: Array<{end: number; start: number}> = [];
@@ -432,7 +432,7 @@ function linkifyIssueShortIds(text: string): string {
     });
   }
   // Find all URLs (http://, https://, or starting with /)
-  const urlPattern = /(https?:\/\/[^\s]+|\/[^\s)]+)/g;
+  const urlPattern = /(https?:\/\/\S+|\/[^\s)]+)/g;
   for (const urlMatch of text.matchAll(urlPattern)) {
     excludedRanges.push({
       end: urlMatch.index + urlMatch[0].length,

--- a/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.spec.tsx
@@ -105,7 +105,7 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
       }
     );
 
-    expect(await screen.findByText(/You[''\u2019]ve exceeded your/i)).toBeInTheDocument();
+    expect(await screen.findByText(/You['\u2019]ve exceeded your/i)).toBeInTheDocument();
 
     const onDemandTexts = screen.getAllByText(/on-demand budget/i);
     expect(onDemandTexts).toHaveLength(2);
@@ -157,7 +157,7 @@ describe('Renders QuotaExceededAlert correctly for spans', () => {
       }
     );
 
-    expect(await screen.findByText(/You[''\u2019]ve exceeded your/i)).toBeInTheDocument();
+    expect(await screen.findByText(/You['\u2019]ve exceeded your/i)).toBeInTheDocument();
 
     const onDemandTexts = screen.getAllByText(/on-demand budget/i);
     expect(onDemandTexts).toHaveLength(2);

--- a/static/gsApp/utils/useReplayInit.tsx
+++ b/static/gsApp/utils/useReplayInit.tsx
@@ -58,7 +58,7 @@ export function useReplayInit() {
             'x-served-by',
           ],
           maskFn: (text: string) =>
-            isStaticString(text) ? text : text.replace(/[\S]/g, '*'),
+            isStaticString(text) ? text : text.replace(/\S/g, '*'),
 
           slowClickIgnoreSelectors: [
             '[aria-label*="download" i]',

--- a/static/gsApp/views/subscriptionPage/usageLog.tsx
+++ b/static/gsApp/views/subscriptionPage/usageLog.tsx
@@ -55,7 +55,7 @@ function LogUsername({logEntryUser}: {logEntryUser: User | undefined}) {
 }
 
 const formatEntryTitle = (name: string) => {
-  const spaceName = name.replace(/-|\./gm, ' ');
+  const spaceName = name.replace(/-|\./g, ' ');
   let capitalizeName = spaceName.replace(/(^\w)|([-\s]\w)/g, match =>
     match.toUpperCase()
   );

--- a/tests/js/sentry-test/snapshots/snapshot.ts
+++ b/tests/js/sentry-test/snapshots/snapshot.ts
@@ -134,7 +134,7 @@ export async function takeSnapshot({
 
     const relativePath = path.relative(PROJECT_ROOT, testFilePath);
     const dirOfTestFile = path.dirname(relativePath);
-    const coreFilename = fileSlug.replace(/[^a-zA-Z0-9_-]/g, '-');
+    const coreFilename = fileSlug.replace(/[^\w-]/g, '-');
     const imageFilename = `${coreFilename}.png`;
 
     const outputDir = path.join(getOutputDir(), dirOfTestFile);


### PR DESCRIPTION
Enables most of [`eslint-plugin-regexp`](https://ota-meshi.github.io/eslint-plugin-regexp)'s recommended rules internally, fixing most of the new reports. To avoid stepping into any implicitly held strong opinions, this disables any plugin rule that doesn't seem to result in immediately objectively "better" code. That'll be a fun set of followups.

[ota-meshi.github.io/eslint-plugin-regexp/rules](https://ota-meshi.github.io/eslint-plugin-regexp/rules) has all the rules in the plugin: search for 🟢 to narrow down to just those in the recommended ruleset. Out of those, these rules produced reports:

| Rule                                                                                                                                     | Description                                                                                                            |
| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| [`regexp/negation`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/negation)                                                     | switches negated character classes to more succinct equivalents, such as `/[^\d]/` -> `/\D/`                           |
| [`regexp/no-dupe-characters-character-class`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-characters-character-class) | removes characters made redundant by previous classes or ranges, such as `/[a-z\\s]/`'s `s` duplicated by `a-z`        |
| [`regexp/no-dupe-disjunctions`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-dupe-disjunctions)                             | removes disjunctions that are made redundant by a previous one, such as `/[ab]\|[ba]/`'s `[ba]` duplicating`[ab]`      |
| [`regexp/no-trivially-nested-quantifier`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-trivially-nested-quantifier)         | simplifies multiple nested quantifiers that can be merged into just one simpler one, such as `/(?:a{1,2})+/` -> `/a+/` |
| [`regexp/no-useless-character-class`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-character-class)                 | simplifies character classes that can be streamlined into just their contents, such as `/a[b]c/` -> `/abc/`            |
| [`regexp/no-useless-escape`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-escape)                                   | removes `\` escacpes that are unnecessary and don't do anything, such as `/\a/` -> `/a/`                               |
| [`regexp/no-useless-flag`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-flag)                                       | removes flags when they don't change behavior, such as `/\w+/i` -> `/\w+/`                                             |
| [`regexp/no-useless-lazy`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-lazy)                                       | removes greedy modifiers that don't change behavior, such as `/a{1}?/` -> `/a{1}/`                                     |
| [`regexp/no-useless-non-capturing-group`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group)         | inlines non-capturing groups that can be without changing behavior, such as `/(?:a)/.test(str)`->`/a/.test(str)`       |
| [`regexp/no-useless-quantifier`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-quantifier)                           | removes quantifiers that don't change behavior, such as `/a{1}/` -> `/a/`                                              |
| [`regexp/prefer-character-class`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-character-class)                         | switches explicit lists to character classes that do the same thing when possible, such as `/[a\|b\|c]/` -> `/[abc]/`  |
| [`regexp/prefer-d`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-d)                                                     | switches numeric ranges to an equivalent succinct matcher, such as `/[0-9]/` -> `/\d/`                                 |
| [`regexp/prefer-plus-quantifier`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-plus-quantifier)                         | switches `{1,}` ranges to an equivalent succinct `+` quantifier, such as `/a{1,}/` -> `/a+/`                           |
| [`regexp/prefer-question-quantifier`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-question-quantifier)                 | switches `{0,1}` ranges to an equivalent succinct `?` quantifier, such as `/a{0,}/` -> `/a?/`                          |
| [`regexp/prefer-w`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-w)                                                     | switches alphabetical ranges to an equivalent succinct matcher, such as `/[0-9a-zA-Z_]/` -> `/\w/`                     |

Fun fact: although this diff is +155 / -76, 75 of those added lines are from config/lock-files and 7 are comments. The actual impact to the codebase is +73 / -76. According to my rough character counting of files (excluding whitespace) the actual number of removed characters is ~235.

Fixes ENG-6934