### PR TITLE
feat(dashboards): Register FRONTEND_ASSETS_SUMMARY prebuilt dashboard

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -86,6 +86,7 @@ class PrebuiltDashboardId(IntEnum):
     MCP_PROMPTS = 22
     LARAVEL_OVERVIEW = 23
     FRONTEND_ASSETS = 24
+    FRONTEND_ASSETS_SUMMARY = 25
 
 
 class PrebuiltDashboard(TypedDict):
@@ -198,6 +199,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS,
         "title": "Frontend Assets",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY,
+        "title": "Frontend Assets Summary",
     },
 ]
 


### PR DESCRIPTION
## Summary
- Adds `FRONTEND_ASSETS_SUMMARY = 25` to the `PrebuiltDashboardId` enum
- Registers the new `FRONTEND_ASSETS_SUMMARY` prebuilt dashboard in the `PREBUILT_DASHBOARDS` list with the title "Frontend Assets Summary"
- Follows the same pattern as the existing `FRONTEND_ASSETS` entry

## Test plan
- [ ] Verify the new enum value `FRONTEND_ASSETS_SUMMARY = 25` does not conflict with any existing IDs
- [ ] Verify the prebuilt dashboard entry is returned by the dashboards API endpoint
- [ ] Verify `sync_prebuilt_dashboards` correctly creates a Dashboard record for the new entry