### PR TITLE
feat(cells): Add synapse paginator

### DIFF
--- a/src/sentry/synapse/paginator.py
+++ b/src/sentry/synapse/paginator.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from django.db.models import Q, QuerySet
+from django.db.models.functions import TruncSecond
+from rest_framework.exceptions import ParseError
+
+from sentry.utils import json
+
+_TRUNC_ANNOTATION = "_synapse_ts_trunc"
+
+
+@dataclass(frozen=True)
+class Cursor:
+    # seconds since 1970-01-01 00:00:00 UTC
+    updated_at: int
+    id: int
+
+    @classmethod
+    def decode(cls, cursor_str: str) -> Cursor:
+        try:
+            decoded = json.loads(base64.b64decode(cursor_str).decode("utf-8"))
+            return cls(updated_at=int(decoded["updated_at"]), id=int(decoded["id"]))
+        except (ValueError, KeyError, TypeError):
+            raise ParseError(detail="Invalid cursor")
+
+    def encode(self) -> str:
+        return base64.b64encode(
+            json.dumps(
+                {
+                    "id": str(self.id),
+                    "updated_at": self.updated_at,
+                }
+            ).encode("utf-8")
+        ).decode("utf-8")
+
+
+@dataclass(frozen=True)
+class SynapsePage:
+    results: list[Any]
+    next_cursor: str | None
+    has_more: bool
+
+
+class SynapsePaginator:
+    """
+    Cursor paginator for Synapse endpoints.
+
+    Uses base64-encoded JSON cursors of the form {"id": integer, "updated_at": integer_seconds}.
+    Results are ordered by (timestamp_field truncated to seconds, id_field) ascending. The cursor
+    points to the last returned item; the next page starts strictly after it via
+    (trunc(timestamp) > T) OR (trunc(timestamp) = T AND id > cursor_id).
+    """
+
+    def __init__(
+        self,
+        queryset: QuerySet,
+        id_field: str,
+        timestamp_field: str,
+    ) -> None:
+        # Synapse cursors carry timestamps as integer seconds, but the DB column may store
+        # sub-second precision. Without truncation, a cursor built from T+0.5s reconstructs
+        # as T+0.0s, causing records within the same second to appear on multiple pages.
+        # Truncating to seconds here keeps ordering and filtering consistent with the cursor.
+        self.queryset = queryset.annotate(
+            **{_TRUNC_ANNOTATION: TruncSecond(timestamp_field)}
+        ).order_by(_TRUNC_ANNOTATION, id_field)
+        self.id_field = id_field
+        self.timestamp_field = timestamp_field
+
+    def get_result(self, limit: int, cursor_str: str | None) -> SynapsePage:
+        query = self.queryset
+
+        if cursor_str:
+            cursor = Cursor.decode(cursor_str)
+            cursor_dt = datetime.fromtimestamp(cursor.updated_at, tz=timezone.utc)
+
+            # Equivalent to (trunc(ts), id) > (cursor_ts, cursor_id): expanded to two OR
+            # conditions for the django ORM.
+            query = query.filter(
+                Q(**{f"{_TRUNC_ANNOTATION}__gt": cursor_dt})
+                | Q(
+                    **{
+                        _TRUNC_ANNOTATION: cursor_dt,
+                        f"{self.id_field}__gt": cursor.id,
+                    }
+                )
+            )
+
+        # Use limit + 1 fetch to determine if there's another page
+        results = list(query[: limit + 1])
+        has_more = len(results) > limit
+        results = results[:limit]
+
+        next_cursor = (
+            Cursor(
+                updated_at=int(getattr(results[-1], self.timestamp_field).timestamp()),
+                id=int(getattr(results[-1], self.id_field)),
+            ).encode()
+            if results
+            else None
+        )
+
+        return SynapsePage(results=results, next_cursor=next_cursor, has_more=has_more)

--- a/src/sentry/synapse/paginator.py
+++ b/src/sentry/synapse/paginator.py
@@ -98,7 +98,7 @@ class SynapsePaginator:
 
         next_cursor = (
             Cursor(
-                updated_at=int(getattr(results[-1], self.timestamp_field).timestamp()),
+                updated_at=int(getattr(results[-1], _TRUNC_ANNOTATION).timestamp()),
                 id=int(getattr(results[-1], self.id_field)),
             ).encode()
             if results

--- a/tests/sentry/synapse/test_paginator.py
+++ b/tests/sentry/synapse/test_paginator.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+from rest_framework.exceptions import ParseError
+
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.synapse.paginator import Cursor, SynapsePaginator
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class CursorTest(TestCase):
+    def test_encode_decode(self) -> None:
+        original = Cursor(updated_at=1234567890, id=42)
+        assert Cursor.decode(original.encode()) == original
+
+    def test_decode_invalid_cursor_raises(self) -> None:
+        with pytest.raises(ParseError):
+            Cursor.decode("!!!not-base64!!!")
+
+
+@control_silo_test
+class SynapsePaginatorTest(TestCase):
+    def test_paginates(self) -> None:
+        orgs = [self.create_organization() for _ in range(5)]
+        paginator = SynapsePaginator(
+            queryset=OrganizationMapping.objects.all(),
+            id_field="organization_id",
+            timestamp_field="date_updated",
+        )
+
+        cursor = None
+
+        expected = [
+            # org ids, expected has_more
+            ([orgs[0].id, orgs[1].id], True),
+            ([orgs[2].id, orgs[3].id], True),
+            ([orgs[4].id], False),
+        ]
+
+        for ids, expected_more in expected:
+            page = paginator.get_result(limit=2, cursor_str=cursor)
+            assert page.has_more is expected_more
+            assert set(ids) == {r.organization_id for r in page.results}
+            cursor = page.next_cursor


### PR DESCRIPTION
this paginator class is designed to be used with the 2 planned synapse enpdoints (org-cell-mappings and projectkey-cell-mappings).

it matches the specific cursor format that synapse expects (described in https://github.com/getsentry/synapse/blob/main/locator/README.md).

not yet wired into either endpoint.

notes:
- cursors are base64-encoded JSON {"id": "<str>", "updated_at": <int_seconds>} to match Synapse's expected format
- the queryset is annotated with a second-truncated timestamp before ordering and filtering, so that it works the same even if the DB column has subsecond granularity
- pagination uses a compound filter: (trunc(ts) > cursor_ts) OR (trunc(ts) = cursor_ts AND id > cursor_id)
- fetches limit + 1 rows to determine whether a next page exists
