### PR TITLE
chore: Unpin remaining skills in agents.lock

### DIFF
--- a/agents.lock
+++ b/agents.lock
@@ -75,8 +75,6 @@ resolved_path = ".agents/skills/iterate-pr"
 source = "getsentry/skills"
 resolved_url = "https://github.com/getsentry/skills.git"
 resolved_path = ".agents/skills/security-review"
-commit = "187c0022b3b676f72227a04f1cfc8921a58a5020"
-integrity = "sha256-/PngFJkQcji7nYQjh1yerMnxIBaEJNiClJJ8FuCGgAo="
 
 [skills.skill-creator]
 source = "getsentry/skills"
@@ -97,19 +95,13 @@ resolved_path = ".agents/skills/sred-project-organizer"
 source = "getsentry/skills"
 resolved_url = "https://github.com/getsentry/skills.git"
 resolved_path = ".agents/skills/sred-work-summary"
-commit = "187c0022b3b676f72227a04f1cfc8921a58a5020"
-integrity = "sha256-pnc14+tLxKiEz1MSbO8Y+uM5+XOYLNF4XaDdtCsXtXQ="
 
 [skills.warden]
 source = "getsentry/warden"
 resolved_url = "https://github.com/getsentry/warden.git"
 resolved_path = "skills/warden"
-commit = "a06b8e184d7662e0e86b8fc23fe46c5be20c5fc6"
-integrity = "sha256-8RK1HNFGZ9yTe0GGVaATUPkBlksOWCvRzwrnVDyJKhU="
 
 [skills.warden-sweep]
 source = "getsentry/warden"
 resolved_url = "https://github.com/getsentry/warden.git"
 resolved_path = "skills/warden-sweep"
-commit = "a06b8e184d7662e0e86b8fc23fe46c5be20c5fc6"
-integrity = "sha256-wcCX6b5D8PADzcR5Teg77s3+nh1GUlVf7gKronVb0ko="


### PR DESCRIPTION
Remove pinned `commit` and `integrity` fields from remaining skills in `agents.lock` (security-review, sred-work-summary, warden, warden-sweep).

Follows the same pattern as 28de8fdf6f0 which unpinned other dotagents skills. This ensures these skills always resolve to the latest version from their source repos rather than being locked to specific commits.