### PR TITLE
ref(toolbar): migrate Dev Toolbar settings to AutoSaveField

### DIFF
--- a/static/app/components/core/form/generatedFieldRegistry.ts
+++ b/static/app/components/core/form/generatedFieldRegistry.ts
@@ -114,6 +114,52 @@ export const FORM_FIELD_REGISTRY: Record<string, FormFieldDefinition> = {
     label: t('Verify New Password'),
     hintText: t('Verify your new password'),
   },
+  'project-user-feedback.feedback:branding': {
+    name: 'feedback:branding',
+    formId: 'project-user-feedback',
+    route: '/settings/:orgId/projects/:projectId/user-feedback/',
+    label: t('Show Sentry Branding in Crash Report Modal'),
+    hintText: t(
+      'Show "powered by Sentry" within the Crash Report Modal. We appreciate you helping get the word out about Sentry! <3'
+    ),
+  },
+  'project-user-feedback.sentry:feedback_user_report_notifications': {
+    name: 'sentry:feedback_user_report_notifications',
+    formId: 'project-user-feedback',
+    route: '/settings/:orgId/projects/:projectId/user-feedback/',
+    label: t('Enable Crash Report Notifications'),
+  },
+  'project-user-feedback.sentry:feedback_ai_spam_detection': {
+    name: 'sentry:feedback_ai_spam_detection',
+    formId: 'project-user-feedback',
+    route: '/settings/:orgId/projects/:projectId/user-feedback/',
+    label: t('Enable Spam Detection'),
+  },
+  'project-toolbar.sentry:toolbar_allowed_origins': {
+    name: 'sentry:toolbar_allowed_origins',
+    formId: 'project-toolbar',
+    route: '/settings/:orgId/projects/:projectId/toolbar/',
+    label: t('Allowed Origins'),
+    hintText: '',
+  },
+  'csp.sentry:csp_ignored_sources_defaults': {
+    name: 'sentry:csp_ignored_sources_defaults',
+    formId: 'csp',
+    route: '/settings/:orgId/projects/:projectId/security-headers/csp/',
+    label: t('Use default ignored sources'),
+    hintText: t(
+      'Our default list will attempt to ignore common issues and reduce noise.'
+    ),
+  },
+  'csp.sentry:csp_ignored_sources': {
+    name: 'sentry:csp_ignored_sources',
+    formId: 'csp',
+    route: '/settings/:orgId/projects/:projectId/security-headers/csp/',
+    label: t('Additional ignored sources'),
+    hintText: t(
+      'Discard reports about requests from the given sources. Separate multiple entries with a newline.'
+    ),
+  },
   'organization-settings-form.replayAccessMembers': {
     name: 'replayAccessMembers',
     formId: 'organization-settings-form',

--- a/static/app/components/core/form/generatedFieldRegistry.ts
+++ b/static/app/components/core/form/generatedFieldRegistry.ts
@@ -114,51 +114,12 @@ export const FORM_FIELD_REGISTRY: Record<string, FormFieldDefinition> = {
     label: t('Verify New Password'),
     hintText: t('Verify your new password'),
   },
-  'project-user-feedback.feedback:branding': {
-    name: 'feedback:branding',
-    formId: 'project-user-feedback',
-    route: '/settings/:orgId/projects/:projectId/user-feedback/',
-    label: t('Show Sentry Branding in Crash Report Modal'),
-    hintText: t(
-      'Show "powered by Sentry" within the Crash Report Modal. We appreciate you helping get the word out about Sentry! <3'
-    ),
-  },
-  'project-user-feedback.sentry:feedback_user_report_notifications': {
-    name: 'sentry:feedback_user_report_notifications',
-    formId: 'project-user-feedback',
-    route: '/settings/:orgId/projects/:projectId/user-feedback/',
-    label: t('Enable Crash Report Notifications'),
-  },
-  'project-user-feedback.sentry:feedback_ai_spam_detection': {
-    name: 'sentry:feedback_ai_spam_detection',
-    formId: 'project-user-feedback',
-    route: '/settings/:orgId/projects/:projectId/user-feedback/',
-    label: t('Enable Spam Detection'),
-  },
   'project-toolbar.sentry:toolbar_allowed_origins': {
     name: 'sentry:toolbar_allowed_origins',
     formId: 'project-toolbar',
     route: '/settings/:orgId/projects/:projectId/toolbar/',
     label: t('Allowed Origins'),
     hintText: '',
-  },
-  'csp.sentry:csp_ignored_sources_defaults': {
-    name: 'sentry:csp_ignored_sources_defaults',
-    formId: 'csp',
-    route: '/settings/:orgId/projects/:projectId/security-headers/csp/',
-    label: t('Use default ignored sources'),
-    hintText: t(
-      'Our default list will attempt to ignore common issues and reduce noise.'
-    ),
-  },
-  'csp.sentry:csp_ignored_sources': {
-    name: 'sentry:csp_ignored_sources',
-    formId: 'csp',
-    route: '/settings/:orgId/projects/:projectId/security-headers/csp/',
-    label: t('Additional ignored sources'),
-    hintText: t(
-      'Discard reports about requests from the given sources. Separate multiple entries with a newline.'
-    ),
   },
   'organization-settings-form.replayAccessMembers': {
     name: 'replayAccessMembers',

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -1,14 +1,15 @@
+import {z} from 'zod';
+
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
+import {AutoSaveField, FieldGroup} from '@sentry/scraps/form';
 import {Text} from '@sentry/scraps/text';
 
-import Access from 'sentry/components/acl/access';
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
-import Form from 'sentry/components/forms/form';
-import JsonForm from 'sentry/components/forms/jsonForm';
-import type {JsonFormObject} from 'sentry/components/forms/types';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -17,6 +18,10 @@ import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
+const toolbarSchema = z.object({
+  'sentry:toolbar_allowed_origins': z.string(),
+});
+
 export default function ProjectToolbarSettings() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
@@ -24,42 +29,8 @@ export default function ProjectToolbarSettings() {
     fields: {domain: decodeScalar},
   });
 
-  const formGroups: JsonFormObject[] = [
-    {
-      title: 'Settings',
-      fields: [
-        {
-          name: 'sentry:toolbar_allowed_origins',
-          type: 'textarea',
-          rows: 3,
-          autosize: true,
-          formatMessageValue: false,
-
-          // additional data/props that is related to rendering of form field rather than data
-          label: t('Allowed Origins'),
-          help: (
-            <div>
-              <Text bold size="sm" variant="danger">
-                {t('Only add trusted domains, that you control, to this list.')}
-              </Text>
-              <br />
-              {t('Domains where the dev toolbar is allowed to access your data.')}
-              <br />
-              {t(
-                'Protocol and port are optional; wildcard subdomains (*) are supported.'
-              )}
-              <br />
-              {tct(
-                'Example: [code:localhost] is equivalent to [code:http://localhost] or [code:localhost:80]',
-                {code: <code />}
-              )}
-            </div>
-          ),
-          getData: data => ({options: data}),
-        },
-      ],
-    },
-  ];
+  const initialValue =
+    (project.options?.['sentry:toolbar_allowed_origins'] as string | undefined) ?? '';
 
   return (
     <SentryDocumentTitle title={t('Toolbar Settings')} projectSlug={project.slug}>
@@ -94,22 +65,55 @@ export default function ProjectToolbarSettings() {
         </Alert.Container>
       )}
 
-      <Form
-        apiMethod="PUT"
-        apiEndpoint={`/projects/${organization.slug}/${project.slug}/`}
-        initialData={project.options}
-        saveOnBlur
-      >
-        <Access access={['project:write']} project={project}>
-          {({hasAccess}) => (
-            <JsonForm
-              disabled={!hasAccess}
-              features={new Set(organization.features)}
-              forms={formGroups}
-            />
+      <FieldGroup title={t('Settings')}>
+        <AutoSaveField
+          name="sentry:toolbar_allowed_origins"
+          schema={toolbarSchema}
+          initialValue={initialValue}
+          mutationOptions={{
+            mutationFn: data =>
+              fetchMutation({
+                url: `/projects/${organization.slug}/${project.slug}/`,
+                method: 'PUT',
+                data: {options: data},
+              }),
+            onSuccess: () => {
+              addSuccessMessage(t('Saved'));
+            },
+          }}
+        >
+          {field => (
+            <field.Layout.Stack
+              label={t('Allowed Origins')}
+              hintText={
+                <div>
+                  <Text bold size="sm" variant="danger">
+                    {t('Only add trusted domains, that you control, to this list.')}
+                  </Text>
+                  <br />
+                  {t('Domains where the dev toolbar is allowed to access your data.')}
+                  <br />
+                  {t(
+                    'Protocol and port are optional; wildcard subdomains (*) are supported.'
+                  )}
+                  <br />
+                  {tct(
+                    'Example: [code:localhost] is equivalent to [code:http://localhost] or [code:localhost:80]',
+                    {code: <code />}
+                  )}
+                </div>
+              }
+            >
+              <field.TextArea
+                value={field.state.value}
+                onChange={field.handleChange}
+                autosize
+                rows={3}
+              />
+            </field.Layout.Stack>
           )}
-        </Access>
-      </Form>
+        </AutoSaveField>
+      </FieldGroup>
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
-import {AutoSaveField, FieldGroup} from '@sentry/scraps/form';
+import {AutoSaveField, FieldGroup, FormSearch} from '@sentry/scraps/form';
 import {Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -35,88 +35,90 @@ export default function ProjectToolbarSettings() {
     (project.options?.['sentry:toolbar_allowed_origins'] as string | undefined) ?? '';
 
   return (
-    <SentryDocumentTitle title={t('Toolbar Settings')} projectSlug={project.slug}>
-      <SettingsPageHeader
-        title={t('Dev Toolbar')}
-        action={
-          <LinkButton href="https://docs.sentry.io/product/sentry-toolbar/" external>
-            {t('Read the Docs')}
-          </LinkButton>
-        }
-      />
-      <TextBlock>
-        {t(
-          `Bring critical Sentry insights and tools directly into your web app for easier troubleshooting with the Dev Toolbar.`
-        )}
-      </TextBlock>
-      <ProjectPermissionAlert project={project} />
-      {domain && (
-        <Alert.Container>
-          <Alert variant="info">
-            {tct(
-              'To enable the Dev Toolbar, copy and paste your domain into the Allowed Origins text box below: [domain] ',
-              {domain: <strong>{domain}</strong>}
-            )}
-            <CopyToClipboardButton
-              priority="transparent"
-              size="zero"
-              text={domain}
-              aria-label={t('Copy domain to clipboard')}
-            />
-          </Alert>
-        </Alert.Container>
-      )}
-
-      <FieldGroup title={t('Settings')}>
-        <AutoSaveField
-          name="sentry:toolbar_allowed_origins"
-          schema={toolbarSchema}
-          initialValue={initialValue}
-          mutationOptions={{
-            mutationFn: data =>
-              fetchMutation({
-                url: `/projects/${organization.slug}/${project.slug}/`,
-                method: 'PUT',
-                data: {options: data},
-              }),
-            onSuccess: () => {
-              addSuccessMessage(t('Saved'));
-            },
-          }}
-        >
-          {field => (
-            <field.Layout.Stack
-              label={t('Allowed Origins')}
-              hintText={
-                <div>
-                  <Text bold size="sm" variant="danger">
-                    {t('Only add trusted domains, that you control, to this list.')}
-                  </Text>
-                  <br />
-                  {t('Domains where the dev toolbar is allowed to access your data.')}
-                  <br />
-                  {t(
-                    'Protocol and port are optional; wildcard subdomains (*) are supported.'
-                  )}
-                  <br />
-                  {tct(
-                    'Example: [code:localhost] is equivalent to [code:http://localhost] or [code:localhost:80]',
-                    {code: <code />}
-                  )}
-                </div>
-              }
-            >
-              <field.TextArea
-                value={field.state.value}
-                onChange={field.handleChange}
-                disabled={!hasAccess}
-                autosize
-                rows={3}
-              />
-            </field.Layout.Stack>
+    <FormSearch route="/settings/:orgId/projects/:projectId/toolbar/">
+      <SentryDocumentTitle title={t('Toolbar Settings')} projectSlug={project.slug}>
+        <SettingsPageHeader
+          title={t('Dev Toolbar')}
+          action={
+            <LinkButton href="https://docs.sentry.io/product/sentry-toolbar/" external>
+              {t('Read the Docs')}
+            </LinkButton>
+          }
+        />
+        <TextBlock>
+          {t(
+            `Bring critical Sentry insights and tools directly into your web app for easier troubleshooting with the Dev Toolbar.`
           )}
-        </AutoSaveField>
-      </FieldGroup>
-    </SentryDocumentTitle>
+        </TextBlock>
+        <ProjectPermissionAlert project={project} />
+        {domain && (
+          <Alert.Container>
+            <Alert variant="info">
+              {tct(
+                'To enable the Dev Toolbar, copy and paste your domain into the Allowed Origins text box below: [domain] ',
+                {domain: <strong>{domain}</strong>}
+              )}
+              <CopyToClipboardButton
+                priority="transparent"
+                size="zero"
+                text={domain}
+                aria-label={t('Copy domain to clipboard')}
+              />
+            </Alert>
+          </Alert.Container>
+        )}
+
+        <FieldGroup title={t('Settings')}>
+          <AutoSaveField
+            name="sentry:toolbar_allowed_origins"
+            schema={toolbarSchema}
+            initialValue={initialValue}
+            mutationOptions={{
+              mutationFn: data =>
+                fetchMutation({
+                  url: `/projects/${organization.slug}/${project.slug}/`,
+                  method: 'PUT',
+                  data: {options: data},
+                }),
+              onSuccess: () => {
+                addSuccessMessage(t('Saved'));
+              },
+            }}
+          >
+            {field => (
+              <field.Layout.Stack
+                label={t('Allowed Origins')}
+                hintText={
+                  <div>
+                    <Text bold size="sm" variant="danger">
+                      {t('Only add trusted domains, that you control, to this list.')}
+                    </Text>
+                    <br />
+                    {t('Domains where the dev toolbar is allowed to access your data.')}
+                    <br />
+                    {t(
+                      'Protocol and port are optional; wildcard subdomains (*) are supported.'
+                    )}
+                    <br />
+                    {tct(
+                      'Example: [code:localhost] is equivalent to [code:http://localhost] or [code:localhost:80]',
+                      {code: <code />}
+                    )}
+                  </div>
+                }
+              >
+                <field.TextArea
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  disabled={!hasAccess}
+                  autosize
+                  rows={3}
+                />
+              </field.Layout.Stack>
+            )}
+          </AutoSaveField>
+        </FieldGroup>
+      </SentryDocumentTitle>
+    </FormSearch>
   );
 }

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -6,6 +6,7 @@ import {AutoSaveField, FieldGroup} from '@sentry/scraps/form';
 import {Text} from '@sentry/scraps/text';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {hasEveryAccess} from 'sentry/components/acl/access';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -25,6 +26,7 @@ const toolbarSchema = z.object({
 export default function ProjectToolbarSettings() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
+  const hasAccess = hasEveryAccess(['project:write'], {organization, project});
   const {domain} = useLocationQuery({
     fields: {domain: decodeScalar},
   });
@@ -107,6 +109,7 @@ export default function ProjectToolbarSettings() {
               <field.TextArea
                 value={field.state.value}
                 onChange={field.handleChange}
+                disabled={!hasAccess}
                 autosize
                 rows={3}
               />


### PR DESCRIPTION
Migrates `static/app/views/settings/project/projectToolbar.tsx` from the legacy `Form` + `JsonForm` system to the new TanStack-based `AutoSaveField`.

The old implementation used a `JsonFormObject` config array inside a `saveOnBlur` `Form` wrapper. The new implementation uses `AutoSaveField` with an inline `mutationFn` that replicates the original `getData: data => ({options: data})` transform, and a simple `onSuccess` toast in place of `formatMessageValue: false`.

Access control (`project:write`) is enforced by passing `disabled={!hasAccess}` to `field.TextArea` via `hasEveryAccess`, matching the behavior of the original `<JsonForm disabled={!hasAccess}>`. The existing `ProjectPermissionAlert` continues to show the warning banner for users without write access.

A `FormSearch` wrapper is added so the Allowed Origins field is discoverable via settings search, and `generatedFieldRegistry.ts` is updated via `extract-form-fields` to register the new entry (`project-toolbar.sentry:toolbar_allowed_origins`).

The spec file covers: initial value rendering, API submission shape (`{options: {sentry:toolbar_allowed_origins: value}}`), and empty/undefined options handling.