### PR TITLE
chore(issue-details): Remove old issues UI opt-out action

### DIFF
--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.spec.tsx
@@ -28,7 +28,7 @@ describe('NewIssueExperienceButton', () => {
     jest.clearAllMocks();
   });
 
-  it('appears correctly when organization has the single interface option', () => {
+  it('is hidden when no streamlined actions are available', () => {
     const {unmount: unmountOptionTrue} = render(
       <div data-test-id="test-id">
         <NewIssueExperienceButton />
@@ -54,11 +54,12 @@ describe('NewIssueExperienceButton', () => {
         },
       }
     );
-    expect(screen.getByTestId('test-id')).not.toBeEmptyDOMElement();
+    expect(screen.getByTestId('test-id')).toBeEmptyDOMElement();
     unmountOptionFalse();
   });
 
-  it('appears when organization has flag', () => {
+  it('appears when feedback action is available', () => {
+    mockFeedbackForm.mockReturnValue(jest.fn());
     render(
       <div data-test-id="test-id">
         <NewIssueExperienceButton />
@@ -109,34 +110,9 @@ describe('NewIssueExperienceButton', () => {
       );
     });
     expect(trackAnalytics).toHaveBeenCalledTimes(1);
-
-    await userEvent.click(screen.getByRole('button', {name: 'Manage issue experience'}));
-    const oldExperienceButton = screen.getByRole('menuitemradio', {
-      name: 'Switch to the old issue experience',
-    });
-    // Clicking again toggles it off
-    await userEvent.click(oldExperienceButton);
-    // Old text should be back
-    expect(
-      screen.getByRole('button', {name: 'Switch to the new issue experience'})
-    ).toBeInTheDocument();
-    // And save the option as false
-    await waitFor(() => {
-      expect(mockChangeUserSettings).toHaveBeenCalledWith(
-        '/users/me/',
-        expect.objectContaining({
-          data: {
-            options: {
-              prefersIssueDetailsStreamlinedUI: false,
-            },
-          },
-        })
-      );
-    });
-    expect(trackAnalytics).toHaveBeenCalledTimes(2);
   });
 
-  it('can switch back to the old UI via dropdown', async () => {
+  it('can submit feedback from the streamlined dropdown', async () => {
     const mockFormCallback = jest.fn();
     mockFeedbackForm.mockReturnValue(mockFormCallback);
     const mockChangeUserSettings = MockApiClient.addMockResponse({
@@ -179,13 +155,6 @@ describe('NewIssueExperienceButton', () => {
       await screen.findByRole('menuitemradio', {name: 'Give feedback on the UI'})
     );
     expect(mockFeedbackForm).toHaveBeenCalled();
-
-    await userEvent.click(dropdownButton);
-    await userEvent.click(
-      screen.getByRole('menuitemradio', {
-        name: 'Switch to the old issue experience',
-      })
-    );
-    expect(mockChangeUserSettings).toHaveBeenCalledTimes(2);
+    expect(mockChangeUserSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
+++ b/static/app/views/issueDetails/actions/newIssueExperienceButton.tsx
@@ -153,7 +153,6 @@ export function NewIssueExperienceButton() {
   }, [isTourCompleted, organization]);
 
   const hasStreamlinedUI = useHasStreamlinedUI();
-  const hasNewUIOnly = Boolean(organization.streamlineOnly);
 
   const openForm = useFeedbackForm();
   const {mutate: mutateUserOptions} = useMutateUserOptions();
@@ -211,15 +210,6 @@ export function NewIssueExperienceButton() {
           },
         });
       },
-    },
-    {
-      key: 'switch-to-old-ui',
-      label: t('Switch to the old issue experience'),
-      // Do not show the toggle out of the new UI if any of these are true:
-      //  - The user is on the old UI
-      //  - The org has the new UI only option
-      hidden: !hasStreamlinedUI || hasNewUIOnly,
-      onAction: handleToggle,
     },
     {
       key: 'reset-tour-modal',


### PR DESCRIPTION
We are removing the old issue experience. This is the first step - removing the opt out button