### PR TITLE
feat(autofix): Add github_app field to autofix PR analytics events

### DIFF
--- a/src/sentry/analytics/events/ai_autofix_pr_events.py
+++ b/src/sentry/analytics/events/ai_autofix_pr_events.py
@@ -8,6 +8,7 @@ class AiAutofixPrEvent(analytics.Event):
     group_id: int
     run_id: int
     integration: str
+    github_app: str
 
 
 @analytics.eventclass("ai.autofix.pr.closed")


### PR DESCRIPTION
## Summary
- Adds a `github_app` field (`"seer"` or `"sentry"`) to the `ai.autofix.pr.opened`, `ai.autofix.pr.closed`, and `ai.autofix.pr.merged` analytics events
- Determines the app by comparing the webhook's `github_user["id"]` against `SEER_AUTOFIX_GITHUB_APP_USER_ID` and `SENTRY_GITHUB_APP_USER_ID` settings
- Adds a test case for PRs opened via the Sentry GitHub app

## Test plan
- [x] Existing tests updated with `github_app` field
- [x] New test `test_opened_sentry_app` verifies Sentry app detection
- [x] All 7 tests pass