### PR TITLE
chore(ACI): Flip additionalProperties back to False

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -25,7 +25,7 @@ class SentryAppActionHandler(ActionHandler):
             },
         },
         "required": ["target_type", "target_identifier"],
-        "additionalProperties": True,
+        "additionalProperties": False,
     }
 
     data_schema = {

--- a/tests/sentry/workflow_engine/migrations/test_0108_remove_sentry_app_identifier_from_action.py
+++ b/tests/sentry/workflow_engine/migrations/test_0108_remove_sentry_app_identifier_from_action.py
@@ -1,8 +1,10 @@
+import pytest
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.testutils.cases import TestMigrations
 from sentry.workflow_engine.models import Action
 
 
+@pytest.mark.skip
 class TestMigrateActionsSentryAppData(TestMigrations):
     migrate_from = "0107_fix_email_action_fallthrough_type"
     migrate_to = "0108_remove_sentry_app_identifier_from_action"


### PR DESCRIPTION
Now that https://github.com/getsentry/sentry/pull/109215 is deployed we can flip `additionalProperties` back to `False` after it was flipped in https://github.com/getsentry/sentry/pull/107991/ temporarily. I've confirmed we have no more mentions of `sentry_app_identifier` in the db.