### PR TITLE
fix(guidedSteps): Reset to first step when currentStep exceeds totalSteps

### DIFF
--- a/static/app/components/guidedSteps/guidedSteps.spec.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.spec.tsx
@@ -138,4 +138,26 @@ describe('GuidedSteps', () => {
     expect(screen.getByText('This is the second step.')).toBeInTheDocument();
     expect(screen.queryByText('This is the third step.')).not.toBeInTheDocument();
   });
+
+  it('resets to first step when initialStep exceeds the number of steps', async () => {
+    const onStepChange = jest.fn();
+
+    render(
+      <GuidedSteps initialStep={3} onStepChange={onStepChange}>
+        <GuidedSteps.Step stepKey="step-1" title="Step 1 Title">
+          This is the first step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="step-2" title="Step 2 Title">
+          This is the second step.
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    );
+
+    // Should reset to the first step instead of showing nothing
+    expect(await screen.findByText('This is the first step.')).toBeInTheDocument();
+    expect(screen.queryByText('This is the second step.')).not.toBeInTheDocument();
+    expect(onStepChange).toHaveBeenCalledWith(1);
+  });
 });

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -116,14 +116,18 @@ function useGuidedStepsContentValue({
   // of available steps (e.g. the guidedStep URL param persists from a
   // project with more steps), reset to step 1.
   useEffect(() => {
+    // Wait for steps to register before running initialization
+    if (totalSteps === 0) {
+      return;
+    }
     if (defined(initialStep)) {
-      if (totalSteps > 0 && initialStep > totalSteps) {
+      if (initialStep > totalSteps) {
         handleSetCurrentStep(1);
       }
       return;
     }
     const firstIncompleteStep = getFirstIncompleteStep();
-    setCurrentStep(firstIncompleteStep?.stepNumber ?? 1);
+    handleSetCurrentStep(firstIncompleteStep?.stepNumber ?? 1);
   }, [getFirstIncompleteStep, initialStep, totalSteps, handleSetCurrentStep]);
 
   return useMemo(

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -103,16 +103,6 @@ function useGuidedStepsContentValue({
     }
   }, [getFirstIncompleteStep]);
 
-  // On initial load, set the current step to the first incomplete step
-  // if the initial step is not defined.
-  useEffect(() => {
-    if (defined(initialStep)) {
-      return;
-    }
-    const firstIncompleteStep = getFirstIncompleteStep();
-    setCurrentStep(firstIncompleteStep?.stepNumber ?? 1);
-  }, [getFirstIncompleteStep, initialStep]);
-
   const handleSetCurrentStep = useCallback(
     (step: number) => {
       setCurrentStep(step);
@@ -121,14 +111,20 @@ function useGuidedStepsContentValue({
     [onStepChange]
   );
 
-  // Reset to the first step when currentStep exceeds totalSteps (e.g. when
-  // switching between projects that have different numbers of steps while the
-  // guidedStep URL param persists from the previous project).
+  // On initial load, set the current step to the first incomplete step
+  // if the initial step is not defined. If initialStep exceeds the number
+  // of available steps (e.g. the guidedStep URL param persists from a
+  // project with more steps), reset to step 1.
   useEffect(() => {
-    if (totalSteps > 0 && currentStep > totalSteps) {
-      handleSetCurrentStep(1);
+    if (defined(initialStep)) {
+      if (totalSteps > 0 && initialStep > totalSteps) {
+        handleSetCurrentStep(1);
+      }
+      return;
     }
-  }, [totalSteps, currentStep, handleSetCurrentStep]);
+    const firstIncompleteStep = getFirstIncompleteStep();
+    setCurrentStep(firstIncompleteStep?.stepNumber ?? 1);
+  }, [getFirstIncompleteStep, initialStep, totalSteps, handleSetCurrentStep]);
 
   return useMemo(
     () => ({

--- a/static/app/components/guidedSteps/guidedSteps.tsx
+++ b/static/app/components/guidedSteps/guidedSteps.tsx
@@ -121,6 +121,15 @@ function useGuidedStepsContentValue({
     [onStepChange]
   );
 
+  // Reset to the first step when currentStep exceeds totalSteps (e.g. when
+  // switching between projects that have different numbers of steps while the
+  // guidedStep URL param persists from the previous project).
+  useEffect(() => {
+    if (totalSteps > 0 && currentStep > totalSteps) {
+      handleSetCurrentStep(1);
+    }
+  }, [totalSteps, currentStep, handleSetCurrentStep]);
+
   return useMemo(
     () => ({
       currentStep,


### PR DESCRIPTION
When switching between projects with different numbers of onboarding steps, the `guidedStep` URL param persists from the previous project. If the new project has fewer steps (e.g. Next.js has 2 visible steps vs Python's 3+), `currentStep` points to a non-existent step and no content renders.

Adds bounds checking to the existing initialization `useEffect` in `GuidedSteps` that resets to step 1 when `initialStep` exceeds `totalSteps`. This also triggers `onStepChange`, which updates the URL param to match.

Additionally:
- Adds a `totalSteps === 0` guard to skip initialization while steps are still registering, avoiding unnecessary effect re-runs
- Uses `handleSetCurrentStep` consistently across all initialization paths so `onStepChange` always fires for URL synchronization

Fixes VDY-14