### PR TITLE
fix(dashboards): Fix threshold unit selector for timeseries widgets and size data types

### DIFF
--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -25,12 +25,14 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
 import {
+  ABYTE_UNITS,
   getAggregateAlias,
   getAggregateArg,
   isEquation,
   isMeasurement,
   RATE_UNIT_MULTIPLIERS,
   RateUnit,
+  SIZE_UNIT_MULTIPLIERS,
   stripEquationPrefix,
 } from 'sentry/utils/discover/fields';
 import {DisplayModes, type SavedQueryDatasets} from 'sentry/utils/discover/types';
@@ -110,6 +112,13 @@ export function getThresholdUnitSelectOptions(
     }));
   }
 
+  if (dataType === 'size') {
+    return Object.values(ABYTE_UNITS).map(unit => ({
+      label: unit,
+      value: unit,
+    }));
+  }
+
   return [];
 }
 
@@ -121,7 +130,10 @@ export function normalizeUnit(value: number, unit: string, dataType: string): nu
       : dataType === 'duration'
         ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
           DURATION_UNITS[unit]
-        : 1;
+        : dataType === 'size'
+          ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+            SIZE_UNIT_MULTIPLIERS[unit]
+          : 1;
   return value * multiplier;
 }
 

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -133,7 +133,9 @@ export function normalizeUnit(value: number, unit: string, dataType: string): nu
         : dataType === 'size'
           ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             SIZE_UNIT_MULTIPLIERS[unit]
-          : 1;
+          : dataType === 'percentage'
+            ? 100
+            : 1;
   return value * multiplier;
 }
 

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -134,7 +134,7 @@ export function normalizeUnit(value: number, unit: string, dataType: string): nu
           ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             SIZE_UNIT_MULTIPLIERS[unit]
           : dataType === 'percentage'
-            ? 100
+            ? 0.01
             : 1;
   return value * multiplier;
 }

--- a/static/app/views/dashboards/utils.tsx
+++ b/static/app/views/dashboards/utils.tsx
@@ -133,9 +133,7 @@ export function normalizeUnit(value: number, unit: string, dataType: string): nu
         : dataType === 'size'
           ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
             SIZE_UNIT_MULTIPLIERS[unit]
-          : dataType === 'percentage'
-            ? 0.01
-            : 1;
+          : 1;
   return value * multiplier;
 }
 

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/thresholdsStep/thresholds.tsx
@@ -106,9 +106,7 @@ export function Thresholds({
   const maxOneValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_1] ?? '';
   const maxTwoValue = thresholdsConfig?.max_values[ThresholdMaxKeys.MAX_2] ?? '';
   const unit = thresholdsConfig?.unit ?? dataUnit;
-  const unitOptions = ['duration', 'rate'].includes(dataType)
-    ? getThresholdUnitSelectOptions(dataType)
-    : [];
+  const unitOptions = getThresholdUnitSelectOptions(dataType);
 
   const isHigherBetter = preferredPolarity === '+';
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -165,6 +165,8 @@ function WidgetBuilderV2({
     } else if (results.timeseriesResultsTypes) {
       const keys = Object.keys(results.timeseriesResultsTypes);
       dataType = results.timeseriesResultsTypes[keys[0]!];
+      const rawUnit = results.timeseriesResultsUnits?.[keys[0]!];
+      dataUnit = rawUnit ?? undefined;
     }
 
     setThresholdMetaState({dataType, dataUnit});

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import {t, tct} from 'sentry/locale';
@@ -25,6 +25,28 @@ function ThresholdsSection({
   setError,
 }: ThresholdsSectionProps) {
   const {state, dispatch} = useWidgetBuilderContext();
+
+  const prevDataTypeRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const prevDataType = prevDataTypeRef.current;
+    prevDataTypeRef.current = dataType;
+    // When the data type changes and there's a stored unit, reset it so the
+    // unit selector shows the correct options for the new data type.
+    if (
+      prevDataType !== undefined &&
+      prevDataType !== dataType &&
+      state.thresholds?.unit
+    ) {
+      dispatch({
+        type: BuilderStateAction.SET_THRESHOLDS,
+        payload: {
+          ...state.thresholds,
+          unit: null,
+        },
+      });
+    }
+  }, [dataType, dispatch, state.thresholds]);
+
   return (
     <Fragment>
       <SectionHeader

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -20,7 +20,7 @@ import type {Series} from 'sentry/types/echarts';
 import type {WithRouterProps} from 'sentry/types/legacyReactRouter';
 import type {Confidence, Organization} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
-import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
+import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
 import {statsPeriodToDays} from 'sentry/utils/duration/statsPeriodToDays';
 import {getFieldDefinition} from 'sentry/utils/fields';
 import {hasOnDemandMetricWidgetFeature} from 'sentry/utils/onDemandMetrics/features';
@@ -63,6 +63,7 @@ import {WidgetFrame} from './widgetFrame';
 export type OnDataFetchedParams = {
   tableResults?: TableDataWithTitle[];
   timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+  timeseriesResultsUnits?: Record<string, DataUnit>;
 };
 
 const DAYS_TO_MS = 24 * 60 * 60 * 1000;
@@ -133,6 +134,7 @@ type Data = {
   tableResults?: TableDataWithTitle[];
   timeseriesResults?: Series[];
   timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+  timeseriesResultsUnits?: Record<string, DataUnit>;
   totalIssuesCount?: string;
 };
 
@@ -149,6 +151,7 @@ function WidgetCard(props: Props) {
       props.onDataFetched({
         tableResults: newData.tableResults,
         timeseriesResultsTypes: newData.timeseriesResultsTypes,
+        timeseriesResultsUnits: newData.timeseriesResultsUnits,
       });
     }
 

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -66,6 +66,7 @@ interface VisualizationWidgetProps {
     tableResults?: any[];
     timeseriesResults?: Series[];
     timeseriesResultsTypes?: Record<string, AggregationOutputType>;
+    timeseriesResultsUnits?: Record<string, DataUnit>;
     totalIssuesCount?: string;
   }) => void;
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -45,6 +45,7 @@ type Props = {
       | 'tableResults'
       | 'timeseriesResults'
       | 'timeseriesResultsTypes'
+      | 'timeseriesResultsUnits'
       | 'totalIssuesCount'
       | 'confidence'
       | 'sampleCount'

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -57,17 +57,16 @@ export class Thresholds implements Plottable {
     const thresholdUnit = thresholds.unit;
 
     // Normalize threshold values to the base unit (e.g., milliseconds for duration)
-    // so they align with the chart's y-axis values.
-    // Percentage types have no unit selector but still need normalization (×100).
-    if ((thresholdUnit || dataType === 'percentage') && dataType) {
+    // so they align with the chart's y-axis values
+    if (thresholdUnit && dataType) {
       this.thresholds = {
         ...thresholds,
         max_values: {
           max1: thresholds.max_values.max1
-            ? normalizeUnit(thresholds.max_values.max1, thresholdUnit ?? '', dataType)
+            ? normalizeUnit(thresholds.max_values.max1, thresholdUnit, dataType)
             : thresholds.max_values.max1,
           max2: thresholds.max_values.max2
-            ? normalizeUnit(thresholds.max_values.max2, thresholdUnit ?? '', dataType)
+            ? normalizeUnit(thresholds.max_values.max2, thresholdUnit, dataType)
             : thresholds.max_values.max2,
         },
       };

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds.tsx
@@ -57,16 +57,17 @@ export class Thresholds implements Plottable {
     const thresholdUnit = thresholds.unit;
 
     // Normalize threshold values to the base unit (e.g., milliseconds for duration)
-    // so they align with the chart's y-axis values
-    if (thresholdUnit && dataType) {
+    // so they align with the chart's y-axis values.
+    // Percentage types have no unit selector but still need normalization (×100).
+    if ((thresholdUnit || dataType === 'percentage') && dataType) {
       this.thresholds = {
         ...thresholds,
         max_values: {
           max1: thresholds.max_values.max1
-            ? normalizeUnit(thresholds.max_values.max1, thresholdUnit, dataType)
+            ? normalizeUnit(thresholds.max_values.max1, thresholdUnit ?? '', dataType)
             : thresholds.max_values.max1,
           max2: thresholds.max_values.max2
-            ? normalizeUnit(thresholds.max_values.max2, thresholdUnit, dataType)
+            ? normalizeUnit(thresholds.max_values.max2, thresholdUnit ?? '', dataType)
             : thresholds.max_values.max2,
         },
       };


### PR DESCRIPTION
Fix several issues with the threshold unit selector in the widget builder that prevented it from working correctly for timeseries (line/area/bar) widgets and size-based metrics.

**Size unit support** (`getThresholdUnitSelectOptions` / `normalizeUnit`): The unit selector only showed options for duration metrics. Added `size` as a supported data type so byte-based units (byte, kilobyte, megabyte, etc.) appear for size metrics like `avg(http.response_content_length)`. Also fixed `normalizeUnit` to handle the `size` type using `SIZE_UNIT_MULTIPLIERS` so threshold values are correctly converted to bytes for y-axis comparison.

**`timeseriesResultsUnits` not forwarded**: `OnDataFetchedParams` was missing `timeseriesResultsUnits`, so the threshold unit selector received no unit information for timeseries widgets. Added the field to the type and threaded it through `widgetCardDataLoader` and `visualizationWidget`.

**`extractSeriesMetadata` missing plain `EventsStats` case**: The spans dataset config's metadata extractor only handled `MultiSeriesEventsStats` and `GroupedMultiSeriesEventsStats`. When the EAP API returns a plain `EventsStats` response (single aggregate, no grouping), `timeseriesResultsTypes` came back empty so `dataType` was never set. Added handling for the plain case using top-level `data.meta`.

**Unit reset on aggregate change**: When switching to an aggregate with a different data type (e.g. from a size metric to a count), the previously selected threshold unit was stale and no longer valid. `ThresholdsSection` now resets `thresholds.unit` to `null` when `dataType` changes.

Refs DAIN-1238