### PR TITLE
(span-repro): add flushing ttl logging

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -561,6 +561,8 @@ class SpansBuffer:
                     has_root_span,
                     len(segment),
                     shard,
+                    queue_key,
+                    now,
                 )
             except Exception:
                 logger.exception("flush_segments: Failed to log debug trace flush info")


### PR DESCRIPTION
Trying to understand some earlier flush behaviour. This doesn't log the advancement of ttl with each batch of spans, but is a good starting point