### PR TITLE
fix(issues): Remove border from start tour modal

### DIFF
--- a/static/app/components/tours/startTour.tsx
+++ b/static/app/components/tours/startTour.tsx
@@ -101,5 +101,6 @@ export const startTourModalCss = css`
   width: 545px;
   [role='document'] {
     box-shadow: none;
+    border: none;
   }
 `;


### PR DESCRIPTION
The tour modal was displaying an unnecessary 1px border from the global modal styles. Suppress it via the existing startTourModalCss override.

<img width="534" height="482" alt="image" src="https://github.com/user-attachments/assets/241f8f32-1f30-4d10-ba46-a493a2dcfe33" />

https://sentry.slack.com/archives/CQDHVRS2W/p1771959211671979