### PR TITLE
feat(slack): Add SlackMentionHandler for parsing @mentions

### DIFF
--- a/src/sentry/integrations/slack/webhooks/mention.py
+++ b/src/sentry/integrations/slack/webhooks/mention.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, TypedDict
+
+from sentry.integrations.slack.unfurl.handlers import match_link
+from sentry.integrations.slack.unfurl.types import LinkType
+
+# Slack formats URLs as <URL|label> or <URL>
+_SLACK_URL_RE = re.compile(r"<(https?://[^|>]+)(?:\|[^>]*)?>")
+
+
+class SlackMessageLink(TypedDict):
+    url: str
+    link_type: str  # LinkType.value: "issues", "metric_alert", "discover"
+    args: dict[str, Any]
+
+
+class SlackThreadMessage(TypedDict):
+    text: str
+    slack_user_id: str
+    timestamp: str
+    links: list[SlackMessageLink]
+
+
+def extract_prompt(text: str, bot_user_id: str) -> str:
+    """Remove the bot mention from text to get the user's clean prompt.
+
+    Slack app_mention events include ``<@BOT_ID>`` in the text.  We only
+    strip the bot's own mention — other user mentions are preserved as
+    they may provide useful context for Seer.
+    """
+    cleaned = re.sub(rf"<@{re.escape(bot_user_id)}>", "", text).strip()
+    # Collapse multiple spaces left by mention removal
+    return re.sub(r" {2,}", " ", cleaned)
+
+
+def extract_issue_links(text: str) -> list[tuple[int, str | None]]:
+    """Extract Sentry issue ``(group_id, event_id)`` tuples from Slack message text."""
+    urls = _SLACK_URL_RE.findall(text)
+    results: list[tuple[int, str | None]] = []
+    seen_issue_ids: set[int] = set()
+
+    for url in urls:
+        link_type, args = match_link(url)
+        if link_type == LinkType.ISSUES and args is not None:
+            issue_id: int = args["issue_id"]
+            if issue_id not in seen_issue_ids:
+                seen_issue_ids.add(issue_id)
+                results.append((issue_id, args.get("event_id")))
+
+    return results
+
+
+def build_thread_context(messages: Sequence[Mapping[str, Any]]) -> str:
+    """Build a context string from thread history for Seer Explorer."""
+    if not messages:
+        return ""
+
+    parts: list[str] = []
+    for msg in messages:
+        user = msg.get("user", "unknown")
+        text = msg.get("text", "")
+        if not text:
+            continue
+        parts.append(f"<@{user}>: {text}")
+
+    return "\n".join(parts)

--- a/tests/sentry/integrations/slack/webhooks/test_mention.py
+++ b/tests/sentry/integrations/slack/webhooks/test_mention.py
@@ -1,0 +1,140 @@
+from sentry.integrations.slack.webhooks.mention import (
+    build_thread_context,
+    extract_issue_links,
+    extract_prompt,
+)
+from sentry.testutils.cases import TestCase
+
+BOT_USER_ID = "U0BOT123"
+
+
+class ExtractPromptTest(TestCase):
+    def test_removes_bot_mention(self):
+        text = "<@U0BOT123> fix this issue"
+        assert extract_prompt(text, BOT_USER_ID) == "fix this issue"
+
+    def test_removes_bot_mention_in_middle(self):
+        text = "hey <@U0BOT123> fix this issue"
+        assert extract_prompt(text, BOT_USER_ID) == "hey fix this issue"
+
+    def test_preserves_other_user_mentions(self):
+        text = "<@U0BOT123> ask <@U0USER456> about this"
+        assert extract_prompt(text, BOT_USER_ID) == "ask <@U0USER456> about this"
+
+    def test_preserves_non_mention_content(self):
+        text = "<@U0BOT123> What is causing https://sentry.io/issues/123/ ?"
+        assert (
+            extract_prompt(text, BOT_USER_ID) == "What is causing https://sentry.io/issues/123/ ?"
+        )
+
+    def test_empty_after_mention(self):
+        text = "<@U0BOT123>"
+        assert extract_prompt(text, BOT_USER_ID) == ""
+
+    def test_no_mentions(self):
+        text = "just a regular message"
+        assert extract_prompt(text, BOT_USER_ID) == "just a regular message"
+
+    def test_collapses_extra_spaces(self):
+        text = "<@U0BOT123>  fix  this"
+        assert extract_prompt(text, BOT_USER_ID) == "fix this"
+
+    def test_preserves_slack_url_formatting(self):
+        text = "<@U0BOT123> check <https://sentry.io/issues/123/|ISSUE-123>"
+        assert (
+            extract_prompt(text, BOT_USER_ID) == "check <https://sentry.io/issues/123/|ISSUE-123>"
+        )
+
+
+class ExtractIssueLinksTest(TestCase):
+    def test_standard_issue_url(self):
+        text = "check <https://sentry.io/organizations/test-org/issues/456/|ISSUE-456>"
+        result = extract_issue_links(text)
+        assert result == [(456, None)]
+
+    def test_issue_url_with_event(self):
+        text = "see <https://sentry.io/organizations/test-org/issues/789/events/abc123/|link>"
+        result = extract_issue_links(text)
+        assert result == [(789, "abc123")]
+
+    def test_customer_domain_issue_url(self):
+        text = "look at <https://test-org.sentry.io/issues/321/|issue>"
+        result = extract_issue_links(text)
+        assert result == [(321, None)]
+
+    def test_multiple_issue_urls(self):
+        text = (
+            "<https://sentry.io/organizations/test-org/issues/111/|one> "
+            "and <https://sentry.io/organizations/test-org/issues/222/|two>"
+        )
+        result = extract_issue_links(text)
+        assert result == [(111, None), (222, None)]
+
+    def test_deduplicates_same_issue(self):
+        text = (
+            "<https://sentry.io/organizations/test-org/issues/111/|first> "
+            "<https://sentry.io/organizations/test-org/issues/111/|second>"
+        )
+        result = extract_issue_links(text)
+        assert result == [(111, None)]
+
+    def test_no_issue_urls(self):
+        text = "no links here, just text"
+        assert extract_issue_links(text) == []
+
+    def test_ignores_non_issue_urls(self):
+        text = "<https://google.com|Google> and <https://sentry.io/organizations/test-org/issues/999/|issue>"
+        result = extract_issue_links(text)
+        assert result == [(999, None)]
+
+    def test_plain_url_without_label(self):
+        text = "<https://sentry.io/organizations/test-org/issues/555/>"
+        result = extract_issue_links(text)
+        assert result == [(555, None)]
+
+    def test_ignores_metric_alert_urls(self):
+        text = "<https://sentry.io/organizations/test-org/alerts/rules/details/42/|alert>"
+        assert extract_issue_links(text) == []
+
+
+class BuildThreadContextTest(TestCase):
+    def test_single_message(self):
+        messages = [{"user": "U123", "text": "hello world", "ts": "1234567890.000001"}]
+        result = build_thread_context(messages)
+        assert result == "<@U123>: hello world"
+
+    def test_multiple_messages(self):
+        messages = [
+            {"user": "U123", "text": "first message", "ts": "1234567890.000001"},
+            {"user": "U456", "text": "second message", "ts": "1234567890.000002"},
+        ]
+        result = build_thread_context(messages)
+        assert result == "<@U123>: first message\n<@U456>: second message"
+
+    def test_empty_messages(self):
+        assert build_thread_context([]) == ""
+
+    def test_skips_empty_text(self):
+        messages = [
+            {"user": "U123", "text": "hello", "ts": "1234567890.000001"},
+            {"user": "U456", "text": "", "ts": "1234567890.000002"},
+            {"user": "U789", "text": "world", "ts": "1234567890.000003"},
+        ]
+        result = build_thread_context(messages)
+        assert result == "<@U123>: hello\n<@U789>: world"
+
+    def test_missing_user_defaults_to_unknown(self):
+        messages = [{"text": "orphan message", "ts": "1234567890.000001"}]
+        result = build_thread_context(messages)
+        assert result == "<@unknown>: orphan message"
+
+    def test_preserves_urls_in_text(self):
+        messages = [
+            {
+                "user": "U123",
+                "text": "check <https://sentry.io/organizations/test-org/issues/123/|ISSUE-123>",
+                "ts": "1234567890.000001",
+            }
+        ]
+        result = build_thread_context(messages)
+        assert "<https://sentry.io/organizations/test-org/issues/123/|ISSUE-123>" in result


### PR DESCRIPTION
## Summary
- Add `extract_prompt()` to strip the bot's `<@BOT_ID>` mention from Slack message text while preserving other user mentions as context for Seer
- Add `extract_issue_links()` to extract `(group_id, event_id)` tuples by reusing existing unfurl regex patterns from `unfurl/issues.py`
- Add `build_thread_context()` to format Slack `conversations.replies` messages into a readable transcript for Seer Explorer

ISWF-2019