### PR TITLE
chore: enable `@typescript-eslint/consistent-generic-constructors`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -627,7 +627,6 @@ export default typescript.config([
       // Stylistic overrides
       '@typescript-eslint/array-type': ['error', {default: 'array-simple'}],
       '@typescript-eslint/class-literal-property-style': 'off', // TODO(ryan953): Fix violations and delete this line
-      '@typescript-eslint/consistent-generic-constructors': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/consistent-type-definitions': 'off', // TODO(ryan953): Fix violations and delete this line
       '@typescript-eslint/no-empty-function': 'off', // TODO(ryan953): Fix violations and delete this line
 

--- a/static/app/actionCreators/projects.tsx
+++ b/static/app/actionCreators/projects.tsx
@@ -59,7 +59,7 @@ export function loadStats(api: Client, params: StatsParams) {
 
 // This is going to queue up a list of project ids we need to fetch stats for
 // Will be cleared when debounced function fires
-export const _projectStatsToFetch: Set<string> = new Set();
+export const _projectStatsToFetch = new Set<string>();
 
 // Max projects to query at a time, otherwise if we fetch too many in the same request
 // it can timeout

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -53,7 +53,7 @@ class SpanTreeModel {
   isNestedSpanGroupExpanded = false;
   // Entries in this set will follow the format 'op.description'.
   // An entry in this set indicates that all siblings with the op and description should be left ungrouped
-  expandedSiblingGroups: Set<string> = new Set();
+  expandedSiblingGroups = new Set<string>();
 
   traceInfo: TraceInfo | undefined = undefined;
 

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -71,7 +71,7 @@ type BaseSpanType = RawSpanType & {
   type?: undefined;
 };
 
-export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
+export const rawSpanKeys = new Set<keyof RawSpanType>([
   'trace_id',
   'parent_span_id',
   'span_id',

--- a/static/app/components/forms/formIndicators.tsx
+++ b/static/app/components/forms/formIndicators.tsx
@@ -116,7 +116,7 @@ export function addUndoableFormChangeMessage(
   );
 }
 
-const PRETTY_VALUES: Map<unknown, string> = new Map([
+const PRETTY_VALUES = new Map<unknown, string>([
   ['', '<empty>'],
   [null, '<none>'],
   [undefined, '<unset>'],

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -113,7 +113,7 @@ class UnwrappedProvider extends Component<Props> {
   getCounts() {
     const {teamKeyTransactions} = this.state;
 
-    const counts: Map<string, number> = new Map();
+    const counts = new Map<string, number>();
 
     teamKeyTransactions.forEach(({team, count}) => {
       counts.set(team, count);
@@ -125,7 +125,7 @@ class UnwrappedProvider extends Component<Props> {
   getKeyedTeams = (projectId: string, transactionName: string) => {
     const {teamKeyTransactions} = this.state;
 
-    const keyedTeams: Set<string> = new Set();
+    const keyedTeams = new Set<string>();
 
     teamKeyTransactions.forEach(({team, keyed}) => {
       const isKeyedByTeam = keyed.find(

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphSidePanel.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphSidePanel.tsx
@@ -67,7 +67,7 @@ export function AggregateFlamegraphSidePanel({
   const examples = useMemo(() => {
     const referenceNodes = frame ? [frame] : flamegraph.root.children;
 
-    const seen: Set<Profiling.ProfileReference> = new Set();
+    const seen = new Set<Profiling.ProfileReference>();
 
     const allExamples = [];
 

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -226,7 +226,7 @@ function sortFrameResults(
   // If frames have the same start times, move frames with lower stack depth first.
   // This results in top down and left to right iteration
   let sid = -1;
-  const spans: Array<SpanChartNode | FlamegraphFrame> = new Array(results.spans.size);
+  const spans = new Array<SpanChartNode | FlamegraphFrame>(results.spans.size);
   for (const n of results.spans.values()) {
     spans[++sid] = n.span;
   }

--- a/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
+++ b/static/app/components/profiling/suspectFunctions/suspectFunctionsTable.tsx
@@ -132,7 +132,7 @@ export function SuspectFunctionsTable({
     const frameInfos = flamegraphQuery.data?.shared?.frame_infos ?? [];
     const profileExamples = flamegraphQuery.data?.shared?.profiles ?? [];
 
-    const examples: Array<Array<Exclude<Profiling.ProfileReference, string>>> = new Array(
+    const examples = new Array<Array<Exclude<Profiling.ProfileReference, string>>>(
       frames.length
     );
 

--- a/static/app/components/replays/deserializeCanvasArgs.ts
+++ b/static/app/components/replays/deserializeCanvasArgs.ts
@@ -12,7 +12,7 @@ type CanvasContexts =
   | CanvasRenderingContext2D
   | WebGLRenderingContext
   | WebGL2RenderingContext;
-const webGLVarMap: Map<CanvasContexts, GLVarMap> = new Map();
+const webGLVarMap = new Map<CanvasContexts, GLVarMap>();
 
 function variableListFor(ctx: CanvasContexts, ctor: string) {
   let contextMap = webGLVarMap.get(ctx);

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchSkeleton.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerSearchSkeleton.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {Stack} from '@sentry/scraps/layout';
 
 function generateThreeUniqueNumbers(): number[] {
-  const numbers: Set<number> = new Set();
+  const numbers = new Set<number>();
   const min = 35;
   const max = 95;
 

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -276,7 +276,7 @@ export const platformsWithNestedInstrumentationGuides: PlatformKey[] = [
 ];
 
 // List of platforms that have performance onboarding checklist content
-export const withPerformanceOnboarding: Set<PlatformKey> = new Set([
+export const withPerformanceOnboarding = new Set<PlatformKey>([
   'javascript',
   'javascript-react',
   'javascript-nextjs',
@@ -289,7 +289,7 @@ export const withPerformanceOnboarding: Set<PlatformKey> = new Set([
 
 // List of platforms that do not have performance support. We make use of this list in the product to not provide any Performance
 // views such as Performance onboarding checklist.
-export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
+export const withoutPerformanceSupport = new Set<PlatformKey>([
   'elixir',
   'minidump',
   'nintendo-switch',
@@ -298,7 +298,7 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that have logging onboarding checklist content
-export const withLoggingOnboarding: Set<PlatformKey> = new Set([
+export const withLoggingOnboarding = new Set<PlatformKey>([
   'android',
   'apple',
   'apple-ios',
@@ -395,13 +395,10 @@ export const withLoggingOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have logging support. We make use of this list in the product to not provide any Logging
-export const withoutLoggingSupport: Set<PlatformKey> = new Set([
-  'elixir',
-  'dotnet-xamarin',
-]);
+export const withoutLoggingSupport = new Set<PlatformKey>(['elixir', 'dotnet-xamarin']);
 
 // List of platforms that have metrics onboarding checklist content
-export const withMetricsOnboarding: Set<PlatformKey> = new Set([
+export const withMetricsOnboarding = new Set<PlatformKey>([
   'android',
   'flutter',
   'apple',
@@ -488,9 +485,9 @@ export const withMetricsOnboarding: Set<PlatformKey> = new Set([
 ]);
 
 // List of platforms that do not have metrics support. We make use of this list in the product to not provide any Metrics
-export const withoutMetricsSupport: Set<PlatformKey> = new Set(['dotnet-xamarin']);
+export const withoutMetricsSupport = new Set<PlatformKey>(['dotnet-xamarin']);
 
-export const limitedMetricsSupportPrefixes: Set<string> = new Set([
+export const limitedMetricsSupportPrefixes = new Set<string>([
   'android',
   'apple',
   'bun',

--- a/static/app/data/platformPickerCategories.tsx
+++ b/static/app/data/platformPickerCategories.tsx
@@ -1,7 +1,7 @@
 import {t} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/project';
 
-const popularPlatformCategories: Set<PlatformKey> = new Set([
+const popularPlatformCategories = new Set<PlatformKey>([
   'javascript-nextjs',
   'javascript-react',
   'react-native',
@@ -32,7 +32,7 @@ const popularPlatformCategories: Set<PlatformKey> = new Set([
   'javascript-remix',
 ]);
 
-const browser: Set<PlatformKey> = new Set([
+const browser = new Set<PlatformKey>([
   'dart',
   'flutter',
   'javascript',
@@ -56,7 +56,7 @@ const browser: Set<PlatformKey> = new Set([
   'unity',
 ]);
 
-const server: Set<PlatformKey> = new Set([
+const server = new Set<PlatformKey>([
   'bun',
   'dart',
   'deno',
@@ -117,7 +117,7 @@ const server: Set<PlatformKey> = new Set([
   'rust',
 ]);
 
-const mobile: Set<PlatformKey> = new Set([
+const mobile = new Set<PlatformKey>([
   'android',
   'apple-ios',
   'capacitor',
@@ -132,7 +132,7 @@ const mobile: Set<PlatformKey> = new Set([
   'unreal',
 ]);
 
-const desktop: Set<PlatformKey> = new Set([
+const desktop = new Set<PlatformKey>([
   'apple-macos',
   'dotnet',
   'dotnet-maui',
@@ -151,7 +151,7 @@ const desktop: Set<PlatformKey> = new Set([
   'unreal',
 ]);
 
-const serverless: Set<PlatformKey> = new Set([
+const serverless = new Set<PlatformKey>([
   'dotnet-awslambda',
   'dotnet-gcpfunctions',
   'node-awslambda',
@@ -164,7 +164,7 @@ const serverless: Set<PlatformKey> = new Set([
   'python-serverless',
 ]);
 
-const gaming: Set<PlatformKey> = new Set([
+const gaming = new Set<PlatformKey>([
   'godot',
   'native',
   'nintendo-switch',
@@ -174,7 +174,7 @@ const gaming: Set<PlatformKey> = new Set([
   'xbox',
 ]);
 
-export const createablePlatforms: Set<PlatformKey> = new Set([
+export const createablePlatforms = new Set<PlatformKey>([
   ...popularPlatformCategories,
   ...browser,
   ...server,

--- a/static/app/utils/displayReprocessEventAction.tsx
+++ b/static/app/utils/displayReprocessEventAction.tsx
@@ -4,7 +4,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 
 /** All platforms that always use Debug Files. */
-const DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set([
+const DEBUG_FILE_PLATFORMS = new Set<PlatformKey>([
   'objc',
   'cocoa',
   'swift',
@@ -12,7 +12,7 @@ const DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set([
   'c',
 ]);
 /** Other platforms that may use Debug Files. */
-const MAYBE_DEBUG_FILE_PLATFORMS: Set<PlatformKey> = new Set(['csharp', 'java']);
+const MAYBE_DEBUG_FILE_PLATFORMS = new Set<PlatformKey>(['csharp', 'java']);
 
 /**
  * Returns whether to display the "Reprocess Event" action.

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2757,7 +2757,7 @@ export const ISSUE_FIELDS: FieldKey[] = [
  * Search locations are defined in sentry/snuba/events.py, anything that
  * references a tag should not be defined here.
  */
-export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS: Set<FieldKey> = new Set([
+export const ISSUE_EVENT_FIELDS_THAT_MAY_CONFLICT_WITH_TAGS = new Set<FieldKey>([
   FieldKey.APP_IN_FOREGROUND,
   FieldKey.DEVICE_ARCH,
   FieldKey.DEVICE_BRAND,

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -32,10 +32,10 @@ export interface FlamegraphEvents {
 type EventStore = {[K in keyof FlamegraphEvents]: Set<FlamegraphEvents[K]>};
 
 export class CanvasScheduler {
-  beforeFrameCallbacks: Set<DrawFn> = new Set();
-  afterFrameCallbacks: Set<DrawFn> = new Set();
+  beforeFrameCallbacks = new Set<DrawFn>();
+  afterFrameCallbacks = new Set<DrawFn>();
 
-  onDisposeCallbacks: Set<() => void> = new Set();
+  onDisposeCallbacks = new Set<() => void>();
   requestAnimationFrame: number | null = null;
 
   events: EventStore = {
@@ -150,7 +150,7 @@ export class CanvasScheduler {
 }
 
 export class CanvasPoolManager {
-  schedulers: Set<CanvasScheduler> = new Set();
+  schedulers = new Set<CanvasScheduler>();
 
   registerScheduler(scheduler: CanvasScheduler): void {
     if (this.schedulers.has(scheduler)) {

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -181,7 +181,7 @@ export function makeColorMapBySymbolName(
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
-  const colorCache: Map<string, ColorChannels> = new Map();
+  const colorCache = new Map<string, ColorChannels>();
 
   const sortedFrames: FlamegraphFrame[] = [...frames].sort(defaultFrameSort);
   const uniqueCount = uniqueCountBy(sortedFrames, t => defaultFrameKey(t));
@@ -235,7 +235,7 @@ export function makeColorMapByLibrary(
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
-  const colorCache: Map<string, ColorChannels> = new Map();
+  const colorCache = new Map<string, ColorChannels>();
 
   const sortedFrames: FlamegraphFrame[] = [...frames].sort((a, b) => {
     return frameLibraryKey(a).localeCompare(frameLibraryKey(b));
@@ -267,7 +267,7 @@ export function makeColorMapBySystemFrame(
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
-  const colorCache: Map<string, ColorChannels> = new Map();
+  const colorCache = new Map<string, ColorChannels>();
 
   const sortedFrames: FlamegraphFrame[] = [...frames].sort((a, b) => {
     return defaultFrameKey(a).localeCompare(defaultFrameKey(b));
@@ -297,7 +297,7 @@ export function makeColorMapBySystemVsApplicationFrame(
   theme: FlamegraphTheme
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
-  const colorCache: Map<string, ColorChannels> = new Map();
+  const colorCache = new Map<string, ColorChannels>();
 
   const sortedFrames: FlamegraphFrame[] = [...frames].sort((a, b) => {
     return defaultFrameKey(a).localeCompare(defaultFrameKey(b));
@@ -323,7 +323,7 @@ export function makeColorMapByApplicationFrame(
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
 ): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
-  const colorCache: Map<string, ColorChannels> = new Map();
+  const colorCache = new Map<string, ColorChannels>();
 
   const sortedFrames: FlamegraphFrame[] = [...frames].sort((a, b) => {
     return defaultFrameKey(a).localeCompare(defaultFrameKey(b));

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -6,7 +6,7 @@ import {Flamegraph, sortFlamegraphAlphabetically} from './flamegraph';
 import type {FlamegraphFrame} from './flamegraphFrame';
 
 export class DifferentialFlamegraph extends Flamegraph {
-  colors: Map<FlamegraphFrame['node'], ColorChannels> = new Map();
+  colors = new Map<FlamegraphFrame['node'], ColorChannels>();
   colorBuffer: number[] = [];
 
   isDifferentialFlamegraph = true;
@@ -19,7 +19,7 @@ export class DifferentialFlamegraph extends Flamegraph {
   static ALPHA_SCALING = 0.8;
   public negated = false;
 
-  weights: Map<FlamegraphFrame['node'], {after: number; before: number}> = new Map();
+  weights = new Map<FlamegraphFrame['node'], {after: number; before: number}>();
 
   static FrameKey(frame: FlamegraphFrame): string {
     return (

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -27,7 +27,7 @@ export class Profile {
   name = 'Unknown';
 
   callTree: CallTreeNode = new CallTreeNode(Frame.Root, null);
-  framesInStack: Set<Profiling.Event['frame']> = new Set();
+  framesInStack = new Set<Profiling.Event['frame']>();
 
   // Min duration of a single frame in our profile
   minFrameDuration = Number.POSITIVE_INFINITY;
@@ -45,10 +45,10 @@ export class Profile {
     negativeSamplesCount: 0,
   };
 
-  callTreeNodeProfileIdMap: Map<
+  callTreeNodeProfileIdMap = new Map<
     CallTreeNode,
     Set<Profiling.ProfileReference> | Set<string>
-  > = new Map();
+  >();
 
   constructor({
     duration,

--- a/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
+++ b/static/app/utils/profiling/renderers/uiFramesRendererWebGL.tsx
@@ -33,7 +33,7 @@ class UIFramesRendererWebGL extends UIFramesRenderer {
   frame_types: Float32Array = new Float32Array();
   bounds: Float32Array = new Float32Array();
 
-  colorMap: Map<string | number, number[]> = new Map();
+  colorMap = new Map<string | number, number[]>();
 
   attributes: {
     a_bounds: number | null;

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -172,7 +172,7 @@ class BaseProjects extends Component<Props, State> {
   /**
    * List of projects that need to be fetched via API
    */
-  fetchQueue: Set<string> = new Set();
+  fetchQueue = new Set<string>();
 
   /**
    * Memoized function that returns a `Map<project.slug, project>`

--- a/static/app/utils/replays/highlightNode.tsx
+++ b/static/app/utils/replays/highlightNode.tsx
@@ -2,8 +2,8 @@ import type {Replayer} from '@sentry-internal/rrweb';
 
 const DEFAULT_HIGHLIGHT_COLOR = 'rgba(168, 196, 236, 0.75)';
 
-const highlightsByNodeIds: Map<number, {canvas: HTMLCanvasElement}> = new Map();
-const highlightsBySelector: Map<string, {canvas: HTMLCanvasElement}> = new Map();
+const highlightsByNodeIds = new Map<number, {canvas: HTMLCanvasElement}>();
+const highlightsBySelector = new Map<string, {canvas: HTMLCanvasElement}>();
 
 type DrawProps = {annotation: string; color: string; spotlight: boolean};
 

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -8,7 +8,7 @@ export class Timer extends EventTarget {
   private _time = 0;
   private _pausedAt = 0;
   private _additionalTime = 0;
-  private _callbacks: Map<number, Array<() => void>> = new Map();
+  private _callbacks = new Map<number, Array<() => void>>();
   private _speed = 1;
 
   step = () => {

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -263,7 +263,7 @@ function findConflictingPriorityConditions(
 
 function findDuplicateTriggerConditions(triggers: DataConditionGroup): Set<string> {
   const conditionCounts: Record<string, string[]> = {};
-  const duplicates: Set<string> = new Set();
+  const duplicates = new Set<string>();
 
   // Count the number of conditions for each type
   for (const condition of triggers.conditions) {

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -185,7 +185,7 @@ export function getWidgetInterval(
 
 export function getFieldsFromEquations(fields: string[]): string[] {
   // Gather all fields and functions used in equations and prepend them to the provided fields
-  const termsSet: Set<string> = new Set();
+  const termsSet = new Set<string>();
   fields.filter(isEquation).forEach(field => {
     const parsed = parseArithmetic(stripEquationPrefix(field)).tc;
     parsed.fields.forEach(({term}) => termsSet.add(term as string));

--- a/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
+++ b/static/app/views/explore/multiQueryMode/hooks/useMultiQueryTable.tsx
@@ -61,7 +61,7 @@ function useMultiQueryTableAggregateModeImpl({
   const {selection} = usePageFilters();
 
   const fields = useMemo(() => {
-    const allFields: Set<string> = new Set();
+    const allFields = new Set<string>();
 
     for (const groupBy of groupBys) {
       allFields.add(groupBy);

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -173,7 +173,7 @@ function TraceRow({
   }, [projects, selection.projects]);
 
   const traceProjects = useMemo(() => {
-    const seenProjects: Set<string> = new Set();
+    const seenProjects = new Set<string>();
 
     const leadingProjects: string[] = [];
     const trailingProjects: string[] = [];

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -486,7 +486,7 @@ export function findSuggestedColumns(
   const oldFilters = oldSearch.filters;
   const newFilters = newSearch.filters;
 
-  const keys: Set<string> = new Set();
+  const keys = new Set<string>();
 
   for (const [key, value] of Object.entries(newFilters)) {
     if (key === 'has' || key === '!has') {

--- a/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
+++ b/static/app/views/insights/database/components/useSystemSelectorOptions.tsx
@@ -34,9 +34,7 @@ export function useSystemSelectorOptions() {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         system in DATABASE_SYSTEM_TO_LABEL ? DATABASE_SYSTEM_TO_LABEL[system] : system;
 
-      const supportedSystemSet: Set<string> = new Set(
-        Object.values(SupportedDatabaseSystem)
-      );
+      const supportedSystemSet = new Set<string>(Object.values(SupportedDatabaseSystem));
 
       if (supportedSystemSet.has(system)) {
         options.push({value: system, label: textValue, textValue});

--- a/static/app/views/insights/pages/agents/components/aiSpanList.tsx
+++ b/static/app/views/insights/pages/agents/components/aiSpanList.tsx
@@ -75,10 +75,10 @@ export function AISpanList({
   compressGaps?: boolean;
 }) {
   const nodesByTransaction = useMemo(() => {
-    const result: Map<
+    const result = new Map<
       TransactionNode | EapSpanNode | AITraceSpanNode,
       AITraceSpanNode[]
-    > = new Map();
+    >();
     // Use a placeholder key for nodes without a transaction (e.g., conversation view)
     let orphanGroup: AITraceSpanNode | null = null;
 

--- a/static/app/views/insights/settings.ts
+++ b/static/app/views/insights/settings.ts
@@ -272,14 +272,12 @@ export const MODULE_FEATURE_VISIBLE_MAP: Record<ModuleName, string[]> = {
 /**
  * Modules that are considered "new", e.g. used to show a badge on the tab.
  */
-export const MODULES_CONSIDERED_NEW: Set<ModuleName> = new Set([
-  ModuleName.MOBILE_VITALS,
-]);
+export const MODULES_CONSIDERED_NEW = new Set<ModuleName>([ModuleName.MOBILE_VITALS]);
 
 /**
  * Modules that are in beta, e.g. used to show a badge on the tab.
  */
-export const MODULES_CONSIDERED_BETA: Set<ModuleName> = new Set();
+export const MODULES_CONSIDERED_BETA = new Set<ModuleName>();
 
 export const INGESTION_DELAY = 90;
 

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -101,8 +101,8 @@ export function getXAxisLabelVisibility(dataPeriod: number, intervals: string[])
     };
   }
 
-  const uniqueLabels: Set<string> = new Set();
-  const labelToPositionMap: Map<string, number> = new Map();
+  const uniqueLabels = new Set<string>();
+  const labelToPositionMap = new Map<string, number>();
   const labelVisibility: boolean[] = new Array(intervals.length).fill(false);
 
   // Collect unique labels and their positions

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -321,7 +321,7 @@ function HighlightedTools({
     Referrer.TRACE_DRAWER_TOOL_USAGE
   );
 
-  const usedTools: Map<string, number> = new Map();
+  const usedTools = new Map<string, number>();
   toolSpansQuery.data?.forEach(span => {
     const toolName = span[SpanFields.GEN_AI_TOOL_NAME];
     usedTools.set(toolName, (usedTools.get(toolName) ?? 0) + 1);

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -365,7 +365,7 @@ export class TraceTree extends TraceTreeEventDispatcher {
   type: 'loading' | 'empty' | 'error' | 'trace' = 'trace';
   root: RootNode = new RootNode(null, null, null);
 
-  vital_types: Set<'web' | 'mobile'> = new Set();
+  vital_types = new Set<'web' | 'mobile'>();
   vitals = new Map<BaseNode, TraceTree.CollectedVital[]>();
 
   profiled_events = new Set<BaseNode>();

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode.tsx
@@ -227,7 +227,7 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
 
   get uniqueErrorIssues(): TraceTree.TraceErrorIssue[] {
     const unique: TraceTree.TraceErrorIssue[] = [];
-    const seenIssues: Set<number> = new Set();
+    const seenIssues = new Set<number>();
 
     for (const error of this.errors) {
       if (seenIssues.has(error.issue_id)) {
@@ -242,7 +242,7 @@ export abstract class BaseNode<T extends TraceTree.NodeValue = TraceTree.NodeVal
 
   get uniqueOccurrenceIssues(): TraceTree.TraceOccurrence[] {
     const unique: TraceTree.TraceOccurrence[] = [];
-    const seenIssues: Set<number> = new Set();
+    const seenIssues = new Set<number>();
 
     for (const issue of this.occurrences) {
       if (seenIssues.has(issue.issue_id)) {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTreeNode/transactionNode.tsx
@@ -25,7 +25,7 @@ export class TransactionNode extends BaseNode<TraceTree.Transaction> {
   id: string;
   type: TraceTree.NodeType;
 
-  private _spanPromises: Map<string, Promise<EventTransaction>> = new Map();
+  private _spanPromises = new Map<string, Promise<EventTransaction>>();
   extra: TraceTreeNodeExtra;
 
   searchPriority = 1;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
@@ -9,7 +9,7 @@ interface TraceRowWidthMeasurerEvents<T> {
 }
 
 export class TraceRowWidthMeasurer<T> {
-  cache: Map<T, number> = new Map();
+  cache = new Map<T, number>();
   queue: Array<[T, HTMLElement]> = [];
   drainRaf: number | null = null;
   max = 0;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceTextMeasurer.tsx
@@ -3,7 +3,7 @@ import type {Theme} from '@emotion/react';
 export class TraceTextMeasurer {
   queue: string[] = [];
   drainRaf: number | null = null;
-  cache: Map<string, number> = new Map();
+  cache = new Map<string, number>();
 
   number = 0;
   dot = 0;

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -51,9 +51,8 @@ export type ViewManagerScrollAnchor = 'top' | 'center if outside' | 'center';
 
 export class VirtualizedViewManager {
   theme: Theme;
-  row_measurer: TraceRowWidthMeasurer<BaseNode> = new TraceRowWidthMeasurer();
-  indicator_label_measurer: TraceRowWidthMeasurer<TraceTree['indicators'][0]> =
-    new TraceRowWidthMeasurer();
+  row_measurer = new TraceRowWidthMeasurer<BaseNode>();
+  indicator_label_measurer = new TraceRowWidthMeasurer<TraceTree['indicators'][0]>();
   text_measurer: TraceTextMeasurer;
 
   resize_observer: ResizeObserver | null = null;

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -110,7 +110,7 @@ export function searchInTraceTreeTokens(
     return handle;
   }
 
-  let result_map: Map<BaseNode, number> = new Map();
+  let result_map = new Map<BaseNode, number>();
 
   let ti = 0;
   let li = 0;
@@ -120,8 +120,8 @@ export function searchInTraceTreeTokens(
   let leftToken: ProcessedTokenResult | Map<BaseNode, number> | null = null;
   let rightToken: ProcessedTokenResult | null = null;
 
-  const left: Map<BaseNode, number> = new Map();
-  const right: Map<BaseNode, number> = new Map();
+  const left = new Map<BaseNode, number>();
+  const right = new Map<BaseNode, number>();
 
   const stack: Array<ProcessedTokenResult | Map<BaseNode, number>> = [];
 

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -57,7 +57,7 @@ type RelocationArtifact = {
 };
 
 // A map of each expected relocation artifact to a user-legible description of what it is.
-const expectedRelocationArtifacts: Map<string, string> = new Map(
+const expectedRelocationArtifacts = new Map<string, string>(
   Object.entries({
     'conf/cloudbuild.yaml':
       'The execution script that Google CloudBuild will run when validating this relocation.',

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -346,7 +346,7 @@ export function ContinuousProfilingBetaSDKAlertBanner() {
   const sdkDeprecationResults = useSDKDeprecations();
 
   const sdkDeprecations = useMemo(() => {
-    const sdks: Map<string, SDKDeprecation> = new Map();
+    const sdks = new Map<string, SDKDeprecation>();
 
     for (const sdk of sdkDeprecationResults.data?.data ?? []) {
       const key = `${sdk.sdkName}:${sdk.sdkVersion}`;


### PR DESCRIPTION
Removes the disable of this wholly auto-fixable lint rule: [`@typescript-eslint/consistent-generic-constructors`](https://typescript-eslint.io/rules/consistent-generic-constructors).

There are no behavioral changes in this PR.

Fixes https://linear.app/getsentry/issue/ENG-6932/linting-typescript-eslintconsistent-generic-constructors