### PR TITLE
refactor(github): Remove mailbox allowlist for drop-unprocessed-events

### DIFF
--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -136,9 +136,6 @@ class GithubRequestParser(BaseRequestParser):
                 self.try_forward_to_codecov(event=event)
 
         github_event = self.request.META.get(GITHUB_WEBHOOK_TYPE_HEADER)
-        mailbox_name = f"{self.provider}:{self.get_mailbox_identifier(integration, event)}"
-        allowlist = options.get("github.webhook.drop-unprocessed-events.mailbox-allowlist") or ()
-        mailbox_in_allowlist = any(mailbox_name == m for m in allowlist)
 
         # Only drop when we have a known unprocessed event type. Missing or empty
         # X-GitHub-Event is malformed; let the request be forwarded so the region
@@ -147,7 +144,6 @@ class GithubRequestParser(BaseRequestParser):
             github_event
             and github_event not in REGION_PROCESSED_GITHUB_EVENTS
             and options.get("github.webhook.drop-unprocessed-events.enabled")
-            and mailbox_in_allowlist
         ):
             metrics.incr(
                 "github.webhook.drop_unprocessed_event",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -748,12 +748,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "github.webhook.drop-unprocessed-events.mailbox-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # GitHub Console SDK App (separate app for repository invitations)
 register("github-console-sdk-app.id", default=0, flags=FLAG_AUTOMATOR_MODIFIABLE)


### PR DESCRIPTION
The experiment has worked for the most backlogged mailbox. We're ready to roll this out across the board.

Remove the mailbox allowlist option for dropping unprocessed GitHub webhook events. When `github.webhook.drop-unprocessed-events.enabled` is on, unprocessed events are now dropped for all mailboxes instead of only those in an allowlist.

**Motivation:** Simplifies rollout and operations by using a single flag; the allowlist was only needed for gradual rollout.

**Changes:**
- `github.py`: Drop condition uses only the enabled flag (no allowlist check).
- `options/defaults.py`: Remove `github.webhook.drop-unprocessed-events.mailbox-allowlist` registration; keep `.enabled`.
- `test_github.py`: Remove allowlist-only test; other tests use only `enabled` in `override_options`.

Made with [Cursor](https://cursor.com)