### PR TITLE
feat(autofix): Allow creating explorer autofix prs from slack

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -122,21 +122,42 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
         elif current_step == AutofixStep.SOLUTION:
             webhook_action_type = SeerActionType.SOLUTION_COMPLETED
         elif current_step == AutofixStep.CODE_CHANGES:
-            webhook_action_type = SeerActionType.CODING_COMPLETED
-            diffs_by_repo = state.get_diffs_by_repo()
-            webhook_payload["code_changes"] = {
-                repo: [
+            if state.repo_pr_states:
+                # When the current step is code changes and there are pr states,
+                # then we are actually in the PR created step.
+                #
+                # One caveat here is that re-running code changes step isn't
+                # handled but the expectation is that we only create PRs once
+                # per seer run.
+                webhook_action_type = SeerActionType.PR_CREATED
+                webhook_payload["pull_requests"] = [
                     {
-                        "diff": p.diff,
-                        "path": p.patch.path,
-                        "type": p.patch.type,
-                        "added": p.patch.added,
-                        "removed": p.patch.removed,
+                        "provider": "unknown",  # TODO: we don't have the repo object readily accessible here
+                        "repo_name": pull_request.repo_name,
+                        "pull_request": {
+                            "pr_id": pull_request.pr_id,
+                            "pr_number": pull_request.pr_number,
+                            "pr_url": pull_request.pr_url,
+                        },
                     }
-                    for p in patches
+                    for pull_request in state.repo_pr_states.values()
                 ]
-                for repo, patches in diffs_by_repo.items()
-            }
+            else:
+                webhook_action_type = SeerActionType.CODING_COMPLETED
+                diffs_by_repo = state.get_diffs_by_repo()
+                webhook_payload["code_changes"] = {
+                    repo: [
+                        {
+                            "diff": p.diff,
+                            "path": p.patch.path,
+                            "type": p.patch.type,
+                            "added": p.patch.added,
+                            "removed": p.patch.removed,
+                        }
+                        for p in patches
+                    ]
+                    for repo, patches in diffs_by_repo.items()
+                }
         elif current_step == AutofixStep.IMPACT_ASSESSMENT:
             webhook_action_type = SeerActionType.IMPACT_ASSESSMENT_COMPLETED
         elif current_step == AutofixStep.TRIAGE:
@@ -391,7 +412,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
 
         try:
             client = SeerExplorerClient(organization=organization, user=None)
-            client.push_changes(run_id)
+            client.push_changes(run_id, blocking=False)
         except Exception:
             logger.exception(
                 "autofix.on_completion_hook.push_changes_failed",

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -26,6 +26,7 @@ from sentry.seer.entrypoints.metrics import (
 )
 from sentry.seer.entrypoints.registry import entrypoint_registry
 from sentry.seer.entrypoints.types import SeerEntrypoint, SeerEntrypointKey
+from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.seer_setup import has_seer_access
 from sentry.sentry_apps.metrics import SentryAppEventType
@@ -211,24 +212,29 @@ class SeerOperator[CachePayloadT]:
                         )
                     return
 
-            if not run_id:
-                run_id = trigger_autofix_explorer(
-                    group=group,
-                    step=AutofixStep.ROOT_CAUSE,
-                    run_id=None,
-                )
-            elif stopping_point == AutofixStoppingPoint.OPEN_PR:
-                pass  # TODO: OPENING PRs is a little more complicated so putting it off for now
-            else:
-                # NOTE: Stopping point here is really just what
-                # step to run next. Not the same as the stopping_point
-                # argument supported by `trigger_autofix_explorer` which allows one
-                # to run multiple steps at once
-                run_id = trigger_autofix_explorer(
-                    group=group,
-                    step=AutofixStep.from_autofix_stopping_point(stopping_point),
-                    run_id=run_id,
-                )
+            try:
+                if not run_id:
+                    run_id = trigger_autofix_explorer(
+                        group=group,
+                        step=AutofixStep.ROOT_CAUSE,
+                        run_id=None,
+                    )
+                elif stopping_point == AutofixStoppingPoint.OPEN_PR:
+                    client = SeerExplorerClient(organization=group.organization)
+                    client.push_changes(run_id, blocking=False)
+                else:
+                    # NOTE: Stopping point here is really just what
+                    # step to run next. Not the same as the stopping_point
+                    # argument supported by `trigger_autofix_explorer` which allows one
+                    # to run multiple steps at once
+                    run_id = trigger_autofix_explorer(
+                        group=group,
+                        step=AutofixStep.from_autofix_stopping_point(stopping_point),
+                        run_id=run_id,
+                    )
+            except Exception as e:
+                lifecycle.record_failure(failure_reason=e)
+                return
 
             lifecycle.add_extra("run_id", str(run_id))
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -233,6 +233,13 @@ class SeerOperator[CachePayloadT]:
                         run_id=run_id,
                     )
             except Exception as e:
+                with SeerOperatorEventLifecycleMetric(
+                    interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,
+                    entrypoint_key=self.entrypoint.key,
+                ).capture():
+                    self.entrypoint.on_trigger_autofix_error(
+                        error="Encountered an error while talking to Seer"
+                    )
                 lifecycle.record_failure(failure_reason=e)
                 return
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -500,9 +500,10 @@ class SeerExplorerClient:
         self,
         run_id: int,
         repo_name: str | None = None,
+        blocking=True,
         poll_interval: float = 2.0,
         poll_timeout: float = 120.0,
-    ) -> SeerRunState:
+    ) -> SeerRunState | None:
         """
         Push code changes to PR(s) and wait for completion.
 
@@ -540,6 +541,9 @@ class SeerExplorerClient:
         )
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
+
+        if not blocking:
+            return None
 
         # Poll until PR creation completes
         start_time = time.time()

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -261,7 +261,7 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
             },
         )
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state)
-        mock_client.push_changes.assert_called_once_with(123)
+        mock_client.push_changes.assert_called_once_with(123, blocking=False)
 
 
 class TestPipelineConstants(TestCase):

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -672,6 +672,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
         assert body["run_id"] == 123
         assert body["payload"]["type"] == "create_pr"
         assert body["payload"]["repo_name"] == "owner/repo"
+        assert result is not None
         assert result.repo_pr_states["owner/repo"].pr_url == "https://github.com/owner/repo/pull/1"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
@@ -710,6 +711,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
         assert mock_fetch.call_count == 2
         assert mock_sleep.call_count == 1
+        assert result is not None
         assert result.repo_pr_states["owner/repo"].pr_creation_status == "completed"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")


### PR DESCRIPTION
This enables the ability to start an explorer autofix PR from slack and handle the webhook from seer and post an update back in slack.