### PR TITLE
feat(span-buffer): Add zerocopy mode 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3239,6 +3239,15 @@ register(
     default=0,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# When > 0, use SMEMBERS+SADD instead of SUNIONSTORE when the destination set
+# exceeds this many bytes (via MEMORY USAGE). This avoids the expensive
+# re-serialisation of the entire destination set during SUNIONSTORE.
+register(
+    "spans.buffer.zero-copy-dest-threshold-bytes",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Latency threshold in milliseconds for logging slow EVALSHA pipeline operations
 register(
     "spans.buffer.evalsha-latency-threshold",

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -28,6 +28,7 @@ ARGS:
 - set_timeout -- int
 - max_segment_bytes -- int -- The maximum number of bytes the segment can contain.
 - byte_count -- int -- The total number of bytes in the subsegment.
+- zero_copy_dest_threshold -- int -- When > 0, use SMEMBERS+SADD instead of SUNIONSTORE when the destination set exceeds this many bytes.
 - *span_id -- str[] -- The span ids in the subsegment.
 
 RETURNS:
@@ -47,7 +48,8 @@ local has_root_span = ARGV[3] == "true"
 local set_timeout = tonumber(ARGV[4])
 local max_segment_bytes = tonumber(ARGV[5])
 local byte_count = tonumber(ARGV[6])
-local NUM_ARGS = 6
+local zero_copy_dest_threshold = tonumber(ARGV[7])
+local NUM_ARGS = 7
 
 local function get_time_ms()
     local time = redis.call("TIME")
@@ -127,17 +129,38 @@ table.insert(latency_table, {"sunionstore_args_step_latency_ms", sunionstore_arg
 -- Used outside the if statement
 local spop_end_time_ms = -1
 if #sunionstore_args > 0 then
-    if (redis.call("memory", "usage", set_key) or 0) > max_segment_bytes then
+    local dest_memory = redis.call("memory", "usage", set_key) or 0
+    if dest_memory > max_segment_bytes then
         table.insert(metrics_table, {"parent_span_set_already_oversized", 1})
     else
         table.insert(metrics_table, {"parent_span_set_already_oversized", 0})
     end
 
+    local use_zero_copy_dest = zero_copy_dest_threshold > 0 and dest_memory > zero_copy_dest_threshold
+
     local start_output_size = redis.call("scard", set_key)
     local scard_end_time_ms = get_time_ms()
     table.insert(latency_table, {"scard_step_latency_ms", scard_end_time_ms - sunionstore_args_end_time_ms})
 
-    local output_size = redis.call("sunionstore", set_key, set_key, unpack(sunionstore_args))
+    local output_size
+    if use_zero_copy_dest then
+        -- Zero-copy: read each source set and SADD its members into dest.
+        -- Avoids SUNIONSTORE re-reading the entire large destination set.
+        local all_members = {}
+        for i = 1, #sunionstore_args do
+            local members = redis.call("smembers", sunionstore_args[i])
+            for j = 1, #members do
+                all_members[#all_members + 1] = members[j]
+            end
+        end
+        if #all_members > 0 then
+            redis.call("sadd", set_key, unpack(all_members))
+        end
+        output_size = redis.call("scard", set_key)
+    else
+        output_size = redis.call("sunionstore", set_key, set_key, unpack(sunionstore_args))
+    end
+    table.insert(metrics_table, {"used_zero_copy_dest", use_zero_copy_dest and 1 or 0})
     local sunionstore_end_time_ms = get_time_ms()
     table.insert(latency_table, {"sunionstore_step_latency_ms", sunionstore_end_time_ms - scard_end_time_ms})
 

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -130,11 +130,8 @@ table.insert(latency_table, {"sunionstore_args_step_latency_ms", sunionstore_arg
 local spop_end_time_ms = -1
 if #sunionstore_args > 0 then
     local dest_memory = redis.call("memory", "usage", set_key) or 0
-    if dest_memory > max_segment_bytes then
-        table.insert(metrics_table, {"parent_span_set_already_oversized", 1})
-    else
-        table.insert(metrics_table, {"parent_span_set_already_oversized", 0})
-    end
+    local already_oversized = dest_memory > max_segment_bytes
+    table.insert(metrics_table, {"parent_span_set_already_oversized", already_oversized and 1 or 0})
 
     local use_zero_copy_dest = zero_copy_dest_threshold > 0 and dest_memory > zero_copy_dest_threshold
 
@@ -143,7 +140,11 @@ if #sunionstore_args > 0 then
     table.insert(latency_table, {"scard_step_latency_ms", scard_end_time_ms - sunionstore_args_end_time_ms})
 
     local output_size
-    if use_zero_copy_dest then
+    if already_oversized then
+        -- Dest already exceeds max_segment_bytes, skip merge entirely.
+        -- The SPOP loop would just remove what we added.
+        output_size = start_output_size
+    elseif use_zero_copy_dest then
         -- Zero-copy: read each source set and SADD its members into dest.
         -- Avoids SUNIONSTORE re-reading the entire large destination set.
         local all_members = {}

--- a/src/sentry/scripts/spans/add-buffer.lua
+++ b/src/sentry/scripts/spans/add-buffer.lua
@@ -133,7 +133,7 @@ if #sunionstore_args > 0 then
     local already_oversized = dest_memory > max_segment_bytes
     table.insert(metrics_table, {"parent_span_set_already_oversized", already_oversized and 1 or 0})
 
-    local use_zero_copy_dest = zero_copy_dest_threshold > 0 and dest_memory > zero_copy_dest_threshold
+    local use_zero_copy_dest = not already_oversized and zero_copy_dest_threshold > 0 and dest_memory > zero_copy_dest_threshold
 
     local start_output_size = redis.call("scard", set_key)
     local scard_end_time_ms = get_time_ms()
@@ -154,8 +154,12 @@ if #sunionstore_args > 0 then
                 all_members[#all_members + 1] = members[j]
             end
         end
-        if #all_members > 0 then
-            redis.call("sadd", set_key, unpack(all_members))
+        table.insert(metrics_table, {"zero_copy_dest_source_members", #all_members})
+        -- Batch SADD in chunks to avoid exceeding Lua's unpack() stack limit.
+        local BATCH = 7000
+        for i = 1, #all_members, BATCH do
+            local last = math.min(i + BATCH - 1, #all_members)
+            redis.call("sadd", set_key, unpack(all_members, i, last))
         end
         output_size = redis.call("scard", set_key)
     else

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -188,6 +188,7 @@ class SpansBuffer:
         root_timeout = options.get("spans.buffer.root-timeout")
         max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
         max_spans_per_evalsha = options.get("spans.buffer.max-spans-per-evalsha")
+        zero_copy_threshold = options.get("spans.buffer.zero-copy-dest-threshold-bytes")
         debug_traces = set(options.get("spans.buffer.debug-traces"))
 
         result_meta = []
@@ -265,6 +266,7 @@ class SpansBuffer:
                             redis_ttl,
                             max_segment_bytes,
                             byte_count,
+                            zero_copy_threshold,
                             *span_ids,
                         )
 

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -31,6 +31,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.debug-traces": [],
     "spans.buffer.evalsha-cumulative-logger-enabled": True,
     "spans.buffer.oob-threshold-bytes": 0,
+    "spans.buffer.zero-copy-dest-threshold-bytes": 0,
 }
 
 
@@ -1262,3 +1263,98 @@ def test_oob_cleanup(buffer: SpansBuffer) -> None:
         assert len(buffer.client.keys("span-buf:p:*")) == 0
 
         assert_clean(buffer.client)
+
+
+@mock.patch("sentry.spans.buffer.emit_observability_metrics")
+def test_zero_copy(emit_observability_metrics: mock.MagicMock) -> None:
+    """
+    Test that zero-copy mode (SMEMBERS+SADD instead of SUNIONSTORE) produces
+    identical results. Uses a threshold of 1 byte so that every merge triggers
+    the zero-copy path.
+    """
+    with override_options(
+        {
+            **DEFAULT_OPTIONS,
+            "spans.buffer.zero-copy-dest-threshold-bytes": 1,
+            "spans.buffer.max-spans-per-evalsha": 1,
+        }
+    ):
+        buf = SpansBuffer(assigned_shards=list(range(32)))
+        buf.client.flushdb()
+
+        spans = [
+            Span(
+                payload=_payload("a" * 16),
+                trace_id="a" * 32,
+                span_id="a" * 16,
+                parent_span_id="b" * 16,
+                segment_id=None,
+                project_id=1,
+                end_timestamp=1700000000.0,
+            ),
+            Span(
+                payload=_payload("d" * 16),
+                trace_id="a" * 32,
+                span_id="d" * 16,
+                parent_span_id="b" * 16,
+                segment_id=None,
+                project_id=1,
+                end_timestamp=1700000000.0,
+            ),
+            Span(
+                payload=_payload("c" * 16),
+                trace_id="a" * 32,
+                span_id="c" * 16,
+                parent_span_id="b" * 16,
+                segment_id=None,
+                project_id=1,
+                end_timestamp=1700000000.0,
+            ),
+            Span(
+                payload=_payload("b" * 16),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=1,
+                end_timestamp=1700000000.0,
+            ),
+        ]
+
+        process_spans(spans, buf, now=0)
+
+        assert_ttls(buf.client)
+
+        assert buf.flush_segments(now=5) == {}
+        rv = buf.flush_segments(now=11)
+        _normalize_output(rv)
+        assert rv == {
+            _segment_id(1, "a" * 32, "b" * 16): FlushedSegment(
+                queue_key=mock.ANY,
+                spans=[
+                    _output_segment(b"a" * 16, b"b" * 16, False),
+                    _output_segment(b"b" * 16, b"b" * 16, True),
+                    _output_segment(b"c" * 16, b"b" * 16, False),
+                    _output_segment(b"d" * 16, b"b" * 16, False),
+                ],
+            )
+        }
+        buf.done_flush_segments(rv)
+        assert buf.flush_segments(now=30) == {}
+
+        assert_clean(buf.client)
+
+        # Verify used_zero_copy_dest metric was emitted
+        emit_observability_metrics.assert_called()
+        args, _ = emit_observability_metrics.call_args
+        gauge_metrics = args[1]
+        zero_copy_values = [
+            value
+            for evalsha_metrics in gauge_metrics
+            for metric_name, value in evalsha_metrics
+            if metric_name == b"used_zero_copy_dest"
+        ]
+        assert any(v == 1 for v in zero_copy_values), (
+            f"Expected at least one evalsha call to use zero-copy, got {zero_copy_values}"
+        )


### PR DESCRIPTION
We are encountering an issue where a huge segment is assembled using a
very low span ingestion rate. This causes issues where SUNIONSTORE
repeatedly copies the destination set. At the same time, SUNIONSTORE is
(probably) generally faster for small segments, as it is a single redis
operation with no return value, so nothing gets allocated or shuffled
around in Lua.

Introduce a new option zero-copy-dest-threshold-bytes. If the
destination set is found to be larger than that threshold, we switch
away from SUNIONSTORE and add items another way. That way involves Lua
code though, and therefore IMO can also lead to issues if
max-spans-per-evalsha is not properly configured.

We now also skip adding any elements to the target set if the
target set is oversized.

We should use this to verify two theories:

* We are able to fix the issue with huge segments + low ingestion rate
  using this option.
* Setting this option to `
1` (which essentially gets rid of SUNIONSTORE
  entirely) is not viable in production. If it is, which I doubt, we
  could simplify the code.