### PR TITLE
fix(preprod): Use theme-aware border color for treemap level-0 gaps

### DIFF
--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -326,6 +326,7 @@ export function AppSizeTreemap(props: AppSizeTreemapProps) {
           itemStyle: {
             gapWidth: 4,
             borderRadius: 6,
+            borderColor: chartSurfaceColor,
           },
           colorSaturation: [0.3, 0.5],
         },


### PR DESCRIPTION
Fix treemap white background areas in dark mode (EME-894)

PR #109308 replaced transparent treemap fills with opaque composited colors to fix color bleed artifacts (EME-889). A side effect was that the outermost treemap level gaps now show white background in dark mode. The root cause: without an explicit `borderColor`, ECharts v5 defaults to a white/light border color. Before the PR this was invisible since everything was transparent, but now that nodes have opaque fills the default white bleeds through.

Adds `borderColor: chartSurfaceColor` to `levels[0]` itemStyle so the outermost level borders use the same theme-aware background color used for compositing node fills, making them blend seamlessly in both light and dark mode.

Before
<img width="2052" height="1084" alt="CleanShot 2026-02-26 at 14 41 03@2x" src="https://github.com/user-attachments/assets/02ed3b70-a290-4dc2-a729-34d87a81c346" />


After
<img width="2042" height="1082" alt="CleanShot 2026-02-26 at 14 41 32@2x" src="https://github.com/user-attachments/assets/49ffb75d-f403-4397-9c7a-032a6bfec15c" />


Refs EME-894