### PR TITLE
chore(tasks) Move task silo limit wrapping outside of TaskNamespace

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -9,9 +9,11 @@ from typing import Any, TypeVar
 import sentry_sdk
 from django.db.models import Model
 
+from sentry.silo.base import SiloMode
 from sentry.taskworker.constants import CompressionType
 from sentry.taskworker.registry import TaskNamespace
 from sentry.taskworker.retry import Retry, RetryTaskError, retry_task
+from sentry.taskworker.silolimiter import TaskSiloLimit
 from sentry.taskworker.state import current_task
 from sentry.taskworker.task import P, R, Task
 from sentry.taskworker.workerchild import ProcessingDeadlineExceeded
@@ -44,7 +46,7 @@ def instrumented_task(
     at_most_once: bool = False,
     wait_for_delivery: bool = False,
     compression_type: CompressionType = CompressionType.PLAINTEXT,
-    silo_mode=None,
+    silo_mode: SiloMode | None = None,
     **kwargs,
 ) -> Callable[[Callable[P, R]], Task[P, R]]:
     """
@@ -85,15 +87,20 @@ def instrumented_task(
             at_most_once=at_most_once,
             wait_for_delivery=wait_for_delivery,
             compression_type=compression_type,
-            silo_mode=silo_mode,
         )(func)
+
+        if silo_mode:
+            silo_limiter = TaskSiloLimit(silo_mode)
+            task = silo_limiter(task)
+            namespace._registered_tasks[name] = task
+
         # If an alias is provided, register the task for both "name" and "alias" under namespace
         # If an alias namespace is provided, register the task in both namespace and alias_namespace
         # When both are provided, register tasks namespace."name" and alias_namespace."alias"
         if alias or alias_namespace:
             target_alias = alias if alias else name
             target_alias_namespace = alias_namespace if alias_namespace else namespace
-            target_alias_namespace.register(
+            alias_task = target_alias_namespace.register(
                 name=target_alias,
                 retry=retry,
                 expires=expires,
@@ -101,8 +108,13 @@ def instrumented_task(
                 at_most_once=at_most_once,
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
-                silo_mode=silo_mode,
             )(func)
+
+            if silo_mode:
+                silo_limiter = TaskSiloLimit(silo_mode)
+                alias_task = silo_limiter(alias_task)
+                target_alias_namespace._registered_tasks[target_alias] = alias_task
+
         return task
 
     return wrapped

--- a/src/sentry/taskworker/registry.py
+++ b/src/sentry/taskworker/registry.py
@@ -15,11 +15,9 @@ from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskActivation
 from sentry_sdk.consts import OP, SPANDATA
 
 from sentry.conf.types.kafka_definition import Topic
-from sentry.silo.base import SiloMode
 from sentry.taskworker.constants import DEFAULT_PROCESSING_DEADLINE, CompressionType
 from sentry.taskworker.retry import Retry
 from sentry.taskworker.router import TaskRouter
-from sentry.taskworker.silolimiter import TaskSiloLimit
 from sentry.taskworker.task import P, R, Task
 from sentry.utils import metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
@@ -87,7 +85,6 @@ class TaskNamespace:
         at_most_once: bool = False,
         wait_for_delivery: bool = False,
         compression_type: CompressionType = CompressionType.PLAINTEXT,
-        silo_mode: SiloMode | None = None,
     ) -> Callable[[Callable[P, R]], Task[P, R]]:
         """
         Register a task.
@@ -134,9 +131,6 @@ class TaskNamespace:
                 wait_for_delivery=wait_for_delivery,
                 compression_type=compression_type,
             )
-            if silo_mode:
-                silo_limiter = TaskSiloLimit(silo_mode)
-                task = silo_limiter(task)
             # TODO(taskworker) tasks should be registered into the registry
             # so that we can ensure task names are globally unique
             self._registered_tasks[name] = task

--- a/tests/sentry/taskworker/scheduler/test_runner.py
+++ b/tests/sentry/taskworker/scheduler/test_runner.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry.conf.types.taskworker import crontab
 from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
 from sentry.taskworker.app import TaskworkerApp
 from sentry.taskworker.scheduler.runner import RunStorage, ScheduleRunner
 from sentry.testutils.helpers.datetime import freeze_time
@@ -537,8 +538,9 @@ def test_schedulerunner_silo_limited_task_has_task_properties() -> None:
     app = TaskworkerApp(name="sentry")
     namespace = app.taskregistry.create_namespace("test")
 
-    @namespace.register(
+    @instrumented_task(
         name="region_task",
+        namespace=namespace,
         at_most_once=True,
         wait_for_delivery=True,
         silo_mode=SiloMode.REGION,


### PR DESCRIPTION
Move the silo_limit wrapping of tasks to `instrumented_task` as I'll be replacing `sentry.taskworker` with the new `taskbroker_client` which is not aware of sentry's silo modes.

Refs STREAM-610
