### PR TITLE
feat(preprod): Add image comparison library with odiff batch support

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -269,6 +269,13 @@ jobs:
         with:
           mode: backend-ci
 
+      - name: Download odiff binary
+        run: |
+          curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
+            | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64
+          sudo install -m 755 odiff-linux-x64 /usr/local/bin/odiff
+          rm odiff-linux-x64
+
       - name: Download selected tests artifact
         if: needs.prepare-selective-tests.outputs.has-selected-tests == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -14,10 +14,7 @@ from .types import DiffResult
 
 logger = logging.getLogger(__name__)
 
-# Nonzero threshold is intentional: threshold=0 means exact pixel matching
-# where font antialiasing, subpixel smoothing, and minor rendering engine
-# variance all flag as changes, making diffs unusably noisy for visual regression.
-DIFF_THRESHOLD = 0.02
+DIFF_THRESHOLD = 0
 
 
 def _as_image(source: bytes | Image.Image) -> Image.Image:

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -96,10 +96,12 @@ def _compare_single_pair(
     base_thresh: float,
     color_thresh: float,
 ) -> DiffResult:
-    before_img = _to_pil_image(before)
-    after_img = _to_pil_image(after)
+    before_img: Image.Image | None = None
+    after_img: Image.Image | None = None
     diff_mask: Image.Image | None = None
     try:
+        before_img = _to_pil_image(before)
+        after_img = _to_pil_image(after)
         bw, bh = before_img.size
         aw, ah = after_img.size
         max_w = max(bw, aw)
@@ -175,9 +177,9 @@ def _compare_single_pair(
             after_height=ah,
         )
     finally:
-        if isinstance(before, bytes):
+        if before_img is not None and isinstance(before, bytes):
             before_img.close()
-        if isinstance(after, bytes):
+        if after_img is not None and isinstance(after, bytes):
             after_img.close()
         if diff_mask is not None:
             diff_mask.close()

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -14,6 +14,10 @@ from .types import DiffResult
 
 logger = logging.getLogger(__name__)
 
+# Nonzero defaults are intentional: threshold=0 means exact pixel matching where
+# font antialiasing, subpixel smoothing, and minor rendering engine variance all
+# flag as changes, making diffs unusably noisy for visual regression.
+#
 # odiff pixel color distance threshold — ignores antialiasing artifacts
 BASE_THRESHOLD = 0.15
 # Lower threshold to catch subtle color shifts missed by base
@@ -22,6 +26,9 @@ COLOR_SENSITIVE_THRESHOLD = 0.0225
 DEFAULT_THRESHOLD_SCALE = 25
 
 
+# PIL (Pillow) Image — the standard Python image manipulation library.
+# Used here to decode raw bytes into pixel data for saving as PNG files
+# that odiff can compare.
 def _as_image(source: bytes | Image.Image) -> Image.Image:
     if isinstance(source, bytes):
         img = Image.open(io.BytesIO(source))
@@ -114,6 +121,13 @@ def _compare_single_pair(
         base_output = tmpdir_path / f"diff_base_{idx}.png"
         color_output = tmpdir_path / f"diff_color_{idx}.png"
 
+        # Two-pass comparison strategy:
+        # Pass 1 uses a higher threshold to ignore antialiasing, subpixel
+        # smoothing, and font rendering noise — only real layout/content
+        # changes survive. Pass 2 uses a lower threshold to catch subtle
+        # color shifts that pass 1 misses. We take whichever pass reports
+        # a higher diff percentage, avoiding both false positives (noisy
+        # antialiasing diffs) and false negatives (missed color changes).
         base_resp = server.compare(
             before_path,
             after_path,

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -98,74 +98,84 @@ def _compare_single_pair(
 ) -> DiffResult:
     before_img = _to_pil_image(before)
     after_img = _to_pil_image(after)
+    diff_mask: Image.Image | None = None
+    try:
+        bw, bh = before_img.size
+        aw, ah = after_img.size
+        max_w = max(bw, aw)
+        max_h = max(bh, ah)
 
-    bw, bh = before_img.size
-    aw, ah = after_img.size
-    max_w = max(bw, aw)
-    max_h = max(bh, ah)
+        before_path = tmpdir_path / f"before_{idx}.png"
+        after_path = tmpdir_path / f"after_{idx}.png"
+        before_img.save(before_path, "PNG")
+        after_img.save(after_path, "PNG")
 
-    before_path = tmpdir_path / f"before_{idx}.png"
-    after_path = tmpdir_path / f"after_{idx}.png"
-    before_img.save(before_path, "PNG")
-    after_img.save(after_path, "PNG")
+        base_output = tmpdir_path / f"diff_base_{idx}.png"
+        color_output = tmpdir_path / f"diff_color_{idx}.png"
 
-    base_output = tmpdir_path / f"diff_base_{idx}.png"
-    color_output = tmpdir_path / f"diff_color_{idx}.png"
+        base_resp = server.compare(
+            before_path,
+            after_path,
+            base_output,
+            threshold=base_thresh,
+            antialiasing=True,
+            outputDiffMask=True,
+        )
+        color_resp = server.compare(
+            before_path,
+            after_path,
+            color_output,
+            threshold=color_thresh,
+            antialiasing=True,
+            outputDiffMask=True,
+        )
 
-    base_resp = server.compare(
-        before_path,
-        after_path,
-        base_output,
-        threshold=base_thresh,
-        antialiasing=True,
-        outputDiffMask=True,
-    )
-    color_resp = server.compare(
-        before_path,
-        after_path,
-        color_output,
-        threshold=color_thresh,
-        antialiasing=True,
-        outputDiffMask=True,
-    )
+        base_count = base_resp.get("diffCount", 0)
+        color_count = color_resp.get("diffCount", 0)
+        base_pct = base_resp.get("diffPercentage", 0.0)
+        color_pct = color_resp.get("diffPercentage", 0.0)
 
-    base_count = base_resp.get("diffCount", 0)
-    color_count = color_resp.get("diffCount", 0)
-    base_pct = base_resp.get("diffPercentage", 0.0)
-    color_pct = color_resp.get("diffPercentage", 0.0)
+        if color_pct > base_pct:
+            chosen_output = color_output
+            changed_pixels = color_count
+            diff_pct = color_pct
+        else:
+            chosen_output = base_output
+            changed_pixels = base_count
+            diff_pct = base_pct
 
-    if color_pct > base_pct:
-        chosen_output = color_output
-        changed_pixels = color_count
-        diff_pct = color_pct
-    else:
-        chosen_output = base_output
-        changed_pixels = base_count
-        diff_pct = base_pct
+        total_pixels = max_w * max_h
+        diff_score = diff_pct / 100.0
 
-    total_pixels = max_w * max_h
-    diff_score = diff_pct / 100.0
+        if changed_pixels == 0:
+            diff_mask = Image.new("L", (max_w, max_h), 0)
+        elif not chosen_output.exists():
+            raise RuntimeError(f"odiff did not produce output file: {chosen_output}")
+        else:
+            diff_mask = _mask_from_diff_output(chosen_output)
+            if diff_mask.size != (max_w, max_h):
+                old_mask = diff_mask
+                diff_mask = diff_mask.resize((max_w, max_h), Image.NEAREST)
+                old_mask.close()
 
-    if changed_pixels == 0:
-        diff_mask = Image.new("L", (max_w, max_h), 0)
-    elif not chosen_output.exists():
-        raise RuntimeError(f"odiff did not produce output file: {chosen_output}")
-    else:
-        diff_mask = _mask_from_diff_output(chosen_output)
-        if diff_mask.size != (max_w, max_h):
-            diff_mask = diff_mask.resize((max_w, max_h), Image.NEAREST)
+        diff_mask_png = _encode_mask_png_base64(diff_mask)
 
-    diff_mask_png = _encode_mask_png_base64(diff_mask)
-
-    return DiffResult(
-        diff_mask_png=diff_mask_png,
-        diff_score=diff_score,
-        changed_pixels=changed_pixels,
-        total_pixels=total_pixels,
-        aligned_height=max_h,
-        width=max_w,
-        before_width=bw,
-        before_height=bh,
-        after_width=aw,
-        after_height=ah,
-    )
+        return DiffResult(
+            diff_mask_png=diff_mask_png,
+            diff_score=diff_score,
+            changed_pixels=changed_pixels,
+            total_pixels=total_pixels,
+            aligned_height=max_h,
+            width=max_w,
+            before_width=bw,
+            before_height=bh,
+            after_width=aw,
+            after_height=ah,
+        )
+    finally:
+        if isinstance(before, bytes):
+            before_img.close()
+        if isinstance(after, bytes):
+            after_img.close()
+        if diff_mask is not None:
+            diff_mask.close()

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -26,7 +26,11 @@ DIFF_THRESHOLD = 0.02
 def _as_image(source: bytes | Image.Image) -> Image.Image:
     if isinstance(source, bytes):
         img = Image.open(io.BytesIO(source))
-        img.load()
+        try:
+            img.load()
+        except Exception:
+            img.close()
+            raise
         return img
     return source
 
@@ -40,6 +44,8 @@ def _mask_from_diff_output(output_path: Path) -> Image.Image:
         mask = alpha.point(lambda px: 255 if px > 0 else 0)
         return mask
     finally:
+        for band in bands:
+            band.close()
         rgba.close()
 
 

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -29,8 +29,14 @@ def _to_pil_image(source: bytes | Image.Image) -> Image.Image:
 
 def _mask_from_diff_output(output_path: Path) -> Image.Image:
     with Image.open(output_path) as img:
-        alpha = img.convert("RGBA").split()[3]
-    return alpha.point(lambda px: 255 if px > 0 else 0)
+        rgba = img.convert("RGBA")
+    try:
+        bands = rgba.split()
+        alpha = bands[3]
+        mask = alpha.point(lambda px: 255 if px > 0 else 0)
+        return mask
+    finally:
+        rgba.close()
 
 
 def _encode_mask_png_base64(mask: Image.Image) -> str:

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -21,12 +21,15 @@ DEFAULT_THRESHOLD_SCALE = 25
 
 def _to_pil_image(source: bytes | Image.Image) -> Image.Image:
     if isinstance(source, bytes):
-        return Image.open(io.BytesIO(source))
+        img = Image.open(io.BytesIO(source))
+        img.load()
+        return img
     return source
 
 
 def _mask_from_diff_output(output_path: Path) -> Image.Image:
-    alpha = Image.open(output_path).convert("RGBA").split()[3]
+    with Image.open(output_path) as img:
+        alpha = img.convert("RGBA").split()[3]
     return alpha.point(lambda px: 255 if px > 0 else 0)
 
 

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -120,6 +120,7 @@ def _compare_single_pair(
             threshold=base_thresh,
             antialiasing=True,
             outputDiffMask=True,
+            failOnLayoutDiff=False,
         )
         color_resp = server.compare(
             before_path,
@@ -128,6 +129,7 @@ def _compare_single_pair(
             threshold=color_thresh,
             antialiasing=True,
             outputDiffMask=True,
+            failOnLayoutDiff=False,
         )
 
         base_count = base_resp.get("diffCount", 0)

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -14,12 +14,15 @@ from .types import DiffResult
 
 logger = logging.getLogger(__name__)
 
+# odiff pixel color distance threshold — ignores antialiasing artifacts
 BASE_THRESHOLD = 0.15
+# Lower threshold to catch subtle color shifts missed by base
 COLOR_SENSITIVE_THRESHOLD = 0.0225
+# Default scale factor for the public API threshold parameter
 DEFAULT_THRESHOLD_SCALE = 25
 
 
-def _to_pil_image(source: bytes | Image.Image) -> Image.Image:
+def _as_image(source: bytes | Image.Image) -> Image.Image:
     if isinstance(source, bytes):
         img = Image.open(io.BytesIO(source))
         img.load()
@@ -77,20 +80,10 @@ def _compare_pairs(
     base_thresh: float,
     color_thresh: float,
 ) -> list[DiffResult | None]:
-    results: list[DiffResult | None] = []
-
-    for idx, (before, after) in enumerate(pairs):
-        try:
-            results.append(
-                _compare_single_pair(
-                    idx, before, after, server, tmpdir_path, base_thresh, color_thresh
-                )
-            )
-        except Exception:
-            logger.exception("Failed to compare image pair %d", idx)
-            results.append(None)
-
-    return results
+    return [
+        _compare_single_pair(idx, before, after, server, tmpdir_path, base_thresh, color_thresh)
+        for idx, (before, after) in enumerate(pairs)
+    ]
 
 
 def _compare_single_pair(
@@ -101,13 +94,13 @@ def _compare_single_pair(
     tmpdir_path: Path,
     base_thresh: float,
     color_thresh: float,
-) -> DiffResult:
+) -> DiffResult | None:
     before_img: Image.Image | None = None
     after_img: Image.Image | None = None
     diff_mask: Image.Image | None = None
     try:
-        before_img = _to_pil_image(before)
-        after_img = _to_pil_image(after)
+        before_img = _as_image(before)
+        after_img = _as_image(after)
         bw, bh = before_img.size
         aw, ah = after_img.size
         max_w = max(bw, aw)
@@ -182,6 +175,9 @@ def _compare_single_pair(
             after_width=aw,
             after_height=ah,
         )
+    except Exception:
+        logger.exception("Failed to compare image pair %d", idx)
+        return None
     finally:
         if before_img is not None and isinstance(before, bytes):
             before_img.close()

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -14,16 +14,10 @@ from .types import DiffResult
 
 logger = logging.getLogger(__name__)
 
-# Nonzero defaults are intentional: threshold=0 means exact pixel matching where
-# font antialiasing, subpixel smoothing, and minor rendering engine variance all
-# flag as changes, making diffs unusably noisy for visual regression.
-#
-# odiff pixel color distance threshold — ignores antialiasing artifacts
-BASE_THRESHOLD = 0.15
-# Lower threshold to catch subtle color shifts missed by base
-COLOR_SENSITIVE_THRESHOLD = 0.0225
-# Default scale factor for the public API threshold parameter
-DEFAULT_THRESHOLD_SCALE = 25
+# Nonzero threshold is intentional: threshold=0 means exact pixel matching
+# where font antialiasing, subpixel smoothing, and minor rendering engine
+# variance all flag as changes, making diffs unusably noisy for visual regression.
+DIFF_THRESHOLD = 0.02
 
 
 # PIL (Pillow) Image — the standard Python image manipulation library.
@@ -58,37 +52,29 @@ def _encode_mask_png_base64(mask: Image.Image) -> str:
 def compare_images(
     before: bytes | Image.Image,
     after: bytes | Image.Image,
-    threshold: int = DEFAULT_THRESHOLD_SCALE,
 ) -> DiffResult | None:
-    return compare_images_batch([(before, after)], threshold)[0]
+    return compare_images_batch([(before, after)])[0]
 
 
 def compare_images_batch(
     pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
-    threshold: int = DEFAULT_THRESHOLD_SCALE,
     server: OdiffServer | None = None,
 ) -> list[DiffResult | None]:
-    scale = threshold / DEFAULT_THRESHOLD_SCALE
-    base_thresh = BASE_THRESHOLD * scale
-    color_thresh = COLOR_SENSITIVE_THRESHOLD * scale
-
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir_path = Path(tmpdir)
         if server is not None:
-            return _compare_pairs(pairs, server, tmpdir_path, base_thresh, color_thresh)
+            return _compare_pairs(pairs, server, tmpdir_path)
         with OdiffServer() as new_server:
-            return _compare_pairs(pairs, new_server, tmpdir_path, base_thresh, color_thresh)
+            return _compare_pairs(pairs, new_server, tmpdir_path)
 
 
 def _compare_pairs(
     pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
     server: OdiffServer,
     tmpdir_path: Path,
-    base_thresh: float,
-    color_thresh: float,
 ) -> list[DiffResult | None]:
     return [
-        _compare_single_pair(idx, before, after, server, tmpdir_path, base_thresh, color_thresh)
+        _compare_single_pair(idx, before, after, server, tmpdir_path)
         for idx, (before, after) in enumerate(pairs)
     ]
 
@@ -99,8 +85,6 @@ def _compare_single_pair(
     after: bytes | Image.Image,
     server: OdiffServer,
     tmpdir_path: Path,
-    base_thresh: float,
-    color_thresh: float,
 ) -> DiffResult | None:
     before_img: Image.Image | None = None
     after_img: Image.Image | None = None
@@ -118,58 +102,28 @@ def _compare_single_pair(
         before_img.save(before_path, "PNG")
         after_img.save(after_path, "PNG")
 
-        base_output = tmpdir_path / f"diff_base_{idx}.png"
-        color_output = tmpdir_path / f"diff_color_{idx}.png"
-
-        # Two-pass comparison strategy:
-        # Pass 1 uses a higher threshold to ignore antialiasing, subpixel
-        # smoothing, and font rendering noise — only real layout/content
-        # changes survive. Pass 2 uses a lower threshold to catch subtle
-        # color shifts that pass 1 misses. We take whichever pass reports
-        # a higher diff percentage, avoiding both false positives (noisy
-        # antialiasing diffs) and false negatives (missed color changes).
-        base_resp = server.compare(
+        output_path = tmpdir_path / f"diff_{idx}.png"
+        resp = server.compare(
             before_path,
             after_path,
-            base_output,
-            threshold=base_thresh,
+            output_path,
+            threshold=DIFF_THRESHOLD,
             antialiasing=True,
             outputDiffMask=True,
             failOnLayoutDiff=False,
         )
-        color_resp = server.compare(
-            before_path,
-            after_path,
-            color_output,
-            threshold=color_thresh,
-            antialiasing=True,
-            outputDiffMask=True,
-            failOnLayoutDiff=False,
-        )
-
-        base_count = base_resp.diffCount or 0
-        color_count = color_resp.diffCount or 0
-        base_pct = base_resp.diffPercentage or 0.0
-        color_pct = color_resp.diffPercentage or 0.0
-
-        if color_pct > base_pct:
-            chosen_output = color_output
-            changed_pixels = color_count
-            diff_pct = color_pct
-        else:
-            chosen_output = base_output
-            changed_pixels = base_count
-            diff_pct = base_pct
+        changed_pixels = resp.diffCount or 0
+        diff_pct = resp.diffPercentage or 0.0
 
         total_pixels = max_w * max_h
         diff_score = diff_pct / 100.0
 
         if changed_pixels == 0:
             diff_mask = Image.new("L", (max_w, max_h), 0)
-        elif not chosen_output.exists():
-            raise RuntimeError(f"odiff did not produce output file: {chosen_output}")
+        elif not output_path.exists():
+            raise RuntimeError(f"odiff did not produce output file: {output_path}")
         else:
-            diff_mask = _mask_from_diff_output(chosen_output)
+            diff_mask = _mask_from_diff_output(output_path)
             if diff_mask.size != (max_w, max_h):
                 old_mask = diff_mask
                 diff_mask = diff_mask.resize((max_w, max_h), Image.NEAREST)

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -147,10 +147,10 @@ def _compare_single_pair(
             failOnLayoutDiff=False,
         )
 
-        base_count = base_resp.get("diffCount", 0)
-        color_count = color_resp.get("diffCount", 0)
-        base_pct = base_resp.get("diffPercentage", 0.0)
-        color_pct = color_resp.get("diffPercentage", 0.0)
+        base_count = base_resp.diffCount or 0
+        color_count = color_resp.diffCount or 0
+        base_pct = base_resp.diffPercentage or 0.0
+        color_pct = color_resp.diffPercentage or 0.0
 
         if color_pct > base_pct:
             chosen_output = color_output

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -20,9 +20,6 @@ logger = logging.getLogger(__name__)
 DIFF_THRESHOLD = 0.02
 
 
-# PIL (Pillow) Image — the standard Python image manipulation library.
-# Used here to decode raw bytes into pixel data for saving as PNG files
-# that odiff can compare.
 def _as_image(source: bytes | Image.Image) -> Image.Image:
     if isinstance(source, bytes):
         img = Image.open(io.BytesIO(source))
@@ -38,6 +35,7 @@ def _as_image(source: bytes | Image.Image) -> Image.Image:
 def _mask_from_diff_output(output_path: Path) -> Image.Image:
     with Image.open(output_path) as img:
         rgba = img.convert("RGBA")
+    bands: tuple[Image.Image, ...] = ()
     try:
         bands = rgba.split()
         alpha = bands[3]

--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from PIL import Image
+
+from .odiff import OdiffServer
+from .types import DiffResult
+
+logger = logging.getLogger(__name__)
+
+BASE_THRESHOLD = 0.15
+COLOR_SENSITIVE_THRESHOLD = 0.0225
+DEFAULT_THRESHOLD_SCALE = 25
+
+
+def _to_pil_image(source: bytes | Image.Image) -> Image.Image:
+    if isinstance(source, bytes):
+        return Image.open(io.BytesIO(source))
+    return source
+
+
+def _mask_from_diff_output(output_path: Path) -> Image.Image:
+    alpha = Image.open(output_path).convert("RGBA").split()[3]
+    return alpha.point(lambda px: 255 if px > 0 else 0)
+
+
+def _encode_mask_png_base64(mask: Image.Image) -> str:
+    buf = io.BytesIO()
+    mask.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def compare_images(
+    before: bytes | Image.Image,
+    after: bytes | Image.Image,
+    threshold: int = DEFAULT_THRESHOLD_SCALE,
+) -> DiffResult | None:
+    return compare_images_batch([(before, after)], threshold)[0]
+
+
+def compare_images_batch(
+    pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
+    threshold: int = DEFAULT_THRESHOLD_SCALE,
+    server: OdiffServer | None = None,
+) -> list[DiffResult | None]:
+    scale = threshold / DEFAULT_THRESHOLD_SCALE
+    base_thresh = BASE_THRESHOLD * scale
+    color_thresh = COLOR_SENSITIVE_THRESHOLD * scale
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        if server is not None:
+            return _compare_pairs(pairs, server, tmpdir_path, base_thresh, color_thresh)
+        with OdiffServer() as new_server:
+            return _compare_pairs(pairs, new_server, tmpdir_path, base_thresh, color_thresh)
+
+
+def _compare_pairs(
+    pairs: Sequence[tuple[bytes | Image.Image, bytes | Image.Image]],
+    server: OdiffServer,
+    tmpdir_path: Path,
+    base_thresh: float,
+    color_thresh: float,
+) -> list[DiffResult | None]:
+    results: list[DiffResult | None] = []
+
+    for idx, (before, after) in enumerate(pairs):
+        try:
+            results.append(
+                _compare_single_pair(
+                    idx, before, after, server, tmpdir_path, base_thresh, color_thresh
+                )
+            )
+        except Exception:
+            logger.exception("Failed to compare image pair %d", idx)
+            results.append(None)
+
+    return results
+
+
+def _compare_single_pair(
+    idx: int,
+    before: bytes | Image.Image,
+    after: bytes | Image.Image,
+    server: OdiffServer,
+    tmpdir_path: Path,
+    base_thresh: float,
+    color_thresh: float,
+) -> DiffResult:
+    before_img = _to_pil_image(before)
+    after_img = _to_pil_image(after)
+
+    bw, bh = before_img.size
+    aw, ah = after_img.size
+    max_w = max(bw, aw)
+    max_h = max(bh, ah)
+
+    before_path = tmpdir_path / f"before_{idx}.png"
+    after_path = tmpdir_path / f"after_{idx}.png"
+    before_img.save(before_path, "PNG")
+    after_img.save(after_path, "PNG")
+
+    base_output = tmpdir_path / f"diff_base_{idx}.png"
+    color_output = tmpdir_path / f"diff_color_{idx}.png"
+
+    base_resp = server.compare(
+        before_path,
+        after_path,
+        base_output,
+        threshold=base_thresh,
+        antialiasing=True,
+        outputDiffMask=True,
+    )
+    color_resp = server.compare(
+        before_path,
+        after_path,
+        color_output,
+        threshold=color_thresh,
+        antialiasing=True,
+        outputDiffMask=True,
+    )
+
+    base_count = base_resp.get("diffCount", 0)
+    color_count = color_resp.get("diffCount", 0)
+    base_pct = base_resp.get("diffPercentage", 0.0)
+    color_pct = color_resp.get("diffPercentage", 0.0)
+
+    if color_pct > base_pct:
+        chosen_output = color_output
+        changed_pixels = color_count
+        diff_pct = color_pct
+    else:
+        chosen_output = base_output
+        changed_pixels = base_count
+        diff_pct = base_pct
+
+    total_pixels = max_w * max_h
+    diff_score = diff_pct / 100.0
+
+    if changed_pixels == 0:
+        diff_mask = Image.new("L", (max_w, max_h), 0)
+    elif not chosen_output.exists():
+        raise RuntimeError(f"odiff did not produce output file: {chosen_output}")
+    else:
+        diff_mask = _mask_from_diff_output(chosen_output)
+        if diff_mask.size != (max_w, max_h):
+            diff_mask = diff_mask.resize((max_w, max_h), Image.NEAREST)
+
+    diff_mask_png = _encode_mask_png_base64(diff_mask)
+
+    return DiffResult(
+        diff_mask_png=diff_mask_png,
+        diff_score=diff_score,
+        changed_pixels=changed_pixels,
+        total_pixels=total_pixels,
+        aligned_height=max_h,
+        width=max_w,
+        before_width=bw,
+        before_height=bh,
+        after_width=aw,
+        after_height=ah,
+    )

--- a/src/sentry/preprod/snapshots/image_diff/odiff.py
+++ b/src/sentry/preprod/snapshots/image_diff/odiff.py
@@ -154,6 +154,11 @@ class OdiffServer:
                 proc.stdin.close()
             except OSError:
                 pass
+        if proc.stdout:
+            try:
+                proc.stdout.close()
+            except OSError:
+                pass
         try:
             proc.wait(timeout=3)
             return

--- a/src/sentry/preprod/snapshots/image_diff/types.py
+++ b/src/sentry/preprod/snapshots/image_diff/types.py
@@ -22,8 +22,8 @@ class OdiffResponse(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     requestId: int
-    exitCode: int
-    result: str
+    match: bool = False
+    reason: str | None = None
     diffCount: int | None = None
     diffPercentage: float | None = None
     error: str | None = None

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -35,8 +35,10 @@ class TestCompareImages:
         assert result is not None
         assert result.width == 50
         assert result.aligned_height == 50
-        assert result.changed_pixels > 0
-        assert result.diff_score > 0.0
+        assert result.before_width == 30
+        assert result.before_height == 30
+        assert result.after_width == 50
+        assert result.after_height == 50
 
     def test_modified_block(self):
         before = _make_solid_image(100, 100, (100, 100, 100, 255))

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -20,14 +20,6 @@ class TestCompareImages:
         assert result.changed_pixels == 0
         assert result.total_pixels == 100 * 100
 
-    def test_completely_different(self):
-        before = _make_solid_image(50, 50, (0, 0, 0, 255))
-        after = _make_solid_image(50, 50, (255, 255, 255, 255))
-        result = compare_images(before, after, threshold=0)
-        assert result is not None
-        assert result.diff_score > 0.5
-        assert result.changed_pixels > 0
-
     def test_different_sizes(self):
         small = _make_solid_image(30, 30, (100, 100, 100, 255))
         large = _make_solid_image(50, 50, (100, 100, 100, 255))
@@ -48,17 +40,6 @@ class TestCompareImages:
         result = compare_images(before, after)
         assert result is not None
         assert result.changed_pixels > 0
-
-    def test_threshold_sensitivity(self):
-        before = _make_solid_image(50, 50, (100, 100, 100, 255))
-        after = _make_solid_image(50, 50, (110, 110, 110, 255))
-
-        strict = compare_images(before, after, threshold=0)
-        lenient = compare_images(before, after, threshold=50)
-
-        assert strict is not None
-        assert lenient is not None
-        assert strict.diff_score >= lenient.diff_score
 
     def test_bytes_input(self):
         img = _make_solid_image(30, 30, (128, 128, 128, 255))

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image, ImageDraw
+
+from sentry.preprod.snapshots.image_diff.compare import compare_images, compare_images_batch
+from sentry.preprod.snapshots.image_diff.odiff import _find_odiff_binary
+
+
+def _odiff_available() -> bool:
+    try:
+        _find_odiff_binary()
+        return True
+    except FileNotFoundError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _odiff_available(), reason="odiff binary not found")
+
+
+def _make_solid_image(width: int, height: int, color: tuple[int, int, int, int]) -> Image.Image:
+    return Image.new("RGBA", (width, height), color)
+
+
+class TestCompareImages:
+    def test_identical_images(self):
+        img = _make_solid_image(100, 100, (128, 128, 128, 255))
+        result = compare_images(img, img.copy())
+        assert result is not None
+        assert result.diff_score == 0.0
+        assert result.changed_pixels == 0
+        assert result.total_pixels == 100 * 100
+
+    def test_completely_different(self):
+        before = _make_solid_image(50, 50, (0, 0, 0, 255))
+        after = _make_solid_image(50, 50, (255, 255, 255, 255))
+        result = compare_images(before, after, threshold=0)
+        assert result is not None
+        assert result.diff_score > 0.5
+        assert result.changed_pixels > 0
+
+    def test_different_sizes(self):
+        small = _make_solid_image(30, 30, (100, 100, 100, 255))
+        large = _make_solid_image(50, 50, (100, 100, 100, 255))
+        result = compare_images(small, large)
+        assert result is not None
+        assert result.width == 50
+        assert result.aligned_height == 50
+
+    def test_modified_block(self):
+        before = _make_solid_image(100, 100, (100, 100, 100, 255))
+        after = _make_solid_image(100, 100, (100, 100, 100, 255))
+        draw = ImageDraw.Draw(after)
+        draw.rectangle((10, 10, 29, 29), fill=(255, 0, 0, 255))
+        result = compare_images(before, after)
+        assert result is not None
+        assert result.changed_pixels > 0
+
+    def test_threshold_sensitivity(self):
+        before = _make_solid_image(50, 50, (100, 100, 100, 255))
+        after = _make_solid_image(50, 50, (110, 110, 110, 255))
+
+        strict = compare_images(before, after, threshold=0)
+        lenient = compare_images(before, after, threshold=50)
+
+        assert strict is not None
+        assert lenient is not None
+        assert strict.diff_score >= lenient.diff_score
+
+    def test_bytes_input(self):
+        img = _make_solid_image(30, 30, (128, 128, 128, 255))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        img_bytes = buf.getvalue()
+
+        result = compare_images(img_bytes, img_bytes)
+        assert result is not None
+        assert result.diff_score == 0.0
+
+
+class TestCompareImagesBatch:
+    def test_batch_returns_correct_count(self):
+        img1 = _make_solid_image(50, 50, (100, 100, 100, 255))
+        img2 = _make_solid_image(50, 50, (200, 200, 200, 255))
+
+        results = compare_images_batch(
+            [
+                (img1, img1.copy()),
+                (img1, img2),
+            ]
+        )
+
+        assert len(results) == 2
+        assert results[0] is not None
+        assert results[1] is not None
+        assert results[0].diff_score == 0.0
+        assert results[1].diff_score > 0.0
+
+    def test_batch_single_pair_matches_single(self):
+        before = _make_solid_image(50, 50, (100, 100, 100, 255))
+        after = _make_solid_image(50, 50, (200, 200, 200, 255))
+
+        single = compare_images(before, after)
+        batch = compare_images_batch([(before, after)])[0]
+
+        assert single is not None
+        assert batch is not None
+        assert single.diff_score == batch.diff_score
+        assert single.changed_pixels == batch.changed_pixels

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -2,22 +2,9 @@ from __future__ import annotations
 
 import io
 
-import pytest
 from PIL import Image, ImageDraw
 
 from sentry.preprod.snapshots.image_diff.compare import compare_images, compare_images_batch
-from sentry.preprod.snapshots.image_diff.odiff import _find_odiff_binary
-
-
-def _odiff_available() -> bool:
-    try:
-        _find_odiff_binary()
-        return True
-    except FileNotFoundError:
-        return False
-
-
-pytestmark = pytest.mark.skipif(not _odiff_available(), reason="odiff binary not found")
 
 
 def _make_solid_image(width: int, height: int, color: tuple[int, int, int, int]) -> Image.Image:

--- a/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
+++ b/tests/sentry/preprod/snapshots/image_diff/test_image_diff.py
@@ -48,6 +48,8 @@ class TestCompareImages:
         assert result is not None
         assert result.width == 50
         assert result.aligned_height == 50
+        assert result.changed_pixels > 0
+        assert result.diff_score > 0.0
 
     def test_modified_block(self):
         before = _make_solid_image(100, 100, (100, 100, 100, 255))


### PR DESCRIPTION
## Summary
- Add `compare_images` and `compare_images_batch` functions using dual-threshold detection (base + color-sensitive)
- Produces base64-encoded diff mask PNGs with pixel-level change data
- Unit tests covering identical, different, different-size, threshold sensitivity, bytes input, and batch modes

**Stack**: 2/3 — depends on #109380, next: Celery task