### PR TITLE
ref(dynamic-sampling): Migrate samplingModeSwitchModal to new form system

### DIFF
--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
@@ -1,0 +1,241 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  act,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
+
+import {openSamplingModeSwitchModal} from 'sentry/views/settings/dynamicSampling/samplingModeSwitchModal';
+
+describe('SamplingModeSwitchModal', () => {
+  const organization = OrganizationFixture({slug: 'org-slug'});
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  function openModal(props: Parameters<typeof openSamplingModeSwitchModal>[0]) {
+    act(() => openSamplingModeSwitchModal(props));
+  }
+
+  describe('samplingMode: organization (Deactivate Advanced Mode)', () => {
+    it('renders the title and pre-fills the target rate input', async () => {
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      expect(await screen.findByText('Deactivate Advanced Mode')).toBeInTheDocument();
+      expect(
+        screen.getByRole('spinbutton', {name: 'Global Target Sample Rate'})
+      ).toHaveValue(50);
+    });
+
+    it('does not call the API when submitting with an out-of-range value', async () => {
+      const putMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture(),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      await screen.findByText('Deactivate Advanced Mode');
+      const input = screen.getByRole('spinbutton', {name: 'Global Target Sample Rate'});
+
+      // Type an out-of-range value and submit — Zod validation should block the API call
+      await userEvent.clear(input);
+      await userEvent.type(input, '150');
+      await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
+
+      // Modal should remain open and API should not have been called
+      await waitFor(() => {
+        expect(screen.getByText('Deactivate Advanced Mode')).toBeInTheDocument();
+      });
+      expect(putMock).not.toHaveBeenCalled();
+    });
+
+    it('submits samplingMode and targetSampleRate to the API', async () => {
+      const putMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({samplingMode: 'organization', targetSampleRate: 0.3}),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      await screen.findByText('Deactivate Advanced Mode');
+      const input = screen.getByRole('spinbutton', {name: 'Global Target Sample Rate'});
+
+      await userEvent.clear(input);
+      await userEvent.type(input, '30');
+
+      await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
+
+      await waitFor(() => {
+        expect(putMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/',
+          expect.objectContaining({
+            data: {samplingMode: 'organization', targetSampleRate: 0.3},
+          })
+        );
+      });
+    });
+
+    it('closes the modal on successful submit', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({samplingMode: 'organization'}),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      await screen.findByText('Deactivate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Deactivate Advanced Mode')).not.toBeInTheDocument();
+      });
+    });
+
+    it('keeps the modal open when the API returns an error', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        statusCode: 500,
+        body: {detail: 'Internal Server Error'},
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      await screen.findByText('Deactivate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
+
+      await waitFor(() => {
+        expect(screen.getByText('Deactivate Advanced Mode')).toBeInTheDocument();
+      });
+    });
+
+    it('closes the modal when Cancel is clicked without submitting', async () => {
+      const putMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture(),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+
+      await screen.findByText('Deactivate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Deactivate Advanced Mode')).not.toBeInTheDocument();
+      });
+      expect(putMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('samplingMode: project (Activate Advanced Mode)', () => {
+    it('renders the title and does not show the target rate input', async () => {
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'project'});
+
+      expect(await screen.findByText('Activate Advanced Mode')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('spinbutton', {name: 'Global Target Sample Rate'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('submits only samplingMode without targetSampleRate', async () => {
+      const putMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({samplingMode: 'project'}),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'project'});
+
+      await screen.findByText('Activate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Activate'}));
+
+      await waitFor(() => {
+        expect(putMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/',
+          expect.objectContaining({
+            data: {samplingMode: 'project'},
+          })
+        );
+      });
+      expect(putMock).not.toHaveBeenCalledWith(
+        '/organizations/org-slug/',
+        expect.objectContaining({
+          data: expect.objectContaining({targetSampleRate: expect.anything()}),
+        })
+      );
+    });
+
+    it('closes the modal on successful submit', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture({samplingMode: 'project'}),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'project'});
+
+      await screen.findByText('Activate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Activate'}));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Activate Advanced Mode')).not.toBeInTheDocument();
+      });
+    });
+
+    it('keeps the modal open when the API returns an error', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        statusCode: 500,
+        body: {detail: 'Internal Server Error'},
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'project'});
+
+      await screen.findByText('Activate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Activate'}));
+
+      await waitFor(() => {
+        expect(screen.getByText('Activate Advanced Mode')).toBeInTheDocument();
+      });
+    });
+
+    it('closes the modal when Cancel is clicked without submitting', async () => {
+      const putMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        method: 'PUT',
+        body: OrganizationFixture(),
+      });
+
+      renderGlobalModal({organization});
+      openModal({samplingMode: 'project'});
+
+      await screen.findByText('Activate Advanced Mode');
+      await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+      await waitFor(() => {
+        expect(screen.queryByText('Activate Advanced Mode')).not.toBeInTheDocument();
+      });
+      expect(putMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
@@ -85,7 +85,7 @@ describe('SamplingModeSwitchModal', () => {
       });
     });
 
-    it('closes the modal on successful submit', async () => {
+    it('closes the modal on successful submit with user-typed value', async () => {
       const putMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/',
         method: 'PUT',
@@ -96,13 +96,17 @@ describe('SamplingModeSwitchModal', () => {
       openModal({samplingMode: 'organization', initialTargetRate: 0.5});
 
       await screen.findByText('Deactivate Advanced Mode');
+      const input = screen.getByRole('spinbutton', {name: 'Global Target Sample Rate'});
+
+      await userEvent.clear(input);
+      await userEvent.type(input, '0.5');
       await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
 
       await waitFor(() => {
         expect(putMock).toHaveBeenCalledWith(
           '/organizations/org-slug/',
           expect.objectContaining({
-            data: {samplingMode: 'organization', targetSampleRate: 0.5},
+            data: {samplingMode: 'organization', targetSampleRate: 0.005},
           })
         );
       });

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
@@ -93,7 +93,7 @@ describe('SamplingModeSwitchModal', () => {
       });
 
       renderGlobalModal({organization});
-      openModal({samplingMode: 'organization', initialTargetRate: 0.5});
+      openModal({samplingMode: 'organization'});
 
       await screen.findByText('Deactivate Advanced Mode');
       const input = screen.getByRole('spinbutton', {name: 'Global Target Sample Rate'});

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.spec.tsx
@@ -86,7 +86,7 @@ describe('SamplingModeSwitchModal', () => {
     });
 
     it('closes the modal on successful submit', async () => {
-      MockApiClient.addMockResponse({
+      const putMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/',
         method: 'PUT',
         body: OrganizationFixture({samplingMode: 'organization'}),
@@ -98,6 +98,14 @@ describe('SamplingModeSwitchModal', () => {
       await screen.findByText('Deactivate Advanced Mode');
       await userEvent.click(screen.getByRole('button', {name: 'Deactivate'}));
 
+      await waitFor(() => {
+        expect(putMock).toHaveBeenCalledWith(
+          '/organizations/org-slug/',
+          expect.objectContaining({
+            data: {samplingMode: 'organization', targetSampleRate: 0.5},
+          })
+        );
+      });
       await waitFor(() => {
         expect(screen.queryByText('Deactivate Advanced Mode')).not.toBeInTheDocument();
       });

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -73,7 +73,7 @@ function SamplingModeSwitchModal({
   });
 
   return (
-    <form.AppForm>
+    <form.AppForm form={form}>
       <Header>
         <h5>
           {samplingMode === 'organization'

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
@@ -13,6 +13,8 @@ import {
 import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
+import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
 
 interface Props {
@@ -29,9 +31,16 @@ interface Props {
 
 const schema = z.object({
   targetSampleRate: z
-    .number()
-    .min(0, {message: t('Must be between 0% and 100%')})
-    .max(100, {message: t('Must be between 0% and 100%')}),
+    .string()
+    .min(1, t('This field is required.'))
+    .refine(val => !isNaN(Number(val)), {message: t('Please enter a valid number.')})
+    .refine(
+      val => {
+        const n = Number(val);
+        return n >= 0 && n <= 100;
+      },
+      {message: t('Must be between 0% and 100%')}
+    ),
 });
 
 function SamplingModeSwitchModal({
@@ -58,7 +67,7 @@ function SamplingModeSwitchModal({
   const form = useScrapsForm({
     ...defaultFormOptions,
     defaultValues: {
-      targetSampleRate: Math.round(initialTargetRate * 100 * 100) / 100,
+      targetSampleRate: formatPercent(initialTargetRate || 0),
     },
     validators: {
       onDynamic: schema,
@@ -66,9 +75,9 @@ function SamplingModeSwitchModal({
     onSubmit: ({value}) => {
       const changes: Parameters<typeof updateOrganization>[0] = {samplingMode};
       if (samplingMode === 'organization') {
-        changes.targetSampleRate = value.targetSampleRate / 100;
+        changes.targetSampleRate = parsePercent(value.targetSampleRate);
       }
-      return updateOrganization(changes);
+      return updateOrganization(changes).catch(() => {});
     },
   });
 
@@ -82,54 +91,59 @@ function SamplingModeSwitchModal({
         </h5>
       </Header>
       <Body>
-        <p>
-          {samplingMode === 'organization'
-            ? tct(
-                'Deactivating advanced mode enables continuous adjustments for your projects based on a global target sample rate. Sentry boosts the sample rates of small projects and ensures equal visibility. [learnMoreLink:Learn more]',
-                {
-                  learnMoreLink: (
-                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/" />
-                  ),
-                }
-              )
-            : tct(
-                'Switching to advanced mode disables automatic adjustments. After the switch, you can configure individual sample rates for each project. [prioritiesLink:Dynamic sampling priorities] continue to apply within the projects. [learnMoreLink:Learn more]',
-                {
-                  prioritiesLink: (
-                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#dynamic-sampling-priorities" />
-                  ),
-                  learnMoreLink: (
-                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#advanced-mode" />
-                  ),
-                }
+        <Stack gap="2xl">
+          <span>
+            {samplingMode === 'organization'
+              ? tct(
+                  'Deactivating advanced mode enables continuous adjustments for your projects based on a global target sample rate. Sentry boosts the sample rates of small projects and ensures equal visibility. [learnMoreLink:Learn more]',
+                  {
+                    learnMoreLink: (
+                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/" />
+                    ),
+                  }
+                )
+              : tct(
+                  'Switching to advanced mode disables automatic adjustments. After the switch, you can configure individual sample rates for each project. [prioritiesLink:Dynamic sampling priorities] continue to apply within the projects. [learnMoreLink:Learn more]',
+                  {
+                    prioritiesLink: (
+                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#dynamic-sampling-priorities" />
+                    ),
+                    learnMoreLink: (
+                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#advanced-mode" />
+                    ),
+                  }
+                )}
+          </span>
+          {samplingMode === 'organization' ? (
+            <form.AppField name="targetSampleRate">
+              {field => (
+                <field.Layout.Stack label={t('Global Target Sample Rate')} required>
+                  {/* Match the width of PercentInput (120px) */}
+                  <div style={{width: 120}}>
+                    <field.Input
+                      type="number"
+                      step="any"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      disabled={isPending}
+                      trailingItems={<strong>%</strong>}
+                    />
+                  </div>
+                </field.Layout.Stack>
               )}
-        </p>
-        {samplingMode === 'organization' ? (
-          <form.AppField name="targetSampleRate">
-            {field => (
-              <field.Layout.Stack label={t('Global Target Sample Rate')} required>
-                <field.Number
-                  value={field.state.value}
-                  onChange={field.handleChange}
-                  min={0}
-                  max={100}
-                  disabled={isPending}
-                  trailingItems={<strong>%</strong>}
-                />
-              </field.Layout.Stack>
-            )}
-          </form.AppField>
-        ) : null}
-        <p>
-          {samplingMode === 'organization'
-            ? tct(
-                'By deactivating advanced mode, [strong:you will lose your manually configured sample rates].',
-                {
-                  strong: <strong />,
-                }
-              )
-            : t('You can deactivate advanced mode at any time.')}
-        </p>
+            </form.AppField>
+          ) : null}
+          <span>
+            {samplingMode === 'organization'
+              ? tct(
+                  'By deactivating advanced mode, [strong:you will lose your manually configured sample rates].',
+                  {
+                    strong: <strong />,
+                  }
+                )
+              : t('You can deactivate advanced mode at any time.')}
+          </span>
+        </Stack>
       </Body>
       <Footer>
         <Flex gap="xl">

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitchModal.tsx
@@ -1,9 +1,8 @@
-import {useId} from 'react';
-import {css, useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
+import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
@@ -12,13 +11,8 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import {openModal, type ModalRenderProps} from 'sentry/actionCreators/modal';
-import {FieldGroup} from 'sentry/components/forms/fieldGroup';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {PercentInput} from 'sentry/views/settings/dynamicSampling/percentInput';
-import {formatPercent} from 'sentry/views/settings/dynamicSampling/utils/formatPercent';
-import {organizationSamplingForm} from 'sentry/views/settings/dynamicSampling/utils/organizationSamplingForm';
-import {parsePercent} from 'sentry/views/settings/dynamicSampling/utils/parsePercent';
 import {useUpdateOrganization} from 'sentry/views/settings/dynamicSampling/utils/useUpdateOrganization';
 
 interface Props {
@@ -33,7 +27,12 @@ interface Props {
   initialTargetRate?: number;
 }
 
-const {FormProvider, useFormState, useFormField} = organizationSamplingForm;
+const schema = z.object({
+  targetSampleRate: z
+    .number()
+    .min(0, {message: t('Must be between 0% and 100%')})
+    .max(100, {message: t('Must be between 0% and 100%')}),
+});
 
 function SamplingModeSwitchModal({
   Header,
@@ -43,13 +42,7 @@ function SamplingModeSwitchModal({
   samplingMode,
   initialTargetRate = 1,
 }: Props & ModalRenderProps) {
-  const formState = useFormState({
-    initialValues: {
-      targetSampleRate: formatPercent(initialTargetRate),
-    },
-  });
-
-  const {mutate: updateOrganization, isPending} = useUpdateOrganization({
+  const {mutateAsync: updateOrganization, isPending} = useUpdateOrganization({
     onMutate: () => {
       addLoadingMessage(t('Switching sampling mode...'));
     },
@@ -62,129 +55,95 @@ function SamplingModeSwitchModal({
     },
   });
 
-  const handleSubmit = () => {
-    if (!formState.isValid) {
-      return;
-    }
-    const changes: Parameters<typeof updateOrganization>[0] = {
-      samplingMode,
-    };
-    if (samplingMode === 'organization') {
-      changes.targetSampleRate = parsePercent(formState.fields.targetSampleRate.value);
-    }
-    updateOrganization(changes);
-  };
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      targetSampleRate: Math.round(initialTargetRate * 100 * 100) / 100,
+    },
+    validators: {
+      onDynamic: schema,
+    },
+    onSubmit: ({value}) => {
+      const changes: Parameters<typeof updateOrganization>[0] = {samplingMode};
+      if (samplingMode === 'organization') {
+        changes.targetSampleRate = value.targetSampleRate / 100;
+      }
+      return updateOrganization(changes);
+    },
+  });
 
   return (
-    <FormProvider formState={formState}>
-      <form
-        onSubmit={event => {
-          event.preventDefault();
-          handleSubmit();
-        }}
-        noValidate
-      >
-        <Header>
-          <h5>
-            {samplingMode === 'organization'
-              ? t('Deactivate Advanced Mode')
-              : t('Activate Advanced Mode')}
-          </h5>
-        </Header>
-        <Body>
-          <p>
-            {samplingMode === 'organization'
-              ? tct(
-                  'Deactivating advanced mode enables continuous adjustments for your projects based on a global target sample rate. Sentry boosts the sample rates of small projects and ensures equal visibility. [learnMoreLink:Learn more]',
-                  {
-                    learnMoreLink: (
-                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/" />
-                    ),
-                  }
-                )
-              : tct(
-                  'Switching to advanced mode disables automatic adjustments. After the switch, you can configure individual sample rates for each project. [prioritiesLink:Dynamic sampling priorities] continue to apply within the projects. [learnMoreLink:Learn more]',
-                  {
-                    prioritiesLink: (
-                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#dynamic-sampling-priorities" />
-                    ),
-                    learnMoreLink: (
-                      <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#advanced-mode" />
-                    ),
-                  }
-                )}
-          </p>
-          {samplingMode === 'organization' && <TargetRateInput disabled={isPending} />}
-          <p>
-            {samplingMode === 'organization'
-              ? tct(
-                  'By deactivating advanced mode, [strong:you will lose your manually configured sample rates].',
-                  {
-                    strong: <strong />,
-                  }
-                )
-              : t('You can deactivate advanced mode at any time.')}
-          </p>
-        </Body>
-        <Footer>
-          <Flex gap="xl">
-            <Button disabled={isPending} onClick={closeModal}>
-              {t('Cancel')}
-            </Button>
-            <Button
-              priority="primary"
-              disabled={isPending || !formState.isValid}
-              onClick={handleSubmit}
-            >
-              {samplingMode === 'organization' ? t('Deactivate') : t('Activate')}
-            </Button>
-          </Flex>
-        </Footer>
-      </form>
-    </FormProvider>
+    <form.AppForm>
+      <Header>
+        <h5>
+          {samplingMode === 'organization'
+            ? t('Deactivate Advanced Mode')
+            : t('Activate Advanced Mode')}
+        </h5>
+      </Header>
+      <Body>
+        <p>
+          {samplingMode === 'organization'
+            ? tct(
+                'Deactivating advanced mode enables continuous adjustments for your projects based on a global target sample rate. Sentry boosts the sample rates of small projects and ensures equal visibility. [learnMoreLink:Learn more]',
+                {
+                  learnMoreLink: (
+                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/" />
+                  ),
+                }
+              )
+            : tct(
+                'Switching to advanced mode disables automatic adjustments. After the switch, you can configure individual sample rates for each project. [prioritiesLink:Dynamic sampling priorities] continue to apply within the projects. [learnMoreLink:Learn more]',
+                {
+                  prioritiesLink: (
+                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#dynamic-sampling-priorities" />
+                  ),
+                  learnMoreLink: (
+                    <ExternalLink href="https://docs.sentry.io/organization/dynamic-sampling/#advanced-mode" />
+                  ),
+                }
+              )}
+        </p>
+        {samplingMode === 'organization' ? (
+          <form.AppField name="targetSampleRate">
+            {field => (
+              <field.Layout.Stack label={t('Global Target Sample Rate')} required>
+                <field.Number
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  min={0}
+                  max={100}
+                  disabled={isPending}
+                  trailingItems={<strong>%</strong>}
+                />
+              </field.Layout.Stack>
+            )}
+          </form.AppField>
+        ) : null}
+        <p>
+          {samplingMode === 'organization'
+            ? tct(
+                'By deactivating advanced mode, [strong:you will lose your manually configured sample rates].',
+                {
+                  strong: <strong />,
+                }
+              )
+            : t('You can deactivate advanced mode at any time.')}
+        </p>
+      </Body>
+      <Footer>
+        <Flex gap="xl">
+          <Button disabled={isPending} onClick={closeModal}>
+            {t('Cancel')}
+          </Button>
+          <form.SubmitButton priority="primary">
+            {samplingMode === 'organization' ? t('Deactivate') : t('Activate')}
+          </form.SubmitButton>
+        </Flex>
+      </Footer>
+    </form.AppForm>
   );
 }
-
-function TargetRateInput({disabled}: {disabled?: boolean}) {
-  const theme = useTheme();
-  const id = useId();
-  const {value, onChange, error} = useFormField('targetSampleRate');
-
-  return (
-    <FieldGroup
-      label={t('Global Target Sample Rate')}
-      css={css`
-        padding-bottom: ${theme.space.xs};
-      `}
-      inline={false}
-      showHelpInTooltip
-      flexibleControlStateSize
-      stacked
-      required
-    >
-      <Stack gap="xs">
-        <PercentInput
-          id={id}
-          aria-label={t('Global Target Sample Rate')}
-          value={value}
-          onChange={event => onChange(event.target.value)}
-          disabled={disabled}
-        />
-        <ErrorMessage>
-          {error
-            ? error
-            : // Placholder character to keep the space occupied
-              '\u200b'}
-        </ErrorMessage>
-      </Stack>
-    </FieldGroup>
-  );
-}
-
-const ErrorMessage = styled('div')`
-  color: ${p => p.theme.colors.red400};
-  font-size: ${p => p.theme.font.size.xs};
-`;
 
 export function openSamplingModeSwitchModal(props: Props) {
   openModal(dialogProps => <SamplingModeSwitchModal {...dialogProps} {...props} />);


### PR DESCRIPTION
Migrates `samplingModeSwitchModal.tsx` from the custom `createForm`/`FormProvider`/`useFormState`/`useFormField` system to the new `useScrapsForm`-based form system.

The custom form context (`organizationSamplingForm`) is replaced with a Zod schema and `useScrapsForm`. Field layout and error display is now handled automatically by `field.Layout.Stack` instead of a manually wired `FieldGroup` and styled `ErrorMessage` component. The `TargetRateInput` subcomponent is inlined into the modal body as a `form.AppField`. The submit button becomes `form.SubmitButton` which handles disabled-during-submission state natively.

Part of the broader effort to migrate dynamic sampling forms off the legacy form system.

ref DE-949