### PR TITLE
feat(ACI): Make ProjectRuleDetailsEndpoint GET method backwards compatible

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -2,10 +2,14 @@ from typing import Any
 
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.models.rule import Rule
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
@@ -33,5 +37,40 @@ class RuleEndpoint(ProjectEndpoint):
                 )
             except Rule.DoesNotExist:
                 raise ResourceDoesNotExist
+
+        return args, kwargs
+
+
+class WorkflowEngineRuleEndpoint(RuleEndpoint):
+    def convert_args(
+        self, request: Request, rule_id: str, *args: Any, **kwargs: Any
+    ) -> tuple[Any, Any]:
+        args, kwargs = super(RuleEndpoint, self).convert_args(request, *args, **kwargs)
+        project = kwargs["project"]
+
+        if not rule_id.isdigit():
+            raise ResourceDoesNotExist
+
+        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+            try:
+                arw = AlertRuleWorkflow.objects.get(rule_id=rule_id)
+                kwargs["rule"] = arw.workflow
+            except AlertRuleWorkflow.DoesNotExist:
+                # XXX: this means the workflow was single written and has no ARW or related Rule object
+                try:
+                    workflow_id = get_object_id_from_fake_id(int(rule_id))
+                    kwargs["rule"] = Workflow.objects.get(
+                        id=workflow_id, organization=project.organization
+                    )
+                except Workflow.DoesNotExist:
+                    raise ResourceDoesNotExist
+
+            return args, kwargs
+
+        report_used_legacy_models()
+        try:
+            kwargs["rule"] = Rule.objects.get(project=project, id=rule_id)
+        except Rule.DoesNotExist:
+            raise ResourceDoesNotExist
 
         return args, kwargs

--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -2,13 +2,10 @@ from typing import Any
 
 from rest_framework.request import Request
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models.rule import Rule
-from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
@@ -25,20 +22,6 @@ class RuleEndpoint(ProjectEndpoint):
         if not rule_id.isdigit():
             raise ResourceDoesNotExist
 
-        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            # Try to get the workflow ID with this rule ID from AlertRuleWorkflow lookup table
-            # If if does not exist, then this was an object that wasn't dual written, so get the real ID from fake ID
-            # Get the workflow from the workflow ID and return the workflow
-            try:
-                arw = AlertRuleWorkflow.objects.get(rule_id=rule_id)
-                kwargs["rule"] = arw.workflow
-            except AlertRuleWorkflow.DoesNotExist:
-                # this means the workflow was single written and has no ARW or related Rule object
-                try:
-                    workflow = Workflow.objects.get(id=rule_id)
-                    kwargs["rule"] = workflow
-                except Workflow.DoesNotExist:
-                    raise ResourceDoesNotExist
         else:
             # Mark that we're using legacy Rule models (before query to track failures too)
             report_used_legacy_models()

--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -26,17 +26,16 @@ class RuleEndpoint(ProjectEndpoint):
         if not rule_id.isdigit():
             raise ResourceDoesNotExist
 
-        else:
-            # Mark that we're using legacy Rule models (before query to track failures too)
-            report_used_legacy_models()
+        # Mark that we're using legacy Rule models (before query to track failures too)
+        report_used_legacy_models()
 
-            try:
-                kwargs["rule"] = Rule.objects.get(
-                    project=project,
-                    id=rule_id,
-                )
-            except Rule.DoesNotExist:
-                raise ResourceDoesNotExist
+        try:
+            kwargs["rule"] = Rule.objects.get(
+                project=project,
+                id=rule_id,
+            )
+        except Rule.DoesNotExist:
+            raise ResourceDoesNotExist
 
         return args, kwargs
 
@@ -53,7 +52,9 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
 
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
             try:
-                arw = AlertRuleWorkflow.objects.get(rule_id=rule_id)
+                arw = AlertRuleWorkflow.objects.get(
+                    rule_id=rule_id, workflow__organization=project.organization
+                )
                 kwargs["rule"] = arw.workflow
             except AlertRuleWorkflow.DoesNotExist:
                 # XXX: this means the workflow was single written and has no ARW or related Rule object

--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -6,6 +6,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.constants import ObjectStatus
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.models.rule import Rule
 from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
@@ -61,9 +62,11 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
                 try:
                     workflow_id = get_object_id_from_fake_id(int(rule_id))
                     kwargs["rule"] = Workflow.objects.get(
-                        id=workflow_id, organization=project.organization
+                        id=workflow_id,
+                        organization=project.organization,
+                        status=ObjectStatus.ACTIVE,
                     )
-                except Workflow.DoesNotExist:
+                except (AlertRuleWorkflow.DoesNotExist, Workflow.DoesNotExist):
                     raise ResourceDoesNotExist
 
             return args, kwargs

--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -2,10 +2,13 @@ from typing import Any
 
 from rest_framework.request import Request
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.bases import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models.rule import Rule
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
@@ -22,15 +25,30 @@ class RuleEndpoint(ProjectEndpoint):
         if not rule_id.isdigit():
             raise ResourceDoesNotExist
 
-        # Mark that we're using legacy Rule models (before query to track failures too)
-        report_used_legacy_models()
+        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+            # Try to get the workflow ID with this rule ID from AlertRuleWorkflow lookup table
+            # If if does not exist, then this was an object that wasn't dual written, so get the real ID from fake ID
+            # Get the workflow from the workflow ID and return the workflow
+            try:
+                arw = AlertRuleWorkflow.objects.get(rule_id=rule_id)
+                kwargs["rule"] = arw.workflow
+            except AlertRuleWorkflow.DoesNotExist:
+                # this means the workflow was single written and has no ARW or related Rule object
+                try:
+                    workflow = Workflow.objects.get(id=rule_id)
+                    kwargs["rule"] = workflow
+                except Workflow.DoesNotExist:
+                    raise ResourceDoesNotExist
+        else:
+            # Mark that we're using legacy Rule models (before query to track failures too)
+            report_used_legacy_models()
 
-        try:
-            kwargs["rule"] = Rule.objects.get(
-                project=project,
-                id=rule_id,
-            )
-        except Rule.DoesNotExist:
-            raise ResourceDoesNotExist
+            try:
+                kwargs["rule"] = Rule.objects.get(
+                    project=project,
+                    id=rule_id,
+                )
+            except Rule.DoesNotExist:
+                raise ResourceDoesNotExist
 
         return args, kwargs

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -19,6 +19,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
+from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
@@ -44,6 +45,8 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -136,13 +139,24 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+            # TODO this won't work because convert_args may have already failed to find a rule with a matching id
+            # however we also can't have this logic in convert_args because other unrelated endpoints use the base class
+            try:
+                arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+                workflow = arw.workflow
+            except AlertRuleWorkflow.DoesNotExist:
+                # this means the workflow was single written and has no ARW or related Rule object
+                try:
+                    workflow = Workflow.objects.get(id=rule.id)
+                except Workflow.DoesNotExist:
+                    raise ResourceDoesNotExist
+
             workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
                 expand=request.GET.getlist("expand", []),
                 prepare_component_fields=True,
                 project_slug=project.slug,
             )
-            # XXX: Note that "rule" here is actually a Workflow object
-            serialized_rule = serialize(rule, request.user, workflow_engine_rule_serializer)
+            serialized_rule = serialize(workflow, request.user, workflow_engine_rule_serializer)
         else:
             # Serialize Rule object
             rule_serializer = RuleSerializer(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -17,9 +17,8 @@ from sentry.analytics.events.rule_disable_opt_out import (
 from sentry.analytics.events.rule_reenable import RuleReenableEdit
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
-from sentry.api.bases.rule import RuleEndpoint
+from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
@@ -45,8 +44,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
-from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
-from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -102,7 +99,7 @@ class ProjectRuleDetailsPutSerializer(serializers.Serializer):
 
 @extend_schema(tags=["Alerts"])
 @region_silo_endpoint
-class ProjectRuleDetailsEndpoint(RuleEndpoint):
+class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,
         "GET": ApiPublishStatus.PUBLIC,
@@ -139,24 +136,13 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            # TODO this won't work because convert_args may have already failed to find a rule with a matching id
-            # however we also can't have this logic in convert_args because other unrelated endpoints use the base class
-            try:
-                arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-                workflow = arw.workflow
-            except AlertRuleWorkflow.DoesNotExist:
-                # this means the workflow was single written and has no ARW or related Rule object
-                try:
-                    workflow = Workflow.objects.get(id=rule.id)
-                except Workflow.DoesNotExist:
-                    raise ResourceDoesNotExist
-
             workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
                 expand=request.GET.getlist("expand", []),
                 prepare_component_fields=True,
                 project_slug=project.slug,
             )
-            serialized_rule = serialize(workflow, request.user, workflow_engine_rule_serializer)
+            # XXX: Note 'rule' here is actually a workflow object
+            serialized_rule = serialize(rule, request.user, workflow_engine_rule_serializer)
         else:
             # Serialize Rule object
             rule_serializer = RuleSerializer(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -38,12 +38,14 @@ from sentry.integrations.jira.actions.create_ticket import JiraCreateTicketActio
 from sentry.integrations.jira_server.actions.create_ticket import JiraServerCreateTicketAction
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
+from sentry.models.project import Project
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.projects.project_rules.updater import ProjectRuleUpdater
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -122,7 +124,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         examples=IssueAlertExamples.GET_PROJECT_RULE,
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-details")
-    def get(self, request: Request, project, rule) -> Response:
+    def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         ## Deprecated
         🚧 Use [Fetch an Alert](/api/monitors/fetch-an-alert) instead.
@@ -184,7 +186,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         examples=IssueAlertExamples.UPDATE_PROJECT_RULE,
     )
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-rule-details")
-    def put(self, request: Request, project, rule) -> Response:
+    def put(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         ## Deprecated
         🚧 Use [Update an Alert by ID](/api/monitors/update-an-alert-by-id) instead.
@@ -198,6 +200,16 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         - Filters - help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
+        if isinstance(rule, Workflow):
+            return Response(
+                {
+                    "rule": [
+                        "Passing a workflow through this endpoint is not yet supported",
+                    ]
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         rule_data_before = dict(rule.data)
         if rule.environment_id:
             rule_data_before["environment_id"] = rule.environment_id
@@ -393,7 +405,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         },
     )
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-rule-details")
-    def delete(self, request: Request, project, rule) -> Response:
+    def delete(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         ## Deprecated
          🚧 Use [Delete an Alert](/api/monitors/delete-an-alert) instead.
@@ -406,6 +418,16 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
          - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
          - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
+        if isinstance(rule, Workflow):
+            return Response(
+                {
+                    "rule": [
+                        "Passing a workflow through this endpoint is not yet supported",
+                    ]
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         report_used_legacy_models()
         with transaction.atomic(router.db_for_write(Rule)):
             rule.update(status=ObjectStatus.PENDING_DELETION)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -9,7 +9,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log
+from sentry import analytics, audit_log, features
 from sentry.analytics.events.rule_disable_opt_out import (
     RuleDisableOptOutEdit,
     RuleDisableOptOutExplicit,
@@ -21,7 +21,7 @@ from sentry.api.bases.rule import RuleEndpoint
 from sentry.api.endpoints.project_rules import find_duplicate_rule
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.rule import RuleSerializer
+from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
 from sentry.apidocs.constants import (
@@ -44,6 +44,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -135,13 +136,26 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Filters - help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
-        # Serialize Rule object
-        rule_serializer = RuleSerializer(
-            expand=request.GET.getlist("expand", []),
-            prepare_component_fields=True,
-            project_slug=project.slug,
-        )
-        serialized_rule = serialize(rule, request.user, rule_serializer)
+        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+            # TODO: replace with convert_args when fully switching over
+            # TODO: handle single written rules that won't be in ARW
+            arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+
+            workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
+                expand=request.GET.getlist("expand", []),
+                prepare_component_fields=True,
+                project_slug=project.slug,
+            )
+            serialized_rule = serialize(arw.workflow, request.user, workflow_engine_rule_serializer)
+        else:
+            # Serialize Rule object
+            rule_serializer = RuleSerializer(
+                expand=request.GET.getlist("expand", []),
+                prepare_component_fields=True,
+                project_slug=project.slug,
+            )
+            serialized_rule = serialize(rule, request.user, rule_serializer)
+
         # Prepare Rule Actions that are SentryApp components using the meta fields
         for action in serialized_rule.get("actions", []):
             # TODO(nisanthan): This is a temporary fix. We need to save both the label and value of

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -44,7 +44,6 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
-from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -137,16 +136,13 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            # TODO: replace with convert_args when fully switching over
-            # TODO: handle single written rules that won't be in ARW
-            arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-
             workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
                 expand=request.GET.getlist("expand", []),
                 prepare_component_fields=True,
                 project_slug=project.slug,
             )
-            serialized_rule = serialize(arw.workflow, request.user, workflow_engine_rule_serializer)
+            # XXX: Note that "rule" here is actually a Workflow object
+            serialized_rule = serialize(rule, request.user, workflow_engine_rule_serializer)
         else:
             # Serialize Rule object
             rule_serializer = RuleSerializer(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -477,7 +477,8 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             result[workflow]["environment"] = workflow.environment
             result[workflow]["projects"] = list(workflow_to_projects[workflow])
-            result[workflow]["rule_id"] = workflow_rule_ids[workflow.id]
+            # XXX: for a single written workflow we won't have a rule id. we could generate a fake one?
+            result[workflow]["rule_id"] = workflow_rule_ids.get(workflow.id, "1234")
 
             result[workflow]["action_match"] = (
                 workflow.when_condition_group.logic_type if workflow.when_condition_group else None

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -449,6 +449,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         return {wf_id: date for wf_id, date in results.items() if date is not None}
 
     def get_attrs(self, item_list: Sequence[Workflow], user, **kwargs):
+        from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
         from sentry.notifications.notification_action.registry import issue_alert_handler_registry
 
         # Bulk fetch users that created workflows
@@ -477,8 +478,9 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             result[workflow]["environment"] = workflow.environment
             result[workflow]["projects"] = list(workflow_to_projects[workflow])
-            # XXX: for a single written workflow we won't have a rule id. we could generate a fake one?
-            result[workflow]["rule_id"] = workflow_rule_ids.get(workflow.id, "1234")
+            result[workflow]["rule_id"] = workflow_rule_ids.get(
+                workflow.id, get_fake_id_from_object_id(workflow.id)
+            )
 
             result[workflow]["action_match"] = (
                 workflow.when_condition_group.logic_type if workflow.when_condition_group else None
@@ -522,7 +524,6 @@ class WorkflowEngineRuleSerializer(Serializer):
             conditions, filters = self._generate_rule_conditions_filters(
                 workflow, result[workflow]["projects"][0], workflow_dcg
             )
-
             result[workflow]["conditions"] = conditions
             result[workflow]["filters"] = filters
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -94,7 +94,7 @@ def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
     assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
 
 
-class ProjectRuleDetailsBaseTestCase(APITestCase):
+class ProjectRuleDetailsBaseTestCase(APITestCase, BaseWorkflowTest):
     endpoint = "sentry-api-0-project-rule-details"
 
     def setUp(self) -> None:
@@ -136,28 +136,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase):
                 "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
             }
         ]
-
-
-class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
-    def test_simple(self) -> None:
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, self.rule.id, status_code=200
-        )
-        assert response.data["id"] == str(self.rule.id)
-        assert response.data["environment"] is None
-        assert response.data["conditions"][0]["name"]
-
-    @with_feature("organizations:workflow-engine-rule-serializers")
-    def test_workflow_engine_serializer_dual_written_rule(self) -> None:
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, self.rule.id, status_code=200
-        )
-        assert response.data["id"] == str(self.rule.id)
-        assert response.data["environment"] is None
-        assert response.data["conditions"][0]["name"]
-
-    @with_feature("organizations:workflow-engine-rule-serializers")
-    def test_workflow_engine_serializer_single_written_rule(self) -> None:
+        # create single written workflow
         self.detector = self.create_detector()
         self.workflow_triggers = self.create_data_condition_group()
         self.workflow = self.create_workflow(
@@ -184,12 +163,33 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
             condition_result=True,
         )
         self.action_group, self.action = self.create_workflow_action(self.workflow)
+        self.fake_workflow_id = get_fake_id_from_object_id(self.workflow.id)
 
-        fake_workflow_id = get_fake_id_from_object_id(self.workflow.id)
+
+class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
+    def test_simple(self) -> None:
         response = self.get_success_response(
-            self.organization.slug, self.project.slug, fake_workflow_id, status_code=200
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200
         )
-        assert response.data["id"] == str(fake_workflow_id)
+        assert response.data["id"] == str(self.rule.id)
+        assert response.data["environment"] is None
+        assert response.data["conditions"][0]["name"]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_serializer_dual_written_rule(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200
+        )
+        assert response.data["id"] == str(self.rule.id)
+        assert response.data["environment"] is None
+        assert response.data["conditions"][0]["name"]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_serializer_single_written_rule(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=200
+        )
+        assert response.data["id"] == str(self.fake_workflow_id)
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
         assert response.data["filters"][0]["name"]
@@ -660,6 +660,12 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
         assert_rule_from_payload(self.rule, payload)
         assert send_robust.called
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_passed(self) -> None:
+        self.get_error_response(
+            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=400
+        )
 
     def test_no_owner(self) -> None:
         conditions = [
@@ -1633,6 +1639,12 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not Rule.objects.filter(
             id=self.rule.id, project=self.project, status=ObjectStatus.PENDING_DELETION
         ).exists()
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_passed(self) -> None:
+        self.get_error_response(
+            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=400
+        )
 
     def test_dual_delete_workflow_engine(self) -> None:
         rule = self.create_project_rule(

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -30,10 +30,11 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
 from sentry.workflow_engine.models import AlertRuleWorkflow
-from sentry.workflow_engine.models.data_condition import DataCondition
+from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
 def assert_rule_from_payload(rule: Rule, payload: Mapping[str, Any]) -> None:
@@ -136,7 +137,7 @@ class ProjectRuleDetailsBaseTestCase(APITestCase):
         ]
 
 
-class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
+class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
     def test_simple(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200
@@ -156,7 +157,28 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_serializer_single_written_rule(self) -> None:
-        pass
+        self.workflow = self.create_workflow()
+        self.detector = self.create_detector()
+        self.detector_workflow = self.create_detector_workflow(
+            detector=self.detector, workflow=self.workflow
+        )
+        self.dcg = self.create_data_condition_group()
+        self.create_data_condition(
+            condition_group=self.dcg,
+            type=Condition.FIRST_SEEN_EVENT,
+            comparison=True,
+            condition_result=True,
+        )
+
+        self.action_group, self.action = self.create_workflow_action(self.workflow)
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.workflow.id, status_code=200
+        )
+        assert (
+            response.data["id"] == "1234"
+        )  # TODO: we probably don't want this, do the fake id stuff
+        assert response.data["environment"] is None
+        assert response.data["conditions"][0]["name"]
 
     def test_non_existing_rule(self) -> None:
         self.get_error_response(self.organization.slug, self.project.slug, 12345, status_code=404)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -24,7 +24,7 @@ from sentry.sentry_apps.services.app.model import RpcAlertRuleActionResult
 from sentry.sentry_apps.utils.errors import SentryAppErrorType
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
@@ -144,6 +144,19 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["id"] == str(self.rule.id)
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_serializer_dual_written_rule(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug, self.project.slug, self.rule.id, status_code=200
+        )
+        assert response.data["id"] == str(self.rule.id)
+        assert response.data["environment"] is None
+        assert response.data["conditions"][0]["name"]
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_serializer_single_written_rule(self) -> None:
+        pass
 
     def test_non_existing_rule(self) -> None:
         self.get_error_response(self.organization.slug, self.project.slug, 12345, status_code=404)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -158,10 +158,12 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_serializer_single_written_rule(self) -> None:
-        # self.workflow = self.create_workflow()
         self.detector = self.create_detector()
         self.workflow_triggers = self.create_data_condition_group()
-        self.workflow = self.create_workflow(when_condition_group=self.workflow_triggers)
+        self.workflow = self.create_workflow(
+            when_condition_group=self.workflow_triggers,
+            organization=self.detector.project.organization,
+        )
         self.detector_workflow = self.create_detector_workflow(
             detector=self.detector, workflow=self.workflow
         )
@@ -182,10 +184,12 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
             condition_result=True,
         )
         self.action_group, self.action = self.create_workflow_action(self.workflow)
+
+        fake_workflow_id = get_fake_id_from_object_id(self.workflow.id)
         response = self.get_success_response(
-            self.organization.slug, self.project.slug, self.workflow.id, status_code=200
+            self.organization.slug, self.project.slug, fake_workflow_id, status_code=200
         )
-        assert response.data["id"] == str(get_fake_id_from_object_id(self.workflow.id))
+        assert response.data["id"] == str(fake_workflow_id)
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
         assert response.data["filters"][0]["name"]

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -16,6 +16,7 @@ from sentry.analytics.events.rule_disable_opt_out import (
 from sentry.analytics.events.rule_reenable import RuleReenableEdit
 from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.utils.channel import strip_channel_name
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
@@ -157,28 +158,37 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase, BaseWorkflowTest):
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_serializer_single_written_rule(self) -> None:
-        self.workflow = self.create_workflow()
+        # self.workflow = self.create_workflow()
         self.detector = self.create_detector()
+        self.workflow_triggers = self.create_data_condition_group()
+        self.workflow = self.create_workflow(when_condition_group=self.workflow_triggers)
         self.detector_workflow = self.create_detector_workflow(
             detector=self.detector, workflow=self.workflow
         )
-        self.dcg = self.create_data_condition_group()
-        self.create_data_condition(
-            condition_group=self.dcg,
-            type=Condition.FIRST_SEEN_EVENT,
-            comparison=True,
+        self.create_data_condition(  # trigger condition
+            condition_group=self.workflow_triggers,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 100},
             condition_result=True,
         )
-
+        self.workflow_filters = self.create_data_condition_group()
+        self.workflow_dcg = self.create_workflow_data_condition_group(
+            workflow=self.workflow, condition_group=self.workflow_filters
+        )
+        self.create_data_condition(  # filter condition
+            condition_group=self.workflow_filters,
+            type=Condition.EVENT_ATTRIBUTE,
+            comparison={"attribute": "platform", "match": "eq", "value": "python"},
+            condition_result=True,
+        )
         self.action_group, self.action = self.create_workflow_action(self.workflow)
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.workflow.id, status_code=200
         )
-        assert (
-            response.data["id"] == "1234"
-        )  # TODO: we probably don't want this, do the fake id stuff
+        assert response.data["id"] == str(get_fake_id_from_object_id(self.workflow.id))
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
+        assert response.data["filters"][0]["name"]
 
     def test_non_existing_rule(self) -> None:
         self.get_error_response(self.organization.slug, self.project.slug, 12345, status_code=404)


### PR DESCRIPTION
Make `ProjectRuleDetailsEndpoint` GET method backwards compatible mostly via a new `convert_args` method that first attempts to looks up the `AlertRuleWorkflow` for dual written rules, and if that fails we assume it is a singly written workflow and look it up directly on the `Workflow` model. 