### PR TITLE
feat(preprod): Add info alert for diff-based threshold types

### DIFF
--- a/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/detectSection.tsx
@@ -1,13 +1,14 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SegmentedRadioField from 'sentry/components/forms/fields/segmentedRadioField';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {
   DETECTOR_PRIORITY_LEVEL_TO_PRIORITY_LEVEL,
@@ -81,6 +82,19 @@ export function MobileBuildDetectSection() {
               preserveOnUnmount
             />
           </section>
+
+          {(thresholdType === 'absolute_diff' || thresholdType === 'relative_diff') && (
+            <Alert variant="muted">
+              {tct(
+                "Base build for comparison is the previous build that matches this monitor's filters and has the same [platform], [packageName], and [buildConfiguration].",
+                {
+                  platform: <code>{'platform'}</code>,
+                  packageName: <code>{'package_name'}</code>,
+                  buildConfiguration: <code>{'build_configuration'}</code>,
+                }
+              )}
+            </Alert>
+          )}
 
           <ThresholdSection thresholdType={thresholdType} />
         </Stack>


### PR DESCRIPTION
Add an informational alert to the Issue Detection section of the mobile build detector form when "Absolute Diff" or "Relative Diff" is selected as the threshold type.

The alert explains that the base build for comparison is the previous build matching the monitor's filters with the same `platform`, `package_name`, and `build_configuration`. This helps users understand what their diff thresholds are being compared against.

Agent transcript: https://claudescope.sentry.dev/share/PMixNvDM_TV5Ek_ele7qNy3667aQ86vhe5OyUW21yMU

<img width="2332" height="754" alt="CleanShot 2026-02-26 at 14 41 28@2x" src="https://github.com/user-attachments/assets/e4a754db-201e-4f73-b70d-811653b74ff4" />
