### PR TITLE
feat(onboarding): Register feature flag for copy instructions on project creation

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -208,6 +208,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:onboarding", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable copy setup instructions button on onboarding surfaces
     manager.add("organizations:onboarding-copy-setup-instructions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable copy setup instructions button on project creation getting-started page
+    manager.add("organizations:onboarding-copy-setup-instructions-project-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new onboarding welcome and SDK setup UI
     manager.add("organizations:onboarding-new-welcome-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable large ownership rule file size limit


### PR DESCRIPTION
## Summary
- Registers `onboarding-copy-setup-instructions-project-creation` feature flag in FlagPole
- Gates the copy-as-markdown button on the project creation getting-started page independently from existing onboarding surfaces

## Companion PR
- [sentry-options-automator](https://github.com/getsentry/sentry-options-automator/pull/6599) enables this flag for the `sentry` org at 100% rollout

Ref: ONB-13

https://linear.app/getsentry/issue/VDY-13/onboarding-add-copy-as-markdown-button-to-project-creation-and-first