### PR TITLE
fix(gettingStartedDocs): Update LangGraph example to use StateGraph API

### DIFF
--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -116,7 +116,7 @@ Sentry.init({
             language: 'javascript',
             code: `${sentryImport}
 import { ChatOpenAI } from "@langchain/openai";
-import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { StateGraph, MessagesAnnotation } from "@langchain/langgraph";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 
 const llm = new ChatOpenAI({
@@ -125,12 +125,19 @@ const llm = new ChatOpenAI({
   apiKey: "OPENAI_API_KEY",
 });
 
-const agent = createReactAgent({ llm, tools: [] });
+const graph = new StateGraph(MessagesAnnotation)
+  .addNode("agent", async (state) => {
+    const response = await llm.invoke(state.messages);
+    return { messages: [response] };
+  })
+  .addEdge("__start__", "agent");
 
-Sentry.instrumentLangGraph(agent, {
+Sentry.instrumentLangGraph(graph, {
   recordInputs: true,
   recordOutputs: true,
 });
+
+const agent = graph.compile();
 
 const result = await agent.invoke({
   messages: [

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -130,7 +130,8 @@ const graph = new StateGraph(MessagesAnnotation)
     const response = await llm.invoke(state.messages);
     return { messages: [response] };
   })
-  .addEdge("__start__", "agent");
+  .addEdge("__start__", "agent")
+  .addEdge("agent", "__end__");
 
 Sentry.instrumentLangGraph(graph, {
   recordInputs: true,


### PR DESCRIPTION
Update the LangGraph code snippet in the agent monitoring getting started guide.

`instrumentLangGraph` works by wrapping the `.compile()` method on a `StateGraph` to intercept the compilation step and inject tracing. This means it must be called before `.compile()` is invoked.

`createReactAgent` calls `.compile()` internally and returns the already-compiled graph — there's no hook point between graph construction and compilation. By the time you get the return value, the compile step has already happened, making it too late for `instrumentLangGraph` to do its job.

In short: `createReactAgent` hides the compile step, but `instrumentLangGraph` needs to wrap that exact step. They are fundamentally incompatible with the current SDK API.

The fix replaces `createReactAgent` with the lower-level `StateGraph` + `MessagesAnnotation` pattern, which keeps the compile step explicit and accessible.