### PR TITLE
ref(explore): Make attribute breakdown components a little more reusable

### DIFF
--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -10,7 +10,6 @@ import {IconExpand} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
-import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
 import {CHART_MAX_BAR_WIDTH} from './constants';
@@ -27,12 +26,17 @@ export function Chart({
   attributeDistribution,
   theme,
   cohortCount,
+  query,
+  onAddSearchFilter,
+  onSetGroupBys,
 }: {
   attributeDistribution: AttributeDistribution[number];
   cohortCount: number;
+  query: string;
   theme: Theme;
+  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
+  onSetGroupBys?: (groupBys: string[], mode: string) => void;
 }) {
-  const query = useQueryParamsQuery();
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
   const formatSingleModeTooltip = useFormatSingleModeTooltip();
@@ -63,11 +67,15 @@ export function Chart({
     [attributeDistribution.attributeName, theme]
   );
 
+  const hasActions = !!(onAddSearchFilter || onSetGroupBys);
+
   const tooltipConfig = useAttributeBreakdownsTooltip({
     chartRef,
     formatter: formatSingleModeTooltip,
     chartWidth,
-    actionsHtmlRenderer,
+    actionsHtmlRenderer: hasActions ? actionsHtmlRenderer : undefined,
+    onAddSearchFilter,
+    onSetGroupBys,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -73,9 +73,13 @@ export function Chart({
     chartRef,
     formatter: formatSingleModeTooltip,
     chartWidth,
-    actionsHtmlRenderer: hasActions ? actionsHtmlRenderer : undefined,
-    onAddSearchFilter,
-    onSetGroupBys,
+    actions: hasActions
+      ? {
+          htmlRenderer: actionsHtmlRenderer,
+          handleAddSearchFilter: onAddSearchFilter,
+          handleSetGroupBys: onSetGroupBys,
+        }
+      : null,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import type {Theme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
@@ -9,6 +9,7 @@ import {openAttributeBreakdownViewerModal} from 'sentry/actionCreators/modal';
 import {IconExpand} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import type {TooltipActions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 
 import type {AttributeDistribution} from './attributeDistributionContent';
@@ -19,7 +20,6 @@ import {
   calculateAttributePopulationPercentage,
   distributionToSeriesData,
   percentageFormatter,
-  tooltipActionsHtmlRenderer,
 } from './utils';
 
 export function Chart({
@@ -27,15 +27,13 @@ export function Chart({
   theme,
   cohortCount,
   query,
-  onAddSearchFilter,
-  onSetGroupBys,
+  actions,
 }: {
   attributeDistribution: AttributeDistribution[number];
   cohortCount: number;
   query: string;
   theme: Theme;
-  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
-  onSetGroupBys?: (groupBys: string[], mode: string) => void;
+  actions?: TooltipActions | null;
 }) {
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
@@ -61,25 +59,11 @@ export function Chart({
     [attributeDistribution.values, cohortCount]
   );
 
-  const actionsHtmlRenderer = useCallback(
-    (value: string) =>
-      tooltipActionsHtmlRenderer(value, attributeDistribution.attributeName, theme),
-    [attributeDistribution.attributeName, theme]
-  );
-
-  const hasActions = !!(onAddSearchFilter || onSetGroupBys);
-
   const tooltipConfig = useAttributeBreakdownsTooltip({
     chartRef,
     formatter: formatSingleModeTooltip,
     chartWidth,
-    actions: hasActions
-      ? {
-          htmlRenderer: actionsHtmlRenderer,
-          handleAddSearchFilter: onAddSearchFilter,
-          handleSetGroupBys: onSetGroupBys,
-        }
-      : null,
+    actions,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -15,12 +15,14 @@ import EventView from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import useAttributeBreakdowns from 'sentry/views/explore/hooks/useAttributeBreakdowns';
+import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {
   useAddSearchFilter,
@@ -33,6 +35,7 @@ import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 import {Chart} from './attributeDistributionChart';
 import {CHART_SELECTION_ALERT_KEY, CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
+import {tooltipActionsHtmlRenderer} from './utils';
 
 export type AttributeDistribution = Array<{
   attributeName: string;
@@ -60,12 +63,28 @@ export function AttributeDistribution() {
   const query = useQueryParamsQuery();
   const addSearchFilter = useAddSearchFilter();
   const setGroupBys = useSetQueryParamsGroupBys();
+  const copyToClipboard = useCopyToClipboard();
 
-  const onSetGroupBys = useCallback(
-    (groupBys: string[], _mode: string) => {
-      setGroupBys(groupBys, Mode.AGGREGATE);
+  const onAction = useCallback(
+    ({action, key, value}: {action: string; key: string; value: string}) => {
+      switch (action) {
+        case Actions.GROUP_BY:
+          setGroupBys([key], Mode.AGGREGATE);
+          break;
+        case Actions.ADD_TO_FILTER:
+          addSearchFilter({key, value});
+          break;
+        case Actions.EXCLUDE_FROM_FILTER:
+          addSearchFilter({key, value, negated: true});
+          break;
+        case Actions.COPY_TO_CLIPBOARD:
+          copyToClipboard.copy(value);
+          break;
+        default:
+          break;
+      }
     },
-    [setGroupBys]
+    [addSearchFilter, setGroupBys, copyToClipboard]
   );
 
   const dataset = useSpansDataset();
@@ -202,8 +221,15 @@ export function AttributeDistribution() {
                     cohortCount={cohortCount}
                     theme={theme}
                     query={query}
-                    onAddSearchFilter={addSearchFilter}
-                    onSetGroupBys={onSetGroupBys}
+                    actions={{
+                      htmlRenderer: (value: string) =>
+                        tooltipActionsHtmlRenderer(
+                          value,
+                          distribution.attributeName,
+                          theme
+                        ),
+                      onAction,
+                    }}
                   />
                 ))}
             </AttributeBreakdownsComponent.ChartsGrid>

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -22,7 +22,12 @@ import useOrganization from 'sentry/utils/useOrganization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import useAttributeBreakdowns from 'sentry/views/explore/hooks/useAttributeBreakdowns';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
+import {
+  useAddSearchFilter,
+  useQueryParamsQuery,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 import {Chart} from './attributeDistributionChart';
@@ -53,6 +58,16 @@ export function AttributeDistribution() {
   });
 
   const query = useQueryParamsQuery();
+  const addSearchFilter = useAddSearchFilter();
+  const setGroupBys = useSetQueryParamsGroupBys();
+
+  const onSetGroupBys = useCallback(
+    (groupBys: string[], _mode: string) => {
+      setGroupBys(groupBys, Mode.AGGREGATE);
+    },
+    [setGroupBys]
+  );
+
   const dataset = useSpansDataset();
   const {selection} = usePageFilters();
   const theme = useTheme();
@@ -186,6 +201,9 @@ export function AttributeDistribution() {
                     attributeDistribution={distribution}
                     cohortCount={cohortCount}
                     theme={theme}
+                    query={query}
+                    onAddSearchFilter={addSearchFilter}
+                    onSetGroupBys={onSetGroupBys}
                   />
                 ))}
             </AttributeBreakdownsComponent.ChartsGrid>

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -15,21 +15,15 @@ import EventView from 'sentry/utils/discover/eventView';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
-import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useDismissAlert from 'sentry/utils/useDismissAlert';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import useAttributeBreakdowns from 'sentry/views/explore/hooks/useAttributeBreakdowns';
-import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
+import {useAttributeBreakdownsTooltipAction} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {
-  useAddSearchFilter,
-  useQueryParamsQuery,
-  useSetQueryParamsGroupBys,
-} from 'sentry/views/explore/queryParams/context';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 import {Chart} from './attributeDistributionChart';
@@ -61,31 +55,7 @@ export function AttributeDistribution() {
   });
 
   const query = useQueryParamsQuery();
-  const addSearchFilter = useAddSearchFilter();
-  const setGroupBys = useSetQueryParamsGroupBys();
-  const copyToClipboard = useCopyToClipboard();
-
-  const onAction = useCallback(
-    ({action, key, value}: {action: string; key: string; value: string}) => {
-      switch (action) {
-        case Actions.GROUP_BY:
-          setGroupBys([key], Mode.AGGREGATE);
-          break;
-        case Actions.ADD_TO_FILTER:
-          addSearchFilter({key, value});
-          break;
-        case Actions.EXCLUDE_FROM_FILTER:
-          addSearchFilter({key, value, negated: true});
-          break;
-        case Actions.COPY_TO_CLIPBOARD:
-          copyToClipboard.copy(value);
-          break;
-        default:
-          break;
-      }
-    },
-    [addSearchFilter, setGroupBys, copyToClipboard]
-  );
+  const onAction = useAttributeBreakdownsTooltipAction();
 
   const dataset = useSpansDataset();
   const {selection} = usePageFilters();

--- a/static/app/views/explore/components/attributeBreakdowns/chartSelectionContext.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/chartSelectionContext.tsx
@@ -4,6 +4,12 @@ import type {Selection} from 'sentry/components/charts/useChartXRangeSelection';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 
+export type ChartSelectionQueryParam = {
+  chartIndex: number;
+  panelId: string;
+  range: [number, number];
+};
+
 type ChartSelectionState = {
   chartIndex: number;
   selection: Selection;
@@ -27,11 +33,13 @@ function serializeChartSelection(state: ChartSelectionState): string {
     return '';
   }
 
-  return JSON.stringify({
+  const chartSelection: ChartSelectionQueryParam = {
     chartIndex: state.chartIndex,
     range: state.selection.range,
     panelId: state.selection.panelId,
-  });
+  };
+
+  return JSON.stringify(chartSelection);
 }
 
 function deserializeChartSelection(value: string | undefined): ChartSelectionState {

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -10,6 +10,7 @@ import {IconExpand} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+import type {TooltipActions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 
 import {
@@ -24,7 +25,6 @@ import {
   calculateAttributePopulationPercentage,
   cohortsToSeriesData,
   percentageFormatter,
-  tooltipActionsHtmlRenderer,
 } from './utils';
 
 export function Chart({
@@ -33,16 +33,14 @@ export function Chart({
   cohort1Total,
   cohort2Total,
   query,
-  onAddSearchFilter,
-  onSetGroupBys,
+  actions,
 }: {
   attribute: AttributeBreakdownsComparison['rankedAttributes'][number];
   cohort1Total: number;
   cohort2Total: number;
   query: string;
   theme: Theme;
-  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
-  onSetGroupBys?: (groupBys: string[], mode: string) => void;
+  actions?: TooltipActions | null;
 }) {
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
@@ -95,24 +93,11 @@ export function Chart({
     [formatComparisonModeTooltip]
   );
 
-  const actionsHtmlRenderer = useCallback(
-    (value: string) => tooltipActionsHtmlRenderer(value, attribute.attributeName, theme),
-    [attribute.attributeName, theme]
-  );
-
-  const hasActions = !!(onAddSearchFilter || onSetGroupBys);
-
   const tooltipConfig = useAttributeBreakdownsTooltip({
     chartRef,
     formatter: toolTipFormatter,
     chartWidth,
-    actions: hasActions
-      ? {
-          htmlRenderer: actionsHtmlRenderer,
-          handleAddSearchFilter: onAddSearchFilter,
-          handleSetGroupBys: onSetGroupBys,
-        }
-      : null,
+    actions,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -106,9 +106,13 @@ export function Chart({
     chartRef,
     formatter: toolTipFormatter,
     chartWidth,
-    actionsHtmlRenderer: hasActions ? actionsHtmlRenderer : undefined,
-    onAddSearchFilter,
-    onSetGroupBys,
+    actions: hasActions
+      ? {
+          htmlRenderer: actionsHtmlRenderer,
+          handleAddSearchFilter: onAddSearchFilter,
+          handleSetGroupBys: onSetGroupBys,
+        }
+      : null,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -11,7 +11,6 @@ import {t, tct} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
 import {useAttributeBreakdownsTooltip} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
-import {useQueryParamsQuery} from 'sentry/views/explore/queryParams/context';
 
 import {
   CHART_BASELINE_SERIES_NAME,
@@ -33,13 +32,18 @@ export function Chart({
   theme,
   cohort1Total,
   cohort2Total,
+  query,
+  onAddSearchFilter,
+  onSetGroupBys,
 }: {
   attribute: AttributeBreakdownsComparison['rankedAttributes'][number];
   cohort1Total: number;
   cohort2Total: number;
+  query: string;
   theme: Theme;
+  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
+  onSetGroupBys?: (groupBys: string[], mode: string) => void;
 }) {
-  const query = useQueryParamsQuery();
   const chartRef = useRef<ReactEchartsRef>(null);
   const [chartWidth, setChartWidth] = useState(0);
 
@@ -96,11 +100,15 @@ export function Chart({
     [attribute.attributeName, theme]
   );
 
+  const hasActions = !!(onAddSearchFilter || onSetGroupBys);
+
   const tooltipConfig = useAttributeBreakdownsTooltip({
     chartRef,
     formatter: toolTipFormatter,
     chartWidth,
-    actionsHtmlRenderer,
+    actionsHtmlRenderer: hasActions ? actionsHtmlRenderer : undefined,
+    onAddSearchFilter,
+    onSetGroupBys,
   });
 
   useLayoutEffect(() => {

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -13,8 +13,10 @@ import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getUserTimezone} from 'sentry/utils/dates';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useAttributeBreakdownComparison from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {useFilteredRankedAttributes} from 'sentry/views/explore/hooks/useFilteredRankedAttributes';
 import {
   useAddSearchFilter,
@@ -27,6 +29,7 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {Chart} from './cohortComparisonChart';
 import {CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
+import {tooltipActionsHtmlRenderer} from './utils';
 
 export function CohortComparison({
   selection,
@@ -39,12 +42,28 @@ export function CohortComparison({
   const query = useQueryParamsQuery();
   const addSearchFilter = useAddSearchFilter();
   const setGroupBys = useSetQueryParamsGroupBys();
+  const copyToClipboard = useCopyToClipboard();
 
-  const onSetGroupBys = useCallback(
-    (groupBys: string[], _mode: string) => {
-      setGroupBys(groupBys, Mode.AGGREGATE);
+  const onAction = useCallback(
+    ({action, key, value}: {action: string; key: string; value: string}) => {
+      switch (action) {
+        case Actions.GROUP_BY:
+          setGroupBys([key], Mode.AGGREGATE);
+          break;
+        case Actions.ADD_TO_FILTER:
+          addSearchFilter({key, value});
+          break;
+        case Actions.EXCLUDE_FROM_FILTER:
+          addSearchFilter({key, value, negated: true});
+          break;
+        case Actions.COPY_TO_CLIPBOARD:
+          copyToClipboard.copy(value);
+          break;
+        default:
+          break;
+      }
     },
-    [setGroupBys]
+    [addSearchFilter, setGroupBys, copyToClipboard]
   );
 
   const yAxis = visualizes[chartIndex]?.yAxis ?? '';
@@ -140,8 +159,15 @@ export function CohortComparison({
                       cohort1Total={data?.cohort1Total ?? 0}
                       cohort2Total={data?.cohort2Total ?? 0}
                       query={query}
-                      onAddSearchFilter={addSearchFilter}
-                      onSetGroupBys={onSetGroupBys}
+                      actions={{
+                        htmlRenderer: (value: string) =>
+                          tooltipActionsHtmlRenderer(
+                            value,
+                            attribute.attributeName,
+                            theme
+                          ),
+                        onAction,
+                      }}
                     />
                   ))}
                 </AttributeBreakdownsComponent.ChartsGrid>

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -16,6 +16,7 @@ import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useAttributeBreakdownComparison from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+import {useAttributeBreakdownsTooltipAction} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {useFilteredRankedAttributes} from 'sentry/views/explore/hooks/useFilteredRankedAttributes';
 
 import {Chart} from './cohortComparisonChart';
@@ -29,7 +30,6 @@ interface CohortComparisonProps {
   yAxis: string;
   dataset?: DiscoverDatasets;
   extrapolate?: string;
-  onAction?: (action: {action: string; key: string; value: string}) => void;
 }
 
 export function CohortComparison({
@@ -38,8 +38,9 @@ export function CohortComparison({
   query,
   dataset,
   extrapolate,
-  onAction,
 }: CohortComparisonProps) {
+  const onAction = useAttributeBreakdownsTooltipAction();
+
   const {data, isLoading, error} = useAttributeBreakdownComparison({
     aggregateFunction: yAxis,
     range: selection.range,

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
@@ -12,65 +12,40 @@ import Panel from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import {getUserTimezone} from 'sentry/utils/dates';
+import type {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
-import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useAttributeBreakdownComparison from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
-import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
 import {useFilteredRankedAttributes} from 'sentry/views/explore/hooks/useFilteredRankedAttributes';
-import {
-  useAddSearchFilter,
-  useQueryParamsQuery,
-  useQueryParamsVisualizes,
-  useSetQueryParamsGroupBys,
-} from 'sentry/views/explore/queryParams/context';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
 
 import {Chart} from './cohortComparisonChart';
 import {CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
 import {tooltipActionsHtmlRenderer} from './utils';
 
+interface CohortComparisonProps {
+  query: string;
+  selection: Selection;
+  yAxis: string;
+  dataset?: DiscoverDatasets;
+  extrapolate?: string;
+  onAction?: (action: {action: string; key: string; value: string}) => void;
+}
+
 export function CohortComparison({
   selection,
-  chartIndex,
-}: {
-  chartIndex: number;
-  selection: Selection;
-}) {
-  const visualizes = useQueryParamsVisualizes();
-  const query = useQueryParamsQuery();
-  const addSearchFilter = useAddSearchFilter();
-  const setGroupBys = useSetQueryParamsGroupBys();
-  const copyToClipboard = useCopyToClipboard();
-
-  const onAction = useCallback(
-    ({action, key, value}: {action: string; key: string; value: string}) => {
-      switch (action) {
-        case Actions.GROUP_BY:
-          setGroupBys([key], Mode.AGGREGATE);
-          break;
-        case Actions.ADD_TO_FILTER:
-          addSearchFilter({key, value});
-          break;
-        case Actions.EXCLUDE_FROM_FILTER:
-          addSearchFilter({key, value, negated: true});
-          break;
-        case Actions.COPY_TO_CLIPBOARD:
-          copyToClipboard.copy(value);
-          break;
-        default:
-          break;
-      }
-    },
-    [addSearchFilter, setGroupBys, copyToClipboard]
-  );
-
-  const yAxis = visualizes[chartIndex]?.yAxis ?? '';
-
+  yAxis,
+  query,
+  dataset,
+  extrapolate,
+  onAction,
+}: CohortComparisonProps) {
   const {data, isLoading, error} = useAttributeBreakdownComparison({
     aggregateFunction: yAxis,
     range: selection.range,
+    query,
+    dataset,
+    extrapolate,
   });
   const [searchQuery, setSearchQuery] = useQueryParamState({
     fieldName: 'attributeBreakdownsSearch',

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
@@ -15,13 +15,18 @@ import {getUserTimezone} from 'sentry/utils/dates';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import useAttributeBreakdownComparison from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
-import {useQueryParamsVisualizes} from 'sentry/views/explore/queryParams/context';
+import {useFilteredRankedAttributes} from 'sentry/views/explore/hooks/useFilteredRankedAttributes';
+import {
+  useAddSearchFilter,
+  useQueryParamsQuery,
+  useQueryParamsVisualizes,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 
 import {Chart} from './cohortComparisonChart';
 import {CHARTS_PER_PAGE} from './constants';
 import {AttributeBreakdownsComponent} from './styles';
-
-type SortingMethod = 'rrr';
 
 export function CohortComparison({
   selection,
@@ -31,6 +36,16 @@ export function CohortComparison({
   selection: Selection;
 }) {
   const visualizes = useQueryParamsVisualizes();
+  const query = useQueryParamsQuery();
+  const addSearchFilter = useAddSearchFilter();
+  const setGroupBys = useSetQueryParamsGroupBys();
+
+  const onSetGroupBys = useCallback(
+    (groupBys: string[], _mode: string) => {
+      setGroupBys(groupBys, Mode.AGGREGATE);
+    },
+    [setGroupBys]
+  );
 
   const yAxis = visualizes[chartIndex]?.yAxis ?? '';
 
@@ -41,46 +56,23 @@ export function CohortComparison({
   const [searchQuery, setSearchQuery] = useQueryParamState({
     fieldName: 'attributeBreakdownsSearch',
   });
-  const sortingMethod: SortingMethod = 'rrr';
-  const [page, setPage] = useState(0);
   const theme = useTheme();
 
   // Debouncing the search query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
-  // query here to ensure smooth typing, by delaying the re-mounts a little as the user types.
   const debouncedSearchQuery = useDebouncedValue(searchQuery ?? '', 100);
 
-  const filteredRankedAttributes = useMemo(() => {
-    const attrs = data?.rankedAttributes;
-    if (!attrs) {
-      return [];
-    }
-
-    let filteredAttrs = attrs;
-    if (debouncedSearchQuery.trim()) {
-      const searchFor = debouncedSearchQuery.toLocaleLowerCase().trim();
-      filteredAttrs = attrs.filter(attr =>
-        attr.attributeName.toLocaleLowerCase().trim().includes(searchFor)
-      );
-    }
-
-    const sortedAttrs = [...filteredAttrs].sort((a, b) => {
-      const aOrder = a.order[sortingMethod];
-      const bOrder = b.order[sortingMethod];
-
-      if (aOrder === null && bOrder === null) return 0;
-      if (aOrder === null) return 1;
-      if (bOrder === null) return -1;
-
-      return aOrder - bOrder;
-    });
-
-    return sortedAttrs;
-  }, [debouncedSearchQuery, data?.rankedAttributes, sortingMethod]);
-
-  useEffect(() => {
-    // Ensure that we are on the first page whenever filtered attributes change.
-    setPage(0);
-  }, [filteredRankedAttributes]);
+  const {
+    filteredRankedAttributes,
+    paginatedAttributes,
+    hasPrevious,
+    hasNext,
+    nextPage,
+    previousPage,
+  } = useFilteredRankedAttributes({
+    rankedAttributes: data?.rankedAttributes,
+    searchQuery: debouncedSearchQuery,
+    pageSize: CHARTS_PER_PAGE,
+  });
 
   const selectedRangeToDates = useMemo(() => {
     if (!selection) {
@@ -109,8 +101,8 @@ export function CohortComparison({
         <AttributeBreakdownsComponent.ControlsContainer>
           <AttributeBreakdownsComponent.StyledBaseSearchBar
             placeholder={t('Search keys')}
-            onChange={query => {
-              setSearchQuery(query);
+            onChange={value => {
+              setSearchQuery(value);
             }}
             query={debouncedSearchQuery}
             size="sm"
@@ -140,30 +132,24 @@ export function CohortComparison({
             {filteredRankedAttributes.length > 0 ? (
               <Fragment>
                 <AttributeBreakdownsComponent.ChartsGrid>
-                  {filteredRankedAttributes
-                    .slice(page * CHARTS_PER_PAGE, (page + 1) * CHARTS_PER_PAGE)
-                    .map(attribute => (
-                      <Chart
-                        key={attribute.attributeName}
-                        attribute={attribute}
-                        theme={theme}
-                        cohort1Total={data?.cohort1Total ?? 0}
-                        cohort2Total={data?.cohort2Total ?? 0}
-                      />
-                    ))}
+                  {paginatedAttributes.map(attribute => (
+                    <Chart
+                      key={attribute.attributeName}
+                      attribute={attribute}
+                      theme={theme}
+                      cohort1Total={data?.cohort1Total ?? 0}
+                      cohort2Total={data?.cohort2Total ?? 0}
+                      query={query}
+                      onAddSearchFilter={addSearchFilter}
+                      onSetGroupBys={onSetGroupBys}
+                    />
+                  ))}
                 </AttributeBreakdownsComponent.ChartsGrid>
                 <AttributeBreakdownsComponent.Pagination
-                  isNextDisabled={
-                    page ===
-                    Math.ceil(filteredRankedAttributes.length / CHARTS_PER_PAGE) - 1
-                  }
-                  isPrevDisabled={page === 0}
-                  onNextClick={() => {
-                    setPage(page + 1);
-                  }}
-                  onPrevClick={() => {
-                    setPage(page - 1);
-                  }}
+                  isNextDisabled={!hasNext}
+                  isPrevDisabled={!hasPrevious}
+                  onNextClick={nextPage}
+                  onPrevClick={previousPage}
                 />
               </Fragment>
             ) : (

--- a/static/app/views/explore/components/attributeBreakdowns/content.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/content.tsx
@@ -1,14 +1,5 @@
-import {useCallback} from 'react';
-
-import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
-import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
-import {
-  useAddSearchFilter,
-  useQueryParamsVisualizes,
-  useSetQueryParamsGroupBys,
-} from 'sentry/views/explore/queryParams/context';
-import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {useQueryParamsVisualizes} from 'sentry/views/explore/queryParams/context';
 import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 import {AttributeDistribution} from './attributeDistributionContent';
@@ -19,35 +10,10 @@ export function AttributeBreakdownsContent() {
   const {chartSelection} = useChartSelection();
   const location = useLocation();
   const visualizes = useQueryParamsVisualizes();
-  const addSearchFilter = useAddSearchFilter();
-  const setGroupBys = useSetQueryParamsGroupBys();
-  const copyToClipboard = useCopyToClipboard();
   const dataset = useSpansDataset();
 
   const query = location.query.query?.toString() ?? '';
   const extrapolate = location.query.extrapolate?.toString() ?? '1';
-
-  const onAction = useCallback(
-    ({action, key, value}: {action: string; key: string; value: string}) => {
-      switch (action) {
-        case Actions.GROUP_BY:
-          setGroupBys([key], Mode.AGGREGATE);
-          break;
-        case Actions.ADD_TO_FILTER:
-          addSearchFilter({key, value});
-          break;
-        case Actions.EXCLUDE_FROM_FILTER:
-          addSearchFilter({key, value, negated: true});
-          break;
-        case Actions.COPY_TO_CLIPBOARD:
-          copyToClipboard.copy(value);
-          break;
-        default:
-          break;
-      }
-    },
-    [addSearchFilter, setGroupBys, copyToClipboard]
-  );
 
   if (chartSelection) {
     const yAxis = visualizes[chartSelection.chartIndex]?.yAxis ?? '';
@@ -59,7 +25,6 @@ export function AttributeBreakdownsContent() {
         query={query}
         dataset={dataset}
         extrapolate={extrapolate}
-        onAction={onAction}
       />
     );
   }

--- a/static/app/views/explore/components/attributeBreakdowns/content.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/content.tsx
@@ -1,15 +1,65 @@
+import {useCallback} from 'react';
+
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import {useLocation} from 'sentry/utils/useLocation';
+import {Actions} from 'sentry/views/explore/hooks/useAttributeBreakdownsTooltip';
+import {
+  useAddSearchFilter,
+  useQueryParamsVisualizes,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
+
 import {AttributeDistribution} from './attributeDistributionContent';
 import {useChartSelection} from './chartSelectionContext';
 import {CohortComparison} from './cohortComparisonContent';
 
 export function AttributeBreakdownsContent() {
   const {chartSelection} = useChartSelection();
+  const location = useLocation();
+  const visualizes = useQueryParamsVisualizes();
+  const addSearchFilter = useAddSearchFilter();
+  const setGroupBys = useSetQueryParamsGroupBys();
+  const copyToClipboard = useCopyToClipboard();
+  const dataset = useSpansDataset();
+
+  const query = location.query.query?.toString() ?? '';
+  const extrapolate = location.query.extrapolate?.toString() ?? '1';
+
+  const onAction = useCallback(
+    ({action, key, value}: {action: string; key: string; value: string}) => {
+      switch (action) {
+        case Actions.GROUP_BY:
+          setGroupBys([key], Mode.AGGREGATE);
+          break;
+        case Actions.ADD_TO_FILTER:
+          addSearchFilter({key, value});
+          break;
+        case Actions.EXCLUDE_FROM_FILTER:
+          addSearchFilter({key, value, negated: true});
+          break;
+        case Actions.COPY_TO_CLIPBOARD:
+          copyToClipboard.copy(value);
+          break;
+        default:
+          break;
+      }
+    },
+    [addSearchFilter, setGroupBys, copyToClipboard]
+  );
 
   if (chartSelection) {
+    const yAxis = visualizes[chartSelection.chartIndex]?.yAxis ?? '';
+
     return (
       <CohortComparison
         selection={chartSelection.selection}
-        chartIndex={chartSelection.chartIndex}
+        yAxis={yAxis}
+        query={query}
+        dataset={dataset}
+        extrapolate={extrapolate}
+        onAction={onAction}
       />
     );
   }

--- a/static/app/views/explore/hooks/useAttributeBreakdownComparison.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownComparison.tsx
@@ -2,15 +2,15 @@ import {useMemo} from 'react';
 
 import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {FieldKey} from 'sentry/utils/fields';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {useSpansDataset} from 'sentry/views/explore/spans/spansQueryParams';
 
 export type AttributeBreakdownsComparison = {
   cohort1Total: number;
@@ -35,22 +35,26 @@ export type AttributeBreakdownsComparison = {
 function useAttributeBreakdownComparison({
   aggregateFunction,
   range,
+  query,
+  dataset = DiscoverDatasets.SPANS,
+  extrapolate = '1',
+  pageFilters: pageFiltersProp,
 }: {
   aggregateFunction: string;
+  query: string;
   range: [number, number];
+  dataset?: DiscoverDatasets;
+  extrapolate?: string;
+  pageFilters?: PageFilters;
 }) {
-  const location = useLocation();
   const organization = useOrganization();
-  const dataset = useSpansDataset();
-  const {selection: pageFilters} = usePageFilters();
-  const aggregateExtrapolation = location.query.extrapolate ?? '1';
+  const {selection: contextPageFilters} = usePageFilters();
+  const pageFilters = pageFiltersProp ?? contextPageFilters;
 
   const [x1, x2] = range;
 
-  // Ensure that we pass the existing queries in the search bar to the attribute breakdowns queries
-  const currentQuery = location.query.query?.toString() ?? '';
-  const selectedRegionQuery = new MutableSearch(currentQuery);
-  const baselineRegionQuery = new MutableSearch(currentQuery);
+  const selectedRegionQuery = new MutableSearch(query);
+  const baselineRegionQuery = new MutableSearch(query);
 
   // round off the x-axis bounds to the minute
   let startTimestamp = Math.floor(x1 / 60_000) * 60_000;
@@ -78,9 +82,9 @@ function useAttributeBreakdownComparison({
       function: aggregateFunction,
       above: 1,
       sampling: SAMPLING_MODE.NORMAL,
-      aggregateExtrapolation,
+      aggregateExtrapolation: extrapolate,
     };
-  }, [query1, query2, pageFilters, dataset, aggregateFunction, aggregateExtrapolation]);
+  }, [query1, query2, pageFilters, dataset, aggregateFunction, extrapolate]);
 
   return useApiQuery<AttributeBreakdownsComparison>(
     [

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -22,19 +22,18 @@ type Params = {
    */
   formatter: (params: TooltipComponentFormatterCallbackParams) => string;
   /**
-   * The function to render the HTML for the tooltip actions. The actions are rendered on click, anywhere on the chart.
+   * Action handlers and renderer for the tooltip. When provided, the tooltip will show
+   * clickable actions on click. When null, no actions are shown.
    */
-  actionsHtmlRenderer?: (value: string) => string;
-  /**
-   * Callback to add a search filter. Used by tooltip actions.
-   * When not provided, the "Add to filter" and "Exclude from filter" actions are no-ops.
-   */
-  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
-  /**
-   * Callback to set group bys. Used by tooltip actions.
-   * When not provided, the "Group by" action is a no-op.
-   */
-  onSetGroupBys?: (groupBys: string[], mode: string) => void;
+  actions?: {
+    htmlRenderer: (value: string) => string;
+    handleAddSearchFilter?: (params: {
+      key: string;
+      value: string;
+      negated?: boolean;
+    }) => void;
+    handleSetGroupBys?: (groupBys: string[], mode: string) => void;
+  } | null;
 };
 
 export enum Actions {
@@ -52,9 +51,7 @@ export function useAttributeBreakdownsTooltip({
   chartRef,
   formatter,
   chartWidth,
-  actionsHtmlRenderer,
-  onAddSearchFilter,
-  onSetGroupBys,
+  actions,
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
   const tooltipParamsRef = useRef<TooltipComponentFormatterCallbackParams | null>(null);
@@ -136,16 +133,16 @@ export function useAttributeBreakdownsTooltip({
       if (action && value && key) {
         switch (action) {
           case Actions.GROUP_BY:
-            onSetGroupBys?.([key], 'aggregate');
+            actions?.handleSetGroupBys?.([key], 'aggregate');
             break;
           case Actions.ADD_TO_FILTER:
-            onAddSearchFilter?.({
+            actions?.handleAddSearchFilter?.({
               key,
               value,
             });
             break;
           case Actions.EXCLUDE_FROM_FILTER:
-            onAddSearchFilter?.({
+            actions?.handleAddSearchFilter?.({
               key,
               value,
               negated: true,
@@ -190,7 +187,7 @@ export function useAttributeBreakdownsTooltip({
       document.removeEventListener('mouseover', handleMouseOver);
       document.removeEventListener('mouseout', handleMouseOut);
     };
-  }, [frozenPosition, copyToClipboard, onAddSearchFilter, onSetGroupBys]);
+  }, [frozenPosition, copyToClipboard, actions]);
 
   const tooltipConfig: TooltipOption = useMemo(
     () => ({
@@ -210,7 +207,7 @@ export function useAttributeBreakdownsTooltip({
         if (!frozenPosition) {
           tooltipParamsRef.current = params;
 
-          const actionsPlaceholder = actionsHtmlRenderer
+          const actionsPlaceholder = actions?.htmlRenderer
             ? `
           <div
             class="tooltip-footer"
@@ -237,7 +234,7 @@ export function useAttributeBreakdownsTooltip({
         // return the formatted content, including the tooltip actions.
         const p = tooltipParamsRef.current;
         const value = (Array.isArray(p) ? p[0]?.name : p.name) ?? '';
-        return wrapContent(formatter(p) + (actionsHtmlRenderer?.(value) ?? ''));
+        return wrapContent(formatter(p) + (actions?.htmlRenderer(value) ?? ''));
       },
       position(
         point: [number, number],
@@ -259,7 +256,7 @@ export function useAttributeBreakdownsTooltip({
         return [x, y];
       },
     }),
-    [frozenPosition, chartWidth, formatter, actionsHtmlRenderer, tooltipParamsRef]
+    [frozenPosition, chartWidth, formatter, actions, tooltipParamsRef]
   );
 
   return tooltipConfig;

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -3,7 +3,6 @@ import type {ECharts, TooltipComponentFormatterCallbackParams} from 'echarts';
 
 import type {TooltipOption} from 'sentry/components/charts/baseChart';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
-import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 
 const TOOLTIP_POSITION_X_OFFSET = 20;
 const TOOLTIP_POSITION_Y_OFFSET = -10;
@@ -25,15 +24,12 @@ type Params = {
    * Action handlers and renderer for the tooltip. When provided, the tooltip will show
    * clickable actions on click. When null, no actions are shown.
    */
-  actions?: {
-    htmlRenderer: (value: string) => string;
-    handleAddSearchFilter?: (params: {
-      key: string;
-      value: string;
-      negated?: boolean;
-    }) => void;
-    handleSetGroupBys?: (groupBys: string[], mode: string) => void;
-  } | null;
+  actions?: TooltipActions | null;
+};
+
+export type TooltipActions = {
+  htmlRenderer: (value: string) => string;
+  onAction: (params: {action: string; key: string; value: string}) => void;
 };
 
 export enum Actions {
@@ -55,8 +51,6 @@ export function useAttributeBreakdownsTooltip({
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
   const tooltipParamsRef = useRef<TooltipComponentFormatterCallbackParams | null>(null);
-
-  const copyToClipboard = useCopyToClipboard();
 
   // This effect runs on load and when the frozen position changes.
   // - If frozen position is set, trigger a re-render of the tooltip with frozen position to show the
@@ -120,8 +114,6 @@ export function useAttributeBreakdownsTooltip({
   useEffect(() => {
     if (!frozenPosition) return;
 
-    // TODO Abdullah Khan: Take the actions in as a prop to the hook, to allow other
-    // product areas to use the component feature. This is explore specific for now.
     const handleClickActions = (event: MouseEvent) => {
       event.preventDefault();
 
@@ -131,29 +123,7 @@ export function useAttributeBreakdownsTooltip({
       const value = target.getAttribute('data-tooltip-action-value');
 
       if (action && value && key) {
-        switch (action) {
-          case Actions.GROUP_BY:
-            actions?.handleSetGroupBys?.([key], 'aggregate');
-            break;
-          case Actions.ADD_TO_FILTER:
-            actions?.handleAddSearchFilter?.({
-              key,
-              value,
-            });
-            break;
-          case Actions.EXCLUDE_FROM_FILTER:
-            actions?.handleAddSearchFilter?.({
-              key,
-              value,
-              negated: true,
-            });
-            break;
-          case Actions.COPY_TO_CLIPBOARD:
-            copyToClipboard.copy(value);
-            break;
-          default:
-            throw new Error(`Unknown attribute breakdowns tooltip action: ${action}`);
-        }
+        actions?.onAction({action, key, value});
       }
     };
 
@@ -187,7 +157,7 @@ export function useAttributeBreakdownsTooltip({
       document.removeEventListener('mouseover', handleMouseOver);
       document.removeEventListener('mouseout', handleMouseOut);
     };
-  }, [frozenPosition, copyToClipboard, actions]);
+  }, [frozenPosition, actions]);
 
   const tooltipConfig: TooltipOption = useMemo(
     () => ({

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -1,8 +1,14 @@
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import type {ECharts, TooltipComponentFormatterCallbackParams} from 'echarts';
 
 import type {TooltipOption} from 'sentry/components/charts/baseChart';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
+import {
+  useAddSearchFilter,
+  useSetQueryParamsGroupBys,
+} from 'sentry/views/explore/queryParams/context';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
 
 const TOOLTIP_POSITION_X_OFFSET = 20;
 const TOOLTIP_POSITION_Y_OFFSET = -10;
@@ -37,6 +43,34 @@ export enum Actions {
   ADD_TO_FILTER = 'add_value_to_filter',
   EXCLUDE_FROM_FILTER = 'exclude_value_from_filter',
   COPY_TO_CLIPBOARD = 'copy_value_to_clipboard',
+}
+
+export function useAttributeBreakdownsTooltipAction(): TooltipActions['onAction'] {
+  const addSearchFilter = useAddSearchFilter();
+  const setGroupBys = useSetQueryParamsGroupBys();
+  const copyToClipboard = useCopyToClipboard();
+
+  return useCallback(
+    ({action, key, value}: {action: string; key: string; value: string}) => {
+      switch (action) {
+        case Actions.GROUP_BY:
+          setGroupBys([key], Mode.AGGREGATE);
+          break;
+        case Actions.ADD_TO_FILTER:
+          addSearchFilter({key, value});
+          break;
+        case Actions.EXCLUDE_FROM_FILTER:
+          addSearchFilter({key, value, negated: true});
+          break;
+        case Actions.COPY_TO_CLIPBOARD:
+          copyToClipboard.copy(value);
+          break;
+        default:
+          break;
+      }
+    },
+    [addSearchFilter, setGroupBys, copyToClipboard]
+  );
 }
 
 // This hook creates a tooltip configuration for attribute breakdowns charts.

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -4,11 +4,6 @@ import type {ECharts, TooltipComponentFormatterCallbackParams} from 'echarts';
 import type {TooltipOption} from 'sentry/components/charts/baseChart';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
 import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
-import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
-import {
-  useAddSearchFilter,
-  useSetQueryParamsGroupBys,
-} from 'sentry/views/explore/queryParams/context';
 
 const TOOLTIP_POSITION_X_OFFSET = 20;
 const TOOLTIP_POSITION_Y_OFFSET = -10;
@@ -30,6 +25,16 @@ type Params = {
    * The function to render the HTML for the tooltip actions. The actions are rendered on click, anywhere on the chart.
    */
   actionsHtmlRenderer?: (value: string) => string;
+  /**
+   * Callback to add a search filter. Used by tooltip actions.
+   * When not provided, the "Add to filter" and "Exclude from filter" actions are no-ops.
+   */
+  onAddSearchFilter?: (params: {key: string; value: string; negated?: boolean}) => void;
+  /**
+   * Callback to set group bys. Used by tooltip actions.
+   * When not provided, the "Group by" action is a no-op.
+   */
+  onSetGroupBys?: (groupBys: string[], mode: string) => void;
 };
 
 export enum Actions {
@@ -48,13 +53,13 @@ export function useAttributeBreakdownsTooltip({
   formatter,
   chartWidth,
   actionsHtmlRenderer,
+  onAddSearchFilter,
+  onSetGroupBys,
 }: Params): TooltipOption {
   const [frozenPosition, setFrozenPosition] = useState<[number, number] | null>(null);
   const tooltipParamsRef = useRef<TooltipComponentFormatterCallbackParams | null>(null);
 
-  const addSearchFilter = useAddSearchFilter();
   const copyToClipboard = useCopyToClipboard();
-  const setGroupBys = useSetQueryParamsGroupBys();
 
   // This effect runs on load and when the frozen position changes.
   // - If frozen position is set, trigger a re-render of the tooltip with frozen position to show the
@@ -131,16 +136,16 @@ export function useAttributeBreakdownsTooltip({
       if (action && value && key) {
         switch (action) {
           case Actions.GROUP_BY:
-            setGroupBys([key], Mode.AGGREGATE);
+            onSetGroupBys?.([key], 'aggregate');
             break;
           case Actions.ADD_TO_FILTER:
-            addSearchFilter({
+            onAddSearchFilter?.({
               key,
               value,
             });
             break;
           case Actions.EXCLUDE_FROM_FILTER:
-            addSearchFilter({
+            onAddSearchFilter?.({
               key,
               value,
               negated: true,
@@ -185,7 +190,7 @@ export function useAttributeBreakdownsTooltip({
       document.removeEventListener('mouseover', handleMouseOver);
       document.removeEventListener('mouseout', handleMouseOut);
     };
-  }, [frozenPosition, copyToClipboard, addSearchFilter, setGroupBys]);
+  }, [frozenPosition, copyToClipboard, onAddSearchFilter, onSetGroupBys]);
 
   const tooltipConfig: TooltipOption = useMemo(
     () => ({
@@ -205,7 +210,8 @@ export function useAttributeBreakdownsTooltip({
         if (!frozenPosition) {
           tooltipParamsRef.current = params;
 
-          const actionsPlaceholder = `
+          const actionsPlaceholder = actionsHtmlRenderer
+            ? `
           <div
             class="tooltip-footer"
             style="
@@ -217,7 +223,8 @@ export function useAttributeBreakdownsTooltip({
           >
             Click for actions
           </div>
-        `.trim();
+        `.trim()
+            : '';
 
           return wrapContent(formatter(params) + actionsPlaceholder);
         }

--- a/static/app/views/explore/hooks/useFilteredRankedAttributes.ts
+++ b/static/app/views/explore/hooks/useFilteredRankedAttributes.ts
@@ -1,0 +1,61 @@
+import {useEffect, useMemo, useState} from 'react';
+
+import type {AttributeBreakdownsComparison} from 'sentry/views/explore/hooks/useAttributeBreakdownComparison';
+
+type RankedAttribute = AttributeBreakdownsComparison['rankedAttributes'][number];
+
+export function useFilteredRankedAttributes({
+  rankedAttributes,
+  searchQuery,
+  pageSize,
+}: {
+  pageSize: number;
+  rankedAttributes: RankedAttribute[] | undefined;
+  searchQuery: string;
+}) {
+  const [page, setPage] = useState(0);
+
+  const filteredRankedAttributes = useMemo(() => {
+    if (!rankedAttributes) {
+      return [];
+    }
+
+    let filtered = rankedAttributes;
+    const trimmed = searchQuery.toLocaleLowerCase().trim();
+    if (trimmed) {
+      filtered = rankedAttributes.filter(attr =>
+        attr.attributeName.toLocaleLowerCase().trim().includes(trimmed)
+      );
+    }
+
+    return [...filtered].sort((a, b) => {
+      const aOrder = a.order.rrr;
+      const bOrder = b.order.rrr;
+      if (aOrder === null && bOrder === null) return 0;
+      if (aOrder === null) return 1;
+      if (bOrder === null) return -1;
+      return aOrder - bOrder;
+    });
+  }, [rankedAttributes, searchQuery]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [filteredRankedAttributes]);
+
+  const totalPages = Math.ceil(filteredRankedAttributes.length / pageSize);
+  const paginatedAttributes = filteredRankedAttributes.slice(
+    page * pageSize,
+    (page + 1) * pageSize
+  );
+
+  return {
+    filteredRankedAttributes,
+    paginatedAttributes,
+    page,
+    totalPages,
+    hasPrevious: page > 0,
+    hasNext: page < totalPages - 1,
+    nextPage: () => setPage(p => p + 1),
+    previousPage: () => setPage(p => p - 1),
+  };
+}

--- a/static/app/views/explore/utils.tsx
+++ b/static/app/views/explore/utils.tsx
@@ -27,6 +27,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {ChartSelectionQueryParam} from 'sentry/views/explore/components/attributeBreakdowns/chartSelectionContext';
 import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {isGroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -60,6 +61,7 @@ export interface GetExploreUrlArgs {
   organization: Organization;
   aggregateField?: Array<GroupBy | BaseVisualize>;
   caseInsensitive?: CaseInsensitive;
+  chartSelection?: ChartSelectionQueryParam;
   field?: string[];
   groupBy?: string[];
   id?: number;
@@ -80,6 +82,7 @@ export function getExploreUrl({
   interval,
   mode,
   aggregateField,
+  chartSelection,
   visualize,
   query,
   groupBy,
@@ -114,6 +117,7 @@ export function getExploreUrl({
     title,
     referrer,
     caseInsensitive: caseInsensitive ? '1' : undefined,
+    chartSelection: chartSelection ? JSON.stringify(chartSelection) : undefined,
   };
 
   return (


### PR DESCRIPTION
Ref ISWF-901

We want to use the attribute comparison components for metric issues so users can debug more easily. It looks like the attribute breakdown components are already pretty reusable, but there are a couple more things that will make it usable in issue details, which this PR seeds to address:

- Support chart selection in getExploreUrl so we can link to the full attribute comparison page
- Pass tooltip actions as handlers so the issue details page can omit those
- Extract the filtering/sorting logic to a hook that both components can use