### PR TITLE
test(ui): Switch hook tests to use renderHookWithProviders

### DIFF
--- a/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctionTrends.spec.tsx
@@ -1,41 +1,19 @@
-import {useMemo} from 'react';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useProfileFunctionTrends} from 'sentry/utils/profiling/hooks/useProfileFunctionTrends';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-function TestContext({children}: {children: React.ReactNode}) {
-  const {organization} = useMemo(() => initializeOrg(), []);
-
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useProfileFunctionTrendss', () => {
-  afterEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('initializes with the loading state', () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/profiling/function-trends/',
       body: {data: []},
     });
 
-    const hook = renderHook(
-      () =>
-        useProfileFunctionTrends({
-          trendFunction: 'p95()',
-          trendType: 'regression',
-        }),
-      {wrapper: TestContext}
+    const hook = renderHookWithProviders(() =>
+      useProfileFunctionTrends({
+        trendFunction: 'p95()',
+        trendType: 'regression',
+      })
     );
     expect(hook.result.current).toMatchObject(
       expect.objectContaining({
@@ -50,13 +28,11 @@ describe('useProfileFunctionTrendss', () => {
       body: {data: []},
     });
 
-    const hook = renderHook(
-      () =>
-        useProfileFunctionTrends({
-          trendFunction: 'p95()',
-          trendType: 'regression',
-        }),
-      {wrapper: TestContext}
+    const hook = renderHookWithProviders(() =>
+      useProfileFunctionTrends({
+        trendFunction: 'p95()',
+        trendType: 'regression',
+      })
     );
     expect(hook.result.current.isPending).toBe(true);
     expect(hook.result.current.isFetched).toBe(false);

--- a/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
+++ b/static/app/utils/replays/hooks/useLoadReplayReader.spec.tsx
@@ -1,28 +1,21 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import useLoadReplayReader from 'sentry/utils/replays/hooks/useLoadReplayReader';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/replays/hooks/useReplayData', () => ({
   __esModule: true,
   default: () => jest.fn().mockReturnValue({}),
 }));
 
-const {organization, project} = initializeOrg();
-
-const wrapper = ({children}: {children?: React.ReactNode}) => (
-  <OrganizationContext value={organization}>{children}</OrganizationContext>
-);
+const organization = OrganizationFixture();
+const project = ProjectFixture();
 
 describe('useLoadReplayReader', () => {
-  beforeEach(() => {
-    MockApiClient.clearMockResponses();
-  });
-
   it('should accept a replaySlug with project and id parts', () => {
-    const {result} = renderHook(useLoadReplayReader, {
-      wrapper,
+    const {result} = renderHookWithProviders(useLoadReplayReader, {
       initialProps: {
         orgSlug: organization.slug,
         replaySlug: `${project.slug}:123`,
@@ -37,8 +30,7 @@ describe('useLoadReplayReader', () => {
   });
 
   it('should accept a replaySlug with only the replay-id', () => {
-    const {result} = renderHook(useLoadReplayReader, {
-      wrapper,
+    const {result} = renderHookWithProviders(useLoadReplayReader, {
       initialProps: {
         orgSlug: organization.slug,
         replaySlug: `123`,

--- a/static/app/utils/replays/hooks/usePollReplayRecord.spec.tsx
+++ b/static/app/utils/replays/hooks/usePollReplayRecord.spec.tsx
@@ -1,34 +1,18 @@
-import {type ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import type {HydratedReplayRecord} from 'sentry/views/replays/types';
 
 import usePollReplayRecord from './usePollReplayRecord';
 
-const {organization, project} = initializeOrg();
-
-const invalidateQueries = jest.fn();
-
-function wrapper({children}: {children?: ReactNode}) {
-  const queryClient = makeTestQueryClient();
-  queryClient.invalidateQueries = invalidateQueries;
-  return (
-    <QueryClientProvider client={queryClient}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
+const organization = OrganizationFixture();
 
 function replayRecordFixture(replayRecord?: Partial<HydratedReplayRecord>) {
   return ReplayRecordFixture({
     ...replayRecord,
-    project_id: project.id,
+    project_id: '1',
   });
 }
 
@@ -36,7 +20,6 @@ jest.useFakeTimers();
 
 describe('usePollReplayRecord', () => {
   beforeEach(() => {
-    invalidateQueries();
     MockApiClient.clearMockResponses();
   });
   it('should fetch count_segments', async () => {
@@ -50,8 +33,7 @@ describe('usePollReplayRecord', () => {
       body: {data: replayRecord},
     });
 
-    const renderedPollHook = renderHook(usePollReplayRecord, {
-      wrapper,
+    const renderedPollHook = renderHookWithProviders(usePollReplayRecord, {
       initialProps: {
         enabled: true,
         orgSlug: organization.slug,
@@ -72,8 +54,7 @@ describe('usePollReplayRecord', () => {
       body: {data: replayRecord},
     });
 
-    const renderedHook = renderHook(usePollReplayRecord, {
-      wrapper,
+    const renderedHook = renderHookWithProviders(usePollReplayRecord, {
       initialProps: {
         enabled: true,
         orgSlug: organization.slug,

--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -1,51 +1,28 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {OrganizationFixture} from 'sentry-fixture/organization';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
-
-import type {Organization} from 'sentry/types/organization';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {TraceItemAttributeProvider} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
-jest.mock('sentry/utils/useLocation');
-const mockedUsedLocation = jest.mocked(useLocation);
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>
-          <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
-            {children}
-          </TraceItemAttributeProvider>
-        </OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
+function wrapper({children}: {children?: React.ReactNode}) {
+  return (
+    <TraceItemAttributeProvider traceItemType={TraceItemDataset.SPANS} enabled>
+      {children}
+    </TraceItemAttributeProvider>
+  );
 }
 
 describe('useSortByFields', () => {
-  const organization = OrganizationFixture();
-
   beforeEach(() => {
-    MockApiClient.clearMockResponses();
-
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/trace-items/attributes/`,
       body: [],
     });
-
-    mockedUsedLocation.mockReturnValue(LocationFixture());
   });
 
   it('returns a valid list of field options in samples mode', () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSortByFields({
           fields: [
@@ -61,7 +38,7 @@ describe('useSortByFields', () => {
           mode: Mode.SAMPLES,
         }),
       {
-        wrapper: createWrapper(organization),
+        additionalWrapper: wrapper,
       }
     );
 
@@ -76,7 +53,7 @@ describe('useSortByFields', () => {
   });
 
   it('returns a valid list of field options in aggregate mode', () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSortByFields({
           fields: ['span.op', 'span.description'],
@@ -85,7 +62,7 @@ describe('useSortByFields', () => {
           mode: Mode.AGGREGATE,
         }),
       {
-        wrapper: createWrapper(organization),
+        additionalWrapper: wrapper,
       }
     );
 


### PR DESCRIPTION
Instead of declaring providers in every file, reuse the prebuilt one. Remove unused location mocks
