### PR TITLE
feat(spans): Add metric to ensure `accepted_outcome_emitted` arrives

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -15,6 +15,7 @@ from sentry_protos.snuba.v1.trace_item_pb2 import (
 )
 
 from sentry.spans.consumers.process_segments.types import CompatibleSpan
+from sentry.utils import metrics
 from sentry.utils.eap import hex_to_item_id
 
 I64_MAX = 2**63 - 1
@@ -105,6 +106,11 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
         except Exception:
             sentry_sdk.capture_exception()
             attributes["sentry.dropped_links_count"] = AnyValue(int_value=len(links))
+
+    metrics.incr(
+        "spans.consumers.process_segments.outcome_emitted",
+        tags={"already_emitted": str(span.get("accepted_outcome_emitted"))},
+    )
 
     return TraceItem(
         organization_id=span["organization_id"],


### PR DESCRIPTION
Follow up to this https://github.com/getsentry/relay/pull/5652 which adds the `accepted_outcome_emitted` on the spans. This emits a metric with the value to ensure that it arrives like we expect. Once we confirmed this, the follow-up is to add the logic to actually write the `Outcomes` into the `TraceItem` based on the `accepted_outcome_emitted` field.