### PR TITLE
feat(preprod): Add odiff server wrapper and Dockerfile binary install

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -84,6 +84,7 @@ const config: KnipConfig = {
     '@babel/preset-react', // Still used in jest
     '@babel/preset-typescript', // Still used in jest
     '@emotion/babel-plugin', // Still used in jest
+    'odiff-bin', // raw binary consumed by Python backend, not a JS import
   ],
   rules: {
     binaries: 'off',

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
     "jest-fail-on-console": "3.3.1",
     "jest-junit": "16.0.0",
     "knip": "5.83.1",
+    "odiff-bin": "^4.3.2",
     "postcss-styled-syntax": "0.7.0",
     "react-refresh": "0.18.0",
     "stylelint": "16.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       knip:
         specifier: 5.83.1
         version: 5.83.1(@types/node@22.15.21)(typescript@5.9.3)
+      odiff-bin:
+        specifier: ^4.3.2
+        version: 4.3.2
       postcss-styled-syntax:
         specifier: 0.7.0
         version: 0.7.0(postcss@8.5.3)
@@ -7334,6 +7337,10 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
+  odiff-bin@4.3.2:
+    resolution: {integrity: sha512-irdWCW/b/b4aQiEfwNolbS0ZYUe2PAK6BKPt9Orzz3mGlko7ZqmEB1oDwCTAd2TQe3RmTpnePyd77xJzvWJHYQ==}
+    hasBin: true
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -17643,6 +17650,8 @@ snapshots:
       es-object-atoms: 1.0.0
 
   obuf@1.1.2: {}
+
+  odiff-bin@4.3.2: {}
 
   on-finished@2.4.1:
     dependencies:

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -10,6 +10,9 @@ ADD --chmod=755 \
     https://github.com/dmtrKovalenko/odiff/releases/download/v4.3.2/odiff-linux-arm64 \
     /odiff
 
+ARG TARGETARCH
+FROM odiff-${TARGETARCH} AS odiff
+
 FROM python:3.13.1-slim-bookworm
 
 LABEL maintainer="oss@sentry.io"
@@ -32,8 +35,7 @@ RUN : \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG TARGETARCH
-COPY --from=odiff-${TARGETARCH} /odiff /usr/local/bin/odiff
+COPY --from=odiff /odiff /usr/local/bin/odiff
 
 WORKDIR /usr/src/sentry
 

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -1,3 +1,15 @@
+FROM scratch AS odiff-amd64
+ADD --chmod=755 \
+    --checksum=sha256:2c17e6bcf92a58e6668f19f17f4a27fa4b1d70840994f31bd837b55bb6b297d7 \
+    https://github.com/dmtrKovalenko/odiff/releases/download/v4.3.2/odiff-linux-x64 \
+    /odiff
+
+FROM scratch AS odiff-arm64
+ADD --chmod=755 \
+    --checksum=sha256:d65f748c463a6aa78fa7bcdd31acd797eaed5160867e7769a3b291cfea42c9a0 \
+    https://github.com/dmtrKovalenko/odiff/releases/download/v4.3.2/odiff-linux-arm64 \
+    /odiff
+
 FROM python:3.13.1-slim-bookworm
 
 LABEL maintainer="oss@sentry.io"
@@ -19,6 +31,9 @@ RUN : \
         tini \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+ARG TARGETARCH
+COPY --from=odiff-${TARGETARCH} /odiff /usr/local/bin/odiff
 
 WORKDIR /usr/src/sentry
 
@@ -45,7 +60,6 @@ RUN set -x \
   && buildDeps=" \
   gcc \
   libpcre2-dev \
-  wget \
   zlib1g-dev \
   " \
   && apt-get update \

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import select
 import shutil
 import subprocess
@@ -53,19 +52,9 @@ class OdiffServer:
     def __exit__(self, *args: object) -> None:
         self.close()
 
-    def _read_json(
-        self, line: bytes, process: subprocess.Popen[bytes] | None = None
-    ) -> dict[str, Any]:
+    def _read_json(self, line: bytes) -> dict[str, Any]:
         if not line:
-            proc = process or self._process
-            stderr = b""
-            if proc and proc.stderr:
-                readable, _, _ = select.select([proc.stderr], [], [], 5)
-                if readable:
-                    stderr = os.read(proc.stderr.fileno(), 4096)
-            raise RuntimeError(
-                f"odiff server exited unexpectedly: {stderr.decode(errors='replace')}"
-            )
+            raise RuntimeError("odiff server exited unexpectedly")
         try:
             return json.loads(line)
         except JSONDecodeError as e:
@@ -88,7 +77,7 @@ class OdiffServer:
             [binary, "--server"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
         try:
@@ -96,7 +85,7 @@ class OdiffServer:
             if not readable:
                 raise RuntimeError("odiff server timed out waiting for ready message")
             line = proc.stdout.readline()  # type: ignore[union-attr]
-            ready = self._read_json(line, proc)
+            ready = self._read_json(line)
             if not ready.get("ready"):
                 raise RuntimeError("odiff server failed to start")
         except BaseException:

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -11,24 +11,15 @@ from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
 
-def _find_repo_root() -> Path:
+def _find_odiff_binary() -> str:
+    candidates: list[Path] = []
     current = Path(__file__).resolve()
     for parent in current.parents:
         if (parent / "pyproject.toml").exists():
-            return parent
-    raise FileNotFoundError("Could not find repository root")
-
-
-_REPO_ROOT = _find_repo_root()
-
-_BINARY_CANDIDATES = [
-    _REPO_ROOT / "node_modules" / ".bin" / "odiff",
-    Path("/usr/local/bin/odiff"),
-]
-
-
-def _find_odiff_binary() -> str:
-    for candidate in _BINARY_CANDIDATES:
+            candidates.append(parent / "node_modules" / ".bin" / "odiff")
+            break
+    candidates.append(Path("/usr/local/bin/odiff"))
+    for candidate in candidates:
         if candidate.exists():
             return str(candidate)
     found = shutil.which("odiff")

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -6,8 +6,8 @@ import shutil
 import subprocess
 import threading
 from pathlib import Path
-from typing import Any
 
+from sentry.preprod.snapshots.image_diff.types import OdiffResponse
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
@@ -54,13 +54,17 @@ class OdiffServer:
     def __exit__(self, *args: object) -> None:
         self.close()
 
-    def _read_json(self, line: bytes) -> dict[str, Any]:
+    def _read_json(self, line: bytes) -> dict[str, object]:
         if not line:
             raise RuntimeError("odiff server exited unexpectedly")
         try:
             return json.loads(line)
         except JSONDecodeError as e:
             raise RuntimeError(f"odiff server returned invalid JSON: {line!r}") from e
+
+    def _read_response(self, line: bytes) -> OdiffResponse:
+        data = self._read_json(line)
+        return OdiffResponse.parse_obj(data)
 
     def _kill_process(self) -> None:
         proc = self._process
@@ -105,7 +109,7 @@ class OdiffServer:
         compare_path: str | Path,
         output_path: str | Path,
         **options: object,
-    ) -> dict[str, Any]:
+    ) -> OdiffResponse:
         with self._lock:
             if self._process is None:
                 self._start()
@@ -136,13 +140,13 @@ class OdiffServer:
                 raise RuntimeError("odiff server timed out after 30s")
             line = process.stdout.readline()
             try:
-                response = self._read_json(line)
+                response = self._read_response(line)
             except RuntimeError:
                 self._kill_process()
                 raise
 
-        if "error" in response:
-            raise RuntimeError(f"odiff error: {response['error']}")
+        if response.error:
+            raise RuntimeError(f"odiff error: {response.error}")
 
         return response
 

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import select
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+from sentry.utils import json
+from sentry.utils.json import JSONDecodeError
+
+
+def _find_repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise FileNotFoundError("Could not find repository root")
+
+
+_REPO_ROOT = _find_repo_root()
+
+_BINARY_CANDIDATES = [
+    _REPO_ROOT / "node_modules" / ".bin" / "odiff",
+    Path("/usr/local/bin/odiff"),
+]
+
+
+def _find_odiff_binary() -> str:
+    for candidate in _BINARY_CANDIDATES:
+        if candidate.exists():
+            return str(candidate)
+    found = shutil.which("odiff")
+    if found:
+        return found
+    raise FileNotFoundError("odiff binary not found. Run 'pnpm install' to install odiff-bin.")
+
+
+class OdiffServer:
+    def __init__(self) -> None:
+        self._process: subprocess.Popen[bytes] | None = None
+        self._request_id = 0
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> OdiffServer:
+        self._start()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def _read_json(
+        self, line: bytes, process: subprocess.Popen[bytes] | None = None
+    ) -> dict[str, Any]:
+        if not line:
+            proc = process or self._process
+            stderr = proc.stderr.read() if proc and proc.stderr else b""
+            raise RuntimeError(
+                f"odiff server exited unexpectedly: {stderr.decode(errors='replace')}"
+            )
+        try:
+            return json.loads(line)
+        except JSONDecodeError as e:
+            raise RuntimeError(f"odiff server returned invalid JSON: {line!r}") from e
+
+    def _start(self) -> None:
+        binary = _find_odiff_binary()
+        proc = subprocess.Popen(
+            [binary, "--server"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            line = proc.stdout.readline()  # type: ignore[union-attr]
+            ready = self._read_json(line, proc)
+            if not ready.get("ready"):
+                raise RuntimeError("odiff server failed to start")
+        except BaseException:
+            proc.kill()
+            proc.wait()
+            raise
+        self._process = proc
+
+    def compare(
+        self,
+        base_path: str | Path,
+        compare_path: str | Path,
+        output_path: str | Path,
+        **options: object,
+    ) -> dict[str, Any]:
+        with self._lock:
+            if self._process is None:
+                self._start()
+
+            process = self._process
+            if process is None or process.stdin is None or process.stdout is None:
+                raise RuntimeError("odiff server failed to initialize")
+            self._request_id += 1
+            request: dict[str, object] = {
+                "requestId": self._request_id,
+                "base": str(base_path),
+                "compare": str(compare_path),
+                "output": str(output_path),
+            }
+            if options:
+                request["options"] = options
+
+            try:
+                process.stdin.write(json.dumps(request).encode() + b"\n")
+                process.stdin.flush()
+            except (BrokenPipeError, OSError) as e:
+                process.kill()
+                process.wait()
+                self._process = None
+                raise RuntimeError("odiff process died unexpectedly") from e
+
+            readable, _, _ = select.select([process.stdout], [], [], 30)
+            if not readable:
+                process.kill()
+                process.wait()
+                self._process = None
+                raise RuntimeError("odiff server timed out after 30s")
+            line = process.stdout.readline()
+            try:
+                response = self._read_json(line)
+            except RuntimeError:
+                process.kill()
+                process.wait()
+                self._process = None
+                raise
+
+        if "error" in response:
+            raise RuntimeError(f"odiff error: {response['error']}")
+
+        return response
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._process:
+                return
+            proc = self._process
+            self._process = None
+
+        if proc.stdin:
+            try:
+                proc.stdin.close()
+            except OSError:
+                pass
+        try:
+            proc.wait(timeout=3)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+            return
+        except subprocess.TimeoutExpired:
+            pass
+        proc.kill()
+        proc.wait()
+
+    def __del__(self) -> None:
+        self.close()

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -174,6 +174,3 @@ class OdiffServer:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             pass
-
-    def __del__(self) -> None:
-        self.close()

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -55,7 +55,11 @@ class OdiffServer:
     ) -> dict[str, Any]:
         if not line:
             proc = process or self._process
-            stderr = proc.stderr.read() if proc and proc.stderr else b""
+            stderr = b""
+            if proc and proc.stderr:
+                readable, _, _ = select.select([proc.stderr], [], [], 5)
+                if readable:
+                    stderr = proc.stderr.read()
             raise RuntimeError(
                 f"odiff server exited unexpectedly: {stderr.decode(errors='replace')}"
             )

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -74,6 +74,9 @@ class OdiffServer:
             start_new_session=True,
         )
         try:
+            readable, _, _ = select.select([proc.stdout], [], [], 30)
+            if not readable:
+                raise RuntimeError("odiff server timed out waiting for ready message")
             line = proc.stdout.readline()  # type: ignore[union-attr]
             ready = self._read_json(line, proc)
             if not ready.get("ready"):
@@ -113,14 +116,20 @@ class OdiffServer:
                 process.stdin.flush()
             except (BrokenPipeError, OSError) as e:
                 process.kill()
-                process.wait()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
                 self._process = None
                 raise RuntimeError("odiff process died unexpectedly") from e
 
             readable, _, _ = select.select([process.stdout], [], [], 30)
             if not readable:
                 process.kill()
-                process.wait()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
                 self._process = None
                 raise RuntimeError("odiff server timed out after 30s")
             line = process.stdout.readline()
@@ -128,7 +137,10 @@ class OdiffServer:
                 response = self._read_json(line)
             except RuntimeError:
                 process.kill()
-                process.wait()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
                 self._process = None
                 raise
 

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import select
 import shutil
 import subprocess
@@ -10,18 +11,28 @@ from typing import Any
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
+ODIFF_PLATFORM_SUFFIXES = {
+    ("arm64", "Darwin"): "macos-arm64",
+    ("aarch64", "Darwin"): "macos-arm64",
+    ("x86_64", "Darwin"): "macos-x64",
+    ("x86_64", "Linux"): "linux-x64",
+    ("aarch64", "Linux"): "linux-arm64",
+    ("arm64", "Linux"): "linux-arm64",
+}
+
 
 def _find_odiff_binary() -> str:
-    candidates: list[Path] = []
+    suffix = ODIFF_PLATFORM_SUFFIXES.get((platform.machine(), platform.system()))
+
     current = Path(__file__).resolve()
     for parent in current.parents:
         if (parent / "pyproject.toml").exists():
-            candidates.append(parent / "node_modules" / ".bin" / "odiff")
+            if suffix:
+                raw = parent / "node_modules" / "odiff-bin" / "raw_binaries" / f"odiff-{suffix}"
+                if raw.exists():
+                    return str(raw)
             break
-    candidates.append(Path("/usr/local/bin/odiff"))
-    for candidate in candidates:
-        if candidate.exists():
-            return str(candidate)
+
     found = shutil.which("odiff")
     if found:
         return found

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from sentry.preprod.snapshots.image_diff.types import OdiffResponse
 from sentry.utils import json
-from sentry.utils.json import JSONDecodeError
 
 ODIFF_PLATFORM_SUFFIXES = {
     ("arm64", "Darwin"): "macos-arm64",
@@ -54,17 +53,10 @@ class OdiffServer:
     def __exit__(self, *args: object) -> None:
         self.close()
 
-    def _read_json(self, line: bytes) -> dict[str, object]:
+    def _read_response(self, line: bytes) -> OdiffResponse:
         if not line:
             raise RuntimeError("odiff server exited unexpectedly")
-        try:
-            return json.loads(line)
-        except JSONDecodeError as e:
-            raise RuntimeError(f"odiff server returned invalid JSON: {line!r}") from e
-
-    def _read_response(self, line: bytes) -> OdiffResponse:
-        data = self._read_json(line)
-        return OdiffResponse.parse_obj(data)
+        return OdiffResponse.parse_obj(json.loads(line))
 
     def _kill_process(self) -> None:
         proc = self._process
@@ -91,7 +83,7 @@ class OdiffServer:
             if not readable:
                 raise RuntimeError("odiff server timed out waiting for ready message")
             line = proc.stdout.readline()  # type: ignore[union-attr]
-            ready = self._read_json(line)
+            ready = json.loads(line)
             if not ready.get("ready"):
                 raise RuntimeError("odiff server failed to start")
         except BaseException:

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import select
 import shutil
 import subprocess
@@ -61,7 +62,7 @@ class OdiffServer:
             if proc and proc.stderr:
                 readable, _, _ = select.select([proc.stderr], [], [], 5)
                 if readable:
-                    stderr = proc.stderr.read()
+                    stderr = os.read(proc.stderr.fileno(), 4096)
             raise RuntimeError(
                 f"odiff server exited unexpectedly: {stderr.decode(errors='replace')}"
             )

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -44,7 +44,9 @@ class OdiffServer:
         self._lock = threading.Lock()
 
     def __enter__(self) -> OdiffServer:
-        self._start()
+        with self._lock:
+            if self._process is None:
+                self._start()
         return self
 
     def __exit__(self, *args: object) -> None:
@@ -68,6 +70,17 @@ class OdiffServer:
         except JSONDecodeError as e:
             raise RuntimeError(f"odiff server returned invalid JSON: {line!r}") from e
 
+    def _kill_process(self) -> None:
+        proc = self._process
+        self._process = None
+        if proc is None:
+            return
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
     def _start(self) -> None:
         binary = _find_odiff_binary()
         proc = subprocess.Popen(
@@ -87,7 +100,10 @@ class OdiffServer:
                 raise RuntimeError("odiff server failed to start")
         except BaseException:
             proc.kill()
-            proc.wait()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
             raise
         self._process = proc
 
@@ -119,33 +135,18 @@ class OdiffServer:
                 process.stdin.write(json.dumps(request).encode() + b"\n")
                 process.stdin.flush()
             except (BrokenPipeError, OSError) as e:
-                process.kill()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-                self._process = None
+                self._kill_process()
                 raise RuntimeError("odiff process died unexpectedly") from e
 
             readable, _, _ = select.select([process.stdout], [], [], 30)
             if not readable:
-                process.kill()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-                self._process = None
+                self._kill_process()
                 raise RuntimeError("odiff server timed out after 30s")
             line = process.stdout.readline()
             try:
                 response = self._read_json(line)
             except RuntimeError:
-                process.kill()
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-                self._process = None
+                self._kill_process()
                 raise
 
         if "error" in response:
@@ -177,7 +178,10 @@ class OdiffServer:
         except subprocess.TimeoutExpired:
             pass
         proc.kill()
-        proc.wait()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
 
     def __del__(self) -> None:
         self.close()

--- a/src/sentry/preprod/snapshots/image_diff/types.py
+++ b/src/sentry/preprod/snapshots/image_diff/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DiffResult:
+    diff_mask_png: str
+    diff_score: float
+    changed_pixels: int
+    total_pixels: int
+    aligned_height: int
+    width: int
+    before_width: int
+    before_height: int
+    after_width: int
+    after_height: int

--- a/src/sentry/preprod/snapshots/image_diff/types.py
+++ b/src/sentry/preprod/snapshots/image_diff/types.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
 
 
-@dataclass(frozen=True)
-class DiffResult:
+class DiffResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     diff_mask_png: str
     diff_score: float
     changed_pixels: int
@@ -15,3 +16,14 @@ class DiffResult:
     before_height: int
     after_width: int
     after_height: int
+
+
+class OdiffResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    requestId: int
+    exitCode: int
+    result: str
+    diffCount: int | None = None
+    diffPercentage: float | None = None
+    error: str | None = None


### PR DESCRIPTION
## Summary
- Add `OdiffServer` subprocess wrapper that communicates with odiff via JSON-over-stdin/stdout protocol
- Add `DiffResult` dataclass for structured diff output
- Install the odiff binary in the self-hosted Dockerfile (x64 + arm64, SHA256-verified)

**Stack**: 1/3 — next: image comparison library