### PR TITLE
feat(discover): Allow ttid/ttfd contribution rate in arithmetic equations

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -208,6 +208,9 @@ class ArithmeticVisitor(NodeVisitor):
         "avg_if",
         "division_if",
         "failure_rate_if",
+        # Mobile vitals uses these functions
+        "ttid_contribution_rate",
+        "ttfd_contribution_rate",
     }
 
     def __init__(self, max_operators: int | None, custom_measurements: set[str] | None):

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -249,6 +249,8 @@ def test_field_values(a, op, b) -> None:
         ("p50_if(span.duration,is_transaction,equals,true)", "/", 2),
         ("tpm()", "+", "failure_rate_if(is_transaction,equals,true)"),
         ("avg_if(span.duration,is_transaction,equals,true)", "*", 100),
+        ("ttid_contribution_rate()", "+", "ttfd_contribution_rate()"),
+        (100, "*", "ttid_contribution_rate()"),
         (
             "performance_score(measurements.score.lcp)",
             "+",


### PR DESCRIPTION
Add `ttid_contribution_rate` and `ttfd_contribution_rate` to the allowed arithmetic functions list in `ArithmeticVisitor`. This is needed so the Mobile Vitals dashboard can use these functions with the `equation|` prefix in widget aggregates.

Without this, any equation containing these functions would fail backend validation, causing the Span Operations table widget to break when the `equation|` prefix is applied (see companion frontend PR).

Follows the same pattern as #107958 (which added `tpm`, conditional `_if` functions for the Frontend Overview dashboard).

Refs DAIN-1243