### PR TITLE
fix(eslint): Use optional chain in restrict-jsx-slot-children rule

### DIFF
--- a/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.mjs
+++ b/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.mjs
@@ -349,7 +349,7 @@ export const restrictJsxSlotChildren = {
           }
         }
 
-        if (!node.value || node.value.type !== 'JSXExpressionContainer') {
+        if (node.value?.type !== 'JSXExpressionContainer') {
           return;
         }
 


### PR DESCRIPTION
Use optional chaining instead of explicit null check to fix the
`@typescript-eslint/prefer-optional-chain` lint error that was breaking
CI on all PRs.