### PR TITLE
fix(aci): Don't dedup actions by workflow

### DIFF
--- a/src/sentry/workflow_engine/models/action.py
+++ b/src/sentry/workflow_engine/models/action.py
@@ -152,11 +152,8 @@ class Action(DefaultFieldsModel, JSONConfigBase):
             },
         )
 
-    def get_dedup_key(self, workflow_id: int | None) -> str:
+    def get_dedup_key(self) -> str:
         key_parts = [self.type]
-        if workflow_id is not None:
-            key_parts.append(str(workflow_id))
-
         if self.integration_id:
             key_parts.append(str(self.integration_id))
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -231,9 +231,7 @@ def get_unique_active_actions(
         if action.status != ObjectStatus.ACTIVE:
             continue
 
-        # workflow_id is annotated in the queryset
-        workflow_id = getattr(action, "workflow_id")
-        dedup_key = action.get_dedup_key(workflow_id)
+        dedup_key = action.get_dedup_key()
         previous_action_id = dedup_key_to_action_id.get(dedup_key)
         if previous_action_id is not None:
             dropped[dedup_key].add(previous_action_id)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -427,7 +427,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
 
         assert WorkflowFireHistory.objects.count() == 3
-        assert mock_trigger_action.call_count == 3
+        assert mock_trigger_action.call_count == 1
 
     def test_uses_issue_stream_workflows(self) -> None:
         issue_occurrence = self.build_occurrence()


### PR DESCRIPTION
We previously deduped by workflow id to preserve consistency with legacy behavior.
However, conceptually, we don't want to send the same notification to the same destination for the same issue just because it came from different sources.

Fixes ISWF-1946.
