### PR TITLE
fix(modal): Skip ESC close when event is already handled by child

### DIFF
--- a/static/app/components/globalModal/index.spec.tsx
+++ b/static/app/components/globalModal/index.spec.tsx
@@ -6,6 +6,7 @@ import {
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
+import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {closeModal, openModal} from 'sentry/actionCreators/modal';
@@ -189,6 +190,38 @@ describe('GlobalModal', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
     expect(closeSpy).toHaveBeenCalled();
     await waitForModalToHide();
+  });
+
+  it('does not close modal when pressing escape to close a select dropdown', async () => {
+    renderGlobalModal();
+
+    act(() =>
+      openModal(({Body}) => (
+        <Body>
+          <CompactSelect
+            options={[
+              {value: 'opt1', label: 'Option One'},
+              {value: 'opt2', label: 'Option Two'},
+            ]}
+            value="opt1"
+            onChange={() => {}}
+          />
+        </Body>
+      ))
+    );
+
+    // Open the select dropdown
+    await userEvent.click(screen.getByRole('button', {name: 'Option One'}));
+    expect(screen.getByRole('option', {name: 'Option One'})).toBeInTheDocument();
+
+    // Press ESC — should close the dropdown, NOT the modal
+    await userEvent.keyboard('{Escape}');
+
+    // Dropdown should be closed
+    expect(screen.queryByRole('option', {name: 'Option One'})).not.toBeInTheDocument();
+
+    // Modal should still be open
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('renders interactive tooltip inside the modal', async () => {

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -136,6 +136,7 @@ function GlobalModal({onClose}: Props) {
     (e: KeyboardEvent) => {
       if (
         e.key !== 'Escape' ||
+        e.defaultPrevented ||
         closeEvents === 'none' ||
         closeEvents === 'backdrop-click'
       ) {


### PR DESCRIPTION
When a `CompactSelect` dropdown is open inside a modal, pressing ESC closes the entire modal instead of just closing the dropdown. In drawers, this already works correctly — ESC first closes the dropdown, then on a subsequent press, closes the drawer.

The modal uses a raw `document.addEventListener('keydown', ...)` that unconditionally closes on any ESC press. React Aria's `useOverlay` (used by CompactSelect) handles ESC by calling `e.preventDefault()` on the native event before it reaches the document-level listener. Adding an `e.defaultPrevented` check to the modal's handler makes it respect events already consumed by child overlays.