### PR TITLE
feat(control): Add support for dropping unprocessed GitHub webhook events

### DIFF
--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -21,7 +21,8 @@ class GithubWebhookType(StrEnum):
     PUSH = "push"
 
 
-# Event types that the region webhook endpoint processes. INSTALLATION is handled in control only.
+# Event type strings (X-GitHub-Event header values) that the region webhook endpoint processes.
+# INSTALLATION is handled in control only.
 REGION_PROCESSED_GITHUB_EVENTS = frozenset(
-    t for t in GithubWebhookType if t != GithubWebhookType.INSTALLATION
+    t.value for t in GithubWebhookType if t != GithubWebhookType.INSTALLATION
 )

--- a/src/sentry/integrations/github/webhook_types.py
+++ b/src/sentry/integrations/github/webhook_types.py
@@ -19,3 +19,9 @@ class GithubWebhookType(StrEnum):
     PULL_REQUEST_REVIEW = "pull_request_review"
     PULL_REQUEST_REVIEW_COMMENT = "pull_request_review_comment"
     PUSH = "push"
+
+
+# Event types that the region webhook endpoint processes. INSTALLATION is handled in control only.
+REGION_PROCESSED_GITHUB_EVENTS = frozenset(
+    t for t in GithubWebhookType if t != GithubWebhookType.INSTALLATION
+)

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -14,7 +14,11 @@ from sentry.integrations.github.webhook import (
     GitHubIntegrationsWebhookEndpoint,
     get_github_external_id,
 )
-from sentry.integrations.github.webhook_types import GITHUB_WEBHOOK_TYPE_HEADER, GithubWebhookType
+from sentry.integrations.github.webhook_types import (
+    GITHUB_WEBHOOK_TYPE_HEADER,
+    REGION_PROCESSED_GITHUB_EVENTS,
+    GithubWebhookType,
+)
 from sentry.integrations.middleware.hybrid_cloud.parser import BaseRequestParser
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -130,6 +134,25 @@ class GithubRequestParser(BaseRequestParser):
             )
             if codecov_regions:
                 self.try_forward_to_codecov(event=event)
+
+        github_event = self.request.META.get(GITHUB_WEBHOOK_TYPE_HEADER)
+        mailbox_name = f"{self.provider}:{self.get_mailbox_identifier(integration, event)}"
+        region_processed_values = {t.value for t in REGION_PROCESSED_GITHUB_EVENTS}
+        allowlist = options.get("github.webhook.drop-unprocessed-events.mailbox-allowlist") or ()
+        mailbox_in_allowlist = any(
+            mailbox_name == m or mailbox_name.startswith(f"{m}:") for m in allowlist
+        )
+
+        if (
+            github_event not in region_processed_values
+            and options.get("github.webhook.drop-unprocessed-events.enabled")
+            and mailbox_in_allowlist
+        ):
+            metrics.incr(
+                "github.webhook.drop_unprocessed_event",
+                tags={"event_type": github_event or "unknown"},
+            )
+            return HttpResponse(status=202)
 
         response = self.get_response_from_webhookpayload(
             regions=regions,

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -140,8 +140,12 @@ class GithubRequestParser(BaseRequestParser):
         allowlist = options.get("github.webhook.drop-unprocessed-events.mailbox-allowlist") or ()
         mailbox_in_allowlist = any(mailbox_name == m for m in allowlist)
 
+        # Only drop when we have a known unprocessed event type. Missing or empty
+        # X-GitHub-Event is malformed; let the request be forwarded so the region
+        # returns 400 and GitHub is notified of the delivery failure.
         if (
-            github_event not in REGION_PROCESSED_GITHUB_EVENTS
+            github_event
+            and github_event not in REGION_PROCESSED_GITHUB_EVENTS
             and options.get("github.webhook.drop-unprocessed-events.enabled")
             and mailbox_in_allowlist
         ):

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -139,9 +139,7 @@ class GithubRequestParser(BaseRequestParser):
         mailbox_name = f"{self.provider}:{self.get_mailbox_identifier(integration, event)}"
         region_processed_values = {t.value for t in REGION_PROCESSED_GITHUB_EVENTS}
         allowlist = options.get("github.webhook.drop-unprocessed-events.mailbox-allowlist") or ()
-        mailbox_in_allowlist = any(
-            mailbox_name == m or mailbox_name.startswith(f"{m}:") for m in allowlist
-        )
+        mailbox_in_allowlist = any(mailbox_name == m for m in allowlist)
 
         if (
             github_event not in region_processed_values

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -137,12 +137,11 @@ class GithubRequestParser(BaseRequestParser):
 
         github_event = self.request.META.get(GITHUB_WEBHOOK_TYPE_HEADER)
         mailbox_name = f"{self.provider}:{self.get_mailbox_identifier(integration, event)}"
-        region_processed_values = {t.value for t in REGION_PROCESSED_GITHUB_EVENTS}
         allowlist = options.get("github.webhook.drop-unprocessed-events.mailbox-allowlist") or ()
         mailbox_in_allowlist = any(mailbox_name == m for m in allowlist)
 
         if (
-            github_event not in region_processed_values
+            github_event not in REGION_PROCESSED_GITHUB_EVENTS
             and options.get("github.webhook.drop-unprocessed-events.enabled")
             and mailbox_in_allowlist
         ):

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -736,6 +736,17 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "github.webhook.drop-unprocessed-events.enabled",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "github.webhook.drop-unprocessed-events.mailbox-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # GitHub Console SDK App (separate app for repository invitations)
 register("github-console-sdk-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 import pytest
 import responses
 from django.db import router, transaction
@@ -399,6 +401,144 @@ class GithubRequestParserMailboxBucketingTest(TestCase):
         )
 
         with override_options({"github.webhook.mailbox-bucketing.enabled": True}):
+            parser = GithubRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+        )
+
+
+@control_silo_test
+class GithubRequestParserDropUnprocessedEventsTest(TestCase):
+    """Tests for dropping GitHub webhook events that the region does not process."""
+
+    factory = RequestFactory()
+    path = reverse("sentry-integration-github-webhook")
+
+    def get_response(self, req: HttpRequest) -> HttpResponse:
+        return HttpResponse(status=200, content="passthrough")
+
+    def get_integration(self) -> Integration:
+        return self.create_integration(
+            organization=self.organization,
+            external_id="1",
+            provider="github",
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @responses.activate
+    @patch("sentry.middleware.integrations.parsers.github.metrics")
+    def test_drops_unprocessed_event_when_flag_and_allowlist(self, mock_metrics: Mock) -> None:
+        """With flag on and mailbox in allowlist, status event is dropped and metric is incremented."""
+        integration = self.get_integration()
+        mailbox_name = f"github:{integration.id}"
+        with override_options(
+            {
+                "github.webhook.drop-unprocessed-events.enabled": True,
+                "github.webhook.drop-unprocessed-events.mailbox-allowlist": [mailbox_name],
+            }
+        ):
+            request = self.factory.post(
+                self.path,
+                data={"installation": {"id": "1"}, "repository": {"id": 123}},
+                content_type="application/json",
+                headers={"X-GITHUB-EVENT": "status"},
+            )
+            parser = GithubRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_no_webhook_payloads()
+        mock_metrics.incr.assert_any_call(
+            "github.webhook.drop_unprocessed_event",
+            tags={"event_type": "status"},
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @override_options(
+        {
+            "github.webhook.drop-unprocessed-events.enabled": False,
+            "github.webhook.drop-unprocessed-events.mailbox-allowlist": ["github:99999"],
+        }
+    )
+    @responses.activate
+    def test_does_not_drop_when_flag_off_creates_payloads(self) -> None:
+        """With flag off, unprocessed event still creates WebhookPayloads."""
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 123}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": "status"},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @override_options(
+        {
+            "github.webhook.drop-unprocessed-events.enabled": True,
+            "github.webhook.drop-unprocessed-events.mailbox-allowlist": ["github:other"],
+        }
+    )
+    @responses.activate
+    def test_does_not_drop_when_mailbox_not_in_allowlist_creates_payloads(self) -> None:
+        """With mailbox not in allowlist, unprocessed event still creates WebhookPayloads."""
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}, "repository": {"id": 123}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": "status"},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+        response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+        )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @responses.activate
+    def test_supported_event_never_dropped_even_with_flag_and_allowlist(self) -> None:
+        """Supported event (push) is never dropped even when flag on and mailbox in allowlist."""
+        integration = self.get_integration()
+        with override_options(
+            {
+                "github.webhook.drop-unprocessed-events.enabled": True,
+                "github.webhook.drop-unprocessed-events.mailbox-allowlist": [
+                    f"github:{integration.id}"
+                ],
+            }
+        ):
+            request = self.factory.post(
+                self.path,
+                data={"installation": {"id": "1"}, "repository": {"id": 123}},
+                content_type="application/json",
+                headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+            )
             parser = GithubRequestParser(request=request, response_handler=self.get_response)
             response = parser.get_response()
 

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -550,6 +550,37 @@ class GithubRequestParserDropUnprocessedEventsTest(TestCase):
             region_names=[region.name],
         )
 
+    @override_settings(SILO_MODE=SiloMode.CONTROL)
+    @override_regions(region_config)
+    @responses.activate
+    def test_missing_x_github_event_not_dropped_forwards_to_region(self) -> None:
+        """Missing X-GitHub-Event is not dropped; request is forwarded so region returns 400."""
+        integration = self.get_integration()
+        with override_options(
+            {
+                "github.webhook.drop-unprocessed-events.enabled": True,
+                "github.webhook.drop-unprocessed-events.mailbox-allowlist": [
+                    f"github:{integration.id}"
+                ],
+            }
+        ):
+            request = self.factory.post(
+                self.path,
+                data={"installation": {"id": "1"}, "repository": {"id": 123}},
+                content_type="application/json",
+                # No X-GitHub-Event header
+            )
+            parser = GithubRequestParser(request=request, response_handler=self.get_response)
+            response = parser.get_response()
+
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+        )
+
 
 @control_silo_test
 class GithubRequestParserTypeRoutingTest(GithubRequestParserTest):


### PR DESCRIPTION
We have noticed some mailboxes having more than 99% of their GitHub webhooks being events we don't process in the region silos (e.g. `status`).

<img width="255" height="227" alt="image" src="https://github.com/user-attachments/assets/96dde7e9-5379-41d6-a6eb-06694a32e42a" />

This change allows dropping events for specific mailboxes. If there are no issues we can make this the default.