### PR TITLE
fix(eap): Fix possibly-undefined group_list in delete helper

### DIFF
--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -149,6 +149,7 @@ def schedule_tasks_to_delete_groups(
     project, org, environment, and search params already bound
     """
     group_ids = request.GET.getlist("id")
+    group_list: list[Group] = []
     if group_ids:
         group_list = list(
             Group.objects.filter(


### PR DESCRIPTION
silences a mypy warning with `--enable-error-code possibly-undefined`. Initialize group_list = [] before the if/elif so mypy can see it's always defined. there's already a check if the list is empty. 