### PR TITLE
chore(ACI): Replace usage of legacy code to populate conditions data in WorkflowEngineRuleSerializer

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -29,6 +29,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
+from sentry.workflow_engine.models.data_condition import is_slow_condition
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -425,12 +426,26 @@ class WorkflowEngineRuleSerializer(Serializer):
         all_filters: list[dict[str, Any]] = []
 
         def update_condition_name(
-            condition_data: dict[str, Any], condition_type: str
+            condition_data: dict[str, Any], condition: DataCondition
         ) -> dict[str, Any]:
-            try:
-                handler = condition_handler_registry.get(condition_type)
-            except NoRegistrationExistsError:
-                raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
+            from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
+                slow_condition_query_handler_registry,
+            )
+
+            # TODO - I think I need to map the condition_data["id"] e.g. 'sentry.rules.filters.tagged_event.TaggedEventFilter'
+            # or 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions' to the condition type
+            # to look up the registry
+
+            if is_slow_condition(condition):
+                try:
+                    handler = slow_condition_query_handler_registry.get(condition.type)
+                except NoRegistrationExistsError:
+                    raise serializers.ValidationError(f"Invalid condition type: {condition.type}")
+            else:
+                try:
+                    handler = condition_handler_registry.get(condition.type)
+                except NoRegistrationExistsError:
+                    raise serializers.ValidationError(f"Invalid condition type: {condition.type}")
 
             condition_data["name"] = handler.render_label(condition_data)
             return condition_data
@@ -439,8 +454,8 @@ class WorkflowEngineRuleSerializer(Serializer):
             for cond in conditions:
                 condition, filters = translate_to_rule_condition_filters(cond, is_filter=is_filter)
                 if condition:
-                    all_conditions.append(update_condition_name(condition, cond.type))
-                all_filters.extend([update_condition_name(f, cond.type) for f in filters])
+                    all_conditions.append(update_condition_name(condition, cond))
+                all_filters.extend([update_condition_name(f, cond) for f in filters])
 
         trigger_conditions = (
             list(workflow.when_condition_group.conditions.all())

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -429,11 +429,14 @@ class WorkflowEngineRuleSerializer(Serializer):
             condition_data: dict[str, Any], is_slow_condition: bool = False
         ) -> dict[str, Any]:
             from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
+                BaseEventFrequencyQueryHandler,
                 slow_condition_query_handler_registry,
             )
+            from sentry.workflow_engine.types import DataConditionHandler
 
             condition_type = condition_data.pop("condition_type", None)
 
+            handler: type[BaseEventFrequencyQueryHandler] | type[DataConditionHandler[Any]]
             if is_slow_condition:
                 try:
                     handler = slow_condition_query_handler_registry.get(condition_type)

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -426,36 +426,38 @@ class WorkflowEngineRuleSerializer(Serializer):
         all_filters: list[dict[str, Any]] = []
 
         def update_condition_name(
-            condition_data: dict[str, Any], condition: DataCondition
+            condition_data: dict[str, Any], is_slow_condition: bool = False
         ) -> dict[str, Any]:
             from sentry.workflow_engine.handlers.condition.event_frequency_query_handlers import (
                 slow_condition_query_handler_registry,
             )
 
-            # TODO - I think I need to map the condition_data["id"] e.g. 'sentry.rules.filters.tagged_event.TaggedEventFilter'
-            # or 'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions' to the condition type
-            # to look up the registry
+            condition_type = condition_data.pop("condition_type", None)
 
-            if is_slow_condition(condition):
+            if is_slow_condition:
                 try:
-                    handler = slow_condition_query_handler_registry.get(condition.type)
+                    handler = slow_condition_query_handler_registry.get(condition_type)
                 except NoRegistrationExistsError:
-                    raise serializers.ValidationError(f"Invalid condition type: {condition.type}")
+                    raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
             else:
                 try:
-                    handler = condition_handler_registry.get(condition.type)
+                    handler = condition_handler_registry.get(condition_type)
                 except NoRegistrationExistsError:
-                    raise serializers.ValidationError(f"Invalid condition type: {condition.type}")
+                    raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
 
             condition_data["name"] = handler.render_label(condition_data)
             return condition_data
 
         def generate_condition_filters(conditions: list[DataCondition], is_filter: bool):
             for cond in conditions:
-                condition, filters = translate_to_rule_condition_filters(cond, is_filter=is_filter)
-                if condition:
-                    all_conditions.append(update_condition_name(condition, cond))
-                all_filters.extend([update_condition_name(f, cond) for f in filters])
+                condition_data, filters = translate_to_rule_condition_filters(
+                    cond, is_filter=is_filter
+                )
+                if condition_data.get("id"):
+                    all_conditions.append(
+                        update_condition_name(condition_data, is_slow_condition(cond))
+                    )
+                all_filters.extend([update_condition_name(f) for f in filters])
 
         trigger_conditions = (
             list(workflow.when_condition_group.conditions.all())

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -419,6 +419,7 @@ class WorkflowEngineRuleSerializer(Serializer):
         self, workflow: Workflow, project: Project, workflow_dcg: WorkflowDataConditionGroup
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         from sentry.workflow_engine.migration_helpers.rule_conditions import (
+            FILTER_ID_TO_CONDITION_TYPE_MAPPING,
             translate_to_rule_condition_filters,
         )
 
@@ -457,9 +458,13 @@ class WorkflowEngineRuleSerializer(Serializer):
                     cond, is_filter=is_filter
                 )
                 if condition_data.get("id"):
+                    condition_data["condition_type"] = cond.type
                     all_conditions.append(
                         update_condition_name(condition_data, is_slow_condition(cond))
                     )
+                for f in filters:
+                    f["condition_type"] = FILTER_ID_TO_CONDITION_TYPE_MAPPING[f["id"]]
+
                 all_filters.extend([update_condition_name(f) for f in filters])
 
         trigger_conditions = (

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -20,6 +20,7 @@ from sentry.sentry_apps.models.sentry_app_installation import prepare_ui_compone
 from sentry.sentry_apps.services.app.model import RpcSentryAppComponentContext
 from sentry.users.services.user import RpcUser
 from sentry.users.services.user.service import user_service
+from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleWorkflow,
@@ -30,6 +31,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.processors.workflow_fire_history import get_last_fired_dates
+from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
@@ -422,16 +424,23 @@ class WorkflowEngineRuleSerializer(Serializer):
         all_conditions: list[dict[str, Any]] = []
         all_filters: list[dict[str, Any]] = []
 
-        def update_condition_name(condition: dict[str, Any]) -> dict[str, Any]:
-            condition["name"] = generate_rule_label(project=project, rule=None, data=condition)
-            return condition
+        def update_condition_name(
+            condition_data: dict[str, Any], condition_type: str
+        ) -> dict[str, Any]:
+            try:
+                handler = condition_handler_registry.get(condition_type)
+            except NoRegistrationExistsError:
+                raise serializers.ValidationError(f"Invalid condition type: {condition_type}")
+
+            condition_data["name"] = handler.render_label(condition_data)
+            return condition_data
 
         def generate_condition_filters(conditions: list[DataCondition], is_filter: bool):
             for cond in conditions:
                 condition, filters = translate_to_rule_condition_filters(cond, is_filter=is_filter)
                 if condition:
-                    all_conditions.append(update_condition_name(condition))
-                all_filters.extend([update_condition_name(f) for f in filters])
+                    all_conditions.append(update_condition_name(condition, cond.type))
+                all_filters.extend([update_condition_name(f, cond.type) for f in filters])
 
         trigger_conditions = (
             list(workflow.when_condition_group.conditions.all())

--- a/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/age_comparison_handler.py
@@ -16,6 +16,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class AgeComparisonConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+    label_template = "The issue is {comparison_type} than {value} {time}"
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -62,17 +62,24 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
 
     @classmethod
     def render_label(cls, condition_data: dict[str, Any]) -> str:
-        target_type = AssigneeTargetType(condition_data.get("targetType"))
-        target_identifer = condition_data.get("targetIdentifier")
-        if target_type == AssigneeTargetType.TEAM:
+        target_type: str | None = condition_data.get("targetType")
+        if target_type is None:
+            return cls.label_template.format(**condition_data)
+        assignee_target_type = AssigneeTargetType(target_type)
+        target_identifer: str | None = condition_data.get("targetIdentifier")
+        if assignee_target_type == AssigneeTargetType.TEAM:
+            if target_identifer is None:
+                return cls.label_template.format(**condition_data)
             try:
                 team = Team.objects.get(id=target_identifer)
             except Team.DoesNotExist:
                 return cls.label_template.format(**condition_data)
             return cls.label_template.format(targetType=f"team #{team.slug}")
 
-        elif target_type == AssigneeTargetType.MEMBER:
-            user = user_service.get_user(user_id=target_identifer)
+        elif assignee_target_type == AssigneeTargetType.MEMBER:
+            if target_identifer is None:
+                return cls.label_template.format(**condition_data)
+            user = user_service.get_user(user_id=int(target_identifer))
             if user is not None:
                 return cls.label_template.format(targetType=user.username)
             else:

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -79,7 +79,11 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
         elif assignee_target_type == AssigneeTargetType.MEMBER:
             if target_identifer is None:
                 return cls.label_template.format(**condition_data)
-            user = user_service.get_user(user_id=int(target_identifer))
+            try:
+                user = user_service.get_user(user_id=int(target_identifer))
+            except (ValueError, TypeError):
+                return cls.label_template.format(**condition_data)
+
             if user is not None:
                 return cls.label_template.format(targetType=user.username)
             else:

--- a/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/assigned_to_handler.py
@@ -3,7 +3,9 @@ from typing import Any
 
 from sentry.models.group import Group
 from sentry.models.groupassignee import GroupAssignee
+from sentry.models.team import Team
 from sentry.notifications.types import AssigneeTargetType
+from sentry.users.services.user.service import user_service
 from sentry.utils.cache import cache
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -14,6 +16,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+    label_template = "The issue is assigned to {targetType}"
 
     comparison_json_schema = {
         "type": "object",
@@ -56,3 +59,23 @@ class AssignedToConditionHandler(DataConditionHandler[WorkflowEventData]):
             return any(assignee.team_id and assignee.team_id == target_id for assignee in assignees)
         elif target_type == AssigneeTargetType.MEMBER:
             return any(assignee.user_id and assignee.user_id == target_id for assignee in assignees)
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        target_type = AssigneeTargetType(condition_data.get("targetType"))
+        target_identifer = condition_data.get("targetIdentifier")
+        if target_type == AssigneeTargetType.TEAM:
+            try:
+                team = Team.objects.get(id=target_identifer)
+            except Team.DoesNotExist:
+                return cls.label_template.format(**condition_data)
+            return cls.label_template.format(targetType=f"team #{team.slug}")
+
+        elif target_type == AssigneeTargetType.MEMBER:
+            user = user_service.get_user(user_id=target_identifer)
+            if user is not None:
+                return cls.label_template.format(targetType=user.username)
+            else:
+                return cls.label_template.format(**condition_data)
+
+        return cls.label_template.format(**condition_data)

--- a/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_attribute_handler.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import sentry_sdk
 
-from sentry.rules import MatchType, match_values
+from sentry.rules import MATCH_CHOICES, MatchType, match_values
 from sentry.rules.conditions.event_attribute import ATTR_CHOICES, attribute_registry
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils.registry import NoRegistrationExistsError
@@ -15,6 +15,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
+    label_template = "The event's {attribute} value {match} {value}"
 
     comparison_json_schema = {
         "type": "object",
@@ -101,3 +102,12 @@ class EventAttributeConditionHandler(DataConditionHandler[WorkflowEventData]):
         return match_values(
             group_values=attribute_values, match_value=desired_value, match_type=match
         )
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        data = {
+            "attribute": condition_data["attribute"],
+            "value": condition_data["value"],
+            "match": MATCH_CHOICES[condition_data["match"]],
+        }
+        return cls.label_template.format(**data)

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_handlers.py
@@ -22,6 +22,7 @@ from sentry.workflow_engine.types import DataConditionHandler, DataConditionResu
 class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.FREQUENCY
+    label_template = "The issue is seen more than {value} times in {interval}"
 
     comparison_json_schema = {
         "type": "object",
@@ -54,6 +55,7 @@ class EventFrequencyCountHandler(DataConditionHandler[list[int]]):
 class EventFrequencyPercentHandler(DataConditionHandler[list[int]]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.FREQUENCY
+    label_template = "The issue is seen more than {value} times in {interval}"
 
     comparison_json_schema = {
         "type": "object",
@@ -87,6 +89,7 @@ class EventFrequencyPercentHandler(DataConditionHandler[list[int]]):
 class PercentSessionsCountHandler(EventFrequencyCountHandler):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.FREQUENCY
+    label_template = "The issue affects more than {value} percent of sessions in {interval}"
     comparison_json_schema = {
         "type": "object",
         "properties": {
@@ -112,6 +115,7 @@ class PercentSessionsCountHandler(EventFrequencyCountHandler):
 class PercentSessionsPercentHandler(EventFrequencyPercentHandler):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.FREQUENCY
+    label_template = "The issue affects more than {value} percent of sessions in {interval}"
     comparison_json_schema = {
         "type": "object",
         "properties": {

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -326,6 +326,8 @@ slow_condition_query_handler_registry = Registry[type[BaseEventFrequencyQueryHan
 @slow_condition_query_handler_registry.register(Condition.EVENT_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_FREQUENCY_PERCENT)
 class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
+    label_template = "The issue is seen more than {value} times in {interval}"
+
     def batch_query(
         self,
         groups: list[GroupValues],
@@ -372,6 +374,8 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
+    label_template = "The issue is seen by more than {value} users in {interval}"
+
     def batch_query(
         self,
         groups: list[GroupValues],
@@ -415,6 +419,7 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.PERCENT_SESSIONS_PERCENT)
 class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = PERCENT_INTERVALS
+    label_template = "The issue affects more than {value} percent of sessions in {interval}"
 
     def get_session_count(
         self, project_id: int, environment_id: int | None, start: datetime, end: datetime

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -70,6 +70,10 @@ class InvalidFilter(Exception):
 class BaseEventFrequencyQueryHandler(ABC):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
 
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]):
+        return cls.label_template.format(**condition_data)
+
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:
         """
         Calculate the start and end times for the query.
@@ -374,7 +378,7 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
-    label_template = "The issue is seen by more than {value} users in {interval}"
+    label_template = "The issue is seen by more than {value} users in {interval} with conditions"
 
     def batch_query(
         self,

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -379,7 +379,20 @@ class EventFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT)
 @slow_condition_query_handler_registry.register(Condition.EVENT_UNIQUE_USER_FREQUENCY_PERCENT)
 class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
-    label_template = "The issue is seen by more than {value} users in {interval} with conditions"
+    label_template = "The issue is seen by more than {value} users in {interval}"
+    label_template_with_conditions = (
+        "The issue is seen by more than {value} users in {interval} with conditions"
+    )
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        from sentry.rules.conditions.event_frequency import (
+            EventUniqueUserFrequencyConditionWithConditions,
+        )
+
+        if condition_data.get("id") == EventUniqueUserFrequencyConditionWithConditions.id:
+            return cls.label_template_with_conditions.format(**condition_data)
+        return cls.label_template.format(**condition_data)
 
     def batch_query(
         self,
@@ -425,6 +438,14 @@ class EventUniqueUserFrequencyQueryHandler(BaseEventFrequencyQueryHandler):
 class PercentSessionsQueryHandler(BaseEventFrequencyQueryHandler):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = PERCENT_INTERVALS
     label_template = "The issue affects more than {value} percent of sessions in {interval}"
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        data = dict(condition_data)
+        value = data.get("value")
+        if isinstance(value, float) and value.is_integer():
+            data["value"] = int(value)
+        return cls.label_template.format(**data)
 
     def get_session_count(
         self, project_id: int, environment_id: int | None, start: datetime, end: datetime

--- a/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
+++ b/src/sentry/workflow_engine/handlers/condition/event_frequency_query_handlers.py
@@ -69,9 +69,10 @@ class InvalidFilter(Exception):
 
 class BaseEventFrequencyQueryHandler(ABC):
     intervals: ClassVar[dict[str, tuple[str, timedelta]]] = STANDARD_INTERVALS
+    label_template = ""
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]):
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
         return cls.label_template.format(**condition_data)
 
     def get_query_window(self, end: datetime, duration: timedelta) -> tuple[datetime, datetime]:

--- a/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/existing_high_priority_issue_handler.py
@@ -10,6 +10,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class ExistingHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
+    label_template = "Sentry marks an existing issue as high priority"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/first_seen_event_handler.py
@@ -20,6 +20,7 @@ def is_new_event(event_data: WorkflowEventData) -> bool:
 class FirstSeenEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
+    label_template = "A new issue is created"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -10,6 +10,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+    label_template = "The issue's category is {include} {value}"
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -1,9 +1,13 @@
+from collections import OrderedDict
 from typing import Any
 
 from sentry.issues.grouptype import GroupCategory
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).lower()) for gc in GroupCategory])
+INCLUDE_CHOICES = OrderedDict([("true", "equal to"), ("false", "not equal to")])
 
 
 @condition_handler_registry.register(Condition.ISSUE_CATEGORY)
@@ -43,3 +47,11 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
             return bool(value == issue_category or value == issue_category_v2)
 
         return bool(value != issue_category and value != issue_category_v2)
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        value = condition_data["value"]
+        title = CATEGORY_CHOICES.get(value)
+        group_category_name = title.title() if title else ""
+        include_label = INCLUDE_CHOICES.get(condition_data.get("include", "true"), "equal to")
+        return cls.label_template.format(include=include_label, value=group_category_name)

--- a/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_occurrences_handler.py
@@ -10,6 +10,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class IssueOccurrencesConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+    label_template = "The issue has happened at least {value} times"
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
@@ -70,4 +70,4 @@ class IssueTypeConditionHandler(DataConditionHandler[WorkflowEventData]):
         title = TYPE_CHOICES.get(value)
         issue_type_name = title if title else ""
         include_label = INCLUDE_CHOICES.get(condition_data.get("include", "true"), "equal to")
-        return cls.label.format(include=include_label, value=issue_type_name)
+        return cls.label_template.format(include=include_label, value=issue_type_name)

--- a/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_type_handler.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import Any
 
 from django.utils.functional import classproperty
@@ -8,6 +9,22 @@ from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 
 
+def get_type_choices() -> OrderedDict[str, str]:
+    """Generate choices from all registered group types."""
+    type_choices = OrderedDict()
+    for group_type_cls in grouptype.registry.all():
+        if not group_type_cls.released:
+            continue
+        # Use slug as key, description for display
+        display_name = getattr(group_type_cls, "description", None) or group_type_cls.slug
+        type_choices[group_type_cls.slug] = display_name
+    return type_choices
+
+
+TYPE_CHOICES = get_type_choices()
+INCLUDE_CHOICES = OrderedDict([("true", "equal to"), ("false", "not equal to")])
+
+
 def get_all_valid_type_slugs() -> list[str]:
     return list(gt.slug for gt in grouptype.registry.all())
 
@@ -16,6 +33,7 @@ def get_all_valid_type_slugs() -> list[str]:
 class IssueTypeConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.ISSUE_ATTRIBUTES
+    label_template = "The issue's type is {include} {value}"
 
     @classproperty
     def comparison_json_schema(cls) -> dict[str, Any]:
@@ -45,3 +63,11 @@ class IssueTypeConditionHandler(DataConditionHandler[WorkflowEventData]):
         include = comparison.get("include", True)
 
         return group.issue_type == value if include else group.issue_type != value
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        value = condition_data["value"]
+        title = TYPE_CHOICES.get(value)
+        issue_type_name = title if title else ""
+        include_label = INCLUDE_CHOICES.get(condition_data.get("include", "true"), "equal to")
+        return cls.label.format(include=include_label, value=issue_type_name)

--- a/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_adopted_release_handler.py
@@ -21,6 +21,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class LatestAdoptedReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
+    label_template = "The {oldest_or_newest} release associated with the event's issue is {older_or_newer} than the latest adopted release in {environment}"
 
     comparison_json_schema = {
         "type": "object",

--- a/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/latest_release_handler.py
@@ -124,6 +124,7 @@ class LatestReleaseConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
     comparison_json_schema = {"type": "boolean"}
+    label_template = "The event is from the latest release"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable
 
 from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
-from sentry.rules import MATCH_CHOICES, MatchType
+from sentry.rules import LEVEL_MATCH_CHOICES, MatchType
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -61,6 +61,6 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     def render_label(cls, condition_data: dict[str, Any]) -> str:
         data = {
             "level": LEVEL_CHOICES[condition_data["level"]],
-            "match": MATCH_CHOICES[condition_data["match"]],
+            "match": LEVEL_MATCH_CHOICES[condition_data["match"]],
         }
         return cls.label_template.format(**data)

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -1,11 +1,14 @@
-from typing import Any
+from typing import Any, Callable
 
-from sentry.constants import LOG_LEVELS_MAP
+from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
 from sentry.rules import MATCH_CHOICES, MatchType
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
+
+key: Callable[[tuple[int, str]], int] = lambda x: x[0]
+LEVEL_CHOICES = {f"{k}": v for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)}
 
 
 @condition_handler_registry.register(Condition.LEVEL)
@@ -57,7 +60,7 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     @classmethod
     def render_label(cls, condition_data: dict[str, Any]) -> str:
         data = {
-            "level": condition_data["level"],
+            "level": LEVEL_CHOICES[condition_data["level"]],
             "match": MATCH_CHOICES[condition_data["match"]],
         }
         return cls.label_template.format(**data)

--- a/src/sentry/workflow_engine/handlers/condition/level_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/level_handler.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry.constants import LOG_LEVELS_MAP
-from sentry.rules import MatchType
+from sentry.rules import MATCH_CHOICES, MatchType
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -12,6 +12,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
+    label_template = "The event's level is {match} {level}"
 
     comparison_json_schema = {
         "type": "object",
@@ -52,3 +53,11 @@ class LevelConditionHandler(DataConditionHandler[WorkflowEventData]):
         elif desired_match == MatchType.LESS_OR_EQUAL:
             return level <= desired_level
         return False
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        data = {
+            "level": condition_data["level"],
+            "match": MATCH_CHOICES[condition_data["match"]],
+        }
+        return cls.label_template.format(**data)

--- a/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/new_high_priority_issue_handler.py
@@ -11,6 +11,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class NewHighPriorityIssueConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
+    label_template = "Sentry marks a new issue as high priority"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/reappeared_event_handler.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class ReappearedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
+    label_template = "The issue changes state from archived to escalating"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/regression_event_handler.py
@@ -9,6 +9,7 @@ from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
 class RegressionEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.WORKFLOW_TRIGGER
     comparison_json_schema = {"type": "boolean"}
+    label_template = "The issue changes state from resolved to unresolved"
 
     @staticmethod
     def evaluate_value(event_data: WorkflowEventData, comparison: Any) -> bool:

--- a/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/tagged_event_handler.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from sentry import tagstore
-from sentry.rules import MatchType, match_values
+from sentry.rules import MATCH_CHOICES, MatchType, match_values
 from sentry.services.eventstore.models import GroupEvent
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
@@ -15,6 +15,7 @@ logger = log_context.get_logger(__name__)
 class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
     group = DataConditionHandler.Group.ACTION_FILTER
     subgroup = DataConditionHandler.Subgroup.EVENT_ATTRIBUTES
+    label_template = "The event's tags match {key} {match} {value}"
 
     comparison_json_schema = {
         "type": "object",
@@ -107,3 +108,12 @@ class TaggedEventConditionHandler(DataConditionHandler[WorkflowEventData]):
         )
 
         return result
+
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
+        data = {
+            "key": condition_data["key"],
+            "value": condition_data["value"],
+            "match": MATCH_CHOICES[condition_data["match"]],
+        }
+        return cls.label_template.format(**data)

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -317,7 +317,7 @@ data_condition_to_rule_condition_mapping = {
     Condition.PERCENT_SESSIONS_COUNT: create_percent_sessions_condition,
     Condition.PERCENT_SESSIONS_PERCENT: create_percent_sessions_condition,
 }
-filter_id_to_condition_type_mapping = {
+FILTER_ID_TO_CONDITION_TYPE_MAPPING = {
     TaggedEventFilter.id: Condition.TAGGED_EVENT.value,
     EventAttributeFilter.id: Condition.EVENT_ATTRIBUTE.value,
     AgeComparisonFilter.id: Condition.AGE_COMPARISON.value,
@@ -338,10 +338,4 @@ def translate_to_rule_condition_filters(
     if not translator:
         raise ValueError(f"Unsupported condition: {data_condition.type}")
 
-    condition_data, filters = translator(data_condition, is_filter)
-    condition_data["condition_type"] = data_condition.type
-
-    for f in filters:
-        f["condition_type"] = filter_id_to_condition_type_mapping[f["id"]]
-
-    return condition_data, filters
+    return translator(data_condition, is_filter)

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -97,7 +97,6 @@ def create_tagged_event_condition(
         "value": data_condition.comparison.get("value", ""),
         "key": data_condition.comparison["key"],
     }
-
     if is_filter:
         return {}, [payload]
 

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -201,7 +201,9 @@ def create_base_event_frequency_condition(
     payload = {
         "id": id,
         "comparisonType": (
-            ComparisonType.COUNT if data_condition.type == count_type else ComparisonType.PERCENT
+            ComparisonType.COUNT.value
+            if data_condition.type == count_type
+            else ComparisonType.PERCENT.value
         ),
         "interval": data_condition.comparison["interval"],
         "value": data_condition.comparison["value"],
@@ -239,13 +241,13 @@ def create_event_unique_user_frequency_condition(
     data_condition: DataCondition, is_filter: bool = False
 ) -> ConditionAndFilters:
     filters: list[dict[str, Any]] = []
-    if data_condition.comparison.get("filters"):
+    if data_condition.comparison.get("filters") is not None:
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions",
             "comparisonType": (
-                ComparisonType.COUNT
+                ComparisonType.COUNT.value
                 if data_condition.type == Condition.EVENT_UNIQUE_USER_FREQUENCY_COUNT
-                else ComparisonType.PERCENT
+                else ComparisonType.PERCENT.value
             ),
             "interval": data_condition.comparison["interval"],
             "value": data_condition.comparison["value"],

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -97,6 +97,7 @@ def create_tagged_event_condition(
         "value": data_condition.comparison.get("value", ""),
         "key": data_condition.comparison["key"],
     }
+
     if is_filter:
         return {}, [payload]
 

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -1,6 +1,16 @@
 from typing import Any
 
 from sentry.rules.conditions.event_frequency import ComparisonType
+from sentry.rules.filters.age_comparison import AgeComparisonFilter
+from sentry.rules.filters.assigned_to import AssignedToFilter
+from sentry.rules.filters.event_attribute import EventAttributeFilter
+from sentry.rules.filters.issue_category import IssueCategoryFilter
+from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
+from sentry.rules.filters.issue_type import IssueTypeFilter
+from sentry.rules.filters.latest_adopted_release_filter import LatestAdoptedReleaseFilter
+from sentry.rules.filters.latest_release import LatestReleaseFilter
+from sentry.rules.filters.level import LevelFilter
+from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 
 ConditionAndFilters = tuple[dict[str, Any], list[dict[str, Any]]]
@@ -135,7 +145,7 @@ def create_issue_category_filter(
 ) -> ConditionAndFilters:
     payload: dict[str, Any] = {
         "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
-        "value": data_condition.comparison["value"],
+        "value": str(data_condition.comparison["value"]),
     }
     include = data_condition.comparison.get("include")
     if isinstance(include, bool):
@@ -164,7 +174,7 @@ def create_issue_occurrences_filter(
     return {}, [
         {
             "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
-            "value": data_condition.comparison["value"],
+            "value": str(data_condition.comparison["value"]),
         }
     ]
 
@@ -241,7 +251,7 @@ def create_event_unique_user_frequency_condition(
     data_condition: DataCondition, is_filter: bool = False
 ) -> ConditionAndFilters:
     filters: list[dict[str, Any]] = []
-    if data_condition.comparison.get("filters") is not None:
+    if data_condition.comparison.get("filters"):
         condition = {
             "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions",
             "comparisonType": (
@@ -307,6 +317,18 @@ data_condition_to_rule_condition_mapping = {
     Condition.PERCENT_SESSIONS_COUNT: create_percent_sessions_condition,
     Condition.PERCENT_SESSIONS_PERCENT: create_percent_sessions_condition,
 }
+filter_id_to_condition_type_mapping = {
+    TaggedEventFilter.id: Condition.TAGGED_EVENT.value,
+    EventAttributeFilter.id: Condition.EVENT_ATTRIBUTE.value,
+    AgeComparisonFilter.id: Condition.AGE_COMPARISON.value,
+    AssignedToFilter.id: Condition.ASSIGNED_TO.value,
+    IssueCategoryFilter.id: Condition.ISSUE_CATEGORY.value,
+    IssueOccurrencesFilter.id: Condition.ISSUE_OCCURRENCES.value,
+    IssueTypeFilter.id: Condition.ISSUE_TYPE.value,
+    LatestAdoptedReleaseFilter.id: Condition.LATEST_ADOPTED_RELEASE.value,
+    LatestReleaseFilter.id: Condition.LATEST_RELEASE.value,
+    LevelFilter.id: Condition.LEVEL.value,
+}
 
 
 def translate_to_rule_condition_filters(
@@ -316,4 +338,10 @@ def translate_to_rule_condition_filters(
     if not translator:
         raise ValueError(f"Unsupported condition: {data_condition.type}")
 
-    return translator(data_condition, is_filter)
+    condition_data, filters = translator(data_condition, is_filter)
+    condition_data["condition_type"] = data_condition.type
+
+    for f in filters:
+        f["condition_type"] = filter_id_to_condition_type_mapping[f["id"]]
+
+    return condition_data, filters

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -363,6 +363,7 @@ class DataConditionHandler(Generic[T]):
     subgroup: ClassVar[Subgroup]
     comparison_json_schema: ClassVar[dict[str, Any]] = {}
     condition_result_schema: ClassVar[dict[str, Any]] = {}
+    label_template = ""
 
     @staticmethod
     def evaluate_value(value: T, comparison: Any) -> DataConditionResult:
@@ -374,7 +375,7 @@ class DataConditionHandler(Generic[T]):
         raise NotImplementedError
 
     @classmethod
-    def render_label(cls, condition_data: dict[str, Any]):
+    def render_label(cls, condition_data: dict[str, Any]) -> str:
         return cls.label_template.format(**condition_data)
 
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -373,6 +373,10 @@ class DataConditionHandler(Generic[T]):
         """
         raise NotImplementedError
 
+    @classmethod
+    def render_label(cls, condition_data: dict[str, Any]):
+        return cls.label_template.format(**condition_data)
+
 
 class DataConditionType(TypedDict):
     id: int | None

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -9,7 +9,17 @@ from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRul
 from sentry.integrations.models import OrganizationIntegration
 from sentry.integrations.pagerduty.utils import add_service
 from sentry.models.rulefirehistory import RuleFireHistory
-from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
+from sentry.rules.conditions.event_attribute import EventAttributeCondition
+from sentry.rules.conditions.event_frequency import (
+    EventFrequencyCondition,
+    EventFrequencyPercentCondition,
+    EventUniqueUserFrequencyCondition,
+    EventUniqueUserFrequencyConditionWithConditions,
+)
+from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
+from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
+from sentry.rules.conditions.level import LevelCondition
+from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssueCondition
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
 from sentry.rules.conditions.regression_event import RegressionEventCondition
 from sentry.rules.conditions.tagged_event import TaggedEventCondition
@@ -450,6 +460,69 @@ class WorkflowRuleSerializerTest(TestCase):
             include_workflow_id=False,
         )
 
+        self.assert_equal_serializers(issue_alert)
+
+    def test_every_condition(self) -> None:
+        conditions = [
+            {"id": ExistingHighPriorityIssueCondition.id},
+            {"id": NewHighPriorityIssueCondition.id},
+            {"id": FirstSeenEventCondition.id},
+            {"id": LevelCondition.id, "match": "eq", "level": "50"},
+            {
+                "id": EventAttributeCondition.id,
+                "attribute": "message",
+                "match": "eq",
+                "value": "test",
+            },
+            {
+                "id": EventFrequencyCondition.id,
+                "interval": "1h",
+                "value": 100,
+                "comparisonType": "count",
+            },
+            {
+                "id": EventFrequencyCondition.id,
+                "interval": "1h",
+                "value": 50,
+                "comparisonType": "percent",
+                "comparisonInterval": "1d",
+            },
+            {
+                "id": EventUniqueUserFrequencyCondition.id,
+                "interval": "1h",
+                "value": 50,
+                "comparisonType": "count",
+            },
+            {
+                "id": EventUniqueUserFrequencyCondition.id,
+                "interval": "1h",
+                "value": 50,
+                "comparisonType": "percent",
+                "comparisonInterval": "1d",
+            },
+            {
+                "id": EventFrequencyPercentCondition.id,
+                "interval": "1h",
+                "value": 50,
+                "comparisonType": "count",
+            },
+            {
+                "id": EventFrequencyPercentCondition.id,
+                "interval": "1h",
+                "value": 50,
+                "comparisonType": "percent",
+                "comparisonInterval": "1d",
+            },
+        ]
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=conditions + self.conditions,
+            action_match="all",
+            filter_match="all",
+            frequency=30,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
         self.assert_equal_serializers(issue_alert)
 
     def test_email_action_simple(self) -> None:

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -12,9 +12,15 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
 from sentry.rules.conditions.regression_event import RegressionEventCondition
-from sentry.rules.conditions.tagged_event import TaggedEventCondition
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
+from sentry.rules.filters.assigned_to import AssignedToFilter
 from sentry.rules.filters.event_attribute import EventAttributeFilter
+from sentry.rules.filters.issue_category import IssueCategoryFilter
+from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
+from sentry.rules.filters.issue_type import IssueTypeFilter
+from sentry.rules.filters.latest_adopted_release_filter import LatestAdoptedReleaseFilter
+from sentry.rules.filters.latest_release import LatestReleaseFilter
+from sentry.rules.filters.level import LevelFilter
 from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
@@ -87,7 +93,7 @@ class WorkflowRuleSerializerTest(TestCase):
         self.conditions = [
             {"id": ReappearedEventCondition.id},
             {"id": RegressionEventCondition.id},
-            {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
+            # {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
             {
                 "id": AgeComparisonFilter.id,
                 "comparison_type": "older",
@@ -343,6 +349,74 @@ class WorkflowRuleSerializerTest(TestCase):
         )
 
         self.assert_equal_serializers(issue_alert)
+
+    def test_every_filter(self) -> None:
+        filters = [
+            {
+                "id": TaggedEventFilter.id,
+                "match": "is",
+                "key": "environment",
+                "value": "",  # initializing RuleBase requires "value" key
+            },
+            # {
+            #     "id": EventAttributeFilter.id, # this one is already in self.conditions
+            #     "match": "eq",
+            #     "value": "hi",
+            #     "attribute": "message",
+            # },
+            {
+                "id": AgeComparisonFilter.id,
+                "comparison_type": "older",
+                "value": 10,
+                "time": "hour",
+            },
+            {
+                "id": AssignedToFilter.id,
+                "targetType": "Member",
+                "targetIdentifier": self.user.id,
+            },
+            {
+                "id": IssueCategoryFilter.id,
+                "value": "1",
+                "include": "true",
+            },
+            {
+                "id": IssueOccurrencesFilter.id,
+                "value": "10",
+            },
+            {
+                "id": IssueTypeFilter.id,
+                "value": "error",
+            },
+            {
+                "id": LatestAdoptedReleaseFilter.id,
+                "oldest_or_newest": "oldest",
+                "older_or_newer": "newer",
+                "environment": self.environment.name + "fake",
+            },
+            {
+                "id": LatestReleaseFilter.id,
+            },
+            {
+                "id": LevelFilter.id,
+                "match": "eq",
+                "level": "50",
+            },
+        ]
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=filters + self.conditions,
+            action_match="all",
+            filter_match="all",
+            frequency=30,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+
+        self.assert_equal_serializers(issue_alert)
+
+    def test_multiple_conditions_and_filters(self) -> None:
+        pass
 
     def test_email_action_simple(self) -> None:
         action_data = [

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -397,6 +397,12 @@ class WorkflowRuleSerializerTest(TestCase):
                 "match": "eq",
                 "level": "50",
             },
+            {
+                "attribute": "message",
+                "match": "ns",
+                "id": EventAttributeFilter.id,
+                "value": "",
+            },
         ]
         # self.conditions contains the remaining filters
         issue_alert = self.create_project_rule(

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -12,6 +12,7 @@ from sentry.models.rulefirehistory import RuleFireHistory
 from sentry.rules.conditions.event_frequency import EventUniqueUserFrequencyConditionWithConditions
 from sentry.rules.conditions.reappeared_event import ReappearedEventCondition
 from sentry.rules.conditions.regression_event import RegressionEventCondition
+from sentry.rules.conditions.tagged_event import TaggedEventCondition
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.rules.filters.assigned_to import AssignedToFilter
 from sentry.rules.filters.event_attribute import EventAttributeFilter
@@ -93,7 +94,7 @@ class WorkflowRuleSerializerTest(TestCase):
         self.conditions = [
             {"id": ReappearedEventCondition.id},
             {"id": RegressionEventCondition.id},
-            # {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
+            {"id": TaggedEventCondition.id, "key": "foo", "match": "eq", "value": "bar"},
             {
                 "id": AgeComparisonFilter.id,
                 "comparison_type": "older",
@@ -358,12 +359,6 @@ class WorkflowRuleSerializerTest(TestCase):
                 "key": "environment",
                 "value": "",  # initializing RuleBase requires "value" key
             },
-            # {
-            #     "id": EventAttributeFilter.id, # this one is already in self.conditions
-            #     "match": "eq",
-            #     "value": "hi",
-            #     "attribute": "message",
-            # },
             {
                 "id": AgeComparisonFilter.id,
                 "comparison_type": "older",
@@ -403,6 +398,7 @@ class WorkflowRuleSerializerTest(TestCase):
                 "level": "50",
             },
         ]
+        # self.conditions contains the remaining filters
         issue_alert = self.create_project_rule(
             name="test",
             condition_data=filters + self.conditions,
@@ -415,8 +411,40 @@ class WorkflowRuleSerializerTest(TestCase):
 
         self.assert_equal_serializers(issue_alert)
 
-    def test_multiple_conditions_and_filters(self) -> None:
-        pass
+    def test_no_conditions_multiple_filters(self) -> None:
+        filters = [
+            {
+                "id": TaggedEventFilter.id,
+                "match": "eq",
+                "key": "LOGGER",
+                "value": "sentry.example",
+            },
+            {
+                "id": AgeComparisonFilter.id,
+                "comparison_type": "older",
+                "value": 10,
+                "time": "hour",
+            },
+            {
+                "id": AssignedToFilter.id,
+                "targetType": "Member",
+                "targetIdentifier": self.user.id,
+            },
+            {
+                "id": LatestReleaseFilter.id,
+            },
+        ]
+        issue_alert = self.create_project_rule(
+            name="test",
+            condition_data=filters,
+            action_match="all",
+            filter_match="all",
+            frequency=30,
+            include_legacy_rule_id=False,
+            include_workflow_id=False,
+        )
+
+        self.assert_equal_serializers(issue_alert)
 
     def test_email_action_simple(self) -> None:
         action_data = [

--- a/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_rule_conditions.py
@@ -125,13 +125,13 @@ class RuleConditionTranslationTest(ConditionTestCase):
         self.assert_basic_filter_translated(payload)
 
     def test_issue_category(self) -> None:
-        payload = {"id": "sentry.rules.filters.issue_category.IssueCategoryFilter", "value": 2}
+        payload = {"id": "sentry.rules.filters.issue_category.IssueCategoryFilter", "value": "2"}
         self.assert_basic_filter_translated(payload)
 
     def test_issue_category_include(self) -> None:
         payload = {
             "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
-            "value": 2,
+            "value": "2",
             "include": "true",
         }
         self.assert_basic_filter_translated(payload)
@@ -139,7 +139,7 @@ class RuleConditionTranslationTest(ConditionTestCase):
     def test_issue_category_exclude(self) -> None:
         payload = {
             "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
-            "value": 2,
+            "value": "2",
             "include": "false",
         }
         self.assert_basic_filter_translated(payload)
@@ -167,7 +167,7 @@ class RuleConditionTranslationTest(ConditionTestCase):
     def test_issue_occurrences(self) -> None:
         payload = {
             "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
-            "value": 120,
+            "value": "120",
         }
         self.assert_basic_filter_translated(payload)
 


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/108419 we must add `render_label` methods to the condition handlers that have an equivalent in a `Rule` so that we can populate the same data the `RuleSerializer` used to using the `WorkflowEngineRuleSerializer`. The previous implementation used `generate_rule_label` to accomplish this but it's tightly coupled with old `Rule` code and was avoided when adding actions for that reason. 