### PR TITLE
feat(dashboards): Add axisRange frontend types, state, wiring, and builder UI

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -28,6 +28,7 @@ import type {
 } from 'sentry/views/dashboards/types';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {getNumEquations} from 'sentry/views/dashboards/utils';
+import type {AxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import type {HookWidgetQueryResult} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import type {FieldValueOption} from 'sentry/views/discover/table/queryField';
 import type {FieldValue} from 'sentry/views/discover/table/types';
@@ -168,7 +169,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
   /**
    * Default Y-axis range for this dataset. Defaults to 'auto' if not set.
    */
-  axisRange?: 'auto' | 'dataMin';
+  axisRange?: AxisRange;
   /**
    * Default field to use as the X-axis category for categorical bar charts.
    * This should be a non-aggregate field name (e.g., 'transaction', 'browser').

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -166,6 +166,10 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     pageFilters: PageFilters
   ) => TableData;
   /**
+   * Default Y-axis range for this dataset. Defaults to 'auto' if not set.
+   */
+  axisRange?: 'auto' | 'dataMin';
+  /**
    * Default field to use as the X-axis category for categorical bar charts.
    * This should be a non-aggregate field name (e.g., 'transaction', 'browser').
    */

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -246,6 +246,7 @@ export const MobileAppSizeConfig: DatasetConfig<
   EventsStats | MultiSeriesEventsStats,
   TableData
 > = {
+  axisRange: 'dataMin',
   defaultField: DEFAULT_FIELD,
   defaultWidgetQuery: DEFAULT_WIDGET_QUERY,
   enableEquations: false,

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -4,6 +4,7 @@ import {t} from 'sentry/locale';
 import type {Tag} from 'sentry/types/group';
 import type {User} from 'sentry/types/user';
 import {SavedQueryDatasets, type DatasetSource} from 'sentry/utils/discover/types';
+import type {AxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import type {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import type {TimeSeriesMeta} from 'sentry/views/dashboards/widgets/common/types';
 
@@ -143,7 +144,7 @@ export type Widget = {
   interval: string;
   queries: WidgetQuery[];
   title: string;
-  axisRange?: 'auto' | 'dataMin';
+  axisRange?: AxisRange;
   changedReason?: WidgetChangedReason[];
   dashboardId?: string;
   datasetSource?: DatasetSource;

--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -143,6 +143,7 @@ export type Widget = {
   interval: string;
   queries: WidgetQuery[];
   title: string;
+  axisRange?: 'auto' | 'dataMin';
   changedReason?: WidgetChangedReason[];
   dashboardId?: string;
   datasetSource?: DatasetSource;

--- a/static/app/views/dashboards/utils/axisRange.ts
+++ b/static/app/views/dashboards/utils/axisRange.ts
@@ -1,12 +1,8 @@
-export const AXIS_RANGE_AUTO = 'auto';
-export const AXIS_RANGE_DATA_MIN = 'dataMin';
-
-export type AxisRange = typeof AXIS_RANGE_AUTO | typeof AXIS_RANGE_DATA_MIN;
-
-export function isAxisRange(value: unknown): value is AxisRange {
-  return value === AXIS_RANGE_AUTO || value === AXIS_RANGE_DATA_MIN;
-}
+export type AxisRange = 'auto' | 'dataMin';
 
 export function getAxisRange(value: unknown): AxisRange | undefined {
-  return isAxisRange(value) ? value : undefined;
+  if (value === 'auto' || value === 'dataMin') {
+    return value;
+  }
+  return undefined;
 }

--- a/static/app/views/dashboards/utils/axisRange.ts
+++ b/static/app/views/dashboards/utils/axisRange.ts
@@ -1,0 +1,12 @@
+export const AXIS_RANGE_AUTO = 'auto';
+export const AXIS_RANGE_DATA_MIN = 'dataMin';
+
+export type AxisRange = typeof AXIS_RANGE_AUTO | typeof AXIS_RANGE_DATA_MIN;
+
+export function isAxisRange(value: unknown): value is AxisRange {
+  return value === AXIS_RANGE_AUTO || value === AXIS_RANGE_DATA_MIN;
+}
+
+export function getAxisRange(value: unknown): AxisRange | undefined {
+  return isAxisRange(value) ? value : undefined;
+}

--- a/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
+++ b/static/app/views/dashboards/utils/widgetCanUseTimeSeriesVisualization.tsx
@@ -7,6 +7,7 @@ const SUPPORTED_WIDGET_TYPES = new Set<WidgetType>([
   WidgetType.LOGS,
   WidgetType.ERRORS,
   WidgetType.TRACEMETRICS,
+  WidgetType.PREPROD_APP_SIZE,
 ]);
 
 const SUPPORTED_DISPLAY_TYPES = new Set<DisplayType>([

--- a/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
@@ -4,14 +4,13 @@ import {Flex} from '@sentry/scraps/layout';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {AXIS_RANGE_AUTO} from 'sentry/views/dashboards/utils/axisRange';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 function AxisRangeSection() {
   const {state, dispatch} = useWidgetBuilderContext();
   const datasetConfig = getDatasetConfig(state.dataset);
-  const value = state.axisRange ?? datasetConfig.axisRange ?? AXIS_RANGE_AUTO;
+  const value = state.axisRange ?? datasetConfig.axisRange ?? 'auto';
 
   return (
     <Flex

--- a/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
@@ -1,5 +1,4 @@
-import {CompactSelect} from '@sentry/scraps/compactSelect';
-
+import RadioGroup from 'sentry/components/forms/controls/radioGroup';
 import {t} from 'sentry/locale';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
@@ -14,16 +13,18 @@ function AxisRangeSection() {
   return (
     <div>
       <SectionHeader title={t('Y-Axis Range')} />
-      <CompactSelect
+      <RadioGroup
+        label=""
         value={value}
-        options={[
-          {value: 'auto' as const, label: t('Auto (start at 0)')},
-          {value: 'dataMin' as const, label: t('Fit to data')},
+        orientInline
+        choices={[
+          ['auto' as const, t('Auto')],
+          ['dataMin' as const, t('Fit to data')],
         ]}
-        onChange={selection => {
+        onChange={selected => {
           dispatch({
             type: BuilderStateAction.SET_AXIS_RANGE,
-            payload: selection.value,
+            payload: selected,
           });
         }}
       />

--- a/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
@@ -1,0 +1,34 @@
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+
+import {t} from 'sentry/locale';
+import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
+import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
+import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+
+function AxisRangeSection() {
+  const {state, dispatch} = useWidgetBuilderContext();
+  const datasetConfig = getDatasetConfig(state.dataset);
+  const value = state.axisRange ?? datasetConfig.axisRange ?? 'auto';
+
+  return (
+    <div>
+      <SectionHeader title={t('Y-Axis Range')} />
+      <CompactSelect
+        value={value}
+        options={[
+          {value: 'auto' as const, label: t('Auto (start at 0)')},
+          {value: 'dataMin' as const, label: t('Fit to data')},
+        ]}
+        onChange={selection => {
+          dispatch({
+            type: BuilderStateAction.SET_AXIS_RANGE,
+            payload: selection.value,
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+export default AxisRangeSection;

--- a/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
@@ -1,34 +1,35 @@
-import RadioGroup from 'sentry/components/forms/controls/radioGroup';
+import {Checkbox} from '@sentry/scraps/checkbox';
+import {Flex} from '@sentry/scraps/layout';
+
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
-import {SectionHeader} from 'sentry/views/dashboards/widgetBuilder/components/common/sectionHeader';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 function AxisRangeSection() {
   const {state, dispatch} = useWidgetBuilderContext();
   const datasetConfig = getDatasetConfig(state.dataset);
-  const value = state.axisRange ?? datasetConfig.axisRange ?? 'auto';
+  const value = state.axisRange || datasetConfig.axisRange || 'auto';
 
   return (
-    <div>
-      <SectionHeader title={t('Y-Axis Range')} />
-      <RadioGroup
-        label=""
-        value={value}
-        orientInline
-        choices={[
-          ['auto' as const, t('Auto')],
-          ['dataMin' as const, t('Fit to data')],
-        ]}
-        onChange={selected => {
+    <Flex
+      as="label"
+      align="center"
+      gap="sm"
+      style={{marginTop: space(1), cursor: 'pointer'}}
+    >
+      <Checkbox
+        checked={value === 'dataMin'}
+        onChange={e => {
           dispatch({
             type: BuilderStateAction.SET_AXIS_RANGE,
-            payload: selected,
+            payload: e.target.checked ? 'dataMin' : 'auto',
           });
         }}
       />
-    </div>
+      {t('Fit Y-Axis to data')}
+    </Flex>
   );
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/axisRangeSection.tsx
@@ -4,13 +4,14 @@ import {Flex} from '@sentry/scraps/layout';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
+import {AXIS_RANGE_AUTO} from 'sentry/views/dashboards/utils/axisRange';
 import {useWidgetBuilderContext} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 
 function AxisRangeSection() {
   const {state, dispatch} = useWidgetBuilderContext();
   const datasetConfig = getDatasetConfig(state.dataset);
-  const value = state.axisRange || datasetConfig.axisRange || 'auto';
+  const value = state.axisRange ?? datasetConfig.axisRange ?? AXIS_RANGE_AUTO;
 
   return (
     <Flex

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -185,4 +185,5 @@ export default WidgetBuilderTypeSelector;
 const StyledFieldGroup = styled(FieldGroup)`
   width: 100%;
   padding: 0px;
+  border-bottom: none;
 `;

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -391,6 +391,7 @@ function WidgetBuilderSlideout({
                   <DisableTransactionWidget>
                     <Section>
                       <WidgetBuilderTypeSelector error={error} setError={setError} />
+                      {isTimeSeriesWidget && <AxisRangeSection />}
                     </Section>
                     <div ref={observeForDraggablePreview}>
                       {isSmallScreen && (
@@ -453,11 +454,6 @@ function WidgetBuilderSlideout({
                     {showSortByStep && (
                       <Section>
                         <WidgetBuilderSortBySelector />
-                      </Section>
-                    )}
-                    {isTimeSeriesWidget && (
-                      <Section>
-                        <AxisRangeSection />
                       </Section>
                     )}
                   </DisableTransactionWidget>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -39,6 +39,7 @@ import {
   doesDisplayTypeSupportThresholds,
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
+import AxisRangeSection from 'sentry/views/dashboards/widgetBuilder/components/axisRangeSection';
 import {animationTransitionSettings} from 'sentry/views/dashboards/widgetBuilder/components/common/animationSettings';
 import WidgetBuilderDatasetSelector from 'sentry/views/dashboards/widgetBuilder/components/datasetSelector';
 import WidgetBuilderFilterBar from 'sentry/views/dashboards/widgetBuilder/components/filtersBar';
@@ -452,6 +453,11 @@ function WidgetBuilderSlideout({
                     {showSortByStep && (
                       <Section>
                         <WidgetBuilderSortBySelector />
+                      </Section>
+                    )}
+                    {isTimeSeriesWidget && (
+                      <Section>
+                        <AxisRangeSection />
                       </Section>
                     )}
                   </DisableTransactionWidget>

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -61,6 +61,7 @@ const DETAIL_WIDGET_FIELDS: DefaultDetailWidgetFields[] = [
 export const MAX_NUM_Y_AXES = 3;
 
 export type WidgetBuilderStateQueryParams = {
+  axisRange?: string;
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
@@ -96,6 +97,7 @@ export const BuilderStateAction = {
   SET_CATEGORICAL_X_AXIS: 'SET_CATEGORICAL_X_AXIS',
   SET_CATEGORICAL_AGGREGATE: 'SET_CATEGORICAL_AGGREGATE',
   DELETE_AGGREGATE: 'DELETE_AGGREGATE',
+  SET_AXIS_RANGE: 'SET_AXIS_RANGE',
 } as const;
 
 type WidgetAction =
@@ -131,12 +133,17 @@ type WidgetAction =
   | {
       payload: number; // index of the field to delete within the visible fields list
       type: typeof BuilderStateAction.DELETE_AGGREGATE;
+    }
+  | {
+      payload: 'auto' | 'dataMin' | undefined;
+      type: typeof BuilderStateAction.SET_AXIS_RANGE;
     };
 type WidgetBuilderStateActionOptions = {
   updateUrl?: boolean;
 };
 
 export interface WidgetBuilderState {
+  axisRange?: 'auto' | 'dataMin';
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
@@ -337,6 +344,10 @@ function useWidgetBuilderState(): {
     deserializer: deserializeTraceMetric,
     serializer: serializeTraceMetric,
   });
+  const [axisRange, setAxisRange] = useQueryParamState<'auto' | 'dataMin' | undefined>({
+    fieldName: 'axisRange',
+    decoder: decodeScalar,
+  });
 
   const state = useMemo(
     () => ({
@@ -353,6 +364,7 @@ function useWidgetBuilderState(): {
       thresholds,
       linkedDashboards,
       traceMetric,
+      axisRange,
       // The selected aggregate is the last aggregate for big number and categorical bar widgets
       // if it hasn't been explicitly set.
       // For categorical bar, only count aggregate fields (FUNCTION/EQUATION), not the X-axis FIELD column
@@ -387,6 +399,7 @@ function useWidgetBuilderState(): {
       thresholds,
       linkedDashboards,
       traceMetric,
+      axisRange,
     ]
   );
 
@@ -559,6 +572,9 @@ function useWidgetBuilderState(): {
           if (!doesDisplayTypeSupportThresholds(action.payload)) {
             setThresholds(undefined, options);
           }
+          if (!usesTimeSeriesData(action.payload)) {
+            setAxisRange(undefined, options);
+          }
           setSelectedAggregate(undefined, options);
           setLinkedDashboards([], options);
           break;
@@ -647,6 +663,7 @@ function useWidgetBuilderState(): {
           }
 
           setThresholds(undefined, options);
+          setAxisRange(undefined, options);
           setQuery([config.defaultWidgetQuery.conditions], options);
           setLegendAlias([], options);
           setSelectedAggregate(undefined, options);
@@ -906,9 +923,16 @@ function useWidgetBuilderState(): {
           if (action.payload.traceMetric) {
             setTraceMetric(deserializeTraceMetric(action.payload.traceMetric), options);
           }
+          setAxisRange(
+            action.payload.axisRange as 'auto' | 'dataMin' | undefined,
+            options
+          );
           break;
         case BuilderStateAction.SET_THRESHOLDS:
           setThresholds(action.payload, options);
+          break;
+        case BuilderStateAction.SET_AXIS_RANGE:
+          setAxisRange(action.payload, options);
           break;
         case BuilderStateAction.SET_TRACE_METRIC:
           if (dataset === WidgetType.TRACEMETRICS) {
@@ -1182,6 +1206,7 @@ function useWidgetBuilderState(): {
       setLegendAlias,
       setSelectedAggregate,
       setThresholds,
+      setAxisRange,
       setLinkedDashboards,
       fields,
       yAxis,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -30,7 +30,7 @@ import {
   doesDisplayTypeSupportThresholds,
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
-import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
+import {getAxisRange, type AxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds';
 import {
   DISABLED_SORT,
@@ -62,7 +62,7 @@ const DETAIL_WIDGET_FIELDS: DefaultDetailWidgetFields[] = [
 export const MAX_NUM_Y_AXES = 3;
 
 export type WidgetBuilderStateQueryParams = {
-  axisRange?: string;
+  axisRange?: AxisRange;
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
@@ -136,7 +136,7 @@ type WidgetAction =
       type: typeof BuilderStateAction.DELETE_AGGREGATE;
     }
   | {
-      payload: 'auto' | 'dataMin' | undefined;
+      payload: AxisRange | undefined;
       type: typeof BuilderStateAction.SET_AXIS_RANGE;
     };
 type WidgetBuilderStateActionOptions = {
@@ -144,7 +144,7 @@ type WidgetBuilderStateActionOptions = {
 };
 
 export interface WidgetBuilderState {
-  axisRange?: 'auto' | 'dataMin';
+  axisRange?: AxisRange;
   dataset?: WidgetType;
   description?: string;
   displayType?: DisplayType;
@@ -345,7 +345,7 @@ function useWidgetBuilderState(): {
     deserializer: deserializeTraceMetric,
     serializer: serializeTraceMetric,
   });
-  const [axisRange, setAxisRange] = useQueryParamState<'auto' | 'dataMin' | undefined>({
+  const [axisRange, setAxisRange] = useQueryParamState<AxisRange | undefined>({
     fieldName: 'axisRange',
     decoder: decodeScalar,
     deserializer: getAxisRange,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -30,6 +30,7 @@ import {
   doesDisplayTypeSupportThresholds,
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
+import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import type {ThresholdsConfig} from 'sentry/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds';
 import {
   DISABLED_SORT,
@@ -347,6 +348,7 @@ function useWidgetBuilderState(): {
   const [axisRange, setAxisRange] = useQueryParamState<'auto' | 'dataMin' | undefined>({
     fieldName: 'axisRange',
     decoder: decodeScalar,
+    deserializer: getAxisRange,
   });
 
   const state = useMemo(
@@ -923,10 +925,7 @@ function useWidgetBuilderState(): {
           if (action.payload.traceMetric) {
             setTraceMetric(deserializeTraceMetric(action.payload.traceMetric), options);
           }
-          setAxisRange(
-            action.payload.axisRange as 'auto' | 'dataMin' | undefined,
-            options
-          );
+          setAxisRange(getAxisRange(action.payload.axisRange), options);
           break;
         case BuilderStateAction.SET_THRESHOLDS:
           setThresholds(action.payload, options);

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -228,4 +228,27 @@ describe('convertBuilderStateToWidget', () => {
 
     expect(widget.limit).toBeUndefined();
   });
+
+  it('uses explicit axisRange from state', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.ERRORS,
+      displayType: DisplayType.LINE,
+      axisRange: 'dataMin',
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.axisRange).toBe('dataMin');
+  });
+
+  it('falls back to dataset config axisRange when state.axisRange is undefined', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.PREPROD_APP_SIZE,
+      displayType: DisplayType.LINE,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.axisRange).toBe('dataMin');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -251,4 +251,16 @@ describe('convertBuilderStateToWidget', () => {
 
     expect(widget.axisRange).toBe('dataMin');
   });
+
+  it('falls back to dataset config axisRange when state.axisRange is invalid', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.PREPROD_APP_SIZE,
+      displayType: DisplayType.LINE,
+      axisRange: 'invalid' as any,
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.axisRange).toBe('dataMin');
+  });
 });

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -161,5 +161,6 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     widgetType: state.dataset,
     limit,
     thresholds: state.thresholds,
+    axisRange: state.axisRange,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -12,6 +12,7 @@ import {
   type WidgetQuery,
 } from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import {
   serializeSorts,
   type WidgetBuilderState,
@@ -161,6 +162,6 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     widgetType: state.dataset,
     limit,
     thresholds: state.thresholds,
-    axisRange: state.axisRange ?? datasetConfig.axisRange,
+    axisRange: getAxisRange(state.axisRange) ?? datasetConfig.axisRange,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.ts
@@ -161,6 +161,6 @@ export function convertBuilderStateToWidget(state: WidgetBuilderState): Widget {
     widgetType: state.dataset,
     limit,
     thresholds: state.thresholds,
-    axisRange: state.axisRange,
+    axisRange: state.axisRange ?? datasetConfig.axisRange,
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -123,6 +123,30 @@ describe('convertWidgetToBuilderStateParams', () => {
     );
   });
 
+  it('omits axisRange when widget axisRange is null', () => {
+    const widget = {
+      ...getDefaultWidget(WidgetType.ERRORS),
+      axisRange: null,
+    };
+
+    const params = convertWidgetToBuilderStateParams(
+      widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
+    );
+    expect(params.axisRange).toBeUndefined();
+  });
+
+  it('omits axisRange when widget axisRange is invalid', () => {
+    const widget = {
+      ...getDefaultWidget(WidgetType.ERRORS),
+      axisRange: 'invalid',
+    };
+
+    const params = convertWidgetToBuilderStateParams(
+      widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
+    );
+    expect(params.axisRange).toBeUndefined();
+  });
+
   describe('traceMetric', () => {
     it('includes the trace metric in the builder params', () => {
       const widget: Widget = WidgetFixture({

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -6,6 +6,7 @@ import {
   type WidgetQuery,
 } from 'sentry/views/dashboards/types';
 import {usesTimeSeriesData} from 'sentry/views/dashboards/utils';
+import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
 import {
   serializeFields,
@@ -75,6 +76,6 @@ export function convertWidgetToBuilderStateParams(
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
-    axisRange: widget.axisRange,
+    axisRange: getAxisRange(widget.axisRange),
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -75,5 +75,6 @@ export function convertWidgetToBuilderStateParams(
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
+    axisRange: widget.axisRange,
   };
 }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -403,6 +403,7 @@ function VisualizationWidgetContent({
             releases={releases}
             showReleaseAs={showReleaseAs}
             showLegend="never"
+            axisRange={widget.axisRange}
           />
         </Container>
         <Flex flex={1} direction="column" borderTop="primary" overflowY="auto">
@@ -420,6 +421,7 @@ function VisualizationWidgetContent({
         plottables={plottables}
         releases={releases}
         showReleaseAs={showReleaseAs}
+        axisRange={widget.axisRange}
       />
     </Container>
   );

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -34,6 +34,7 @@ import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useWidgetSyncContext} from 'sentry/views/dashboards/contexts/widgetSyncContext';
+import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   LegendSelection,
@@ -232,7 +233,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     return FALLBACK_UNIT_FOR_FIELD_TYPE[type as AggregationOutputType];
   });
 
-  const axisRangeProp = props.axisRange ?? 'auto';
+  const axisRangeProp = getAxisRange(props.axisRange) ?? 'auto';
 
   const leftYAxis: YAXisComponentOption = TimeSeriesWidgetYAxis(
     {

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -34,7 +34,7 @@ import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useWidgetSyncContext} from 'sentry/views/dashboards/contexts/widgetSyncContext';
-import {getAxisRange} from 'sentry/views/dashboards/utils/axisRange';
+import {getAxisRange, type AxisRange} from 'sentry/views/dashboards/utils/axisRange';
 import {NO_PLOTTABLE_VALUES} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   LegendSelection,
@@ -67,7 +67,7 @@ export interface TimeSeriesWidgetVisualizationProps extends Partial<LoadableChar
    * - `dataMin`: The Y axis starts at the minimum value of the data, and ends at the maximum value of the data.
    * Default: `auto`
    */
-  axisRange?: 'auto' | 'dataMin';
+  axisRange?: AxisRange;
 
   /**
    * Reference to the chart instance

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetYAxis.tsx
@@ -1,6 +1,8 @@
 import type {YAXisComponentOption} from 'echarts';
 import merge from 'lodash/merge';
 
+import type {AxisRange} from 'sentry/views/dashboards/utils/axisRange';
+
 import {Y_AXIS_INTEGER_TOLERANCE} from './settings';
 
 type TimeSeriesWidgetYAxisProps = YAXisComponentOption;
@@ -8,7 +10,7 @@ type TimeSeriesWidgetYAxisProps = YAXisComponentOption;
 export function TimeSeriesWidgetYAxis(
   props: TimeSeriesWidgetYAxisProps,
   yAxisFieldType: string,
-  yAxisRange: 'auto' | 'dataMin'
+  yAxisRange: AxisRange
 ): YAXisComponentOption {
   return merge(
     {


### PR DESCRIPTION
Add configurable Y-axis range behavior for dashboard time-series widgets.

This introduces `axisRange` in the frontend widget model and widget-builder state,
adds a "Fit Y-Axis to data" control in the builder for time-series display types,
and wires the setting through widget conversion and rendering so charts respect
`auto` vs `dataMin` consistently.

It also sets the mobile app size dataset default to `dataMin` and enables
`PREPROD_APP_SIZE` to use the time-series visualization path so app-size charts
benefit from the same axis-range controls.

A follow-up fix in this PR normalizes runtime `axisRange` values from URL/query
state and widget payloads. Without normalization, null/invalid values could make
preview behavior diverge from the builder control state. We now accept only
`auto` and `dataMin`, and fall back safely to default behavior otherwise.

Depends on #109389.

Closes EME-890 (frontend portion)