### PR TITLE
ref(billing): Remove maxAdminGift frontend limits for gifting

### DIFF
--- a/static/gsAdmin/components/addGiftEventsAction.spec.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.spec.tsx
@@ -78,18 +78,15 @@ describe('AddGiftEventsAction', () => {
     expect(screen.getByTestId('confirm-button')).toBeDisabled();
   });
 
-  it('disallows gifts greater than max gift limit', async () => {
-    const billedCategoryInfo = BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SPAN];
-    const maxValue =
-      billedCategoryInfo.maxAdminGift / billedCategoryInfo.freeEventsMultiple;
+  it('allows gifts of any size', async () => {
     triggerGiftModal();
     renderGlobalModal();
 
     const input = getInput();
 
-    await setNumEvents(`${maxValue + 5}`);
-    expect(input).toHaveValue(maxValue.toString());
-    expect(input).toHaveAccessibleDescription('Total: 1,000,000,000');
+    await setNumEvents('50000');
+    expect(input).toHaveValue('50000');
+    expect(input).toHaveAccessibleDescription('Total: 5,000,000,000');
   });
 
   it('renders label and help text with hours for continuous profiling categories', async () => {

--- a/static/gsAdmin/components/addGiftEventsAction.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.tsx
@@ -50,18 +50,13 @@ class AddGiftEventsAction extends Component<Props, State> {
   };
 
   coerceValue(value: string) {
-    const {billedCategoryInfo} = this.props;
-
     const intValue = parseInt(value, 10);
-    const maxValue =
-      (billedCategoryInfo?.maxAdminGift ?? 0) /
-      (billedCategoryInfo?.freeEventsMultiple ?? 1); // prevent ZeroDivisionError
 
     if (isNaN(intValue) || intValue < 0) {
       return undefined;
     }
 
-    return intValue > maxValue ? maxValue : intValue;
+    return intValue;
   }
 
   handleConfirm = (params: AdminConfirmParams) => {
@@ -152,7 +147,6 @@ class AddGiftEventsAction extends Component<Props, State> {
         name={dataCategory}
         inputMode="numeric"
         pattern="[0-9]*"
-        maxLength={dataCategory === DataCategory.REPLAYS ? 7 : 5}
         value={freeEvents && !isNaN(freeEvents) ? freeEvents.toString() : ''}
         onChange={this.handleChange}
       />

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -244,7 +244,7 @@ export default function CustomerDetails() {
       subscription.planDetails.categories
         .filter(category => {
           const categoryInfo = getCategoryInfoFromPlural(category);
-          return categoryInfo?.maxAdminGift && categoryInfo.freeEventsMultiple;
+          return categoryInfo?.freeEventsMultiple;
         })
         .map(category => {
           const reserved = subscription.categories?.[category]?.reserved;

--- a/static/gsApp/constants.tsx
+++ b/static/gsApp/constants.tsx
@@ -54,7 +54,6 @@ Object.entries(DEFAULT_BILLED_DATA_CATEGORY_INFO).forEach(
       ...categoryInfo,
       canAllocate: false,
       canProductTrial: false,
-      maxAdminGift: 0,
       freeEventsMultiple: 0,
       feature: null,
       hasSpikeProtection: false,
@@ -76,7 +75,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.ERROR]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.ERROR],
     canAllocate: true,
-    maxAdminGift: 10_000_000,
     freeEventsMultiple: 1_000,
     hasSpikeProtection: true,
     checkoutTooltip: t(
@@ -88,7 +86,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.TRANSACTION],
     canAllocate: true,
     canProductTrial: true,
-    maxAdminGift: 50_000_000,
     freeEventsMultiple: 1_000,
     feature: 'performance-view',
     hasSpikeProtection: true,
@@ -101,7 +98,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.ATTACHMENT]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.ATTACHMENT],
     canAllocate: true,
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'event-attachments',
     hasSpikeProtection: true,
@@ -112,7 +108,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.REPLAY]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.REPLAY],
     canProductTrial: true,
-    maxAdminGift: 1_000_000,
     freeEventsMultiple: 1,
     feature: 'session-replay',
     checkoutTooltip: t(
@@ -123,7 +118,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.SPAN]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SPAN],
     canProductTrial: true,
-    maxAdminGift: 1_000_000_000,
     freeEventsMultiple: 100_000,
     feature: 'spans-usage-tracking',
     hasSpikeProtection: true,
@@ -134,13 +128,11 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.SPAN_INDEXED]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SPAN_INDEXED],
     canProductTrial: true,
-    maxAdminGift: 1_000_000_000,
     freeEventsMultiple: 100_000,
     feature: 'spans-usage-tracking',
   },
   [DataCategoryExact.MONITOR_SEAT]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.MONITOR_SEAT],
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'monitor-seat-billing',
     tallyType: 'seat',
@@ -152,7 +144,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   },
   [DataCategoryExact.UPTIME]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.UPTIME],
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     feature: 'uptime-billing',
     tallyType: 'seat',
@@ -165,7 +156,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.PROFILE_DURATION]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PROFILE_DURATION],
     canProductTrial: true,
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1, // in hours
     hasPerCategory: true,
     checkoutTooltip: t(
@@ -176,7 +166,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
   [DataCategoryExact.PROFILE_DURATION_UI]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.PROFILE_DURATION_UI],
     canProductTrial: true,
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1, // in hours
     hasPerCategory: true,
     checkoutTooltip: t(
@@ -199,7 +188,6 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.LOG_BYTE],
     canAllocate: false,
     canProductTrial: true,
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     hasSpikeProtection: false,
     feature: 'logs-billing',
@@ -212,21 +200,18 @@ export const BILLED_DATA_CATEGORY_INFO = {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SEER_USER],
     feature: 'seer-user-billing-launch',
     canProductTrial: false,
-    maxAdminGift: 100,
     freeEventsMultiple: 1,
     tallyType: 'seat',
     shortenedUnitName: t('contributor'),
   },
   [DataCategoryExact.SIZE_ANALYSIS]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.SIZE_ANALYSIS],
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     shortenedUnitName: t('build'),
     adminOnlyProductTrialFeature: 'expose-category-size-analysis',
   },
   [DataCategoryExact.INSTALLABLE_BUILD]: {
     ...DEFAULT_BILLED_DATA_CATEGORY_INFO[DataCategoryExact.INSTALLABLE_BUILD],
-    maxAdminGift: 10_000,
     freeEventsMultiple: 1,
     shortenedUnitName: t('install'),
     adminOnlyProductTrialFeature: 'expose-category-installable-build',

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -1190,10 +1190,6 @@ export interface BilledDataCategoryInfo extends DataCategoryInfo {
    */
   hasSpikeProtection: boolean;
   /**
-   * The maximum number of free events that can be gifted
-   */
-  maxAdminGift: number;
-  /**
    * How usage is tallied for the category
    */
   tallyType: 'usage' | 'seat';


### PR DESCRIPTION
Gifting limits are now fully enforced in the backend, so remove the frontend maxAdminGift constants and input clamping. The gift category filter now uses freeEventsMultiple to determine giftability.