### PR TITLE
ref(explorer): rm unused category params from continue_run

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -366,10 +366,6 @@ class SeerExplorerClient:
             payload["artifact_key"] = artifact_key
             payload["artifact_schema"] = artifact_schema.schema()
 
-        if self.category_key and self.category_value:
-            payload["category_key"] = self.category_key
-            payload["category_value"] = self.category_value
-
         # Add conduit params for streaming if provided
         if conduit_channel_id and conduit_url:
             payload["conduit_channel_id"] = conduit_channel_id


### PR DESCRIPTION
not used by the seer endpoint branch: https://github.com/getsentry/seer/blob/main/src/seer/automation/explorer/tasks.py#L67-L69

category is set once on new runs and cannot be modified like the other flags