### PR TITLE
fix(aci): Single query in toggle_detector

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -34,8 +34,7 @@ def log_alerting_quota_hit(
 
 def toggle_detector(detector: Detector, enabled: bool) -> None:
     updated_detector_status = ObjectStatus.ACTIVE if enabled else ObjectStatus.DISABLED
-    detector.update(status=updated_detector_status)
-    detector.update(enabled=enabled)
+    detector.update(status=updated_detector_status, enabled=enabled)
 
 
 def validate_json_schema(value: Any, schema: Any) -> Any:


### PR DESCRIPTION
We're using post_save hooks to invalidate caches, so we'd like them to not run more than they need to.
Plus, one query is better than two.
