### PR TITLE
fix(issue-detection): Use LLM-resolved project_id for cross-project issue attribution

### DIFF
--- a/src/sentry/seer/issue_detection.py
+++ b/src/sentry/seer/issue_detection.py
@@ -30,9 +30,9 @@ def create_issue_occurrence(
     Returns:
         Dict with "success": True on successful issue creation
     """
-    project = Project.objects.get(id=project_id, organization_id=organization_id)  # IDOR check
-
     issue = DetectedIssue.parse_obj(detected_issue)
+    effective_project_id = issue.project_id if issue.project_id is not None else project_id
+    project = Project.objects.get(id=effective_project_id, organization_id=organization_id)
     create_issue_occurrence_from_detection(detected_issue=issue, project=project)
 
     logger.info(
@@ -41,7 +41,7 @@ def create_issue_occurrence(
             "organization_id": organization_id,
             "title": issue.title,
             "trace_id": issue.trace_id,
-            "project_id": project_id,
+            "project_id": effective_project_id,
             "category": issue.category,
             "subcategory": issue.subcategory,
         },

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -86,6 +86,7 @@ class DetectedIssue(BaseModel):
     subcategory: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     verification_reason: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
     group_for_fingerprint: str = Field(..., max_length=MAX_LLM_FIELD_LENGTH)
+    project_id: int | None = None
     # context field, not LLM generated
     trace_id: str
 


### PR DESCRIPTION
Distributed traces span multiple projects. When the LLM detects an issue in spans belonging to project B, prefer the issue-level project_id over the request-level one so the issue is attributed to the correct project.
