### PR TITLE
feat(sentry-apps): Expose sentryAppId in SentryAppInstallation API

### DIFF
--- a/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
+++ b/src/sentry/sentry_apps/api/serializers/sentry_app_installation.py
@@ -17,6 +17,7 @@ from sentry.users.services.user import RpcUser
 class SentryAppInstallationAppResult(TypedDict):
     uuid: str
     slug: str
+    sentryAppId: int
 
 
 class SentryAppInstallationOrganizationResult(TypedDict):
@@ -64,7 +65,11 @@ class SentryAppInstallationSerializer(Serializer):
     ) -> SentryAppInstallationResult:
         access = kwargs.get("access")
         data: SentryAppInstallationResult = {
-            "app": {"uuid": attrs["sentry_app"].uuid, "slug": attrs["sentry_app"].slug},
+            "app": {
+                "uuid": attrs["sentry_app"].uuid,
+                "slug": attrs["sentry_app"].slug,
+                "sentryAppId": attrs["sentry_app"].id,
+            },
             "organization": {"slug": attrs["organization"].slug, "id": attrs["organization"].id},
             "uuid": obj.uuid,
             "status": SentryAppInstallationStatus.as_str(obj.status),

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -71,7 +71,11 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "app": {"uuid": self.unpublished_app.uuid, "slug": self.unpublished_app.slug},
+            "app": {
+                "uuid": self.unpublished_app.uuid,
+                "slug": self.unpublished_app.slug,
+                "sentryAppId": self.unpublished_app.id,
+            },
             "organization": {"slug": self.org.slug, "id": self.org.id},
             "uuid": self.installation2.uuid,
             "status": "pending",
@@ -86,7 +90,11 @@ class GetSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            "app": {"uuid": self.unpublished_app.uuid, "slug": self.unpublished_app.slug},
+            "app": {
+                "uuid": self.unpublished_app.uuid,
+                "slug": self.unpublished_app.slug,
+                "sentryAppId": self.unpublished_app.id,
+            },
             "organization": {"slug": self.org.slug, "id": self.org.id},
             "uuid": self.installation2.uuid,
             "code": self.installation2.api_grant.code,

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
@@ -130,7 +130,7 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         installation = SentryAppInstallation.objects.get(sentry_app=app, organization_id=org.id)
         assert installation.api_grant is not None
         return {
-            "app": {"slug": app.slug, "uuid": app.uuid},
+            "app": {"slug": app.slug, "uuid": app.uuid, "sentryAppId": app.id},
             "organization": {"slug": org.slug, "id": org.id},
             "code": installation.api_grant.code,
         }

--- a/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_organization_sentry_app_installations.py
@@ -53,7 +53,11 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
         assert response.data == [
             {
-                "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
+                "app": {
+                    "slug": self.unpublished_app.slug,
+                    "uuid": self.unpublished_app.uuid,
+                    "sentryAppId": self.unpublished_app.id,
+                },
                 "organization": {"slug": self.org.slug, "id": self.org.id},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,
@@ -65,7 +69,11 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
         assert response.data == [
             {
-                "app": {"slug": self.published_app.slug, "uuid": self.published_app.uuid},
+                "app": {
+                    "slug": self.published_app.slug,
+                    "uuid": self.published_app.uuid,
+                    "sentryAppId": self.published_app.id,
+                },
                 "organization": {"slug": self.super_org.slug, "id": self.super_org.id},
                 "uuid": self.installation.uuid,
                 "code": self.installation.api_grant.code,
@@ -97,7 +105,11 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
 
         assert response.data == [
             {
-                "app": {"slug": self.unpublished_app.slug, "uuid": self.unpublished_app.uuid},
+                "app": {
+                    "slug": self.unpublished_app.slug,
+                    "uuid": self.unpublished_app.uuid,
+                    "sentryAppId": self.unpublished_app.id,
+                },
                 "organization": {"slug": self.org.slug, "id": self.org.id},
                 "uuid": self.installation2.uuid,
                 "code": self.installation2.api_grant.code,

--- a/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
+++ b/tests/sentry/sentry_apps/test_sentry_app_installation_notifier.py
@@ -56,7 +56,11 @@ class TestInstallationNotifier(TestCase):
             "installation": {"uuid": self.install.uuid},
             "data": {
                 "installation": {
-                    "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
+                    "app": {
+                        "uuid": self.sentry_app.uuid,
+                        "slug": self.sentry_app.slug,
+                        "sentryAppId": self.sentry_app.id,
+                    },
                     "organization": {"slug": self.organization.slug, "id": self.organization.id},
                     "uuid": self.install.uuid,
                     "code": self.install.api_grant.code,
@@ -89,7 +93,11 @@ class TestInstallationNotifier(TestCase):
             "installation": {"uuid": self.install.uuid},
             "data": {
                 "installation": {
-                    "app": {"uuid": self.sentry_app.uuid, "slug": self.sentry_app.slug},
+                    "app": {
+                        "uuid": self.sentry_app.uuid,
+                        "slug": self.sentry_app.slug,
+                        "sentryAppId": self.sentry_app.id,
+                    },
                     "organization": {"slug": self.organization.slug, "id": self.organization.id},
                     "uuid": self.install.uuid,
                     "code": self.install.api_grant.code,


### PR DESCRIPTION
Expose sentryAppId in SentryAppInstallation API response

The metric alert trigger action endpoint requires a numeric sentryAppId when creating Sentry App actions, but the installations list endpoint only returned app.uuid and app.slug — making it impossible to build a metric alert via the API without first creating a metric alert with the required sentry app via the UI.

Add sentryAppId to the app object in the SentryAppInstallation serializer response. The SentryApp object is already fetched in get_attrs(), so this adds no extra database queries

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive API change: installation responses and webhook payloads now include a new numeric `app.sentryAppId`, with tests updated accordingly.
> 
> **Overview**
> Adds `app.sentryAppId` (numeric Sentry App ID) to the `SentryAppInstallationSerializer` output, extending the `app` object beyond `uuid` and `slug`.
> 
> Updates API endpoint and notifier tests to assert the new field is present in installation detail/list responses and installation created/deleted webhook payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3b474d4e571d97ffee681f8cb2a0f9e0f77fb7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->