### PR TITLE
fix(workflows): Account for no associated workflow

### DIFF
--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -284,8 +284,10 @@ def filter_recently_fired_workflow_actions(
     workflow_ids: set[int] = set()
 
     for action_id, workflow_id in data_condition_group_actions:
-        action_to_workflows_ids[action_id].add(workflow_id)
-        workflow_ids.add(workflow_id)
+        # If we are mid-deletion, the workflow_id can be none.
+        if workflow_id is not None:
+            action_to_workflows_ids[action_id].add(workflow_id)
+            workflow_ids.add(workflow_id)
 
     workflows = Workflow.objects.filter(id__in=workflow_ids)
 

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -307,6 +307,22 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         assert set(triggered_actions) == {self.action}
         assert getattr(triggered_actions[0], "workflow_id") == workflow.id
 
+    def test_skips_action_with_no_workflow(self) -> None:
+        orphan_group = self.create_data_condition_group(logic_type="any-short")
+        orphan_action = self.create_action(type=Action.Type.PLUGIN)
+        self.create_data_condition_group_action(
+            condition_group=orphan_group,
+            action=orphan_action,
+        )
+        # No WorkflowDataConditionGroup links orphan_group to any workflow
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            {self.action_group, orphan_group}, self.event_data
+        )
+
+        # The orphan action should not appear; the normal action still fires
+        assert set(triggered_actions) == {self.action}
+
 
 class TestIsActionPermitted(BaseWorkflowTest):
     @patch("sentry.workflow_engine.processors.action._get_integration_features")


### PR DESCRIPTION
The type system was lying to us.
In filter_recently_fired_workflow_actions, data_condition_group_actions is populated with (action_id, workflow_id) associations, and is typed as  `[int, int]`. However, in practice the `WorkflowDataConditionGroup` may have been deleted, which results in `[int, None]`. This results in a None getting misused and causing problems downstream, including malformed queries.

Simply skipping these actions avoids this issue, and the action gets filtered out as we would like.



Fixes SENTRY-5KDK.