### PR TITLE
ref(seer): Refactor useCodingAgentIntegrations to be based on apiOptions instead

### DIFF
--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -20,7 +20,7 @@ import {
 } from 'sentry/components/events/autofix/types';
 import {
   makeAutofixQueryKey,
-  useCodingAgentIntegrations,
+  organizationIntegrationsCodingAgents,
   useLaunchCodingAgent,
   type CodingAgentIntegration,
 } from 'sentry/components/events/autofix/useAutofix';
@@ -33,7 +33,7 @@ import {space} from 'sentry/styles/space';
 import type {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
-import {useMutation, useQueryClient} from 'sentry/utils/queryClient';
+import {useMutation, useQuery, useQueryClient} from 'sentry/utils/queryClient';
 import testableTransition from 'sentry/utils/testableTransition';
 import useApi from 'sentry/utils/useApi';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
@@ -442,8 +442,9 @@ function AutofixRootCauseDisplay({
     groupId,
     runId,
   });
-  const {data: codingAgentResponse, isLoading: isLoadingAgents} =
-    useCodingAgentIntegrations();
+  const {data: codingAgentResponse, isLoading: isLoadingAgents} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
   const codingAgentIntegrations = codingAgentResponse?.integrations ?? [];
   const {mutate: launchCodingAgent, isPending: isLaunchingAgent} = useLaunchCodingAgent(
     groupId,

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -8,13 +8,14 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
-import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
@@ -30,8 +31,9 @@ export function CursorIntegrationCta({project}: CursorIntegrationCtaProps) {
     useProjectSeerPreferences(project);
   const {mutate: updateProjectSeerPreferences, isPending: isUpdatingPreferences} =
     useUpdateProjectSeerPreferences(project);
-  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
-    useCodingAgentIntegrations();
+  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
   const {mutateAsync: updateProjectAutomation} = useUpdateProject(project);
 
   const cursorIntegration = codingAgentIntegrations?.integrations.find(

--- a/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
+++ b/static/app/components/events/autofix/githubCopilotIntegrationCta.tsx
@@ -5,11 +5,12 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import Placeholder from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 
@@ -17,8 +18,9 @@ export function GithubCopilotIntegrationCta() {
   const organization = useOrganization();
   const user = useUser();
 
-  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
-    useCodingAgentIntegrations();
+  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
 
   const handleInstallClick = useCallback(() => {
     trackAnalytics('coding_integration.install_clicked', {

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -14,6 +14,8 @@ import {
 } from 'sentry/components/events/autofix/types';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {
   fetchMutation,
@@ -327,23 +329,13 @@ export type CodingAgentIntegration = {
   requires_identity?: boolean;
 };
 
-export function useCodingAgentIntegrations() {
-  const organization = useOrganization();
-
-  return useApiQuery<{
+export function organizationIntegrationsCodingAgents(organization: Organization) {
+  return apiOptions.as<{
     integrations: CodingAgentIntegration[];
-  }>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/integrations/coding-agents/', {
-        path: {
-          organizationIdOrSlug: organization.slug,
-        },
-      }),
-    ],
-    {
-      staleTime: 5 * 60 * 1000,
-    }
-  );
+  }>()('/organizations/$organizationIdOrSlug/integrations/coding-agents/', {
+    path: {organizationIdOrSlug: organization.slug},
+    staleTime: 5 * 60 * 1000,
+  });
 }
 
 interface LaunchCodingAgentParams {

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -11,7 +11,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {
-  useCodingAgentIntegrations,
+  organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
 } from 'sentry/components/events/autofix/useAutofix';
 import type {AutofixExplorerStep} from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -19,6 +19,7 @@ import {cardAnimationProps} from 'sentry/components/events/autofix/v2/utils';
 import {IconChat, IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {PluginIcon} from 'sentry/plugins/components/pluginIcon';
+import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import type {Artifact} from 'sentry/views/seerExplorer/types';
 
@@ -238,7 +239,10 @@ export function ExplorerNextSteps({
   onOpenChat,
   isLoading,
 }: ExplorerNextStepsProps) {
-  const {data: codingAgentResponse} = useCodingAgentIntegrations();
+  const organization = useOrganization();
+  const {data: codingAgentResponse} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
   const codingAgentIntegrations = codingAgentResponse?.integrations ?? [];
 
   const availableSteps = getAvailableNextSteps(

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -17,8 +17,8 @@ import {useProjectSeerPreferences} from 'sentry/components/events/autofix/prefer
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import StarFixabilityViewButton from 'sentry/components/events/autofix/seerCreateViewButton';
 import {
+  organizationIntegrationsCodingAgents,
   useAutofixRepos,
-  useCodingAgentIntegrations,
 } from 'sentry/components/events/autofix/useAutofix';
 import {
   GuidedSteps,
@@ -32,6 +32,7 @@ import type {Project} from 'sentry/types/project';
 import {FieldKey} from 'sentry/utils/fields';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useQuery} from 'sentry/utils/queryClient';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useHasIssueViews} from 'sentry/views/nav/secondary/sections/issues/issueViews/useHasIssueViews';
@@ -98,7 +99,9 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   } = useProjectSeerPreferences(project);
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
   const {mutateAsync: updateProjectAutomation} = useUpdateProject(project);
-  const {data: codingAgentIntegrations} = useCodingAgentIntegrations();
+  const {data: codingAgentIntegrations} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
   const {starredViews: views} = useStarredIssueViews();
 
   const detailedProject = useDetailedProject({

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -13,7 +13,7 @@ import {useProjectSeerPreferences} from 'sentry/components/events/autofix/prefer
 import {useUpdateProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useUpdateProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import {
-  useCodingAgentIntegrations,
+  organizationIntegrationsCodingAgents,
   type CodingAgentIntegration,
 } from 'sentry/components/events/autofix/useAutofix';
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
@@ -34,7 +34,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {setApiQueryData} from 'sentry/utils/queryClient';
+import {setApiQueryData, useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
@@ -181,7 +181,9 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
   const queryClient = useQueryClient();
   const {preference} = useProjectSeerPreferences(project);
   const {mutate: updateProjectSeerPreferences} = useUpdateProjectSeerPreferences(project);
-  const {data: codingAgentIntegrations} = useCodingAgentIntegrations();
+  const {data: codingAgentIntegrations} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
 
   const canWriteProject = hasEveryAccess(['project:read'], {organization, project});
 

--- a/static/gsApp/views/seerAutomation/components/projectDetails/seerSettingsContainer.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/seerSettingsContainer.tsx
@@ -4,13 +4,14 @@ import styled from '@emotion/styled';
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
-import {useCodingAgentIntegrations} from 'sentry/components/events/autofix/useAutofix';
+import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
+import {useQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import AutoTriggeredFixesToggle from 'getsentry/views/seerAutomation/components/projectDetails/autoTriggeredFixesToggle';
@@ -29,8 +30,9 @@ interface Props {
 export default function SeerSettingsContainer({canWrite, preference, project}: Props) {
   const organization = useOrganization();
 
-  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} =
-    useCodingAgentIntegrations();
+  const {data: codingAgentIntegrations, isLoading: isLoadingIntegrations} = useQuery(
+    organizationIntegrationsCodingAgents(organization)
+  );
 
   const supportedIntegrations = useMemo(
     () =>


### PR DESCRIPTION
I'm liking some kind of options object. This is setting up some existing code before i go use it in a new place.