### PR TITLE
SentryApps: improve path normalization

### DIFF
--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -163,7 +163,7 @@ class ApiApplication(Model):
 
     def normalize_url(self, value):
         parts = urlparse(value)
-        decoded_path = unquote(parts.path).replace("\\", "/")
+        decoded_path = unquote(parts.path)
         normalized_path = posixpath.normpath(decoded_path)
         if normalized_path == ".":
             normalized_path = "/"

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -217,9 +217,11 @@ class ApiApplication(Model):
 
         # Then: prefix-only match (legacy behavior). Log on success.
         if not self.has_feature(ApiApplicationFeature.STRICT_REDIRECT_URI):
-            # After normalize_url, reject any redirect URI that contains a residual '%'
-            # in the path. Effectively prevent additional URL encoding.
-            if "%" in urlparse(value).path:
+            # Reject multi-layer percent-encoding: if decoding the
+            # already-decoded path changes it further, the input was
+            # double-encoded (or deeper) and must not be prefix-matched.
+            normalized_path = urlparse(value).path
+            if unquote(normalized_path) != normalized_path:
                 return False
             for ruri in normalized_ruris:
                 if value.startswith(ruri):

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -177,6 +177,12 @@ class ApiApplication(Model):
         #     https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2.3
         #   - Native apps loopback exception (RFC 8252 §8.4):
         #     https://datatracker.ietf.org/doc/html/rfc8252#section-8.4
+
+        # Capture the raw path before normalization for the double-encoding
+        # guard below.  This must happen on the unprocessed input so that
+        # quote() inside normalize_url doesn't interfere with the check.
+        raw_path = urlparse(value).path
+
         value = self.normalize_url(value)
 
         # First: exact match only (spec-compliant), no logging.
@@ -217,11 +223,11 @@ class ApiApplication(Model):
 
         # Then: prefix-only match (legacy behavior). Log on success.
         if not self.has_feature(ApiApplicationFeature.STRICT_REDIRECT_URI):
-            # Reject multi-layer percent-encoding: if decoding the
-            # already-decoded path changes it further, the input was
-            # double-encoded (or deeper) and must not be prefix-matched.
-            normalized_path = urlparse(value).path
-            if unquote(normalized_path) != normalized_path:
+            # Reject multi-layer percent-encoding by checking the raw input:
+            # decode once, then check if a second decode would change it.
+            # If so, the input was double-encoded (or deeper).
+            decoded_once = unquote(raw_path)
+            if unquote(decoded_once) != decoded_once:
                 return False
             for ruri in normalized_ruris:
                 if value.startswith(ruri):

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -1,9 +1,9 @@
 import logging
-import os
+import posixpath
 import secrets
 from enum import Enum
 from typing import Any, ClassVar, Literal, Self, TypeIs
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse
 
 import petname
 from django.contrib.postgres.fields.array import ArrayField
@@ -163,7 +163,8 @@ class ApiApplication(Model):
 
     def normalize_url(self, value):
         parts = urlparse(value)
-        normalized_path = os.path.normpath(parts.path)
+        decoded_path = unquote(parts.path).replace("\\", "/")
+        normalized_path = posixpath.normpath(decoded_path)
         if normalized_path == ".":
             normalized_path = "/"
         elif value.endswith("/") and not normalized_path.endswith("/"):
@@ -216,6 +217,10 @@ class ApiApplication(Model):
 
         # Then: prefix-only match (legacy behavior). Log on success.
         if not self.has_feature(ApiApplicationFeature.STRICT_REDIRECT_URI):
+            # After normalize_url, reject any redirect URI that contains a residual '%'
+            # in the path. Effectively prevent additional URL encoding.
+            if "%" in urlparse(value).path:
+                return False
             for ruri in normalized_ruris:
                 if value.startswith(ruri):
                     logger.warning(

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -3,7 +3,7 @@ import posixpath
 import secrets
 from enum import Enum
 from typing import Any, ClassVar, Literal, Self, TypeIs
-from urllib.parse import unquote, urlparse, urlunparse
+from urllib.parse import quote, unquote, urlparse, urlunparse
 
 import petname
 from django.contrib.postgres.fields.array import ArrayField
@@ -169,7 +169,7 @@ class ApiApplication(Model):
             normalized_path = "/"
         elif value.endswith("/") and not normalized_path.endswith("/"):
             normalized_path += "/"
-        return urlunparse(parts._replace(path=normalized_path))
+        return urlunparse(parts._replace(path=quote(normalized_path, safe="/")))
 
     def is_valid_redirect_uri(self, value):
         # Spec references:

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -47,6 +47,80 @@ class ApiApplicationTest(TestCase):
         assert not app.is_valid_redirect_uri("http://sub.example.com/path/../baz")
         assert not app.is_valid_redirect_uri("https://sub.example.com")
 
+    def test_is_valid_redirect_uri_encoded_traversal(self) -> None:
+        """Percent-encoded path traversal sequences must be resolved before comparison."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/path/path/",
+            version=0,
+        )
+
+        # Single-encoded traversal (%2e = '.')
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/%2e%2e/%2e%2e/new/path")
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/%2E%2E/%2E%2E/new/path")
+
+        # Mixed case encoding
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/%2e%2E/%2E%2e/new/path")
+
+        # Partial encoding (%2e mixed with literal dot)
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/.%2e/.%2e/new/path")
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/%2e./%2e./new/path")
+
+    def test_is_valid_redirect_uri_multi_layer_encoding(self) -> None:
+        """Double/triple percent-encoding must be fully resolved, not just one layer."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/path/path/",
+            version=0,
+        )
+
+        # Double-encoded: %252e%252e → (unquote) %2e%2e → (unquote) ..
+        assert not app.is_valid_redirect_uri(
+            "http://example.com/path/path/%252e%252e/%252e%252e/new/path"
+        )
+
+        # Triple-encoded: %25252e → %252e → %2e → .
+        assert not app.is_valid_redirect_uri(
+            "http://example.com/path/path/%25252e%25252e/%25252e%25252e/new/path"
+        )
+
+    def test_is_valid_redirect_uri_backslash_traversal(self) -> None:
+        r"""Backslash path separators (e.g. '..\') must not bypass validation."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/path/path/",
+            version=0,
+        )
+
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/..\\..\\new/path")
+
+        # Encoded backslash: %5c = '\'
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/..%5c..%5cnew/path")
+
+    def test_is_valid_redirect_uri_encoded_slash_traversal(self) -> None:
+        """Encoded forward slash (%2f) in traversal sequences must be resolved."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/path/path/",
+            version=0,
+        )
+
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/..%2f..%2fnew/path")
+
+    def test_is_valid_redirect_uri_encoded_traversal_strict(self) -> None:
+        """Encoded traversal must also be rejected in strict mode."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/path/path/",
+            version=1,
+        )
+
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/%2e%2e/%2e%2e/new/path")
+        assert not app.is_valid_redirect_uri(
+            "http://example.com/path/path/%252e%252e/%252e%252e/new/path"
+        )
+        assert not app.is_valid_redirect_uri("http://example.com/path/path/..\\..\\new/path")
+
     def test_is_valid_redirect_uri_strict_version(self) -> None:
         # In strict policy version, require exact matching (no prefix, no trailing-slash equivalence).
         app = ApiApplication.objects.create(

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -108,6 +108,32 @@ class ApiApplicationTest(TestCase):
         assert app.is_valid_redirect_uri("http://example.com/callback/deep/nested/path")
         assert not app.is_valid_redirect_uri("http://example.com/other")
 
+    def test_is_valid_redirect_uri_legitimate_encoded_characters(self) -> None:
+        """URIs with legitimately encoded characters must not be rejected."""
+        # Encoded space in registered URI
+        app_space = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/my%20app/",
+            version=0,
+        )
+        assert app_space.is_valid_redirect_uri("http://example.com/my%20app/callback")
+
+        # Non-ASCII (UTF-8 encoded) in registered URI
+        app_utf8 = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/caf%C3%A9/",
+            version=0,
+        )
+        assert app_utf8.is_valid_redirect_uri("http://example.com/caf%C3%A9/callback")
+
+        # Literal percent (%25) in registered URI
+        app_pct = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/100%25done/",
+            version=0,
+        )
+        assert app_pct.is_valid_redirect_uri("http://example.com/100%25done/callback")
+
     def test_is_valid_redirect_uri_encoded_slash_traversal(self) -> None:
         """Encoded forward slash (%2f) in traversal sequences must be resolved."""
         app = ApiApplication.objects.create(

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -84,6 +84,17 @@ class ApiApplicationTest(TestCase):
             "http://example.com/path/path/%25252e%25252e/%25252e%25252e/new/path"
         )
 
+    def test_is_valid_redirect_uri_multi_layer_encoding_after_encoded_delimiters(self) -> None:
+        """Encoded path delimiters must not bypass the multi-layer encoding guard."""
+        app = ApiApplication.objects.create(
+            owner=self.user,
+            redirect_uris="http://example.com/callback/",
+            version=0,
+        )
+
+        assert not app.is_valid_redirect_uri("http://example.com/callback/%23%252e%252e/secret")
+        assert not app.is_valid_redirect_uri("http://example.com/callback/%3f%252e%252e/secret")
+
     def test_is_valid_redirect_uri_legitimate_prefix_match_with_guard(self) -> None:
         """Clean sub-paths must still prefix-match after the double-encoding guard."""
         app = ApiApplication.objects.create(

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -67,19 +67,19 @@ class ApiApplicationTest(TestCase):
         assert not app.is_valid_redirect_uri("http://example.com/path/path/%2e./%2e./new/path")
 
     def test_is_valid_redirect_uri_multi_layer_encoding(self) -> None:
-        """Double/triple percent-encoding must be fully resolved, not just one layer."""
+        """Multi-layer percent-encoding must be rejected by the prefix match guard."""
         app = ApiApplication.objects.create(
             owner=self.user,
             redirect_uris="http://example.com/path/path/",
             version=0,
         )
 
-        # Double-encoded: %252e%252e → (unquote) %2e%2e → (unquote) ..
+        # Double-encoded: %252e%252e → (unquote) %2e%2e → rejected (residual encoding)
         assert not app.is_valid_redirect_uri(
             "http://example.com/path/path/%252e%252e/%252e%252e/new/path"
         )
 
-        # Triple-encoded: %25252e → %252e → %2e → .
+        # Triple-encoded: %25252e%25252e → (unquote) %252e%252e → rejected
         assert not app.is_valid_redirect_uri(
             "http://example.com/path/path/%25252e%25252e/%25252e%25252e/new/path"
         )

--- a/tests/sentry/models/test_apiapplication.py
+++ b/tests/sentry/models/test_apiapplication.py
@@ -84,18 +84,18 @@ class ApiApplicationTest(TestCase):
             "http://example.com/path/path/%25252e%25252e/%25252e%25252e/new/path"
         )
 
-    def test_is_valid_redirect_uri_backslash_traversal(self) -> None:
-        r"""Backslash path separators (e.g. '..\') must not bypass validation."""
+    def test_is_valid_redirect_uri_legitimate_prefix_match_with_guard(self) -> None:
+        """Clean sub-paths must still prefix-match after the double-encoding guard."""
         app = ApiApplication.objects.create(
             owner=self.user,
-            redirect_uris="http://example.com/path/path/",
+            redirect_uris="http://example.com/callback/",
             version=0,
         )
 
-        assert not app.is_valid_redirect_uri("http://example.com/path/path/..\\..\\new/path")
-
-        # Encoded backslash: %5c = '\'
-        assert not app.is_valid_redirect_uri("http://example.com/path/path/..%5c..%5cnew/path")
+        assert app.is_valid_redirect_uri("http://example.com/callback/")
+        assert app.is_valid_redirect_uri("http://example.com/callback/extra")
+        assert app.is_valid_redirect_uri("http://example.com/callback/deep/nested/path")
+        assert not app.is_valid_redirect_uri("http://example.com/other")
 
     def test_is_valid_redirect_uri_encoded_slash_traversal(self) -> None:
         """Encoded forward slash (%2f) in traversal sequences must be resolved."""
@@ -119,7 +119,6 @@ class ApiApplicationTest(TestCase):
         assert not app.is_valid_redirect_uri(
             "http://example.com/path/path/%252e%252e/%252e%252e/new/path"
         )
-        assert not app.is_valid_redirect_uri("http://example.com/path/path/..\\..\\new/path")
 
     def test_is_valid_redirect_uri_strict_version(self) -> None:
         # In strict policy version, require exact matching (no prefix, no trailing-slash equivalence).


### PR DESCRIPTION
Bypasses around our path normalization allowed for path traversal in redirect_uri's. 
- Switched from os to posixpath since url paths are always forward-slash and we don't need to worry about Windows. 
- Allow for only one layer of URL encoding
- Regression tests