### PR TITLE
ref(seer): Migrate explorer to urllib3 connection pools

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -24,7 +24,7 @@ from sentry.seer.explorer.on_completion_hook import (
     ExplorerOnCompletionHook,
     extract_hook_definition,
 )
-from sentry.seer.models import SeerPermissionError
+from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User
@@ -306,7 +306,7 @@ class SeerExplorerClient:
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
         result = response.json()
         return result["run_id"]
 
@@ -383,7 +383,7 @@ class SeerExplorerClient:
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
         result = response.json()
         return result["run_id"]
 
@@ -469,7 +469,7 @@ class SeerExplorerClient:
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
         result = response.json()
 
         runs = [ExplorerRun(**run) for run in result.get("data", [])]
@@ -518,7 +518,7 @@ class SeerExplorerClient:
             body,
         )
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         # Poll until PR creation completes
         start_time = time.time()

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -11,10 +11,10 @@ from rest_framework.request import Request
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.seer.autofix.utils import autofix_connection_pool
 from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
+    explorer_connection_pool,
     fetch_run_status,
     poll_until_done,
 )
@@ -300,7 +300,7 @@ class SeerExplorerClient:
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
         response = make_signed_seer_api_request(
-            autofix_connection_pool,
+            explorer_connection_pool,
             path,
             body,
         )
@@ -377,7 +377,7 @@ class SeerExplorerClient:
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
         response = make_signed_seer_api_request(
-            autofix_connection_pool,
+            explorer_connection_pool,
             path,
             body,
         )
@@ -463,7 +463,7 @@ class SeerExplorerClient:
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
         response = make_signed_seer_api_request(
-            autofix_connection_pool,
+            explorer_connection_pool,
             path,
             body,
         )
@@ -513,7 +513,7 @@ class SeerExplorerClient:
         }
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
         response = make_signed_seer_api_request(
-            autofix_connection_pool,
+            explorer_connection_pool,
             path,
             body,
         )

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -242,7 +242,7 @@ class SeerExplorerClient:
             int: The run ID that can be used to fetch results or continue the conversation
 
         Raises:
-            requests.HTTPError: If the Seer API request fails
+            SeerApiError: If the Seer API request fails
             ValueError: If artifact_schema is provided without artifact_key
         """
         if bool(artifact_schema) != bool(artifact_key):
@@ -339,7 +339,7 @@ class SeerExplorerClient:
             int: The run ID (same as input)
 
         Raises:
-            requests.HTTPError: If the Seer API request fails
+            SeerApiError: If the Seer API request fails
             ValueError: If artifact_schema is provided without artifact_key
         """
         if bool(artifact_schema) != bool(artifact_key):
@@ -407,7 +407,7 @@ class SeerExplorerClient:
             SeerRunState: State object with blocks, status, and reconstructed artifacts.
 
         Raises:
-            requests.HTTPError: If the Seer API request fails
+            SeerApiError: If the Seer API request fails
             TimeoutError: If polling exceeds poll_timeout when blocking=True
         """
         if blocking:
@@ -440,7 +440,7 @@ class SeerExplorerClient:
             list[ExplorerRun]: List of runs matching the filters, sorted by most recent first
 
         Raises:
-            requests.HTTPError: If the Seer API request fails
+            SeerApiError: If the Seer API request fails
         """
         path = "/v1/automation/explorer/runs"
 
@@ -499,7 +499,7 @@ class SeerExplorerClient:
 
         Raises:
             TimeoutError: If polling exceeds timeout
-            requests.HTTPError: If the Seer API request fails
+            SeerApiError: If the Seer API request fails
         """
         # Trigger PR creation
         path = "/v1/automation/explorer/update"

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -5,14 +5,13 @@ import time
 from typing import Any, Literal
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from pydantic import BaseModel
 from rest_framework.request import Request
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.seer.autofix.utils import autofix_connection_pool
 from sentry.seer.explorer.client_models import ExplorerRun, SeerRunState
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
@@ -27,7 +26,7 @@ from sentry.seer.explorer.on_completion_hook import (
 )
 from sentry.seer.models import SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -300,16 +299,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
         return result["run_id"]
 
@@ -379,16 +376,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
         return result["run_id"]
 
@@ -467,16 +462,14 @@ class SeerExplorerClient:
 
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         result = response.json()
 
         runs = [ExplorerRun(**run) for run in result.get("data", [])]
@@ -519,15 +512,13 @@ class SeerExplorerClient:
             },
         }
         body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            autofix_connection_pool,
+            path,
+            body,
         )
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         # Poll until PR creation completes
         start_time = time.time()

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -12,8 +12,6 @@ import time
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 
@@ -22,9 +20,10 @@ from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
+from sentry.seer.autofix.utils import autofix_connection_pool
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User as SentryUser
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user_option import user_option_service
@@ -131,16 +130,14 @@ def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        autofix_connection_pool,
+        path,
+        body,
     )
 
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     data = response.json()
 
     session = data.get("session")

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -23,6 +23,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.seer.explorer.client_models import SeerRunState
+from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User as SentryUser
@@ -142,7 +143,7 @@ def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
     )
 
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     data = response.json()
 
     session = data.get("session")

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 
 import orjson
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 
@@ -20,7 +21,7 @@ from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
-from sentry.seer.autofix.utils import autofix_connection_pool
+from sentry.net.http import connection_from_url
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
@@ -30,6 +31,10 @@ from sentry.users.services.user_option import user_option_service
 from sentry.users.services.user_option.service import get_option_from_list
 
 logger = logging.getLogger(__name__)
+
+explorer_connection_pool = connection_from_url(
+    settings.SEER_AUTOFIX_URL,
+)
 
 
 def has_seer_explorer_access_with_detail(
@@ -131,7 +136,7 @@ def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
     )
 
     response = make_signed_seer_api_request(
-        autofix_connection_pool,
+        explorer_connection_pool,
         path,
         body,
     )

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -650,7 +650,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
     def test_push_changes_sends_correct_payload(self, mock_post, mock_fetch, mock_access):
         """Test that push_changes sends correct payload"""
         mock_access.return_value = (True, None)
-        mock_post.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status=200)
         mock_fetch.return_value = SeerRunState(
             run_id=123,
             blocks=[],
@@ -683,7 +683,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
     ):
         """Test that push_changes polls until PR creation completes"""
         mock_access.return_value = (True, None)
-        mock_post.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status=200)
 
         creating_state = SeerRunState(
             run_id=123,
@@ -720,7 +720,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
     def test_push_changes_timeout(self, mock_time, mock_sleep, mock_post, mock_fetch, mock_access):
         """Test that push_changes raises TimeoutError after timeout"""
         mock_access.return_value = (True, None)
-        mock_post.return_value = MagicMock()
+        mock_post.return_value = MagicMock(status=200)
         mock_fetch.return_value = SeerRunState(
             run_id=123,
             blocks=[],

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -13,7 +13,7 @@ from sentry.seer.explorer.client_models import (
     RepoPRState,
     SeerRunState,
 )
-from sentry.seer.models import SeerPermissionError
+from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import make_request
 
@@ -122,7 +122,7 @@ class TestSeerExplorerClient(TestCase):
         mock_post.return_value.status = 500
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(Exception):
+        with pytest.raises(SeerApiError):
             client.start_run("Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
@@ -245,7 +245,7 @@ class TestSeerExplorerClient(TestCase):
         mock_post.return_value.status = 500
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(Exception):
+        with pytest.raises(SeerApiError):
             client.continue_run(123, "Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
@@ -293,10 +293,10 @@ class TestSeerExplorerClient(TestCase):
     def test_get_run_http_error(self, mock_fetch, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
-        mock_fetch.side_effect = Exception("API Error")
+        mock_fetch.side_effect = SeerApiError("API Error", 500)
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(Exception):
+        with pytest.raises(SeerApiError):
             client.get_run(123)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import orjson
 import pytest
-import requests
 from pydantic import BaseModel
 
 from sentry.seer.explorer.client import SeerExplorerClient
@@ -60,7 +59,7 @@ class TestSeerExplorerClient(TestCase):
         assert client.enable_coding is True
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_basic(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run collects user context"""
@@ -68,6 +67,7 @@ class TestSeerExplorerClient(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -78,7 +78,7 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_request(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run passes request object to collect_user_org_context"""
@@ -86,6 +86,7 @@ class TestSeerExplorerClient(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -97,12 +98,13 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_start_run_with_optional_params(self, mock_post, mock_access):
         """Test starting a run with optional parameters"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 789}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -113,18 +115,18 @@ class TestSeerExplorerClient(TestCase):
         assert call_args is not None
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_start_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
-        mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("API Error")
+        mock_post.return_value.status = 500
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(Exception):
             client.start_run("Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_categories(self, mock_collect_context, mock_post, mock_access):
         """Test starting a run with category fields"""
@@ -132,6 +134,7 @@ class TestSeerExplorerClient(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 999}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(
@@ -140,7 +143,7 @@ class TestSeerExplorerClient(TestCase):
         run_id = client.start_run("Fix bug")
 
         assert run_id == 999
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
@@ -181,7 +184,7 @@ class TestSeerExplorerClient(TestCase):
         assert client.intelligence_level == "medium"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_includes_intelligence_level(
         self, mock_collect_context, mock_post, mock_access
@@ -191,22 +194,24 @@ class TestSeerExplorerClient(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 555}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user, intelligence_level="low")
         run_id = client.start_run("Test query")
 
         assert run_id == 555
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["intelligence_level"] == "low"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_continue_run_basic(self, mock_post, mock_access):
         """Test continuing an existing run"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 456}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -216,12 +221,13 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_continue_run_with_all_params(self, mock_post, mock_access):
         """Test continuing a run with all optional parameters"""
         mock_access.return_value = (True, None)
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 789}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -232,14 +238,14 @@ class TestSeerExplorerClient(TestCase):
         assert call_args is not None
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_continue_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
-        mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("API Error")
+        mock_post.return_value.status = 500
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(Exception):
             client.continue_run(123, "Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
@@ -287,14 +293,14 @@ class TestSeerExplorerClient(TestCase):
     def test_get_run_http_error(self, mock_fetch, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
-        mock_fetch.side_effect = requests.HTTPError("API Error")
+        mock_fetch.side_effect = Exception("API Error")
 
         client = SeerExplorerClient(self.organization, self.user)
-        with pytest.raises(requests.HTTPError):
+        with pytest.raises(Exception):
             client.get_run(123)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_get_runs_basic(self, mock_post, mock_access):
         """Test getting runs with filters"""
         mock_access.return_value = (True, None)
@@ -311,6 +317,7 @@ class TestSeerExplorerClient(TestCase):
                 }
             ]
         }
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         client = SeerExplorerClient(self.organization, self.user)
@@ -318,7 +325,7 @@ class TestSeerExplorerClient(TestCase):
 
         assert len(runs) == 1
         assert runs[0].category_key == "bug-fixer"
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
@@ -332,7 +339,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         self.organization = self.create_organization(owner=self.user)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
         """Test that artifact key and schema are serialized and sent to API"""
@@ -340,6 +347,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         class IssueAnalysis(BaseModel):
@@ -354,7 +362,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         assert run_id == 123
 
         # Verify artifact_key and artifact_schema were included in payload
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["artifact_key"] == "analysis"
         assert "artifact_schema" in body
         assert body["artifact_schema"]["type"] == "object"
@@ -362,7 +370,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         assert "severity" in body["artifact_schema"]["properties"]
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_start_run_artifact_schema_requires_key(self, mock_post, mock_access):
         """Test that artifact_schema without artifact_key raises ValueError"""
         mock_access.return_value = (True, None)
@@ -377,7 +385,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
             client.start_run("Analyze", artifact_schema=IssueAnalysis)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_continue_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
         """Test continuing a run with a new artifact key and schema"""
@@ -385,6 +393,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 123}
+        mock_response.status = 200
         mock_post.return_value = mock_response
 
         class Solution(BaseModel):
@@ -398,14 +407,14 @@ class TestSeerExplorerClientArtifacts(TestCase):
 
         assert run_id == 123
 
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["artifact_key"] == "solution"
         assert "artifact_schema" in body
         assert body["artifact_schema"]["type"] == "object"
         assert "description" in body["artifact_schema"]["properties"]
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_continue_run_artifact_schema_requires_key(self, mock_post, mock_access):
         """Test that artifact_schema without artifact_key raises ValueError"""
         mock_access.return_value = (True, None)
@@ -637,7 +646,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     def test_push_changes_sends_correct_payload(self, mock_post, mock_fetch, mock_access):
         """Test that push_changes sends correct payload"""
         mock_access.return_value = (True, None)
@@ -659,7 +668,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
         client = SeerExplorerClient(self.organization, self.user, enable_coding=True)
         result = client.push_changes(123, repo_name="owner/repo")
 
-        body = orjson.loads(mock_post.call_args[1]["data"])
+        body = orjson.loads(mock_post.call_args[0][2])
         assert body["run_id"] == 123
         assert body["payload"]["type"] == "create_pr"
         assert body["payload"]["repo_name"] == "owner/repo"
@@ -667,7 +676,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.time.sleep")
     def test_push_changes_polls_until_complete(
         self, mock_sleep, mock_post, mock_fetch, mock_access
@@ -705,7 +714,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.requests.post")
+    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
     @patch("sentry.seer.explorer.client.time.sleep")
     @patch("sentry.seer.explorer.client.time.time")
     def test_push_changes_timeout(self, mock_time, mock_sleep, mock_post, mock_fetch, mock_access):


### PR DESCRIPTION
Migrates all Seer Explorer API calls from `requests.post` + `sign_with_seer_secret` to the canonical `make_signed_seer_api_request` with urllib3 connection pools, using `autofix_connection_pool`.

This is the explorer counterpart to #109205 which did the same for autofix and summarization. Consolidating on `make_signed_seer_api_request` gives us a single canonical way to call Seer with consistent request signing, connection pooling, and error handling across all callers.

The test updates reflect the new response interface: urllib3's `BaseHTTPResponse` uses `.status` (int) instead of requests' `.status_code`, and error checking is now `response.status >= 400` instead of `.raise_for_status()`.