### PR TITLE
feat(profiling): Back SuspectFunctionsTable with EAP

### DIFF
--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -118,11 +118,10 @@ export function SuspectFunctionsTable({
   const organization = useOrganization();
 
   const flamegraphQuery = useAggregateFlamegraphQuery({
-    // User query is only permitted when using transactions.
-    // If this is to be reused for strictly continuous profiling,
-    // it'll need to be swapped to use the `profiles` data source
-    // with no user query.
-    dataSource: 'transactions',
+    // Note: the 'profiles' data source does not support user queries.
+    // If reusing this for continuous profiling, remove the query param
+    // and switch to dataSource: 'profiles'.
+    dataSource: 'spans',
     query: eventView.query,
     metrics: true,
   });

--- a/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
+++ b/static/app/utils/profiling/hooks/useAggregateFlamegraphQuery.ts
@@ -33,10 +33,16 @@ interface ProfilesAggregateFlamegraphQueryParameters extends BaseAggregateFlameg
   dataSource: 'profiles';
 }
 
+interface SpansAggregateFlamegraphQueryParameters extends BaseAggregateFlamegraphQueryParameters {
+  dataSource: 'spans';
+  query: string;
+}
+
 export type AggregateFlamegraphQueryParameters =
   | FunctionsAggregateFlamegraphQueryParameters
   | TransactionsAggregateFlamegraphQueryParameters
-  | ProfilesAggregateFlamegraphQueryParameters;
+  | ProfilesAggregateFlamegraphQueryParameters
+  | SpansAggregateFlamegraphQueryParameters;
 
 type UseAggregateFlamegraphQueryResult = UseApiQueryResult<
   Profiling.Schema,
@@ -54,7 +60,7 @@ export function useAggregateFlamegraphQuery(
   if (isDataSourceFunctions(props)) {
     fingerprint = props.fingerprint;
     query = props.query;
-  } else if (isDataSourceTransactions(props)) {
+  } else if (isDataSourceTransactions(props) || isDataSourceSpans(props)) {
     query = props.query;
   }
 
@@ -118,8 +124,18 @@ function isDataSourceFunctions(
   return 'fingerprint' in props;
 }
 
+function isDataSourceSpans(
+  props: AggregateFlamegraphQueryParameters
+): props is SpansAggregateFlamegraphQueryParameters {
+  return 'dataSource' in props && props.dataSource === 'spans';
+}
+
 function isDataSourceTransactions(
   props: AggregateFlamegraphQueryParameters
 ): props is TransactionsAggregateFlamegraphQueryParameters {
-  return !isDataSourceProfiles(props) && !isDataSourceFunctions(props);
+  return (
+    !isDataSourceProfiles(props) &&
+    !isDataSourceFunctions(props) &&
+    !isDataSourceSpans(props)
+  );
 }


### PR DESCRIPTION
As part of the effort to port the Transaction Summary to EAP, this updates the transaction summary's suspect functions table to query EAP instead of the transactions dataset. Add support in the frontend for `useAggregateFlamegraphQuery` to query the `spans` dataset, and update `SuspectFunctionsTable` to use it. The `spans` dataset is already supported by the flamegraphs endpoint, so the Suspect Functions table starts working with this change.

Closes DAIN-1230.