### PR TITLE
feat(assets): Link frontend overview assets widget to assets summary dashboard

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -133,6 +133,13 @@ const SECOND_ROW_WIDGETS: Widget[] = spaceWidgetsEquallyOnRow(
           aggregates: ['p75(span.duration)'],
           columns: [SpanFields.NORMALIZED_DESCRIPTION],
           orderby: `-sum(span.duration)`,
+          linkedDashboards: [
+            {
+              dashboardId: '-1',
+              field: SpanFields.NORMALIZED_DESCRIPTION,
+              staticDashboardId: 25,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
Adds a `linkedDashboards` entry to the top assets by time spent widget in the frontend overview prebuilt dashboard, pointing to the frontend assets summary prebuilt dashboard (static id 25).

This enables drill-through navigation from the assets widget on the frontend overview page directly into the dedicated assets summary dashboard.

Refs BROWSE-363