### PR TITLE
perf(issues): Add select_related("project") to by_qualified_short_id_bulk

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -363,13 +363,17 @@ class GroupManager(BaseManager["Group"]):
             ],
         )
 
-        base_group_queryset = self.exclude(
-            status__in=[
-                GroupStatus.PENDING_DELETION,
-                GroupStatus.DELETION_IN_PROGRESS,
-                GroupStatus.PENDING_MERGE,
-            ]
-        ).filter(project__organization=organization_id)
+        base_group_queryset = (
+            self.exclude(
+                status__in=[
+                    GroupStatus.PENDING_DELETION,
+                    GroupStatus.DELETION_IN_PROGRESS,
+                    GroupStatus.PENDING_MERGE,
+                ]
+            )
+            .filter(project__organization=organization_id)
+            .select_related("project")
+        )
 
         groups = list(base_group_queryset.filter(short_id_lookup))
         group_lookup: set[int] = {group.short_id for group in groups}


### PR DESCRIPTION
Bulk issue updates via short ID (e.g. `PROJECT-123`) were hitting N extra project queries, one per group. The integer ID path already had `select_related("project")`; this adds the same to the short ID path.

`by_qualified_short_id_bulk` is called from `get_groups_by_id` in the bulk issue update flow. The caller immediately builds a project lookup via `{g.project_id: g.project for g in groups}`, which is what triggers the extra queries without the prefetch.

Refs https://github.com/getsentry/sentry/pull/109152