### PR TITLE
feat(processing-errors): Add `SourcemapConfigurationType GroupType` and `CONFIGURATION` category

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -457,6 +457,7 @@ INSTALLED_APPS: tuple[str, ...] = (
     "sentry.notifications",
     "sentry.flags",
     "sentry.monitors",
+    "sentry.processing_errors",
     "sentry.uptime",
     "sentry.tempest",
     "sentry.replays",

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -82,6 +82,12 @@ class GroupCategory(IntEnum):
     """
     INSTRUMENTATION = 18
 
+    """
+    Issues detected from SDK/tooling configuration problems,
+    such as missing or broken source maps.
+    """
+    CONFIGURATION = 19
+
 
 GROUP_CATEGORIES_CUSTOM_EMAIL = (
     GroupCategory.ERROR,

--- a/src/sentry/processing_errors/apps.py
+++ b/src/sentry/processing_errors/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry.processing_errors"
+
+    def ready(self) -> None:
+        pass

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sentry_redis_tools.sliding_windows_rate_limiter import Quota
+
+from sentry.issues.grouptype import GroupCategory, GroupType, NotificationConfig
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.types import DetectorSettings
+
+
+@dataclass(frozen=True)
+class SourcemapConfigurationType(GroupType):
+    type_id = 13001
+    slug = "sourcemap_configuration"
+    description = "Source Map Configuration Issue"
+    category = GroupCategory.CONFIGURATION.value
+    category_v2 = GroupCategory.CONFIGURATION.value
+    released = False
+    default_priority = PriorityLevel.LOW
+    enable_auto_resolve = False
+    enable_escalation_detection = False
+    creation_quota = Quota(3600, 60, 100)
+    notification_config = NotificationConfig(context=[])
+    detector_settings = DetectorSettings(
+        handler=None,
+        validator=None,
+        config_schema={},
+    )
+    enable_user_status_and_priority_changes = False
+    # For the moment, we only want to show these issue types in the ui
+    enable_status_change_workflow_notifications = False
+    enable_workflow_notifications = False
+    # We want to show these separately to normal issue types
+    in_default_search = False


### PR DESCRIPTION
Registers a new GroupType for sourcemap configuration issues (type_id=13001) and a new CONFIGURATION GroupCategory. This is the foundation for proactively detecting broken source map configurations from processing errors.
