### PR TITLE
feat(autofix): Render diff in explorer autofix slack integration

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -127,6 +127,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
             webhook_payload["code_changes"] = {
                 repo: [
                     {
+                        "diff": p.diff,
                         "path": p.patch.path,
                         "type": p.patch.type,
                         "added": p.patch.added,

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -254,10 +254,9 @@ class SlackEntrypoint(SeerEntrypoint[SlackEntrypointCachePayload]):
                     changes_list = [
                         {
                             "repo_name": repo,
-                            "title": change["path"],
-                            # TODO: add the diff to the change list
-                            "description": "",
-                            "diff": "",
+                            "title": change.get("path", ""),
+                            "description": "",  # No description available in explorer autofix
+                            "diff": change.get("diff", ""),
                         }
                         for repo, changes in explorer_changes.items()
                         for change in changes

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -62,6 +62,7 @@ class ExplorerFilePatch(BaseModel):
 
     repo_name: str
     patch: FilePatch
+    diff: str = ""
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
Following up from getsentry/seer#4965 to render the computed diff in slack.