### PR TITLE
ref(performance): Convert TagExplorer from class to functional component

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -199,13 +199,15 @@ export function TagExplorer(props: Props) {
 
   const handleResizeColumn = useCallback(
     (columnIndex: number, nextColumn: GridColumn) => {
-      const newWidths: number[] = [...widths];
-      newWidths[columnIndex] = nextColumn.width
-        ? Number(nextColumn.width)
-        : COL_WIDTH_UNDEFINED;
-      setWidths(newWidths);
+      setWidths(prevWidths => {
+        const newWidths = [...prevWidths];
+        newWidths[columnIndex] = nextColumn.width
+          ? Number(nextColumn.width)
+          : COL_WIDTH_UNDEFINED;
+        return newWidths;
+      });
     },
-    [widths]
+    []
   );
 
   function getColumnOrder(columns: GridColumnOrder[]) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import type {Location, LocationDescriptorObject} from 'history';
 
@@ -29,7 +29,6 @@ import type {
 } from 'sentry/utils/performance/segmentExplorer/segmentExplorerQuery';
 import SegmentExplorerQuery from 'sentry/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {
@@ -185,34 +184,40 @@ type Props = {
   domainViewFilters?: DomainViewFilters;
 };
 
-type State = {
-  widths: number[];
-};
-export class TagExplorer extends Component<Props> {
-  state: State = {
-    widths: [],
-  };
+export function TagExplorer(props: Props) {
+  const {
+    eventView,
+    organization,
+    location,
+    currentFilter,
+    projects,
+    transactionName,
+    domainViewFilters,
+  } = props;
 
-  handleResizeColumn = (columnIndex: number, nextColumn: GridColumn) => {
-    const widths: number[] = [...this.state.widths];
-    widths[columnIndex] = nextColumn.width
-      ? Number(nextColumn.width)
-      : COL_WIDTH_UNDEFINED;
-    this.setState({widths});
-  };
+  const [widths, setWidths] = useState<number[]>([]);
 
-  getColumnOrder = (columns: GridColumnOrder[]) => {
-    const {widths} = this.state;
+  const handleResizeColumn = useCallback(
+    (columnIndex: number, nextColumn: GridColumn) => {
+      const newWidths: number[] = [...widths];
+      newWidths[columnIndex] = nextColumn.width
+        ? Number(nextColumn.width)
+        : COL_WIDTH_UNDEFINED;
+      setWidths(newWidths);
+    },
+    [widths]
+  );
+
+  function getColumnOrder(columns: GridColumnOrder[]) {
     return columns.map((col: GridColumnOrder, i: number) => {
       if (typeof widths[i] === 'number') {
         return {...col, width: widths[i]};
       }
       return col;
     });
-  };
+  }
 
-  onSortClick(currentSortKind?: string, currentSortField?: string) {
-    const {organization} = this.props;
+  function onSortClick(currentSortKind?: string, currentSortField?: string) {
     trackAnalytics('performance_views.summary.tag_explorer.sort', {
       organization,
       field: currentSortField,
@@ -220,13 +225,12 @@ export class TagExplorer extends Component<Props> {
     });
   }
 
-  renderHeadCell(
+  function renderHeadCell(
     sortedEventView: EventView,
     tableMeta: TableData['meta'],
     column: TableColumn<ColumnKeys>,
     columnInfo: TagColumn
   ): React.ReactNode {
-    const {location} = this.props;
     const align = fieldAlignment(column.key, column.type, tableMeta);
     const field = {field: column.key, width: column.width};
 
@@ -256,43 +260,26 @@ export class TagExplorer extends Component<Props> {
         direction={currentSortKind}
         canSort={canSort}
         generateSortLink={generateSortLink}
-        onClick={() => this.onSortClick(currentSortKind, currentSortField)}
+        onClick={() => onSortClick(currentSortKind, currentSortField)}
       />
     );
   }
 
-  renderHeadCellWithMeta = (
+  function renderHeadCellWithMeta(
     sortedEventView: EventView,
     tableMeta: TableData['meta'],
     columns: TagColumn[]
-  ) => {
+  ) {
     return (column: TableColumn<ColumnKeys>, index: number): React.ReactNode =>
-      this.renderHeadCell(sortedEventView, tableMeta, column, columns[index]!);
-  };
+      renderHeadCell(sortedEventView, tableMeta, column, columns[index]!);
+  }
 
-  handleTagValueClick = (location: Location, tagKey: string, tagValue: string) => {
-    const queryString = decodeScalar(location.query.query);
-    const conditions = new MutableSearch(queryString ?? '');
-
-    conditions.addFilterValues(tagKey, [tagValue]);
-
-    const query = conditions.formatString();
-    browserHistory.push({
-      pathname: location.pathname,
-      query: {
-        ...location.query,
-        query: String(query).trim(),
-      },
-    });
-  };
-
-  handleCellAction = (
+  function handleCellAction(
     column: TableColumn<ColumnKeys>,
     tagValue: string | number,
     actionRow: any
-  ) => {
+  ) {
     return (action: Actions) => {
-      const {eventView, location, organization} = this.props;
       trackAnalytics('performance_views.summary.tag_explorer.cell_action', {
         organization,
       });
@@ -310,23 +297,20 @@ export class TagExplorer extends Component<Props> {
         },
       });
     };
-  };
+  }
 
-  onTagKeyClick() {
-    const {organization} = this.props;
+  function onTagKeyClick() {
     trackAnalytics('performance_views.summary.tag_explorer.visit_tag_key', {
       organization,
     });
   }
 
-  renderBodyCell = (
-    parentProps: Props,
+  function renderBodyCell(
     column: TableColumn<ColumnKeys>,
     dataRow: TableDataRow
-  ): React.ReactNode => {
+  ): React.ReactNode {
     // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     const value = dataRow[column.key];
-    const {location, organization, transactionName} = parentProps;
 
     if (column.key === 'key') {
       const target = tagsRouteWithQuery({
@@ -334,10 +318,10 @@ export class TagExplorer extends Component<Props> {
         transaction: transactionName,
         projectID: decodeScalar(location.query.project),
         query: {...location.query, tagKey: dataRow.tags_key},
-        view: this.props.domainViewFilters?.view,
+        view: domainViewFilters?.view,
       });
       return (
-        <Link to={target} onClick={() => this.onTagKeyClick()}>
+        <Link to={target} onClick={() => onTagKeyClick()}>
           {dataRow.tags_key}
         </Link>
       );
@@ -351,7 +335,7 @@ export class TagExplorer extends Component<Props> {
         <CellAction
           column={column}
           dataRow={actionRow}
-          handleCellAction={this.handleCellAction(column, dataRow.tags_value, actionRow)}
+          handleCellAction={handleCellAction(column, dataRow.tags_value, actionRow)}
           allowActions={allowActions}
         >
           <div className="truncate">{dataRow.tags_value}</div>
@@ -389,88 +373,83 @@ export class TagExplorer extends Component<Props> {
       );
     }
     return value;
-  };
-
-  renderBodyCellWithData = (parentProps: Props) => {
-    return (column: TableColumn<ColumnKeys>, dataRow: TableDataRow): React.ReactNode =>
-      this.renderBodyCell(parentProps, column, dataRow);
-  };
-
-  render() {
-    const {eventView, organization, location, currentFilter, projects, transactionName} =
-      this.props;
-
-    const tagSort = decodeScalar(location.query?.tagSort);
-    const cursor = decodeScalar(location.query?.[TAGS_CURSOR_NAME]);
-
-    const tagEventView = eventView.clone();
-    tagEventView.fields = TAG_EXPLORER_COLUMN_ORDER;
-
-    const tagSorts = decodeSorts(tagSort);
-
-    const sortedEventView = tagEventView.withSorts(
-      tagSorts.length
-        ? tagSorts
-        : [
-            {
-              field: 'sumdelta',
-              kind: 'desc',
-            },
-          ]
-    );
-
-    const aggregateColumn = getTransactionField(currentFilter, projects, sortedEventView);
-
-    const adjustedColumns = getColumnsWithReplacedDuration(
-      currentFilter,
-      projects,
-      sortedEventView
-    );
-    const columns = this.getColumnOrder(adjustedColumns);
-
-    const columnSortBy = sortedEventView.getSorts();
-
-    return (
-      <SegmentExplorerQuery
-        eventView={sortedEventView}
-        orgSlug={organization.slug}
-        location={location}
-        aggregateColumn={aggregateColumn}
-        limit={5}
-        cursor={cursor}
-      >
-        {({isLoading, tableData, pageLinks}) => {
-          return (
-            <Fragment>
-              <GuideAnchor target="tag_explorer">
-                <TagsHeader
-                  transactionName={transactionName}
-                  location={location}
-                  organization={organization}
-                  pageLinks={pageLinks}
-                />
-              </GuideAnchor>
-              <GridEditable
-                isLoading={isLoading}
-                data={tableData?.data ? tableData.data : []}
-                columnOrder={columns}
-                columnSortBy={columnSortBy}
-                grid={{
-                  renderHeadCell: this.renderHeadCellWithMeta(
-                    sortedEventView,
-                    tableData?.meta || {},
-                    adjustedColumns
-                  ) as any,
-                  renderBodyCell: this.renderBodyCellWithData(this.props) as any,
-                  onResizeColumn: this.handleResizeColumn as any,
-                }}
-              />
-            </Fragment>
-          );
-        }}
-      </SegmentExplorerQuery>
-    );
   }
+
+  function renderBodyCellWithData() {
+    return (column: TableColumn<ColumnKeys>, dataRow: TableDataRow): React.ReactNode =>
+      renderBodyCell(column, dataRow);
+  }
+
+  const tagSort = decodeScalar(location.query?.tagSort);
+  const cursor = decodeScalar(location.query?.[TAGS_CURSOR_NAME]);
+
+  const tagEventView = eventView.clone();
+  tagEventView.fields = TAG_EXPLORER_COLUMN_ORDER;
+
+  const tagSorts = decodeSorts(tagSort);
+
+  const sortedEventView = tagEventView.withSorts(
+    tagSorts.length
+      ? tagSorts
+      : [
+          {
+            field: 'sumdelta',
+            kind: 'desc',
+          },
+        ]
+  );
+
+  const aggregateColumn = getTransactionField(currentFilter, projects, sortedEventView);
+
+  const adjustedColumns = getColumnsWithReplacedDuration(
+    currentFilter,
+    projects,
+    sortedEventView
+  );
+  const columns = getColumnOrder(adjustedColumns);
+
+  const columnSortBy = sortedEventView.getSorts();
+
+  return (
+    <SegmentExplorerQuery
+      eventView={sortedEventView}
+      orgSlug={organization.slug}
+      location={location}
+      aggregateColumn={aggregateColumn}
+      limit={5}
+      cursor={cursor}
+    >
+      {({isLoading, tableData, pageLinks}) => {
+        return (
+          <Fragment>
+            <GuideAnchor target="tag_explorer">
+              <TagsHeader
+                transactionName={transactionName}
+                location={location}
+                organization={organization}
+                pageLinks={pageLinks}
+              />
+            </GuideAnchor>
+            <GridEditable
+              isLoading={isLoading}
+              data={tableData?.data ? tableData.data : []}
+              columnOrder={columns}
+              columnSortBy={columnSortBy}
+              grid={{
+                renderHeadCell: renderHeadCellWithMeta(
+                  sortedEventView,
+                  tableData?.meta || {},
+                  adjustedColumns
+                ) as any,
+                renderBodyCell: renderBodyCellWithData() as any,
+                onResizeColumn: handleResizeColumn as any,
+              }}
+            />
+          </Fragment>
+        );
+      }}
+    </SegmentExplorerQuery>
+  );
 }
 
 type HeaderProps = {

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -377,11 +377,6 @@ export function TagExplorer(props: Props) {
     return value;
   }
 
-  function renderBodyCellWithData() {
-    return (column: TableColumn<ColumnKeys>, dataRow: TableDataRow): React.ReactNode =>
-      renderBodyCell(column, dataRow);
-  }
-
   const tagSort = decodeScalar(location.query?.tagSort);
   const cursor = decodeScalar(location.query?.[TAGS_CURSOR_NAME]);
 
@@ -443,7 +438,7 @@ export function TagExplorer(props: Props) {
                   tableData?.meta || {},
                   adjustedColumns
                 ) as any,
-                renderBodyCell: renderBodyCellWithData() as any,
+                renderBodyCell: renderBodyCell as any,
                 onResizeColumn: handleResizeColumn as any,
               }}
             />


### PR DESCRIPTION
Converts `TagExplorer` to a functional component. First in a series of steps to get this thing to support EAP.

First commit is a strictly mechanical refactor to a functional component (with one unused function, `handleTagValueClick`, removed).

Second and third are little improvements that became available after the refactor:

> Use the functional updater form of `setWidths` to eliminate the stale closure risk and produce a stable callback reference with an empty dependency array.

> `renderBodyCellWithData` existed to curry props into renderBodyCell in the class component. Now that renderBodyCell closes over props via the function component scope, the wrapper is a no-op pass-through.
