### PR TITLE
fix(issues): Fix possibly-undefined variables across issues module

### DIFF
--- a/src/sentry/issues/ignored.py
+++ b/src/sentry/issues/ignored.py
@@ -138,6 +138,7 @@ def handle_ignored(
             Group.objects.filter(id=group.id, status=GroupStatus.UNRESOLVED).update(
                 substatus=GroupSubStatus.UNTIL_CONDITION_MET, status=GroupStatus.IGNORED
             )
+            serialized_user = None
             with in_test_hide_transaction_boundary():
                 if acting_user:
                     serialized_user = user_service.serialize_many(

--- a/src/sentry/issues/status_change_consumer.py
+++ b/src/sentry/issues/status_change_consumer.py
@@ -106,7 +106,6 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
         # Update the group status, priority, and add the group to the inbox
         manage_issue_states(group=group, group_inbox_reason=GroupInboxReason.ESCALATING)
     elif new_status == GroupStatus.UNRESOLVED:
-        activity_type = None
         if new_substatus == GroupSubStatus.REGRESSED:
             activity_type = ActivityType.SET_REGRESSION
             group_inbox_reason = GroupInboxReason.REGRESSION
@@ -119,9 +118,9 @@ def update_status(group: Group, status_change: StatusChangeMessageData) -> None:
             else:
                 activity_type = ActivityType.SET_UNRESOLVED
 
-        # We don't support setting the UNRESOLVED status with substatus NEW as it
-        # is automatically set on creation. All other issues should be set to ONGOING.
-        if activity_type is None:
+        else:
+            # We don't support setting the UNRESOLVED status with substatus NEW as it
+            # is automatically set on creation. All other issues should be set to ONGOING.
             logger.error(
                 "group.update_status.invalid_substatus",
                 extra={**log_extra},


### PR DESCRIPTION
silencing a few warnings in the `src/sentry/issues` folder from `--enable-error-code possibly-undefined`

- ignored.py: initialize serialized_user = None before the in_test_hide_transaction_boundary block so it's always defined at the actor= assignment, regardless of acting_user
- status_change_consumer.py: replace activity_type = None sentinel with an explicit else: return, making group_inbox_reason always defined when update_group_status is called
- organization_group_search_views.py: annotate createdBy as Literal["me", "others"] and add else: raise so starred_query and non_starred_query are always defined before paginate()
