### PR TITLE
chore(llm-detection): Store trace id, category, and subcategory in issue metadata

### DIFF
--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -21,7 +21,11 @@ from sentry_sdk.tracing import NoOpSpan, Span, Transaction
 
 from sentry import nodestore, options
 from sentry.event_manager import GroupInfo
-from sentry.issues.grouptype import InvalidGroupTypeError, get_group_type_by_type_id
+from sentry.issues.grouptype import (
+    InvalidGroupTypeError,
+    LLMDetectedExperimentalGroupTypeV2,
+    get_group_type_by_type_id,
+)
 from sentry.issues.ingest import process_occurrence_data, save_issue_occurrence
 from sentry.issues.issue_occurrence import DEFAULT_LEVEL, IssueOccurrence, IssueOccurrenceData
 from sentry.issues.json_schemas import EVENT_PAYLOAD_SCHEMA, LEGACY_EVENT_PAYLOAD_SCHEMA
@@ -302,10 +306,15 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Mapping[str, Any]:
                         )
                         raise
 
-                event_data["metadata"] = {
-                    # This allows us to show the title consistently in discover
-                    "title": occurrence_data["issue_title"],
-                }
+                if occurrence_data["type"] == LLMDetectedExperimentalGroupTypeV2.type_id:
+                    event_data["metadata"] = {
+                        **event_payload.get("metadata", {}),
+                        "title": occurrence_data["issue_title"],
+                    }
+                else:
+                    event_data["metadata"] = {
+                        "title": occurrence_data["issue_title"],
+                    }
 
                 return {
                     "occurrence_data": occurrence_data,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -190,6 +190,11 @@ def create_issue_occurrence_from_detection(
                 "type": "trace",
             }
         },
+        "metadata": {
+            "trace_id": trace_id,
+            "category": detected_issue.category,
+            "subcategory": detected_issue.subcategory,
+        },
     }
 
     produce_occurrence_to_kafka(

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -13,7 +13,11 @@ from django.core.cache import cache
 from jsonschema import ValidationError
 
 from sentry import options
-from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType, ProfileFileIOGroupType
+from sentry.issues.grouptype import (
+    LLMDetectedExperimentalGroupTypeV2,
+    PerformanceSlowDBQueryGroupType,
+    ProfileFileIOGroupType,
+)
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.occurrence_consumer import (
     EventLookupError,
@@ -607,6 +611,35 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         message = deepcopy(get_test_message(self.project.id))
         message["event"].pop("received", None)
         self.run_test(message)
+
+    def test_preserves_event_metadata_for_llm_detected_issues(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["type"] = LLMDetectedExperimentalGroupTypeV2.type_id
+        message["event"]["metadata"] = {
+            "category": "Database",
+            "subcategory": "N+1 Query",
+            "trace_id": "abc123",
+        }
+        kwargs = _get_kwargs(message)
+
+        # Title should always be set from occurrence
+        assert kwargs["event_data"]["metadata"]["title"] == message["issue_title"]
+        # Custom metadata should be preserved for LLM issues
+        assert kwargs["event_data"]["metadata"]["category"] == "Database"
+        assert kwargs["event_data"]["metadata"]["subcategory"] == "N+1 Query"
+        assert kwargs["event_data"]["metadata"]["trace_id"] == "abc123"
+
+    def test_does_not_preserve_event_metadata_for_other_issue_types(self) -> None:
+        message = deepcopy(get_test_message(self.project.id))
+        message["event"]["metadata"] = {
+            "category": "Database",
+        }
+        kwargs = _get_kwargs(message)
+
+        # Title should be set
+        assert kwargs["event_data"]["metadata"]["title"] == message["issue_title"]
+        # Custom metadata should NOT be preserved for non-LLM issues
+        assert "category" not in kwargs["event_data"]["metadata"]
 
     @freeze_time("2024-07-11 00:00:00")
     def test_missing_received_fills_with_current_time(self) -> None:


### PR DESCRIPTION
This feels hacky, but I'm wondering if it's possible to include these additional fields on the issue, without displaying them on the frontend, just to make issue quality analysis queries easier.

## Summary
- Adds `category`, `subcategory`, and `trace_id` to the event metadata for LLM-detected issues
- These fields flow through the existing ingestion pipeline and persist to `sentry_groupedmessage.data["metadata"]`
- Enables querying for an llm-detected issue by `trace_id`
- `category`, `subcategory` can now be accessed from the db without having to cross-reference logs