### PR TITLE
feat(explorer): return meta dict from table rpcs

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -183,7 +183,10 @@ def execute_table_query(
             path=f"/organizations/{organization.slug}/events/",
             params=params,
         )
-        return {"data": resp.data["data"]}
+        return {
+            "data": resp.data["data"],
+            **({"meta": resp.data["meta"]} if resp.data.get("meta") else {}),
+        }
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:
@@ -352,7 +355,10 @@ def execute_trace_table_query(
             path=f"/organizations/{organization.slug}/traces/",
             params=params,
         )
-        return {"data": resp.data["data"]}
+        return {
+            "data": resp.data["data"],
+            **({"meta": resp.data["meta"]} if resp.data.get("meta") else {}),
+        }
     except client.ApiError as e:
         # For 400 errors, return an error string for the query builder agent.
         if e.status_code == 400:


### PR DESCRIPTION
useful field to have from /events/ api response. [example](https://us.sentry.io/api/0/organizations/sentry/events/?dataset=spans&disableAggregateExtrapolation=1&field=count%28span.duration%29&project=6178942&referrer=api.explore.spans.raw-count.normal&sampling=NORMAL&statsPeriod=7d)

query agent optionally reads this for context on fields/units, but right now we're never passing it