### PR TITLE
fix(crons): Try to fix deletion spikes from crons

### DIFF
--- a/src/sentry/deletions/defaults/monitor.py
+++ b/src/sentry/deletions/defaults/monitor.py
@@ -1,6 +1,5 @@
 from sentry.deletions.base import (
     BaseRelation,
-    BulkModelDeletionTask,
     ModelDeletionTask,
     ModelRelation,
 )
@@ -13,9 +12,6 @@ class MonitorDeletionTask(ModelDeletionTask[Monitor]):
 
         return [
             ModelRelation(models.MonitorIncident, {"monitor_id": instance.id}),
-            # Use BulkModelDeletionTask here since MonitorIncidents are already handled above
-            ModelRelation(
-                models.MonitorCheckIn, {"monitor_id": instance.id}, BulkModelDeletionTask
-            ),
+            ModelRelation(models.MonitorCheckIn, {"monitor_id": instance.id}, ModelDeletionTask),
             ModelRelation(models.MonitorEnvironment, {"monitor_id": instance.id}),
         ]


### PR DESCRIPTION
We're seeing periodic random deletion spikes from crons that cause high cpu load and for us to page. Switching back to the standard `ModelDeletionTask` is much slower for deletions, and will hopefully prevent these load spikes.

<!-- Describe your PR here. -->