### PR TITLE
chore(deps): bump typescript-eslint to 8.56.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,7 +236,7 @@
     "stylelint": "16.10.0",
     "stylelint-config-recommended": "^14.0.1",
     "terser": "5.40.0",
-    "typescript-eslint": "8.39.0"
+    "typescript-eslint": "8.56.1"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,13 +618,13 @@ importers:
         version: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-boundaries:
         specifier: 5.3.1
-        version: 5.3.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+        version: 5.3.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: 2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       eslint-plugin-jest:
         specifier: 29.0.1
-        version: 29.0.1(@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(jest@30.0.4(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.0.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(jest@30.0.4(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.3)))(typescript@5.9.3)
       eslint-plugin-jest-dom:
         specifier: ^5.5.0
         version: 5.5.0(@testing-library/dom@10.4.0)(eslint@9.34.0(jiti@2.6.1))
@@ -651,7 +651,7 @@ importers:
         version: 7.1.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-typescript-sort-keys:
         specifier: ^3.3.0
-        version: 3.3.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 3.3.0(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-unicorn:
         specifier: ^57.0.0
         version: 57.0.0(eslint@9.34.0(jiti@2.6.1))
@@ -695,8 +695,8 @@ importers:
         specifier: 5.40.0
         version: 5.40.0
       typescript-eslint:
-        specifier: 8.39.0
-        version: 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.56.1
+        version: 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       fsevents:
         specifier: ^2.3.3
@@ -1807,8 +1807,18 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/config-array@0.21.0':
@@ -2494,36 +2504,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.99.0':
     resolution: {integrity: sha512-qhftDo2D37SqCEl3ZTa367NqWSZNb1Ddp34CTmShLKFrnKdNiUn55RdokLnHtf1AL5ssaQlYDwBECX7XiBWOhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.99.0':
     resolution: {integrity: sha512-zxn/xkf519f12FKkpL5XwJipsylfSSnm36h6c1zBDTz4fbIDMGyIhHfWfwM7uUmHo9Aqw1pLxFpY39Etv398+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.99.0':
     resolution: {integrity: sha512-Y1eSDKDS5E4IVC7Oxw+NbYAKRmJPMJTIjW+9xOWwteDHkFqpocKe0USxog+Q1uhzalD9M0p9eXWEWdGQCMDBMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.99.0':
     resolution: {integrity: sha512-YVJMfk5cFWB8i2/nIrbk6n15bFkMHqWnMIWkVx7r2KwpTxHyFMfu2IpeVKo1ITDSmt5nBrGdLHD36QRlu2nDLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.99.0':
     resolution: {integrity: sha512-2+SDPrie5f90A1b9EirtVggOgsqtsYU5raZwkDYKyS1uvJzjqHCDhG/f4TwQxHmIc5YkczdQfwvN91lwmjsKYQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.99.0':
     resolution: {integrity: sha512-DKA4j0QerUWSMADziLM5sAyM7V53Fj95CV9SjP77bPfEfT7MnvFKnneaRMqPK1cpzjAGiQF52OBUIKyk0dwOQA==}
@@ -2584,41 +2600,49 @@ packages:
     resolution: {integrity: sha512-SVjjjtMW66Mza76PBGJLqB0KKyFTBnxmtDXLJPbL6ZPGSctcXVmujz7/WAc0rb9m2oV0cHQTtVjnq6orQnI/jg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.15.0':
     resolution: {integrity: sha512-JDv2/AycPF2qgzEiDeMJCcSzKNDm3KxNg0KKWipoKEMDFqfM7LxNwwSVyAOGmrYlE4l3dg290hOMsr9xG7jv9g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.15.0':
     resolution: {integrity: sha512-zbu9FhvBLW4KJxo7ElFvZWbSt4vP685Qc/Gyk/Ns3g2gR9qh2qWXouH8PWySy+Ko/qJ42+HJCLg+ZNcxikERfg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.15.0':
     resolution: {integrity: sha512-Kfleehe6B09C2qCnyIU01xLFqFXCHI4ylzkicfX/89j+gNHh9xyNdpEvit88Kq6i5tTGdavVnM6DQfOE2qNtlg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.15.0':
     resolution: {integrity: sha512-J7LPiEt27Tpm8P+qURDwNc8q45+n+mWgyys4/V6r5A8v5gDentHRGUx3iVk5NxdKhgoGulrzQocPTZVosq25Eg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.15.0':
     resolution: {integrity: sha512-+8/d2tAScPjVJNyqa7GPGnqleTB/XW9dZJQ2D/oIM3wpH3TG+DaFEXBbk4QFJ9K9AUGBhvQvWU2mQyhK/yYn3Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.15.0':
     resolution: {integrity: sha512-xtvSzH7Nr5MCZI2FKImmOdTl9kzuQ51RPyLh451tvD2qnkg3BaqI9Ox78bTk57YJhlXPuxWSOL5aZhKAc9J6qg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.15.0':
     resolution: {integrity: sha512-14YL1zuXj06+/tqsuUZuzL0T425WA/I4nSVN1kBXeC5WHxem6lQ+2HGvG+crjeJEqHgZUT62YIgj88W+8E7eyg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.15.0':
     resolution: {integrity: sha512-/7Qli+1Wk93coxnrQaU8ySlICYN8HsgyIrzqjgIkQEpI//9eUeaeIHZptNl2fMvBGeXa7k2QgLbRNaBRgpnvMw==}
@@ -3037,21 +3061,25 @@ packages:
     resolution: {integrity: sha512-SodEX3+1/GLz0LobX9cY1QdjJ1NftSEh4C2vGpr71iA3MS9HyXuw4giqSeRQ4DpCybqpdS/3RLjVqFQEfGpcnw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.7.3':
     resolution: {integrity: sha512-ydD2fNdEy+G7EYJ/a3FfdFZPfrLj/UnZocCNlZTTSHEhu+jURdQk0hwV11CvL+sjnKU5e/8IVMGUzhu3Gu8Ghg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.7.3':
     resolution: {integrity: sha512-adnDbUqafSAI6/N6vZ+iONSo1W3yUpnNtJqP3rVp7+YdABhUpbOhtaY37qpIJ3uFajXctYFyISPrb4MWl1M9Yg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.7.3':
     resolution: {integrity: sha512-5jnjdODk5HCUFPN6rTaFukynDU4Fn9eCL+4TSp6mqo6YAnfnJEuzDjfetA8t3aQFcAs7WriQfNwvdcA4HvYtbA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.7.3':
     resolution: {integrity: sha512-WLQK0ksUzMkVeGoHAMIxenmeEU5tMvFDK36Aip7VRj7T6vZTcAwvbMwc38QrIAvlG7dqWoxgPQi35ba1igNNDw==}
@@ -3856,12 +3884,12 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@typescript-eslint/eslint-plugin@8.39.0':
-    resolution: {integrity: sha512-bhEz6OZeUR+O/6yx9Jk6ohX6H9JSFTaiY0v9/PuKT3oGK0rn0jNplLmyFUGV+a9gfYnVNwGDwS/UkLIuXNb2Rw==}
+  '@typescript-eslint/eslint-plugin@8.56.1':
+    resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.39.0
-      eslint: ^8.57.0 || ^9.0.0
+      '@typescript-eslint/parser': ^8.56.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/experimental-utils@5.62.0':
@@ -3870,15 +3898,21 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@typescript-eslint/parser@8.39.0':
-    resolution: {integrity: sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==}
+  '@typescript-eslint/parser@8.56.1':
+    resolution: {integrity: sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/project-service@8.39.0':
     resolution: {integrity: sha512-CTzJqaSq30V/Z2Og9jogzZt8lJRR5TKlAdXmWgdu4hgcC9Kww5flQ+xFvMxIBWVNdxJO7OifgdOK4PokMIWPew==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.56.1':
+    resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -3895,17 +3929,27 @@ packages:
     resolution: {integrity: sha512-8QOzff9UKxOh6npZQ/4FQu4mjdOCGSdO3p44ww0hk8Vu+IGbg0tB/H1LcTARRDzGCC8pDGbh2rissBuuoPgH8A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.56.1':
+    resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.39.0':
     resolution: {integrity: sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.39.0':
-    resolution: {integrity: sha512-6B3z0c1DXVT2vYA9+z9axjtc09rqKUPRmijD5m9iv8iQpHBRYRMBcgxSiKTZKm6FwWw1/cI4v6em35OsKCiN5Q==}
+  '@typescript-eslint/tsconfig-utils@8.56.1':
+    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.56.1':
+    resolution: {integrity: sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@5.62.0':
@@ -3918,6 +3962,10 @@ packages:
 
   '@typescript-eslint/types@8.39.0':
     resolution: {integrity: sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.56.1':
+    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
@@ -3937,6 +3985,12 @@ packages:
 
   '@typescript-eslint/typescript-estree@8.39.0':
     resolution: {integrity: sha512-ndWdiflRMvfIgQRpckQQLiB5qAKQ7w++V4LlCHwp62eym1HLB/kw7D9f2e8ytONls/jt89TEasgvb+VwnRprsw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/typescript-estree@8.56.1':
+    resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
@@ -3961,6 +4015,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
+  '@typescript-eslint/utils@8.56.1':
+    resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3971,6 +4032,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.39.0':
     resolution: {integrity: sha512-ldgiJ+VAhQCfIjeOgu8Kj5nSxds0ktPOSO9p4+0VDH2R2pLvQraaM5Oen2d7NxzMCm+Sn/vJT+mv2H5u6b/3fA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.56.1':
+    resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260112.1':
@@ -4044,41 +4109,49 @@ packages:
     resolution: {integrity: sha512-uNpLKxlDF+NF6aUztbAVhhFSF65zf/6QEfk5NifUgYFbpBObzvMnl2ydEsXV96spwPcmeNTpG9byvq+Twwd3HQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.13':
     resolution: {integrity: sha512-mEFL6q7vtxA6YJ9sLbxCnKOBynOvClVOcqwUErmaCxA94hgP11rlstouySxJCGeFAb8KfUX9mui82waYrqoBlQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.13':
     resolution: {integrity: sha512-MjJaNk8HK3rCOIPS6AQPJXlrDfG1LaePum+CZddHZygPqDNZyVrVdWTadT+U51vIx5QOdEE0oXcgTY+7VYsU1g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.13':
     resolution: {integrity: sha512-9gAuT1+ed2eIuOXHSu4SdJOe7SUEzPTpOTEuTjGePvMEoWHywY5pvlcY7xMn3d8rhKHpwMzEhl8F8Oy+rkudzA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.13':
     resolution: {integrity: sha512-CNrJythJN9jC8SIJGoawebYylzGNJuWAWTKxxxx5Fr3DGEXbex/We4U7N4u6/dQAK3cLVOuAE/9a4D2JH35JIA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.13':
     resolution: {integrity: sha512-J0MVXXPvM2Bv+f+gzOZHLHEmXUJNKwJqkfMDTwE763w/tD+OA7UlTMLQihrcYRXwW5jZ8nbM2cEWTeFsTiH2JQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.13':
     resolution: {integrity: sha512-Ii2WhtIpeWUe6XG/YhPUX3JNL3PiyXe56PJzqAYDUyB0gctkk/nngpuPnNKlLMcN9FID0T39mIJPhA6YpRcGDQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.13':
     resolution: {integrity: sha512-8F5E9EhtGYkfEM1OhyVgq76+SnMF5NfZS4v5Rq9JlfuqPnqXWgUjg903hxnG54PQr4I3jmG5bEeT77pGAA3Vvg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.13':
     resolution: {integrity: sha512-7RXGTyDtyR/5o1FlBcjEaQQmQ2rKvu5Jq0Uhvce3PsbreZ61M4LQ5Mey2OMomIq4opphAkfDdm/lkHhWJNKNrw==}
@@ -4394,6 +4467,10 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
@@ -4447,6 +4524,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4908,6 +4989,15 @@ packages:
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -5466,6 +5556,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.34.0:
     resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5907,9 +6001,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   graphemesplit@2.6.0:
     resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
@@ -7119,6 +7210,10 @@ packages:
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
+
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -8651,6 +8746,12 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-checker-rspack-plugin@1.2.6:
     resolution: {integrity: sha512-aAJIfoNr2cPu8G6mqp/oPoNlUT/LgNoqt2n3SsbxWG0TwQogbjsYsr2f/fdsufUDoGDu8Jolmpf3L4PmIH/cEg==}
     peerDependencies:
@@ -8750,11 +8851,11 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-eslint@8.39.0:
-    resolution: {integrity: sha512-lH8FvtdtzcHJCkMOKnN73LIn6SLTpoojgJqDAxPm1jCR14eWSGPX8ul/gggBdPMk/d5+u9V854vTYQ8T5jF/1Q==}
+  typescript-eslint@8.56.1:
+    resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   typescript-template-language-service-decorator@2.3.2:
@@ -10292,10 +10393,10 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@boundaries/elements@1.1.2(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))':
+  '@boundaries/elements@1.1.2(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))':
     dependencies:
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       handlebars: 4.7.8
       is-core-module: 2.16.1
       micromatch: 4.0.8
@@ -10623,7 +10724,14 @@ snapshots:
       eslint: 9.34.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.34.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.34.0(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.0':
     dependencies:
@@ -13325,19 +13433,18 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 15.0.0
 
-  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/type-utils': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.39.0
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
       eslint: 9.34.0(jiti@2.6.1)
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -13350,13 +13457,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.39.0
-      debug: 4.4.1
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3
       eslint: 9.34.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13367,6 +13474,15 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.39.0
       debug: 4.4.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -13386,18 +13502,27 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
 
+  '@typescript-eslint/scope-manager@8.56.1':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
+
   '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      debug: 4.4.1
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
       eslint: 9.34.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
+      ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -13407,6 +13532,8 @@ snapshots:
   '@typescript-eslint/types@8.26.0': {}
 
   '@typescript-eslint/types@8.39.0': {}
+
+  '@typescript-eslint/types@8.56.1': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.3)':
     dependencies:
@@ -13452,6 +13579,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3
+      minimatch: 10.2.3
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@5.62.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.34.0(jiti@2.6.1))
@@ -13489,6 +13631,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.34.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      eslint: 9.34.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -13503,6 +13656,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.39.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript-eslint/visitor-keys@8.56.1':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      eslint-visitor-keys: 5.0.1
 
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260112.1':
     optional: true
@@ -13979,6 +14137,8 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  balanced-match@4.0.4: {}
+
   base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -14046,6 +14206,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.0
+
+  brace-expansion@5.0.3:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -14476,6 +14640,10 @@ snapshots:
       ms: 2.1.3
 
   debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -15000,7 +15168,7 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15024,24 +15192,24 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.32.0)(eslint@9.34.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-boundaries@5.3.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-boundaries@5.3.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
-      '@boundaries/elements': 1.1.2(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+      '@boundaries/elements': 1.1.2(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       chalk: 4.1.2
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       micromatch: 4.0.8
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -15049,7 +15217,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15060,7 +15228,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.34.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@9.34.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15072,7 +15240,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -15086,12 +15254,12 @@ snapshots:
     optionalDependencies:
       '@testing-library/dom': 10.4.0
 
-  eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(jest@30.0.4(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.3)))(typescript@5.9.3):
+  eslint-plugin-jest@29.0.1(@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(jest@30.0.4(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/utils': 8.26.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.34.0(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       jest: 30.0.4(@types/node@22.15.21)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.21)(typescript@5.9.3))
     transitivePeerDependencies:
       - supports-color
@@ -15170,10 +15338,10 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/experimental-utils': 5.62.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.34.0(jiti@2.6.1)
       json-schema: 0.4.0
       natural-compare-lite: 1.4.0
@@ -15221,6 +15389,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.34.0(jiti@2.6.1):
     dependencies:
@@ -15751,8 +15921,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   graphemesplit@2.6.0:
     dependencies:
@@ -17570,6 +17738,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
 
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.3
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -19302,6 +19474,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-checker-rspack-plugin@1.2.6(@rspack/core@1.7.3(@swc/helpers@0.5.15))(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -19417,12 +19593,12 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.34.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.34.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -137,7 +137,7 @@ export const initApiClientErrorHandling = () =>
     );
 
     // Ignore error unless it is a 401
-    if (!resp || resp.status !== 401 || pageAllowsAnon) {
+    if (resp?.status !== 401 || pageAllowsAnon) {
       return false;
     }
     if (resp && options.allowAuthError && resp.status === 401) {

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -288,7 +288,7 @@ function InternalInput({
   );
 
   const attributesFilter = useMemo(() => {
-    if (parameterDefinition && parameterDefinition.kind === 'column') {
+    if (parameterDefinition?.kind === 'column') {
       const columnTypes = parameterDefinition.columnTypes;
       return typeof columnTypes === 'function'
         ? columnTypes
@@ -397,11 +397,7 @@ function InternalInput({
   const onInputCommit = useCallback(() => {
     let value = inputValue.trim() || argument.label;
 
-    if (
-      defined(getSuggestedKey) &&
-      parameterDefinition &&
-      parameterDefinition.kind === 'column'
-    ) {
+    if (defined(getSuggestedKey) && parameterDefinition?.kind === 'column') {
       value = getSuggestedKey(value) ?? value;
     }
 

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -249,14 +249,14 @@ function AutofixHighlightPopupContent({
       const lastServerMessage = serverMessages[serverMessages.length - 1];
 
       // If the last server message is from the assistant, clear all pending messages
-      if (lastServerMessage && lastServerMessage.role === 'assistant') {
+      if (lastServerMessage?.role === 'assistant') {
         setPendingUserMessage(null);
         setShowLoadingAssistant(false);
       }
 
       // If the last server message is from the user, keep loading assistant state
       // but clear the pending user message
-      if (lastServerMessage && lastServerMessage.role === 'user') {
+      if (lastServerMessage?.role === 'user') {
         setPendingUserMessage(null);
         setShowLoadingAssistant(true);
       }

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -136,8 +136,7 @@ function ActiveLogDisplay({
   const erroredStepIndex = erroredStep?.index ?? 0;
   let retainInsightCardIndex: number | null = null;
   if (
-    erroredStep &&
-    erroredStep.type === AutofixStepType.DEFAULT &&
+    erroredStep?.type === AutofixStepType.DEFAULT &&
     Array.isArray((erroredStep as any).insights)
   ) {
     const insights = (erroredStep as any).insights;

--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -250,7 +250,7 @@ export function isIssueQuickFixable(group: Group) {
 }
 
 export function getAutofixRunErrorMessage(autofixData: AutofixData | undefined) {
-  if (!autofixData || autofixData.status !== AutofixStatus.ERROR) {
+  if (autofixData?.status !== AutofixStatus.ERROR) {
     return null;
   }
 

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -270,7 +270,7 @@ const FlamegraphDrawer = memo(function FlamegraphDrawer(props: FlamegraphDrawerP
       {props.profileGroup.type === 'transaction' ? (
         <ProfileDetails
           transaction={
-            props.profileTransaction && props.profileTransaction.type === 'resolved'
+            props.profileTransaction?.type === 'resolved'
               ? props.profileTransaction.data
               : null
           }

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -115,8 +115,7 @@ function calculateNextFocus(
 ): FocusOverride | undefined {
   if (
     defined(parameterIndex) &&
-    definition &&
-    definition.kind === FieldKind.FUNCTION &&
+    definition?.kind === FieldKind.FUNCTION &&
     definition.parameters?.length &&
     parameterIndex + 1 < definition.parameters.length
   ) {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -149,11 +149,7 @@ function calculateNextFocusForFilter(
       ? 'op'
       : 'value';
 
-  if (
-    definition &&
-    definition.kind === FieldKind.FUNCTION &&
-    definition.parameters?.length
-  ) {
+  if (definition?.kind === FieldKind.FUNCTION && definition.parameters?.length) {
     part = 'key';
   } else if (key === FilterType.IS || key === FilterType.HAS) {
     part = 'value';

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -436,9 +436,7 @@ const storeConfig: GroupStoreDefinition = {
     // Looks like the `PUT /api/0/projects/:orgId/:projectId/issues/` endpoint
     // actually returns a 204, so there is no `response` body
     this.items = this.items.filter(
-      item =>
-        !mergedIdSet.has(item.id) ||
-        (response?.merge && item.id === response.merge.parent)
+      item => !mergedIdSet.has(item.id) || item.id === response?.merge?.parent
     );
 
     if (ids.length > 0) {

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -296,9 +296,7 @@ const storeConfig: GuideStoreDefinition = {
 
     this.updatePrevGuide(nextGuide);
     const currentStep =
-      this.state.currentGuide &&
-      nextGuide &&
-      this.state.currentGuide.guide === nextGuide.guide
+      this.state.currentGuide && this.state.currentGuide.guide === nextGuide?.guide
         ? this.state.currentStep
         : 0;
     this.state = {...this.state, currentGuide: nextGuide, currentStep};

--- a/static/app/stories/type-loader.ts
+++ b/static/app/stories/type-loader.ts
@@ -99,23 +99,17 @@ function prodTypeloader(this: LoaderContext<any>, _source: string) {
 
   const module = extractRequest(this._module);
 
-  Promise.all([
-    extractComponentProps(this._module, this.resourcePath),
-    extractModuleExports(program, sourceFile),
-  ])
-    .then(([moduleProps, moduleExports]) => {
-      const typeLoaderResult: TypeLoader.TypeLoaderResult = {
-        props: moduleProps,
-        exports: {
-          module,
-          exports: moduleExports,
-        },
-      };
-      return callback(null, `export default ${JSON.stringify(typeLoaderResult)}`);
-    })
-    .catch(error => {
-      return callback(error);
-    });
+  const moduleProps = extractComponentProps(this._module, this.resourcePath);
+  const moduleExports = extractModuleExports(program, sourceFile);
+
+  const typeLoaderResult: TypeLoader.TypeLoaderResult = {
+    props: moduleProps,
+    exports: {
+      module,
+      exports: moduleExports,
+    },
+  };
+  return callback(null, `export default ${JSON.stringify(typeLoaderResult)}`);
 }
 
 function noopTypeLoader(this: LoaderContext<any>, _source: string) {

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -940,7 +940,7 @@ export function getAggregateArg(field: string): string | null {
 
 export function parseFunction(field: string): ParsedFunction | null {
   const results = field.match(AGGREGATE_PATTERN);
-  if (results && results.length === 3) {
+  if (results?.length === 3) {
     return {
       name: results[1]!,
       arguments: parseArguments(results[2]!),
@@ -1041,7 +1041,7 @@ export function stripEquationPrefix(field: string): string {
 export function getEquationAliasIndex(field: string): number {
   const results = field.match(EQUATION_ALIAS_PATTERN);
 
-  if (results && results.length === 2) {
+  if (results?.length === 2) {
     return parseInt(results[1]!, 10);
   }
   return -1;

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -78,7 +78,7 @@ export const getSentryAppInstallStatus = (install: SentryAppInstallation | undef
   if (install && install.status !== 'pending_deletion') {
     return capitalize(install.status) as IntegrationInstallationStatus;
   }
-  if (install && install.status === 'pending_deletion') {
+  if (install?.status === 'pending_deletion') {
     return 'Pending Deletion';
   }
   return 'Not Installed';

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -69,7 +69,7 @@ export function makeColorBufferForNodes(
     }
 
     const c = colorMap.get(frame.node);
-    const colorWithAlpha = c && c.length === 3 ? c.concat(1) : c ? c : fallbackColor;
+    const colorWithAlpha = c?.length === 3 ? c.concat(1) : c ? c : fallbackColor;
 
     for (let i = 0; i < 6; i++) {
       const offset = index * 6 * 4 + i * 4;
@@ -100,7 +100,7 @@ function makeColorBuffer(
     }
 
     const c = colorMap.get(frame.key);
-    const colorWithAlpha = c && c.length === 3 ? c.concat(1) : c ? c : fallbackColor;
+    const colorWithAlpha = c?.length === 3 ? c.concat(1) : c ? c : fallbackColor;
 
     for (let i = 0; i < 6; i++) {
       const offset = index * 6 * 4 + i * 4;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
@@ -57,7 +57,7 @@ export function markRowAsHovered(
   }
 ) {
   for (const row of renderedItems) {
-    if (row.ref && row.ref.dataset.hovered === 'true') {
+    if (row.ref?.dataset.hovered === 'true') {
       delete row.ref.dataset.hovered;
     }
   }

--- a/static/app/views/alerts/list/incidents/index.tsx
+++ b/static/app/views/alerts/list/incidents/index.tsx
@@ -88,7 +88,7 @@ class IncidentsList extends DeprecatedAsyncComponent<
   async onLoadAllEndpointsSuccess() {
     const {incidentList} = this.state;
 
-    if (!incidentList || incidentList.length !== 0) {
+    if (incidentList?.length !== 0) {
       this.setState({hasAlertRule: true, firstVisitShown: false});
       return;
     }

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -72,8 +72,7 @@ function RuleListRow({
       : rule.projects[0]!;
 
   const ruleType =
-    rule &&
-    rule.type === CombinedAlertType.METRIC &&
+    rule?.type === CombinedAlertType.METRIC &&
     getAlertTypeFromAggregateDataset({
       aggregate: rule.aggregate,
       dataset: rule.dataset,

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -485,7 +485,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
 
     const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${ruleId}`;
 
-    if (rule && rule.environment === ALL_ENVIRONMENTS_KEY) {
+    if (rule?.environment === ALL_ENVIRONMENTS_KEY) {
       delete rule.environment;
     }
 

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -323,7 +323,7 @@ export function getThresholdUnits(
   }
 
   const parsed = parseFunction(aggregate);
-  if (parsed && parsed.name === 'count') {
+  if (parsed?.name === 'count') {
     return '';
   }
 

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -338,7 +338,7 @@ export function getMetricAlertChartOption(
           }
         });
 
-        if (selectedIncident && incident.id === selectedIncident.id) {
+        if (incident.id === selectedIncident?.id) {
           const selectedIncidentColor =
             incidentColor === theme.colors.yellow400
               ? theme.colors.yellow100

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -402,8 +402,7 @@ class ActionsPanel extends PureComponent<Props> {
                           actionIdx
                         )}
                       />
-                    ) : availableAction &&
-                      availableAction.type === 'sentry_app' &&
+                    ) : availableAction?.type === 'sentry_app' &&
                       availableAction.settings ? (
                       <Button
                         icon={<IconSettings />}

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/tree.tsx
@@ -159,7 +159,7 @@ export class Tree {
       // After the logical ops have been merged, if the root has only one GROUP op child,
       // we can remove the root to simplify the tree.
       // Example: 'Assert All then Assert Any' to just 'Assert Any'
-      if (this.root && this.root.children.length === 1) {
+      if (this.root?.children.length === 1) {
         const child = this.root.children[0];
         if (child && isGroupOp(child.value)) {
           this.removeNode(this.root);

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -262,7 +262,7 @@ function _getWidgetExploreUrl(
             field !== SpanFields.IS_STARRED_TRANSACTION // starred transactions are not supported in explore
         )
       : query.columns.filter(column => column !== SpanFields.IS_STARRED_TRANSACTION);
-  if (groupBy && groupBy.length === 0) {
+  if (groupBy?.length === 0) {
     // Force the groupBy to be an array with a single empty string
     // so that qs.stringify appends the key to the URL. If the key
     // is not present, the Explore UI will assign a default groupBy

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -176,19 +176,18 @@ export function getColumnOptions(
   )?.value;
 
   if (
-    fieldData &&
-    fieldData.kind === FieldValueKind.FUNCTION &&
+    fieldData?.kind === FieldValueKind.FUNCTION &&
     fieldData.meta.parameters.length > 0 &&
     fieldData.meta.parameters[0]
   ) {
     const parameter = fieldData.meta.parameters[0];
-    if (parameter && parameter.kind === 'dropdown') {
+    if (parameter?.kind === 'dropdown') {
       // Parameters for dropdowns are already formatted in the correct manner
       // for select fields
       return parameter.options;
     }
 
-    if (parameter && parameter.kind === 'column' && parameter.columnTypes) {
+    if (parameter?.kind === 'column' && parameter.columnTypes) {
       // Release Health widgets are the only widgets that actually have different
       // columns than the aggregates accept. e.g. project will never be a valid
       // parameter for any of the aggregates.

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsAndTransactionsWidgetQuery.tsx
@@ -323,7 +323,7 @@ export function useErrorsAndTransactionsSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -538,7 +538,7 @@ export function useErrorsAndTransactionsTableQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.tsx
@@ -186,7 +186,7 @@ export function useErrorsSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -366,7 +366,7 @@ export function useErrorsTableQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.tsx
@@ -196,7 +196,7 @@ export function useIssuesSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -370,7 +370,7 @@ export function useIssuesTableQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.tsx
@@ -191,7 +191,7 @@ export function useLogsSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -359,7 +359,7 @@ export function useLogsTableQuery(
 
     // Check if rawData is the same as before to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useMobileAppSizeWidgetQuery.tsx
@@ -207,7 +207,7 @@ export function useMobileAppSizeSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.tsx
@@ -205,7 +205,7 @@ export function useReleasesSeriesQuery(params: WidgetQueryParams): HookWidgetQue
 
     // Memoize raw data to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -407,7 +407,7 @@ export function useReleasesTableQuery(params: WidgetQueryParams): HookWidgetQuer
 
     // Memoize raw data to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.tsx
@@ -244,7 +244,7 @@ export function useSpansSeriesQuery(
     // Check if rawData is the same as before to prevent unnecessary rerenders
     // Compare each data object reference - if they're all the same, reuse previous array
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -463,7 +463,7 @@ export function useSpansTableQuery(
     // Check if rawData is the same as before to prevent unnecessary rerenders
     // Compare each data object reference - if they're all the same, reuse previous array
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.tsx
@@ -224,7 +224,7 @@ export function useTraceMetricsSeriesQuery(
     });
 
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -391,7 +391,7 @@ export function useTraceMetricsTableQuery(
 
     // Check if rawData is the same as before to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.tsx
@@ -270,7 +270,7 @@ export function useTransactionsSeriesQuery(
 
     // Check if rawData is the same as before to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;
@@ -489,7 +489,7 @@ export function useTransactionsTableQuery(
 
     // Check if rawData is the same as before to prevent unnecessary rerenders
     let finalRawData = rawData;
-    if (prevRawDataRef.current && prevRawDataRef.current.length === rawData.length) {
+    if (prevRawDataRef.current?.length === rawData.length) {
       const allSame = rawData.every((data, i) => data === prevRawDataRef.current?.[i]);
       if (allSame) {
         finalRawData = prevRawDataRef.current;

--- a/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/releaseWidgetQueries.tsx
@@ -248,7 +248,7 @@ function ReleaseWidgetQueries({
       let releaseCondition = '';
       const releasesArray: string[] = [];
       if (isCustomReleaseSorting) {
-        if (releases && releases.length === 1) {
+        if (releases?.length === 1) {
           releaseCondition += `release:${releases[0]!.version}`;
           releasesArray.push(releases[0]!.version);
         }
@@ -281,7 +281,7 @@ function ReleaseWidgetQueries({
 
       const releasesArray: string[] = [];
       if (requiresCustomReleaseSorting(widget.queries[0]!)) {
-        if (releases && releases.length === 1) {
+        if (releases?.length === 1) {
           releasesArray.push(releases[0]!.version);
         }
         if (releases && releases.length > 1) {

--- a/static/app/views/detectors/components/details/metric/charts/metricDetectorChartOptions.tsx
+++ b/static/app/views/detectors/components/details/metric/charts/metricDetectorChartOptions.tsx
@@ -334,7 +334,7 @@ export function getMetricDetectorChartOption(
           }
         });
 
-        if (selectedOpenPeriod && openPeriod.id === selectedOpenPeriod.id) {
+        if (openPeriod.id === selectedOpenPeriod?.id) {
           const selectedIncidentColor =
             incidentColor === theme.colors.yellow400
               ? theme.colors.yellow100

--- a/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
+++ b/static/app/views/detectors/hooks/useFilteredAnomalyThresholdSeries.tsx
@@ -39,7 +39,7 @@ export function useFilteredAnomalyThresholdSeries({
 
     if (detector) {
       const condition = detector.conditionGroup?.conditions[0];
-      if (!condition || condition.type !== 'anomaly_detection') {
+      if (condition?.type !== 'anomaly_detection') {
         return [];
       }
 

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -382,8 +382,7 @@ class _QueryField extends Component<Props> {
     let parameterDescriptions: ParameterDescription[] = [];
     // Generate options and values for each parameter.
     if (
-      field &&
-      field.kind === FieldValueKind.FUNCTION &&
+      field?.kind === FieldValueKind.FUNCTION &&
       field.meta.parameters.length > 0 &&
       fieldValue?.kind === FieldValueKind.FUNCTION
     ) {
@@ -866,11 +865,11 @@ function appendFieldIfUnknown(
     return fieldOptions;
   }
 
-  if (field && field.kind === FieldValueKind.TAG && field.meta.unknown) {
+  if (field?.kind === FieldValueKind.TAG && field.meta.unknown) {
     // Clone the options so we don't mutate other rows.
     fieldOptions = Object.assign({}, fieldOptions);
     fieldOptions[field.meta.name] = {label: field.meta.name, value: field};
-  } else if (field && field.kind === FieldValueKind.CUSTOM_MEASUREMENT) {
+  } else if (field?.kind === FieldValueKind.CUSTOM_MEASUREMENT) {
     fieldOptions = Object.assign({}, fieldOptions);
     fieldOptions[`measurement:${field.meta.name}`] = {
       label: field.meta.name,

--- a/static/app/views/explore/spans/charts/index.tsx
+++ b/static/app/views/explore/spans/charts/index.tsx
@@ -271,9 +271,7 @@ function Chart({
   );
 
   const initialChartSelection =
-    chartSelection && chartSelection.chartIndex === index
-      ? chartSelection.selection
-      : undefined;
+    chartSelection?.chartIndex === index ? chartSelection.selection : undefined;
 
   return (
     <ChartWrapper ref={chartWrapperRef}>

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -41,7 +41,7 @@ function AssignedMessage({activity, author, issueType}: AssignedMessageProps) {
     const team = teams.find(({id}) => id === data.assignee);
     // TODO: could show a loading indicator if the team is loading
     assignee = team ? `#${team.slug}` : '<unknown-team>';
-  } else if (activity.user && data.assignee === activity.user.id) {
+  } else if (data.assignee === activity.user?.id) {
     assignee = t('themselves');
   } else if (data.assigneeType === 'user' && data.assigneeEmail) {
     assignee = data.assigneeEmail;

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -338,8 +338,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
       // - The previous environments are not the same as the current environments
       if (
         !groupData &&
-        previousInstance?.cachedGroup &&
-        previousInstance.cachedGroup.id === groupId &&
+        previousInstance?.cachedGroup?.id === groupId &&
         !isEqual(previousInstance.previousEnvironments, environments)
       ) {
         return {

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -123,7 +123,7 @@ export default function getGroupActivityItem(
       const team = teams.find(({id}) => id === data.assignee);
       // TODO: could show a loading indicator if the team is loading
       assignee = team ? `#${team.slug}` : '<unknown-team>';
-    } else if (activity.user && data.assignee === activity.user.id) {
+    } else if (data.assignee === activity.user?.id) {
       assignee = t('themselves');
     } else if (data.assigneeType === 'user' && data.assigneeEmail) {
       assignee = data.assigneeEmail;

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -112,7 +112,7 @@ export function SeerSectionCtaButton({
       step => step.type === AutofixStepType.DEFAULT
     );
 
-    if (processingStep && processingStep.status === AutofixStatus.COMPLETED) {
+    if (processingStep?.status === AutofixStatus.COMPLETED) {
       // Check if this is a new completion (wasn't completed in previous state)
       const prevProcessingStep = prevSteps.findLast(
         step => step.type === AutofixStepType.DEFAULT

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -131,8 +131,7 @@ export function OnboardingWithoutContext() {
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);
 
-  const projectSlug =
-    stepObj && stepObj.id === 'setup-docs' ? selectedProjectSlug : undefined;
+  const projectSlug = stepObj?.id === 'setup-docs' ? selectedProjectSlug : undefined;
 
   const {project: recentCreatedProject, isProjectActive} = useRecentCreatedProject({
     orgSlug: organization.slug,

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -819,8 +819,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
       let end = head.space[0] + head.space[1];
 
       while (
-        tail &&
-        tail.children.length === 1 &&
+        tail?.children.length === 1 &&
         tail.children[0]!.canAutogroup &&
         // skip `op: default` spans as `default` is added to op-less spans:
         tail.children[0]!.op !== 'default' &&

--- a/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
+++ b/static/app/views/prevent/tokens/repoTokenTable/repoTokenTable.tsx
@@ -117,7 +117,7 @@ export default function RepoTokenTable({response, sort}: Props) {
 
     const newQuery = {...queryWithoutPagination};
 
-    if (!sort || sort.field !== field) {
+    if (sort?.field !== field) {
       newQuery.sort = field;
     } else if (sort.direction === 'asc') {
       newQuery.sort = `-${field}`;

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -143,7 +143,7 @@ const redirectDeprecatedProjectRoute = (generateRedirectRoute: RedirectCallback)
             }
 
             if (!hasProjectId || !organizationId) {
-              if (error && error.status === 404) {
+              if (error?.status === 404) {
                 return (
                   <Alert.Container>
                     <Alert variant="danger" showIcon={false}>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -217,8 +217,7 @@ export default function ReleasesList() {
       return projects[0];
     }
 
-    const selectedProjectId =
-      selection.projects && selection.projects.length === 1 && selection.projects[0];
+    const selectedProjectId = selection.projects?.length === 1 && selection.projects[0];
     return projects?.find(p => p.id === `${selectedProjectId}`);
   }, [selection.projects, projects]);
 

--- a/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
+++ b/static/app/views/seerExplorer/fileChangeApprovalBlock.tsx
@@ -37,7 +37,7 @@ function FileChangeApprovalBlock({
   pendingInput,
 }: FileChangeApprovalBlockProps) {
   const data = useMemo(() => {
-    if (!pendingInput || pendingInput.input_type !== 'file_change_approval') {
+    if (pendingInput?.input_type !== 'file_change_approval') {
       return null;
     }
     return pendingInput.data as FileChangeApprovalData;

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -182,10 +182,7 @@ export default function AccountSecurityEnroll() {
   const authenticatorName = authenticator?.name ?? 'Authenticator';
 
   const alreadyEnrolled =
-    error &&
-    error.status === 400 &&
-    error.responseJSON &&
-    error.responseJSON.details === 'Already enrolled';
+    error?.status === 400 && error.responseJSON?.details === 'Already enrolled';
 
   useEffect(() => {
     if (!isError) {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -224,7 +224,7 @@ export default function SentryApplicationDetails() {
     return location.pathname.endsWith('new-internal/');
   };
 
-  const showAuthInfo = () => !(app?.clientSecret && app.clientSecret[0] === '*');
+  const showAuthInfo = () => !(app?.clientSecret?.[0] === '*');
 
   const headerTitle = () => {
     const action = app ? 'Edit' : 'Create';
@@ -442,7 +442,7 @@ export default function SentryApplicationDetails() {
             }}
           </Observer>
 
-          {app && app.status === 'internal' && (
+          {app?.status === 'internal' && (
             <PanelTable
               headers={[
                 t('Token'),

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -135,7 +135,7 @@ function OrganizationProjects() {
                 </ProjectStatsGraphWrapper>
               </GridPanelItem>
             ))}
-          {projectList && projectList.length === 0 && (
+          {projectList?.length === 0 && (
             <EmptyMessage>{t('No projects found.')}</EmptyMessage>
           )}
         </PanelBody>

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -132,8 +132,7 @@ function KeyRateLimitsForm({data, disabled, organization, params, updateData}: P
                 validate={({form}: any) => {
                   // TODO(TS): is validate actually doing anything because it's an unexpected prop
                   const isValid =
-                    form?.rateLimit &&
-                    typeof form.rateLimit.count !== 'undefined' &&
+                    typeof form?.rateLimit?.count !== 'undefined' &&
                     typeof form.rateLimit.window !== 'undefined';
 
                   if (isValid) {

--- a/static/app/views/setupWizard/wizardProjectSelection.tsx
+++ b/static/app/views/setupWizard/wizardProjectSelection.tsx
@@ -187,7 +187,7 @@ export function WizardProjectSelection({
 
   // Set the selected team to the first team if there is only one
   useEffect(() => {
-    if (selectableTeams && selectableTeams.length === 1) {
+    if (selectableTeams?.length === 1) {
       setNewProjectTeam(selectableTeams[0]!.slug);
     }
   }, [selectableTeams]);

--- a/static/eslint/eslintPluginScraps/src/ast/extractor/css-prop.mjs
+++ b/static/eslint/eslintPluginScraps/src/ast/extractor/css-prop.mjs
@@ -115,7 +115,7 @@ export function createCssPropExtractor({collector, themeTracker, ruleContext}) {
       }
 
       const value = node.value;
-      if (!value || value.type !== 'JSXExpressionContainer') {
+      if (value?.type !== 'JSXExpressionContainer') {
         return;
       }
 

--- a/static/eslint/eslintPluginScraps/src/ast/extractor/style-prop.mjs
+++ b/static/eslint/eslintPluginScraps/src/ast/extractor/style-prop.mjs
@@ -76,7 +76,7 @@ export function createStylePropExtractor({collector, themeTracker, ruleContext})
       }
 
       const value = node.value;
-      if (!value || value.type !== 'JSXExpressionContainer') {
+      if (value?.type !== 'JSXExpressionContainer') {
         return;
       }
 

--- a/static/eslint/eslintPluginScraps/src/rules/no-core-import.mjs
+++ b/static/eslint/eslintPluginScraps/src/rules/no-core-import.mjs
@@ -27,7 +27,7 @@ export const noCoreImport = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        if (!node || node.source.type !== 'Literal') return;
+        if (node?.source.type !== 'Literal') return;
 
         const importPath = node.source.value;
 

--- a/static/eslint/eslintPluginScraps/src/rules/no-token-import.mjs
+++ b/static/eslint/eslintPluginScraps/src/rules/no-token-import.mjs
@@ -40,7 +40,7 @@ export const noTokenImport = {
 
     return {
       ImportDeclaration(node) {
-        if (!node || node.source.type !== 'Literal') return;
+        if (node?.source.type !== 'Literal') return;
         if (importerIsInAllowedDir) return;
 
         const value = node.source.value;

--- a/static/eslint/eslintPluginSentry/no-static-translations.mjs
+++ b/static/eslint/eslintPluginSentry/no-static-translations.mjs
@@ -20,7 +20,7 @@ const noStaticTranslations = {
     return {
       CallExpression(node) {
         const callee = node.callee;
-        if (!callee || callee.type !== 'Identifier') return;
+        if (callee?.type !== 'Identifier') return;
         if (!DYNAMIC_TRANSLATION_FNS.includes(callee.name)) return;
         if (node.arguments.length === 0) return;
 

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -174,7 +174,6 @@ function PlanList({
                     value={fieldValue}
                     options={(activePlan.planCategories[category] || []).map(
                       (level: {events: {toLocaleString: () => any}}) => ({
-                        // eslint-disable-next-line @typescript-eslint/no-base-to-string
                         label: level.events.toLocaleString(),
                         value: level.events,
                       })

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -67,10 +67,7 @@ export function MetricAlertQuotaMessage() {
     );
   }
 
-  if (
-    metricAlertQuota &&
-    metricAlertQuota.detectorLimit === metricAlertQuota.detectorCount + 1
-  ) {
+  if (metricAlertQuota?.detectorLimit === metricAlertQuota.detectorCount + 1) {
     return tct(
       'You have used [count] of [limit] metric monitors for your plan. To increase the limit, [upgradeLink:upgrade your plan].',
       {

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesItem.tsx
@@ -37,8 +37,7 @@ function areOverridesEqual(a: BranchOverride[], b: BranchOverride[]) {
   return a.every((override, idx) => {
     const other = b[idx];
     return (
-      other &&
-      override.branch_name === other.branch_name &&
+      override.branch_name === other?.branch_name &&
       override.tag_name === other.tag_name &&
       override.tag_value === other.tag_value
     );


### PR DESCRIPTION
I noticed while working on #109310 that the latest version of [`@typescript-eslint/prefer-optional-chain`](https://typescript-eslint.io/rules/prefer-optional-chain) wasn't being used. Some code snippets like this weren't being reported:

```ts
if (apple && apple.banana === "cherry") {
```

That was fixed by https://github.com/typescript-eslint/typescript-eslint/pull/11533. This PR bumps typescript-eslint to the latest version and fixes new lint rule reports. It was mostly prefer-optional-chain reports; others are noted inline.

Fixes https://linear.app/getsentry/issue/ENG-6929/bump-typescript-eslint-to-855