### PR TITLE
feat(seer): Wire up defaultCodingAgent and defaultCodingAgentIntegrationId in org API

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -82,6 +82,7 @@ from sentry.models.team import Team, TeamStatus
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
+from sentry.seer.models.organization_settings import SeerOrganizationSettings
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -560,6 +561,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     autoEnableCodeReview: bool
     autoOpenPrs: bool
     defaultCodeReviewTriggers: list[str]
+    defaultCodingAgentIntegrationId: int | None
     hasGranularReplayPermissions: bool
     replayAccessMembers: list[int]
 
@@ -569,6 +571,13 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
         self, item_list: Sequence[Organization], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
         attrs = super().get_attrs(item_list, user)
+
+        seer_settings_by_org = {
+            s.organization_id: s
+            for s in SeerOrganizationSettings.objects.filter(organization__in=item_list)
+        }
+        for item in item_list:
+            attrs[item]["seer_settings"] = seer_settings_by_org.get(item.id)
 
         replay_permissions = {}
         has_feature = features.batch_has_for_organizations(
@@ -774,6 +783,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 team__organization=obj
             ).count(),
             "isDynamicallySampled": is_dynamically_sampled,
+            "defaultCodingAgentIntegrationId": (
+                attrs["seer_settings"].default_coding_agent_integration_id
+                if attrs.get("seer_settings")
+                else None
+            ),
             "hasGranularReplayPermissions": False,
             "replayAccessMembers": [],
         }

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -82,7 +82,7 @@ from sentry.models.team import Team, TeamStatus
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.organizations.services.organization import RpcOrganizationSummary
 from sentry.replays.models import OrganizationMemberReplayAccess
-from sentry.seer.models.organization_settings import SeerOrganizationSettings
+from sentry.seer.models.organization_settings import CodingAgent, SeerOrganizationSettings
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.service import user_service
@@ -561,6 +561,7 @@ class DetailedOrganizationSerializerResponse(_DetailedOrganizationSerializerResp
     autoEnableCodeReview: bool
     autoOpenPrs: bool
     defaultCodeReviewTriggers: list[str]
+    defaultCodingAgent: str | None
     defaultCodingAgentIntegrationId: int | None
     hasGranularReplayPermissions: bool
     replayAccessMembers: list[int]
@@ -783,6 +784,11 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 team__organization=obj
             ).count(),
             "isDynamicallySampled": is_dynamically_sampled,
+            "defaultCodingAgent": (
+                attrs["seer_settings"].default_coding_agent
+                if attrs.get("seer_settings")
+                else CodingAgent.SEER
+            ),
             "defaultCodingAgentIntegrationId": (
                 attrs["seer_settings"].default_coding_agent_integration_id
                 if attrs.get("seer_settings")

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -312,6 +312,7 @@ class OrganizationExamples:
                 "orgRole": "owner",
                 "pendingAccessRequests": 0,
                 "isDynamicallySampled": False,
+                "defaultCodingAgentIntegrationId": None,
                 "teams": [
                     {
                         "id": "1",

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -312,6 +312,7 @@ class OrganizationExamples:
                 "orgRole": "owner",
                 "pendingAccessRequests": 0,
                 "isDynamicallySampled": False,
+                "defaultCodingAgent": "seer",
                 "defaultCodingAgentIntegrationId": None,
                 "teams": [
                     {

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from copy import copy
 from datetime import datetime, timedelta, timezone
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
@@ -108,7 +108,11 @@ from sentry.organizations.services.organization.model import (
 from sentry.relay.datascrubbing import validate_pii_config_update, validate_pii_selectors
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
-from sentry.seer.models.organization_settings import SeerOrganizationSettings
+from sentry.seer.models.organization_settings import (
+    INTEGRATION_REQUIRED_AGENTS,
+    CodingAgent,
+    SeerOrganizationSettings,
+)
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.audit import create_audit_entry
@@ -370,10 +374,16 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     ingestThroughTrustedRelaysOnly = serializers.ChoiceField(
         choices=[("enabled", "enabled"), ("disabled", "disabled")], required=False
     )
+    defaultCodingAgent = serializers.ChoiceField(
+        choices=CodingAgent.choices + [("", "")],
+        required=False,
+        allow_null=True,
+        help_text='Which coding agent to use for new projects. Valid values: "seer" (default), "cursor", or null (disabled).',
+    )
     defaultCodingAgentIntegrationId = serializers.IntegerField(
         required=False,
         allow_null=True,
-        help_text="The default coding agent integration ID for new projects. When null, Sentry's built-in Seer agent is used.",
+        help_text="The integration ID for the coding agent, required when defaultCodingAgent requires an integration (e.g. cursor).",
     )
     hasGranularReplayPermissions = serializers.BooleanField(required=False)
     replayAccessMembers = serializers.ListField(
@@ -558,6 +568,30 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                 "Must be in Automatic Mode to configure the organization sample rate."
             )
 
+        agent = attrs.get("defaultCodingAgent")
+        integration_id = attrs.get("defaultCodingAgentIntegrationId")
+        if agent is not None and agent in INTEGRATION_REQUIRED_AGENTS and integration_id is None:
+            # Check if the org already has an integration set that we can keep
+            org = self.context["organization"]
+            existing = SeerOrganizationSettings.objects.filter(organization=org).first()
+            if existing is None or existing.default_coding_agent_integration_id is None:
+                raise serializers.ValidationError(
+                    {
+                        "defaultCodingAgentIntegrationId": f"An integration ID is required when using the {agent} agent."
+                    }
+                )
+
+        if (
+            agent is not None
+            and agent not in INTEGRATION_REQUIRED_AGENTS
+            and integration_id is not None
+        ):
+            raise serializers.ValidationError(
+                {
+                    "defaultCodingAgentIntegrationId": f"An integration ID must not be set for the {agent} agent."
+                }
+            )
+
         return attrs
 
     def save_trusted_relays(self, incoming, changed_data, organization):
@@ -641,19 +675,43 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                     changed_data[key] = f"from {old_val} to {option_inst.value}"
                 option_inst.save()
 
+        seer_fields_to_update: dict[str, Any] = {}
+        if "defaultCodingAgent" in data:
+            seer_fields_to_update["default_coding_agent"] = data["defaultCodingAgent"] or None
         if "defaultCodingAgentIntegrationId" in data:
-            new_value = data["defaultCodingAgentIntegrationId"]
+            seer_fields_to_update["default_coding_agent_integration_id"] = data[
+                "defaultCodingAgentIntegrationId"
+            ]
+
+        if seer_fields_to_update:
             settings, created = SeerOrganizationSettings.objects.get_or_create(
                 organization=org,
-                defaults={"default_coding_agent_integration_id": new_value},
+                defaults=seer_fields_to_update,
             )
-            if not created and settings.default_coding_agent_integration_id != new_value:
-                old_val = settings.default_coding_agent_integration_id
-                settings.default_coding_agent_integration_id = new_value
-                settings.save(update_fields=["default_coding_agent_integration_id", "date_updated"])
-                changed_data["defaultCodingAgentIntegrationId"] = f"from {old_val} to {new_value}"
-            elif created and new_value is not None:
-                changed_data["defaultCodingAgentIntegrationId"] = f"to {new_value}"
+            if not created:
+                update_fields = ["date_updated"]
+                for field, new_value in seer_fields_to_update.items():
+                    old_val = getattr(settings, field)
+                    if old_val != new_value:
+                        setattr(settings, field, new_value)
+                        update_fields.append(field)
+                        camel_key = (
+                            "defaultCodingAgent"
+                            if field == "default_coding_agent"
+                            else "defaultCodingAgentIntegrationId"
+                        )
+                        changed_data[camel_key] = f"from {old_val} to {new_value}"
+                if len(update_fields) > 1:
+                    settings.save(update_fields=update_fields)
+            else:
+                for field, new_value in seer_fields_to_update.items():
+                    if new_value is not None:
+                        camel_key = (
+                            "defaultCodingAgent"
+                            if field == "default_coding_agent"
+                            else "defaultCodingAgentIntegrationId"
+                        )
+                        changed_data[camel_key] = f"to {new_value}"
 
         trusted_relay_info = data.get("trustedRelays")
         if trusted_relay_info is not None:
@@ -1097,8 +1155,14 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
     )
 
     # seer features
+    defaultCodingAgent = serializers.ChoiceField(
+        choices=CodingAgent.choices + [("", "")],
+        help_text='Which coding agent to use for new projects. Valid values: "seer" (default), "cursor", or null (disabled).',
+        required=False,
+        allow_null=True,
+    )
     defaultCodingAgentIntegrationId = serializers.IntegerField(
-        help_text="The default coding agent integration ID for new projects. When null, Sentry's built-in Seer agent is used.",
+        help_text="The integration ID for the coding agent, required when defaultCodingAgent requires an integration (e.g. cursor).",
         required=False,
         allow_null=True,
     )

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -86,6 +86,7 @@ from sentry.dynamic_sampling.utils import (
 )
 from sentry.hybridcloud.rpc import IDEMPOTENCY_KEY_LENGTH
 from sentry.hybridcloud.rpc.service import RpcValidationException
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.utils.codecov import has_codecov_integration
 from sentry.lang.native.utils import (
     STORE_CRASH_REPORTS_DEFAULT,
@@ -107,6 +108,7 @@ from sentry.organizations.services.organization.model import (
 from sentry.relay.datascrubbing import validate_pii_config_update, validate_pii_selectors
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.models.organization_settings import SeerOrganizationSettings
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.audit import create_audit_entry
@@ -368,6 +370,11 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     ingestThroughTrustedRelaysOnly = serializers.ChoiceField(
         choices=[("enabled", "enabled"), ("disabled", "disabled")], required=False
     )
+    defaultCodingAgentIntegrationId = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="The default coding agent integration ID for new projects. When null, Sentry's built-in Seer agent is used.",
+    )
     hasGranularReplayPermissions = serializers.BooleanField(required=False)
     replayAccessMembers = serializers.ListField(
         child=serializers.IntegerField(),
@@ -465,6 +472,19 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                 "Only staff members can change console SDK invite quota limit."
             )
 
+        return value
+
+    def validate_defaultCodingAgentIntegrationId(self, value):
+        if value is None:
+            return value
+        organization = self.context["organization"]
+        org_integration = integration_service.get_organization_integration(
+            organization_id=organization.id, integration_id=value
+        )
+        if org_integration is None:
+            raise serializers.ValidationError(
+                "Invalid integration ID, or integration does not belong to this organization."
+            )
         return value
 
     def validate_targetSampleRate(self, value):
@@ -620,6 +640,20 @@ class OrganizationSerializer(BaseOrganizationSerializer):
                     old_val = old_value(option_inst, "value")
                     changed_data[key] = f"from {old_val} to {option_inst.value}"
                 option_inst.save()
+
+        if "defaultCodingAgentIntegrationId" in data:
+            new_value = data["defaultCodingAgentIntegrationId"]
+            settings, created = SeerOrganizationSettings.objects.get_or_create(
+                organization=org,
+                defaults={"default_coding_agent_integration_id": new_value},
+            )
+            if not created and settings.default_coding_agent_integration_id != new_value:
+                old_val = settings.default_coding_agent_integration_id
+                settings.default_coding_agent_integration_id = new_value
+                settings.save(update_fields=["default_coding_agent_integration_id", "date_updated"])
+                changed_data["defaultCodingAgentIntegrationId"] = f"from {old_val} to {new_value}"
+            elif created and new_value is not None:
+                changed_data["defaultCodingAgentIntegrationId"] = f"to {new_value}"
 
         trusted_relay_info = data.get("trustedRelays")
         if trusted_relay_info is not None:
@@ -1060,6 +1094,13 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
     cancelDeletion = serializers.BooleanField(
         help_text="Specify `true` to restore an organization that is pending deletion.",
         required=False,
+    )
+
+    # seer features
+    defaultCodingAgentIntegrationId = serializers.IntegerField(
+        help_text="The default coding agent integration ID for new projects. When null, Sentry's built-in Seer agent is used.",
+        required=False,
+        allow_null=True,
     )
 
     # private attributes

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -33,6 +33,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationslugreservation import OrganizationSlugReservation
 from sentry.replays.models import OrganizationMemberReplayAccess
+from sentry.seer.models.organization_settings import SeerOrganizationSettings
 from sentry.signals import project_created
 from sentry.silo.safety import unguarded_write
 from sentry.snuba.metrics import TransactionMRI
@@ -1895,6 +1896,75 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert response.data["hasGranularReplayPermissions"] is False
         assert response.data["replayAccessMembers"] == []
+
+
+class OrganizationDefaultCodingAgentTest(OrganizationDetailsTestBase):
+    method = "put"
+
+    def test_get_returns_null_by_default(self) -> None:
+        response = self.get_success_response(self.organization.slug, method="get")
+        assert response.data["defaultCodingAgentIntegrationId"] is None
+
+    def test_set_default_coding_agent(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        self.get_success_response(
+            self.organization.slug, defaultCodingAgentIntegrationId=integration.id
+        )
+
+        settings = SeerOrganizationSettings.objects.get(organization=self.organization)
+        assert settings.default_coding_agent_integration_id == integration.id
+
+    def test_get_returns_set_value(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        SeerOrganizationSettings.objects.create(
+            organization=self.organization,
+            default_coding_agent_integration_id=integration.id,
+        )
+
+        response = self.get_success_response(self.organization.slug, method="get")
+        assert response.data["defaultCodingAgentIntegrationId"] == integration.id
+
+    def test_clear_default_coding_agent(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        SeerOrganizationSettings.objects.create(
+            organization=self.organization,
+            default_coding_agent_integration_id=integration.id,
+        )
+
+        self.get_success_response(self.organization.slug, defaultCodingAgentIntegrationId=None)
+
+        settings = SeerOrganizationSettings.objects.get(organization=self.organization)
+        assert settings.default_coding_agent_integration_id is None
+
+    def test_rejects_invalid_integration_id(self) -> None:
+        self.get_error_response(
+            self.organization.slug, defaultCodingAgentIntegrationId=99999, status_code=400
+        )
+
+    def test_rejects_other_org_integration(self) -> None:
+        other_org = self.create_organization(owner=self.create_user())
+        integration = self.create_integration(
+            organization=other_org,
+            provider="github",
+            external_id="99999",
+        )
+        self.get_error_response(
+            self.organization.slug,
+            defaultCodingAgentIntegrationId=integration.id,
+            status_code=400,
+        )
 
 
 class OrganizationDeleteTest(OrganizationDetailsTestBase):

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -33,7 +33,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationslugreservation import OrganizationSlugReservation
 from sentry.replays.models import OrganizationMemberReplayAccess
-from sentry.seer.models.organization_settings import SeerOrganizationSettings
+from sentry.seer.models.organization_settings import CodingAgent, SeerOrganizationSettings
 from sentry.signals import project_created
 from sentry.silo.safety import unguarded_write
 from sentry.snuba.metrics import TransactionMRI
@@ -1901,11 +1901,57 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 class OrganizationDefaultCodingAgentTest(OrganizationDetailsTestBase):
     method = "put"
 
-    def test_get_returns_null_by_default(self) -> None:
+    def test_get_returns_defaults(self) -> None:
         response = self.get_success_response(self.organization.slug, method="get")
+        assert response.data["defaultCodingAgent"] == CodingAgent.SEER
         assert response.data["defaultCodingAgentIntegrationId"] is None
 
-    def test_set_default_coding_agent(self) -> None:
+    def test_set_coding_agent_to_seer(self) -> None:
+        self.get_success_response(self.organization.slug, defaultCodingAgent=CodingAgent.SEER)
+        settings = SeerOrganizationSettings.objects.get(organization=self.organization)
+        assert settings.default_coding_agent == CodingAgent.SEER
+        assert settings.default_coding_agent_integration_id is None
+
+    def test_set_coding_agent_to_cursor_with_integration(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        self.get_success_response(
+            self.organization.slug,
+            defaultCodingAgent=CodingAgent.CURSOR,
+            defaultCodingAgentIntegrationId=integration.id,
+        )
+        settings = SeerOrganizationSettings.objects.get(organization=self.organization)
+        assert settings.default_coding_agent == CodingAgent.CURSOR
+        assert settings.default_coding_agent_integration_id == integration.id
+
+    def test_set_coding_agent_to_null_disables(self) -> None:
+        SeerOrganizationSettings.objects.create(
+            organization=self.organization,
+            default_coding_agent=CodingAgent.SEER,
+        )
+        self.get_success_response(self.organization.slug, defaultCodingAgent=None)
+        settings = SeerOrganizationSettings.objects.get(organization=self.organization)
+        assert settings.default_coding_agent is None
+
+    def test_get_returns_set_values(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        SeerOrganizationSettings.objects.create(
+            organization=self.organization,
+            default_coding_agent=CodingAgent.CURSOR,
+            default_coding_agent_integration_id=integration.id,
+        )
+        response = self.get_success_response(self.organization.slug, method="get")
+        assert response.data["defaultCodingAgent"] == CodingAgent.CURSOR
+        assert response.data["defaultCodingAgentIntegrationId"] == integration.id
+
+    def test_set_integration_id_only(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",
@@ -1914,11 +1960,10 @@ class OrganizationDefaultCodingAgentTest(OrganizationDetailsTestBase):
         self.get_success_response(
             self.organization.slug, defaultCodingAgentIntegrationId=integration.id
         )
-
         settings = SeerOrganizationSettings.objects.get(organization=self.organization)
         assert settings.default_coding_agent_integration_id == integration.id
 
-    def test_get_returns_set_value(self) -> None:
+    def test_clear_integration_id(self) -> None:
         integration = self.create_integration(
             organization=self.organization,
             provider="github",
@@ -1928,25 +1973,29 @@ class OrganizationDefaultCodingAgentTest(OrganizationDetailsTestBase):
             organization=self.organization,
             default_coding_agent_integration_id=integration.id,
         )
-
-        response = self.get_success_response(self.organization.slug, method="get")
-        assert response.data["defaultCodingAgentIntegrationId"] == integration.id
-
-    def test_clear_default_coding_agent(self) -> None:
-        integration = self.create_integration(
-            organization=self.organization,
-            provider="github",
-            external_id="12345",
-        )
-        SeerOrganizationSettings.objects.create(
-            organization=self.organization,
-            default_coding_agent_integration_id=integration.id,
-        )
-
         self.get_success_response(self.organization.slug, defaultCodingAgentIntegrationId=None)
-
         settings = SeerOrganizationSettings.objects.get(organization=self.organization)
         assert settings.default_coding_agent_integration_id is None
+
+    def test_rejects_cursor_without_integration(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            defaultCodingAgent=CodingAgent.CURSOR,
+            status_code=400,
+        )
+
+    def test_rejects_seer_with_integration(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="12345",
+        )
+        self.get_error_response(
+            self.organization.slug,
+            defaultCodingAgent=CodingAgent.SEER,
+            defaultCodingAgentIntegrationId=integration.id,
+            status_code=400,
+        )
 
     def test_rejects_invalid_integration_id(self) -> None:
         self.get_error_response(
@@ -1963,6 +2012,13 @@ class OrganizationDefaultCodingAgentTest(OrganizationDetailsTestBase):
         self.get_error_response(
             self.organization.slug,
             defaultCodingAgentIntegrationId=integration.id,
+            status_code=400,
+        )
+
+    def test_rejects_invalid_agent_choice(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            defaultCodingAgent="invalid_agent",
             status_code=400,
         )
 


### PR DESCRIPTION
## Summary
- Adds `defaultCodingAgent` and `defaultCodingAgentIntegrationId` to the org details GET/PUT endpoint
- `defaultCodingAgent` accepts `"seer"` (default), `"cursor"`, or `null` (disabled)
- `defaultCodingAgentIntegrationId` is the integration ID, required when the agent needs one (e.g. cursor)
- Cross-field validation enforces that agents in `INTEGRATION_REQUIRED_AGENTS` must have an integration ID, and others must not

## Test plan
- [x] 12 tests in `OrganizationDefaultCodingAgentTest` covering:
  - GET returns defaults and set values
  - SET seer, cursor+integration, null (disabled)
  - SET/clear integration ID independently
  - Rejects cursor without integration
  - Rejects seer with integration
  - Rejects invalid integration ID and other-org integration
  - Rejects invalid agent choice