### PR TITLE
fix(dashboards): Use equation prefix for ttid/ttfd contribution rate in Mobile Vitals

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
@@ -249,14 +249,14 @@ const SPAN_OPERATIONS_TABLE: Widget = {
       fields: [
         SpanFields.SPAN_OP,
         SpanFields.SPAN_DESCRIPTION,
-        `ttid_contribution_rate()`,
-        `ttfd_contribution_rate()`,
+        `equation|ttid_contribution_rate()`,
+        `equation|ttfd_contribution_rate()`,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],
       aggregates: [
-        `ttid_contribution_rate()`,
-        `ttfd_contribution_rate()`,
+        `equation|ttid_contribution_rate()`,
+        `equation|ttfd_contribution_rate()`,
         `avg(${SpanFields.SPAN_SELF_TIME})`,
         `sum(${SpanFields.SPAN_SELF_TIME})`,
       ],


### PR DESCRIPTION
The Span Operations table in the Mobile Vitals dashboard uses `ttid_contribution_rate()` and `ttfd_contribution_rate()` as aggregates. When clicking "Open in Explore", these were silently dropped because `getWidgetExploreUrl` filters aggregates to only those present in `eventView.getYAxisOptions()` — which only recognizes functions known natively to Explore.

Prefixing with `equation|` fixes this: equations pass the `isAggregateEquation()` check in `getYAxisOptions()`, so they're included in the yAxis options and flow through to Explore correctly. The functions are defined in EAP (`src/sentry/search/eap/spans/formulas.py`), so Explore can resolve them.

The backend companion PR (#109521) adds these functions to the arithmetic allowed list so they pass equation validation.

Follows the same pattern as #108045 (Frontend Overview dashboard).

**Note:** This PR depends on #109521 landing first.

Fixes DAIN-1243