### PR TITLE
fix(issues): Remove border from start tour modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,5 +316,5 @@
       "current node"
     ]
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.30.2"
 }

--- a/static/app/components/tours/startTour.tsx
+++ b/static/app/components/tours/startTour.tsx
@@ -101,5 +101,6 @@ export const startTourModalCss = css`
   width: 545px;
   [role='document'] {
     box-shadow: none;
+    border: none;
   }
 `;


### PR DESCRIPTION
The "Welcome to issue details" start tour modal was displaying an
unnecessary 1px border inherited from the global modal styles. The
`startTourModalCss` override already suppressed `box-shadow`; this
adds `border: none` to the same `[role='document']` selector.