### PR TITLE
feat(onboarding): Add copy-as-markdown button to project creation and signup setup docs

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -90,30 +90,32 @@ export function OnboardingCopyMarkdownButton({
   );
 }
 
-const DEFAULT_FEATURE_FLAG = 'onboarding-copy-setup-instructions';
-export const PROJECT_CREATION_FEATURE_FLAG =
-  'onboarding-copy-setup-instructions-project-creation';
+type CopySetupInstructionsType = 'onboarding' | 'project_creation';
+
+const FEATURE_FLAGS: Record<CopySetupInstructionsType, string> = {
+  onboarding: 'onboarding-copy-setup-instructions',
+  project_creation: 'onboarding-copy-setup-instructions-project-creation',
+};
 
 /**
- * Returns whether the copy setup instructions button should be shown.
- * Defaults to the `onboarding-copy-setup-instructions` flag, but callers
- * can pass a different flag name (e.g. for project-creation-specific gating).
+ * Returns whether the copy setup instructions button should be shown
+ * for the given context type.
  */
 export function useCopySetupInstructionsEnabled(
-  featureFlag: string = DEFAULT_FEATURE_FLAG
+  type: CopySetupInstructionsType = 'onboarding'
 ): boolean {
   const organization = useOrganization();
-  return organization.features.includes(featureFlag);
+  return organization.features.includes(FEATURE_FLAGS[type]);
 }
 
 export function CopySetupInstructionsGate({
   children,
-  featureFlag,
+  type,
 }: {
   children: React.ReactNode;
-  featureFlag?: string;
+  type?: CopySetupInstructionsType;
 }) {
-  const enabled = useCopySetupInstructionsEnabled(featureFlag);
+  const enabled = useCopySetupInstructionsEnabled(type);
   if (!enabled) {
     return null;
   }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -91,6 +91,8 @@ export function OnboardingCopyMarkdownButton({
 }
 
 const DEFAULT_FEATURE_FLAG = 'onboarding-copy-setup-instructions';
+export const PROJECT_CREATION_FEATURE_FLAG =
+  'onboarding-copy-setup-instructions-project-creation';
 
 /**
  * Returns whether the copy setup instructions button should be shown.

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton.tsx
@@ -90,20 +90,28 @@ export function OnboardingCopyMarkdownButton({
   );
 }
 
-const FEATURE_FLAG = 'onboarding-copy-setup-instructions';
+const DEFAULT_FEATURE_FLAG = 'onboarding-copy-setup-instructions';
 
 /**
- * Feature-gated wrapper that renders its children only when the
- * `onboarding-copy-setup-instructions` flag is enabled. Includes spacing
- * so callsites don't render an empty Container when the flag is off.
+ * Returns whether the copy setup instructions button should be shown.
+ * Defaults to the `onboarding-copy-setup-instructions` flag, but callers
+ * can pass a different flag name (e.g. for project-creation-specific gating).
  */
-export function useCopySetupInstructionsEnabled(): boolean {
+export function useCopySetupInstructionsEnabled(
+  featureFlag: string = DEFAULT_FEATURE_FLAG
+): boolean {
   const organization = useOrganization();
-  return organization.features.includes(FEATURE_FLAG);
+  return organization.features.includes(featureFlag);
 }
 
-export function CopySetupInstructionsGate({children}: {children: React.ReactNode}) {
-  const enabled = useCopySetupInstructionsEnabled();
+export function CopySetupInstructionsGate({
+  children,
+  featureFlag,
+}: {
+  children: React.ReactNode;
+  featureFlag?: string;
+}) {
+  const enabled = useCopySetupInstructionsEnabled(featureFlag);
   if (!enabled) {
     return null;
   }

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -10,7 +10,6 @@ import ListItem from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
   OnboardingCopyMarkdownButton,
-  PROJECT_CREATION_FEATURE_FLAG,
   useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -67,7 +66,7 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled(PROJECT_CREATION_FEATURE_FLAG);
+  const copyEnabled = useCopySetupInstructionsEnabled('project_creation');
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -188,6 +188,7 @@ export function OnboardingLayout({
             <Flex justify="end" margin="0 0 md">
               <OnboardingCopyMarkdownButton
                 steps={steps}
+                borderless
                 source={newOrg ? 'first_time_setup' : 'project_getting_started'}
               />
             </Flex>

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -182,14 +182,13 @@ export function OnboardingLayout({
               />
             ) : null}
           </Stack>
-          <Divider />
+          <Divider withBottomMargin />
           <div>
             {steps.map((step, index) => {
               const copyButton =
                 copyEnabled && index === 0 ? (
                   <OnboardingCopyMarkdownButton
                     steps={steps}
-                    borderless
                     source={newOrg ? 'first_time_setup' : 'project_getting_started'}
                   />
                 ) : null;

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -1,7 +1,7 @@
 import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -183,20 +183,40 @@ export function OnboardingLayout({
               />
             ) : null}
           </Stack>
-          <Divider withBottomMargin={!copyEnabled} />
-          {copyEnabled && (
-            <Flex justify="end" margin="0 0 md">
-              <OnboardingCopyMarkdownButton
-                steps={steps}
-                borderless
-                source={newOrg ? 'first_time_setup' : 'project_getting_started'}
-              />
-            </Flex>
-          )}
+          <Divider />
           <div>
-            {steps.map((step, index) => (
-              <StyledStep key={step.title ?? step.type} stepIndex={index} {...step} />
-            ))}
+            {steps.map((step, index) => {
+              const copyButton =
+                copyEnabled && index === 0 ? (
+                  <OnboardingCopyMarkdownButton
+                    steps={steps}
+                    borderless
+                    source={newOrg ? 'first_time_setup' : 'project_getting_started'}
+                  />
+                ) : null;
+
+              const trailingItems = copyButton ? (
+                step.trailingItems ? (
+                  <Fragment>
+                    {step.trailingItems}
+                    {copyButton}
+                  </Fragment>
+                ) : (
+                  copyButton
+                )
+              ) : (
+                step.trailingItems
+              );
+
+              return (
+                <StyledStep
+                  key={step.title ?? step.type}
+                  stepIndex={index}
+                  {...step}
+                  trailingItems={trailingItems}
+                />
+              );
+            })}
           </div>
           {nextSteps.length > 0 && (
             <Fragment>
@@ -235,13 +255,12 @@ export function OnboardingLayout({
   );
 }
 
-const Divider = styled('hr')<{withBottomMargin?: boolean}>`
+const Divider = styled('hr')`
   height: 1px;
   width: 100%;
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   background: ${p => p.theme.tokens.border.primary};
   border: none;
-  ${p => p.withBottomMargin && `margin-bottom: ${space(3)}`}
 `;
 
 const StyledStep = styled(Step)`

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -10,6 +10,7 @@ import ListItem from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
 import {
   OnboardingCopyMarkdownButton,
+  PROJECT_CREATION_FEATURE_FLAG,
   useCopySetupInstructionsEnabled,
 } from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
@@ -66,9 +67,7 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
-  const copyEnabled = useCopySetupInstructionsEnabled(
-    'onboarding-copy-setup-instructions-project-creation'
-  );
+  const copyEnabled = useCopySetupInstructionsEnabled(PROJECT_CREATION_FEATURE_FLAG);
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -254,12 +254,13 @@ export function OnboardingLayout({
   );
 }
 
-const Divider = styled('hr')`
+const Divider = styled('hr')<{withBottomMargin?: boolean}>`
   height: 1px;
   width: 100%;
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
   background: ${p => p.theme.tokens.border.primary};
   border: none;
+  ${p => p.withBottomMargin && `margin-bottom: ${space(3)}`}
 `;
 
 const StyledStep = styled(Step)`

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -1,13 +1,17 @@
 import {Fragment, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {AuthTokenGeneratorProvider} from 'sentry/components/onboarding/gettingStartedDoc/authTokenGenerator';
+import {
+  OnboardingCopyMarkdownButton,
+  useCopySetupInstructionsEnabled,
+} from 'sentry/components/onboarding/gettingStartedDoc/onboardingCopyMarkdownButton';
 import {TabSelectionScope} from 'sentry/components/onboarding/gettingStartedDoc/selectedCodeTabContext';
 import {Step} from 'sentry/components/onboarding/gettingStartedDoc/step';
 import {
@@ -62,6 +66,9 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
+  const copyEnabled = useCopySetupInstructionsEnabled(
+    'onboarding-copy-setup-instructions-project-creation'
+  );
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
   const selectedOptions = useUrlPlatformOptions(docsConfig.platformOptions);
@@ -176,7 +183,15 @@ export function OnboardingLayout({
               />
             ) : null}
           </Stack>
-          <Divider withBottomMargin />
+          <Divider withBottomMargin={!copyEnabled} />
+          {copyEnabled && (
+            <Flex justify="end" margin="0 0 md">
+              <OnboardingCopyMarkdownButton
+                steps={steps}
+                source={newOrg ? 'first_time_setup' : 'project_getting_started'}
+              />
+            </Flex>
+          )}
           <div>
             {steps.map((step, index) => (
               <StyledStep key={step.title ?? step.type} stepIndex={index} {...step} />


### PR DESCRIPTION
## Summary
- Makes `useCopySetupInstructionsEnabled` and `CopySetupInstructionsGate` accept an optional `featureFlag` parameter (defaults to existing flag, fully backward-compatible)
- Exports `PROJECT_CREATION_FEATURE_FLAG` constant for the new `onboarding-copy-setup-instructions-project-creation` flag
- Adds `OnboardingCopyMarkdownButton` to `OnboardingLayout` (shared by both the project creation getting-started page and the first-time signup wizard), positioned inline with the first step header via `trailingItems`

## Related PRs
- Feature flag registration: https://github.com/getsentry/sentry/pull/109232 (merged)
- sentry-options-automator: https://github.com/getsentry/sentry-options-automator/pull/6599 (enables flag for sentry org)

## Test plan
- [ ] Verify button appears on `/projects/:projectId/getting-started/` when flag is enabled
- [ ] Verify button appears on `/onboarding/:step/` signup wizard when flag is enabled
- [ ] Verify button does not appear when flag is disabled
- [ ] Verify clicking button copies markdown to clipboard
- [ ] Verify existing onboarding surfaces are unaffected (they use the default flag)

Refs ONB-13