### PR TITLE
perf(options): Add get_many() for batch Redis lookups

### DIFF
--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     "default_store",
     "delete",
     "get",
+    "get_many",
     "get_last_update_channel",
     "isset",
     "lookup_key",
@@ -61,6 +62,7 @@ default_manager = OptionsManager(store=default_store)
 
 # expose public API
 get = default_manager.get
+get_many = default_manager.get_many
 set = default_manager.set
 delete = default_manager.delete
 register = default_manager.register

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -332,6 +332,76 @@ class OptionsManager:
         record_option(key, optval)
         return optval
 
+    def get_many(self, keys: Sequence[str], silent: bool = False) -> dict[str, TAny]:
+        """
+        Get values for multiple options in a single batch.
+        Returns a dict mapping key -> value.
+
+        This is more efficient than calling get() in a loop as it batches
+        Redis cache lookups into a single MGET call.
+        """
+
+        results: dict[str, TAny] = {}
+        store_keys: list[Key] = []
+
+        for key_name in keys:
+            opt = self.lookup_key(key_name)
+
+            # Check FLAG_PRIORITIZE_DISK first
+            if opt.has_any_flag({FLAG_PRIORITIZE_DISK}):
+                try:
+                    result = settings.SENTRY_OPTIONS[key_name]
+                    if result is not None:
+                        results[key_name] = result
+                        record_option(key_name, result)
+                        continue
+                except KeyError:
+                    pass
+
+            if not (opt.flags & FLAG_NOSTORE):
+                store_keys.append(opt)
+            else:
+                # For NOSTORE options, use defaults
+                default_val = self._get_default(opt)
+                results[key_name] = default_val
+                record_option(key_name, default_val)
+
+        # Batch fetch from store (uses MGET internally)
+        if store_keys:
+            store_results = self.store.get_many(store_keys, silent=silent)
+
+            # Collect defaults that need caching as list of tuples
+            defaults_to_cache: list[tuple[Key, TAny]] = []
+
+            for opt in store_keys:
+                if opt.name in store_results and store_results[opt.name] is not None:
+                    results[opt.name] = store_results[opt.name]
+                    record_option(opt.name, results[opt.name])
+                else:
+                    # Fall back to default
+                    default_val = self._get_default(opt)
+                    results[opt.name] = default_val
+                    defaults_to_cache.append((opt, default_val))
+                    record_option(opt.name, default_val)
+
+            # Bulk cache defaults (1 Redis call via set_many)
+            if defaults_to_cache:
+                self.store.set_cache_many(defaults_to_cache)
+
+        return results
+
+    def _get_default(self, opt: Key) -> TAny:
+        """Get default value for an option."""
+        if opt.has_any_flag({FLAG_STOREONLY}):
+            return opt.default()
+        try:
+            return settings.SENTRY_OPTIONS[opt.name]
+        except KeyError:
+            try:
+                return settings.SENTRY_DEFAULT_OPTIONS[opt.name]
+            except KeyError:
+                return opt.default()
+
     def delete(self, key: str):
         """
         Permanently remove the value of an option.

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -313,19 +313,7 @@ class OptionsManager:
                 record_option(key, result)
                 return result
 
-        # Some values we don't want to allow them to be configured through
-        # config files and should only exist in the datastore
-        if opt.has_any_flag({FLAG_STOREONLY}):
-            optval = opt.default()
-        else:
-            try:
-                # default to the hardcoded local configuration for this key
-                optval = settings.SENTRY_OPTIONS[key]
-            except KeyError:
-                try:
-                    optval = settings.SENTRY_DEFAULT_OPTIONS[key]
-                except KeyError:
-                    optval = opt.default()
+        optval = self._get_default(opt)
         # options already present in store are cached by store
         # caching here to avoid database queries
         self.store.set_cache(opt, optval)

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -285,6 +285,15 @@ class OptionsStore:
             store_results = self.get_store_many(keys_needing_store, silent=silent)
             results.update(store_results)
 
+            # 4. Last ditch effort: return stale-but-within-grace-window values
+            # from local cache for keys that both Redis and DB failed to return.
+            # This matches the disaster-recovery fallback in get().
+            for key in keys_needing_store:
+                if key.name not in results:
+                    value = self.get_local_cache(key, force_grace=True)
+                    if value is not None:
+                        results[key.name] = value
+
         return results
 
     def get_store_many(self, keys: Sequence[Key], silent: bool = False) -> dict[str, Any]:

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from collections.abc import Sequence
 from random import random
 from time import time
 from typing import Any
@@ -236,6 +237,91 @@ class OptionsStore:
                     )
         return value
 
+    def get_many(self, keys: Sequence[Key], silent: bool = False) -> dict[str, Any]:
+        """
+        Fetch multiple values from the options store in a single batch.
+        Returns a dict mapping key.name -> value (only for keys that have values).
+        """
+        results: dict[str, Any] = {}
+        keys_needing_cache: list[Key] = []
+
+        # 1. Check local cache first (no network calls)
+        for key in keys:
+            value = self.get_local_cache(key)
+            if value is not None:
+                results[key.name] = value
+            else:
+                keys_needing_cache.append(key)
+
+        if not keys_needing_cache:
+            return results
+
+        # 2. Batch fetch from network cache using MGET (1 Redis call)
+        assert self.cache is not None, (
+            "Options requested before cache initialization, which could result in excessive store queries"
+        )
+
+        cache_keys_map = {key.cache_key: key for key in keys_needing_cache}
+        try:
+            cache_results = self.cache.get_many(list(cache_keys_map))
+        except Exception:
+            if not silent:
+                logger.warning("options.get_many.cache_error", exc_info=True)
+            cache_results = {}
+
+        keys_needing_store: list[Key] = []
+        for cache_key, key in cache_keys_map.items():
+            value = cache_results.get(cache_key)
+            if value is not None:
+                results[key.name] = value
+                # Populate local cache (no network call)
+                if key.ttl > 0:
+                    self._local_cache[cache_key] = _make_cache_value(key, value)
+            else:
+                keys_needing_store.append(key)
+
+        # 3. Batch fetch remaining from database (1 DB query)
+        if keys_needing_store:
+            store_results = self.get_store_many(keys_needing_store, silent=silent)
+            results.update(store_results)
+
+        return results
+
+    def get_store_many(self, keys: Sequence[Key], silent: bool = False) -> dict[str, Any]:
+        """
+        Batch fetch from database and populate caches.
+        Uses set_cache_many for bulk Redis write.
+        """
+        results: dict[str, Any] = {}
+        key_map = {key.name: key for key in keys}
+
+        items_to_cache: list[tuple[Key, Any]] = []
+        try:
+            with in_test_hide_transaction_boundary():
+                # 1 DB query for all keys
+                db_results = self.model.objects.filter(key__in=key_map)
+
+                for opt in db_results:
+                    results[opt.key] = opt.value
+                    items_to_cache.append((key_map[opt.key], opt.value))
+
+        except (ProgrammingError, OperationalError):
+            pass
+        except Exception:
+            if settings.SENTRY_OPTIONS_COMPLAIN_ON_ERRORS:
+                raise
+            elif not silent:
+                logger.exception("option.failed-lookup-many")
+        else:
+            if items_to_cache:
+                try:
+                    self.set_cache_many(items_to_cache)
+                except Exception:
+                    if not silent:
+                        logger.warning("options.get_store_many.cache_error", exc_info=True)
+
+        return results
+
     def get_last_update_channel(self, key) -> UpdateChannel | None:
         """
         Gets how the option was last updated to check for drift.
@@ -283,6 +369,34 @@ class OptionsStore:
             return True
         except Exception:
             logger.warning(CACHE_UPDATE_ERR, key.name, extra={"key": key.name}, exc_info=True)
+            return False
+
+    def set_cache_many(self, items: Sequence[tuple[Key, Any]]) -> bool | None:
+        """
+        Batch set multiple values in both local and network cache.
+        Returns True if network cache write succeeded.
+
+        Args:
+            items: Sequence of (Key, value) tuples to cache
+        """
+        if self.cache is None:
+            return None
+
+        cache_items: dict[str, Any] = {}
+        for key, value in items:
+            cache_key = key.cache_key
+            if key.ttl > 0:
+                self._local_cache[cache_key] = _make_cache_value(key, value)
+            cache_items[cache_key] = value
+
+        if not cache_items:
+            return True
+
+        try:
+            self.cache.set_many(cache_items, self.ttl)
+            return True
+        except Exception:
+            logger.warning("options.set_cache_many.error", exc_info=True)
             return False
 
     def delete(self, key):

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -401,3 +401,118 @@ class OptionsManagerTest(TestCase):
         assert opt.has_any_flag({FLAG_NOSTORE})
         assert opt.has_any_flag({FLAG_NOSTORE, FLAG_REQUIRED})
         assert not opt.has_any_flag({FLAG_REQUIRED})
+
+    def test_get_many_simple(self) -> None:
+        self.manager.register("option1", default="default1")
+        self.manager.register("option2", default="default2")
+
+        # Set some values
+        self.manager.set("option1", "value1")
+        self.manager.set("option2", "value2")
+
+        results = self.manager.get_many(["option1", "option2", "foo"])
+        assert results["option1"] == "value1"
+        assert results["option2"] == "value2"
+        assert results["foo"] == ""  # default for "foo" which was registered in fixture
+
+    def test_get_many_returns_defaults(self) -> None:
+        self.manager.register("with_default", default="my_default")
+
+        # Don't set any value, should return default
+        results = self.manager.get_many(["with_default"])
+        assert results["with_default"] == "my_default"
+
+    def test_get_many_respects_flag_nostore(self) -> None:
+        self.manager.register("nostore_option", flags=FLAG_NOSTORE, default="nostore_default")
+
+        # NOSTORE options should not touch the store at all
+        with patch.object(self.store, "get_many") as mock_get_many:
+            results = self.manager.get_many(["nostore_option"])
+            mock_get_many.assert_not_called()
+
+        assert results["nostore_option"] == "nostore_default"
+
+    def test_get_many_respects_flag_prioritize_disk(self) -> None:
+        self.manager.register("disk_option", flags=FLAG_PRIORITIZE_DISK, default="disk_default")
+
+        # Set a value in the store
+        self.manager.set("disk_option", "store_value")
+
+        # Without disk setting, should get store value
+        results = self.manager.get_many(["disk_option"])
+        assert results["disk_option"] == "store_value"
+
+        # With disk setting, should prioritize disk
+        with self.settings(SENTRY_OPTIONS={"disk_option": "disk_value"}):
+            results = self.manager.get_many(["disk_option"])
+            assert results["disk_option"] == "disk_value"
+
+    def test_get_many_batches_cache_writes(self) -> None:
+        self.manager.register("batch1", default="default1")
+        self.manager.register("batch2", default="default2")
+
+        # Clear store completely
+        self.store.flush_local_cache()
+        self.store.cache.clear()
+
+        # Mock set_cache_many to verify it's called
+        with (
+            patch.object(self.store, "set_cache_many") as mock_set_cache_many,
+            patch.object(self.store, "get_many") as mock_get_many,
+        ):
+            mock_set_cache_many.return_value = True
+            mock_get_many.return_value = {}
+            results = self.manager.get_many(["batch1", "batch2"])
+
+            # Should have called set_cache_many once with both defaults
+            mock_set_cache_many.assert_called_once()
+            call_args = mock_set_cache_many.call_args[0][0]
+            assert len(call_args) == 2
+
+        assert results["batch1"] == "default1"
+        assert results["batch2"] == "default2"
+
+    def test_get_many_empty(self) -> None:
+        results = self.manager.get_many([])
+        assert results == {}
+
+    def test_get_many_mixed_flags(self) -> None:
+        self.manager.register("normal", default="normal_default")
+        self.manager.register("nostore", flags=FLAG_NOSTORE, default="nostore_default")
+        self.manager.register("disk", flags=FLAG_PRIORITIZE_DISK, default="disk_default")
+
+        self.manager.set("normal", "normal_value")
+
+        with self.settings(SENTRY_OPTIONS={"disk": "disk_value"}):
+            results = self.manager.get_many(["normal", "nostore", "disk"])
+
+        assert results["normal"] == "normal_value"
+        assert results["nostore"] == "nostore_default"
+        assert results["disk"] == "disk_value"
+
+    def test_get_many_uses_store_get_many(self) -> None:
+        self.manager.register("stored1", default="default1")
+        self.manager.register("stored2", default="default2")
+
+        # Populate store
+        self.manager.set("stored1", "value1")
+        self.manager.set("stored2", "value2")
+        self.store.flush_local_cache()
+
+        # Mock store.get_many to verify batch fetching
+        with patch.object(self.store, "get_many") as mock_get_many:
+            mock_get_many.return_value = {"stored1": "value1", "stored2": "value2"}
+            results = self.manager.get_many(["stored1", "stored2"])
+
+            # Should call get_many once with both keys
+            mock_get_many.assert_called_once()
+            call_keys = [key.name for key in mock_get_many.call_args[0][0]]
+            assert "stored1" in call_keys
+            assert "stored2" in call_keys
+
+        assert results["stored1"] == "value1"
+        assert results["stored2"] == "value2"
+
+    def test_get_many_raises_on_unknown_key(self) -> None:
+        with pytest.raises(UnknownOption):
+            self.manager.get_many(["totally_unknown_key"])

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -176,3 +176,141 @@ class OptionsStoreTest(TestCase):
         mocked_time.return_value = 26
         store.clean_local_cache()
         assert not store._local_cache
+
+    def test_set_cache_many(self) -> None:
+        store = self.store
+        key1 = self.make_key()
+        key2 = self.make_key()
+        key3 = self.make_key()
+
+        # Batch set multiple values using list of tuples
+        result = store.set_cache_many([(key1, "val1"), (key2, "val2"), (key3, "val3")])
+        assert result is True
+
+        # Verify local cache was populated
+        assert key1.cache_key in store._local_cache
+        assert key2.cache_key in store._local_cache
+        assert key3.cache_key in store._local_cache
+
+        # Verify network cache was populated (flush local, then get)
+        store.flush_local_cache()
+        assert store.cache.get(key1.cache_key) == "val1"
+        assert store.cache.get(key2.cache_key) == "val2"
+        assert store.cache.get(key3.cache_key) == "val3"
+
+    def test_set_cache_many_empty(self) -> None:
+        store = self.store
+        result = store.set_cache_many([])
+        assert result is True
+
+    def test_set_cache_many_without_cache(self) -> None:
+        store = OptionsStore(cache=None)
+        key = self.make_key()
+        result = store.set_cache_many([(key, "val")])
+        assert result is None
+
+    def test_get_many_all_local_cache(self) -> None:
+        store = self.store
+        key1 = self.make_key()
+        key2 = self.make_key()
+
+        # Populate local cache via set
+        store.set(key1, "val1", UpdateChannel.CLI)
+        store.set(key2, "val2", UpdateChannel.CLI)
+
+        # Get many should hit local cache only (no network calls)
+        with patch.object(store.cache, "get_many") as mock_get_many:
+            results = store.get_many([key1, key2])
+            mock_get_many.assert_not_called()
+
+        assert results == {key1.name: "val1", key2.name: "val2"}
+
+    def test_get_many_all_network_cache(self) -> None:
+        store = self.store
+        key1 = self.make_key()
+        key2 = self.make_key()
+
+        # Populate network cache directly
+        store.cache.set(key1.cache_key, "val1", 60)
+        store.cache.set(key2.cache_key, "val2", 60)
+
+        # Ensure local cache is empty
+        store.flush_local_cache()
+
+        results = store.get_many([key1, key2])
+        assert results == {key1.name: "val1", key2.name: "val2"}
+
+        # Local cache should now be populated
+        assert key1.cache_key in store._local_cache
+        assert key2.cache_key in store._local_cache
+
+    def test_get_many_db_fallback(self) -> None:
+        store = self.store
+        key1 = self.make_key()
+        key2 = self.make_key()
+
+        # Store values in DB via full set
+        store.set(key1, "db_val1", UpdateChannel.CLI)
+        store.set(key2, "db_val2", UpdateChannel.CLI)
+
+        # Clear all caches
+        store.flush_local_cache()
+        store.cache.clear()
+
+        # get_many should fall back to DB
+        results = store.get_many([key1, key2])
+        assert results == {key1.name: "db_val1", key2.name: "db_val2"}
+
+        # Should have populated both local and network cache
+        assert key1.cache_key in store._local_cache
+        assert key2.cache_key in store._local_cache
+        assert store.cache.get(key1.cache_key) == "db_val1"
+        assert store.cache.get(key2.cache_key) == "db_val2"
+
+    def test_get_many_mixed_sources(self) -> None:
+        store = self.store
+        key1 = self.make_key()  # will be in local cache
+        key2 = self.make_key()  # will be in network cache only
+        key3 = self.make_key()  # will be in DB only
+        key4 = self.make_key()  # won't exist anywhere
+
+        # Set up key1 in local cache
+        store.set(key1, "local_val", UpdateChannel.CLI)
+
+        # Set up key2 in network cache only
+        store.cache.set(key2.cache_key, "network_val", 60)
+
+        # Set up key3 in DB only
+        store.set(key3, "db_val", UpdateChannel.CLI)
+        store.flush_local_cache()
+        store.cache.delete(key3.cache_key)
+
+        # Get all keys
+        results = store.get_many([key1, key2, key3, key4])
+
+        assert results[key1.name] == "local_val"
+        assert results[key2.name] == "network_val"
+        assert results[key3.name] == "db_val"
+        assert key4.name not in results  # Not found anywhere
+
+    def test_get_many_empty(self) -> None:
+        store = self.store
+        results = store.get_many([])
+        assert results == {}
+
+    @override_settings(SENTRY_OPTIONS_COMPLAIN_ON_ERRORS=False)
+    def test_get_many_cache_error_falls_back_to_db(self) -> None:
+        store = self.store
+        key1 = self.make_key()
+
+        # Store in DB
+        store.set(key1, "db_val", UpdateChannel.CLI)
+        store.flush_local_cache()
+        store.cache.clear()
+
+        # Make network cache fail
+        with patch.object(store.cache, "get_many", side_effect=RuntimeError()):
+            results = store.get_many([key1], silent=True)
+
+        # Should still get value from DB
+        assert results == {key1.name: "db_val"}

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from time import time
 from unittest.mock import MagicMock, patch
 from uuid import uuid1
 
@@ -297,6 +298,26 @@ class OptionsStoreTest(TestCase):
         store = self.store
         results = store.get_many([])
         assert results == {}
+
+    @override_settings(SENTRY_OPTIONS_COMPLAIN_ON_ERRORS=False)
+    def test_get_many_grace_fallback(self) -> None:
+        store = self.store
+        key1 = self.make_key(ttl=10, grace=20)
+
+        # Populate local cache via set (creates entry with expiry and grace window)
+        store.set(key1, "stale_val", UpdateChannel.CLI)
+
+        # Advance time past TTL but within grace window
+        with patch("sentry.options.store.time") as mocked_time:
+            mocked_time.return_value = time() + 15  # past ttl=10, within grace=20
+
+            # Local cache miss (expired), Redis fails, DB returns nothing
+            with patch.object(store.cache, "get_many", side_effect=RuntimeError()):
+                with patch.object(store, "get_store_many", return_value={}):
+                    results = store.get_many([key1], silent=True)
+
+            # Should return stale value from grace period fallback
+            assert results == {key1.name: "stale_val"}
 
     @override_settings(SENTRY_OPTIONS_COMPLAIN_ON_ERRORS=False)
     def test_get_many_cache_error_falls_back_to_db(self) -> None:


### PR DESCRIPTION
## Summary

[This Issue](https://sentry.sentry.io/issues/7278808946/?project=1) was raised by `LLM Detection`, we're evaluating detection quality and whether the Issues it finds can be fixed. If you have feedback, of course you can leave it on this pr, you can also find us in #proj-llm-detected-issues

Add `get_many()` to the options system to batch cache lookups, reducing N sequential GET calls to 1 MGET operation.

This addresses connection pressure from flagpole feature flag checks, where `bulk_parse_flagpole_features()` was calling `options.get()` in a loop for each feature flag.

## Changes

- Add `OptionsStore.set_cache_many()` for bulk cache writes
- Add `OptionsStore.get_many()` and `get_store_many()` for batch retrieval
- Add `OptionsManager.get_many()` with flag handling and default caching
- Export `options.get_many` in public API
- Add comprehensive tests for all new methods

## Redis Call Comparison

| Scenario | Before | After |
|----------|--------|-------|
| All keys in local cache | 0 | 0 |
| All keys in Memcache | N GET | 1 MGET |
| All keys need DB lookup | N GET + N SET | 1 MGET + 1 DB + 1 set_many |

fixes SENTRY-5K3R