### PR TITLE
fix(alerts): Tolerate missing threshold_type in AlertRuleSerializer partial use

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -198,7 +198,12 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
                 raise serializers.ValidationError(
                     f'Trigger {i + 1} must be labeled "{expected_label}"'
                 )
-        threshold_type = data["threshold_type"]
+        if "threshold_type" in data:
+            threshold_type = data["threshold_type"]
+        elif self.instance is not None:
+            threshold_type = AlertRuleThresholdType(self.instance.threshold_type)
+        else:
+            raise serializers.ValidationError({"threshold_type": "This field is required."})
         self._translate_thresholds(threshold_type, data.get("comparison_delta"), triggers, data)
 
         critical = triggers[0]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -713,6 +713,25 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             == list(audit_log_entry)[0].ip_address
         )
 
+    def test_partial_update_without_threshold_type(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        alert_rule = self.alert_rule
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        original_threshold_type = serialized_alert_rule.pop("thresholdType")
+        serialized_alert_rule["name"] = "updated without threshold type"
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            resp = self.get_success_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        assert resp.data["name"] == "updated without threshold type"
+        assert resp.data["thresholdType"] == original_threshold_type
+
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_update_to_count_converts_internally_but_shows_count_on_upsampled_project(
         self, mock_are_any_projects_error_upsampled


### PR DESCRIPTION
partial=True makes assumptions about required and defaulted fields being present inaccurate.

Fixes SENTRY-5KEC.
