### PR TITLE
chore: Remove unused processing area label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -47,7 +47,6 @@ body:
         - 'Issues'
         - 'Issues - Source Maps'
         - 'Issues - Suggested Fix'
-        - 'Processing'
         - 'Projects - Project Creation'
         - 'Projects - Project Details'
         - 'Profiling'

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -31,7 +31,6 @@ body:
         - 'Issues'
         - 'Issues - Source Maps'
         - 'Issues - Suggested Fix'
-        - 'Processing'
         - 'Projects - Project Creation'
         - 'Projects - Project Details'
         - 'Profiling'


### PR DESCRIPTION
Remove unused and misleading "Processing" area label. 