### PR TITLE
fix(preprod): Replace transparent treemap colors with opaque composites (EME-889)

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -273,6 +273,10 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
   const chartDataChildren = root.children.map((child: TreemapElement) =>
     convertToEChartsData(child, chartSurfaceColor)
   );
+  const chartData =
+    chartDataChildren.length > 0
+      ? chartDataChildren
+      : [convertToEChartsData(root, chartSurfaceColor)];
   const totalSize = root.size;
 
   const series: TreemapSeriesOption[] = [
@@ -347,7 +351,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
           colorSaturation: [0.4, 0.6],
         },
       ],
-      data: chartDataChildren,
+      data: chartData,
     },
   ];
 

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -270,7 +270,9 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     );
   }
 
-  const chartData = convertToEChartsData(root);
+  const chartDataChildren = root.children.map((child: TreemapElement) =>
+    convertToEChartsData(child, chartSurfaceColor)
+  );
   const totalSize = root.size;
 
   const series: TreemapSeriesOption[] = [
@@ -345,7 +347,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
           colorSaturation: [0.4, 0.6],
         },
       ],
-      data: chartData.children || [chartData],
+      data: chartDataChildren,
     },
   ];
 

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -21,7 +21,10 @@ import {
 import {t} from 'sentry/locale';
 import {formatBytesBase10} from 'sentry/utils/bytes/formatBytesBase10';
 import {ChartRenderingContext} from 'sentry/views/insights/common/components/chart';
-import {getAppSizeCategoryInfo} from 'sentry/views/preprod/components/visualizations/appSizeTreemapTheme';
+import {
+  getAppSizeCategoryInfo,
+  getOpaqueColorFromComposite,
+} from 'sentry/views/preprod/components/visualizations/appSizeTreemapTheme';
 import {
   TreemapControlButtons,
   type TreemapControlButton,
@@ -158,24 +161,44 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
     }
   };
 
-  function convertToEChartsData(element: TreemapElement): any {
+  const chartSurfaceColor = theme.tokens.background.primary;
+
+  function convertToEChartsData(
+    element: TreemapElement,
+    parentCompositeColor: string = chartSurfaceColor
+  ): any {
     const categoryInfo =
       appSizeCategoryInfo[element.type] ?? appSizeCategoryInfo[TreemapType.OTHER];
     if (!categoryInfo) {
       throw new Error(`Category ${element.type} not found`);
     }
 
-    // Use headerColor for parent nodes, regular color for leaf nodes
-    const hasChildren = element.children && element.children.length > 0;
+    const hasChildren = element.children.length > 0;
     const hasFlaggedInsights =
       element.flagged_insights && element.flagged_insights.length > 0;
     const shouldHighlight = highlightInsights && hasFlaggedInsights;
 
-    const borderColor = shouldHighlight
-      ? theme.tokens.border.danger.vibrant
-      : hasChildren && categoryInfo.translucentColor
+    const baselineNodeColor =
+      hasChildren && categoryInfo.translucentColor
         ? categoryInfo.translucentColor
         : categoryInfo.color;
+
+    const compositeNodeColor = getOpaqueColorFromComposite(
+      baselineNodeColor,
+      parentCompositeColor
+    );
+
+    const borderColor = shouldHighlight
+      ? theme.tokens.border.danger.vibrant
+      : compositeNodeColor;
+
+    const fillColor =
+      shouldHighlight && !hasChildren
+        ? getOpaqueColorFromComposite(
+            theme.tokens.border.danger.vibrant,
+            parentCompositeColor
+          )
+        : compositeNodeColor;
 
     const data: any = {
       name: element.name,
@@ -185,11 +208,11 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       misc: element.misc,
       flagged_insights: element.flagged_insights,
       itemStyle: {
-        color: 'transparent',
+        color: fillColor,
         borderColor,
         borderWidth: 6,
         gapWidth: 2,
-        gapColor: 'transparent',
+        gapColor: fillColor,
       },
       label: {
         fontSize: 12,
@@ -217,9 +240,9 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
       },
     };
 
-    if (element.children && element.children.length > 0) {
+    if (element.children.length > 0) {
       data.children = element.children.map((child: TreemapElement) =>
-        convertToEChartsData(child)
+        convertToEChartsData(child, compositeNodeColor)
       );
     }
 
@@ -293,7 +316,6 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
         {
           itemStyle: {
             gapWidth: 4,
-            borderColor: 'transparent',
             borderRadius: 6,
           },
           colorSaturation: [0.3, 0.5],

--- a/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.spec.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.spec.ts
@@ -1,0 +1,34 @@
+import {getOpaqueColorFromComposite} from 'sentry/views/preprod/components/visualizations/appSizeTreemapTheme';
+
+function parseRgbString(colorValue: string): [number, number, number] {
+  const match = colorValue.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+
+  if (!match) {
+    throw new Error(`Invalid color value: ${colorValue}`);
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+describe('getOpaqueColorFromComposite', () => {
+  it('returns foreground color when foreground is fully opaque', () => {
+    const result = getOpaqueColorFromComposite('rgb(10, 20, 30)', 'rgb(40, 50, 60)');
+
+    expect(parseRgbString(result)).toEqual([10, 20, 30]);
+  });
+
+  it('composites a semi-transparent foreground over background', () => {
+    const result = getOpaqueColorFromComposite(
+      'rgba(200, 100, 0, 0.25)',
+      'rgb(40, 20, 240)'
+    );
+
+    expect(parseRgbString(result)).toEqual([80, 40, 180]);
+  });
+
+  it('returns background when foreground is fully transparent', () => {
+    const result = getOpaqueColorFromComposite('rgba(200, 100, 0, 0)', 'rgb(40, 50, 60)');
+
+    expect(parseRgbString(result)).toEqual([40, 50, 60]);
+  });
+});

--- a/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.ts
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemapTheme.ts
@@ -15,6 +15,20 @@ function createTranslucentColor(baseColor: string): string {
   return color(baseColor).alpha(0.6).string();
 }
 
+export function getOpaqueColorFromComposite(
+  foregroundColor: string,
+  backgroundColor: string
+): string {
+  const foreground = color(foregroundColor);
+  const alpha = foreground.alpha();
+
+  if (alpha >= 1) {
+    return foreground.rgb().string();
+  }
+
+  return color(backgroundColor).mix(foreground.alpha(1), alpha).rgb().string();
+}
+
 export function getAppSizeCategoryInfo(
   theme: Theme
 ): Record<string, AppSizeCategoryInfo> {


### PR DESCRIPTION
Replace transparent fill and gap colors in the treemap with pre-computed opaque
composites. Nodes previously relied on parent colors showing through transparent
fills, which caused colour bleed artifacts — particularly visible on parent nodes
with flagged insights.

The new `getOpaqueColorFromComposite` utility performs standard alpha-over
compositing, and the treemap recursively passes each node's resolved colour to
its children so nested translucent layers resolve correctly against the chart
surface.

Also cleans up redundant `children` truthiness checks (the type guarantees an
array) and removes a stale `borderColor: 'transparent'` from the ECharts level
config.

## Before

Pay attention __LINKEDIT child node blending.

https://github.com/user-attachments/assets/574e8840-9a52-4724-a51e-e59b6f6e5892

## After 

https://github.com/user-attachments/assets/41c91834-ac2a-4707-9309-e545eeb5349a 

Refs EME-889