### PR TITLE
feat(preprod): Add detector_id to size analysis occurrence evidence data

### DIFF
--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -186,7 +186,9 @@ class PreprodSizeAnalysisDetectorHandler(
 
         platform = metadata["platform"] if metadata else "unknown"
 
-        evidence_data: dict[str, Any] = {}
+        evidence_data: dict[str, Any] = {
+            "detector_id": self.detector.id,
+        }
         if metadata:
             evidence_data["head_artifact_id"] = metadata["head_artifact_id"]
             evidence_data["base_artifact_id"] = metadata["base_artifact_id"]

--- a/tests/sentry/preprod/size_analysis/test_grouptype.py
+++ b/tests/sentry/preprod/size_analysis/test_grouptype.py
@@ -560,4 +560,4 @@ class PreprodSizeAnalysisOccurrenceContentTest(TestCase):
         assert occurrence.issue_title == "Install size regression"
         assert event_data["platform"] == "unknown"
         assert event_data["tags"] == {}
-        assert occurrence.evidence_data == {}
+        assert occurrence.evidence_data == {"detector_id": detector.id}


### PR DESCRIPTION
This allows the issue platform to link occurrences back to the detector
that created them, enabling detector-group associations and workflow processing.

Agent transcript: https://claudescope.sentry.dev/share/0aobI3aV0NKda6frQ7Lq3Mmn1EJSQSHOwHuASXjzQwo
