### PR TITLE
feat(cells): expand locality/cell distinction

### DIFF
--- a/src/sentry/conf/types/region_config.py
+++ b/src/sentry/conf/types/region_config.py
@@ -7,11 +7,13 @@ class CellConfig(TypedDict):
     name: str
     snowflake_id: int
     address: str
-    category: str
+    category: str  # TODO(cells): drop once category is fully moved to LocalityConfig
     visible: NotRequired[bool]
 
 
 # Locality is a collection of cells
 class LocalityConfig(TypedDict):
     name: str
+    category: str
     cells: list[str]
+    visible: NotRequired[bool]

--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -25,7 +25,10 @@ class TestEnvRegionDirectory(RegionDirectory):
         )
 
     def localities_from_regions(self, regions: Collection[Region]) -> frozenset[Locality]:
-        return frozenset(Locality(name=cell.name, cells=frozenset([cell.name])) for cell in regions)
+        return frozenset(
+            Locality(name=cell.name, cells=frozenset([cell.name]), category=cell.category)
+            for cell in regions
+        )
 
     @contextmanager
     def swap_state(
@@ -84,7 +87,7 @@ class TestEnvRegionDirectory(RegionDirectory):
         region = self.get_by_name(cell_name)
         if region is None:
             return None
-        return Locality(name=cell_name, cells=frozenset([cell_name]))
+        return Locality(name=cell_name, cells=frozenset([cell_name]), category=region.category)
 
     def get_cells_for_locality(self, locality_name: str) -> Iterable[Region]:
         region = self.get_by_name(locality_name)

--- a/src/sentry/testutils/region.py
+++ b/src/sentry/testutils/region.py
@@ -76,6 +76,18 @@ class TestEnvRegionDirectory(RegionDirectory):
     def regions(self) -> frozenset[Region]:
         return self._tmp_state.regions
 
+    @property
+    def localities(self) -> frozenset[Locality]:
+        return frozenset(
+            Locality(
+                name=r.name,
+                cells=frozenset([r.name]),
+                category=r.category,
+                visible=r.visible,
+            )
+            for r in self._tmp_state.regions
+        )
+
     def get_by_name(self, region_name: str) -> Region | None:
         match = (r for r in self._tmp_state.regions if r.name == region_name)
         try:
@@ -83,11 +95,27 @@ class TestEnvRegionDirectory(RegionDirectory):
         except StopIteration:
             return None
 
+    def get_locality_by_name(self, locality_name: str) -> Locality | None:
+        region = self.get_by_name(locality_name)
+        if region is None:
+            return None
+        return Locality(
+            name=locality_name,
+            cells=frozenset([locality_name]),
+            category=region.category,
+            visible=region.visible,
+        )
+
     def get_locality_for_cell(self, cell_name: str) -> Locality | None:
         region = self.get_by_name(cell_name)
         if region is None:
             return None
-        return Locality(name=cell_name, cells=frozenset([cell_name]), category=region.category)
+        return Locality(
+            name=cell_name,
+            cells=frozenset([cell_name]),
+            category=region.category,
+            visible=region.visible,
+        )
 
     def get_cells_for_locality(self, locality_name: str) -> Iterable[Region]:
         region = self.get_by_name(locality_name)

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
     from sentry.sentry_apps.models.sentry_app import SentryApp
 
 
+class RegionCategory(Enum):
+    MULTI_TENANT = "MULTI_TENANT"
+    SINGLE_TENANT = "SINGLE_TENANT"
+
+
 @dataclass(frozen=True, eq=True)
 class Locality:
     """A grouping of one or more cells (e.g. "us" contains "us1", "us2")."""
@@ -45,11 +50,6 @@ class Locality:
 
     def api_serialize(self) -> dict[str, Any]:
         return {"name": self.name, "url": self.to_url("")}
-
-
-class RegionCategory(Enum):
-    MULTI_TENANT = "MULTI_TENANT"
-    SINGLE_TENANT = "SINGLE_TENANT"
 
 
 # TODO(cells): rename to LocalityConfigurationError

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -29,6 +29,23 @@ class Locality:
     cells: frozenset[str]
     """The set of cell names that belong to this locality."""
 
+    category: RegionCategory
+
+    visible: bool = True
+    """Whether the locality is visible in API responses."""
+
+    def to_url(self, path: str) -> str:
+        from sentry.api.utils import generate_region_url
+
+        if SiloMode.get_current_mode() == SiloMode.MONOLITH:
+            base_url = options.get("system.url-prefix")
+        else:
+            base_url = generate_region_url(self.name)
+        return urljoin(base_url, path)
+
+    def api_serialize(self) -> dict[str, Any]:
+        return {"name": self.name, "url": self.to_url("")}
+
 
 class RegionCategory(Enum):
     MULTI_TENANT = "MULTI_TENANT"
@@ -73,8 +90,8 @@ class Region:
     and `system.region-api-url-template`
     """
 
+    # TODO(cells): drop once category is fully moved to Locality
     category: RegionCategory
-    """The region's category."""
 
     visible: bool = True
     """Whether the region is visible in API responses"""
@@ -99,12 +116,6 @@ class Region:
             base_url = generate_region_url(self.name)
 
         return urljoin(base_url, path)
-
-    def api_serialize(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "url": self.to_url(""),
-        }
 
     def is_historic_monolith_region(self) -> bool:
         """Check whether this is a historic monolith region.
@@ -162,6 +173,9 @@ class RegionDirectory:
 
     def get_by_name(self, region_name: str) -> Region | None:
         return self._by_name.get(region_name)
+
+    def get_locality_by_name(self, locality_name: str) -> Locality | None:
+        return self._localities_by_name.get(locality_name)
 
     def get_regions(self, category: RegionCategory | None = None) -> Iterable[Region]:
         return (r for r in self.regions if (category is None or r.category == category))
@@ -245,7 +259,9 @@ def _parse_locality_config(
     for config_value in locality_config:
         yield Locality(
             name=config_value["name"],
+            category=RegionCategory(config_value["category"]),
             cells=frozenset(config_value["cells"]),
+            visible=bool(config_value.get("visible", True)),
         )
 
 
@@ -263,7 +279,14 @@ def load_from_config(
             # as a temporary fallback. Once SENTRY_LOCALITIES is configured, all cells
             # must be explicitly assigned; missing cells will have no locality mapping.
             for region in regions:
-                localities.add(Locality(name=region.name, cells=frozenset([region.name])))
+                localities.add(
+                    Locality(
+                        name=region.name,
+                        category=region.category,
+                        cells=frozenset([region.name]),
+                        visible=region.visible,
+                    )
+                )
 
         return RegionDirectory(regions, localities)
     except RegionConfigurationError as e:
@@ -302,8 +325,8 @@ def get_global_directory() -> RegionDirectory:
     return _global_regions
 
 
-def get_region_by_name(name: str) -> Region:
-    """Look up a region by name."""
+def get_cell_by_name(name: str) -> Region:
+    """Look up a cell by name."""
     global_regions = get_global_directory()
     region = global_regions.get_by_name(name)
     if region is not None:
@@ -311,9 +334,27 @@ def get_region_by_name(name: str) -> Region:
     else:
         region_names = list(global_regions.get_region_names(RegionCategory.MULTI_TENANT))
         raise RegionResolutionError(
-            f"No region with name: {name!r} "
+            f"No cell with name: {name!r} "
             f"(expected one of {region_names!r} or a single-tenant name)"
         )
+
+
+def get_locality_by_name(name: str) -> Locality:
+    """Look up a locality by name."""
+    global_regions = get_global_directory()
+    locality = global_regions.get_locality_by_name(name)
+    if locality is not None:
+        return locality
+    else:
+        locality_names = [loc.name for loc in global_regions.localities]
+        raise RegionResolutionError(
+            f"No locality with name: {name!r} (expected one of {locality_names!r})"
+        )
+
+
+def get_region_by_name(name: str) -> Region:
+    """Deprecated. Use get_cell_by_name."""
+    return get_cell_by_name(name)
 
 
 def is_region_name(name: str) -> bool:
@@ -438,6 +479,17 @@ def find_all_multitenant_region_names() -> list[str]:
     """
     regions = get_global_directory().get_regions(RegionCategory.MULTI_TENANT)
     return list([r.name for r in regions if r.visible])
+
+
+def find_all_multitenant_locality_names() -> list[str]:
+    """
+    Return all visible multi-tenant localities.
+    """
+    return [
+        loc.name
+        for loc in get_global_directory().localities
+        if loc.category == RegionCategory.MULTI_TENANT and loc.visible
+    ]
 
 
 def find_all_region_addresses() -> Iterable[str]:


### PR DESCRIPTION
this is the next step in splitting the "region" into distinct locality and cell concepts

- add category, visible, to_url() and api_serialize() to locality
- api_serialize() is removed from cell since it shouldn't be serialized or returned in API responses (it's internal only)
- category will be removed from cell in a later step - right now it's needed as is it inherited from here for the synthetic 1:1 locality fallback
- update the UserRegionsEndpoint to return locality not cell
- update the client config used to bootstrap the frontend app with localities

