### PR TITLE
fix(eco): Ensures user mappings are deleted alongside their associated organization membership

### DIFF
--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -5,10 +5,17 @@ from sentry.models.organizationmember import OrganizationMember
 
 class OrganizationMemberDeletionTask(ModelDeletionTask[OrganizationMember]):
     def get_child_relations(self, instance: OrganizationMember) -> list[BaseRelation]:
-        relations: list[BaseRelation] = [
-            ModelRelation(
-                ExternalActor,
-                {"user_id": instance.user_id, "organization_id": instance.organization_id},
-            ),
-        ]
+        relations: list[BaseRelation] = []
+
+        if instance.user_id:
+            # We need to clean up external actors (user mappings for integrations),
+            #  but only if the org member is not an invite.
+            # This prevents us from accidentally cleaning up team mappings.
+            relations.append(
+                ModelRelation(
+                    ExternalActor,
+                    {"user_id": instance.user_id, "organization_id": instance.organization_id},
+                )
+            )
+
         return relations

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -1,9 +1,14 @@
-from sentry.deletions.base import BaseRelation, ModelDeletionTask
+from sentry.deletions.base import BaseRelation, ModelDeletionTask, ModelRelation
+from sentry.integrations.models.external_actor import ExternalActor
 from sentry.models.organizationmember import OrganizationMember
 
 
 class OrganizationMemberDeletionTask(ModelDeletionTask[OrganizationMember]):
     def get_child_relations(self, instance: OrganizationMember) -> list[BaseRelation]:
-        relations: list[BaseRelation] = []
-
+        relations: list[BaseRelation] = [
+            ModelRelation(
+                ExternalActor,
+                {"user_id": instance.user_id, "organization_id": instance.organization_id},
+            ),
+        ]
         return relations

--- a/src/sentry/deletions/defaults/organizationmember.py
+++ b/src/sentry/deletions/defaults/organizationmember.py
@@ -7,7 +7,7 @@ class OrganizationMemberDeletionTask(ModelDeletionTask[OrganizationMember]):
     def get_child_relations(self, instance: OrganizationMember) -> list[BaseRelation]:
         relations: list[BaseRelation] = []
 
-        if instance.user_id:
+        if instance.user_id is not None:
             # We need to clean up external actors (user mappings for integrations),
             #  but only if the org member is not an invite.
             # This prevents us from accidentally cleaning up team mappings.

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -18,7 +18,9 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
 
         assert not OrganizationMember.objects.filter(id=member.id).exists()
 
-    def _create_org_member_with_external_actor(self, org: Organization) -> OrganizationMember:
+    def _create_org_member_with_external_actor(
+        self, org: Organization
+    ) -> tuple[OrganizationMember, ExternalActor]:
         user = self.create_user()
         member = self.create_member(organization=org, user=user)
         external_actor = self.create_external_user(user=user, organization=org)

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -1,4 +1,6 @@
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
+from sentry.integrations.models.external_actor import ExternalActor
+from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.testutils.cases import APITestCase, TransactionTestCase
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
@@ -15,3 +17,30 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
             run_scheduled_deletions()
 
         assert not OrganizationMember.objects.filter(id=member.id).exists()
+
+    def _create_org_member_with_external_actor(self, org: Organization) -> OrganizationMember:
+        user = self.create_user()
+        member = self.create_member(organization=org, user=user)
+        external_actor = self.create_external_user(user=user, organization=org)
+
+        return member, external_actor
+
+    def test_deletes_external_actor(self) -> None:
+        organization = self.create_organization(name="test")
+
+        member, external_actor = self._create_org_member_with_external_actor(organization)
+        unaffected_members = [
+            self._create_org_member_with_external_actor(organization) for _ in range(3)
+        ]
+
+        self.ScheduledDeletion.schedule(instance=member, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not OrganizationMember.objects.filter(id=member.id).exists()
+        assert not ExternalActor.objects.filter(id=external_actor.id).exists()
+
+        for member, external_actor in unaffected_members:
+            assert OrganizationMember.objects.filter(id=member.id).exists()
+            assert ExternalActor.objects.filter(id=external_actor.id).exists()

--- a/tests/sentry/deletions/test_organizationmember.py
+++ b/tests/sentry/deletions/test_organizationmember.py
@@ -25,8 +25,13 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
 
         return member, external_actor
 
+    def _create_team_mapping(self, org: Organization) -> ExternalActor:
+        team = self.create_team(organization=org)
+        return self.create_external_team(team=team)
+
     def test_deletes_external_actor(self) -> None:
         organization = self.create_organization(name="test")
+        team_mapping = self._create_team_mapping(organization)
 
         member, external_actor = self._create_org_member_with_external_actor(organization)
         unaffected_members = [
@@ -44,3 +49,19 @@ class DeleteOrganizationMemberTest(APITestCase, TransactionTestCase, HybridCloud
         for member, external_actor in unaffected_members:
             assert OrganizationMember.objects.filter(id=member.id).exists()
             assert ExternalActor.objects.filter(id=external_actor.id).exists()
+
+        assert ExternalActor.objects.filter(id=team_mapping.id).exists()
+
+    def test_does_not_delete_team_mappings_for_invites(self) -> None:
+        organization = self.create_organization(name="test")
+        team_mapping = self._create_team_mapping(organization)
+
+        invite_member = self.create_member(organization=organization)
+
+        self.ScheduledDeletion.schedule(instance=invite_member, days=0)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not OrganizationMember.objects.filter(id=invite_member.id).exists()
+        assert ExternalActor.objects.filter(id=team_mapping.id).exists()


### PR DESCRIPTION
Currently, when `OrganizationMembers` are deleted, we don't clean up the assocaited `ExternalActor` objects that reference their user and organization IDs. As a result, we orphan these mappings, causing collisions in the future when that same user attempts to re-add their external mapping.

This ensures these deletions are done in an eventually consistent manner, post-deletion.

Fixes ISWF-2122
