### PR TITLE
feat(preprod): Post build distribution comments to GitHub PRs

### DIFF
--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -31,9 +31,9 @@ COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
 # Build configurations - set to None to disable a build
 BUILDS = [
     {
-        "artifact_id": 5,
-        "app_id": "com.emerge.hackernews.ios",
-        "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
+        "artifact_id": 1,
+        "app_id": "com.emergetools.hackernews.debug",
+        "artifact_type": PreprodArtifact.ArtifactType.APK,
         "app_name": "HackerNews",
         "build_version": "1.0.3",
         "build_number": 15,

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -206,13 +206,10 @@ def main() -> None:
         logger.info("Done!")
 
         # Show results
-        comment_ids = set()
-        for aid in artifact_ids:
-            artifact = PreprodArtifact.objects.get(id=aid)
-            extras = artifact.extras or {}
-            pr_comments = extras.get("posted_pr_comments", {}).get("build_distribution", {})
-            if pr_comments.get("success"):
-                comment_ids.add(pr_comments["comment_id"])
+        commit_comparison.refresh_from_db()
+        cc_extras = commit_comparison.extras or {}
+        build_dist = cc_extras.get("pr_comments", {}).get("build_distribution", {})
+        comment_ids = {build_dist["comment_id"]} if build_dist.get("success") else set()
 
         if comment_ids:
             logger.info(

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -24,9 +24,9 @@ from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 #################
 ORG_SLUG = "sentry"
 PROJECT_SLUG = "internal"
-REPO_NAME = "runningcode/Test-github-sentry"
+REPO_NAME = "EmergeTools/hackernews"
 PR_NUMBER = 1
-COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
+COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
 
 # Build configurations - set to None to disable a build
 BUILDS = [

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -23,30 +23,29 @@ from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 #################
 ORG_SLUG = "sentry"
 PROJECT_SLUG = "internal"
-REPO_NAME = "runningcode/Test-github-sentry"
+REPO_NAME = "EmergeTools/hackernews"
 PR_NUMBER = 1
-# Use the HEAD SHA of the PR (visible on the PR's commits tab)
-COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
+COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
 
 # Build configurations - set to None to disable a build
 BUILDS = [
     {
         "artifact_id": 1,
-        "app_id": "com.emergetools.hackernews.debug",
-        "artifact_type": PreprodArtifact.ArtifactType.APK,
+        "app_id": "com.emerge.hackernews.android",
+        "artifact_type": PreprodArtifact.ArtifactType.AAB,
         "app_name": "HackerNews",
         "build_version": "1.0.3",
-        "build_number": 15,
-        "build_configuration": "Release",
+        "build_number": 42,
+        "build_configuration": "Debug",
     },
     # Uncomment to test multi-build (monorepo) comments:
     # {
     #     "artifact_id": 6,
-    #     "app_id": "com.emerge.hackernews.android",
-    #     "artifact_type": PreprodArtifact.ArtifactType.AAB,
+    #     "app_id": "com.emerge.hackernews.ios",
+    #     "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
     #     "app_name": "HackerNews",
     #     "build_version": "1.0.3",
-    #     "build_number": 42,
+    #     "build_number": 15,
     #     "build_configuration": "Release",
     # },
 ]

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -6,6 +6,7 @@ configure()
 
 import logging
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 logger = logging.getLogger(__name__)
 
@@ -23,9 +24,9 @@ from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 #################
 ORG_SLUG = "sentry"
 PROJECT_SLUG = "internal"
-REPO_NAME = "EmergeTools/hackernews"
+REPO_NAME = "runningcode/Test-github-sentry"
 PR_NUMBER = 1
-COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
+COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
 
 # Build configurations - set to None to disable a build
 BUILDS = [
@@ -38,17 +39,28 @@ BUILDS = [
         "build_number": 42,
         "build_configuration": "Debug",
     },
-    # Uncomment to test multi-build (monorepo) comments:
-    # {
-    #     "artifact_id": 6,
-    #     "app_id": "com.emerge.hackernews.ios",
-    #     "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
-    #     "app_name": "HackerNews",
-    #     "build_version": "1.0.3",
-    #     "build_number": 15,
-    #     "build_configuration": "Release",
-    # },
+    {
+        "artifact_id": 6,
+        "app_id": "com.emerge.hackernews.ios",
+        "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
+        "app_name": "HackerNews",
+        "build_version": "1.0.3",
+        "build_number": 15,
+        "build_configuration": "Release",
+    },
+    {
+        "artifact_id": 7,
+        "app_id": "com.emerge.hackernews.ios",
+        "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
+        "app_name": "HackerNews",
+        "build_version": "1.0.3",
+        "build_number": 15,
+        "build_configuration": "Debug",
+    },
 ]
+
+# Pass --concurrent to trigger all builds in parallel (tests lock serialization)
+CONCURRENT = "--concurrent" in sys.argv
 
 
 def get_or_create_build_configuration(
@@ -106,15 +118,11 @@ def main() -> None:
         else:
             logger.info("  No existing artifacts (clean slate)")
 
-        logger.info("\nCreating %s installable artifact(s):", len(BUILDS))
-
-        created_artifacts = []
-        for build_config in BUILDS:
+        def create_artifact(build_config):
             build_conf = get_or_create_build_configuration(
                 project, build_config.get("build_configuration")
             )
 
-            # Use a fixed ID so the PR comment links to a predictable URL.
             artifact_id = build_config.get("artifact_id")
             PreprodArtifact.objects.filter(id=artifact_id).delete()
 
@@ -126,9 +134,6 @@ def main() -> None:
                 commit_comparison=commit_comparison,
                 state=PreprodArtifact.ArtifactState.PROCESSED,
                 build_configuration=build_conf,
-                # Set installable_app_file_id to a non-null value so is_installable_artifact() passes.
-                # In production this points to a real File object; for testing the comment
-                # template we just need it to be truthy.
                 installable_app_file_id=1,
             )
             PreprodArtifactMobileAppInfo.objects.create(
@@ -137,36 +142,94 @@ def main() -> None:
                 build_version=build_config["build_version"],
                 build_number=build_config["build_number"],
             )
-            created_artifacts.append(artifact)
             logger.info(
                 "  Created artifact %s: %s (%s)",
                 artifact.id,
                 build_config["app_id"],
                 artifact.get_platform_label(),
             )
+            return artifact
 
-        logger.info(
-            "\nCalling create_preprod_pr_comment_task with artifact %s...",
-            created_artifacts[0].id,
-        )
-        create_preprod_pr_comment_task(preprod_artifact_id=created_artifacts[0].id)
+        if CONCURRENT:
+            logger.info(
+                "\nTriggering %s builds with 60s delays (testing lock serialization)...",
+                len(BUILDS),
+            )
+
+            def run_build(build_config: dict, delay: int) -> int:
+                import time
+
+                from django import db
+
+                if delay:
+                    logger.info(
+                        "  Build %s waiting %ss...",
+                        build_config["app_id"],
+                        delay,
+                    )
+                    time.sleep(delay)
+                db.connections.close_all()
+                artifact = create_artifact(build_config)
+                create_preprod_pr_comment_task(preprod_artifact_id=artifact.id)
+                return artifact.id
+
+            artifact_ids = []
+            with ThreadPoolExecutor(max_workers=len(BUILDS)) as pool:
+                futures = {
+                    pool.submit(run_build, build, i * 60): build["artifact_id"]
+                    for i, build in enumerate(BUILDS)
+                }
+                for future in as_completed(futures):
+                    aid = futures[future]
+                    try:
+                        artifact_ids.append(future.result())
+                        logger.info("  Task for artifact %s completed", aid)
+                    except Exception:
+                        logger.exception("  Task for artifact %s failed", aid)
+        else:
+            import time
+
+            artifact_ids = []
+            for i, build_config in enumerate(BUILDS):
+                if i > 0:
+                    logger.info("  Waiting 60s before next build...")
+                    time.sleep(60)
+                logger.info(
+                    "\nBuild %s/%s:",
+                    i + 1,
+                    len(BUILDS),
+                )
+                artifact = create_artifact(build_config)
+                artifact_ids.append(artifact.id)
+                create_preprod_pr_comment_task(preprod_artifact_id=artifact.id)
+
         logger.info("Done!")
 
-        # Show result
-        artifact = PreprodArtifact.objects.get(id=created_artifacts[0].id)
-        extras = artifact.extras or {}
-        pr_comments = extras.get("posted_pr_comments", {}).get("build_distribution", {})
-        if pr_comments.get("success"):
+        # Show results
+        comment_ids = set()
+        for aid in artifact_ids:
+            artifact = PreprodArtifact.objects.get(id=aid)
+            extras = artifact.extras or {}
+            pr_comments = extras.get("posted_pr_comments", {}).get("build_distribution", {})
+            if pr_comments.get("success"):
+                comment_ids.add(pr_comments["comment_id"])
+
+        if comment_ids:
             logger.info(
                 "\nComment posted! Check: https://github.com/%s/pull/%s",
                 REPO_NAME,
                 PR_NUMBER,
             )
-            logger.info("  comment_id: %s", pr_comments.get("comment_id"))
+            logger.info("  Unique comment IDs: %s", comment_ids)
+            if CONCURRENT and len(comment_ids) > 1:
+                logger.warning(
+                    "  RACE CONDITION: %s comments were created instead of 1!",
+                    len(comment_ids),
+                )
+            elif CONCURRENT:
+                logger.info("  Lock serialization working: only 1 comment created")
         else:
             logger.info("\nComment was NOT posted. Check logs above for early-return reasons.")
-            if pr_comments:
-                logger.info("  error_type: %s", pr_comments.get("error_type"))
 
     except Project.DoesNotExist:
         logger.exception("Project not found: %s/%s", ORG_SLUG, PROJECT_SLUG)

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+
+from sentry.runner import configure
+
+configure()
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.project import Project
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodBuildConfiguration,
+)
+from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
+
+#################
+# Configuration #
+#################
+ORG_SLUG = "sentry"
+PROJECT_SLUG = "internal"
+REPO_NAME = "runningcode/Test-github-sentry"
+PR_NUMBER = 1
+# Use the HEAD SHA of the PR (visible on the PR's commits tab)
+COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
+
+# Build configurations - set to None to disable a build
+BUILDS = [
+    {
+        "app_id": "com.emerge.hackernews.ios",
+        "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
+        "app_name": "HackerNews",
+        "build_version": "1.0.3",
+        "build_number": 15,
+        "build_configuration": "Release",
+    },
+    # Uncomment to test multi-build (monorepo) comments:
+    # {
+    #     "app_id": "com.emerge.hackernews.android",
+    #     "artifact_type": PreprodArtifact.ArtifactType.AAB,
+    #     "app_name": "HackerNews",
+    #     "build_version": "1.0.3",
+    #     "build_number": 42,
+    #     "build_configuration": "Release",
+    # },
+]
+
+
+def get_or_create_build_configuration(
+    project: "Project", config_name: str
+) -> "PreprodBuildConfiguration | None":
+    if not config_name:
+        return None
+
+    build_config, created = PreprodBuildConfiguration.objects.get_or_create(
+        project=project,
+        name=config_name,
+    )
+    action = "Created" if created else "Found"
+    logger.info("  %s build configuration: %s", action, config_name)
+    return build_config
+
+
+def main() -> None:
+    try:
+        project = Project.objects.get(slug=PROJECT_SLUG, organization__slug=ORG_SLUG)
+        logger.info("Found project: %s (ID: %s)", project.name, project.id)
+
+        commit_comparison, created = CommitComparison.objects.get_or_create(
+            head_repo_name=REPO_NAME,
+            head_sha=COMMIT_SHA,
+            provider="github",
+            organization_id=project.organization.id,
+            defaults={
+                "head_ref": "main",
+                "base_ref": "main",
+                "pr_number": PR_NUMBER,
+            },
+        )
+        if not created and not commit_comparison.pr_number:
+            commit_comparison.pr_number = PR_NUMBER
+            commit_comparison.save(update_fields=["pr_number"])
+
+        logger.info(
+            "%s commit comparison: %s (pr_number=%s)",
+            "Created" if created else "Found",
+            commit_comparison.id,
+            commit_comparison.pr_number,
+        )
+
+        # Clean up existing artifacts for this commit
+        logger.info("\nCleaning up existing artifacts for commit %s...", COMMIT_SHA[:8])
+        existing = PreprodArtifact.objects.filter(
+            commit_comparison=commit_comparison,
+            project__organization_id=project.organization_id,
+        )
+        if existing.exists():
+            count = existing.count()
+            existing.delete()
+            logger.info("  Deleted %s existing artifacts", count)
+        else:
+            logger.info("  No existing artifacts (clean slate)")
+
+        logger.info("\nCreating %s installable artifact(s):", len(BUILDS))
+
+        created_artifacts = []
+        for build_config in BUILDS:
+            build_conf = get_or_create_build_configuration(
+                project, build_config.get("build_configuration")
+            )
+
+            artifact = PreprodArtifact.objects.create(
+                project=project,
+                artifact_type=build_config["artifact_type"],
+                app_id=build_config["app_id"],
+                commit_comparison=commit_comparison,
+                state=PreprodArtifact.ArtifactState.PROCESSED,
+                build_configuration=build_conf,
+                # Set installable_app_file_id to a non-null value so is_installable_artifact() passes.
+                # In production this points to a real File object; for testing the comment
+                # template we just need it to be truthy.
+                installable_app_file_id=1,
+            )
+            PreprodArtifactMobileAppInfo.objects.create(
+                preprod_artifact=artifact,
+                app_name=build_config["app_name"],
+                build_version=build_config["build_version"],
+                build_number=build_config["build_number"],
+            )
+            created_artifacts.append(artifact)
+            logger.info(
+                "  Created artifact %s: %s (%s)",
+                artifact.id,
+                build_config["app_id"],
+                artifact.get_platform_label(),
+            )
+
+        logger.info(
+            "\nCalling create_preprod_pr_comment_task with artifact %s...",
+            created_artifacts[0].id,
+        )
+        create_preprod_pr_comment_task(preprod_artifact_id=created_artifacts[0].id)
+        logger.info("Done!")
+
+        # Show result
+        artifact = PreprodArtifact.objects.get(id=created_artifacts[0].id)
+        extras = artifact.extras or {}
+        pr_comments = extras.get("posted_pr_comments", {}).get("build_distribution", {})
+        if pr_comments.get("success"):
+            logger.info(
+                "\nComment posted! Check: https://github.com/%s/pull/%s",
+                REPO_NAME,
+                PR_NUMBER,
+            )
+            logger.info("  comment_id: %s", pr_comments.get("comment_id"))
+        else:
+            logger.info("\nComment was NOT posted. Check logs above for early-return reasons.")
+            if pr_comments:
+                logger.info("  error_type: %s", pr_comments.get("error_type"))
+
+    except Project.DoesNotExist:
+        logger.exception("Project not found: %s/%s", ORG_SLUG, PROJECT_SLUG)
+        for p in Project.objects.select_related("organization").all()[:10]:
+            logger.info("  - %s/%s", p.organization.slug, p.slug)
+        sys.exit(1)
+    except Exception:
+        logger.exception("Error running trigger_pr_comment")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/preprod/trigger_pr_comment
+++ b/bin/preprod/trigger_pr_comment
@@ -31,6 +31,7 @@ COMMIT_SHA = "746a4f8b311bb179a2057272cae04855404b4137"
 # Build configurations - set to None to disable a build
 BUILDS = [
     {
+        "artifact_id": 5,
         "app_id": "com.emerge.hackernews.ios",
         "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
         "app_name": "HackerNews",
@@ -40,6 +41,7 @@ BUILDS = [
     },
     # Uncomment to test multi-build (monorepo) comments:
     # {
+    #     "artifact_id": 6,
     #     "app_id": "com.emerge.hackernews.android",
     #     "artifact_type": PreprodArtifact.ArtifactType.AAB,
     #     "app_name": "HackerNews",
@@ -113,7 +115,12 @@ def main() -> None:
                 project, build_config.get("build_configuration")
             )
 
+            # Use a fixed ID so the PR comment links to a predictable URL.
+            artifact_id = build_config.get("artifact_id")
+            PreprodArtifact.objects.filter(id=artifact_id).delete()
+
             artifact = PreprodArtifact.objects.create(
+                id=artifact_id,
                 project=project,
                 artifact_type=build_config["artifact_type"],
                 app_id=build_config["app_id"],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -893,6 +893,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.preprod.size_analysis.tasks",
     "sentry.preprod.snapshots.tasks",
     "sentry.preprod.tasks",
+    "sentry.preprod.vcs.pr_comments.tasks",
     "sentry.preprod.vcs.status_checks.size.tasks",
     "sentry.profiles.task",
     "sentry.release_health.tasks",

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_admin_info.py
@@ -84,7 +84,7 @@ class PreprodArtifactAdminInfoEndpoint(Endpoint):
             InstallablePreprodArtifact.objects.filter(preprod_artifact_id=head_artifact_id_int)
         )
 
-        mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+        mobile_app_info = preprod_artifact.get_mobile_app_info()
 
         artifact_info = {
             "id": preprod_artifact.id,

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -68,7 +68,7 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
         if format_type == "plist":
             app_id = preprod_artifact.app_id
 
-            mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+            mobile_app_info = preprod_artifact.get_mobile_app_info()
             build_version = mobile_app_info.build_version if mobile_app_info else None
             app_name = mobile_app_info.app_name if mobile_app_info else None
             if not app_id or not build_version or not app_name:
@@ -138,7 +138,7 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
 
             fp = file_obj.getfile()
             filename = preprod_artifact.app_id or "app"
-            mobile_app_info = getattr(preprod_artifact, "mobile_app_info", None)
+            mobile_app_info = preprod_artifact.get_mobile_app_info()
             build_version = mobile_app_info.build_version if mobile_app_info else None
             if build_version:
                 filename += f"@{build_version}"

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -388,7 +388,7 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
                 }
             )
 
-        mobile_app_info = getattr(head_artifact, "mobile_app_info", None)
+        mobile_app_info = head_artifact.get_mobile_app_info()
         build_version = mobile_app_info.build_version if mobile_app_info else None
         build_number = mobile_app_info.build_number if mobile_app_info else None
         if (

--- a/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_check_for_updates.py
@@ -43,7 +43,7 @@ class CheckForUpdatesApiResponse(BaseModel):
 
 def _build_details_from_artifact(artifact: PreprodArtifact) -> InstallableBuildDetails | None:
     """Convert a PreprodArtifact to InstallableBuildDetails, or None."""
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     if (
         not mobile_app_info
         or not mobile_app_info.build_version

--- a/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_comments.py
+++ b/src/sentry/preprod/api/endpoints/pull_request/organization_pullrequest_comments.py
@@ -11,7 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionEvent,
     SCMIntegrationInteractionType,
@@ -158,7 +158,7 @@ class OrganizationPrCommentsEndpoint(OrganizationEndpoint):
     def _fetch_pr_general_comments(
         self,
         organization_id: int,
-        client: GitHubApiClient,
+        client: GitHubBaseClient,
         repo_name: str,
         pr_number: str,
     ) -> list[dict[str, Any]]:
@@ -185,7 +185,7 @@ class OrganizationPrCommentsEndpoint(OrganizationEndpoint):
     def _fetch_pr_review_comments(
         self,
         organization_id: int,
-        client: GitHubApiClient,
+        client: GitHubBaseClient,
         repo_name: str,
         pr_number: str,
     ) -> list[dict[str, Any]]:

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -174,7 +174,7 @@ def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppI
             )
         )
 
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
 
     return BuildDetailsAppInfo(
         app_id=artifact.app_id,

--- a/src/sentry/preprod/api/models/public/shared.py
+++ b/src/sentry/preprod/api/models/public/shared.py
@@ -27,7 +27,7 @@ class GitInfoResponseDict(TypedDict):
 
 
 def create_app_info_dict(artifact: PreprodArtifact) -> AppInfoResponseDict:
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
 
     return {
         "appId": artifact.app_id,

--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -82,7 +82,7 @@ def get_artifact_install_info(artifact: PreprodArtifact) -> ArtifactInstallInfo:
 
 def is_installable_artifact(artifact: PreprodArtifact) -> bool:
     # TODO: Adjust this logic when we have a better way to determine if an artifact is installable
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     build_number = mobile_app_info.build_number if mobile_app_info else None
     return artifact.installable_app_file_id is not None and build_number is not None
 

--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -60,7 +60,7 @@ def produce_preprod_size_metric_to_eap(
     item_id_str = f"size_metric_{size_metric.id}"
     item_id = hex_to_item_id(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex)
 
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     attributes: dict[str, Any] = {
         "preprod_artifact_id": size_metric.preprod_artifact_id,
         "size_metric_id": size_metric.id,
@@ -159,7 +159,7 @@ def produce_preprod_build_distribution_to_eap(
     item_id_str = f"build_distribution_{artifact.id}"
     item_id = hex_to_item_id(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex)
 
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     attributes: dict[str, Any] = {
         "preprod_artifact_id": artifact.id,
         "sub_item_type": "build_distribution",

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -65,7 +65,7 @@ def bulk_delete_artifacts(
             all_file_ids.append(artifact.file_id)
         if artifact.installable_app_file_id:
             all_file_ids.append(artifact.installable_app_file_id)
-        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        mobile_app_info = artifact.get_mobile_app_info()
         app_icon_id = mobile_app_info.app_icon_id if mobile_app_info else None
         if app_icon_id:
             try:

--- a/src/sentry/preprod/integration_utils.py
+++ b/src/sentry/preprod/integration_utils.py
@@ -4,7 +4,7 @@ import logging
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
-from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.organization import Organization
@@ -13,12 +13,14 @@ from sentry.models.repository import Repository
 logger = logging.getLogger(__name__)
 
 
-def get_github_client(organization: Organization, repo_name: str) -> GitHubApiClient | None:
+def get_github_client(
+    organization: Organization, repo_name: str, provider: str = "github"
+) -> GitHubBaseClient | None:
     """Get the GitHub client for this organization and repository."""
     repository = Repository.objects.filter(
         organization_id=organization.id,
         name=repo_name,
-        provider="integrations:github",
+        provider=f"integrations:{provider}",
     ).first()
     if not repository:
         logger.info(
@@ -57,7 +59,7 @@ def get_github_client(organization: Organization, repo_name: str) -> GitHubApiCl
     )
     client = installation.get_client()
 
-    if not isinstance(client, GitHubApiClient):
+    if not isinstance(client, GitHubBaseClient):
         logger.info(
             "preprod.integration_utils.not_github_client",
             extra={

--- a/src/sentry/preprod/integration_utils.py
+++ b/src/sentry/preprod/integration_utils.py
@@ -7,10 +7,22 @@ from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.github.client import GitHubBaseClient
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
+from sentry.integrations.source_code_management.commit_context import CommitContextClient
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 
 logger = logging.getLogger(__name__)
+
+
+def get_commit_context_client(
+    organization: Organization, repo_name: str, provider: str = "github"
+) -> CommitContextClient | None:
+    """Get a CommitContextClient for this organization and repository.
+
+    Currently delegates to get_github_client; any integration that
+    implements CommitContextClient will work automatically.
+    """
+    return get_github_client(organization, repo_name, provider)
 
 
 def get_github_client(

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -229,6 +229,10 @@ class PreprodArtifact(DefaultFieldsModel):
     )
     installable_app_error_message = models.TextField(null=True)
 
+    def get_mobile_app_info(self) -> PreprodArtifactMobileAppInfo | None:
+        """Safely access the related mobile_app_info without raising RelatedObjectDoesNotExist."""
+        return getattr(self, "mobile_app_info", None)
+
     @property
     def platform(self) -> Platform | None:
         if self.artifact_type is None:

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -798,10 +798,6 @@ class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
             parts.append(f"({self.build_number})")
         return " ".join(parts) if parts else "--"
 
-    @property
-    def version_string(self) -> str:
-        return self.format_version_string()
-
     class Meta:
         app_label = "preprod"
         db_table = "sentry_preprodartifactmobileappinfo"

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -790,6 +790,18 @@ class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
     # Miscellaneous fields that we don't need columns for
     extras = models.JSONField(null=True)
 
+    def format_version_string(self) -> str:
+        parts: list[str] = []
+        if self.build_version:
+            parts.append(self.build_version)
+        if self.build_number:
+            parts.append(f"({self.build_number})")
+        return " ".join(parts) if parts else "--"
+
+    @property
+    def version_string(self) -> str:
+        return self.format_version_string()
+
     class Meta:
         app_label = "preprod"
         db_table = "sentry_preprodartifactmobileappinfo"

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -794,13 +794,13 @@ class PreprodArtifactMobileAppInfo(DefaultFieldsModel):
     # Miscellaneous fields that we don't need columns for
     extras = models.JSONField(null=True)
 
-    def format_version_string(self) -> str:
+    def format_version_string(self, default: str = "--") -> str:
         parts: list[str] = []
         if self.build_version:
             parts.append(self.build_version)
         if self.build_number:
             parts.append(f"({self.build_number})")
-        return " ".join(parts) if parts else "--"
+        return " ".join(parts) if parts else default
 
     class Meta:
         app_label = "preprod"

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -41,7 +41,7 @@ def _artifact_to_tags(artifact: PreprodArtifact) -> dict[str, str]:
     if artifact.app_id:
         tags["app_id"] = artifact.app_id
 
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     if mobile_app_info is not None:
         if mobile_app_info.app_name:
             tags["app_name"] = mobile_app_info.app_name

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -30,6 +30,7 @@ from sentry.preprod.producer import PreprodFeature, produce_preprod_artifact_to_
 from sentry.preprod.quotas import has_installable_quota, has_size_quota
 from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.preprod.size_analysis.tasks import compare_preprod_artifact_size_analysis
+from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.assemble import (
@@ -789,6 +790,13 @@ def _assemble_preprod_artifact_installable_app(
         event_id=None,
         # The id of the DSN.
         key_id=None,
+    )
+
+    create_preprod_pr_comment_task.apply_async(
+        kwargs={
+            "preprod_artifact_id": artifact_id,
+            "caller": "installable_app_assembled",
+        }
     )
 
 

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+from typing import Any
+
+from django.db import router, transaction
+
+from sentry import features
+from sentry.preprod.build_distribution_utils import is_installable_artifact
+from sentry.preprod.integration_utils import get_github_client
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.vcs.pr_comments.templates import format_pr_comment
+from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import preprod_tasks
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.create_preprod_pr_comment",
+    namespace=preprod_tasks,
+    processing_deadline_duration=30,
+    silo_mode=SiloMode.REGION,
+)
+def create_preprod_pr_comment_task(
+    preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
+) -> None:
+    try:
+        artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "build_configuration",
+            "commit_comparison",
+            "project",
+            "project__organization",
+        ).get(id=preprod_artifact_id)
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.pr_comments.create.artifact_not_found",
+            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+        )
+        return
+
+    if not artifact.commit_comparison:
+        logger.info(
+            "preprod.pr_comments.create.no_commit_comparison",
+            extra={"artifact_id": artifact.id},
+        )
+        return
+
+    commit_comparison = artifact.commit_comparison
+    if not commit_comparison.pr_number or not commit_comparison.head_repo_name:
+        logger.info(
+            "preprod.pr_comments.create.no_pr_info",
+            extra={
+                "artifact_id": artifact.id,
+                "pr_number": commit_comparison.pr_number,
+                "head_repo_name": commit_comparison.head_repo_name,
+            },
+        )
+        return
+
+    if commit_comparison.provider != "github":
+        logger.info(
+            "preprod.pr_comments.create.unsupported_provider",
+            extra={"artifact_id": artifact.id, "provider": commit_comparison.provider},
+        )
+        return
+
+    if not is_installable_artifact(artifact):
+        logger.info(
+            "preprod.pr_comments.create.not_installable",
+            extra={"artifact_id": artifact.id},
+        )
+        return
+
+    organization = artifact.project.organization
+    if not features.has("organizations:preprod-build-distribution", organization):
+        logger.info(
+            "preprod.pr_comments.create.feature_disabled",
+            extra={"artifact_id": artifact.id, "organization_id": organization.id},
+        )
+        return
+
+    siblings = artifact.get_sibling_artifacts_for_commit()
+    installable_siblings = [s for s in siblings if is_installable_artifact(s)]
+    if not installable_siblings:
+        return
+
+    existing_comment_id = _find_existing_comment_id(installable_siblings)
+
+    client = get_github_client(organization, commit_comparison.head_repo_name)
+    if not client:
+        logger.info(
+            "preprod.pr_comments.create.no_github_client",
+            extra={"artifact_id": artifact.id},
+        )
+        return
+
+    comment_body = format_pr_comment(installable_siblings)
+
+    try:
+        if existing_comment_id:
+            client.update_comment(
+                repo=commit_comparison.head_repo_name,
+                issue_id=str(commit_comparison.pr_number),
+                comment_id=str(existing_comment_id),
+                data={"body": comment_body},
+            )
+            comment_id = existing_comment_id
+            logger.info(
+                "preprod.pr_comments.create.updated",
+                extra={"artifact_id": artifact.id, "comment_id": comment_id},
+            )
+        else:
+            resp = client.create_comment(
+                repo=commit_comparison.head_repo_name,
+                issue_id=str(commit_comparison.pr_number),
+                data={"body": comment_body},
+            )
+            comment_id = str(resp["id"])
+            logger.info(
+                "preprod.pr_comments.create.created",
+                extra={"artifact_id": artifact.id, "comment_id": comment_id},
+            )
+    except Exception as e:
+        extra: dict[str, Any] = {
+            "artifact_id": artifact.id,
+            "organization_id": organization.id,
+            "error_type": type(e).__name__,
+        }
+        if isinstance(e, ApiError):
+            extra["status_code"] = e.code
+        logger.exception("preprod.pr_comments.create.failed", extra=extra)
+        _update_posted_pr_comment(artifact, success=False, error=e)
+        raise
+
+    _update_posted_pr_comment(artifact, success=True, comment_id=comment_id)
+
+
+def _find_existing_comment_id(artifacts: list[PreprodArtifact]) -> str | None:
+    for a in artifacts:
+        extras = a.extras or {}
+        pr_comments = extras.get("posted_pr_comments", {})
+        build_dist = pr_comments.get("build_distribution", {})
+        comment_id = build_dist.get("comment_id")
+        if comment_id and build_dist.get("success"):
+            return str(comment_id)
+    return None
+
+
+def _update_posted_pr_comment(
+    artifact: PreprodArtifact,
+    success: bool,
+    comment_id: str | None = None,
+    error: Exception | None = None,
+) -> None:
+    with transaction.atomic(router.db_for_write(PreprodArtifact)):
+        fresh = PreprodArtifact.objects.select_for_update().get(id=artifact.id)
+        extras = fresh.extras or {}
+
+        posted_pr_comments = extras.get("posted_pr_comments", {})
+        result: dict[str, Any] = {"success": success}
+        if success and comment_id:
+            result["comment_id"] = comment_id
+        if not success:
+            result["error_type"] = _get_error_type(error)
+
+        posted_pr_comments["build_distribution"] = result
+        extras["posted_pr_comments"] = posted_pr_comments
+        fresh.extras = extras
+        fresh.save(update_fields=["extras"])
+
+
+class _ErrorType(StrEnum):
+    UNKNOWN = "unknown"
+    API_ERROR = "api_error"
+    INTEGRATION_ERROR = "integration_error"
+
+
+def _get_error_type(error: Exception | None) -> str:
+    if error is None:
+        return _ErrorType.UNKNOWN
+    if isinstance(error, IntegrationConfigurationError):
+        return _ErrorType.INTEGRATION_ERROR
+    if isinstance(error, ApiError):
+        return _ErrorType.API_ERROR
+    return _ErrorType.UNKNOWN

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -156,7 +156,7 @@ def _find_existing_comment_id(commit_comparison: CommitComparison) -> str | None
     extras = commit_comparison.extras or {}
     build_dist = extras.get("pr_comments", {}).get("build_distribution", {})
     comment_id = build_dist.get("comment_id")
-    if comment_id and build_dist.get("success"):
+    if comment_id:
         return str(comment_id)
     return None
 
@@ -174,8 +174,14 @@ def _save_pr_comment_result(
     """
     extras = commit_comparison.extras or {}
 
+    # Preserve the existing comment_id on failure so retries use
+    # update_comment instead of creating a duplicate.
+    if not comment_id:
+        existing = extras.get("pr_comments", {}).get("build_distribution", {})
+        comment_id = existing.get("comment_id")
+
     result: dict[str, Any] = {"success": success}
-    if success and comment_id:
+    if comment_id:
         result["comment_id"] = comment_id
     if not success:
         result["error_type"] = _get_error_type(error)

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -8,7 +8,7 @@ from django.db import router, transaction
 
 from sentry import features
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.locks import locks
+from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.integration_utils import get_github_client
 from sentry.preprod.models import PreprodArtifact
@@ -17,7 +17,6 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigura
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
-from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
@@ -94,108 +93,97 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    # Serialize access per commit comparison so concurrent tasks don't create
-    # duplicate comments.  The lock ensures that sibling queries, the GitHub
-    # API call, and the extras update all happen atomically with respect to
-    # other tasks for the same commit.
-    lock = locks.get(
-        f"preprod:pr_comment:{commit_comparison.id}",
-        duration=60,
-        name="preprod_pr_comment",
-    )
-    try:
-        with lock.acquire():
-            siblings = artifact.get_sibling_artifacts_for_commit()
-            installable_siblings = [s for s in siblings if is_installable_artifact(s)]
-            if not installable_siblings:
-                return
+    # Use select_for_update on the commit_comparison row to serialize
+    # concurrent tasks for the same commit.  This prevents duplicate
+    # comments when multiple builds finish at the same time and also
+    # guarantees a fresh read of extras (where the comment_id lives).
+    api_error: Exception | None = None
 
-            existing_comment_id = _find_existing_comment_id(installable_siblings)
-            comment_body = format_pr_comment(installable_siblings)
+    with transaction.atomic(router.db_for_write(CommitComparison)):
+        cc = CommitComparison.objects.select_for_update().get(id=commit_comparison.id)
 
-            try:
-                if existing_comment_id:
-                    client.update_comment(
-                        repo=commit_comparison.head_repo_name,
-                        issue_id=str(commit_comparison.pr_number),
-                        comment_id=str(existing_comment_id),
-                        data={"body": comment_body},
-                    )
-                    comment_id = existing_comment_id
-                    logger.info(
-                        "preprod.pr_comments.create.updated",
-                        extra={"artifact_id": artifact.id, "comment_id": comment_id},
-                    )
-                else:
-                    resp = client.create_comment(
-                        repo=commit_comparison.head_repo_name,
-                        issue_id=str(commit_comparison.pr_number),
-                        data={"body": comment_body},
-                    )
-                    comment_id = str(resp["id"])
-                    logger.info(
-                        "preprod.pr_comments.create.created",
-                        extra={"artifact_id": artifact.id, "comment_id": comment_id},
-                    )
-            except Exception as e:
-                extra: dict[str, Any] = {
-                    "artifact_id": artifact.id,
-                    "organization_id": organization.id,
-                    "error_type": type(e).__name__,
-                }
-                if isinstance(e, ApiError):
-                    extra["status_code"] = e.code
-                logger.exception("preprod.pr_comments.create.failed", extra=extra)
-                _update_posted_pr_comment(artifact, success=False, error=e)
-                raise
+        siblings = artifact.get_sibling_artifacts_for_commit()
+        installable_siblings = [s for s in siblings if is_installable_artifact(s)]
+        if not installable_siblings:
+            return
 
-            _update_posted_pr_comment(artifact, success=True, comment_id=comment_id)
-    except UnableToAcquireLock:
-        logger.info(
-            "preprod.pr_comments.create.locked",
-            extra={"artifact_id": artifact.id, "commit_comparison_id": commit_comparison.id},
-        )
-        create_preprod_pr_comment_task.apply_async(
-            kwargs={
-                "preprod_artifact_id": preprod_artifact_id,
-                "caller": "retry_after_lock",
-            },
-            countdown=5,
-        )
+        existing_comment_id = _find_existing_comment_id(cc)
+        comment_body = format_pr_comment(installable_siblings)
+
+        try:
+            if existing_comment_id:
+                client.update_comment(
+                    repo=cc.head_repo_name,
+                    issue_id=str(cc.pr_number),
+                    comment_id=str(existing_comment_id),
+                    data={"body": comment_body},
+                )
+                comment_id = existing_comment_id
+                logger.info(
+                    "preprod.pr_comments.create.updated",
+                    extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                )
+            else:
+                resp = client.create_comment(
+                    repo=cc.head_repo_name,
+                    issue_id=str(cc.pr_number),
+                    data={"body": comment_body},
+                )
+                comment_id = str(resp["id"])
+                logger.info(
+                    "preprod.pr_comments.create.created",
+                    extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                )
+        except Exception as e:
+            extra: dict[str, Any] = {
+                "artifact_id": artifact.id,
+                "organization_id": organization.id,
+                "error_type": type(e).__name__,
+            }
+            if isinstance(e, ApiError):
+                extra["status_code"] = e.code
+            logger.exception("preprod.pr_comments.create.failed", extra=extra)
+            _save_pr_comment_result(cc, success=False, error=e)
+            api_error = e
+        else:
+            _save_pr_comment_result(cc, success=True, comment_id=comment_id)
+
+    if api_error is not None:
+        raise api_error
 
 
-def _find_existing_comment_id(artifacts: list[PreprodArtifact]) -> str | None:
-    for a in artifacts:
-        extras = a.extras or {}
-        pr_comments = extras.get("posted_pr_comments", {})
-        build_dist = pr_comments.get("build_distribution", {})
-        comment_id = build_dist.get("comment_id")
-        if comment_id and build_dist.get("success"):
-            return str(comment_id)
+def _find_existing_comment_id(commit_comparison: CommitComparison) -> str | None:
+    extras = commit_comparison.extras or {}
+    build_dist = extras.get("pr_comments", {}).get("build_distribution", {})
+    comment_id = build_dist.get("comment_id")
+    if comment_id and build_dist.get("success"):
+        return str(comment_id)
     return None
 
 
-def _update_posted_pr_comment(
-    artifact: PreprodArtifact,
+def _save_pr_comment_result(
+    commit_comparison: CommitComparison,
     success: bool,
     comment_id: str | None = None,
     error: Exception | None = None,
 ) -> None:
-    with transaction.atomic(router.db_for_write(PreprodArtifact)):
-        fresh = PreprodArtifact.objects.select_for_update().get(id=artifact.id)
-        extras = fresh.extras or {}
+    """Save the PR comment result to the commit_comparison row.
 
-        posted_pr_comments = extras.get("posted_pr_comments", {})
-        result: dict[str, Any] = {"success": success}
-        if success and comment_id:
-            result["comment_id"] = comment_id
-        if not success:
-            result["error_type"] = _get_error_type(error)
+    Must be called inside a transaction that already holds a
+    select_for_update lock on the commit_comparison row.
+    """
+    extras = commit_comparison.extras or {}
 
-        posted_pr_comments["build_distribution"] = result
-        extras["posted_pr_comments"] = posted_pr_comments
-        fresh.extras = extras
-        fresh.save(update_fields=["extras"])
+    result: dict[str, Any] = {"success": success}
+    if success and comment_id:
+        result["comment_id"] = comment_id
+    if not success:
+        result["error_type"] = _get_error_type(error)
+
+    pr_comments = extras.setdefault("pr_comments", {})
+    pr_comments["build_distribution"] = result
+    commit_comparison.extras = extras
+    commit_comparison.save(update_fields=["extras"])
 
 
 class _ErrorType(StrEnum):

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -7,6 +7,7 @@ from typing import Any
 from django.db import router, transaction
 
 from sentry import features
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.integration_utils import get_github_client
 from sentry.preprod.models import PreprodArtifact
@@ -62,17 +63,14 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    if commit_comparison.provider != "github":
+    _SUPPORTED_PROVIDERS = {
+        IntegrationProviderSlug.GITHUB.value,
+        IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+    }
+    if commit_comparison.provider not in _SUPPORTED_PROVIDERS:
         logger.info(
             "preprod.pr_comments.create.unsupported_provider",
             extra={"artifact_id": artifact.id, "provider": commit_comparison.provider},
-        )
-        return
-
-    if not is_installable_artifact(artifact):
-        logger.info(
-            "preprod.pr_comments.create.not_installable",
-            extra={"artifact_id": artifact.id},
         )
         return
 
@@ -91,7 +89,9 @@ def create_preprod_pr_comment_task(
 
     existing_comment_id = _find_existing_comment_id(installable_siblings)
 
-    client = get_github_client(organization, commit_comparison.head_repo_name)
+    client = get_github_client(
+        organization, commit_comparison.head_repo_name, commit_comparison.provider
+    )
     if not client:
         logger.info(
             "preprod.pr_comments.create.no_github_client",

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -8,6 +8,7 @@ from django.db import router, transaction
 
 from sentry import features
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.locks import locks
 from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.integration_utils import get_github_client
 from sentry.preprod.models import PreprodArtifact
@@ -16,6 +17,7 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigura
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
+from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
@@ -82,13 +84,6 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    siblings = artifact.get_sibling_artifacts_for_commit()
-    installable_siblings = [s for s in siblings if is_installable_artifact(s)]
-    if not installable_siblings:
-        return
-
-    existing_comment_id = _find_existing_comment_id(installable_siblings)
-
     client = get_github_client(
         organization, commit_comparison.head_repo_name, commit_comparison.provider
     )
@@ -99,45 +94,74 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    comment_body = format_pr_comment(installable_siblings)
-
+    # Serialize access per commit comparison so concurrent tasks don't create
+    # duplicate comments.  The lock ensures that sibling queries, the GitHub
+    # API call, and the extras update all happen atomically with respect to
+    # other tasks for the same commit.
+    lock = locks.get(
+        f"preprod:pr_comment:{commit_comparison.id}",
+        duration=60,
+        name="preprod_pr_comment",
+    )
     try:
-        if existing_comment_id:
-            client.update_comment(
-                repo=commit_comparison.head_repo_name,
-                issue_id=str(commit_comparison.pr_number),
-                comment_id=str(existing_comment_id),
-                data={"body": comment_body},
-            )
-            comment_id = existing_comment_id
-            logger.info(
-                "preprod.pr_comments.create.updated",
-                extra={"artifact_id": artifact.id, "comment_id": comment_id},
-            )
-        else:
-            resp = client.create_comment(
-                repo=commit_comparison.head_repo_name,
-                issue_id=str(commit_comparison.pr_number),
-                data={"body": comment_body},
-            )
-            comment_id = str(resp["id"])
-            logger.info(
-                "preprod.pr_comments.create.created",
-                extra={"artifact_id": artifact.id, "comment_id": comment_id},
-            )
-    except Exception as e:
-        extra: dict[str, Any] = {
-            "artifact_id": artifact.id,
-            "organization_id": organization.id,
-            "error_type": type(e).__name__,
-        }
-        if isinstance(e, ApiError):
-            extra["status_code"] = e.code
-        logger.exception("preprod.pr_comments.create.failed", extra=extra)
-        _update_posted_pr_comment(artifact, success=False, error=e)
-        raise
+        with lock.acquire():
+            siblings = artifact.get_sibling_artifacts_for_commit()
+            installable_siblings = [s for s in siblings if is_installable_artifact(s)]
+            if not installable_siblings:
+                return
 
-    _update_posted_pr_comment(artifact, success=True, comment_id=comment_id)
+            existing_comment_id = _find_existing_comment_id(installable_siblings)
+            comment_body = format_pr_comment(installable_siblings)
+
+            try:
+                if existing_comment_id:
+                    client.update_comment(
+                        repo=commit_comparison.head_repo_name,
+                        issue_id=str(commit_comparison.pr_number),
+                        comment_id=str(existing_comment_id),
+                        data={"body": comment_body},
+                    )
+                    comment_id = existing_comment_id
+                    logger.info(
+                        "preprod.pr_comments.create.updated",
+                        extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                    )
+                else:
+                    resp = client.create_comment(
+                        repo=commit_comparison.head_repo_name,
+                        issue_id=str(commit_comparison.pr_number),
+                        data={"body": comment_body},
+                    )
+                    comment_id = str(resp["id"])
+                    logger.info(
+                        "preprod.pr_comments.create.created",
+                        extra={"artifact_id": artifact.id, "comment_id": comment_id},
+                    )
+            except Exception as e:
+                extra: dict[str, Any] = {
+                    "artifact_id": artifact.id,
+                    "organization_id": organization.id,
+                    "error_type": type(e).__name__,
+                }
+                if isinstance(e, ApiError):
+                    extra["status_code"] = e.code
+                logger.exception("preprod.pr_comments.create.failed", extra=extra)
+                _update_posted_pr_comment(artifact, success=False, error=e)
+                raise
+
+            _update_posted_pr_comment(artifact, success=True, comment_id=comment_id)
+    except UnableToAcquireLock:
+        logger.info(
+            "preprod.pr_comments.create.locked",
+            extra={"artifact_id": artifact.id, "commit_comparison_id": commit_comparison.id},
+        )
+        create_preprod_pr_comment_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": preprod_artifact_id,
+                "caller": "retry_after_lock",
+            },
+            countdown=5,
+        )
 
 
 def _find_existing_comment_id(artifacts: list[PreprodArtifact]) -> str | None:

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -77,7 +77,7 @@ def create_preprod_pr_comment_task(
         return
 
     organization = artifact.project.organization
-    if not features.has("organizations:preprod-build-distribution", organization):
+    if not features.has("organizations:preprod-build-distribution-pr-comments", organization):
         logger.info(
             "preprod.pr_comments.create.feature_disabled",
             extra={"artifact_id": artifact.id, "organization_id": organization.id},

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -7,10 +7,9 @@ from typing import Any
 from django.db import router, transaction
 
 from sentry import features
-from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.build_distribution_utils import is_installable_artifact
-from sentry.preprod.integration_utils import get_github_client
+from sentry.preprod.integration_utils import get_commit_context_client
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.vcs.pr_comments.templates import format_pr_comment
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
@@ -66,17 +65,6 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    _SUPPORTED_PROVIDERS = {
-        IntegrationProviderSlug.GITHUB.value,
-        IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
-    }
-    if commit_comparison.provider not in _SUPPORTED_PROVIDERS:
-        logger.info(
-            "preprod.pr_comments.create.unsupported_provider",
-            extra={"artifact_id": artifact.id, "provider": commit_comparison.provider},
-        )
-        return
-
     organization = artifact.project.organization
     if not features.has("organizations:preprod-build-distribution-pr-comments", organization):
         logger.info(
@@ -85,12 +73,12 @@ def create_preprod_pr_comment_task(
         )
         return
 
-    client = get_github_client(
+    client = get_commit_context_client(
         organization, commit_comparison.head_repo_name, commit_comparison.provider
     )
     if not client:
         logger.info(
-            "preprod.pr_comments.create.no_github_client",
+            "preprod.pr_comments.create.no_client",
             extra={"artifact_id": artifact.id},
         )
         return

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -54,7 +54,11 @@ def create_preprod_pr_comment_task(
         return
 
     commit_comparison = artifact.commit_comparison
-    if not commit_comparison.pr_number or not commit_comparison.head_repo_name:
+    if (
+        not commit_comparison.pr_number
+        or not commit_comparison.head_repo_name
+        or not commit_comparison.provider
+    ):
         logger.info(
             "preprod.pr_comments.create.no_pr_info",
             extra={

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -17,6 +17,7 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigura
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.retry import Retry
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
     namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.REGION,
+    retry=Retry(times=5, delay=60 * 5),
 )
 def create_preprod_pr_comment_task(
     preprod_artifact_id: int, caller: str | None = None, **kwargs: Any

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -21,7 +21,7 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
         app_id = artifact.app_id or "Unknown"
         version_string = _format_version_string(artifact)
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
-        artifact_url = get_preprod_artifact_url(artifact, view_type="distribution")
+        artifact_url = get_preprod_artifact_url(artifact, view_type="install")
 
         name_cell = f"[{app_name or app_id}]({artifact_url})"
 

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -12,10 +12,10 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
     ios_rows: list[str] = []
 
     for artifact in artifacts:
-        mobile_app_info = artifact.mobile_app_info
-        app_name = mobile_app_info.app_name
+        mobile_app_info = artifact.get_mobile_app_info()
+        app_name = mobile_app_info.app_name if mobile_app_info else None
         app_id = artifact.app_id or "Unknown"
-        version_string = mobile_app_info.format_version_string()
+        version_string = mobile_app_info.format_version_string() if mobile_app_info else "--"
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
         artifact_url = get_preprod_artifact_url(artifact, view_type="install")
 

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 
@@ -8,14 +7,13 @@ COMMENT_ANCHOR = "<!-- sentry-build-distribution -->"
 
 
 def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
-    installable = [a for a in artifacts if is_installable_artifact(a)]
-    if not installable:
+    if not artifacts:
         raise ValueError("No installable artifacts to format")
 
     android_rows: list[str] = []
     ios_rows: list[str] = []
 
-    for artifact in installable:
+    for artifact in artifacts:
         mobile_app_info = getattr(artifact, "mobile_app_info", None)
         app_name = mobile_app_info.app_name if mobile_app_info else None
         app_id = artifact.app_id or "Unknown"

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from sentry.preprod.build_distribution_utils import (
+    get_download_url_for_artifact,
+    is_installable_artifact,
+)
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.url_utils import get_preprod_artifact_url
+
+COMMENT_ANCHOR = "<!-- sentry-build-distribution -->"
+
+
+def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
+    installable = [a for a in artifacts if is_installable_artifact(a)]
+    if not installable:
+        raise ValueError("No installable artifacts to format")
+
+    android_rows: list[str] = []
+    ios_rows: list[str] = []
+
+    for artifact in installable:
+        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        app_name = mobile_app_info.app_name if mobile_app_info else None
+        app_id = artifact.app_id or "Unknown"
+        version_string = _format_version_string(artifact)
+        config = artifact.build_configuration.name if artifact.build_configuration else "--"
+        artifact_url = get_preprod_artifact_url(artifact, view_type="distribution")
+        download_url = get_download_url_for_artifact(artifact)
+
+        name_cell = f"[{app_name or app_id}]({artifact_url})"
+        install_cell = f"[Install]({download_url})"
+
+        row = f"| {name_cell} | {version_string} | {config} | {install_cell} |"
+
+        if artifact.is_android():
+            android_rows.append(row)
+        else:
+            ios_rows.append(row)
+
+    sections: list[str] = [COMMENT_ANCHOR, "## Sentry Build Distribution"]
+
+    if ios_rows:
+        header = "| App | Version | Configuration | Install |"
+        separator = "|-----|---------|---------------|---------|"
+        if android_rows:
+            sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
+        else:
+            sections.append(f"{header}\n{separator}\n" + "\n".join(ios_rows))
+
+    if android_rows:
+        header = "| App | Version | Configuration | Install |"
+        separator = "|-----|---------|---------------|---------|"
+        if ios_rows:
+            sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
+        else:
+            sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
+
+    sections.append(
+        "> Install links expire after 12 hours. View builds on Sentry to generate new links."
+    )
+
+    return "\n\n".join(sections)
+
+
+def _format_version_string(artifact: PreprodArtifact) -> str:
+    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    build_version = mobile_app_info.build_version if mobile_app_info else None
+    build_number = mobile_app_info.build_number if mobile_app_info else None
+    parts = []
+    if build_version:
+        parts.append(build_version)
+    if build_number:
+        parts.append(f"({build_number})")
+    return " ".join(parts) if parts else "--"

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from sentry.preprod.build_distribution_utils import (
-    get_download_url_for_artifact,
-    is_installable_artifact,
-)
+from sentry.preprod.build_distribution_utils import is_installable_artifact
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 
@@ -25,12 +22,10 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
         version_string = _format_version_string(artifact)
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
         artifact_url = get_preprod_artifact_url(artifact, view_type="distribution")
-        download_url = get_download_url_for_artifact(artifact)
 
         name_cell = f"[{app_name or app_id}]({artifact_url})"
-        install_cell = f"[Install]({download_url})"
 
-        row = f"| {name_cell} | {version_string} | {config} | {install_cell} |"
+        row = f"| {name_cell} | {version_string} | {config} |"
 
         if artifact.is_android():
             android_rows.append(row)
@@ -39,25 +34,20 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
 
     sections: list[str] = [COMMENT_ANCHOR, "## Sentry Build Distribution"]
 
+    header = "| App | Version | Configuration |"
+    separator = "|-----|---------|---------------|"
+
     if ios_rows:
-        header = "| App | Version | Configuration | Install |"
-        separator = "|-----|---------|---------------|---------|"
         if android_rows:
             sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
         else:
             sections.append(f"{header}\n{separator}\n" + "\n".join(ios_rows))
 
     if android_rows:
-        header = "| App | Version | Configuration | Install |"
-        separator = "|-----|---------|---------------|---------|"
         if ios_rows:
             sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
         else:
             sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
-
-    sections.append(
-        "> Install links expire after 12 hours. View builds on Sentry to generate new links."
-    )
 
     return "\n\n".join(sections)
 

--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.url_utils import get_preprod_artifact_url
 
-COMMENT_ANCHOR = "<!-- sentry-build-distribution -->"
-
 
 def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
     if not artifacts:
@@ -14,10 +12,10 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
     ios_rows: list[str] = []
 
     for artifact in artifacts:
-        mobile_app_info = getattr(artifact, "mobile_app_info", None)
-        app_name = mobile_app_info.app_name if mobile_app_info else None
+        mobile_app_info = artifact.mobile_app_info
+        app_name = mobile_app_info.app_name
         app_id = artifact.app_id or "Unknown"
-        version_string = _format_version_string(artifact)
+        version_string = mobile_app_info.format_version_string()
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
         artifact_url = get_preprod_artifact_url(artifact, view_type="install")
 
@@ -30,7 +28,7 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
         else:
             ios_rows.append(row)
 
-    sections: list[str] = [COMMENT_ANCHOR, "## Sentry Build Distribution"]
+    sections: list[str] = ["## Sentry Build Distribution"]
 
     header = "| App | Version | Configuration |"
     separator = "|-----|---------|---------------|"
@@ -48,15 +46,3 @@ def format_pr_comment(artifacts: list[PreprodArtifact]) -> str:
             sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
 
     return "\n\n".join(sections)
-
-
-def _format_version_string(artifact: PreprodArtifact) -> str:
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
-    build_version = mobile_app_info.build_version if mobile_app_info else None
-    build_number = mobile_app_info.build_number if mobile_app_info else None
-    parts = []
-    if build_version:
-        parts.append(build_version)
-    if build_number:
-        parts.append(f"({build_number})")
-    return " ".join(parts) if parts else "--"

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -213,7 +213,7 @@ def _format_artifact_summary(
         if metric_type_display:
             qualifiers.append(metric_type_display)
 
-        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        mobile_app_info = artifact.get_mobile_app_info()
         artifact_app_name = mobile_app_info.app_name if mobile_app_info else None
         app_name = (
             f"{artifact_app_name or '--'}{' (' + ', '.join(qualifiers) + ')' if qualifiers else ''}"
@@ -469,7 +469,7 @@ def _get_size_metric_display_data(
 def _format_version_string(artifact: PreprodArtifact, default: str = "-") -> str:
     """Format version string from build_version and build_number."""
     version_parts = []
-    mobile_app_info = getattr(artifact, "mobile_app_info", None)
+    mobile_app_info = artifact.get_mobile_app_info()
     build_version = mobile_app_info.build_version if mobile_app_info else None
     build_number = mobile_app_info.build_number if mobile_app_info else None
     if build_version:

--- a/src/sentry/preprod/vcs/status_checks/size/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/size/templates.py
@@ -468,15 +468,10 @@ def _get_size_metric_display_data(
 
 def _format_version_string(artifact: PreprodArtifact, default: str = "-") -> str:
     """Format version string from build_version and build_number."""
-    version_parts = []
     mobile_app_info = artifact.get_mobile_app_info()
-    build_version = mobile_app_info.build_version if mobile_app_info else None
-    build_number = mobile_app_info.build_number if mobile_app_info else None
-    if build_version:
-        version_parts.append(build_version)
-    if build_number:
-        version_parts.append(f"({build_number})")
-    return " ".join(version_parts) if version_parts else default
+    if mobile_app_info is None:
+        return default
+    return mobile_app_info.format_version_string(default=default)
 
 
 def _get_size_metric_type_display_name(

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -102,7 +102,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
 
         artifact = self._create_artifact()
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
         mock_client.create_comment.assert_called_once_with(
@@ -155,7 +155,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             artifact_type=PreprodArtifact.ArtifactType.AAB,
         )
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(second.id)
 
         mock_client.update_comment.assert_called_once_with(
@@ -169,7 +169,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
     def test_skips_when_no_commit_comparison(self):
         artifact = self._create_artifact(with_commit_comparison=False)
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
         # No error — just returns early
@@ -177,19 +177,19 @@ class CreatePreprodPrCommentTaskTest(TestCase):
     def test_skips_when_no_pr_number(self):
         artifact = self._create_artifact(pr_number=None)
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
     def test_skips_when_not_github(self):
         artifact = self._create_artifact(provider="gitlab")
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
     def test_skips_when_not_installable(self):
         artifact = self._create_artifact(installable_app_file_id=None, build_number=None)
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
     def test_skips_when_feature_flag_disabled(self):
@@ -206,7 +206,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         mock_get_client.return_value = None
         artifact = self._create_artifact()
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
     @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
@@ -219,7 +219,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
 
         artifact = self._create_artifact()
 
-        with self.feature("organizations:preprod-build-distribution"):
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
             with pytest.raises(ApiError):
                 create_preprod_pr_comment_task(artifact.id)
 

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -285,6 +285,52 @@ class CreatePreprodPrCommentTaskTest(TestCase):
 
     @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_retry_after_create_failure_creates_again(self, mock_format, mock_get_client):
+        """When create_comment fails, no comment_id is stored, so the retry
+        calls create_comment again rather than update_comment."""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+
+        artifact = self._create_artifact()
+
+        # First call: create_comment fails
+        mock_client.create_comment.side_effect = ApiError("server error", code=500)
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            with pytest.raises(ApiError):
+                create_preprod_pr_comment_task(artifact.id)
+
+        # No comment_id should be stored
+        assert artifact.commit_comparison is not None
+        artifact.commit_comparison.refresh_from_db()
+        build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is False
+        assert "comment_id" not in build_dist
+
+        # Second call (retry): should call create_comment again
+        mock_client.reset_mock()
+        mock_client.create_comment.side_effect = None
+        mock_client.create_comment.return_value = {"id": 77777}
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            data={"body": "body"},
+        )
+        mock_client.update_comment.assert_not_called()
+
+        # Now the comment_id should be stored
+        artifact.commit_comparison.refresh_from_db()
+        build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is True
+        assert build_dist["comment_id"] == "77777"
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_reads_fresh_extras_via_select_for_update(self, mock_format, mock_get_client):
         """select_for_update gives a fresh DB read, so a comment_id written
         by a concurrent task between artifact load and row lock is found."""

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -16,6 +16,7 @@ from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.locking import UnableToAcquireLock
 
 
 @region_silo_test
@@ -228,3 +229,25 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
         assert pr_comments["success"] is False
         assert pr_comments["error_type"] == "api_error"
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.create_preprod_pr_comment_task.apply_async")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.locks")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    def test_retries_when_lock_unavailable(self, mock_get_client, mock_locks, mock_apply_async):
+        mock_get_client.return_value = Mock()
+        mock_lock = Mock()
+        mock_lock.acquire.side_effect = UnableToAcquireLock()
+        mock_locks.get.return_value = mock_lock
+
+        artifact = self._create_artifact()
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_apply_async.assert_called_once_with(
+            kwargs={
+                "preprod_artifact_id": artifact.id,
+                "caller": "retry_after_lock",
+            },
+            countdown=5,
+        )

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -92,7 +92,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             integration_id=123,
         )
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_creates_comment(self, mock_format, mock_get_client):
         mock_client = Mock()
@@ -118,7 +118,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         assert build_dist["success"] is True
         assert build_dist["comment_id"] == "99999"
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_updates_existing_comment(self, mock_format, mock_get_client):
         mock_client = Mock()
@@ -201,7 +201,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
     def test_skips_nonexistent_artifact(self):
         create_preprod_pr_comment_task(99999)
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     def test_skips_when_no_github_client(self, mock_get_client):
         mock_get_client.return_value = None
         artifact = self._create_artifact()
@@ -209,7 +209,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_handles_api_error(self, mock_format, mock_get_client):
         mock_client = Mock()
@@ -229,7 +229,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         assert build_dist["success"] is False
         assert build_dist["error_type"] == "api_error"
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_retry_after_update_failure_uses_update_not_create(self, mock_format, mock_get_client):
         """When update_comment fails, the stored comment_id must survive so
@@ -283,7 +283,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         )
         mock_client.create_comment.assert_not_called()
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_retry_after_create_failure_creates_again(self, mock_format, mock_get_client):
         """When create_comment fails, no comment_id is stored, so the retry
@@ -329,7 +329,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         assert build_dist["success"] is True
         assert build_dist["comment_id"] == "77777"
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_reads_fresh_extras_via_select_for_update(self, mock_format, mock_get_client):
         """select_for_update gives a fresh DB read, so a comment_id written

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import uuid
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.repository import Repository
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodBuildConfiguration,
+)
+from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class CreatePreprodPrCommentTaskTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+        self.build_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="Release"
+        )
+
+    def _create_artifact(
+        self,
+        with_commit_comparison=True,
+        pr_number=42,
+        provider="github",
+        installable_app_file_id=1,
+        app_id="com.example.app",
+        artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        build_number=456,
+        extras=None,
+        commit_comparison=None,
+    ) -> PreprodArtifact:
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=artifact_type,
+            app_id=app_id,
+            build_configuration=self.build_config,
+            installable_app_file_id=installable_app_file_id,
+            extras=extras,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
+            app_name="TestApp",
+            build_version="1.0.0",
+            build_number=build_number,
+        )
+
+        if with_commit_comparison:
+            if commit_comparison is None:
+                unique = str(uuid.uuid4()).replace("-", "")[:8]
+                commit_comparison = CommitComparison.objects.create(
+                    organization_id=self.organization.id,
+                    head_sha=unique.ljust(40, "a"),
+                    base_sha=unique.ljust(40, "b"),
+                    provider=provider,
+                    head_repo_name="owner/repo",
+                    base_repo_name="owner/repo",
+                    head_ref="feature/test",
+                    base_ref="main",
+                    pr_number=pr_number,
+                )
+            artifact.commit_comparison = commit_comparison
+            artifact.save()
+
+        return PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "build_configuration",
+            "commit_comparison",
+            "project",
+            "project__organization",
+        ).get(id=artifact.id)
+
+    def _create_repo(self):
+        return Repository.objects.create(
+            organization_id=self.organization.id,
+            name="owner/repo",
+            provider="integrations:github",
+            integration_id=123,
+        )
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_creates_comment(self, mock_format, mock_get_client):
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 99999}
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "## Sentry Build Distribution\n..."
+
+        artifact = self._create_artifact()
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            data={"body": "## Sentry Build Distribution\n..."},
+        )
+
+        # Verify extras were updated
+        artifact.refresh_from_db()
+        pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
+        assert pr_comments["success"] is True
+        assert pr_comments["comment_id"] == "99999"
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_updates_existing_comment(self, mock_format, mock_get_client):
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "updated body"
+
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="a" * 40,
+            base_sha="b" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        # First artifact already has a comment posted
+        self._create_artifact(
+            commit_comparison=commit_comparison,
+            app_id="com.example.first",
+            extras={
+                "posted_pr_comments": {
+                    "build_distribution": {"success": True, "comment_id": "existing_123"}
+                }
+            },
+        )
+
+        # Second artifact for the same commit
+        second = self._create_artifact(
+            commit_comparison=commit_comparison,
+            app_id="com.example.second",
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(second.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="existing_123",
+            data={"body": "updated body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
+    def test_skips_when_no_commit_comparison(self):
+        artifact = self._create_artifact(with_commit_comparison=False)
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        # No error — just returns early
+
+    def test_skips_when_no_pr_number(self):
+        artifact = self._create_artifact(pr_number=None)
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+    def test_skips_when_not_github(self):
+        artifact = self._create_artifact(provider="gitlab")
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+    def test_skips_when_not_installable(self):
+        artifact = self._create_artifact(installable_app_file_id=None, build_number=None)
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+    def test_skips_when_feature_flag_disabled(self):
+        artifact = self._create_artifact()
+
+        # Feature flag not enabled — should skip
+        create_preprod_pr_comment_task(artifact.id)
+
+    def test_skips_nonexistent_artifact(self):
+        create_preprod_pr_comment_task(99999)
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    def test_skips_when_no_github_client(self, mock_get_client):
+        mock_get_client.return_value = None
+        artifact = self._create_artifact()
+
+        with self.feature("organizations:preprod-build-distribution"):
+            create_preprod_pr_comment_task(artifact.id)
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_handles_api_error(self, mock_format, mock_get_client):
+        mock_client = Mock()
+        mock_client.create_comment.side_effect = ApiError("rate limited", code=429)
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+
+        artifact = self._create_artifact()
+
+        with self.feature("organizations:preprod-build-distribution"):
+            with pytest.raises(ApiError):
+                create_preprod_pr_comment_task(artifact.id)
+
+        artifact.refresh_from_db()
+        pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
+        assert pr_comments["success"] is False
+        assert pr_comments["error_type"] == "api_error"

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -112,6 +112,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         )
 
         # Verify comment ID stored on commit comparison
+        assert artifact.commit_comparison is not None
         artifact.commit_comparison.refresh_from_db()
         build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
         assert build_dist["success"] is True
@@ -222,6 +223,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             with pytest.raises(ApiError):
                 create_preprod_pr_comment_task(artifact.id)
 
+        assert artifact.commit_comparison is not None
         artifact.commit_comparison.refresh_from_db()
         build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
         assert build_dist["success"] is False

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -113,6 +113,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
 
         # Verify extras were updated
         artifact.refresh_from_db()
+        assert artifact.extras is not None
         pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
         assert pr_comments["success"] is True
         assert pr_comments["comment_id"] == "99999"
@@ -223,6 +224,7 @@ class CreatePreprodPrCommentTaskTest(TestCase):
                 create_preprod_pr_comment_task(artifact.id)
 
         artifact.refresh_from_db()
+        assert artifact.extras is not None
         pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
         assert pr_comments["success"] is False
         assert pr_comments["error_type"] == "api_error"

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -16,7 +16,6 @@ from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
-from sentry.utils.locking import UnableToAcquireLock
 
 
 @region_silo_test
@@ -112,12 +111,11 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             data={"body": "## Sentry Build Distribution\n..."},
         )
 
-        # Verify extras were updated
-        artifact.refresh_from_db()
-        assert artifact.extras is not None
-        pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
-        assert pr_comments["success"] is True
-        assert pr_comments["comment_id"] == "99999"
+        # Verify comment ID stored on commit comparison
+        artifact.commit_comparison.refresh_from_db()
+        build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is True
+        assert build_dist["comment_id"] == "99999"
 
     @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
@@ -138,15 +136,15 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             pr_number=42,
         )
 
-        # First artifact already has a comment posted
+        # Store existing comment on the commit comparison
+        commit_comparison.extras = {
+            "pr_comments": {"build_distribution": {"success": True, "comment_id": "existing_123"}}
+        }
+        commit_comparison.save(update_fields=["extras"])
+
         self._create_artifact(
             commit_comparison=commit_comparison,
             app_id="com.example.first",
-            extras={
-                "posted_pr_comments": {
-                    "build_distribution": {"success": True, "comment_id": "existing_123"}
-                }
-            },
         )
 
         # Second artifact for the same commit
@@ -224,30 +222,51 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             with pytest.raises(ApiError):
                 create_preprod_pr_comment_task(artifact.id)
 
-        artifact.refresh_from_db()
-        assert artifact.extras is not None
-        pr_comments = artifact.extras["posted_pr_comments"]["build_distribution"]
-        assert pr_comments["success"] is False
-        assert pr_comments["error_type"] == "api_error"
+        artifact.commit_comparison.refresh_from_db()
+        build_dist = artifact.commit_comparison.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is False
+        assert build_dist["error_type"] == "api_error"
 
-    @patch("sentry.preprod.vcs.pr_comments.tasks.create_preprod_pr_comment_task.apply_async")
-    @patch("sentry.preprod.vcs.pr_comments.tasks.locks")
     @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
-    def test_retries_when_lock_unavailable(self, mock_get_client, mock_locks, mock_apply_async):
-        mock_get_client.return_value = Mock()
-        mock_lock = Mock()
-        mock_lock.acquire.side_effect = UnableToAcquireLock()
-        mock_locks.get.return_value = mock_lock
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_reads_fresh_extras_via_select_for_update(self, mock_format, mock_get_client):
+        """select_for_update gives a fresh DB read, so a comment_id written
+        by a concurrent task between artifact load and row lock is found."""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "updated body"
 
-        artifact = self._create_artifact()
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="c" * 40,
+            base_sha="d" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        # Simulate a concurrent task having written the comment_id to the DB
+        # *after* this task loaded the artifact (and its commit_comparison).
+        CommitComparison.objects.filter(id=commit_comparison.id).update(
+            extras={
+                "pr_comments": {
+                    "build_distribution": {"success": True, "comment_id": "concurrent_456"}
+                }
+            }
+        )
 
         with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
-        mock_apply_async.assert_called_once_with(
-            kwargs={
-                "preprod_artifact_id": artifact.id,
-                "caller": "retry_after_lock",
-            },
-            countdown=5,
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="concurrent_456",
+            data={"body": "updated body"},
         )
+        mock_client.create_comment.assert_not_called()

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -231,6 +231,60 @@ class CreatePreprodPrCommentTaskTest(TestCase):
 
     @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
     @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
+    def test_retry_after_update_failure_uses_update_not_create(self, mock_format, mock_get_client):
+        """When update_comment fails, the stored comment_id must survive so
+        that the retry calls update_comment again instead of create_comment."""
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="e" * 40,
+            base_sha="f" * 40,
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+            extras={
+                "pr_comments": {"build_distribution": {"success": True, "comment_id": "orig_789"}}
+            },
+        )
+
+        artifact = self._create_artifact(commit_comparison=commit_comparison)
+
+        # First call: update_comment fails
+        mock_client.update_comment.side_effect = ApiError("server error", code=500)
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            with pytest.raises(ApiError):
+                create_preprod_pr_comment_task(artifact.id)
+
+        # comment_id must be preserved despite the failure
+        commit_comparison.refresh_from_db()
+        build_dist = commit_comparison.extras["pr_comments"]["build_distribution"]
+        assert build_dist["success"] is False
+        assert build_dist["comment_id"] == "orig_789"
+
+        # Second call (retry): should call update_comment, not create_comment
+        mock_client.reset_mock()
+        mock_client.update_comment.side_effect = None
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        mock_client.update_comment.assert_called_once_with(
+            repo="owner/repo",
+            issue_id="42",
+            comment_id="orig_789",
+            data={"body": "body"},
+        )
+        mock_client.create_comment.assert_not_called()
+
+    @patch("sentry.preprod.vcs.pr_comments.tasks.get_github_client")
+    @patch("sentry.preprod.vcs.pr_comments.tasks.format_pr_comment")
     def test_reads_fresh_extras_via_select_for_update(self, mock_format, mock_get_client):
         """select_for_update gives a fresh DB read, so a comment_id written
         by a concurrent task between artifact load and row lock is found."""

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodBuildConfiguration,
+)
+from sentry.preprod.vcs.pr_comments.templates import COMMENT_ANCHOR, format_pr_comment
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class FormatPrCommentTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+        self.build_config = PreprodBuildConfiguration.objects.create(
+            project=self.project, name="Release"
+        )
+
+    def _create_artifact(
+        self,
+        artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        app_id="com.example.app",
+        app_name="MyApp",
+        build_version="1.2.3",
+        build_number=456,
+        installable_app_file_id=1,
+    ) -> PreprodArtifact:
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=artifact_type,
+            app_id=app_id,
+            build_configuration=self.build_config,
+            installable_app_file_id=installable_app_file_id,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
+            app_name=app_name,
+            build_version=build_version,
+            build_number=build_number,
+        )
+        # Re-fetch to load relations
+        return PreprodArtifact.objects.select_related(
+            "mobile_app_info", "build_configuration", "project", "project__organization"
+        ).get(id=artifact.id)
+
+    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
+    def test_single_ios_artifact(self, mock_download_url):
+        mock_download_url.return_value = "https://sentry.io/install/abc123/"
+        artifact = self._create_artifact()
+
+        result = format_pr_comment([artifact])
+
+        assert COMMENT_ANCHOR in result
+        assert "## Sentry Build Distribution" in result
+        assert "MyApp" in result
+        assert "1.2.3 (456)" in result
+        assert "Release" in result
+        assert "[Install](https://sentry.io/install/abc123/)" in result
+        assert "Install links expire after 12 hours" in result
+        # Single platform — no subheader
+        assert "### iOS" not in result
+
+    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
+    def test_single_android_artifact(self, mock_download_url):
+        mock_download_url.return_value = "https://sentry.io/install/def456/"
+        artifact = self._create_artifact(
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+            app_name="AndroidApp",
+        )
+
+        result = format_pr_comment([artifact])
+
+        assert "AndroidApp" in result
+        assert "[Install](https://sentry.io/install/def456/)" in result
+        assert "### Android" not in result
+
+    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
+    def test_multiple_platforms_shows_subheaders(self, mock_download_url):
+        mock_download_url.return_value = "https://sentry.io/install/xxx/"
+        ios_artifact = self._create_artifact(app_name="iOSApp")
+        android_artifact = self._create_artifact(
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+            app_id="com.example.android",
+            app_name="AndroidApp",
+        )
+
+        result = format_pr_comment([ios_artifact, android_artifact])
+
+        assert "### iOS" in result
+        assert "### Android" in result
+        assert "iOSApp" in result
+        assert "AndroidApp" in result
+
+    def test_no_installable_artifacts_raises(self):
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            installable_app_file_id=None,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=artifact,
+            build_number=123,
+        )
+        artifact = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "build_configuration"
+        ).get(id=artifact.id)
+
+        with pytest.raises(ValueError, match="No installable artifacts"):
+            format_pr_comment([artifact])
+
+    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
+    def test_filters_non_installable_from_mixed_list(self, mock_download_url):
+        mock_download_url.return_value = "https://sentry.io/install/xxx/"
+
+        installable = self._create_artifact(app_name="Installable")
+        non_installable = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.other",
+            installable_app_file_id=None,
+        )
+        PreprodArtifactMobileAppInfo.objects.create(
+            preprod_artifact=non_installable,
+            app_name="NonInstallable",
+            build_number=789,
+        )
+        non_installable = PreprodArtifact.objects.select_related(
+            "mobile_app_info", "build_configuration"
+        ).get(id=non_installable.id)
+
+        result = format_pr_comment([installable, non_installable])
+
+        assert "Installable" in result
+        assert "NonInstallable" not in result

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -7,7 +7,7 @@ from sentry.preprod.models import (
     PreprodArtifactMobileAppInfo,
     PreprodBuildConfiguration,
 )
-from sentry.preprod.vcs.pr_comments.templates import COMMENT_ANCHOR, format_pr_comment
+from sentry.preprod.vcs.pr_comments.templates import format_pr_comment
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -58,7 +58,6 @@ class FormatPrCommentTest(TestCase):
 
         result = format_pr_comment([artifact])
 
-        assert COMMENT_ANCHOR in result
         assert "## Sentry Build Distribution" in result
         assert "MyApp" in result
         assert "1.2.3 (456)" in result

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from sentry.preprod.models import (
@@ -55,9 +53,7 @@ class FormatPrCommentTest(TestCase):
             "mobile_app_info", "build_configuration", "project", "project__organization"
         ).get(id=artifact.id)
 
-    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
-    def test_single_ios_artifact(self, mock_download_url):
-        mock_download_url.return_value = "https://sentry.io/install/abc123/"
+    def test_single_ios_artifact(self):
         artifact = self._create_artifact()
 
         result = format_pr_comment([artifact])
@@ -67,14 +63,10 @@ class FormatPrCommentTest(TestCase):
         assert "MyApp" in result
         assert "1.2.3 (456)" in result
         assert "Release" in result
-        assert "[Install](https://sentry.io/install/abc123/)" in result
-        assert "Install links expire after 12 hours" in result
         # Single platform — no subheader
         assert "### iOS" not in result
 
-    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
-    def test_single_android_artifact(self, mock_download_url):
-        mock_download_url.return_value = "https://sentry.io/install/def456/"
+    def test_single_android_artifact(self):
         artifact = self._create_artifact(
             artifact_type=PreprodArtifact.ArtifactType.AAB,
             app_name="AndroidApp",
@@ -83,12 +75,9 @@ class FormatPrCommentTest(TestCase):
         result = format_pr_comment([artifact])
 
         assert "AndroidApp" in result
-        assert "[Install](https://sentry.io/install/def456/)" in result
         assert "### Android" not in result
 
-    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
-    def test_multiple_platforms_shows_subheaders(self, mock_download_url):
-        mock_download_url.return_value = "https://sentry.io/install/xxx/"
+    def test_multiple_platforms_shows_subheaders(self):
         ios_artifact = self._create_artifact(app_name="iOSApp")
         android_artifact = self._create_artifact(
             artifact_type=PreprodArtifact.ArtifactType.APK,
@@ -122,10 +111,7 @@ class FormatPrCommentTest(TestCase):
         with pytest.raises(ValueError, match="No installable artifacts"):
             format_pr_comment([artifact])
 
-    @patch("sentry.preprod.vcs.pr_comments.templates.get_download_url_for_artifact")
-    def test_filters_non_installable_from_mixed_list(self, mock_download_url):
-        mock_download_url.return_value = "https://sentry.io/install/xxx/"
-
+    def test_filters_non_installable_from_mixed_list(self):
         installable = self._create_artifact(app_name="Installable")
         non_installable = PreprodArtifact.objects.create(
             project=self.project,

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -92,44 +92,6 @@ class FormatPrCommentTest(TestCase):
         assert "iOSApp" in result
         assert "AndroidApp" in result
 
-    def test_no_installable_artifacts_raises(self):
-        artifact = PreprodArtifact.objects.create(
-            project=self.project,
-            state=PreprodArtifact.ArtifactState.PROCESSED,
-            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
-            app_id="com.example.app",
-            installable_app_file_id=None,
-        )
-        PreprodArtifactMobileAppInfo.objects.create(
-            preprod_artifact=artifact,
-            build_number=123,
-        )
-        artifact = PreprodArtifact.objects.select_related(
-            "mobile_app_info", "build_configuration"
-        ).get(id=artifact.id)
-
+    def test_empty_list_raises(self):
         with pytest.raises(ValueError, match="No installable artifacts"):
-            format_pr_comment([artifact])
-
-    def test_filters_non_installable_from_mixed_list(self):
-        installable = self._create_artifact(app_name="Installable")
-        non_installable = PreprodArtifact.objects.create(
-            project=self.project,
-            state=PreprodArtifact.ArtifactState.PROCESSED,
-            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
-            app_id="com.example.other",
-            installable_app_file_id=None,
-        )
-        PreprodArtifactMobileAppInfo.objects.create(
-            preprod_artifact=non_installable,
-            app_name="NonInstallable",
-            build_number=789,
-        )
-        non_installable = PreprodArtifact.objects.select_related(
-            "mobile_app_info", "build_configuration"
-        ).get(id=non_installable.id)
-
-        result = format_pr_comment([installable, non_installable])
-
-        assert "Installable" in result
-        assert "NonInstallable" not in result
+            format_pr_comment([])


### PR DESCRIPTION
## Summary
- Adds a Celery task that posts (or updates) a comment on GitHub PRs when installable builds finish processing
- Includes a markdown template for rendering build info (app name, version, config) with iOS/Android support
- Links in the comment point to the install page for each artifact
- Triggered automatically from `_assemble_preprod_artifact_installable_app` after installable app assembly completes
- Supports both GitHub and GitHub Enterprise integrations
- Gated behind the `organizations:preprod-build-distribution-pr-comments` feature flag
- Uses `select_for_update` on the commit comparison row to serialize concurrent tasks, preventing duplicate comments when multiple builds finish at the same time (e.g., monorepo with iOS + Android)
- Stores PR comment state on `CommitComparison.extras` rather than individual artifacts
- Preserves the `comment_id` on API failure so retries update the existing comment instead of creating duplicates
- Adds `format_version_string()` to `PreprodArtifactMobileAppInfo` for rendering version info in the comment

In follow up PR we will add the settings toggle for this.

Here's what this looks like visually. It links to the `install` page for the artifact.
<img width="625" height="319" alt="Screenshot 2026-02-27 at 18 37 51" src="https://github.com/user-attachments/assets/7d35dcec-088a-4a83-845c-bbe7c4c8a195" />

Here's a link to a test comment the script created with a 60 second delay between the builds. You can see that it updated the comment twice: https://github.com/runningcode/Test-github-sentry/pull/1#issuecomment-3996213802

EME-795