### PR TITLE
ref(settings): convert KeyStats from class to function component

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {Theme} from '@emotion/react';
 
 import type {Client} from 'sentry/api';
@@ -26,109 +26,114 @@ type Props = {
   'params'
 >;
 
-type State = {
+type State = StateLoading | StateError | StateSuccess;
+
+type StateError = {
+  status: 'error';
+};
+
+type StateLoading = {
+  status: 'loading';
+};
+
+type StateSuccess = {
   emptyStats: boolean;
-  error: boolean;
-  loading: boolean;
   series: Series[];
   since: number;
+  status: 'success';
   until: number;
 };
 
-const getInitialState = (): State => {
-  const until = Math.floor(Date.now() / 1000);
-  return {
-    since: until - 3600 * 24 * 30,
-    until,
-    loading: true,
-    error: false,
-    series: [],
-    emptyStats: false,
-  };
-};
+function KeyStats({api, organization, params, theme}: Props) {
+  const {keyId, projectId} = params;
+  const queryBase = useMemo(() => {
+    const until = Math.floor(Date.now() / 1000);
+    return {
+      since: until - 3600 * 24 * 30,
+      until,
+    };
+  }, []);
+  const [state, setState] = useState<State>({
+    status: 'loading',
+  });
 
-class KeyStats extends Component<Props, State> {
-  state = getInitialState();
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  fetchData = () => {
-    const {organization} = this.props;
-    const {keyId, projectId} = this.props.params;
-    this.props.api.request(
-      `/projects/${organization.slug}/${projectId}/keys/${keyId}/stats/`,
-      {
-        query: {
-          since: this.state.since,
-          until: this.state.until,
-          resolution: '1d',
-        },
-        success: data => {
-          let emptyStats = true;
-          const dropped: Series['data'] = [];
-          const accepted: Series['data'] = [];
-          data.forEach((p: any) => {
-            if (p.total) {
-              emptyStats = false;
-            }
-            dropped.push({name: p.ts * 1000, value: p.dropped});
-            accepted.push({name: p.ts * 1000, value: p.accepted});
-          });
-          const series = [
-            {
-              seriesName: t('Accepted'),
-              data: accepted,
-            },
-            {
-              seriesName: t('Rate Limited'),
-              data: dropped,
-            },
-          ];
-          this.setState({
-            series,
-            emptyStats,
-            error: false,
-            loading: false,
-          });
-        },
-        error: () => {
-          this.setState({error: true, loading: false});
-        },
-      }
-    );
-  };
-
-  render() {
-    if (this.state.error) {
-      return <LoadingError onRetry={this.fetchData} />;
+  const fetchData = useCallback(() => {
+    if (state.status !== 'loading') {
+      return;
     }
 
-    return (
-      <Panel>
-        <PanelHeader>{t('Key usage in the last 30 days (by day)')}</PanelHeader>
-        <PanelBody withPadding>
-          {this.state.loading ? (
-            <Placeholder height="150px" />
-          ) : this.state.emptyStats ? (
-            <EmptyMessage title={t('Nothing recorded in the last 30 days.')}>
-              {t('Total events captured using these credentials.')}
-            </EmptyMessage>
-          ) : (
-            <MiniBarChart
-              isGroupedByDate
-              series={this.state.series}
-              height={150}
-              colors={[this.props.theme.colors.gray200, this.props.theme.colors.red400]}
-              stacked
-              labelYAxisExtents
-            />
-          )}
-        </PanelBody>
-      </Panel>
-    );
+    api.request(`/projects/${organization.slug}/${projectId}/keys/${keyId}/stats/`, {
+      query: {
+        ...queryBase,
+        resolution: '1d',
+      },
+      success: data => {
+        let emptyStats = true;
+        const dropped: Series['data'] = [];
+        const accepted: Series['data'] = [];
+        data.forEach((p: any) => {
+          if (p.total) {
+            emptyStats = false;
+          }
+          dropped.push({name: p.ts * 1000, value: p.dropped});
+          accepted.push({name: p.ts * 1000, value: p.accepted});
+        });
+        const series = [
+          {
+            seriesName: t('Accepted'),
+            data: accepted,
+          },
+          {
+            seriesName: t('Rate Limited'),
+            data: dropped,
+          },
+        ];
+        setState({
+          ...queryBase,
+          series,
+          emptyStats,
+          status: 'success',
+        });
+      },
+      error: () => {
+        setState({status: 'error'});
+      },
+    });
+  }, [api, keyId, organization.slug, projectId, queryBase, state.status]);
+
+  const retry = useCallback(() => {
+    setState({status: 'loading'});
+  }, []);
+
+  useEffect(fetchData, [fetchData]);
+
+  if (state.status === 'error') {
+    return <LoadingError onRetry={retry} />;
   }
+
+  return (
+    <Panel>
+      <PanelHeader>{t('Key usage in the last 30 days (by day)')}</PanelHeader>
+      <PanelBody withPadding>
+        {state.status === 'loading' ? (
+          <Placeholder height="150px" />
+        ) : state.emptyStats ? (
+          <EmptyMessage title={t('Nothing recorded in the last 30 days.')}>
+            {t('Total events captured using these credentials.')}
+          </EmptyMessage>
+        ) : (
+          <MiniBarChart
+            isGroupedByDate
+            series={state.series}
+            height={150}
+            colors={[theme.colors.gray200, theme.colors.red400]}
+            stacked
+            labelYAxisExtents
+          />
+        )}
+      </PanelBody>
+    </Panel>
+  );
 }
 
 export default KeyStats;


### PR DESCRIPTION
The component's state was pretty close to a discriminated union already, so I normalized it to one. In theory we could split it out into granular pieces of React state (or is there a shared util Sentaurs prefer to use?) but 🤷 I figured this seems to be pretty straightforward as-is.

Tested under `/settings/projects/*/keys/*/` for a key that has usage, and a key that doesn't.

Fixes EXP-834.