### PR TITLE
feat(dev-infra): Includes `al`, the dev-infra mcp in the `dotagents` config 

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,9 @@
       "Bash(uv pip list:*)",
       "Bash(uv tree:*)",
       "Bash(wc:*)",
+      "mcp__al-devinfra-mcp__list_docs",
+      "mcp__al-devinfra-mcp__read_doc",
+      "mcp__al-devinfra-mcp__search_docs",
       "mcp__sentry__analyze_issue_with_seer",
       "mcp__sentry__find_organizations",
       "mcp__sentry__find_projects",
@@ -91,5 +94,5 @@
   },
   "enableAllProjectMcpServers": true,
   "includeCoAuthoredBy": false,
-  "enabledMcpjsonServers": ["sentry"]
+  "enabledMcpjsonServers": ["sentry", "al-devinfra-mcp"]
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,6 +2,10 @@
   "mcpServers": {
     "sentry": {
       "url": "https://mcp.sentry.dev/mcp/sentry?experimental=1"
+    },
+    "al-devinfra-mcp": {
+      "type": "http",
+      "url": "https://server-941971168213.us-west1.run.app/mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "sentry": {
       "type": "http",
       "url": "https://mcp.sentry.dev/mcp/sentry?experimental=1"
+    },
+    "al-devinfra-mcp": {
+      "type": "http",
+      "url": "https://server-941971168213.us-west1.run.app/mcp"
     }
   }
 }

--- a/agents.toml
+++ b/agents.toml
@@ -18,3 +18,7 @@ source = "getsentry/warden"
 [[skills]]
 name = "warden"
 source = "getsentry/warden"
+
+[[mcp]]
+name = "al-devinfra-mcp"
+url = "https://server-941971168213.us-west1.run.app/mcp"


### PR DESCRIPTION
dev-infra has developed an experimental mcp server to help developers debug dev-infra related issues (devenv, devservices, ci, running the devserver, etc.)

This PR adds said MCP to the dotagents so that it's installed automatically when you run `dotagents install` 