### PR TITLE
fix(org) auth token layout

### DIFF
--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -145,6 +145,7 @@ function AuthTokenDetailsForm({token}: {token: OrgAuthToken}) {
         <form.AppField name="name">
           {field => (
             <field.Layout.Row
+              padding="xl"
               label={t('Name')}
               hintText={t('A name to help you identify this token.')}
               required

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -138,37 +138,37 @@ function AuthTokenDetailsForm({token}: {token: OrgAuthToken}) {
 
   return (
     <form.AppForm form={form}>
-        <form.FieldGroup title={t('Organization Token Details')}>
-          <form.AppField name="name">
-            {field => (
-              <field.Layout.Row
-                label={t('Name')}
-                hintText={t('A name to help you identify this token.')}
-                required
-              >
-                <field.Input value={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </form.AppField>
-          <FieldGroup
-            label={t('Token')}
-            help={t('You can only view the token once after creation.')}
-          >
-            <div>{tokenPreview(token.tokenLastCharacters || '****')}</div>
-          </FieldGroup>
+      <form.FieldGroup title={t('Organization Token Details')}>
+        <form.AppField name="name">
+          {field => (
+            <field.Layout.Row
+              label={t('Name')}
+              hintText={t('A name to help you identify this token.')}
+              required
+            >
+              <field.Input value={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Row>
+          )}
+        </form.AppField>
+        <FieldGroup
+          label={t('Token')}
+          help={t('You can only view the token once after creation.')}
+        >
+          <div>{tokenPreview(token.tokenLastCharacters || '****')}</div>
+        </FieldGroup>
 
-          <FieldGroup
-            label={t('Scopes')}
-            help={t('You cannot change the scopes of an existing token.')}
-          >
-            <div>{token.scopes.slice().sort().join(', ')}</div>
-          </FieldGroup>
-        </form.FieldGroup>
+        <FieldGroup
+          label={t('Scopes')}
+          help={t('You cannot change the scopes of an existing token.')}
+        >
+          <div>{token.scopes.slice().sort().join(', ')}</div>
+        </FieldGroup>
+      </form.FieldGroup>
 
-        <Flex justify="end" gap="md" padding="md">
-          <Button onClick={handleGoBack}>{t('Cancel')}</Button>
-          <form.SubmitButton>{t('Save Changes')}</form.SubmitButton>
-        </Flex>
+      <Flex justify="end" gap="md" padding="md">
+        <Button onClick={handleGoBack}>{t('Cancel')}</Button>
+        <form.SubmitButton>{t('Save Changes')}</form.SubmitButton>
+      </Flex>
     </form.AppForm>
   );
 }

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -143,7 +143,6 @@ function AuthTokenDetailsForm({token}: {token: OrgAuthToken}) {
           <form.AppField name="name">
             {field => (
               <field.Layout.Row
-                padding="xl"
                 label={t('Name')}
                 hintText={t('A name to help you identify this token.')}
                 required

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -14,9 +14,6 @@ import {
 import FieldGroup from 'sentry/components/forms/fieldGroup';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {OrgAuthToken} from 'sentry/types/user';
@@ -142,32 +139,33 @@ function AuthTokenDetailsForm({token}: {token: OrgAuthToken}) {
   return (
     <form.AppForm>
       <form.FormWrapper>
-        <form.AppField name="name">
-          {field => (
-            <field.Layout.Row
-              padding="xl"
-              label={t('Name')}
-              hintText={t('A name to help you identify this token.')}
-              required
-            >
-              <field.Input value={field.state.value} onChange={field.handleChange} />
-            </field.Layout.Row>
-          )}
-        </form.AppField>
+        <form.FieldGroup title="Organization Token Details">
+          <form.AppField name="name">
+            {field => (
+              <field.Layout.Row
+                padding="xl"
+                label={t('Name')}
+                hintText={t('A name to help you identify this token.')}
+                required
+              >
+                <field.Input value={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
+          <FieldGroup
+            label={t('Token')}
+            help={t('You can only view the token once after creation.')}
+          >
+            <div>{tokenPreview(token.tokenLastCharacters || '****')}</div>
+          </FieldGroup>
 
-        <FieldGroup
-          label={t('Token')}
-          help={t('You can only view the token once after creation.')}
-        >
-          <div>{tokenPreview(token.tokenLastCharacters || '****')}</div>
-        </FieldGroup>
-
-        <FieldGroup
-          label={t('Scopes')}
-          help={t('You cannot change the scopes of an existing token.')}
-        >
-          <div>{token.scopes.slice().sort().join(', ')}</div>
-        </FieldGroup>
+          <FieldGroup
+            label={t('Scopes')}
+            help={t('You cannot change the scopes of an existing token.')}
+          >
+            <div>{token.scopes.slice().sort().join(', ')}</div>
+          </FieldGroup>
+        </form.FieldGroup>
 
         <Flex justify="end" gap="md" padding="md">
           <Button onClick={handleGoBack}>{t('Cancel')}</Button>
@@ -212,22 +210,17 @@ function OrganizationAuthTokensDetails() {
           }
         )}
       </TextBlock>
-      <Panel>
-        <PanelHeader>{t('Organization Token Details')}</PanelHeader>
 
-        <PanelBody>
-          {isError && (
-            <LoadingError
-              message={t('Failed to load organization token.')}
-              onRetry={refetchToken}
-            />
-          )}
+      {isError && (
+        <LoadingError
+          message={t('Failed to load organization token.')}
+          onRetry={refetchToken}
+        />
+      )}
 
-          {isPending && <LoadingIndicator />}
+      {isPending && <LoadingIndicator />}
 
-          {!isPending && !isError && token && <AuthTokenDetailsForm token={token} />}
-        </PanelBody>
-      </Panel>
+      {!isPending && !isError && token && <AuthTokenDetailsForm token={token} />}
     </div>
   );
 }

--- a/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
+++ b/static/app/views/settings/organizationAuthTokens/authTokenDetails.tsx
@@ -139,7 +139,7 @@ function AuthTokenDetailsForm({token}: {token: OrgAuthToken}) {
   return (
     <form.AppForm>
       <form.FormWrapper>
-        <form.FieldGroup title="Organization Token Details">
+        <form.FieldGroup title={t('Organization Token Details')}>
           <form.AppField name="name">
             {field => (
               <field.Layout.Row

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -102,6 +102,7 @@ function AuthTokenCreateForm({
         <form.AppField name="name">
           {field => (
             <field.Layout.Row
+              padding="xl"
               label={t('Name')}
               hintText={t('A name to help you identify this token.')}
               required

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -13,9 +13,6 @@ import {
   addSuccessMessage,
 } from 'sentry/actionCreators/indicator';
 import FieldGroup from 'sentry/components/forms/fieldGroup';
-import Panel from 'sentry/components/panels/panel';
-import PanelBody from 'sentry/components/panels/panelBody';
-import PanelHeader from 'sentry/components/panels/panelHeader';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -99,29 +96,29 @@ function AuthTokenCreateForm({
   return (
     <form.AppForm>
       <form.FormWrapper>
-        <form.AppField name="name">
-          {field => (
-            <field.Layout.Row
-              padding="xl"
-              label={t('Name')}
-              hintText={t('A name to help you identify this token.')}
-              required
-            >
-              <field.Input value={field.state.value} onChange={field.handleChange} />
-            </field.Layout.Row>
-          )}
-        </form.AppField>
+        <form.FieldGroup title="Create New Organization Token">
+          <form.AppField name="name">
+            {field => (
+              <field.Layout.Row
+                label={t('Name')}
+                hintText={t('A name to help you identify this token.')}
+                required
+              >
+                <field.Input value={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </form.AppField>
 
-        <FieldGroup
-          label={t('Scopes')}
-          help={t('Organization tokens currently have a limited set of scopes.')}
-        >
-          <div>
-            <div>org:ci</div>
-            <ScopeHelpText>{t('Source Map Upload, Release Creation')}</ScopeHelpText>
-          </div>
-        </FieldGroup>
-
+          <FieldGroup
+            label={t('Scopes')}
+            help={t('Organization tokens currently have a limited set of scopes.')}
+          >
+            <div>
+              <div>org:ci</div>
+              <ScopeHelpText>{t('Source Map Upload, Release Creation')}</ScopeHelpText>
+            </div>
+          </FieldGroup>
+        </form.FieldGroup>
         <Flex justify="end" gap="md" padding="md">
           <Button onClick={handleGoBack}>{t('Cancel')}</Button>
           <form.SubmitButton>{t('Create Token')}</form.SubmitButton>
@@ -158,16 +155,10 @@ export default function OrganizationAuthTokensNewAuthToken() {
           }
         )}
       </TextBlock>
-      <Panel>
-        <PanelHeader>{t('Create New Organization Token')}</PanelHeader>
-
-        <PanelBody>
-          <AuthTokenCreateForm
-            organization={organization}
-            onCreatedToken={token => displayNewToken(token.token, handleGoBack)}
-          />
-        </PanelBody>
-      </Panel>
+      <AuthTokenCreateForm
+        organization={organization}
+        onCreatedToken={token => displayNewToken(token.token, handleGoBack)}
+      />
     </div>
   );
 }

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -95,33 +95,33 @@ function AuthTokenCreateForm({
 
   return (
     <form.AppForm form={form}>
-        <form.FieldGroup title={t('Create New Organization Token')}>
-          <form.AppField name="name">
-            {field => (
-              <field.Layout.Row
-                label={t('Name')}
-                hintText={t('A name to help you identify this token.')}
-                required
-              >
-                <field.Input value={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </form.AppField>
+      <form.FieldGroup title={t('Create New Organization Token')}>
+        <form.AppField name="name">
+          {field => (
+            <field.Layout.Row
+              label={t('Name')}
+              hintText={t('A name to help you identify this token.')}
+              required
+            >
+              <field.Input value={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Row>
+          )}
+        </form.AppField>
 
-          <FieldGroup
-            label={t('Scopes')}
-            help={t('Organization tokens currently have a limited set of scopes.')}
-          >
-            <div>
-              <div>org:ci</div>
-              <ScopeHelpText>{t('Source Map Upload, Release Creation')}</ScopeHelpText>
-            </div>
-          </FieldGroup>
-        </form.FieldGroup>
-        <Flex justify="end" gap="md" padding="md">
-          <Button onClick={handleGoBack}>{t('Cancel')}</Button>
-          <form.SubmitButton>{t('Create Token')}</form.SubmitButton>
-        </Flex>
+        <FieldGroup
+          label={t('Scopes')}
+          help={t('Organization tokens currently have a limited set of scopes.')}
+        >
+          <div>
+            <div>org:ci</div>
+            <ScopeHelpText>{t('Source Map Upload, Release Creation')}</ScopeHelpText>
+          </div>
+        </FieldGroup>
+      </form.FieldGroup>
+      <Flex justify="end" gap="md" padding="md">
+        <Button onClick={handleGoBack}>{t('Cancel')}</Button>
+        <form.SubmitButton>{t('Create Token')}</form.SubmitButton>
+      </Flex>
     </form.AppForm>
   );
 }

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -96,7 +96,7 @@ function AuthTokenCreateForm({
   return (
     <form.AppForm>
       <form.FormWrapper>
-        <form.FieldGroup title="Create New Organization Token">
+        <form.FieldGroup title={t('Create New Organization Token')}>
           <form.AppField name="name">
             {field => (
               <field.Layout.Row


### PR DESCRIPTION
Fixes auth token layout.

<img width="1966" height="234" alt="CleanShot 2026-02-25 at 21 15 14@2x" src="https://github.com/user-attachments/assets/2bce8bcd-d08a-43c8-afdf-ea82f620dbb4" />

