### PR TITLE
feat(dashboards): Add AI Model icons to Visualization Widget breakdown labels

### DIFF
--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -36,6 +36,7 @@ import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/setti
 import type {
   TabularColumn,
   TimeSeries,
+  TimeSeriesGroupBy,
 } from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
@@ -46,10 +47,12 @@ import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/tim
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {TextAlignRight} from 'sentry/views/insights/common/components/textAlign';
 import type {LoadableChartWidgetProps} from 'sentry/views/insights/common/components/widgets/types';
+import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
 import {
   SeriesColorIndicator,
   WidgetFooterTable,
 } from 'sentry/views/insights/pages/platform/shared/styles';
+import {SpanFields} from 'sentry/views/insights/types';
 
 import {WidgetCardDataLoader} from './widgetCardDataLoader';
 
@@ -274,7 +277,13 @@ function VisualizationWidgetContent({
         const dataUnit = timeSeries.meta.valueUnit ?? undefined;
         const label = plottable?.label ?? timeSeries.yAxis;
 
-        let labelContent = <Text>{label}</Text>;
+        const labelDisplay = renderBreakdownLabel(
+          firstColumn,
+          firstColumnGroupByValue,
+          label
+        );
+
+        let labelContent = <Text>{labelDisplay}</Text>;
 
         // TODO: to simplify things, we only support one widget query for explore urls right now
         // Otherwise we have to map the correct widget query to the timeseries result
@@ -298,7 +307,7 @@ function VisualizationWidgetContent({
               widget.widgetType
             ),
           });
-          labelContent = <Link to={exploreUrl}>{label}</Link>;
+          labelContent = <Link to={exploreUrl}>{labelDisplay}</Link>;
         }
 
         if (
@@ -317,7 +326,7 @@ function VisualizationWidgetContent({
             locationQuery: location.query,
           });
           if (linkedDashbordUrl) {
-            labelContent = <Link to={linkedDashbordUrl}>{label}</Link>;
+            labelContent = <Link to={linkedDashbordUrl}>{labelDisplay}</Link>;
           }
         }
 
@@ -413,4 +422,24 @@ function VisualizationWidgetContent({
       />
     </Container>
   );
+}
+
+/**
+ * Returns a custom label element for breakdown legend rows that need special rendering
+ * (e.g., model icons for AI model fields), or falls back to the plain text label.
+ */
+function renderBreakdownLabel(
+  column?: string,
+  groupByValue?: TimeSeriesGroupBy['value'],
+  fallbackLabel?: string
+): React.ReactNode {
+  if (
+    typeof groupByValue === 'string' &&
+    (column === SpanFields.GEN_AI_REQUEST_MODEL ||
+      column === SpanFields.GEN_AI_RESPONSE_MODEL)
+  ) {
+    return <ModelName modelId={groupByValue} size={14} />;
+  }
+
+  return fallbackLabel;
 }


### PR DESCRIPTION
Updates visualization label breakdown rendering to display AI Model icon when detected
<img width="434" height="146" alt="image" src="https://github.com/user-attachments/assets/f794ab8e-37ec-4d47-a2c9-8a02864812e6" />