### PR TITLE
feat(preprod): Add snapshot diff comparison UI

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,7 +10,10 @@ import {Client} from 'sentry/api';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import type {SnapshotComparisonRunInfo} from 'sentry/views/preprod/types/snapshotTypes';
+import {
+  ComparisonState,
+  type SnapshotComparisonRunInfo,
+} from 'sentry/views/preprod/types/snapshotTypes';
 
 function formatDuration(ms: number): string {
   if (ms < 60_000) {
@@ -44,18 +47,16 @@ export function SnapshotDevTools({
   const [devToolsCollapsed, setDevToolsCollapsed] = useState(
     () => localStorage.getItem('snapshot-dev-tools-collapsed') === 'true'
   );
-  const [polling, setPolling] = useState(false);
   const [recompareLoading, setRecompareLoading] = useState(false);
   const [recompareError, setRecompareError] = useState<string | null>(null);
   const clientRef = useRef(new Client());
 
-  useEffect(() => {
-    if (comparisonState) {
-      setPolling(true);
-    } else {
-      setPolling(false);
-    }
-  }, [comparisonState]);
+  const polling = useMemo(
+    () =>
+      comparisonState === ComparisonState.PENDING ||
+      comparisonState === ComparisonState.PROCESSING,
+    [comparisonState]
+  );
 
   useEffect(() => {
     if (!polling) {
@@ -79,7 +80,6 @@ export function SnapshotDevTools({
         method: 'POST',
         success: () => {
           setRecompareLoading(false);
-          setPolling(true);
           refetch();
         },
         error: (err: any) => {
@@ -91,9 +91,9 @@ export function SnapshotDevTools({
   }, [organizationSlug, projectSlug, snapshotId, refetch]);
 
   let stateLabel: string;
-  if (comparisonState === 'PROCESSING') {
+  if (comparisonState === ComparisonState.PROCESSING) {
     stateLabel = t('Processing...');
-  } else if (comparisonState === 'PENDING') {
+  } else if (comparisonState === ComparisonState.PENDING) {
     stateLabel = t('Queued...');
   } else if (comparisonCompletedAt) {
     stateLabel = t('Done');

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -10,7 +10,7 @@ import {Client} from 'sentry/api';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
-import {formatDuration} from 'sentry/utils/duration/formatDuration';
+import formatDuration from 'sentry/utils/duration/formatDuration';
 import {
   ComparisonState,
   type SnapshotComparisonRunInfo,
@@ -195,7 +195,9 @@ export function SnapshotDevTools({
         </Flex>
       )}
       {!devToolsCollapsed && recompareError && (
-        <ErrorText size="xs">{recompareError}</ErrorText>
+        <Text size="xs" variant="danger">
+          {recompareError}
+        </Text>
       )}
     </DevToolsBox>
   );
@@ -241,8 +243,4 @@ const PulsingDot = styled('div')<{active: boolean}>`
   border-radius: 50%;
   background: ${p => (p.active ? p.theme.colors.yellow300 : p.theme.colors.gray200)};
   animation: ${p => (p.active ? pulse : 'none')} 1.2s ease-in-out infinite;
-`;
-
-const ErrorText = styled(Text)`
-  color: ${p => p.theme.colors.red300};
 `;

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -19,8 +19,12 @@ function formatDuration(ms: number): string {
   if (ms < 60_000) {
     return `${(ms / 1000).toFixed(1)}s`;
   }
-  const minutes = Math.floor(ms / 60_000);
-  const seconds = Math.round((ms % 60_000) / 1000);
+  let minutes = Math.floor(ms / 60_000);
+  let seconds = Math.round((ms % 60_000) / 1000);
+  if (seconds === 60) {
+    minutes += 1;
+    seconds = 0;
+  }
   return `${minutes}m ${seconds}s`;
 }
 
@@ -95,6 +99,8 @@ export function SnapshotDevTools({
     stateLabel = t('Processing...');
   } else if (comparisonState === ComparisonState.PENDING) {
     stateLabel = t('Queued...');
+  } else if (comparisonState === ComparisonState.FAILED) {
+    stateLabel = t('Failed');
   } else if (comparisonCompletedAt) {
     stateLabel = t('Done');
   } else {

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -30,7 +30,7 @@ type Props = {
   projectSlug: string;
   refetch: () => void;
   snapshotId: string;
-  comparisonRunInfo?: SnapshotComparisonRunInfo;
+  comparisonRunInfo?: SnapshotComparisonRunInfo | null;
 };
 
 export function SnapshotDevTools({

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -10,27 +10,20 @@ import {Client} from 'sentry/api';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
+import {formatDuration} from 'sentry/utils/duration/formatDuration';
 import {
   ComparisonState,
   type SnapshotComparisonRunInfo,
 } from 'sentry/views/preprod/types/snapshotTypes';
 
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) {
-    return `${totalSeconds}s`;
-  }
-  return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`;
-}
-
-type Props = {
+interface SnapshotDevToolsProps {
   hasBaseArtifact: boolean;
   organizationSlug: string;
   projectSlug: string;
   refetch: () => void;
   snapshotId: string;
   comparisonRunInfo?: SnapshotComparisonRunInfo | null;
-};
+}
 
 export function SnapshotDevTools({
   organizationSlug,
@@ -39,7 +32,7 @@ export function SnapshotDevTools({
   comparisonRunInfo,
   hasBaseArtifact,
   refetch,
-}: Props) {
+}: SnapshotDevToolsProps) {
   const comparisonState = comparisonRunInfo?.state;
   const comparisonCompletedAt = comparisonRunInfo?.completed_at;
   const comparisonDurationMs = comparisonRunInfo?.duration_ms;
@@ -181,7 +174,11 @@ export function SnapshotDevTools({
                 {t('comparison e2e:')}
               </Text>
               <Text size="xs" bold>
-                {formatDuration(comparisonDurationMs)}
+                {formatDuration({
+                  duration: [comparisonDurationMs, 'ms'],
+                  precision: 'sec',
+                  style: 'h:mm:ss',
+                })}
               </Text>
             </Flex>
           )}

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -16,16 +16,11 @@ import {
 } from 'sentry/views/preprod/types/snapshotTypes';
 
 function formatDuration(ms: number): string {
-  if (ms < 60_000) {
-    return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
   }
-  let minutes = Math.floor(ms / 60_000);
-  let seconds = Math.round((ms % 60_000) / 1000);
-  if (seconds === 60) {
-    minutes += 1;
-    seconds = 0;
-  }
-  return `${minutes}m ${seconds}s`;
+  return `${Math.floor(totalSeconds / 60)}m ${totalSeconds % 60}s`;
 }
 
 type Props = {

--- a/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotDevTools.tsx
@@ -1,0 +1,250 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {keyframes} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {Client} from 'sentry/api';
+import {IconAdd, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
+import type {SnapshotComparisonRunInfo} from 'sentry/views/preprod/types/snapshotTypes';
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+type Props = {
+  hasBaseArtifact: boolean;
+  organizationSlug: string;
+  projectSlug: string;
+  refetch: () => void;
+  snapshotId: string;
+  comparisonRunInfo?: SnapshotComparisonRunInfo;
+};
+
+export function SnapshotDevTools({
+  organizationSlug,
+  projectSlug,
+  snapshotId,
+  comparisonRunInfo,
+  hasBaseArtifact,
+  refetch,
+}: Props) {
+  const comparisonState = comparisonRunInfo?.state;
+  const comparisonCompletedAt = comparisonRunInfo?.completed_at;
+  const comparisonDurationMs = comparisonRunInfo?.duration_ms;
+  const [devToolsCollapsed, setDevToolsCollapsed] = useState(
+    () => localStorage.getItem('snapshot-dev-tools-collapsed') === 'true'
+  );
+  const [polling, setPolling] = useState(false);
+  const [recompareLoading, setRecompareLoading] = useState(false);
+  const [recompareError, setRecompareError] = useState<string | null>(null);
+  const clientRef = useRef(new Client());
+
+  useEffect(() => {
+    if (comparisonState) {
+      setPolling(true);
+    } else {
+      setPolling(false);
+    }
+  }, [comparisonState]);
+
+  useEffect(() => {
+    if (!polling) {
+      return undefined;
+    }
+    const interval = setInterval(() => refetch(), 1000);
+    return () => clearInterval(interval);
+  }, [polling, refetch]);
+
+  const setCollapsed = (collapsed: boolean) => {
+    setDevToolsCollapsed(collapsed);
+    localStorage.setItem('snapshot-dev-tools-collapsed', String(collapsed));
+  };
+
+  const handleRecompare = useCallback(() => {
+    setRecompareLoading(true);
+    setRecompareError(null);
+    clientRef.current.request(
+      `/projects/${organizationSlug}/${projectSlug}/preprodartifacts/snapshots/${snapshotId}/recompare/`,
+      {
+        method: 'POST',
+        success: () => {
+          setRecompareLoading(false);
+          setPolling(true);
+          refetch();
+        },
+        error: (err: any) => {
+          setRecompareLoading(false);
+          setRecompareError(err?.responseJSON?.detail ?? 'Failed to recompare');
+        },
+      }
+    );
+  }, [organizationSlug, projectSlug, snapshotId, refetch]);
+
+  let stateLabel: string;
+  if (comparisonState === 'PROCESSING') {
+    stateLabel = t('Processing...');
+  } else if (comparisonState === 'PENDING') {
+    stateLabel = t('Queued...');
+  } else if (comparisonCompletedAt) {
+    stateLabel = t('Done');
+  } else {
+    stateLabel = t('No comparison');
+  }
+
+  return (
+    <DevToolsBox data-collapsed={devToolsCollapsed}>
+      {devToolsCollapsed ? (
+        <Flex align="center" justify="center" gap="xs">
+          <Text size="xs" variant="muted">
+            {t('temp dev tools')}
+          </Text>
+          <Button
+            size="zero"
+            priority="transparent"
+            icon={<IconAdd size="xs" />}
+            aria-label={t('Expand')}
+            onClick={() => setCollapsed(false)}
+          />
+        </Flex>
+      ) : (
+        <Flex direction="column" gap="sm">
+          <CollapseButton
+            size="zero"
+            priority="transparent"
+            icon={<IconSubtract size="xs" />}
+            aria-label={t('Collapse')}
+            onClick={() => setCollapsed(true)}
+          />
+          <Flex align="center" justify="center">
+            <Text size="xs" variant="muted">
+              {t('temp dev tools')}
+            </Text>
+          </Flex>
+        </Flex>
+      )}
+      {!devToolsCollapsed && (
+        <Flex align="center" gap="sm">
+          <StatusPill>
+            <Text size="xs" variant="muted">
+              {t('Mode:')}
+            </Text>
+            <Text size="xs" bold>
+              {hasBaseArtifact ? t('Diff') : t('Solo')}
+            </Text>
+          </StatusPill>
+          <Text size="xs" variant="muted">
+            {'|'}
+          </Text>
+          <StatusPill>
+            <PulsingDot active={polling} />
+            <Text size="xs" variant="muted">
+              {t('State:')}
+            </Text>
+            <Text size="xs" bold>
+              {stateLabel}
+            </Text>
+          </StatusPill>
+          {comparisonCompletedAt && (
+            <Text size="xs" variant="muted">
+              {'|'}
+            </Text>
+          )}
+          {comparisonCompletedAt && (
+            <Flex align="center" gap="xs">
+              <Text size="xs" variant="muted">
+                {t('Last run:')}
+              </Text>
+              <Text size="xs" bold>
+                {new Date(comparisonCompletedAt).toLocaleTimeString()}
+              </Text>
+            </Flex>
+          )}
+          {comparisonDurationMs !== undefined && (
+            <Text size="xs" variant="muted">
+              {'|'}
+            </Text>
+          )}
+          {comparisonDurationMs !== undefined && (
+            <Flex align="center" gap="xs">
+              <Text size="xs" variant="muted">
+                {t('comparison e2e:')}
+              </Text>
+              <Text size="xs" bold>
+                {formatDuration(comparisonDurationMs)}
+              </Text>
+            </Flex>
+          )}
+          {hasBaseArtifact && (
+            <Text size="xs" variant="muted">
+              {'|'}
+            </Text>
+          )}
+          {hasBaseArtifact && (
+            <Button size="xs" onClick={handleRecompare} disabled={recompareLoading}>
+              {recompareLoading ? t('Queuing...') : t('Re-run Comparison')}
+            </Button>
+          )}
+        </Flex>
+      )}
+      {!devToolsCollapsed && recompareError && (
+        <ErrorText size="xs">{recompareError}</ErrorText>
+      )}
+    </DevToolsBox>
+  );
+}
+
+const pulse = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+`;
+
+const DevToolsBox = styled('div')`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: ${space(0.5)};
+  padding: ${space(0.75)} ${space(1)};
+  border: 1px dashed ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+
+  &:not([data-collapsed='true']) {
+    padding-right: 48px;
+  }
+`;
+
+const CollapseButton = styled(Button)`
+  position: absolute;
+  top: ${space(0.5)};
+  right: ${space(0.5)};
+`;
+
+const StatusPill = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  padding: 2px ${space(0.75)};
+  border: 1px solid ${p => p.theme.tokens.border.accent};
+  border-radius: 12px;
+`;
+
+const PulsingDot = styled('div')<{active: boolean}>`
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: ${p => (p.active ? p.theme.colors.yellow300 : p.theme.colors.gray200)};
+  animation: ${p => (p.active ? pulse : 'none')} 1.2s ease-in-out infinite;
+`;
+
+const ErrorText = styled(Text)`
+  color: ${p => p.theme.colors.red300};
+`;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -102,16 +102,7 @@ export function DiffImageDisplay({
             <ImageWrapper>
               <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
               {showOverlay && diffMaskUrl && (
-                <DiffOverlay
-                  style={{
-                    backgroundColor: overlayColor,
-                    maskImage: `url(${diffMaskUrl})`,
-                    maskSize: '100% 100%',
-                    maskMode: 'luminance',
-                    WebkitMaskImage: `url(${diffMaskUrl})`,
-                    WebkitMaskSize: '100% 100%',
-                  }}
-                />
+                <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
               )}
             </ImageWrapper>
           </Flex>
@@ -130,11 +121,17 @@ const ImageWrapper = styled('div')`
   position: relative;
 `;
 
-const DiffOverlay = styled('span')`
+const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   position: absolute;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
+  background-color: ${p => p.$overlayColor};
+  mask-image: url(${p => p.$maskUrl});
+  mask-size: 100% 100%;
+  mask-mode: luminance;
+  -webkit-mask-image: url(${p => p.$maskUrl});
+  -webkit-mask-size: 100% 100%;
 `;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -2,7 +2,7 @@ import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -74,19 +74,21 @@ export function DiffImageDisplay({
       <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
         <Flex direction="column" gap="sm">
           <Heading as="h4">{t('Base')}</Heading>
-          <CenteredContainer
+          <Flex
+            justify="center"
             border="primary"
             radius="md"
             overflow="hidden"
             background="secondary"
           >
             <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
-          </CenteredContainer>
+          </Flex>
         </Flex>
 
         <Flex direction="column" gap="sm">
           <Heading as="h4">{t('Current Branch')}</Heading>
-          <CenteredContainer
+          <Flex
+            justify="center"
             border="primary"
             radius="md"
             overflow="hidden"
@@ -107,17 +109,12 @@ export function DiffImageDisplay({
                 />
               )}
             </ImageWrapper>
-          </CenteredContainer>
+          </Flex>
         </Flex>
       </Grid>
     </Flex>
   );
 }
-
-const CenteredContainer = styled(Container)`
-  display: flex;
-  justify-content: center;
-`;
 
 const ConstrainedImage = styled(Image)`
   max-height: 65vh;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -1,0 +1,126 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Image} from '@sentry/scraps/image';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
+
+interface DiffImageDisplayProps {
+  diffImageBaseUrl: string;
+  imageBaseUrl: string;
+  overlayColor: string;
+  pair: SnapshotDiffPair;
+  showOverlay: boolean;
+}
+
+export function DiffImageDisplay({
+  pair,
+  imageBaseUrl,
+  diffImageBaseUrl,
+  showOverlay,
+  overlayColor,
+}: DiffImageDisplayProps) {
+  const [diffMaskUrl, setDiffMaskUrl] = useState<string | null>(null);
+
+  const baseImageUrl = `${imageBaseUrl}${pair.base_image.key}/`;
+  const headImageUrl = `${imageBaseUrl}${pair.head_image.key}/`;
+  const diffImageUrl = pair.diff_image_key
+    ? `${diffImageBaseUrl}${pair.diff_image_key}`
+    : null;
+
+  useEffect(() => {
+    if (!diffImageUrl) {
+      return undefined;
+    }
+    let cancelled = false;
+    fetch(diffImageUrl)
+      .then(r => r.blob())
+      .then(blob => {
+        if (!cancelled) {
+          setDiffMaskUrl(URL.createObjectURL(blob));
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (diffMaskUrl) {
+        URL.revokeObjectURL(diffMaskUrl);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [diffImageUrl]);
+
+  const diffPercent = pair.diff === null ? null : `${(pair.diff * 100).toFixed(1)}%`;
+
+  return (
+    <Flex direction="column" gap="lg" padding="xl" height="100%">
+      {diffPercent && (
+        <Text variant="muted" size="sm">
+          {t('Diff: %s', diffPercent)}
+        </Text>
+      )}
+      <TwoColumnGrid gap="xl">
+        <Flex direction="column" gap="sm">
+          <Heading as="h4">{t('Base')}</Heading>
+          <Container
+            border="primary"
+            radius="md"
+            overflow="hidden"
+            background="secondary"
+          >
+            <Image src={baseImageUrl} alt={t('Base')} />
+          </Container>
+        </Flex>
+
+        <Flex direction="column" gap="sm">
+          <Heading as="h4">{t('Current Branch')}</Heading>
+          <Container
+            border="primary"
+            radius="md"
+            overflow="hidden"
+            background="secondary"
+          >
+            <ImageWrapper>
+              <Image src={headImageUrl} alt={t('Current Branch')} />
+              {showOverlay && diffMaskUrl && (
+                <DiffOverlay
+                  style={{
+                    backgroundColor: overlayColor,
+                    maskImage: `url(${diffMaskUrl})`,
+                    maskSize: '100% 100%',
+                    maskMode: 'luminance',
+                    WebkitMaskImage: `url(${diffMaskUrl})`,
+                    WebkitMaskSize: '100% 100%',
+                  }}
+                />
+              )}
+            </ImageWrapper>
+          </Container>
+        </Flex>
+      </TwoColumnGrid>
+    </Flex>
+  );
+}
+
+const TwoColumnGrid = styled(Grid)`
+  grid-template-columns: 1fr 1fr;
+  flex: 1;
+  min-height: 0;
+`;
+
+const ImageWrapper = styled('div')`
+  position: relative;
+  width: 100%;
+`;
+
+const DiffOverlay = styled('span')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+`;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -70,26 +70,26 @@ export function DiffImageDisplay({
       <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
         <Flex direction="column" gap="sm">
           <Heading as="h4">{t('Base')}</Heading>
-          <Container
+          <CenteredContainer
             border="primary"
             radius="md"
             overflow="hidden"
             background="secondary"
           >
-            <Image src={baseImageUrl} alt={t('Base')} />
-          </Container>
+            <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
+          </CenteredContainer>
         </Flex>
 
         <Flex direction="column" gap="sm">
           <Heading as="h4">{t('Current Branch')}</Heading>
-          <Container
+          <CenteredContainer
             border="primary"
             radius="md"
             overflow="hidden"
             background="secondary"
           >
             <ImageWrapper>
-              <Image src={headImageUrl} alt={t('Current Branch')} />
+              <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
               {showOverlay && diffMaskUrl && (
                 <DiffOverlay
                   style={{
@@ -103,16 +103,25 @@ export function DiffImageDisplay({
                 />
               )}
             </ImageWrapper>
-          </Container>
+          </CenteredContainer>
         </Flex>
       </Grid>
     </Flex>
   );
 }
 
+const CenteredContainer = styled(Container)`
+  display: flex;
+  justify-content: center;
+`;
+
+const ConstrainedImage = styled(Image)`
+  max-height: 65vh;
+  width: auto;
+`;
+
 const ImageWrapper = styled('div')`
   position: relative;
-  width: 100%;
 `;
 
 const DiffOverlay = styled('span')`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -67,7 +67,7 @@ export function DiffImageDisplay({
           {t('Diff: %s', diffPercent)}
         </Text>
       )}
-      <TwoColumnGrid gap="xl">
+      <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
         <Flex direction="column" gap="sm">
           <Heading as="h4">{t('Base')}</Heading>
           <Container
@@ -105,16 +105,10 @@ export function DiffImageDisplay({
             </ImageWrapper>
           </Container>
         </Flex>
-      </TwoColumnGrid>
+      </Grid>
     </Flex>
   );
 }
-
-const TwoColumnGrid = styled(Grid)`
-  grid-template-columns: 1fr 1fr;
-  flex: 1;
-  min-height: 0;
-`;
 
 const ImageWrapper = styled('div')`
   position: relative;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -55,6 +55,10 @@ export function DiffImageDisplay({
       .catch(() => {});
     return () => {
       cancelled = true;
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
     };
   }, [diffImageUrl]);
 

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
@@ -24,6 +24,7 @@ export function DiffImageDisplay({
   overlayColor,
 }: DiffImageDisplayProps) {
   const [diffMaskUrl, setDiffMaskUrl] = useState<string | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
 
   const baseImageUrl = `${imageBaseUrl}${pair.base_image.key}/`;
   const headImageUrl = `${imageBaseUrl}${pair.head_image.key}/`;
@@ -32,6 +33,12 @@ export function DiffImageDisplay({
     : null;
 
   useEffect(() => {
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+    setDiffMaskUrl(null);
+
     if (!diffImageUrl) {
       return undefined;
     }
@@ -40,17 +47,15 @@ export function DiffImageDisplay({
       .then(r => r.blob())
       .then(blob => {
         if (!cancelled) {
-          setDiffMaskUrl(URL.createObjectURL(blob));
+          const url = URL.createObjectURL(blob);
+          blobUrlRef.current = url;
+          setDiffMaskUrl(url);
         }
       })
       .catch(() => {});
     return () => {
       cancelled = true;
-      if (diffMaskUrl) {
-        URL.revokeObjectURL(diffMaskUrl);
-      }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [diffImageUrl]);
 
   const diffPercent = pair.diff === null ? null : `${(pair.diff * 100).toFixed(1)}%`;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -44,7 +44,12 @@ export function DiffImageDisplay({
     }
     let cancelled = false;
     fetch(diffImageUrl)
-      .then(r => r.blob())
+      .then(r => {
+        if (!r.ok) {
+          throw new Error(`Failed to fetch diff image: ${r.status}`);
+        }
+        return r.blob();
+      })
       .then(blob => {
         if (!cancelled) {
           const url = URL.createObjectURL(blob);

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -117,7 +117,9 @@ export function SnapshotMainContent({
       ? t('Added')
       : selectedItem.type === 'removed'
         ? t('Removed')
-        : t('Unchanged');
+        : selectedItem.type === 'renamed'
+          ? t('Renamed')
+          : t('Unchanged');
 
   return (
     <Flex direction="column" gap="0" padding="0" height="100%" width="100%">

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -112,14 +112,12 @@ export function SnapshotMainContent({
   const image = selectedItem.image;
   const displayName = image.display_name ?? image.image_file_name;
   const imageUrl = `${imageBaseUrl}${image.key}/`;
-  const statusLabel =
-    selectedItem.type === 'added'
-      ? t('Added')
-      : selectedItem.type === 'removed'
-        ? t('Removed')
-        : selectedItem.type === 'renamed'
-          ? t('Renamed')
-          : t('Unchanged');
+  const STATUS_LABELS: Record<string, string> = {
+    added: t('Added'),
+    removed: t('Removed'),
+    renamed: t('Renamed'),
+  };
+  const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
 
   return (
     <Flex direction="column" gap="0" padding="0" height="100%" width="100%">

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -5,6 +5,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {DiffImageDisplay} from './imageDisplay/diffImageDisplay';
@@ -38,9 +39,7 @@ export function SnapshotMainContent({
   }
 
   if (selectedItem.type === 'changed') {
-    const displayName =
-      selectedItem.pair.head_image.display_name ??
-      selectedItem.pair.head_image.image_file_name;
+    const displayName = getImageName(selectedItem.pair.head_image);
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
         <Flex align="center" gap="md" padding="xl">
@@ -65,7 +64,7 @@ export function SnapshotMainContent({
     if (!currentImage) {
       return null;
     }
-    const displayName = currentImage.display_name ?? currentImage.image_file_name;
+    const displayName = getImageName(currentImage);
     const totalVariants = selectedItem.images.length;
     const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
 
@@ -110,7 +109,7 @@ export function SnapshotMainContent({
   }
 
   const image = selectedItem.image;
-  const displayName = image.display_name ?? image.image_file_name;
+  const displayName = getImageName(image);
   const imageUrl = `${imageBaseUrl}${image.key}/`;
   const STATUS_LABELS: Record<string, string> = {
     added: t('Added'),

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -5,73 +5,129 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
+import {DiffImageDisplay} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
 
 interface SnapshotMainContentProps {
-  currentGroupImages: SnapshotImage[];
-  currentGroupName: string | null;
+  diffImageBaseUrl: string;
+  imageBaseUrl: string;
   onVariantChange: (index: number) => void;
-  organizationSlug: string;
-  projectId: string;
+  overlayColor: string;
+  selectedItem: SidebarItem | null;
+  showOverlay: boolean;
   variantIndex: number;
 }
 
 export function SnapshotMainContent({
-  currentGroupName,
-  currentGroupImages,
+  selectedItem,
   variantIndex,
   onVariantChange,
-  organizationSlug,
-  projectId,
+  imageBaseUrl,
+  diffImageBaseUrl,
+  showOverlay,
+  overlayColor,
 }: SnapshotMainContentProps) {
-  const selectedImage = currentGroupImages[variantIndex];
-  if (!currentGroupName || !selectedImage) {
+  if (!selectedItem) {
     return (
-      <Flex align="center" justify="center" padding="3xl">
+      <Flex align="center" justify="center" padding="3xl" width="100%">
         <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
       </Flex>
     );
   }
 
-  const imageUrl = `/api/0/projects/${organizationSlug}/${projectId}/files/images/${selectedImage.key}/`;
-  const totalVariants = currentGroupImages.length;
-  const displayName = selectedImage.display_name ?? selectedImage.image_file_name;
+  if (selectedItem.type === 'changed') {
+    const displayName =
+      selectedItem.pair.head_image.display_name ??
+      selectedItem.pair.head_image.image_file_name;
+    return (
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" gap="md" padding="xl">
+          <Text size="lg" bold>
+            {displayName}
+          </Text>
+        </Flex>
+        <Separator orientation="horizontal" />
+        <DiffImageDisplay
+          pair={selectedItem.pair}
+          imageBaseUrl={imageBaseUrl}
+          diffImageBaseUrl={diffImageBaseUrl}
+          showOverlay={showOverlay}
+          overlayColor={overlayColor}
+        />
+      </Flex>
+    );
+  }
+
+  if (selectedItem.type === 'solo') {
+    const currentImage = selectedItem.images[variantIndex];
+    if (!currentImage) {
+      return null;
+    }
+    const displayName = currentImage.display_name ?? currentImage.image_file_name;
+    const totalVariants = selectedItem.images.length;
+    const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+
+    return (
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" gap="md" padding="xl">
+          {totalVariants > 1 && (
+            <Flex align="center" gap="sm">
+              <Button
+                size="md"
+                priority="transparent"
+                icon={<IconChevron direction="left" />}
+                aria-label={t('Previous variant')}
+                disabled={variantIndex === 0}
+                onClick={() => onVariantChange(variantIndex - 1)}
+              />
+              <Button
+                size="md"
+                priority="transparent"
+                icon={<IconChevron direction="right" />}
+                aria-label={t('Next variant')}
+                disabled={variantIndex === totalVariants - 1}
+                onClick={() => onVariantChange(variantIndex + 1)}
+              />
+            </Flex>
+          )}
+          <Stack gap="md">
+            <Text size="lg" bold>
+              {displayName}
+            </Text>
+            {totalVariants > 1 && (
+              <Text variant="muted" size="sm">
+                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+              </Text>
+            )}
+          </Stack>
+        </Flex>
+        <Separator orientation="horizontal" />
+        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+      </Flex>
+    );
+  }
+
+  const image = selectedItem.image;
+  const displayName = image.display_name ?? image.image_file_name;
+  const imageUrl = `${imageBaseUrl}${image.key}/`;
+  const statusLabel =
+    selectedItem.type === 'added'
+      ? t('Added')
+      : selectedItem.type === 'removed'
+        ? t('Removed')
+        : t('Unchanged');
 
   return (
     <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
       <Flex align="center" gap="md" padding="xl">
-        {totalVariants > 1 && (
-          <Flex align="center" gap="sm">
-            <Button
-              size="md"
-              priority="transparent"
-              icon={<IconChevron direction="left" />}
-              aria-label={t('Previous variant')}
-              disabled={variantIndex === 0}
-              onClick={() => onVariantChange(variantIndex - 1)}
-            />
-            <Button
-              size="md"
-              priority="transparent"
-              icon={<IconChevron direction="right" />}
-              aria-label={t('Next variant')}
-              disabled={variantIndex === totalVariants - 1}
-              onClick={() => onVariantChange(variantIndex + 1)}
-            />
-          </Flex>
-        )}
-        <Stack gap="md">
-          <Text size="lg" bold>
-            {displayName}
-          </Text>
-          {totalVariants > 1 && (
-            <Text variant="muted" size="sm">
-              {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-            </Text>
-          )}
-        </Stack>
+        <Text size="lg" bold>
+          {displayName}
+        </Text>
+        <Text variant="muted" size="sm">
+          ({statusLabel})
+        </Text>
       </Flex>
       <Separator orientation="horizontal" />
       <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -16,7 +16,7 @@ import {
   IconSubtract,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {DiffStatus, SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
+import {DiffStatus, type SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 interface SectionConfig {
   defaultExpanded: boolean;
@@ -27,26 +27,31 @@ interface SectionConfig {
 
 const SECTION_ORDER: SectionConfig[] = [
   {
-    type: 'changed',
+    type: DiffStatus.CHANGED,
     label: t('Modified'),
     icon: <IconEdit size="xs" />,
     defaultExpanded: true,
   },
-  {type: 'added', label: t('Added'), icon: <IconAdd size="xs" />, defaultExpanded: false},
   {
-    type: 'removed',
+    type: DiffStatus.ADDED,
+    label: t('Added'),
+    icon: <IconAdd size="xs" />,
+    defaultExpanded: false,
+  },
+  {
+    type: DiffStatus.REMOVED,
     label: t('Removed'),
     icon: <IconSubtract size="xs" />,
     defaultExpanded: false,
   },
   {
-    type: 'renamed',
+    type: DiffStatus.RENAMED,
     label: t('Renamed'),
     icon: <IconCopy size="xs" />,
     defaultExpanded: false,
   },
   {
-    type: 'unchanged',
+    type: DiffStatus.UNCHANGED,
     label: t('Unchanged'),
     icon: <IconCheckmark size="xs" />,
     defaultExpanded: false,

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -130,12 +130,15 @@ export function SnapshotSidebarContent({
   const isSearching = searchQuery.length > 0;
 
   const handleExpandedChange = (type: string, expanded: boolean) => {
+    if (isSearching) return;
     setExpandedSections(prev => ({...prev, [type]: expanded}));
   };
 
+  const isGroupedDiff = isDiffMode && groupedItems !== null;
+
   return (
     <Flex direction="column" gap="md" height="100%">
-      <SearchContainer>
+      <Flex padding="xl" paddingBottom="0">
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch size="sm" />
@@ -147,9 +150,9 @@ export function SnapshotSidebarContent({
             onChange={e => onSearchChange(e.target.value)}
           />
         </InputGroup>
-      </SearchContainer>
+      </Flex>
       <Stack overflow="auto" flex="1">
-        {isDiffMode && groupedItems
+        {isGroupedDiff
           ? SECTION_ORDER.map(section => {
               const sectionItems = groupedItems.get(section.type);
               if (!sectionItems || sectionItems.length === 0) {
@@ -252,11 +255,6 @@ export function SnapshotSidebarContent({
     </Flex>
   );
 }
-
-const SearchContainer = styled('div')`
-  padding: ${p => p.theme.space.xl};
-  padding-bottom: 0;
-`;
 
 const SectionWrapper = styled('div')`
   &:not(:first-child) {

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,38 +1,108 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Tag} from '@sentry/scraps/badge';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {InputGroup} from '@sentry/scraps/input';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import {IconSearch} from 'sentry/icons';
+import {
+  IconAdd,
+  IconCheckmark,
+  IconCopy,
+  IconEdit,
+  IconSearch,
+  IconSubtract,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+import type {DiffStatus, SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
+
+interface SectionConfig {
+  defaultExpanded: boolean;
+  icon: React.ReactNode;
+  label: string;
+  type: DiffStatus;
+}
+
+const SECTION_ORDER: SectionConfig[] = [
+  {
+    type: 'changed',
+    label: t('Modified'),
+    icon: <IconEdit size="xs" />,
+    defaultExpanded: true,
+  },
+  {type: 'added', label: t('Added'), icon: <IconAdd size="xs" />, defaultExpanded: false},
+  {
+    type: 'removed',
+    label: t('Removed'),
+    icon: <IconSubtract size="xs" />,
+    defaultExpanded: false,
+  },
+  {
+    type: 'renamed',
+    label: t('Renamed'),
+    icon: <IconCopy size="xs" />,
+    defaultExpanded: false,
+  },
+  {
+    type: 'unchanged',
+    label: t('Unchanged'),
+    icon: <IconCheckmark size="xs" />,
+    defaultExpanded: false,
+  },
+];
 
 interface SnapshotSidebarContentProps {
-  currentGroupName: string | null;
+  currentItemName: string | null;
   fetchNextPage: () => Promise<unknown>;
-  filteredGroups: Map<string, SnapshotImage[]>;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
+  items: SidebarItem[];
   onSearchChange: (query: string) => void;
-  onSelectGroupName: (name: string) => void;
+  onSelectItem: (name: string) => void;
   searchQuery: string;
 }
 
 export function SnapshotSidebarContent({
-  filteredGroups,
-  currentGroupName,
+  items,
+  currentItemName,
   searchQuery,
   onSearchChange,
-  onSelectGroupName,
+  onSelectItem,
   hasNextPage,
   isFetchingNextPage,
   fetchNextPage,
 }: SnapshotSidebarContentProps) {
   const loadMoreRef = useRef<HTMLDivElement>(null);
+
+  const isDiffMode = items.length > 0 && items[0]!.type !== 'solo';
+
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(
+    () => {
+      const initial: Record<string, boolean> = {};
+      for (const section of SECTION_ORDER) {
+        initial[section.type] = section.defaultExpanded;
+      }
+      return initial;
+    }
+  );
+
+  const groupedItems = useMemo(() => {
+    if (!isDiffMode) {
+      return null;
+    }
+    const groups = new Map<string, SidebarItem[]>();
+    for (const item of items) {
+      const existing = groups.get(item.type);
+      if (existing) {
+        existing.push(item);
+      } else {
+        groups.set(item.type, [item]);
+      }
+    }
+    return groups;
+  }, [items, isDiffMode]);
 
   useEffect(() => {
     const sentinel = loadMoreRef.current;
@@ -52,9 +122,15 @@ export function SnapshotSidebarContent({
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  const isSearching = searchQuery.length > 0;
+
+  const handleExpandedChange = (type: string, expanded: boolean) => {
+    setExpandedSections(prev => ({...prev, [type]: expanded}));
+  };
+
   return (
-    <Flex direction="column" gap="md" minWidth="300px">
-      <Container padding="xl">
+    <Flex direction="column" gap="md" height="100%">
+      <SearchContainer>
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch size="sm" />
@@ -66,29 +142,95 @@ export function SnapshotSidebarContent({
             onChange={e => onSearchChange(e.target.value)}
           />
         </InputGroup>
-      </Container>
+      </SearchContainer>
       <Stack overflow="auto" flex="1">
-        {[...filteredGroups.entries()].map(([name, images]) => {
-          const isSelected = name === currentGroupName;
-          return (
-            <SidebarItem
-              key={name}
-              isSelected={isSelected}
-              onClick={() => onSelectGroupName(name)}
-            >
-              <Text
-                size="md"
-                variant={isSelected ? 'accent' : 'muted'}
-                bold={isSelected}
-                ellipsis
-              >
-                {name}
-              </Text>
-              <Tag variant="muted">{images.length}</Tag>
-            </SidebarItem>
-          );
-        })}
-        {filteredGroups.size === 0 && !hasNextPage && !isFetchingNextPage && (
+        {isDiffMode && groupedItems
+          ? SECTION_ORDER.map(section => {
+              const sectionItems = groupedItems.get(section.type);
+              if (!sectionItems || sectionItems.length === 0) {
+                return null;
+              }
+              const isExpanded = isSearching || expandedSections[section.type];
+              return (
+                <SectionWrapper key={section.type}>
+                  <Disclosure
+                    size="xs"
+                    expanded={isExpanded}
+                    onExpandedChange={expanded =>
+                      handleExpandedChange(section.type, expanded)
+                    }
+                  >
+                    <Disclosure.Title
+                      trailingItems={
+                        <Flex align="center" gap="xs">
+                          <Text size="xs" variant="muted">
+                            {sectionItems.length}
+                          </Text>
+                          {section.icon}
+                        </Flex>
+                      }
+                    >
+                      <Text size="xs" bold uppercase>
+                        {section.label}
+                      </Text>
+                    </Disclosure.Title>
+                    <Disclosure.Content>
+                      {sectionItems.map(item => (
+                        <SidebarItemRow
+                          key={item.name}
+                          isSelected={item.name === currentItemName}
+                          onClick={() => onSelectItem(item.name)}
+                        >
+                          <Flex align="center" gap="sm" flex="1" minWidth="0">
+                            <Text
+                              size="md"
+                              variant={item.name === currentItemName ? 'accent' : 'muted'}
+                              bold={item.name === currentItemName}
+                              ellipsis
+                            >
+                              {item.name}
+                            </Text>
+                          </Flex>
+                          {item.type === 'changed' && item.pair.diff !== null && (
+                            <Text variant="muted" size="xs">
+                              {`${(item.pair.diff * 100).toFixed(1)}%`}
+                            </Text>
+                          )}
+                        </SidebarItemRow>
+                      ))}
+                    </Disclosure.Content>
+                  </Disclosure>
+                </SectionWrapper>
+              );
+            })
+          : items.map(item => {
+              const isSelected = item.name === currentItemName;
+
+              return (
+                <SidebarItemRow
+                  key={item.name}
+                  isSelected={isSelected}
+                  onClick={() => onSelectItem(item.name)}
+                >
+                  <Flex align="center" gap="sm" flex="1" minWidth="0">
+                    <Text
+                      size="md"
+                      variant={isSelected ? 'accent' : 'muted'}
+                      bold={isSelected}
+                      ellipsis
+                    >
+                      {item.name}
+                    </Text>
+                  </Flex>
+                  {item.type === 'solo' && item.images.length > 1 && (
+                    <Text variant="muted" size="xs">
+                      {item.images.length}
+                    </Text>
+                  )}
+                </SidebarItemRow>
+              );
+            })}
+        {items.length === 0 && !hasNextPage && !isFetchingNextPage && (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
               {t('No images found.')}
@@ -106,10 +248,27 @@ export function SnapshotSidebarContent({
   );
 }
 
-const SidebarItem = styled('div')<{isSelected: boolean}>`
+const SearchContainer = styled('div')`
+  padding: ${p => p.theme.space.xl};
+  padding-bottom: 0;
+`;
+
+const SectionWrapper = styled('div')`
+  &:not(:first-child) {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+  }
+
+  [data-disclosure] > :not(:first-child) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+`;
+
+const SidebarItemRow = styled('div')<{isSelected: boolean}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: ${p => p.theme.space.sm};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
   cursor: pointer;
   border-right: 3px solid

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,25 +1,35 @@
 import {useMemo, useState} from 'react';
+import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
-import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {space} from 'sentry/styles/space';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import type {
+  SidebarItem,
   SnapshotDetailsApiResponse,
   SnapshotImage,
 } from 'sentry/views/preprod/types/snapshotTypes';
 
+import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import {SnapshotMainContent} from './main/snapshotMainContent';
 import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
+
+function getImageName(image: SnapshotImage): string {
+  return image.display_name ?? image.image_file_name;
+}
 
 export default function SnapshotsPage() {
   const organization = useOrganization();
@@ -27,39 +37,86 @@ export default function SnapshotsPage() {
     snapshotId: string;
   }>();
 
-  const {data, isPending, isError, hasNextPage, isFetchingNextPage, fetchNextPage} =
-    useInfiniteApiQuery<SnapshotDetailsApiResponse>({
-      queryKey: [
-        'infinite',
-        getApiUrl(
-          '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/',
-          {
-            path: {
-              organizationIdOrSlug: organization.slug,
-              snapshotId,
-            },
-          }
-        ),
-        {query: {per_page: 20}},
-      ],
-      staleTime: 0,
-      enabled: !!snapshotId,
-    });
+  const {
+    data,
+    isPending,
+    isError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    refetch,
+  } = useInfiniteApiQuery<SnapshotDetailsApiResponse>({
+    queryKey: [
+      'infinite',
+      getApiUrl(
+        '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            snapshotId,
+          },
+        }
+      ),
+      {query: {per_page: 20}},
+    ],
+    staleTime: 0,
+    enabled: !!snapshotId,
+  });
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedGroupName, setSelectedGroupName] = useState<string | null>(null);
+  const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
+  const [showOverlay, setShowOverlay] = useState(true);
+  const [overlayColor, setOverlayColor] = useState('#00cc44');
+
+  const {
+    size: sidebarWidth,
+    isHeld,
+    onMouseDown,
+    onDoubleClick,
+  } = useResizableDrawer({
+    direction: 'left',
+    initialSize: 350,
+    min: 200,
+    onResize: () => {},
+    sizeStorageKey: 'snapshot-sidebar-width',
+  });
 
   const firstPageData = data?.pages[0]?.[0];
+  const comparisonType = firstPageData?.comparison_type ?? 'solo';
+  const comparisonRunInfo = firstPageData?.comparison_run_info;
 
-  const groupedImages = useMemo(() => {
+  const sidebarItems: SidebarItem[] = useMemo(() => {
     if (!data?.pages) {
-      return new Map<string, SnapshotImage[]>();
+      return [];
     }
+
+    if (comparisonType === 'diff' && firstPageData) {
+      const items: SidebarItem[] = [];
+
+      for (const pair of firstPageData.changed) {
+        items.push({type: 'changed', name: getImageName(pair.head_image), pair});
+      }
+      for (const img of firstPageData.added) {
+        items.push({type: 'added', name: getImageName(img), image: img});
+      }
+      for (const img of firstPageData.removed) {
+        items.push({type: 'removed', name: getImageName(img), image: img});
+      }
+      for (const img of firstPageData.renamed ?? []) {
+        items.push({type: 'renamed', name: getImageName(img), image: img});
+      }
+      for (const img of firstPageData.unchanged) {
+        items.push({type: 'unchanged', name: getImageName(img), image: img});
+      }
+
+      return items;
+    }
+
     const allImages = data.pages.flatMap(page => page[0].images);
     const groups = new Map<string, SnapshotImage[]>();
     for (const image of allImages) {
-      const name = image.display_name ?? image.image_file_name;
+      const name = getImageName(image);
       const existing = groups.get(name);
       if (existing) {
         existing.push(image);
@@ -67,36 +124,35 @@ export default function SnapshotsPage() {
         groups.set(name, [image]);
       }
     }
-    return new Map([...groups.entries()].sort(([a], [b]) => a.localeCompare(b)));
-  }, [data?.pages]);
 
-  const filteredGroups = useMemo(() => {
+    return [...groups.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, images]) => ({type: 'solo' as const, name, images}));
+  }, [data?.pages, comparisonType, firstPageData]);
+
+  const filteredItems = useMemo(() => {
     if (!searchQuery) {
-      return groupedImages;
+      return sidebarItems;
     }
     const query = searchQuery.toLowerCase();
-    const filtered = new Map<string, SnapshotImage[]>();
-    for (const [name, images] of groupedImages) {
-      if (name.toLowerCase().includes(query)) {
-        filtered.set(name, images);
-      }
-    }
-    return filtered;
-  }, [groupedImages, searchQuery]);
+    return sidebarItems.filter(item => item.name.toLowerCase().includes(query));
+  }, [sidebarItems, searchQuery]);
 
-  // Default to first group if nothing selected or selection no longer in filtered results
-  const currentGroupName =
-    selectedGroupName && filteredGroups.has(selectedGroupName)
-      ? selectedGroupName
-      : (filteredGroups.keys().next().value ?? null);
-  const currentGroupImages = currentGroupName
-    ? (filteredGroups.get(currentGroupName) ?? [])
-    : [];
+  const currentItemName =
+    selectedItemName && filteredItems.some(i => i.name === selectedItemName)
+      ? selectedItemName
+      : (filteredItems[0]?.name ?? null);
+  const currentItem = filteredItems.find(i => i.name === currentItemName) ?? null;
 
-  const handleSelectGroupName = (name: string) => {
-    setSelectedGroupName(name);
+  const handleSelectItem = (name: string) => {
+    setSelectedItemName(name);
     setVariantIndex(0);
   };
+
+  const imageBaseUrl = `/api/0/projects/${organization.slug}/${firstPageData?.project_id ?? ''}/files/images/`;
+  const diffImageBaseUrl = firstPageData
+    ? `/api/0/organizations/${organization.slug}/objectstore/v1/objects/preprod/org=${organization.id};project=${firstPageData.project_id}/${organization.id}/${firstPageData.project_id}/`
+    : '';
 
   if (isPending) {
     return (
@@ -130,29 +186,128 @@ export default function SnapshotsPage() {
             projectId={firstPageData.project_id}
             data={firstPageData}
           />
+          <Layout.HeaderActions>
+            <SnapshotDevTools
+              organizationSlug={organization.slug}
+              projectSlug={firstPageData.project_id}
+              snapshotId={snapshotId}
+              comparisonRunInfo={comparisonRunInfo}
+              hasBaseArtifact={firstPageData.base_artifact_id !== null}
+              refetch={refetch}
+            />
+          </Layout.HeaderActions>
         </Layout.Header>
-        <Flex direction="row" gap="0" height="100%" width="100%">
-          <SnapshotSidebarContent
-            filteredGroups={filteredGroups}
-            currentGroupName={currentGroupName}
-            searchQuery={searchQuery}
-            onSearchChange={setSearchQuery}
-            onSelectGroupName={handleSelectGroupName}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            fetchNextPage={fetchNextPage}
-          />
-          <Separator orientation="vertical" />
-          <SnapshotMainContent
-            currentGroupName={currentGroupName}
-            currentGroupImages={currentGroupImages}
-            variantIndex={variantIndex}
-            onVariantChange={setVariantIndex}
-            organizationSlug={organization.slug}
-            projectId={firstPageData.project_id}
-          />
+
+        {comparisonType === 'diff' && (
+          <Flex
+            align="center"
+            justify="between"
+            gap="lg"
+            padding="lg xl"
+            background="secondary"
+          >
+            <Text size="sm" bold>
+              {t('Comparison')}
+            </Text>
+            <Text size="sm" variant="muted">
+              {t(
+                '%s changed, %s added, %s removed, %s renamed, %s unchanged',
+                firstPageData.changed_count,
+                firstPageData.added_count,
+                firstPageData.removed_count,
+                firstPageData.renamed_count ?? 0,
+                firstPageData.unchanged_count
+              )}
+            </Text>
+            <Flex align="center" gap="sm">
+              <Button
+                size="xs"
+                priority={showOverlay ? 'primary' : 'default'}
+                onClick={() => setShowOverlay(!showOverlay)}
+              >
+                {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
+              </Button>
+              <ColorInput
+                type="color"
+                value={overlayColor}
+                onChange={e => setOverlayColor(e.target.value)}
+              />
+            </Flex>
+          </Flex>
+        )}
+
+        <Flex direction="row" height="100%" width="100%" overflow="hidden">
+          <SidebarPanel style={{width: sidebarWidth}}>
+            <SnapshotSidebarContent
+              items={filteredItems}
+              currentItemName={currentItemName}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              onSelectItem={handleSelectItem}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              fetchNextPage={fetchNextPage}
+            />
+          </SidebarPanel>
+          <DragHandle
+            data-is-held={isHeld}
+            onMouseDown={onMouseDown}
+            onDoubleClick={onDoubleClick}
+          >
+            <IconGrabbable size="sm" />
+          </DragHandle>
+          <MainPanel>
+            <SnapshotMainContent
+              selectedItem={currentItem}
+              variantIndex={variantIndex}
+              onVariantChange={setVariantIndex}
+              imageBaseUrl={imageBaseUrl}
+              diffImageBaseUrl={diffImageBaseUrl}
+              showOverlay={showOverlay}
+              overlayColor={overlayColor}
+            />
+          </MainPanel>
         </Flex>
       </Layout.Page>
     </SentryDocumentTitle>
   );
 }
+
+const SidebarPanel = styled('div')`
+  flex-shrink: 0;
+  overflow: hidden;
+`;
+
+const MainPanel = styled('div')`
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const DragHandle = styled('div')`
+  display: grid;
+  place-items: center;
+  width: ${space(2)};
+  height: 100%;
+  cursor: ew-resize;
+  user-select: inherit;
+  background: ${p => p.theme.tokens.background.secondary};
+
+  &:hover {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &[data-is-held='true'] {
+    user-select: none;
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
+  }
+`;
+
+const ColorInput = styled('input')`
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.sm};
+  padding: 0;
+`;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -241,7 +241,7 @@ export default function SnapshotsPage() {
         )}
 
         <Flex direction="row" height="100%" width="100%" overflow="hidden">
-          <SidebarPanel style={{width: sidebarWidth}}>
+          <Flex flexShrink={0} overflow="hidden" style={{width: sidebarWidth}}>
             <SnapshotSidebarContent
               items={filteredItems}
               currentItemName={currentItemName}
@@ -252,7 +252,7 @@ export default function SnapshotsPage() {
               isFetchingNextPage={isFetchingNextPage}
               fetchNextPage={fetchNextPage}
             />
-          </SidebarPanel>
+          </Flex>
           <DragHandle
             data-is-held={isHeld}
             onMouseDown={onMouseDown}
@@ -260,7 +260,7 @@ export default function SnapshotsPage() {
           >
             <IconGrabbable size="sm" />
           </DragHandle>
-          <MainPanel>
+          <Flex flex="1" minWidth={0} overflow="hidden">
             <SnapshotMainContent
               selectedItem={currentItem}
               variantIndex={variantIndex}
@@ -270,23 +270,12 @@ export default function SnapshotsPage() {
               showOverlay={showOverlay}
               overlayColor={overlayColor}
             />
-          </MainPanel>
+          </Flex>
         </Flex>
       </Layout.Page>
     </SentryDocumentTitle>
   );
 }
-
-const SidebarPanel = styled('div')`
-  flex-shrink: 0;
-  overflow: hidden;
-`;
-
-const MainPanel = styled('div')`
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-`;
 
 const DragHandle = styled('div')`
   display: grid;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -16,6 +16,7 @@ import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
+import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -26,10 +27,6 @@ import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import {SnapshotMainContent} from './main/snapshotMainContent';
 import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
-
-function getImageName(image: SnapshotImage): string {
-  return image.display_name ?? image.image_file_name;
-}
 
 export default function SnapshotsPage() {
   const organization = useOrganization();

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -143,6 +143,10 @@ export default function SnapshotsPage() {
       ? selectedItemName
       : (filteredItems[0]?.name ?? null);
   const currentItem = filteredItems.find(i => i.name === currentItemName) ?? null;
+
+  useEffect(() => {
+    setVariantIndex(0);
+  }, [currentItemName]);
 
   const handleSelectItem = (name: string) => {
     setSelectedItemName(name);

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -47,9 +47,20 @@ export interface SnapshotDetailsApiResponse {
   unchanged_count: number;
 }
 
-export type ComparisonState = 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'FAILED';
+export enum ComparisonState {
+  PENDING = 'PENDING',
+  PROCESSING = 'PROCESSING',
+  SUCCESS = 'SUCCESS',
+  FAILED = 'FAILED',
+}
 
-export type DiffStatus = 'changed' | 'added' | 'removed' | 'renamed' | 'unchanged';
+export enum DiffStatus {
+  CHANGED = 'changed',
+  ADDED = 'added',
+  REMOVED = 'removed',
+  RENAMED = 'renamed',
+  UNCHANGED = 'unchanged',
+}
 
 export type SidebarItem =
   | {type: 'solo'; name: string; images: SnapshotImage[]}

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -16,6 +16,12 @@ export interface SnapshotDiffPair {
   head_image: SnapshotImage;
 }
 
+export interface SnapshotComparisonRunInfo {
+  completed_at?: string;
+  duration_ms?: number;
+  state?: ComparisonState;
+}
+
 export interface SnapshotDetailsApiResponse {
   comparison_type: 'solo' | 'diff';
   head_artifact_id: string;
@@ -25,6 +31,8 @@ export interface SnapshotDetailsApiResponse {
   state: string;
   vcs_info: BuildDetailsVcsInfo;
 
+  comparison_run_info?: SnapshotComparisonRunInfo;
+
   // Diff fields
   added: SnapshotImage[];
   added_count: number;
@@ -33,6 +41,20 @@ export interface SnapshotDetailsApiResponse {
   changed_count: number;
   removed: SnapshotImage[];
   removed_count: number;
+  renamed?: SnapshotImage[];
+  renamed_count?: number;
   unchanged: SnapshotImage[];
   unchanged_count: number;
 }
+
+export type ComparisonState = 'PENDING' | 'PROCESSING' | 'SUCCESS' | 'FAILED';
+
+export type DiffStatus = 'changed' | 'added' | 'removed' | 'renamed' | 'unchanged';
+
+export type SidebarItem =
+  | {type: 'solo'; name: string; images: SnapshotImage[]}
+  | {type: 'changed'; name: string; pair: SnapshotDiffPair}
+  | {type: 'added'; name: string; image: SnapshotImage}
+  | {type: 'removed'; name: string; image: SnapshotImage}
+  | {type: 'renamed'; name: string; image: SnapshotImage}
+  | {type: 'unchanged'; name: string; image: SnapshotImage};

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -62,6 +62,10 @@ export enum DiffStatus {
   UNCHANGED = 'unchanged',
 }
 
+export function getImageName(image: SnapshotImage): string {
+  return image.display_name ?? image.image_file_name;
+}
+
 export type SidebarItem =
   | {type: 'solo'; name: string; images: SnapshotImage[]}
   | {type: 'changed'; name: string; pair: SnapshotDiffPair}

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -31,7 +31,7 @@ export interface SnapshotDetailsApiResponse {
   state: string;
   vcs_info: BuildDetailsVcsInfo;
 
-  comparison_run_info?: SnapshotComparisonRunInfo;
+  comparison_run_info?: SnapshotComparisonRunInfo | null;
 
   // Diff fields
   added: SnapshotImage[];


### PR DESCRIPTION
## Summary

Adds the frontend diff comparison UI for the preprod snapshot viewer, enabling side-by-side visual comparison of snapshot images between a base artifact and the current branch.

**New components:**
- `DiffImageDisplay` — side-by-side base vs current branch image view with diff mask overlay support
- `SnapshotDevTools` — dev tools panel showing comparison state, polling status, duration, and a "Re-run Comparison" button

**Sidebar improvements:**
- Collapsible sections grouped by diff status (Modified, Added, Removed, Renamed, Unchanged) using `Disclosure`
- Diff percentage shown per changed image
- Resizable sidebar panel via drag handle

**Comparison toolbar:**
- Summary counts (changed, added, removed, renamed, unchanged)
- Toggle diff overlay on/off with configurable color picker

**Type additions:**
- `SnapshotComparisonRunInfo`, `ComparisonState`, `DiffStatus`, and `SidebarItem` discriminated union

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.