### PR TITLE
chore(devenv): Remove --frozen flag from dotagents install

### DIFF
--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -226,7 +226,7 @@ def main(context: dict[str, str]) -> int:
             repo,
             reporoot,
             venv_dir,
-            (("agent skills", ("pnpm", "dlx", "@sentry/dotagents", "install", "--frozen"), {}),),
+            (("agent skills", ("pnpm", "dlx", "@sentry/dotagents", "install"), {}),),
             verbose,
         ):
             print("⚠️  agent skills failed to install (non-fatal)")


### PR DESCRIPTION
The lockfile is no longer the source of truth for agent skills, so the `--frozen` flag on `dotagents install` during `devenv sync` is no longer needed. This allows the install to resolve and update dependencies normally.


Agent transcript: https://claudescope.sentry.dev/share/YMQ0fBjCNz-2mR1J4Gdq4hn4F6j4rYZXWwuColmf09E