### PR TITLE
feat(dashboards): Register FRONTEND_ASSETS prebuilt dashboard

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -85,6 +85,7 @@ class PrebuiltDashboardId(IntEnum):
     MCP_RESOURCES = 21
     MCP_PROMPTS = 22
     LARAVEL_OVERVIEW = 23
+    FRONTEND_ASSETS = 24
 
 
 class PrebuiltDashboard(TypedDict):
@@ -193,6 +194,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.LARAVEL_OVERVIEW,
         "title": "Laravel Overview",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS,
+        "title": "Frontend Assets",
     },
 ]
 


### PR DESCRIPTION
Register a new `FRONTEND_ASSETS` prebuilt dashboard with id 24 in the `PrebuiltDashboardId` enum and `PREBUILT_DASHBOARDS` list. Backend-only change to support the upcoming frontend assets dashboard.

Followup change for frontend will be created