### PR TITLE
ref(aci): Automatically zoom metric issues to the event's open period

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -333,32 +333,40 @@ describe('MetricDetectorTriggeredSection', () => {
             pathname: `/organizations/org-slug/issues/${defaultGroup.id}/`,
             query: {},
           },
-          route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+          routes: [
+            '/organizations/:orgId/issues/:groupId/',
+            '/organizations/:orgId/issues/:groupId/events/:eventId/',
+          ],
         },
       });
 
       await screen.findByRole('region', {name: 'Triggered Condition'});
 
-      expect(router.location.pathname).toMatch(`/events/${defaultEvent.id}`);
-      expect(router.location.query.start).toBeDefined();
-      expect(router.location.query.end).toBeDefined();
-      expect(router.location.query.statsPeriod).toBeUndefined();
+      expect(router.location.pathname).toMatch(
+        `/organizations/org-slug/issues/${defaultGroup.id}/events/${defaultEvent.id}/`
+      );
+      expect(router.location.query.statsPeriod).toBeDefined();
     });
 
     it('does not apply detector zoom range when URL already has a time period', async () => {
       const {router} = render(<MetricDetectorTriggeredSection {...defaultProps} />, {
         initialRouterConfig: {
           location: {
-            pathname: `/organizations/org-slug/issues/123/events/${defaultEvent.id}/`,
+            pathname: `/organizations/org-slug/issues/${defaultGroup.id}/`,
             query: {statsPeriod: '24h'},
           },
-          route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+          routes: [
+            '/organizations/:orgId/issues/:groupId/',
+            '/organizations/:orgId/issues/:groupId/events/:eventId/',
+          ],
         },
       });
 
       await screen.findByRole('region', {name: 'Triggered Condition'});
 
-      expect(router.location.pathname).toMatch(`/events/${defaultEvent.id}/`);
+      expect(router.location.pathname).toMatch(
+        `/organizations/org-slug/issues/${defaultGroup.id}/`
+      );
       expect(router.location.query.statsPeriod).toBe('24h');
       expect(router.location.query.start).toBeUndefined();
       expect(router.location.query.end).toBeUndefined();

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -5,6 +5,7 @@ import {GroupFixture} from 'sentry-fixture/group';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {IssueCategory, IssueType} from 'sentry/types/group';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {MetricCondition} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
@@ -20,8 +21,30 @@ describe('MetricDetectorTriggeredSection', () => {
   const dataSource = SnubaQueryDataSourceFixture();
   const openPeriodStartDate = '2024-01-01T00:00:00Z';
   const openPeriodEndDate = '2024-01-01T00:05:00.000Z';
-  const defaultGroup = GroupFixture();
-  const defaultEvent = EventFixture();
+  const defaultGroup = GroupFixture({
+    issueType: IssueType.METRIC_ISSUE,
+    issueCategory: IssueCategory.METRIC,
+  });
+  const defaultEvent = EventFixture({
+    id: 'event-1',
+    eventID: 'event-1',
+    occurrence: {
+      id: '1',
+      eventId: 'event-1',
+      fingerprint: ['fingerprint'],
+      issueTitle: 'Test Issue',
+      subtitle: 'Subtitle',
+      resourceId: 'resource-1',
+      evidenceData: {
+        conditions: [condition],
+        dataSources: [dataSource],
+        value: 150,
+      },
+      evidenceDisplay: [],
+      type: 8001,
+      detectionTime: '2024-01-01T00:00:00Z',
+    },
+  });
   const defaultProps: ComponentProps<typeof MetricDetectorTriggeredSection> = {
     group: defaultGroup,
     event: defaultEvent,
@@ -300,5 +323,45 @@ describe('MetricDetectorTriggeredSection', () => {
       'href',
       '/organizations/org-slug/explore/discover/results/?dataset=errors&end=2024-01-01T00%3A05%3A00.000&field=issue&field=count%28%29&field=count_unique%28user%29&interval=1m&name=Transactions&project=1&query=event.type%3Aerror%20browser.name%3AChrome%20OR%20browser.name%3AFirefox&sort=-count&start=2023-12-31T23%3A58%3A00.000&yAxis=count%28%29'
     );
+  });
+
+  describe('zoom to open period', () => {
+    it('applies detector zoom range when URL has no time period', async () => {
+      const {router} = render(<MetricDetectorTriggeredSection {...defaultProps} />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/org-slug/issues/${defaultGroup.id}/`,
+            query: {},
+          },
+          route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        },
+      });
+
+      await screen.findByRole('region', {name: 'Triggered Condition'});
+
+      expect(router.location.pathname).toMatch(`/events/${defaultEvent.id}`);
+      expect(router.location.query.start).toBeDefined();
+      expect(router.location.query.end).toBeDefined();
+      expect(router.location.query.statsPeriod).toBeUndefined();
+    });
+
+    it('does not apply detector zoom range when URL already has a time period', async () => {
+      const {router} = render(<MetricDetectorTriggeredSection {...defaultProps} />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/org-slug/issues/123/events/${defaultEvent.id}/`,
+            query: {statsPeriod: '24h'},
+          },
+          route: '/organizations/:orgId/issues/:groupId/events/:eventId/',
+        },
+      });
+
+      await screen.findByRole('region', {name: 'Triggered Condition'});
+
+      expect(router.location.pathname).toMatch(`/events/${defaultEvent.id}/`);
+      expect(router.location.query.statsPeriod).toBe('24h');
+      expect(router.location.query.start).toBeUndefined();
+      expect(router.location.query.end).toBeUndefined();
+    });
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -138,6 +138,83 @@ function getFormattedEvaluatedValue({
 }
 
 /**
+ * Once the open period loads, this hook will set the time range to visibly center the open period.
+ * If the URL already has a time period, this hook will do nothing
+ */
+function useZoomTimeRangeToOpenPeriod({
+  eventId,
+  intervalSeconds,
+  openPeriodStart,
+  openPeriodEnd,
+}: {
+  eventId: string;
+  intervalSeconds: number | undefined;
+  openPeriodEnd: string | null;
+  openPeriodStart: string | null;
+}) {
+  const organization = useOrganization();
+  const params = useParams<{groupId: string; eventId?: string}>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const zoomTimeRangeToOpenPeriod = useEffectEvent(() => {
+    const hasTimePeriod =
+      defined(location.query.statsPeriod) ||
+      defined(location.query.start) ||
+      defined(location.query.end);
+
+    if (hasTimePeriod) {
+      return;
+    }
+
+    if (openPeriodStart) {
+      const zoomRange = computeZoomRangeMs({
+        startMs: new Date(openPeriodStart).getTime(),
+        endMs: openPeriodEnd ? new Date(openPeriodEnd).getTime() : Date.now(),
+        intervalSeconds,
+      });
+
+      const query = buildDetectorZoomQuery(location.query, zoomRange);
+
+      navigate(
+        {
+          pathname: normalizeUrl(
+            `/organizations/${organization.slug}/issues/${params.groupId}/events/${eventId}/`
+          ),
+          query,
+        },
+        {replace: true}
+      );
+    }
+  });
+
+  useEffect(() => {
+    zoomTimeRangeToOpenPeriod();
+  }, [openPeriodStart, openPeriodEnd, intervalSeconds]);
+}
+
+function ZoomToOpenPeriod({
+  eventId,
+  intervalSeconds,
+  openPeriodStart,
+  openPeriodEnd,
+}: {
+  eventId: string;
+  intervalSeconds: number | undefined;
+  openPeriodEnd: string;
+  openPeriodStart: string;
+}) {
+  useZoomTimeRangeToOpenPeriod({
+    eventId,
+    openPeriodStart,
+    openPeriodEnd,
+    intervalSeconds,
+  });
+
+  return null;
+}
+
+/**
  * Issues list does not support AND/OR in the query, but Discover does.
  */
 function BooleanLogicError({discoverUrl}: {discoverUrl: LocationDescriptor}) {
@@ -280,27 +357,6 @@ function OpenInDestinationButton({
       {destination.buttonText}
     </LinkButton>
   );
-}
-
-function ZoomToOpenPeriod({
-  eventId,
-  intervalSeconds,
-  openPeriodStart,
-  openPeriodEnd,
-}: {
-  eventId: string;
-  intervalSeconds: number | undefined;
-  openPeriodEnd: string;
-  openPeriodStart: string;
-}) {
-  useApplyMetricDetectorDefaults({
-    eventId,
-    openPeriodStart,
-    openPeriodEnd,
-    intervalSeconds,
-  });
-
-  return null;
 }
 
 function TriggeredConditionDetails({
@@ -447,62 +503,6 @@ function TriggeredConditionDetails({
 const GroupListWrapper = styled('div')`
   margin-top: ${space(1)};
 `;
-
-function useApplyMetricDetectorDefaults({
-  eventId,
-  intervalSeconds,
-  openPeriodStart,
-  openPeriodEnd,
-}: {
-  eventId: string;
-  intervalSeconds: number | undefined;
-  openPeriodEnd: string | null;
-  openPeriodStart: string | null;
-}) {
-  const organization = useOrganization();
-  const params = useParams<{groupId: string; eventId?: string}>();
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const applyDefaults = useEffectEvent(() => {
-    const hasTimePeriod =
-      defined(location.query.statsPeriod) ||
-      defined(location.query.start) ||
-      defined(location.query.end);
-
-    if (hasTimePeriod) {
-      return;
-    }
-
-    if (openPeriodStart) {
-      const zoomRange = computeZoomRangeMs({
-        startMs: new Date(openPeriodStart).getTime(),
-        endMs: openPeriodEnd ? new Date(openPeriodEnd).getTime() : Date.now(),
-        intervalSeconds,
-      });
-
-      const query = buildDetectorZoomQuery(
-        location.query,
-        zoomRange.start,
-        zoomRange.end
-      );
-
-      navigate(
-        {
-          pathname: normalizeUrl(
-            `/organizations/${organization.slug}/issues/${params.groupId}/events/${eventId}/`
-          ),
-          query,
-        },
-        {replace: true}
-      );
-    }
-  });
-
-  useEffect(() => {
-    applyDefaults();
-  }, [openPeriodStart, openPeriodEnd, intervalSeconds]);
-}
 
 export function MetricDetectorTriggeredSection({
   group,

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState} from 'react';
+import {Fragment, useEffect, useEffectEvent, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -29,7 +29,15 @@ import type {
 import {defined} from 'sentry/utils';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 import {getExactDuration} from 'sentry/utils/duration/getExactDuration';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {
+  buildDetectorZoomQuery,
+  computeZoomRangeMs,
+} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
 import {getConditionDescription} from 'sentry/views/detectors/components/details/metric/detect';
 import {getDetectorOpenInDestination} from 'sentry/views/detectors/components/details/metric/getDetectorOpenInDestination';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
@@ -274,6 +282,27 @@ function OpenInDestinationButton({
   );
 }
 
+function ZoomToOpenPeriod({
+  eventId,
+  intervalSeconds,
+  openPeriodStart,
+  openPeriodEnd,
+}: {
+  eventId: string;
+  intervalSeconds: number | undefined;
+  openPeriodEnd: string;
+  openPeriodStart: string;
+}) {
+  useApplyMetricDetectorDefaults({
+    eventId,
+    openPeriodStart,
+    openPeriodEnd,
+    intervalSeconds,
+  });
+
+  return null;
+}
+
 function TriggeredConditionDetails({
   evidenceData,
   eventDateCreated,
@@ -319,6 +348,12 @@ function TriggeredConditionDetails({
 
   return (
     <Fragment>
+      <ZoomToOpenPeriod
+        eventId={eventId}
+        intervalSeconds={snubaQuery?.timeWindow}
+        openPeriodStart={startDate}
+        openPeriodEnd={endDate}
+      />
       <InterimSection
         title="Triggered Condition"
         type="triggered_condition"
@@ -412,6 +447,62 @@ function TriggeredConditionDetails({
 const GroupListWrapper = styled('div')`
   margin-top: ${space(1)};
 `;
+
+function useApplyMetricDetectorDefaults({
+  eventId,
+  intervalSeconds,
+  openPeriodStart,
+  openPeriodEnd,
+}: {
+  eventId: string;
+  intervalSeconds: number | undefined;
+  openPeriodEnd: string | null;
+  openPeriodStart: string | null;
+}) {
+  const organization = useOrganization();
+  const params = useParams<{groupId: string; eventId?: string}>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const applyDefaults = useEffectEvent(() => {
+    const hasTimePeriod =
+      defined(location.query.statsPeriod) ||
+      defined(location.query.start) ||
+      defined(location.query.end);
+
+    if (hasTimePeriod) {
+      return;
+    }
+
+    if (openPeriodStart) {
+      const zoomRange = computeZoomRangeMs({
+        startMs: new Date(openPeriodStart).getTime(),
+        endMs: openPeriodEnd ? new Date(openPeriodEnd).getTime() : Date.now(),
+        intervalSeconds,
+      });
+
+      const query = buildDetectorZoomQuery(
+        location.query,
+        zoomRange.start,
+        zoomRange.end
+      );
+
+      navigate(
+        {
+          pathname: normalizeUrl(
+            `/organizations/${organization.slug}/issues/${params.groupId}/events/${eventId}/`
+          ),
+          query,
+        },
+        {replace: true}
+      );
+    }
+  });
+
+  useEffect(() => {
+    applyDefaults();
+  }, [openPeriodStart, openPeriodEnd, intervalSeconds]);
+}
 
 export function MetricDetectorTriggeredSection({
   group,


### PR DESCRIPTION
Closes ISWF-907

When a metric issue loads, this will look at the open period start/end times and apply time range filters so that it is centered in the chart. This is a much better user experience than the default 14 days. This will only happen if a time range isn't already present in the URL.

Before:

<img width="700" height="258" alt="CleanShot 2026-02-24 at 11 01 24" src="https://github.com/user-attachments/assets/c40c3119-9ce4-4b26-9a04-99f9c6346fbe" />

After:

<img width="687" height="252" alt="CleanShot 2026-02-24 at 11 01 01" src="https://github.com/user-attachments/assets/0d1319d9-1370-4e92-b5bc-d39fcda13ef0" />
