### PR TITLE
fix(aci): Use types to ensure migration helpers aren't modifying input data

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/issue_alert_conditions.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, Mapping
 
 from sentry.notifications.types import AssigneeTargetType
 from sentry.rules.age import AgeComparisonType
@@ -19,7 +19,7 @@ class DataConditionKwargs:
 
 
 def create_every_event_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.EVERY_EVENT,
@@ -30,7 +30,7 @@ def create_every_event_data_condition(
 
 
 def create_escalating_event_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.REAPPEARED_EVENT,
@@ -41,7 +41,7 @@ def create_escalating_event_data_condition(
 
 
 def create_regression_event_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.REGRESSION_EVENT,
@@ -52,7 +52,7 @@ def create_regression_event_data_condition(
 
 
 def create_existing_high_priority_issue_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.EXISTING_HIGH_PRIORITY_ISSUE,
@@ -63,7 +63,7 @@ def create_existing_high_priority_issue_data_condition(
 
 
 def create_event_attribute_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {
         "match": data["match"],
@@ -81,7 +81,7 @@ def create_event_attribute_data_condition(
 
 
 def create_first_seen_event_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.FIRST_SEEN_EVENT,
@@ -92,7 +92,7 @@ def create_first_seen_event_data_condition(
 
 
 def create_new_high_priority_issue_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.NEW_HIGH_PRIORITY_ISSUE,
@@ -103,7 +103,7 @@ def create_new_high_priority_issue_data_condition(
 
 
 def create_level_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {"match": data["match"], "level": int(data["level"])}
 
@@ -116,7 +116,7 @@ def create_level_data_condition(
 
 
 def create_tagged_event_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {
         "match": data["match"],
@@ -134,7 +134,7 @@ def create_tagged_event_data_condition(
 
 
 def create_age_comparison_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison_type = AgeComparisonType(data["comparison_type"])
     value = int(data["value"])
@@ -162,7 +162,7 @@ def create_age_comparison_data_condition(
 
 
 def create_assigned_to_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {
         "target_type": data["targetType"],
@@ -180,7 +180,7 @@ def create_assigned_to_data_condition(
 
 
 def create_issue_category_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {
         "value": int(data["value"]),
@@ -201,7 +201,7 @@ def create_issue_category_data_condition(
 
 
 def create_issue_type_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison: dict[str, Any] = {
         "value": str(data["value"]),
@@ -222,7 +222,7 @@ def create_issue_type_data_condition(
 
 
 def create_issue_occurrences_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {"value": max(int(data["value"]), 0)}
 
@@ -235,7 +235,7 @@ def create_issue_occurrences_data_condition(
 
 
 def create_latest_release_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     return DataConditionKwargs(
         type=Condition.LATEST_RELEASE,
@@ -246,7 +246,7 @@ def create_latest_release_data_condition(
 
 
 def create_latest_adopted_release_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     comparison = {
         "release_age_type": data["oldest_or_newest"],
@@ -263,7 +263,7 @@ def create_latest_adopted_release_data_condition(
 
 def create_base_event_frequency_data_condition(
     value: int | float,
-    data: dict[str, Any],
+    data: Mapping[str, Any],
     dcg: DataConditionGroup,
     count_type: Condition,
     percent_type: Condition,
@@ -294,7 +294,7 @@ def create_base_event_frequency_data_condition(
 
 
 def create_event_frequency_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     value = int(data["value"])
     return create_base_event_frequency_data_condition(
@@ -307,7 +307,7 @@ def create_event_frequency_data_condition(
 
 
 def create_event_unique_user_frequency_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     value = int(data["value"])
     return create_base_event_frequency_data_condition(
@@ -320,7 +320,7 @@ def create_event_unique_user_frequency_data_condition(
 
 
 def create_percent_sessions_data_condition(
-    data: dict[str, Any], dcg: DataConditionGroup
+    data: Mapping[str, Any], dcg: DataConditionGroup
 ) -> DataConditionKwargs:
     value = float(data["value"])
     return create_base_event_frequency_data_condition(
@@ -333,7 +333,7 @@ def create_percent_sessions_data_condition(
 
 
 def create_event_unique_user_frequency_condition_with_conditions(
-    data: dict[str, Any], dcg: DataConditionGroup, conditions: list[dict[str, Any]] | None = None
+    data: Mapping[str, Any], dcg: DataConditionGroup, conditions: list[dict[str, Any]] | None = None
 ) -> DataCondition:
     comparison_type = data.get("comparisonType", ComparisonType.COUNT)
     comparison_type = ComparisonType(comparison_type)
@@ -384,7 +384,7 @@ def create_event_unique_user_frequency_condition_with_conditions(
 
 
 data_condition_translator_mapping: dict[
-    str, Callable[[dict[str, Any], Any], DataConditionKwargs]
+    str, Callable[[Mapping[str, Any], Any], DataConditionKwargs]
 ] = {
     "sentry.rules.conditions.every_event.EveryEventCondition": create_every_event_data_condition,
     "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": create_escalating_event_data_condition,
@@ -411,7 +411,7 @@ data_condition_translator_mapping: dict[
 }
 
 
-def translate_to_data_condition(data: dict[str, Any], dcg: DataConditionGroup) -> DataCondition:
+def translate_to_data_condition(data: Mapping[str, Any], dcg: DataConditionGroup) -> DataCondition:
     translator = data_condition_translator_mapping.get(data["id"])
     if not translator:
         raise ValueError(f"Unsupported condition: {data['id']}")

--- a/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_assigned_to_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -10,7 +12,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestAssignedToCondition(ConditionTestCase):
     condition = Condition.ASSIGNED_TO
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": AssignedToFilter.id,
         "targetType": "Member",
         "targetIdentifier": 0,

--- a/tests/sentry/workflow_engine/handlers/condition/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_base.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any
+from typing import Any, Mapping
 from uuid import uuid4
 
 from sentry.issues.grouptype import PerformanceNPlusOneGroupType
@@ -20,7 +20,7 @@ class ConditionTestCase(BaseWorkflowTest):
         self.group, self.event, self.group_event = self.create_group_event()
 
     def translate_to_data_condition(
-        self, data: dict[str, Any], dcg: DataConditionGroup
+        self, data: Mapping[str, Any], dcg: DataConditionGroup
     ) -> DataCondition:
         data_condition = dual_write_condition(data, dcg)
         data_condition.save()

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_attribute_handler.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,7 +16,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestEventAttributeCondition(ConditionTestCase):
     condition = Condition.EVENT_ATTRIBUTE
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": EventAttributeCondition.id,
         "match": MatchType.EQUAL,
         "value": "php",
@@ -160,9 +160,11 @@ class TestEventAttributeCondition(ConditionTestCase):
         assert dc.condition_group == dcg
 
     def test_dual_write_filter(self) -> None:
-        self.payload["id"] = EventAttributeFilter.id
+        payload_copy = dict(self.payload)
+        payload_copy["id"] = EventAttributeFilter.id
+
         dcg = self.create_data_condition_group()
-        dc = self.translate_to_data_condition(self.payload, dcg)
+        dc = self.translate_to_data_condition(payload_copy, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_existing_high_priority_issue_handler.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from typing import Any, Mapping
 
 import pytest
 from jsonschema import ValidationError
@@ -13,7 +14,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestExistingHighPriorityIssueCondition(ConditionTestCase):
     condition = Condition.EXISTING_HIGH_PRIORITY_ISSUE
-    payload = {"id": ExistingHighPriorityIssueCondition.id}
+    payload: Mapping[str, Any] = {"id": ExistingHighPriorityIssueCondition.id}
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_first_seen_event_handler.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from typing import Any, Mapping
 
 import pytest
 from jsonschema import ValidationError
@@ -12,7 +13,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestFirstSeenEventCondition(ConditionTestCase):
     condition = Condition.FIRST_SEEN_EVENT
-    payload = {"id": FirstSeenEventCondition.id}
+    payload: Mapping[str, Any] = {"id": FirstSeenEventCondition.id}
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -1,3 +1,4 @@
+from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestIssueCategoryCondition(ConditionTestCase):
     condition = Condition.ISSUE_CATEGORY
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": IssueCategoryFilter.id,
         "value": "1",
     }

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_occurrences_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -11,7 +13,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestIssueOccurrencesCondition(ConditionTestCase):
     condition = Condition.ISSUE_OCCURRENCES
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": IssueOccurrencesFilter.id,
         "value": "10",
     }
@@ -41,7 +43,7 @@ class TestIssueOccurrencesCondition(ConditionTestCase):
 
     def test_dual_write__min_zero(self) -> None:
         dcg = self.create_data_condition_group()
-        local_payload = self.payload.copy()
+        local_payload = dict(self.payload)
         local_payload["value"] = "-10"
         dc = self.translate_to_data_condition(local_payload, dcg)
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_adopted_release_handler.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,7 +21,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestLatestAdoptedReleaseCondition(ConditionTestCase):
     condition = Condition.LATEST_ADOPTED_RELEASE
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": LatestAdoptedReleaseFilter.id,
         "oldest_or_newest": "oldest",
         "older_or_newer": "newer",

--- a/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_latest_release_handler.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from typing import Any, Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -17,7 +18,7 @@ pytestmark = [requires_snuba, pytest.mark.sentry_metrics]
 
 class TestLatestReleaseCondition(ConditionTestCase):
     condition = Condition.LATEST_RELEASE
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": LatestReleaseFilter.id,
     }
 

--- a/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_level_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -11,7 +13,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestLevelCondition(ConditionTestCase):
     condition = Condition.LEVEL
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": LevelCondition.id,
         "match": MatchType.EQUAL,
         "level": "20",
@@ -45,9 +47,10 @@ class TestLevelCondition(ConditionTestCase):
         assert dc.condition_group == dcg
 
     def test_dual_write_filter(self) -> None:
-        self.payload["id"] = LevelFilter.id
+        payload_copy = dict(self.payload)
+        payload_copy["id"] = LevelFilter.id
         dcg = self.create_data_condition_group()
-        dc = self.translate_to_data_condition(self.payload, dcg)
+        dc = self.translate_to_data_condition(payload_copy, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {

--- a/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_new_high_priority_issue_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -11,7 +13,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestNewHighPriorityIssueCondition(ConditionTestCase):
     condition = Condition.NEW_HIGH_PRIORITY_ISSUE
-    payload = {"id": NewHighPriorityIssueCondition.id}
+    payload: Mapping[str, Any] = {"id": NewHighPriorityIssueCondition.id}
 
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_reappeared_event_handler.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+from typing import Any, Mapping
 
 import pytest
 from jsonschema import ValidationError
@@ -11,7 +12,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestReappearedEventCondition(ConditionTestCase):
     condition = Condition.REAPPEARED_EVENT
-    payload = {"id": ReappearedEventCondition.id}
+    payload: Mapping[str, Any] = {"id": ReappearedEventCondition.id}
 
     def test_dual_write(self) -> None:
         dcg = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_regression_event_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -10,7 +12,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestRegressionEventCondition(ConditionTestCase):
     condition = Condition.REGRESSION_EVENT
-    payload = {"id": RegressionEventCondition.id}
+    payload: Mapping[str, Any] = {"id": RegressionEventCondition.id}
 
     def test_dual_write(self) -> None:
         dcg = self.create_data_condition_group()

--- a/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_tagged_event_handler.py
@@ -1,3 +1,5 @@
+from typing import Any, Mapping
+
 import pytest
 from jsonschema import ValidationError
 
@@ -12,7 +14,7 @@ from tests.sentry.workflow_engine.handlers.condition.test_base import ConditionT
 
 class TestTaggedEventCondition(ConditionTestCase):
     condition = Condition.TAGGED_EVENT
-    payload = {
+    payload: Mapping[str, Any] = {
         "id": TaggedEventCondition.id,
         "match": MatchType.EQUAL,
         "key": "LOGGER",
@@ -71,9 +73,10 @@ class TestTaggedEventCondition(ConditionTestCase):
         assert dc.condition_group == dcg
 
     def test_dual_write_filter(self) -> None:
-        self.payload["id"] = TaggedEventFilter.id
+        payload_copy = dict(self.payload)
+        payload_copy["id"] = TaggedEventFilter.id
         dcg = self.create_data_condition_group()
-        dc = self.translate_to_data_condition(self.payload, dcg)
+        dc = self.translate_to_data_condition(payload_copy, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {
@@ -84,13 +87,13 @@ class TestTaggedEventCondition(ConditionTestCase):
         assert dc.condition_result is True
         assert dc.condition_group == dcg
 
-        self.payload = {
+        other_payload = {
             "id": TaggedEventFilter.id,
             "match": MatchType.IS_SET,
             "key": "logger",
         }
         dcg = self.create_data_condition_group()
-        dc = self.translate_to_data_condition(self.payload, dcg)
+        dc = self.translate_to_data_condition(other_payload, dcg)
 
         assert dc.type == self.condition
         assert dc.comparison == {


### PR DESCRIPTION
We had test flakes from tests modifying our class-level input dict; this was fixed, but to ensure it doesn't happen again, we make the input dict a Mapping and ensure the code using it works with Mapping.