### PR TITLE
fix(profiling): Show empty state when no suspect functions found

### DIFF
--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -270,7 +270,7 @@ export function SuspectFunctionsTable({
             <TableStatus>
               <IconWarning data-test-id="error-indicator" variant="muted" size="lg" />
             </TableStatus>
-          ) : flamegraphQuery.isFetched ? (
+          ) : flamegraphQuery.isFetched && metrics.length > 0 ? (
             metrics.map((metric, i) => (
               <TableEntry
                 key={i}


### PR DESCRIPTION
The `SuspectFunctionsTable` component has an `EmptyStateWarning` that should
display "No functions found" when a query returns no data. However, the
conditional rendering chain checked `flamegraphQuery.isFetched` without
verifying the result was non-empty. Since `isFetched` is true whenever the
query completes — even with an empty array — the code would map over `[]`
and render an empty table body instead of the empty state.

Adds a `metrics.length > 0` guard so the `EmptyStateWarning` fallback
renders when the query succeeds but returns no matching function metrics.

Before:
<img width="1035" height="94" alt="Screenshot 2026-02-24 at 20 39 50" src="https://github.com/user-attachments/assets/bc632155-effe-4a56-98ca-c93bdde3484c" />

After:
<img width="1035" height="262" alt="Screenshot 2026-02-24 at 20 40 30" src="https://github.com/user-attachments/assets/8e1c00e8-8f25-4d4e-9b51-2212489dff25" />