### PR TITLE
ref(seer): Migrate seer endpoints to urllib3 connection pools

### DIFF
--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import orjson
 
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_anomaly_detection_default_connection_pool,
@@ -41,5 +42,5 @@ def compare_distributions(
         body,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     return response.json()

--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -4,10 +4,11 @@ import logging
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_anomaly_detection_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +35,11 @@ def compare_distributions(
             "meta": meta,
         }
     )
-    response = requests.post(
-        f"{settings.SEER_ANOMALY_DETECTION_URL}/v1/workflows/compare/cohort",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_anomaly_detection_default_connection_pool,
+        "/v1/workflows/compare/cohort",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()

--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -10,6 +10,7 @@ from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_anomaly_detection_default_connection_pool,
 )
+from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -43,4 +44,8 @@ def compare_distributions(
     )
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
-    return response.json()
+    try:
+        return response.json()
+    except JSONDecodeError:
+        logger.exception("Failed to parse Seer compare_distributions response")
+        raise SeerApiError("Seer returned invalid JSON response", response.status)

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import orjson
-import requests
 import sentry_sdk
 from django.conf import settings
 from rest_framework.request import Request
@@ -27,7 +26,10 @@ from sentry.seer.autofix.utils import (
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -84,16 +86,14 @@ def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         repos_and_access.append({**repo, "ok": response.json().get("has_access", False)})
 

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -26,6 +26,7 @@ from sentry.seer.autofix.utils import (
     is_seer_seat_based_tier_enabled,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -93,7 +94,7 @@ def get_repos_and_access(project: Project, group_id: int) -> list[dict]:
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         repos_and_access.append({**repo, "ok": response.json().get("has_access", False)})
 

--- a/src/sentry/seer/endpoints/group_autofix_update.py
+++ b/src/sentry/seer/endpoints/group_autofix_update.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
@@ -16,11 +15,12 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
-
-from rest_framework.request import Request
 
 
 @region_silo_endpoint
@@ -60,16 +60,14 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         group.update(seer_autofix_last_triggered=timezone.now())
 

--- a/src/sentry/seer/endpoints/group_autofix_update.py
+++ b/src/sentry/seer/endpoints/group_autofix_update.py
@@ -15,6 +15,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -67,7 +68,7 @@ class GroupAutofixUpdateEndpoint(GroupAiEndpoint):
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         group.update(seer_autofix_last_triggered=timezone.now())
 

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,7 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,16 +49,14 @@ def generate_title_from_query(query: str) -> str | None:
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/llm/generate",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/llm/generate",
+        body,
         timeout=10,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     data = response.json()
     return data.get("content")
 
@@ -100,7 +99,7 @@ class IssueViewTitleGenerateEndpoint(OrganizationEndpoint):
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
             return Response({"title": title.strip()})
-        except requests.RequestException:
+        except Exception:
             logger.exception("Failed to call Seer LLM proxy")
             return Response(
                 {"detail": "Failed to generate title"},

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -13,6 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -56,7 +57,7 @@ def generate_title_from_query(query: str) -> str | None:
         timeout=10,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     data = response.json()
     return data.get("content")
 

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -14,7 +12,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,13 @@ class OrganizationSeerExplorerUpdateEndpoint(OrganizationEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         return Response(status=202, data=response.json())

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -11,11 +11,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
-from sentry.seer.signed_seer_api import (
-    make_signed_seer_api_request,
-    seer_autofix_default_connection_pool,
+from sentry.seer.explorer.client_utils import (
+    explorer_connection_pool,
+    has_seer_explorer_access_with_detail,
 )
+from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 
 logger = logging.getLogger(__name__)
 
@@ -56,12 +57,12 @@ class OrganizationSeerExplorerUpdateEndpoint(OrganizationEndpoint):
         )
 
         response = make_signed_seer_api_request(
-            seer_autofix_default_connection_pool,
+            explorer_connection_pool,
             path,
             body,
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         return Response(status=202, data=response.json())

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -15,7 +15,7 @@ from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
-from sentry.seer.models import PreferenceResponse, SeerProjectPreference
+from sentry.seer.models import PreferenceResponse, SeerApiError, SeerProjectPreference
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -149,7 +149,7 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         return Response(status=204)
 
@@ -168,7 +168,7 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
         )
 
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
 
         result = response.json()
 

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -18,7 +16,10 @@ from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import get_autofix_repos_from_project_code_mappings
 from sentry.seer.models import PreferenceResponse, SeerProjectPreference
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -141,16 +142,14 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         return Response(status=204)
 
@@ -162,16 +161,14 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
             }
         )
 
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
 
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
 
         result = response.json()
 

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -17,6 +17,7 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.explorer.client_utils import collect_user_org_context
+from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
@@ -24,14 +25,6 @@ from sentry.seer.signed_seer_api import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class SeerHTTPError(Exception):
-    """Exception raised when Seer API returns an HTTP error status."""
-
-    def __init__(self, status_code: int, message: str):
-        self.status_code = status_code
-        super().__init__(message)
 
 
 class SearchAgentStartSerializer(serializers.Serializer):
@@ -108,7 +101,7 @@ def send_search_agent_start_request(
         timeout=30,
     )
     if response.status >= 400:
-        raise SeerHTTPError(response.status, f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     return response.json()
 
 
@@ -208,13 +201,13 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
             # Return the run_id for polling
             return Response({"run_id": run_id})
 
-        except SeerHTTPError as e:
+        except SeerApiError as e:
             logger.exception(
                 "search_agent.start_error",
                 extra={
                     "organization_id": organization.id,
                     "project_ids": project_ids,
-                    "status_code": e.status_code,
+                    "status_code": e.status,
                 },
             )
             return Response(

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -19,9 +18,20 @@ from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.explorer.client_utils import collect_user_org_context
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class SeerHTTPError(Exception):
+    """Exception raised when Seer API returns an HTTP error status."""
+
+    def __init__(self, status_code: int, message: str):
+        self.status_code = status_code
+        super().__init__(message)
 
 
 class SearchAgentStartSerializer(serializers.Serializer):
@@ -91,16 +101,14 @@ def send_search_agent_start_request(
 
     body = orjson.dumps(body_dict)
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/start",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/start",
+        body,
         timeout=30,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise SeerHTTPError(response.status, f"Seer request failed with status {response.status}")
     return response.json()
 
 
@@ -200,13 +208,13 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
             # Return the run_id for polling
             return Response({"run_id": run_id})
 
-        except requests.HTTPError as e:
+        except SeerHTTPError as e:
             logger.exception(
                 "search_agent.start_error",
                 extra={
                     "organization_id": organization.id,
                     "project_ids": project_ids,
-                    "status_code": e.response.status_code if e.response is not None else None,
+                    "status_code": e.status_code,
                 },
             )
             return Response(

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
@@ -18,7 +17,10 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,16 +33,14 @@ def fetch_search_agent_state(run_id: int, organization_id: int) -> dict[str, Any
     """
     body = orjson.dumps({"run_id": run_id, "organization_id": organization_id})
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/state",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/state",
+        body,
         timeout=10,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 
@@ -119,24 +119,6 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
             # Return the session data directly from Seer
             return Response(data)
 
-        except requests.HTTPError as e:
-            if e.response is not None and e.response.status_code == 404:
-                logger.warning(
-                    "search_agent.state_not_found",
-                    extra={"run_id": run_id_int},
-                )
-                return Response(
-                    {"session": None},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
-            logger.exception(
-                "search_agent.state_error",
-                extra={"run_id": run_id_int},
-            )
-            return Response(
-                {"detail": "Failed to fetch run state"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
         except Exception:
             logger.exception(
                 "search_agent.state_error",

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -16,6 +16,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
@@ -40,7 +41,7 @@ def fetch_search_agent_state(run_id: int, organization_id: int) -> dict[str, Any
         timeout=10,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     return response.json()
 
 

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -120,6 +120,24 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
             # Return the session data directly from Seer
             return Response(data)
 
+        except SeerApiError as e:
+            if e.status == 404:
+                logger.warning(
+                    "search_agent.state_not_found",
+                    extra={"run_id": run_id_int},
+                )
+                return Response(
+                    {"session": None},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            logger.exception(
+                "search_agent.state_error",
+                extra={"run_id": run_id_int, "status_code": e.status},
+            )
+            return Response(
+                {"detail": "Failed to fetch run state"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         except Exception:
             logger.exception(
                 "search_agent.state_error",

--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
@@ -17,7 +16,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +39,13 @@ def send_translate_request(
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/translate",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 

--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -16,6 +16,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -45,7 +46,7 @@ def send_translate_request(
         body,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     return response.json()
 
 

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import status
 from rest_framework.exceptions import ParseError
@@ -16,7 +15,10 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.models.organization import Organization
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,15 +43,13 @@ def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/create-cache",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/create-cache",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
 
 @region_silo_endpoint

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -15,6 +15,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.models.organization import Organization
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -49,7 +50,7 @@ def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
         body,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
 
 
 @region_silo_endpoint

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -16,6 +16,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
+from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
@@ -90,7 +91,7 @@ def send_translate_agentic_request(
         body,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
     return response.json()
 
 

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -4,7 +4,6 @@ import logging
 from typing import Any
 
 import orjson
-import requests
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -18,7 +17,10 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -82,15 +84,13 @@ def send_translate_agentic_request(
 
     body = orjson.dumps(body_dict)
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}/v1/assisted-query/translate-agentic",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate-agentic",
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
     return response.json()
 
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -18,6 +18,14 @@ seer_summarization_default_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
 )
 
+seer_autofix_default_connection_pool = connection_from_url(
+    settings.SEER_AUTOFIX_URL,
+)
+
+seer_anomaly_detection_default_connection_pool = connection_from_url(
+    settings.SEER_ANOMALY_DETECTION_URL,
+)
+
 
 @sentry_sdk.tracing.trace
 def make_signed_seer_api_request(

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -432,6 +432,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_non_github_provider(self, mock_get_repos: MagicMock, mock_request: MagicMock) -> None:
         # Mock the response from the Seer service
         mock_response = mock_request.return_value
+        mock_response.status = 200
         mock_response.json.return_value = {"has_access": True}
 
         group = self.create_group()
@@ -450,10 +451,9 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
 
         # Verify the API call was made correctly
         mock_request.assert_called_once()
-        call_kwargs = mock_request.call_args.kwargs
-        assert "data" in call_kwargs
-        assert "headers" in call_kwargs
-        assert "content-type" in call_kwargs["headers"]
+        call_args = mock_request.call_args[0]
+        assert call_args[1] == "/v1/automation/codebase/repo/check-access"
+        assert len(call_args[2]) > 0  # body is non-empty bytes
 
     @patch("sentry.seer.endpoints.group_autofix_setup_check.make_signed_seer_api_request")
     @patch(
@@ -470,6 +470,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
     def test_repo_without_access(self, mock_get_repos: MagicMock, mock_request: MagicMock) -> None:
         # Mock the response to indicate no access
         mock_response = mock_request.return_value
+        mock_response.status = 200
         mock_response.json.return_value = {"has_access": False}
 
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -417,7 +417,7 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
             "repos": [],
         }
 
-    @patch("sentry.seer.endpoints.group_autofix_setup_check.requests.post")
+    @patch("sentry.seer.endpoints.group_autofix_setup_check.make_signed_seer_api_request")
     @patch(
         "sentry.seer.endpoints.group_autofix_setup_check.get_autofix_repos_from_project_code_mappings",
         return_value=[
@@ -429,9 +429,9 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
             }
         ],
     )
-    def test_non_github_provider(self, mock_get_repos: MagicMock, mock_post: MagicMock) -> None:
+    def test_non_github_provider(self, mock_get_repos: MagicMock, mock_request: MagicMock) -> None:
         # Mock the response from the Seer service
-        mock_response = mock_post.return_value
+        mock_response = mock_request.return_value
         mock_response.json.return_value = {"has_access": True}
 
         group = self.create_group()
@@ -449,13 +449,13 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
         ]
 
         # Verify the API call was made correctly
-        mock_post.assert_called_once()
-        call_kwargs = mock_post.call_args.kwargs
+        mock_request.assert_called_once()
+        call_kwargs = mock_request.call_args.kwargs
         assert "data" in call_kwargs
         assert "headers" in call_kwargs
         assert "content-type" in call_kwargs["headers"]
 
-    @patch("sentry.seer.endpoints.group_autofix_setup_check.requests.post")
+    @patch("sentry.seer.endpoints.group_autofix_setup_check.make_signed_seer_api_request")
     @patch(
         "sentry.seer.endpoints.group_autofix_setup_check.get_autofix_repos_from_project_code_mappings",
         return_value=[
@@ -467,9 +467,9 @@ class GroupAIAutofixEndpointFailureTest(APITestCase, SnubaTestCase):
             }
         ],
     )
-    def test_repo_without_access(self, mock_get_repos: MagicMock, mock_post: MagicMock) -> None:
+    def test_repo_without_access(self, mock_get_repos: MagicMock, mock_request: MagicMock) -> None:
         # Mock the response to indicate no access
-        mock_response = mock_post.return_value
+        mock_response = mock_request.return_value
         mock_response.json.return_value = {"has_access": False}
 
         group = self.create_group()

--- a/tests/sentry/seer/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_update.py
@@ -18,10 +18,10 @@ class TestGroupAutofixUpdate(APITestCase):
             f"/api/0/organizations/{self.organization.slug}/issues/{self.group.id}/autofix/update/"
         )
 
-    @patch("sentry.seer.endpoints.group_autofix_update.requests.post")
-    def test_autofix_update_successful(self, mock_post: MagicMock) -> None:
-        mock_post.return_value.status_code = 202
-        mock_post.return_value.json.return_value = {}
+    @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
+    def test_autofix_update_successful(self, mock_request: MagicMock) -> None:
+        mock_request.return_value.status_code = 202
+        mock_request.return_value.json.return_value = {}
 
         response = self.client.post(
             self.url,
@@ -55,15 +55,15 @@ class TestGroupAutofixUpdate(APITestCase):
             "content-type": "application/json;charset=utf-8",
             **sign_with_seer_secret(expected_body),
         }
-        mock_post.assert_called_once_with(
+        mock_request.assert_called_once_with(
             expected_url,
             data=expected_body,
             headers=expected_headers,
         )
 
-    @patch("sentry.seer.endpoints.group_autofix_update.requests.post")
-    def test_autofix_update_failure(self, mock_post: MagicMock) -> None:
-        mock_post.return_value.raise_for_status.side_effect = Exception("Failed to update")
+    @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
+    def test_autofix_update_failure(self, mock_request: MagicMock) -> None:
+        mock_request.return_value.raise_for_status.side_effect = Exception("Failed to update")
 
         response = self.client.post(
             self.url,
@@ -83,11 +83,11 @@ class TestGroupAutofixUpdate(APITestCase):
         response = self.client.post(self.url, data={}, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    @patch("sentry.seer.endpoints.group_autofix_update.requests.post")
-    def test_autofix_update_updates_last_triggered_field(self, mock_post):
+    @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
+    def test_autofix_update_updates_last_triggered_field(self, mock_request):
         """Test that a successful call updates the seer_autofix_last_triggered field."""
-        mock_post.return_value.status_code = 202
-        mock_post.return_value.json.return_value = {}
+        mock_request.return_value.status_code = 202
+        mock_request.return_value.json.return_value = {}
 
         self.group.refresh_from_db()
         assert self.group.seer_autofix_last_triggered is None

--- a/tests/sentry/seer/endpoints/test_group_autofix_update.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_update.py
@@ -2,10 +2,8 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import orjson
-from django.conf import settings
 from rest_framework import status
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
 from sentry.testutils.cases import APITestCase
 
 
@@ -20,7 +18,7 @@ class TestGroupAutofixUpdate(APITestCase):
 
     @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
     def test_autofix_update_successful(self, mock_request: MagicMock) -> None:
-        mock_request.return_value.status_code = 202
+        mock_request.return_value.status = 202
         mock_request.return_value.json.return_value = {}
 
         response = self.client.post(
@@ -36,34 +34,18 @@ class TestGroupAutofixUpdate(APITestCase):
         )
 
         assert response.status_code == status.HTTP_202_ACCEPTED
-        expected_body = orjson.dumps(
-            {
-                "run_id": 123,
-                "payload": {
-                    "type": "select_root_cause",
-                    "cause_id": 456,
-                },
-                "invoking_user": {
-                    "id": self.user.id,
-                    "display_name": self.user.get_display_name(),
-                },
-                "organization_id": self.organization.id,
-            }
-        )
-        expected_url = f"{settings.SEER_AUTOFIX_URL}/v1/automation/autofix/update"
-        expected_headers = {
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(expected_body),
-        }
-        mock_request.assert_called_once_with(
-            expected_url,
-            data=expected_body,
-            headers=expected_headers,
-        )
+        mock_request.assert_called_once()
+        body = orjson.loads(mock_request.call_args[0][2])
+        assert body["run_id"] == 123
+        assert body["payload"]["type"] == "select_root_cause"
+        assert body["payload"]["cause_id"] == 456
+        assert body["invoking_user"]["id"] == self.user.id
+        assert body["organization_id"] == self.organization.id
+        assert mock_request.call_args[0][1] == "/v1/automation/autofix/update"
 
     @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
     def test_autofix_update_failure(self, mock_request: MagicMock) -> None:
-        mock_request.return_value.raise_for_status.side_effect = Exception("Failed to update")
+        mock_request.return_value.status = 500
 
         response = self.client.post(
             self.url,
@@ -86,7 +68,7 @@ class TestGroupAutofixUpdate(APITestCase):
     @patch("sentry.seer.endpoints.group_autofix_update.make_signed_seer_api_request")
     def test_autofix_update_updates_last_triggered_field(self, mock_request):
         """Test that a successful call updates the seer_autofix_last_triggered field."""
-        mock_request.return_value.status_code = 202
+        mock_request.return_value.status = 202
         mock_request.return_value.json.return_value = {}
 
         self.group.refresh_from_db()

--- a/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
+++ b/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
@@ -30,12 +30,11 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
         )
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_successful_title_generation(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_successful_title_generation(self, mock_request: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": "My Assigned Errors"}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = self.client.post(
             self.url,
@@ -45,15 +44,14 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
 
         assert response.status_code == 200
         assert response.data == {"title": "My Assigned Errors"}
-        mock_post.assert_called_once()
+        mock_request.assert_called_once()
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_title_is_stripped(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_title_is_stripped(self, mock_request: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": "  Title With Whitespace  "}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = self.client.post(
             self.url,
@@ -102,9 +100,9 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
         assert response.data == {"detail": "AI features are disabled for this organization."}
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_seer_api_error(self, mock_post: MagicMock) -> None:
-        mock_post.side_effect = requests.RequestException("Connection error")
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_seer_api_error(self, mock_request: MagicMock) -> None:
+        mock_request.side_effect = requests.RequestException("Connection error")
 
         response = self.client.post(
             self.url,
@@ -116,12 +114,11 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
         assert response.data == {"detail": "Failed to generate title"}
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_empty_response_from_seer(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_empty_response_from_seer(self, mock_request: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": None}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         response = self.client.post(
             self.url,
@@ -133,12 +130,11 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
         assert response.data == {"detail": "Failed to generate title"}
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_long_query_is_truncated(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_long_query_is_truncated(self, mock_request: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": "Generated Title"}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         long_query = "x" * 600
 
@@ -149,19 +145,18 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
         )
 
         assert response.status_code == 200
-        call_args = mock_post.call_args
+        call_args = mock_request.call_args
         request_body = call_args.kwargs["data"]
         assert len(long_query[:500]) == 500
         assert b"x" * 500 in request_body
         assert b"x" * 600 not in request_body
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_org_read_permission(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_org_read_permission(self, mock_request: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.json.return_value = {"content": "My Assigned Errors"}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_request.return_value = mock_response
 
         for scope in ["org:read", "org:write", "org:admin"]:
             token = self._create_token(scope)
@@ -174,8 +169,8 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
             assert response.data == {"title": "My Assigned Errors"}
 
     @with_feature("organizations:issue-view-ai-title")
-    @patch("sentry.seer.endpoints.issue_view_title_generate.requests.post")
-    def test_requires_org_scope(self, mock_post: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
+    def test_requires_org_scope(self, mock_request: MagicMock) -> None:
         token = self._create_token("project:read")
         response = self._post_with_token(
             token,
@@ -184,4 +179,4 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
 
         assert response.status_code == 403
         assert response.data == {"detail": "You do not have permission to perform this action."}
-        mock_post.assert_not_called()
+        mock_request.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
+++ b/tests/sentry/seer/endpoints/test_issue_view_title_generate.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import requests
-
 from sentry.models.apitoken import ApiToken
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
@@ -32,7 +30,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_successful_title_generation(self, mock_request: MagicMock) -> None:
-        mock_response = MagicMock()
+        mock_response = MagicMock(status=200)
         mock_response.json.return_value = {"content": "My Assigned Errors"}
         mock_request.return_value = mock_response
 
@@ -49,7 +47,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_title_is_stripped(self, mock_request: MagicMock) -> None:
-        mock_response = MagicMock()
+        mock_response = MagicMock(status=200)
         mock_response.json.return_value = {"content": "  Title With Whitespace  "}
         mock_request.return_value = mock_response
 
@@ -102,7 +100,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_seer_api_error(self, mock_request: MagicMock) -> None:
-        mock_request.side_effect = requests.RequestException("Connection error")
+        mock_request.side_effect = Exception("Connection error")
 
         response = self.client.post(
             self.url,
@@ -116,7 +114,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_empty_response_from_seer(self, mock_request: MagicMock) -> None:
-        mock_response = MagicMock()
+        mock_response = MagicMock(status=200)
         mock_response.json.return_value = {"content": None}
         mock_request.return_value = mock_response
 
@@ -132,7 +130,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_long_query_is_truncated(self, mock_request: MagicMock) -> None:
-        mock_response = MagicMock()
+        mock_response = MagicMock(status=200)
         mock_response.json.return_value = {"content": "Generated Title"}
         mock_request.return_value = mock_response
 
@@ -146,7 +144,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
 
         assert response.status_code == 200
         call_args = mock_request.call_args
-        request_body = call_args.kwargs["data"]
+        request_body = call_args[0][2]
         assert len(long_query[:500]) == 500
         assert b"x" * 500 in request_body
         assert b"x" * 600 not in request_body
@@ -154,7 +152,7 @@ class IssueViewTitleGenerateEndpointTest(APITestCase):
     @with_feature("organizations:issue-view-ai-title")
     @patch("sentry.seer.endpoints.issue_view_title_generate.make_signed_seer_api_request")
     def test_org_read_permission(self, mock_request: MagicMock) -> None:
-        mock_response = MagicMock()
+        mock_response = MagicMock(status=200)
         mock_response.json.return_value = {"content": "My Assigned Errors"}
         mock_request.return_value = mock_response
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_runs.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from unittest.mock import ANY, MagicMock, patch
 
-import requests
 from django.urls import reverse
 
 from sentry.seer.explorer.client_models import ExplorerRun
+from sentry.seer.models import SeerApiError
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils.cursors import Cursor
@@ -131,7 +131,7 @@ class TestOrganizationSeerExplorerRunsEndpoint(APITestCase):
         assert call_args.kwargs["limit"] == 3
 
     def test_get_with_seer_error(self) -> None:
-        self.mock_client.get_runs.side_effect = requests.HTTPError("API Error")
+        self.mock_client.get_runs.side_effect = SeerApiError("API Error", 500)
         response = self.client.get(self.url)
         assert response.status_code == 500
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import orjson
-from django.conf import settings
 from rest_framework import status
 
 from sentry.testutils.cases import APITestCase
@@ -28,7 +27,7 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
         self, mock_request: MagicMock, mock_has_access: MagicMock
     ) -> None:
         mock_has_access.return_value = (True, None)
-        mock_request.return_value.status_code = 200
+        mock_request.return_value.status = 200
         mock_request.return_value.json.return_value = {"run_id": 123}
 
         response = self.client.post(
@@ -47,10 +46,10 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
         # Verify the request was made to Seer
         mock_request.assert_called_once()
         call_args = mock_request.call_args
-        assert f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/update" in call_args[0]
+        assert call_args[0][1] == "/v1/automation/explorer/update"
 
         # Verify the payload
-        sent_data = orjson.loads(call_args[1]["data"])
+        sent_data = orjson.loads(call_args[0][2])
         assert sent_data["run_id"] == "123"
         assert sent_data["organization_id"] == self.organization.id
         assert sent_data["payload"]["type"] == "interrupt"

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_update.py
@@ -23,13 +23,13 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
     @patch(
         "sentry.seer.endpoints.organization_seer_explorer_update.has_seer_explorer_access_with_detail"
     )
-    @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.make_signed_seer_api_request")
     def test_explorer_update_successful(
-        self, mock_post: MagicMock, mock_has_access: MagicMock
+        self, mock_request: MagicMock, mock_has_access: MagicMock
     ) -> None:
         mock_has_access.return_value = (True, None)
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.json.return_value = {"run_id": 123}
+        mock_request.return_value.status_code = 200
+        mock_request.return_value.json.return_value = {"run_id": 123}
 
         response = self.client.post(
             self.url,
@@ -45,8 +45,8 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
         assert response.data == {"run_id": 123}
 
         # Verify the request was made to Seer
-        mock_post.assert_called_once()
-        call_args = mock_post.call_args
+        mock_request.assert_called_once()
+        call_args = mock_request.call_args
         assert f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/update" in call_args[0]
 
         # Verify the payload
@@ -58,9 +58,9 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
     @patch(
         "sentry.seer.endpoints.organization_seer_explorer_update.has_seer_explorer_access_with_detail"
     )
-    @patch("sentry.seer.endpoints.organization_seer_explorer_update.requests.post")
+    @patch("sentry.seer.endpoints.organization_seer_explorer_update.make_signed_seer_api_request")
     def test_explorer_update_missing_payload(
-        self, mock_post: MagicMock, mock_has_access: MagicMock
+        self, mock_request: MagicMock, mock_has_access: MagicMock
     ) -> None:
         mock_has_access.return_value = (True, None)
 
@@ -72,7 +72,7 @@ class TestOrganizationSeerExplorerUpdate(APITestCase):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "Need a body with a payload" in str(response.data)
-        mock_post.assert_not_called()
+        mock_request.assert_not_called()
 
     @patch(
         "sentry.seer.endpoints.organization_seer_explorer_update.has_seer_explorer_access_with_detail"


### PR DESCRIPTION
Migrate all Seer endpoint API calls from `requests.post` + `sign_with_seer_secret` to `make_signed_seer_api_request` with urllib3 connection pools, continuing the work from #109205 (autofix/summarization) and #109224 (explorer).

Changes:
- Add missing `seer_autofix_default_connection_pool` and `seer_anomaly_detection_default_connection_pool` to `signed_seer_api.py`
- Replace bare `Exception` raises with `SeerApiError` across all 11 endpoint files to preserve HTTP status context
- Fix `organization_seer_explorer_update` to use the correct `explorer_connection_pool` instead of the autofix pool
- Remove local `SeerHTTPError` class from `search_agent_start.py` in favor of the shared `SeerApiError`
- Update all endpoint tests for urllib3 response patterns (`.status` instead of `.status_code`, positional `call_args` instead of kwargs, `SeerApiError` instead of `requests.HTTPError`)