### PR TITLE
fix(eap): Silence possibly-undefined warning in SearchResolver

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -46,7 +46,6 @@ from sentry.search.eap.columns import (
     AttributeArgumentDefinition,
     ColumnDefinitions,
     FormulaDefinition,
-    ResolvedArgument,
     ResolvedArguments,
     ResolvedAttribute,
     ResolvedColumn,
@@ -1124,7 +1123,6 @@ class SearchResolver:
 
         resolved_arguments: ResolvedArguments = []
         for parsed_arg in parsed_args:
-            resolved_argument: ResolvedArgument
             if not isinstance(parsed_arg, ResolvedAttribute):
                 resolved_argument = parsed_arg
                 search_type = function_definition.default_search_type

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -46,6 +46,7 @@ from sentry.search.eap.columns import (
     AttributeArgumentDefinition,
     ColumnDefinitions,
     FormulaDefinition,
+    ResolvedArgument,
     ResolvedArguments,
     ResolvedAttribute,
     ResolvedColumn,
@@ -1123,6 +1124,7 @@ class SearchResolver:
 
         resolved_arguments: ResolvedArguments = []
         for parsed_arg in parsed_args:
+            resolved_argument: ResolvedArgument
             if not isinstance(parsed_arg, ResolvedAttribute):
                 resolved_argument = parsed_arg
                 search_type = function_definition.default_search_type


### PR DESCRIPTION
silences a mypy warning with `--enable-error-code possibly-undefined`

- `if type == "number"` should be `elif` — integer args were appending both int(argument) and the raw string, breaking http_response_count
- Drop redundant AttributeKey isinstance guard on proto_definition — ResolvedAttribute.proto_definition returns AttributeKey, so the else was unreachable; annotate resolved_argument as ResolvedArgument
- Tighten parsed_args from list[ResolvedAttribute | Any] to concrete types
