### PR TITLE
fix(metric-issue): Defer chart request until open period has loaded

### DIFF
--- a/static/app/views/detectors/components/details/metric/chart.tsx
+++ b/static/app/views/detectors/components/details/metric/chart.tsx
@@ -98,6 +98,7 @@ const CHART_HEIGHT = 180;
 interface UseMetricDetectorChartProps {
   detector: MetricDetector;
   openPeriods: GroupOpenPeriod[];
+  enabled?: boolean;
   /**
    * Relative time period (e.g., '7d'). Use either statsPeriod or absolute start/end.
    */
@@ -178,6 +179,7 @@ export function useMetricDetectorChart({
   start,
   end,
   detector,
+  enabled = true,
   openPeriods,
   highlightedOpenPeriodId,
   height = CHART_HEIGHT,
@@ -206,6 +208,7 @@ export function useMetricDetectorChart({
     statsPeriod,
     start,
     end,
+    options: {enabled},
   });
 
   const metricTimestamps = useMetricTimestamps(series);

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
@@ -87,7 +87,10 @@ function MetricIssueChartContent({
   openPeriods: GroupOpenPeriod[];
 }) {
   const {selection} = usePageFilters();
-  const {openPeriod} = useEventOpenPeriod({groupId: group.id, eventId: event?.id});
+  const {openPeriod, isPending: isOpenPeriodPending} = useEventOpenPeriod({
+    groupId: group.id,
+    eventId: event?.id,
+  });
 
   const {
     chartProps,
@@ -98,10 +101,11 @@ function MetricIssueChartContent({
     openPeriods,
     highlightedOpenPeriodId: openPeriod?.id,
     height: CHART_HEIGHT,
+    enabled: !isOpenPeriodPending,
     ...normalizeDateTimeParams(selection.datetime),
   });
 
-  if (isLoading) {
+  if (isOpenPeriodPending || isLoading) {
     return <MetricIssueChartPlaceholder />;
   }
 


### PR DESCRIPTION
The open period, when it loads, may (and most often does) change the selected time range. To avoid the chart loading twice, this waits for the open period to be loaded before firing the request.