### PR TITLE
fix(spans): log oversized subsegments before merging

### DIFF
--- a/src/sentry/spans/buffer_logger.py
+++ b/src/sentry/spans/buffer_logger.py
@@ -331,6 +331,10 @@ def emit_observability_metrics(
         )
 
     if oversized_count > 0:
+        logger.info(
+            "Parent span set oversized, skipping SUNIONSTORE",
+            extra={"oversized_count": oversized_count},
+        )
         metrics.incr(
             "spans.buffer.process_spans.parent_span_set_already_oversized.count",
             amount=oversized_count,


### PR DESCRIPTION
Emitted metrics could be sampled and not show up in our dashboards. Since we are now skipping SUNIONSTORE if the parent set size exceeds `max-segment-bytes`, it's important to know exactly when this happens.
