### PR TITLE
feat(preprod): Add GitHub Enterprise support for size analysis status checks

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -882,7 +882,7 @@ def _get_status_check_provider(
     organization_slug: str,
     integration_id: int,
 ) -> _StatusCheckProvider | None:
-    if provider == IntegrationProviderSlug.GITHUB:
+    if provider in (IntegrationProviderSlug.GITHUB, IntegrationProviderSlug.GITHUB_ENTERPRISE):
         return _GitHubStatusCheckProvider(
             client, provider, organization_id, organization_slug, integration_id
         )

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -831,6 +831,83 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         assert summary_bytes <= 65535, f"Summary has {summary_bytes} bytes, exceeds GitHub limit"
         assert summary.endswith("..."), "Truncated summary should end with '...'"
 
+    @responses.activate
+    def test_create_preprod_status_check_task_github_enterprise(self):
+        """Test that status checks work with GitHub Enterprise integration."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            provider="github_enterprise",
+            head_repo_name="Test-Organization/foo",
+        )
+
+        preprod_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.ghe",
+            commit_comparison=commit_comparison,
+        )
+
+        self.create_preprod_artifact_size_metrics(preprod_artifact=preprod_artifact)
+
+        integration = self.create_integration(
+            organization=self.organization,
+            external_id="ghe-1",
+            provider="github_enterprise",
+            metadata={
+                "access_token": "test_token",
+                "expires_at": "2099-01-01T00:00:00Z",
+                "domain_name": "github.example.org/Test-Organization",
+                "account_type": "Organization",
+                "installation_id": "install_id_1",
+                "installation": {
+                    "client_id": "client_id",
+                    "client_secret": "client_secret",
+                    "id": "2",
+                    "name": "test-app",
+                    "private_key": "private_key",
+                    "url": "github.example.org",
+                    "webhook_secret": "webhook_secret",
+                    "verify_ssl": True,
+                },
+            },
+        )
+
+        Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            provider="integrations:github_enterprise",
+            integration_id=integration.id,
+        )
+
+        responses.add(
+            responses.POST,
+            "https://github.example.org/api/v3/repos/Test-Organization/foo/check-runs",
+            status=201,
+            json={"id": 12345, "status": "completed"},
+        )
+
+        with (
+            patch(
+                "sentry.integrations.github_enterprise.client.get_jwt",
+                return_value="jwt_token_1",
+            ),
+            patch(
+                "sentry.integrations.github_enterprise.integration.get_jwt",
+                return_value="jwt_token_1",
+            ),
+        ):
+            with self.tasks():
+                create_preprod_status_check_task(preprod_artifact.id)
+
+        assert len(responses.calls) == 1
+        assert (
+            responses.calls[0].request.url
+            == "https://github.example.org/api/v3/repos/Test-Organization/foo/check-runs"
+        )
+
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["head_sha"] == commit_comparison.head_sha
+
     def test_sibling_deduplication_after_reprocessing(self):
         """Test that get_sibling_artifacts_for_commit() deduplicates by (app_id, artifact_type, build_configuration_id).
 


### PR DESCRIPTION
Add GitHub Enterprise support for size analysis status checks.

The status check provider factory (`_get_status_check_provider`) only matched `IntegrationProviderSlug.GITHUB`, so GitHub Enterprise repos would silently get no status checks posted even though `GitHubEnterpriseApiClient` already implements `StatusCheckClient` via `GitHubBaseClient`. This adds `GITHUB_ENTERPRISE` to the provider check.

Includes an end-to-end test that creates a GHE integration, repo, and commit comparison, and verifies the check run is posted to the correct GHE API URL (`/api/v3/repos/.../check-runs`).