### PR TITLE
fix(seer): Apply stacktrace length filtering to all platforms for V2 grouping model

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -159,7 +159,8 @@ def _event_content_is_seer_eligible(event: Event) -> bool:
 
 
 def _stacktrace_exceeds_limits(event: Event, variants: dict[str, BaseVariant]) -> bool:
-    if stacktrace_exceeds_limits(event, variants, ReferrerOptions.INGEST):
+    model_version = get_grouping_model_version(event.project)
+    if stacktrace_exceeds_limits(event, variants, ReferrerOptions.INGEST, model_version):
         record_did_call_seer_metric(event, call_made=False, blocker="stacktrace-too-long")
         return True
 

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -91,11 +91,13 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
         latest_event = group.get_latest_event()
         stacktrace_string = ""
 
+        model_version = get_grouping_model_version(group.project)
+
         if latest_event and event_content_has_stacktrace(latest_event):
             variants = latest_event.get_grouping_variants(normalize_stacktraces=True)
 
             if not stacktrace_exceeds_limits(
-                latest_event, variants, ReferrerOptions.SIMILAR_ISSUES_TAB
+                latest_event, variants, ReferrerOptions.SIMILAR_ISSUES_TAB, model_version
             ):
                 grouping_info = get_grouping_info_from_variants_legacy(variants)
                 try:
@@ -105,8 +107,6 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         if not stacktrace_string or not latest_event:
             return Response([])  # No exception, stacktrace or in-app frames, or event
-
-        model_version = get_grouping_model_version(group.project)
 
         similar_issues_params: SimilarIssuesEmbeddingsRequest = {
             "event_id": latest_event.event_id,


### PR DESCRIPTION
Previously, certain platforms (python, javascript, node, go, php, ruby) bypassed
stacktrace length checks to maintain backward compatibility with data backfilled
before length filtering was introduced. For V2 grouping model, we re-embed
everything anyway, so there's no need to maintain this bypass — we now apply
length checks uniformly across all platforms.

Changes:
- `stacktrace_exceeds_limits()` now accepts an optional `model_version` parameter
- When `model_version` is V2, the platform bypass list is skipped
- Both callers (ingest path and similar issues endpoint) now pass the model version
- Updated and added tests to cover V1 bypass and V2 enforcement behavior