### PR TITLE
ref(performance): convert OperationSort from class to function component

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -45,9 +45,9 @@ function OperationSort({eventView, location, tableMeta, title: Title}: Props) {
     };
   }, [handleClickOutside, isOpen]);
 
-  const toggleOpen = () => {
+  const toggleOpen = useCallback(() => {
     setIsOpen(previousIsOpen => !previousIsOpen);
-  };
+  }, []);
 
   function generateSortLink(field: any): LocationDescriptorObject | undefined {
     if (!tableMeta) {

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
@@ -13,7 +13,6 @@ import {t} from 'sentry/locale';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
-import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 
 export type TitleProps = Partial<ReturnType<GetActorPropsFn>>;
 
@@ -26,13 +25,25 @@ type Props = {
 
 function OperationSort({eventView, location, tableMeta, title: Title}: Props) {
   const [isOpen, setIsOpen] = useState(false);
-  const menuEl = useRef<HTMLElement | null>(null);
+  const menuEl = useRef<Element | null>(null);
 
-  const handleClickOutside = useCallback(() => {
-    setIsOpen(false);
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (event.target instanceof Element && !menuEl.current?.contains(event.target)) {
+      setIsOpen(false);
+    }
   }, []);
 
-  useOnClickOutside(menuEl, handleClickOutside);
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('click', handleClickOutside, true);
+    } else {
+      document.removeEventListener('click', handleClickOutside, true);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, [handleClickOutside, isOpen]);
 
   const toggleOpen = () => {
     setIsOpen(previousIsOpen => !previousIsOpen);

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
@@ -13,6 +13,7 @@ import {t} from 'sentry/locale';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 
 export type TitleProps = Partial<ReturnType<GetActorPropsFn>>;
 
@@ -25,25 +26,13 @@ type Props = {
 
 function OperationSort({eventView, location, tableMeta, title: Title}: Props) {
   const [isOpen, setIsOpen] = useState(false);
-  const menuEl = useRef<Element | null>(null);
+  const menuEl = useRef<HTMLElement | null>(null);
 
-  const handleClickOutside = useCallback((event: MouseEvent) => {
-    if (event.target instanceof Element && !menuEl.current?.contains(event.target)) {
-      setIsOpen(false);
-    }
+  const handleClickOutside = useCallback(() => {
+    setIsOpen(false);
   }, []);
 
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener('click', handleClickOutside, true);
-    } else {
-      document.removeEventListener('click', handleClickOutside, true);
-    }
-
-    return () => {
-      document.removeEventListener('click', handleClickOutside, true);
-    };
-  }, [handleClickOutside, isOpen]);
+  useOnClickOutside(menuEl, handleClickOutside);
 
   const toggleOpen = () => {
     setIsOpen(previousIsOpen => !previousIsOpen);

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
@@ -23,49 +23,33 @@ type Props = {
   title: React.ComponentType<TitleProps>;
 };
 
-type State = {
-  isOpen: boolean;
-};
+function OperationSort({eventView, location, tableMeta, title: Title}: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuEl = useRef<Element | null>(null);
 
-class OperationSort extends Component<Props, State> {
-  state: State = {
-    isOpen: false,
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (event.target instanceof Element && !menuEl.current?.contains(event.target)) {
+      setIsOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('click', handleClickOutside, true);
+    } else {
+      document.removeEventListener('click', handleClickOutside, true);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  }, [handleClickOutside, isOpen]);
+
+  const toggleOpen = () => {
+    setIsOpen(previousIsOpen => !previousIsOpen);
   };
 
-  componentDidUpdate(_props: Props, prevState: State) {
-    if (this.state.isOpen && prevState.isOpen === false) {
-      document.addEventListener('click', this.handleClickOutside, true);
-    }
-    if (this.state.isOpen === false && prevState.isOpen) {
-      document.removeEventListener('click', this.handleClickOutside, true);
-    }
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('click', this.handleClickOutside, true);
-  }
-
-  private menuEl: Element | null = null;
-
-  handleClickOutside = (event: MouseEvent) => {
-    if (!this.menuEl) {
-      return;
-    }
-    if (!(event.target instanceof Element)) {
-      return;
-    }
-    if (this.menuEl.contains(event.target)) {
-      return;
-    }
-    this.setState({isOpen: false});
-  };
-
-  toggleOpen = () => {
-    this.setState(({isOpen}) => ({isOpen: !isOpen}));
-  };
-
-  generateSortLink(field: any): LocationDescriptorObject | undefined {
-    const {eventView, tableMeta, location} = this.props;
+  function generateSortLink(field: any): LocationDescriptorObject | undefined {
     if (!tableMeta) {
       return undefined;
     }
@@ -79,8 +63,7 @@ class OperationSort extends Component<Props, State> {
     };
   }
 
-  renderMenuItem(operation: any, title: any) {
-    const {eventView} = this.props;
+  function renderMenuItem(operation: any, title: any) {
     return (
       <DropdownMenuItem>
         <Flex justify="start" align="center" width="100%">
@@ -90,7 +73,7 @@ class OperationSort extends Component<Props, State> {
               size="sm"
               checked={eventView.sorts.some(({field}) => field === operation)}
               onClick={() => {
-                const sortLink = this.generateSortLink({field: operation});
+                const sortLink = generateSortLink({field: operation});
                 if (sortLink) {
                   browserHistory.push(sortLink);
                 }
@@ -103,18 +86,18 @@ class OperationSort extends Component<Props, State> {
     );
   }
 
-  renderMenuContent() {
+  function renderMenuContent() {
     return (
       <DropdownContent>
-        {this.renderMenuItem('spans.http', t('Sort By HTTP'))}
-        {this.renderMenuItem('spans.db', t('Sort By DB'))}
-        {this.renderMenuItem('spans.resource', t('Sort By Resource'))}
-        {this.renderMenuItem('spans.browser', t('Sort By Browser'))}
+        {renderMenuItem('spans.http', t('Sort By HTTP'))}
+        {renderMenuItem('spans.db', t('Sort By DB'))}
+        {renderMenuItem('spans.resource', t('Sort By Resource'))}
+        {renderMenuItem('spans.browser', t('Sort By Browser'))}
       </DropdownContent>
     );
   }
 
-  renderMenu() {
+  function renderMenu() {
     const modifiers = [
       {
         name: 'hide',
@@ -133,12 +116,12 @@ class OperationSort extends Component<Props, State> {
           <DropdownWrapper
             ref={ref => {
               (popperRef as CallableFunction)(ref);
-              this.menuEl = ref;
+              menuEl.current = ref;
             }}
             style={style}
             data-placement={placement}
           >
-            {this.renderMenuContent()}
+            {renderMenuContent()}
           </DropdownWrapper>
         )}
       </Popper>,
@@ -146,24 +129,20 @@ class OperationSort extends Component<Props, State> {
     );
   }
 
-  render() {
-    const {title: Title} = this.props;
-    const {isOpen} = this.state;
-    const menu = isOpen ? this.renderMenu() : null;
+  const menu = isOpen ? renderMenu() : null;
 
-    return (
-      <Manager>
-        <Reference>
-          {({ref}) => (
-            <TitleWrapper ref={ref}>
-              <Title onClick={this.toggleOpen} />
-            </TitleWrapper>
-          )}
-        </Reference>
-        {menu}
-      </Manager>
-    );
-  }
+  return (
+    <Manager>
+      <Reference>
+        {({ref}) => (
+          <TitleWrapper ref={ref}>
+            <Title onClick={toggleOpen} />
+          </TitleWrapper>
+        )}
+      </Reference>
+      {menu}
+    </Manager>
+  );
 }
 
 const DropdownWrapper = styled('div')`


### PR DESCRIPTION
I picked an existing class component arbitrarily and went with it. There is only one piece of state, `isOpen`, that needed fancy handling around event listeners.

Tested on `/insights/summary/events/?project=*&sort=-spans.http&statsPeriod=14d&transaction=*`.

Closes https://linear.app/getsentry/issue/EXP-806/convert-operationsort-from-class-to-function-component