### PR TITLE
fix(cursor): Fall back to /v0/models for API key verification

### DIFF
--- a/src/sentry/integrations/cursor/client.py
+++ b/src/sentry/integrations/cursor/client.py
@@ -107,7 +107,7 @@ class CursorAgentClient(CodingAgentClient):
             logger.info("coding_agent.cursor.verify_api_key.v0_me_success")
             return metadata
         except Exception:
-            logger.exception("coding_agent.cursor.verify_api_key.v0_me_failed_trying_models")
+            logger.warning("coding_agent.cursor.verify_api_key.v0_me_failed_trying_models")
 
         # Fall back to /v0/models for service accounts
         self.get(

--- a/src/sentry/integrations/cursor/client.py
+++ b/src/sentry/integrations/cursor/client.py
@@ -82,23 +82,44 @@ class CursorAgentClient(CodingAgentClient):
     def _get_auth_headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"}
 
-    def get_api_key_metadata(self) -> CursorApiKeyMetadata:
-        """Fetch metadata about the API key from Cursor's /v0/me endpoint."""
+    def verify_api_key(self) -> CursorApiKeyMetadata | None:
+        """Verify the API key and optionally fetch metadata.
+
+        Tries /v0/me first to get user metadata (apiKeyName, userEmail).
+        Falls back to /v0/models if /v0/me fails, since /v0/me doesn't work
+        with Cursor service accounts. Returns None when falling back.
+        """
         logger.info(
-            "coding_agent.cursor.get_api_key_metadata",
+            "coding_agent.cursor.verify_api_key",
             extra={"agent_type": self.__class__.__name__},
         )
 
-        api_response = self.get(
-            "/v0/me",
+        try:
+            api_response = self.get(
+                "/v0/me",
+                headers={
+                    "content-type": "application/json;charset=utf-8",
+                    **self._get_auth_headers(),
+                },
+                timeout=30,
+            )
+            metadata = CursorApiKeyMetadata.validate(api_response.json)
+            logger.info("coding_agent.cursor.verify_api_key.v0_me_success")
+            return metadata
+        except Exception:
+            logger.exception("coding_agent.cursor.verify_api_key.v0_me_failed_trying_models")
+
+        # Fall back to /v0/models for service accounts
+        self.get(
+            "/v0/models",
             headers={
                 "content-type": "application/json;charset=utf-8",
                 **self._get_auth_headers(),
             },
             timeout=30,
         )
-
-        return CursorApiKeyMetadata.validate(api_response.json)
+        logger.info("coding_agent.cursor.verify_api_key.v0_models_fallback_success")
+        return None
 
     def get_available_models(self) -> list[str]:
         """Fetch available models from Cursor's /v0/models endpoint."""


### PR DESCRIPTION
The `/v0/me` endpoint doesn't work with Cursor service accounts, which
prevents service account API keys from being used to set up the Cursor
integration.

This changes `verify_api_key` to try `/v0/me` first (to get user metadata
like email and key name), then fall back to `/v0/models` if `/v0/me` fails.
A 200 from `/v0/models` is sufficient to confirm the key is valid.

When metadata from `/v0/me` is available (regular user keys), the integration
is named `Cursor Cloud Agent - email/keyName` as before. When it's not
(service accounts), the name includes the first 8 characters of the API key
(e.g. `key_xxxx`) for distinguishability: `Cursor Cloud Agent (key_xxxx...)`.