### PR TITLE
fix(dashboards): Prevent threshold lines from overlapping the chart legend

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -472,6 +472,11 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const showLegend =
     (showLegendProp !== 'never' && visibleSeriesCount > 1) || showLegendProp === 'always';
 
+  // The threshold maxOffset must account for the legend height so that threshold
+  // lines/areas drawn at pixel coordinates (for "infinite" thresholds) don't overlap
+  // the legend. These values must stay in sync with the `grid.top` config below.
+  const thresholdMaxOffset = showLegend ? 25 : 10;
+
   // Keep track of which `Series[]` indexes correspond to which `Plottable` so
   // we can look up the types in the tooltip. We need this so we can find the
   // plottable responsible for a given value in the tooltip formatter. The only
@@ -524,6 +529,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
       yAxisPosition,
       unit: unitForType[plottable.dataType ?? FALLBACK_TYPE],
       theme,
+      maxOffset: thresholdMaxOffset,
     });
 
     seriesIndexToPlottableMapRanges.push({


### PR DESCRIPTION
Fixes bug where thresholds overlapped with legend
before
<img width="544" height="278" alt="image" src="https://github.com/user-attachments/assets/94c75c41-f4d5-4104-8f66-0a518a677199" />


after
<img width="504" height="275" alt="image" src="https://github.com/user-attachments/assets/9388f4f0-b8f7-4c01-abe9-87f28efb2887" />


Threshold mark lines and areas use pixel coordinates (`y: maxOffset`) when their value is `Infinity`, since ECharts can't render at `y=Infinity`. The previous hardcoded `maxOffset` of `5px` placed these elements near the top of the SVG container — which falls inside the legend area when a legend is visible (the legend occupies roughly the first 25px).

The fix passes the computed grid top offset from `TimeSeriesWidgetVisualization` into `Thresholds.toSeries()` as `maxOffset`. This matches the existing `maxOffset` class property name and ensures infinite-value threshold lines/areas are always positioned at the top edge of the chart grid rather than the SVG container.

Fixes DAIN-1239