### PR TITLE
fix(fixability): Always pass issue summary to fixability endpoint

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -310,14 +310,26 @@ def _generate_fixability_score(
 def get_and_update_group_fixability_score(
     group: Group,
     force_generate: bool = False,
-    summary: dict[str, Any] | None = None,
 ) -> float:
     """
     Get the fixability score for a group and update the group with the score.
     If the fixability score is already set, return it without generating a new one.
+    Reads the issue summary from cache to pass to Seer, avoiding a DB lookup.
     """
     if not force_generate and group.seer_fixability_score is not None:
         return group.seer_fixability_score
+
+    # Read summary from cache to pass to Seer, avoiding a DB lookup
+    summary = None
+    cache_key = get_issue_summary_cache_key(group.id)
+    cached = cache.get(cache_key)
+    if cached:
+        required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
+        if all(cached.get(k) is not None for k in required_fields):
+            summary = {
+                "group_id": group.id,
+                **{k: cached[k] for k in required_fields},
+            }
 
     with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
         issue_summary = _generate_fixability_score(group, summary=summary)
@@ -479,6 +491,11 @@ def _generate_summary(
         trace_tree,
     )
 
+    summary_dict = issue_summary.dict()
+    summary_dict["event_id"] = event.event_id
+
+    cache.set(cache_key, summary_dict, timeout=int(timedelta(days=7).total_seconds()))
+
     if should_run_automation:
         try:
             run_automation(group, user, event, source)
@@ -486,11 +503,6 @@ def _generate_summary(
             logger.exception(
                 "Error auto-triggering autofix from issue summary", extra={"group_id": group.id}
             )
-
-    summary_dict = issue_summary.dict()
-    summary_dict["event_id"] = event.event_id
-
-    cache.set(cache_key, summary_dict, timeout=int(timedelta(days=7).total_seconds()))
 
     return summary_dict, 200
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -314,7 +314,7 @@ def get_and_update_group_fixability_score(
     """
     Get the fixability score for a group and update the group with the score.
     If the fixability score is already set, return it without generating a new one.
-    Reads the issue summary from cache to pass to Seer, avoiding a DB lookup.
+    Reads the issue summary from cache to pass to Seer, avoiding a DB lookup for the summary on Seer's side.
     """
     if not force_generate and group.seer_fixability_score is not None:
         return group.seer_fixability_score

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -319,17 +319,22 @@ def get_and_update_group_fixability_score(
     if not force_generate and group.seer_fixability_score is not None:
         return group.seer_fixability_score
 
-    # Read summary from cache to pass to Seer, avoiding a DB lookup
     summary = None
-    cache_key = get_issue_summary_cache_key(group.id)
-    cached = cache.get(cache_key)
-    if cached:  # If it's not in the cache, we fallback to reading from Seer DB
-        required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
-        if all(cached.get(k) is not None for k in required_fields):
-            summary = {
-                "group_id": group.id,
-                **{k: cached[k] for k in required_fields},
-            }
+    try:
+        cache_key = get_issue_summary_cache_key(group.id)
+        cached = cache.get(cache_key)
+        if cached:
+            required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
+            if all(cached.get(k) is not None for k in required_fields):
+                summary = {
+                    "group_id": group.id,
+                    **{k: cached[k] for k in required_fields},
+                }
+    except Exception:
+        logger.exception(
+            "Failed to read issue summary from cache for fixability score",
+            extra={"group_id": group.id},
+        )
 
     with sentry_sdk.start_span(op="ai_summary.generate_fixability_score"):
         issue_summary = _generate_fixability_score(group, summary=summary)
@@ -493,7 +498,6 @@ def _generate_summary(
 
     summary_dict = issue_summary.dict()
     summary_dict["event_id"] = event.event_id
-
     cache.set(cache_key, summary_dict, timeout=int(timedelta(days=7).total_seconds()))
 
     if should_run_automation:

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -323,7 +323,7 @@ def get_and_update_group_fixability_score(
     summary = None
     cache_key = get_issue_summary_cache_key(group.id)
     cached = cache.get(cache_key)
-    if cached:
+    if cached:  # If it's not in the cache, we fallback to reading from Seer DB
         required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
         if all(cached.get(k) is not None for k in required_fields):
             summary = {

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -116,7 +116,7 @@ def generate_issue_summary_only(group_id: int) -> None:
             )
         )
 
-    # Generate and cache the summary (cache is read by get_and_update_group_fixability_score)
+    # Generate and cache the summary
     get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )

--- a/src/sentry/tasks/autofix.py
+++ b/src/sentry/tasks/autofix.py
@@ -94,10 +94,6 @@ def generate_issue_summary_only(group_id: int) -> None:
     Generate issue summary WITHOUT triggering automation.
     Used for triage signals flow when event count < 10 or when summary doesn't exist yet.
     """
-    from sentry.api.serializers.rest_framework.base import (
-        camel_to_snake_case,
-        convert_dict_key_case,
-    )
     from sentry.seer.autofix.issue_summary import (
         get_and_update_group_fixability_score,
         get_issue_summary,
@@ -120,21 +116,12 @@ def generate_issue_summary_only(group_id: int) -> None:
             )
         )
 
-    summary_data, status_code = get_issue_summary(
+    # Generate and cache the summary (cache is read by get_and_update_group_fixability_score)
+    get_issue_summary(
         group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
     )
 
-    summary_payload = None
-    if status_code == 200:
-        summary_snake = convert_dict_key_case(summary_data, camel_to_snake_case)
-        required_fields = ["headline", "whats_wrong", "trace", "possible_cause"]
-        if all(summary_snake.get(k) is not None for k in required_fields):
-            summary_payload = {
-                "group_id": group.id,
-                **{k: summary_snake[k] for k in required_fields},
-            }
-
-    get_and_update_group_fixability_score(group, force_generate=True, summary=summary_payload)
+    get_and_update_group_fixability_score(group, force_generate=True)
 
 
 @instrumented_task(

--- a/tests/sentry/tasks/test_autofix.py
+++ b/tests/sentry/tasks/test_autofix.py
@@ -109,10 +109,10 @@ class TestCheckAutofixStatus(TestCase):
 class TestGenerateIssueSummaryOnly(SentryTestCase):
     @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
     @patch("sentry.seer.autofix.issue_summary.get_issue_summary")
-    def test_generates_fixability_score_with_summary(
+    def test_generates_fixability_score_after_summary(
         self, mock_get_issue_summary: MagicMock, mock_generate_fixability: MagicMock
     ) -> None:
-        """Test that fixability score is generated with summary passed to Seer."""
+        """Test that fixability score is generated after issue summary is fetched."""
         group = self.create_group(project=self.project)
 
         mock_get_issue_summary.return_value = (
@@ -140,48 +140,9 @@ class TestGenerateIssueSummaryOnly(SentryTestCase):
             group=group, source=SeerAutomationSource.POST_PROCESS, should_run_automation=False
         )
         mock_generate_fixability.assert_called_once()
-        call_args = mock_generate_fixability.call_args
-        assert call_args[0][0] == group
-        summary_arg = call_args[1]["summary"]
-        assert isinstance(summary_arg, dict)
-        assert summary_arg["headline"] == "Test Headline"
 
         group.refresh_from_db()
         assert group.seer_fixability_score == 0.75
-
-    @patch("sentry.seer.autofix.issue_summary._generate_fixability_score")
-    @patch("sentry.seer.autofix.issue_summary.get_issue_summary")
-    def test_does_not_pass_summary_when_fields_are_none(
-        self, mock_get_issue_summary: MagicMock, mock_generate_fixability: MagicMock
-    ) -> None:
-        """Test that summary is not passed when required fields are None."""
-        group = self.create_group(project=self.project)
-
-        mock_get_issue_summary.return_value = (
-            {
-                "groupId": str(group.id),
-                "headline": "Test Headline",
-                "whatsWrong": None,
-                "trace": "Test trace",
-                "possibleCause": None,
-            },
-            200,
-        )
-        mock_generate_fixability.return_value = SummarizeIssueResponse(
-            group_id=str(group.id),
-            headline="Test",
-            whats_wrong="Test",
-            trace="Test",
-            possible_cause="Test",
-            scores=SummarizeIssueScores(fixability_score=0.80),
-        )
-
-        generate_issue_summary_only(group.id)
-
-        mock_generate_fixability.assert_called_once_with(group, summary=None)
-
-        group.refresh_from_db()
-        assert group.seer_fixability_score == 0.80
 
 
 class TestConfigureSeerForExistingOrg(SentryTestCase):


### PR DESCRIPTION
## PR Details
+ Changed the `get_and_update_group_fixability_score` function to always use issue summary from the cache and pass it to the fixability Seer endpoint. This function is called everytime fixability needs to be calculated.
+ If it's not in the cache then we will fallback to looking up in the seer DB. 