### PR TITLE
fix(build): Exclude react-select from SWC loader to fix emotion warning

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -303,8 +303,11 @@ const appConfig: Configuration = {
     rules: [
       {
         test: /\.(js|jsx|ts|tsx)$/,
-        // Avoids recompiling core-js based on usage imports
-        exclude: /node_modules[\\/]core-js/,
+        // core-js: Avoids recompiling core-js based on usage imports
+        // react-select: Ships pre-compiled ESM with emotion's keyframes already
+        // compiled via Babel. Re-processing with @swc/plugin-emotion causes
+        // "illegal escape sequence" warnings in dev mode.
+        exclude: /node_modules[\\/](core-js|react-select)/,
         loader: 'builtin:swc-loader',
         options: swcReactLoaderConfig,
       },


### PR DESCRIPTION
Exclude `react-select` from the `builtin:swc-loader` rule in rspack config.

React-select ships pre-compiled ESM where emotion's `keyframes` tagged template literal has already been Babel-compiled to use `_taggedTemplateLiteral`. When `@swc/plugin-emotion` re-processes this already-compiled code, it produces output that triggers emotion's development-mode "illegal escape sequence in your template literal" warning in `serializeStyles`.

Since react-select's ESM is fully pre-compiled (JSX already compiled to `jsx()` calls, imports resolved), it doesn't need SWC processing at all.