### PR TITLE
feat(skills): add create-branch skill

### DIFF
--- a/.agents/skills/create-branch/SKILL.md
+++ b/.agents/skills/create-branch/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: create-branch
+description: Create a git branch following Sentry naming conventions. Use when asked to "create a branch", "new branch", "start a branch", "make a branch", "switch to a new branch", or when starting new work on main/master.
+argument-hint: '[optional description of the work]'
+---
+
+# Create Branch
+
+Create a git branch with the correct type prefix and a descriptive name following Sentry conventions.
+
+## Step 1: Get the Username Prefix
+
+Run `git config user.name` and extract the **first name only**, lowercased.
+
+Example: "Priscila Oliveira" becomes `priscila`.
+
+If empty, ask the user for their preferred prefix.
+
+## Step 2: Determine the Branch Description
+
+**If `$ARGUMENTS` is provided**, use it as the description of the work.
+
+**If no arguments**, check for local changes:
+
+```bash
+git diff --stat
+git diff --cached --stat
+git status --short
+```
+
+- **Changes exist**: read the diff to understand what the work is about and generate a description.
+- **No changes**: ask the user what they are about to work on.
+
+## Step 3: Classify the Type
+
+Pick the type from this table based on the description:
+
+| Type      | Use when                                            |
+| --------- | --------------------------------------------------- |
+| `feat`    | New user-facing functionality                       |
+| `fix`     | Broken behavior now works                           |
+| `ref`     | Same behavior, different structure                  |
+| `chore`   | Deps, config, tooling, version bumps — no app logic |
+| `perf`    | Same behavior, faster                               |
+| `style`   | CSS, formatting, visual-only                        |
+| `docs`    | Documentation only                                  |
+| `test`    | Tests only                                          |
+| `ci`      | CI/CD config                                        |
+| `build`   | Build system                                        |
+| `meta`    | Repo metadata changes                               |
+| `license` | License changes                                     |
+
+When unsure: `feat` for new things, `ref` for restructuring existing things.
+
+## Step 4: Generate and Propose
+
+Build the branch name as `<username>/<type>/<short-description>`.
+
+Rules for `<short-description>`:
+
+- Kebab-case, lowercase
+- 3 to 6 words, concise but clear
+- Describe the change, not file names
+
+Present it to the user and ask if they want to use it, modify it, or change the type.
+
+### Examples
+
+| Work description                           | Branch name                                 |
+| ------------------------------------------ | ------------------------------------------- |
+| Dropdown menu not closing on outside click | `priscila/fix/dropdown-not-closing-on-blur` |
+| Adding search to conversations page        | `priscila/feat/add-search-to-conversations` |
+| Restructuring drawer components            | `priscila/ref/simplify-drawer-components`   |
+| Updating test fixtures                     | `priscila/chore/update-test-fixtures`       |
+| Bumping @sentry/react to latest version    | `priscila/chore/bump-sentry-react`          |
+
+## Step 5: Create the Branch
+
+Once confirmed:
+
+```bash
+git checkout -b <branch-name>
+```
+
+If already on a non-main branch, warn the user and ask whether to branch from here or from `master` first.
+
+## References
+
+- [Sentry Branch Naming](https://develop.sentry.dev/sdk/getting-started/standards/code-submission/#branch-naming)


### PR DESCRIPTION
Every day, I create many branches, usually starting by adding my name as a prefix .... like most of us do. After that, I need to classify the changes (feat, refactor, chore, etc.), make sure they follow our conventions, and add a meaningful description.

What if Claude does that for us? That’s exactly what this PR introduces. Done! ✅
__

Add an agent skill that automates git branch creation following Sentry naming conventions. Detects username from git config, classifies the change type from local diffs, and proposes a branch name for confirmation.