### PR TITLE
chore(aci): Update metric issue threshold copy

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -5,8 +5,9 @@ import * as Sentry from '@sentry/react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
 
 import type {Indicator} from 'sentry/actionCreators/indicator';
@@ -1427,6 +1428,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       dataset,
       traceItemType
     );
+    const showWorkflowEngineMetricIssueUi = organization.features.includes(
+      'workflow-engine-metric-issue-ui'
+    );
 
     // Rendering the main form body
     return (
@@ -1531,31 +1535,45 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
 
                   <AlertListItem>
                     {
-                      <Flex align="center" gap="sm">
-                        {t('Set thresholds')}
-                        {showExtrapolationModeChangeWarning && (
-                          <WarningIcon
-                            tooltipProps={{
-                              title: tct(
-                                'Your thresholds may need to be adjusted to take into account [samplingLink:sampling].',
-                                {
-                                  samplingLink: (
-                                    <ExternalLink
-                                      href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
-                                      openInNewTab
-                                    />
-                                  ),
-                                }
-                              ),
-                              isHoverable: true,
-                            }}
-                            id="thresholds-warning-icon"
-                          />
-                        )}
-                      </Flex>
+                      <div>
+                        <Flex align="center" gap="sm">
+                          {showWorkflowEngineMetricIssueUi
+                            ? t('Set issue detection thresholds')
+                            : t('Set thresholds')}
+
+                          {showExtrapolationModeChangeWarning && (
+                            <WarningIcon
+                              tooltipProps={{
+                                title: tct(
+                                  'Your thresholds may need to be adjusted to take into account [samplingLink:sampling].',
+                                  {
+                                    samplingLink: (
+                                      <ExternalLink
+                                        href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer"
+                                        openInNewTab
+                                      />
+                                    ),
+                                  }
+                                ),
+                                isHoverable: true,
+                              }}
+                              id="thresholds-warning-icon"
+                            />
+                          )}
+                        </Flex>
+                      </div>
                     }
                   </AlertListItem>
-                  {thresholdTypeForm(formDisabled)}
+                  <Stack gap="lg">
+                    {showWorkflowEngineMetricIssueUi && (
+                      <Text>
+                        {t(
+                          'Metric alerts create metric issues and events. The thresholds below will determine: when the issue is created, resolved, and re-opened, as well as the issue priority.'
+                        )}
+                      </Text>
+                    )}
+                    {thresholdTypeForm(formDisabled)}
+                  </Stack>
                   {showErrorMigrationWarning && (
                     <Alert.Container>
                       <Alert variant="warning">


### PR DESCRIPTION
Closes ISWF-2014

Before:

<img width="1045" height="158" alt="CleanShot 2026-02-24 at 12 07 04" src="https://github.com/user-attachments/assets/c876b3f0-758f-488e-ade0-7849b5c32a7b" />

After:

<img width="1041" height="214" alt="CleanShot 2026-02-24 at 12 06 46" src="https://github.com/user-attachments/assets/e1a7a1f0-79b1-4bba-900b-7a738846a41a" />
