### PR TITLE
ref(seer): Migrate remaining seer calls to urllib3 connection pools

### DIFF
--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -13,6 +13,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -93,7 +94,7 @@ class SeerModelsEndpoint(Endpoint):
                 method="GET",
             )
             if response.status >= 400:
-                raise Exception(f"Seer request failed with status {response.status}")
+                raise SeerApiError("Seer request failed", response.status)
 
             data = response.json()
             cache.set(SEER_MODELS_CACHE_KEY, data, SEER_MODELS_CACHE_TIMEOUT)

--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -19,7 +19,6 @@ from sentry.seer.signed_seer_api import (
     seer_autofix_default_connection_pool,
 )
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-from sentry.utils import json
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
@@ -103,6 +102,6 @@ class SeerModelsEndpoint(Endpoint):
         except TimeoutError:
             logger.warning("Timeout when fetching models from Seer")
             raise SeerTimeoutError()
-        except (Exception, json.JSONDecodeError):
+        except Exception:
             logger.exception("Error fetching models from Seer")
             raise SeerConnectionError()

--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 from typing import TypedDict
 
-import requests
-from django.conf import settings
 from drf_spectacular.utils import extend_schema
 from rest_framework.exceptions import APIException
 from rest_framework.request import Request
@@ -15,7 +13,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
 from sentry.utils.cache import cache
@@ -84,23 +85,23 @@ class SeerModelsEndpoint(Endpoint):
         path = "/v1/models"
 
         try:
-            response = requests.get(
-                f"{settings.SEER_AUTOFIX_URL}{path}",
-                headers={
-                    "content-type": "application/json;charset=utf-8",
-                    **sign_with_seer_secret(b""),
-                },
+            response = make_signed_seer_api_request(
+                seer_autofix_default_connection_pool,
+                path,
+                b"",
                 timeout=5,
+                method="GET",
             )
-            response.raise_for_status()
+            if response.status >= 400:
+                raise Exception(f"Seer request failed with status {response.status}")
 
             data = response.json()
             cache.set(SEER_MODELS_CACHE_KEY, data, SEER_MODELS_CACHE_TIMEOUT)
             return Response(data, status=200)
 
-        except requests.exceptions.Timeout:
+        except TimeoutError:
             logger.warning("Timeout when fetching models from Seer")
             raise SeerTimeoutError()
-        except (requests.exceptions.RequestException, json.JSONDecodeError):
+        except (Exception, json.JSONDecodeError):
             logger.exception("Error fetching models from Seer")
             raise SeerConnectionError()

--- a/src/sentry/seer/services/test_generation/impl.py
+++ b/src/sentry/seer/services/test_generation/impl.py
@@ -1,17 +1,18 @@
 import orjson
-import requests
-from django.conf import settings
 
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.seer.services.test_generation.model import CreateUnitTestResponse
 from sentry.seer.services.test_generation.service import TestGenerationService
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 
 class RegionBackedTestGenerationService(TestGenerationService):
     def start_unit_test_generation(
         self, *, region_name: str, github_org: str, repo: str, pr_id: int, external_id: str
     ) -> CreateUnitTestResponse:
-        url = f"{settings.SEER_AUTOFIX_URL}/v1/automation/codegen/unit-tests"
         body = orjson.dumps(
             {
                 "repo": {
@@ -25,15 +26,13 @@ class RegionBackedTestGenerationService(TestGenerationService):
             option=orjson.OPT_NON_STR_KEYS,
         )
 
-        response = requests.post(
-            url,
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            "/v1/automation/codegen/unit-tests",
+            body,
         )
 
-        if response.status_code == 200:
+        if response.status == 200:
             return CreateUnitTestResponse()
         else:
-            return CreateUnitTestResponse(error_detail=response.text)
+            return CreateUnitTestResponse(error_detail=response.data.decode("utf-8"))

--- a/src/sentry/seer/services/test_generation/impl.py
+++ b/src/sentry/seer/services/test_generation/impl.py
@@ -35,4 +35,10 @@ class RegionBackedTestGenerationService(TestGenerationService):
         if response.status == 200:
             return CreateUnitTestResponse()
         else:
-            return CreateUnitTestResponse(error_detail=response.data.decode("utf-8"))
+            try:
+                error_detail = response.data.decode("utf-8") if response.data else None
+            except (AttributeError, UnicodeDecodeError):
+                error_detail = None
+            return CreateUnitTestResponse(
+                error_detail=error_detail or f"Request failed with status {response.status}"
+            )

--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 
 
 def trigger_supergroups_embedding(
@@ -21,13 +22,11 @@ def trigger_supergroups_embedding(
         }
     )
 
-    response = requests.post(
-        f"{settings.SEER_AUTOFIX_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        path,
+        body,
         timeout=5,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")

--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import orjson
 
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -29,4 +30,4 @@ def trigger_supergroups_embedding(
         timeout=5,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from sentry import features
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.organization import Organization
-from sentry.seer.models import SummarizeTraceResponse
+from sentry.seer.models import SeerApiError, SummarizeTraceResponse
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_summarization_default_connection_pool,
@@ -86,6 +86,6 @@ def _call_seer(
         body,
     )
     if response.status >= 400:
-        raise Exception(f"Seer request failed with status {response.status}")
+        raise SeerApiError("Seer request failed", response.status)
 
     return SummarizeTraceResponse.validate(response.json())

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -3,15 +3,16 @@ from datetime import timedelta
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 
 from sentry import features
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.organization import Organization
 from sentry.seer.models import SummarizeTraceResponse
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_summarization_default_connection_pool,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.cache import cache
@@ -79,14 +80,12 @@ def _call_seer(
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = requests.post(
-        f"{settings.SEER_SUMMARIZATION_URL}{path}",
-        data=body,
-        headers={
-            "content-type": "application/json;charset=utf-8",
-            **sign_with_seer_secret(body),
-        },
+    response = make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        path,
+        body,
     )
-    response.raise_for_status()
+    if response.status >= 400:
+        raise Exception(f"Seer request failed with status {response.status}")
 
     return SummarizeTraceResponse.validate(response.json())

--- a/src/sentry/tasks/seer.py
+++ b/src/sentry/tasks/seer.py
@@ -4,6 +4,7 @@ import logging
 
 import orjson
 
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -47,7 +48,7 @@ def cleanup_seer_repository_preferences(
             body,
         )
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
         logger.info(
             "cleanup_seer_repository_preferences.success",
             extra={

--- a/src/sentry/tasks/seer.py
+++ b/src/sentry/tasks/seer.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 
 import orjson
-import requests
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
@@ -40,15 +41,13 @@ def cleanup_seer_repository_preferences(
     )
 
     try:
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
         )
-        response.raise_for_status()
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
         logger.info(
             "cleanup_seer_repository_preferences.success",
             extra={

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -12,6 +12,7 @@ from sentry import features, options
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.options.rollout import in_rollout_group
+from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     seer_autofix_default_connection_pool,
@@ -235,7 +236,7 @@ def run_explorer_index_for_projects(
             timeout=30,
         )
         if response.status >= 400:
-            raise Exception(f"Seer request failed with status {response.status}")
+            raise SeerApiError("Seer request failed", response.status)
     except Exception as e:
         logger.exception(
             "Failed to schedule explorer index tasks in seer",

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -5,16 +5,17 @@ from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta
 
 import orjson
-import requests
 import sentry_sdk
-from django.conf import settings
 from django.utils import timezone as django_timezone
 
 from sentry import features, options
 from sentry.constants import ObjectStatus
 from sentry.models.project import Project
 from sentry.options.rollout import in_rollout_group
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.statistical_detectors import compute_delay
 from sentry.taskworker.namespaces import seer_tasks
@@ -227,17 +228,15 @@ def run_explorer_index_for_projects(
     path = "/v1/automation/explorer/index"
 
     try:
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}{path}",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            path,
+            body,
             timeout=30,
         )
-        response.raise_for_status()
-    except requests.RequestException as e:
+        if response.status >= 400:
+            raise Exception(f"Seer request failed with status {response.status}")
+    except Exception as e:
         logger.exception(
             "Failed to schedule explorer index tasks in seer",
             extra={

--- a/src/sentry/uptime/seer_assertions.py
+++ b/src/sentry/uptime/seer_assertions.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import orjson
 from pydantic import BaseModel, Field
+from urllib3.exceptions import MaxRetryError
+from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
 
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
@@ -361,7 +363,7 @@ def generate_assertion_suggestions(
         )
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
-    except SeerApiError as e:
+    except (SeerApiError, MaxRetryError, Urllib3TimeoutError) as e:
         logger.exception("Failed to call Seer LLM proxy")
         return None, f"Seer LLM proxy request failed: {e}"
 

--- a/src/sentry/uptime/seer_assertions.py
+++ b/src/sentry/uptime/seer_assertions.py
@@ -10,11 +10,13 @@ import logging
 from typing import Any
 
 import orjson
-import requests
-from django.conf import settings
 from pydantic import BaseModel, Field
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import (
+    make_signed_seer_api_request,
+    seer_autofix_default_connection_pool,
+)
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -351,17 +353,15 @@ def generate_assertion_suggestions(
     )
 
     try:
-        response = requests.post(
-            f"{settings.SEER_AUTOFIX_URL}/v1/llm/generate",
-            data=body,
-            headers={
-                "content-type": "application/json;charset=utf-8",
-                **sign_with_seer_secret(body),
-            },
+        response = make_signed_seer_api_request(
+            seer_autofix_default_connection_pool,
+            "/v1/llm/generate",
+            body,
             timeout=30,
         )
-        response.raise_for_status()
-    except requests.RequestException as e:
+        if response.status >= 400:
+            raise SeerApiError("Seer request failed", response.status)
+    except SeerApiError as e:
         logger.exception("Failed to call Seer LLM proxy")
         return None, f"Seer LLM proxy request failed: {e}"
 

--- a/tests/sentry/seer/test_supergroups.py
+++ b/tests/sentry/seer/test_supergroups.py
@@ -1,17 +1,15 @@
 from unittest.mock import patch
 
 import orjson
-from django.conf import settings
 
 from sentry.seer.supergroups import trigger_supergroups_embedding
 from sentry.testutils.cases import TestCase
 
 
 class TriggerSupergroupsEmbeddingTest(TestCase):
-    @patch("sentry.seer.supergroups.requests.post")
-    @patch("sentry.seer.supergroups.sign_with_seer_secret", return_value={})
-    def test_calls_seer_with_correct_payload(self, mock_sign, mock_post):
-        mock_post.return_value.raise_for_status.return_value = None
+    @patch("sentry.seer.supergroups.make_signed_seer_api_request")
+    def test_calls_seer_with_correct_payload(self, mock_request):
+        mock_request.return_value.status = 200
 
         trigger_supergroups_embedding(
             organization_id=1,
@@ -19,12 +17,14 @@ class TriggerSupergroupsEmbeddingTest(TestCase):
             artifact_data={"one_line_description": "Null pointer in auth module"},
         )
 
-        mock_post.assert_called_once()
-        assert mock_post.call_args.args[0] == f"{settings.SEER_AUTOFIX_URL}/v0/issues/supergroups"
-        assert mock_post.call_args.kwargs["timeout"] == 5
+        mock_request.assert_called_once()
+        # First arg is connection pool, second is path
+        call_args = mock_request.call_args
+        assert "/v0/issues/supergroups" in call_args.args[1]
+        assert call_args.kwargs["timeout"] == 5
 
-        mock_sign.assert_called_once()
-        payload = orjson.loads(mock_sign.call_args.args[0])
+        # Third arg is the body (payload)
+        payload = orjson.loads(call_args.args[2])
         assert payload["organization_id"] == 1
         assert payload["group_id"] == 123
         assert payload["artifact_data"] == {"one_line_description": "Null pointer in auth module"}

--- a/tests/sentry/seer/test_test_generation.py
+++ b/tests/sentry/seer/test_test_generation.py
@@ -8,7 +8,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import control_silo_test
 
 
-@patch("sentry.seer.services.test_generation.impl.requests.post")
+@patch("sentry.seer.services.test_generation.impl.make_signed_seer_api_request")
 @django_db_all
 @control_silo_test
 def test_start_unit_test_generation(posts_mock: MagicMock) -> None:

--- a/tests/sentry/seer/test_test_generation.py
+++ b/tests/sentry/seer/test_test_generation.py
@@ -1,6 +1,5 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
-import requests
 from django.conf import settings
 
 from sentry.seer.services.test_generation.service import test_generation_service
@@ -11,11 +10,9 @@ from sentry.testutils.silo import control_silo_test
 @patch("sentry.seer.services.test_generation.impl.make_signed_seer_api_request")
 @django_db_all
 @control_silo_test
-def test_start_unit_test_generation(posts_mock: MagicMock) -> None:
-    response_object: requests.Response = requests.Response()
-    response_object.json = Mock(method="json", return_value={})  # type: ignore[method-assign]
-    response_object.status_code = 200
-    posts_mock.return_value = response_object
+def test_start_unit_test_generation(mock_request: MagicMock) -> None:
+    mock_request.return_value.status = 200
+    mock_request.return_value.json.return_value = {}
     response = test_generation_service.start_unit_test_generation(
         region_name=settings.SENTRY_MONOLITH_REGION,
         github_org="some-org",
@@ -25,4 +22,4 @@ def test_start_unit_test_generation(posts_mock: MagicMock) -> None:
     )
     assert response.success
 
-    posts_mock.assert_called_once()
+    mock_request.assert_called_once()

--- a/tests/sentry/tasks/test_seer.py
+++ b/tests/sentry/tasks/test_seer.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import orjson
 import pytest
-import responses
-from django.conf import settings
 
-from sentry.seer.signed_seer_api import sign_with_seer_secret
+from sentry.seer.models import SeerApiError
 from sentry.tasks.seer import cleanup_seer_repository_preferences
 from sentry.testutils.cases import TestCase
 
@@ -17,91 +17,56 @@ class TestSeerRepositoryCleanup(TestCase):
         self.repo_external_id = "12345"
         self.repo_provider = "github"
 
-    @responses.activate
-    def test_cleanup_seer_repository_preferences_success(self) -> None:
+    @patch("sentry.tasks.seer.make_signed_seer_api_request")
+    def test_cleanup_seer_repository_preferences_success(self, mock_request: MagicMock) -> None:
         """Test successful cleanup of Seer repository preferences."""
-        # Mock the Seer API response
-        responses.add(
-            responses.POST,
-            f"{settings.SEER_AUTOFIX_URL}/v1/project-preference/remove-repository",
-            status=200,
-        )
+        mock_request.return_value.status = 200
 
-        # Call the task
         cleanup_seer_repository_preferences(
             organization_id=self.organization.id,
             repo_external_id=self.repo_external_id,
             repo_provider=self.repo_provider,
         )
 
-        # Verify the request was made with correct data
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
+        mock_request.assert_called_once()
+        body = orjson.loads(mock_request.call_args[0][2])
+        assert body == {
+            "organization_id": self.organization.id,
+            "repo_provider": self.repo_provider,
+            "repo_external_id": self.repo_external_id,
+        }
 
-        expected_body = orjson.dumps(
-            {
-                "organization_id": self.organization.id,
-                "repo_provider": self.repo_provider,
-                "repo_external_id": self.repo_external_id,
-            }
-        )
-
-        assert request.body == expected_body
-        assert request.headers["content-type"] == "application/json;charset=utf-8"
-
-        # Verify the request was signed
-        expected_headers = sign_with_seer_secret(expected_body)
-        for header_name, header_value in expected_headers.items():
-            assert request.headers[header_name] == header_value
-
-    @responses.activate
-    def test_cleanup_seer_repository_preferences_api_error(self) -> None:
+    @patch("sentry.tasks.seer.make_signed_seer_api_request")
+    def test_cleanup_seer_repository_preferences_api_error(self, mock_request: MagicMock) -> None:
         """Test handling of Seer API errors."""
-        # Mock the Seer API to return an error
-        responses.add(
-            responses.POST,
-            f"{settings.SEER_AUTOFIX_URL}/v1/project-preference/remove-repository",
-            status=500,
-        )
+        mock_request.return_value.status = 500
 
-        # Call the task and expect it to raise an exception
-        with pytest.raises(Exception):
+        with pytest.raises(SeerApiError):
             cleanup_seer_repository_preferences(
                 organization_id=self.organization.id,
                 repo_external_id=self.repo_external_id,
                 repo_provider=self.repo_provider,
             )
 
-    @responses.activate
-    def test_cleanup_seer_repository_preferences_organization_not_found(self) -> None:
+    @patch("sentry.tasks.seer.make_signed_seer_api_request")
+    def test_cleanup_seer_repository_preferences_organization_not_found(
+        self, mock_request: MagicMock
+    ) -> None:
         """Test handling when organization doesn't exist."""
-        # Mock the Seer API response for non-existent organization
-        responses.add(
-            responses.POST,
-            f"{settings.SEER_AUTOFIX_URL}/v1/project-preference/remove-repository",
-            status=200,
-        )
+        mock_request.return_value.status = 200
 
-        # Use a non-existent organization ID
         nonexistent_organization_id = 99999
 
-        # Call the task - it should still make the API call even if org doesn't exist locally
         cleanup_seer_repository_preferences(
             organization_id=nonexistent_organization_id,
             repo_external_id=self.repo_external_id,
             repo_provider=self.repo_provider,
         )
 
-        # The API call should be made regardless of local organization existence
-        assert len(responses.calls) == 1
-        request = responses.calls[0].request
-
-        expected_body = orjson.dumps(
-            {
-                "organization_id": nonexistent_organization_id,
-                "repo_provider": self.repo_provider,
-                "repo_external_id": self.repo_external_id,
-            }
-        )
-
-        assert request.body == expected_body
+        mock_request.assert_called_once()
+        body = orjson.loads(mock_request.call_args[0][2])
+        assert body == {
+            "organization_id": nonexistent_organization_id,
+            "repo_provider": self.repo_provider,
+            "repo_external_id": self.repo_external_id,
+        }

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -452,6 +452,6 @@ class TestRunExplorerIndexForProjects(TestCase):
 
     def test_skips_when_option_disabled(self):
         with self.options({"seer.explorer_index.enable": False}):
-            with mock.patch("sentry.tasks.seer_explorer_index.requests.post") as mock_post:
+            with mock.patch("sentry.tasks.seer_explorer_index.requests.post") as mock_request:
                 run_explorer_index_for_projects([(1, 100)], "2024-01-15T12:00:00+00:00")
-                mock_post.assert_not_called()
+                mock_request.assert_not_called()

--- a/tests/sentry/tasks/test_seer_explorer_index.py
+++ b/tests/sentry/tasks/test_seer_explorer_index.py
@@ -1,10 +1,9 @@
 from datetime import UTC, datetime
 from unittest import mock
+from unittest.mock import patch
 
 import orjson
 import pytest
-import responses
-from django.conf import settings
 
 from sentry.constants import ObjectStatus
 from sentry.models.promptsactivity import PromptsActivity
@@ -412,39 +411,31 @@ class TestDispatchExplorerIndexProjects(TestCase):
 
 @django_db_all
 class TestRunExplorerIndexForProjects(TestCase):
-    @responses.activate
-    def test_calls_seer_endpoint_successfully(self):
+    @patch("sentry.tasks.seer_explorer_index.make_signed_seer_api_request")
+    def test_calls_seer_endpoint_successfully(self, mock_request):
+        mock_request.return_value.status = 200
+        mock_request.return_value.json.return_value = {"scheduled_count": 3, "projects": []}
+
         projects = [(1, 100), (2, 100), (3, 200)]
         start = "2024-01-15T12:00:00+00:00"
-
-        responses.add(
-            responses.POST,
-            f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/index",
-            json={"scheduled_count": 3, "projects": []},
-            status=200,
-        )
 
         with self.options({"seer.explorer_index.enable": True}):
             run_explorer_index_for_projects(projects, start)
 
-        request_body = orjson.loads(responses.calls[0].request.body)
-        assert request_body["projects"] == [
+        mock_request.assert_called_once()
+        body = orjson.loads(mock_request.call_args[0][2])
+        assert body["projects"] == [
             {"org_id": 100, "project_id": 1},
             {"org_id": 100, "project_id": 2},
             {"org_id": 200, "project_id": 3},
         ]
 
-    @responses.activate
-    def test_handles_request_error(self):
+    @patch("sentry.tasks.seer_explorer_index.make_signed_seer_api_request")
+    def test_handles_request_error(self, mock_request):
+        mock_request.return_value.status = 500
+
         projects = [(1, 100)]
         start = "2024-01-15T12:00:00+00:00"
-
-        responses.add(
-            responses.POST,
-            f"{settings.SEER_AUTOFIX_URL}/v1/automation/explorer/index",
-            json={"error": "Internal server error"},
-            status=500,
-        )
 
         with self.options({"seer.explorer_index.enable": True}):
             with pytest.raises(Exception):
@@ -452,6 +443,8 @@ class TestRunExplorerIndexForProjects(TestCase):
 
     def test_skips_when_option_disabled(self):
         with self.options({"seer.explorer_index.enable": False}):
-            with mock.patch("sentry.tasks.seer_explorer_index.requests.post") as mock_request:
+            with mock.patch(
+                "sentry.tasks.seer_explorer_index.make_signed_seer_api_request"
+            ) as mock_request:
                 run_explorer_index_for_projects([(1, 100)], "2024-01-15T12:00:00+00:00")
                 mock_request.assert_not_called()


### PR DESCRIPTION
Migrate all remaining `requests.post` + `sign_with_seer_secret` calls to `make_signed_seer_api_request` with urllib3 connection pools, completing the migration started in #109205, #109224, and #109254.

**Migrated callers** (requests.post → connection pool):
- `tasks/explorer_context_engine_tasks.py`
- `uptime/seer_assertions.py`
- `seer/services/test_generation/impl.py` (also adds signing that was previously missing)

**SeerApiError cleanup** (bare Exception → SeerApiError):
- `api/endpoints/seer_models.py`
- `seer/supergroups.py`
- `seer/trace_summary.py`
- `tasks/seer.py`
- `tasks/seer_explorer_index.py`

After this change, no external `requests.post` or `sign_with_seer_secret` calls remain outside of `make_signed_seer_api_request`. The only remaining `sign_with_seer_secret` usage is the internal definition and call within `signed_seer_api.py` itself.

Note: `explorer_service_map_utils.py` has a `_send_to_seer` stub with a TODO comment — it doesn't make any actual requests yet.