### PR TITLE
chore(context engine): Keep 1 kill switch option for all of context engine indexing

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1143,9 +1143,9 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Explorer service map options
+# Explorer context engine indexing options
 register(
-    "explorer.service_map.enable",
+    "explorer.context_engine_indexing.enable",
     default=False,
     type=Bool,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/tasks/explorer_context_engine_tasks.py
+++ b/src/sentry/tasks/explorer_context_engine_tasks.py
@@ -145,10 +145,6 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
         extra={"org_id": organization_id},
     )
 
-    if not options.get("explorer.service_map.enable"):
-        logger.info("explorer.service_map.enable flag is disabled")
-        return
-
     try:
         organization = Organization.objects.get(id=organization_id)
         projects = list(
@@ -210,6 +206,10 @@ def schedule_context_engine_indexing_tasks() -> None:
     option and dispatches index_org_project_knowledge and build_service_map
     for each org.
     """
+    if not options.get("explorer.context_engine_indexing.enable"):
+        logger.info("explorer.context_engine_indexing.enable flag is disabled")
+        return
+
     allowed_org_ids = options.get("explorer.service_map.allowed_organizations")
     if not allowed_org_ids:
         logger.info("No allowed organizations for context engine indexing")

--- a/src/sentry/tasks/explorer_context_engine_tasks.py
+++ b/src/sentry/tasks/explorer_context_engine_tasks.py
@@ -44,6 +44,10 @@ def index_org_project_knowledge(org_id: int) -> None:
     For a given org, list active projects, assemble project metadata and call
     the Seer endpoint to generate LLM summaries and embeddings.
     """
+    if not options.get("explorer.context_engine_indexing.enable"):
+        logger.info("explorer.context_engine_indexing.enable flag is disabled")
+        return
+
     projects = list(
         Project.objects.filter(organization_id=org_id, status=ObjectStatus.ACTIVE).select_related(
             "organization"
@@ -140,6 +144,10 @@ def build_service_map(organization_id: int, *args, **kwargs) -> None:
     Args:
         organization_id: Organization ID to build map for
     """
+    if not options.get("explorer.context_engine_indexing.enable"):
+        logger.info("explorer.context_engine_indexing.enable flag is disabled")
+        return
+
     logger.info(
         "Starting service map build",
         extra={"org_id": organization_id},

--- a/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
+++ b/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
@@ -67,14 +67,13 @@ class TestSendToSeer(TestCase):
 
 @django_db_all
 class TestBuildServiceMap(TestCase):
-    def test_respects_enable_flag(self):
+    def test_handles_no_projects(self):
         org = self.create_organization()
 
-        with override_options({"explorer.service_map.enable": False}):
-            with mock.patch(
-                "sentry.tasks.explorer_context_engine_tasks._query_service_dependencies"
-            ) as mock_query:
-                build_service_map(org.id)
+        with mock.patch(
+            "sentry.tasks.explorer_context_engine_tasks._query_service_dependencies"
+        ) as mock_query:
+            build_service_map(org.id)
 
         mock_query.assert_not_called()
 
@@ -89,8 +88,7 @@ class TestBuildServiceMap(TestCase):
             {"source_project_id": project1.id, "target_project_id": project2.id, "count": 10}
         ]
 
-        with override_options({"explorer.service_map.enable": True}):
-            build_service_map(org.id)
+        build_service_map(org.id)
 
         mock_dependencies.assert_called_once()
         snuba_params = mock_dependencies.call_args[0][0]
@@ -103,11 +101,8 @@ class TestBuildServiceMap(TestCase):
 
         mock_dependencies.return_value = []
 
-        with override_options({"explorer.service_map.enable": True}):
-            with mock.patch(
-                "sentry.tasks.explorer_context_engine_tasks._send_to_seer"
-            ) as mock_send:
-                build_service_map(org.id)
+        with mock.patch("sentry.tasks.explorer_context_engine_tasks._send_to_seer") as mock_send:
+            build_service_map(org.id)
 
         mock_send.assert_not_called()
 
@@ -117,8 +112,7 @@ class TestBuildServiceMap(TestCase):
 
         mock_dependencies.side_effect = Exception("Test error")
 
-        with override_options({"explorer.service_map.enable": True}):
-            build_service_map(org.id)
+        build_service_map(org.id)
 
 
 @django_db_all
@@ -962,7 +956,6 @@ class TestBuildServiceMapIntegration(SnubaTestCase, SpanTestCase):
 
     def test_complete_workflow_realistic_topology(self):
         """Test complete workflow with realistic multi-service topology"""
-        from sentry.testutils.helpers.options import override_options
 
         # Setup realistic topology: frontend → api → [database, cache]
         project_frontend = self.create_project(organization=self.organization, slug="frontend")
@@ -1083,7 +1076,6 @@ class TestBuildServiceMapIntegration(SnubaTestCase, SpanTestCase):
         with mock.patch("sentry.tasks.explorer_context_engine_tasks._send_to_seer") as mock_send:
             with override_options(
                 {
-                    "explorer.service_map.enable": True,
                     "explorer.service_map.max_edges": 5000,
                 }
             ):

--- a/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
+++ b/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
@@ -70,10 +70,11 @@ class TestBuildServiceMap(TestCase):
     def test_handles_no_projects(self):
         org = self.create_organization()
 
-        with mock.patch(
-            "sentry.tasks.explorer_context_engine_tasks._query_service_dependencies"
-        ) as mock_query:
-            build_service_map(org.id)
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with mock.patch(
+                "sentry.tasks.explorer_context_engine_tasks._query_service_dependencies"
+            ) as mock_query:
+                build_service_map(org.id)
 
         mock_query.assert_not_called()
 
@@ -88,7 +89,8 @@ class TestBuildServiceMap(TestCase):
             {"source_project_id": project1.id, "target_project_id": project2.id, "count": 10}
         ]
 
-        build_service_map(org.id)
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            build_service_map(org.id)
 
         mock_dependencies.assert_called_once()
         snuba_params = mock_dependencies.call_args[0][0]
@@ -101,8 +103,11 @@ class TestBuildServiceMap(TestCase):
 
         mock_dependencies.return_value = []
 
-        with mock.patch("sentry.tasks.explorer_context_engine_tasks._send_to_seer") as mock_send:
-            build_service_map(org.id)
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with mock.patch(
+                "sentry.tasks.explorer_context_engine_tasks._send_to_seer"
+            ) as mock_send:
+                build_service_map(org.id)
 
         mock_send.assert_not_called()
 
@@ -112,7 +117,8 @@ class TestBuildServiceMap(TestCase):
 
         mock_dependencies.side_effect = Exception("Test error")
 
-        build_service_map(org.id)
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            build_service_map(org.id)
 
 
 @django_db_all
@@ -1076,6 +1082,7 @@ class TestBuildServiceMapIntegration(SnubaTestCase, SpanTestCase):
         with mock.patch("sentry.tasks.explorer_context_engine_tasks._send_to_seer") as mock_send:
             with override_options(
                 {
+                    "explorer.context_engine_indexing.enable": True,
                     "explorer.service_map.max_edges": 5000,
                 }
             ):

--- a/tests/sentry/tasks/test_explorer_context_engine_tasks.py
+++ b/tests/sentry/tasks/test_explorer_context_engine_tasks.py
@@ -27,22 +27,24 @@ class TestIndexOrgProjectKnowledge(TestCase):
 
     def test_returns_early_when_no_projects_found(self):
         org_without_projects = self.create_organization()
-        with mock.patch(
-            "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects"
-        ) as mock_counts:
-            index_org_project_knowledge(org_without_projects.id)
-            mock_counts.assert_not_called()
+        with override_options({"explorer.context_engine_indexing.enable": True}):
+            with mock.patch(
+                "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects"
+            ) as mock_counts:
+                index_org_project_knowledge(org_without_projects.id)
+                mock_counts.assert_not_called()
 
     def test_returns_early_when_no_high_volume_projects(self):
-        with mock.patch(
-            "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
-            return_value={},
-        ):
+        with override_options({"explorer.context_engine_indexing.enable": True}):
             with mock.patch(
-                "sentry.tasks.explorer_context_engine_tasks.requests.post"
-            ) as mock_post:
-                index_org_project_knowledge(self.org.id)
-                mock_post.assert_not_called()
+                "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
+                return_value={},
+            ):
+                with mock.patch(
+                    "sentry.tasks.explorer_context_engine_tasks.requests.post"
+                ) as mock_post:
+                    index_org_project_knowledge(self.org.id)
+                    mock_post.assert_not_called()
 
     @responses.activate
     def test_calls_seer_endpoint_with_correct_payload(self):
@@ -57,27 +59,28 @@ class TestIndexOrgProjectKnowledge(TestCase):
             self.project.id: ProjectEventCounts(error_count=5000, transaction_count=2000)
         }
 
-        with mock.patch(
-            "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
-            return_value=event_counts,
-        ):
+        with override_options({"explorer.context_engine_indexing.enable": True}):
             with mock.patch(
-                "sentry.tasks.explorer_context_engine_tasks.get_top_transactions_for_org_projects",
-                return_value={self.project.id: ["GET /api/0/projects/"]},
+                "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
+                return_value=event_counts,
             ):
                 with mock.patch(
-                    "sentry.tasks.explorer_context_engine_tasks.get_top_span_ops_for_org_projects",
-                    return_value={self.project.id: [("db", "SELECT * FROM table")]},
+                    "sentry.tasks.explorer_context_engine_tasks.get_top_transactions_for_org_projects",
+                    return_value={self.project.id: ["GET /api/0/projects/"]},
                 ):
                     with mock.patch(
-                        "sentry.tasks.explorer_context_engine_tasks.get_sdk_names_for_org_projects",
-                        return_value={self.project.id: "sentry.python"},
+                        "sentry.tasks.explorer_context_engine_tasks.get_top_span_ops_for_org_projects",
+                        return_value={self.project.id: [("db", "SELECT * FROM table")]},
                     ):
                         with mock.patch(
-                            "sentry.tasks.explorer_context_engine_tasks.sign_with_seer_secret",
-                            return_value={},
+                            "sentry.tasks.explorer_context_engine_tasks.get_sdk_names_for_org_projects",
+                            return_value={self.project.id: "sentry.python"},
                         ):
-                            index_org_project_knowledge(self.org.id)
+                            with mock.patch(
+                                "sentry.tasks.explorer_context_engine_tasks.sign_with_seer_secret",
+                                return_value={},
+                            ):
+                                index_org_project_knowledge(self.org.id)
 
         assert len(responses.calls) == 1
         body = orjson.loads(responses.calls[0].request.body)
@@ -104,30 +107,31 @@ class TestIndexOrgProjectKnowledge(TestCase):
             status=500,
         )
 
-        with mock.patch(
-            "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
-            return_value={
-                self.project.id: ProjectEventCounts(error_count=5000, transaction_count=2000)
-            },
-        ):
+        with override_options({"explorer.context_engine_indexing.enable": True}):
             with mock.patch(
-                "sentry.tasks.explorer_context_engine_tasks.get_top_transactions_for_org_projects",
-                return_value={},
+                "sentry.tasks.explorer_context_engine_tasks.get_event_counts_for_org_projects",
+                return_value={
+                    self.project.id: ProjectEventCounts(error_count=5000, transaction_count=2000)
+                },
             ):
                 with mock.patch(
-                    "sentry.tasks.explorer_context_engine_tasks.get_top_span_ops_for_org_projects",
+                    "sentry.tasks.explorer_context_engine_tasks.get_top_transactions_for_org_projects",
                     return_value={},
                 ):
                     with mock.patch(
-                        "sentry.tasks.explorer_context_engine_tasks.get_sdk_names_for_org_projects",
+                        "sentry.tasks.explorer_context_engine_tasks.get_top_span_ops_for_org_projects",
                         return_value={},
                     ):
                         with mock.patch(
-                            "sentry.tasks.explorer_context_engine_tasks.sign_with_seer_secret",
+                            "sentry.tasks.explorer_context_engine_tasks.get_sdk_names_for_org_projects",
                             return_value={},
                         ):
-                            with pytest.raises(Exception):
-                                index_org_project_knowledge(self.org.id)
+                            with mock.patch(
+                                "sentry.tasks.explorer_context_engine_tasks.sign_with_seer_secret",
+                                return_value={},
+                            ):
+                                with pytest.raises(Exception):
+                                    index_org_project_knowledge(self.org.id)
 
 
 @django_db_all

--- a/tests/sentry/tasks/test_explorer_context_engine_tasks.py
+++ b/tests/sentry/tasks/test_explorer_context_engine_tasks.py
@@ -140,7 +140,12 @@ class TestScheduleContextEngineIndexingTasks(TestCase):
         org1 = self.create_organization()
         org2 = self.create_organization()
 
-        with override_options({"explorer.service_map.allowed_organizations": [org1.id, org2.id]}):
+        with override_options(
+            {
+                "explorer.context_engine_indexing.enable": True,
+                "explorer.service_map.allowed_organizations": [org1.id, org2.id],
+            }
+        ):
             schedule_context_engine_indexing_tasks()
 
         assert mock_index.call_count == 2
@@ -153,7 +158,12 @@ class TestScheduleContextEngineIndexingTasks(TestCase):
         "sentry.tasks.explorer_context_engine_tasks.index_org_project_knowledge.apply_async"
     )
     def test_noop_when_no_allowed_orgs(self, mock_index, mock_build):
-        with override_options({"explorer.service_map.allowed_organizations": []}):
+        with override_options(
+            {
+                "explorer.context_engine_indexing.enable": True,
+                "explorer.service_map.allowed_organizations": [],
+            }
+        ):
             schedule_context_engine_indexing_tasks()
 
         mock_index.assert_not_called()


### PR DESCRIPTION
## PR Details
+ Renames explorer.service_map.enable to explorer.context_engine_indexing.enable and moves the kill switch from build_service_map to schedule_context_engine_indexing_tasks, so disabling it prevents all context engine indexing tasks (both project knowledge indexing and service map building) from being dispatched. 
+ Updates tests accordingly.