### PR TITLE
fix(snuba): Handle direct project.id groupby in top event conditions

### DIFF
--- a/src/sentry/snuba/rpc_dataset_common.py
+++ b/src/sentry/snuba/rpc_dataset_common.py
@@ -825,9 +825,12 @@ class RPCBase:
             other_row_conditions = []
             for key in groupby_columns:
                 if key == "project.id":
-                    value = resolver.params.project_slug_map[
-                        event.get("project") or event["project.slug"]
-                    ]
+                    if "project.id" in event:
+                        value = event["project.id"]
+                    else:
+                        value = resolver.params.project_slug_map[
+                            event.get("project") or event["project.slug"]
+                        ]
                 else:
                     value = event[key]
                 resolved_term, context = resolver.resolve_term(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -2615,3 +2615,27 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             time_series_by_transaction["foo"]["meta"]["order"]
             < time_series_by_transaction["bar"]["meta"]["order"]
         )
+
+    def test_group_by_project_id(self) -> None:
+        self.store_spans([self.create_span({}, project=self.project)])
+        response = self._do_request(
+            data={
+                "yAxis": "count()",
+                "dataset": "spans",
+                "groupBy": ["project.id", "project.name"],
+                "query": "",
+                "topEvents": 5,
+                "project": self.project.id,
+            },
+        )
+        assert response.status_code == 200, response.content
+
+        time_series_by_project_id = {
+            ts["groupBy"][0]["value"]: ts
+            for ts in response.data["timeSeries"]
+            if ts["groupBy"] is not None
+        }
+        assert time_series_by_project_id[str(self.project.id)]["groupBy"] == [
+            {"key": "project.id", "value": str(self.project.id)},
+            {"key": "project.name", "value": self.project.slug},
+        ]


### PR DESCRIPTION
Handle direct `project.id` groupby in `build_top_event_conditions`

When grouping by `project.id` directly in the timeseries spans endpoint, the top events query returns data keyed by `"project.id"` with the integer project ID as value. The existing code only handled the case where `project.id` appeared as a derived groupby key (from grouping by `project` or `project.name`), where the data contains the slug under a `"project"` or `"project.slug"` key. This caused a `KeyError: 'project.slug'`.

The fix checks if the event data already has a `"project.id"` key and uses the value directly, falling back to the slug-based lookup for the derived case.

Fixes SENTRY-5KF8