### PR TITLE
fix(preprod): Rename absolute_threshold to absolute in size analysis config

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -118,7 +118,7 @@ class PreprodSizeAnalysisDetectorHandler(
     def extract_value(self, data_packet: SizeAnalysisDataPacket) -> SizeAnalysisEvaluation:
         threshold_type = self.detector.config["threshold_type"]
         match threshold_type:
-            case "absolute_threshold":
+            case "absolute":
                 return self._extract_head(data_packet)
             case "absolute_diff":
                 return self._extract_head(data_packet) - self._extract_base(data_packet)
@@ -192,7 +192,7 @@ class PreprodSizeAnalysisGroupType(GroupType):
             "properties": {
                 "threshold_type": {
                     "type": "string",
-                    "enum": ["absolute_diff", "absolute_threshold", "relative_diff"],
+                    "enum": ["absolute_diff", "absolute", "relative_diff"],
                     "description": "The type of threshold to apply",
                 },
                 "measurement": {

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -44,7 +44,7 @@ class PreprodSizeAnalysisDetectorValidatorTest(TestCase):
                 ],
             },
             "config": {
-                "threshold_type": "absolute_threshold",
+                "threshold_type": "absolute",
                 "measurement": "install_size",
             },
         }
@@ -72,7 +72,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=self.condition_group,
         )
 
@@ -96,7 +96,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=self.condition_group,
         )
 
@@ -132,7 +132,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 
@@ -170,7 +170,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 
@@ -193,7 +193,7 @@ class PreprodSizeAnalysisDetectorHandlerTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
         )
 
         data_packet: SizeAnalysisDataPacket = DataPacket(
@@ -390,7 +390,7 @@ class PreprodSizeAnalysisDetectorHandlerIntegrationTest(TestCase):
             name="test-detector",
             type=PreprodSizeAnalysisGroupType.slug,
             project=self.project,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 

--- a/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
+++ b/tests/sentry/preprod/size_analysis/test_size_analysis_tasks.py
@@ -68,7 +68,7 @@ class MaybeEmitIssuesTest(TestCase):
             name="test-detector",
             project=self.project,
             type=PreprodSizeAnalysisGroupType.slug,
-            config={"threshold_type": "absolute_threshold", "measurement": "install_size"},
+            config={"threshold_type": "absolute", "measurement": "install_size"},
             workflow_condition_group=condition_group,
         )
 


### PR DESCRIPTION
The threshold_type value was inconsistent with the naming pattern of
the other options (absolute_diff, relative_diff). Rename to "absolute"
to match frontend.

Agent transcript: https://claudescope.sentry.dev/share/jcxjbOICFORZAKIK0O7_MqTBcU8T7ADMVCpZZm4ilYg
