### PR TITLE
fix(dashboards): Replace TOP_N display type with AREA in dashboard templates

### DIFF
--- a/static/app/views/dashboards/data.tsx
+++ b/static/app/views/dashboards/data.tsx
@@ -291,7 +291,7 @@ export const getDashboardTemplates = (organization: Organization) => {
           },
           {
             title: t('High Throughput Transactions'),
-            displayType: DisplayType.TOP_N,
+            displayType: DisplayType.AREA,
             limit: TOP_N,
             interval: '5m',
             widgetType: WidgetType.SPANS,
@@ -364,7 +364,7 @@ export const getDashboardTemplates = (organization: Organization) => {
           },
           {
             title: t('Errors by Browser Over Time'),
-            displayType: DisplayType.TOP_N,
+            displayType: DisplayType.AREA,
             limit: TOP_N,
             interval: '5m',
             widgetType: WidgetType.ERRORS,
@@ -400,7 +400,7 @@ export const getDashboardTemplates = (organization: Organization) => {
         widgets: [
           {
             title: t('Top 5 Issues by Unique Users Over Time'),
-            displayType: DisplayType.TOP_N,
+            displayType: DisplayType.AREA,
             limit: TOP_N,
             interval: '5m',
             widgetType: WidgetType.ERRORS,
@@ -783,7 +783,7 @@ export const getDashboardTemplates = (organization: Organization) => {
         widgets: [
           {
             title: t('Top 5 Issues by Unique Users Over Time'),
-            displayType: DisplayType.TOP_N,
+            displayType: DisplayType.AREA,
             interval: '5m',
             widgetType: WidgetType.ERRORS,
             tempId: uniqueId(),
@@ -808,7 +808,7 @@ export const getDashboardTemplates = (organization: Organization) => {
           },
           {
             title: t('Transactions Erroring Over Time'),
-            displayType: DisplayType.TOP_N,
+            displayType: DisplayType.AREA,
             interval: '5m',
             widgetType: WidgetType.SPANS,
             tempId: uniqueId(),
@@ -1823,7 +1823,7 @@ export const getDashboardTemplates = (organization: Organization) => {
         },
         {
           title: t('High Throughput Transactions'),
-          displayType: DisplayType.TOP_N,
+          displayType: DisplayType.AREA,
           limit: TOP_N,
           interval: '5m',
           widgetType: hasDatasetSelector(organization)
@@ -1902,7 +1902,7 @@ export const getDashboardTemplates = (organization: Organization) => {
         },
         {
           title: t('Errors by Browser Over Time'),
-          displayType: DisplayType.TOP_N,
+          displayType: DisplayType.AREA,
           limit: TOP_N,
           interval: '5m',
           widgetType: hasDatasetSelector(organization)
@@ -1942,7 +1942,7 @@ export const getDashboardTemplates = (organization: Organization) => {
       widgets: [
         {
           title: t('Top 5 Issues by Unique Users Over Time'),
-          displayType: DisplayType.TOP_N,
+          displayType: DisplayType.AREA,
           limit: TOP_N,
           interval: '5m',
           widgetType: hasDatasetSelector(organization)
@@ -2349,7 +2349,7 @@ export const getDashboardTemplates = (organization: Organization) => {
       widgets: [
         {
           title: t('Top 5 Issues by Unique Users Over Time'),
-          displayType: DisplayType.TOP_N,
+          displayType: DisplayType.AREA,
           interval: '5m',
           widgetType: hasDatasetSelector(organization)
             ? WidgetType.ERRORS
@@ -2376,7 +2376,7 @@ export const getDashboardTemplates = (organization: Organization) => {
         },
         {
           title: t('Transactions Erroring Over Time'),
-          displayType: DisplayType.TOP_N,
+          displayType: DisplayType.AREA,
           interval: '5m',
           widgetType: hasDatasetSelector(organization)
             ? WidgetType.TRANSACTIONS


### PR DESCRIPTION
Replace hardcoded `DisplayType.TOP_N` with `DisplayType.AREA` in dashboard templates. The TOP_N behavior is determined by the presence of a group by column, not the display type itself. Using `DisplayType.TOP_N` causes the widget builder to show a blank display type since it's not a selectable option in the type selector.