### PR TITLE
ref(performance): convert TransactionThresholdModal from class to function component

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 
@@ -16,6 +16,7 @@ import withProjects from 'sentry/utils/withProjects';
 
 import type {TransactionThresholdMetric} from './transactionThresholdModal';
 import TransactionThresholdModal, {modalCss} from './transactionThresholdModal';
+import {useEventViewProject} from './useEventViewProject';
 
 type Props = {
   api: Client;
@@ -39,14 +40,7 @@ function TransactionThresholdButton({
   const [transactionThresholdMetric, setTransactionThresholdMetric] =
     useState<TransactionThresholdMetric>();
 
-  const project = useMemo(() => {
-    if (!defined(eventView)) {
-      return undefined;
-    }
-
-    const projectId = String(eventView.project[0]);
-    return projects.find(proj => proj.id === projectId);
-  }, [eventView, projects]);
+  const project = useEventViewProject(projects, eventView);
 
   useEffect(() => {
     if (!defined(project)) {

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -1,8 +1,6 @@
-import {Component, Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
 
 import {Button} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
@@ -23,6 +21,7 @@ import type EventView from 'sentry/utils/discover/eventView';
 import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 
+import {useEventViewProject} from './useEventViewProject';
 import {transactionSummaryRouteWithQuery} from './utils';
 
 export enum TransactionThresholdMetric {
@@ -47,35 +46,32 @@ type Props = {
   project?: string;
 } & ModalRenderProps;
 
-type State = {
-  error: string | null;
-  metric: TransactionThresholdMetric | undefined;
-  threshold: number | undefined;
-};
+function TransactionThresholdModal({
+  api,
+  Body,
+  eventView,
+  Footer,
+  Header,
+  organization,
+  closeModal,
+  onApply,
+  project: projectId,
+  projects,
+  transactionName,
+  transactionThreshold,
+  transactionThresholdMetric,
+}: Props) {
+  const [threshold, setThreshold] = useState<number | string | undefined>(
+    transactionThreshold
+  );
+  const [metric, setMetric] = useState<TransactionThresholdMetric | undefined>(
+    transactionThresholdMetric
+  );
+  const project = useEventViewProject(projects, eventView, projectId);
 
-class TransactionThresholdModal extends Component<Props, State> {
-  state: State = {
-    threshold: this.props.transactionThreshold,
-    metric: this.props.transactionThresholdMetric,
-    error: null,
-  };
-
-  getProject() {
-    const {projects, eventView, project} = this.props;
-
-    if (defined(project)) {
-      return projects.find(proj => proj.id === project);
-    }
-    const projectId = String(eventView.project[0]);
-    return projects.find(proj => proj.id === projectId);
-  }
-
-  handleApply = (event: React.FormEvent) => {
+  const handleApply = (event: React.FormEvent) => {
     event.preventDefault();
 
-    const {api, closeModal, organization, transactionName, onApply} = this.props;
-
-    const project = this.getProject();
     if (!defined(project)) {
       return;
     }
@@ -91,20 +87,17 @@ class TransactionThresholdModal extends Component<Props, State> {
         },
         data: {
           transaction: transactionName,
-          threshold: this.state.threshold,
-          metric: this.state.metric,
+          threshold,
+          metric,
         },
       })
       .then(() => {
         closeModal();
         if (onApply) {
-          onApply(this.state.threshold, this.state.metric);
+          onApply(threshold, metric);
         }
       })
       .catch(err => {
-        this.setState({
-          error: err,
-        });
         let errorMessage =
           err.responseJSON?.threshold ?? err.responseJSON?.non_field_errors ?? null;
         if (Array.isArray(errorMessage)) {
@@ -114,21 +107,9 @@ class TransactionThresholdModal extends Component<Props, State> {
       });
   };
 
-  handleFieldChange = (field: string) => (value: string) => {
-    this.setState(prevState => {
-      const newState = cloneDeep(prevState);
-      set(newState, field, value);
-
-      return {...newState, errors: undefined};
-    });
-  };
-
-  handleReset = (event: React.FormEvent) => {
+  const handleReset = (event: React.FormEvent) => {
     event.preventDefault();
 
-    const {api, closeModal, organization, transactionName, onApply} = this.props;
-
-    const project = this.getProject();
     if (!defined(project)) {
       return;
     }
@@ -148,7 +129,7 @@ class TransactionThresholdModal extends Component<Props, State> {
       })
       .then(() => {
         const projectThresholdUrl = `/projects/${organization.slug}/${project.slug}/transaction-threshold/configure/`;
-        this.props.api
+        return api
           .requestPromise(projectThresholdUrl, {
             method: 'GET',
             includeAllArgs: true,
@@ -157,28 +138,21 @@ class TransactionThresholdModal extends Component<Props, State> {
             },
           })
           .then(([data]) => {
-            this.setState({
-              threshold: data.threshold,
-              metric: data.metric,
-            });
+            setThreshold(data.threshold);
+            setMetric(data.metric);
             closeModal();
             if (onApply) {
-              onApply(this.state.threshold, this.state.metric);
+              onApply(data.threshold, data.metric);
             }
-          })
-          .catch(err => {
-            const errorMessage = err.responseJSON?.threshold ?? null;
-            addErrorMessage(errorMessage);
           });
       })
       .catch(err => {
-        this.setState({
-          error: err,
-        });
+        const errorMessage = err.responseJSON?.threshold ?? null;
+        addErrorMessage(errorMessage);
       });
   };
 
-  renderModalFields() {
+  function renderModalFields() {
     return (
       <Fragment>
         <FieldGroup
@@ -198,9 +172,9 @@ class TransactionThresholdModal extends Component<Props, State> {
             options={METRIC_CHOICES.slice()}
             name="responseMetric"
             label={t('Calculation Method')}
-            value={this.state.metric}
-            onChange={(option: {label: string; value: string}) => {
-              this.handleFieldChange('metric')(option.value);
+            value={metric}
+            onChange={(option: {value: TransactionThresholdMetric}) => {
+              setMetric(option.value);
             }}
           />
         </FieldGroup>
@@ -221,9 +195,9 @@ class TransactionThresholdModal extends Component<Props, State> {
             name="threshold"
             pattern="[0-9]*(\.[0-9]*)?"
             onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              this.handleFieldChange('threshold')(event.target.value);
+              setThreshold(event.target.value);
             }}
-            value={this.state.threshold}
+            value={threshold}
             step={100}
             min={100}
           />
@@ -232,63 +206,53 @@ class TransactionThresholdModal extends Component<Props, State> {
     );
   }
 
-  render() {
-    const {Header, Body, Footer, organization, transactionName, eventView} = this.props;
+  const summaryView = eventView.clone();
+  summaryView.query = summaryView.getQueryWithAdditionalConditions();
+  const target = transactionSummaryRouteWithQuery({
+    organization,
+    transaction: transactionName,
+    query: summaryView.generateQueryStringObject(),
+    projectID: project?.id,
+  });
 
-    const project = this.getProject();
-
-    const summaryView = eventView.clone();
-    summaryView.query = summaryView.getQueryWithAdditionalConditions();
-    const target = transactionSummaryRouteWithQuery({
-      organization,
-      transaction: transactionName,
-      query: summaryView.generateQueryStringObject(),
-      projectID: project?.id,
-    });
-
-    return (
-      <Fragment>
-        <Header closeButton>
-          <h4>{t('Transaction Settings')}</h4>
-        </Header>
-        <Body>
-          <Instruction>
-            {tct(
-              'The changes below will only be applied to [transaction]. To set it at a more global level, go to [projectSettings: Project Settings].',
-              {
-                transaction: <Link to={target}>{transactionName}</Link>,
-                projectSettings: (
-                  <Link
-                    to={`/settings/${organization.slug}/projects/${project?.slug}/performance/`}
-                  />
-                ),
-              }
-            )}
-          </Instruction>
-          {this.renderModalFields()}
-        </Body>
-        <Footer>
-          <Grid flow="column" align="center" gap="md">
-            <Button
-              priority="default"
-              onClick={this.handleReset}
-              data-test-id="reset-all"
-            >
-              {t('Reset All')}
-            </Button>
-            <Button
-              aria-label={t('Apply')}
-              priority="primary"
-              onClick={this.handleApply}
-              data-test-id="apply-threshold"
-            >
-              {t('Apply')}
-            </Button>
-          </Grid>
-        </Footer>
-      </Fragment>
-    );
-  }
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{t('Transaction Settings')}</h4>
+      </Header>
+      <Body>
+        <Instruction>
+          {tct(
+            'The changes below will only be applied to [transaction]. To set it at a more global level, go to [projectSettings: Project Settings].',
+            {
+              transaction: <Link to={target}>{transactionName}</Link>,
+              projectSettings: (
+                <Link
+                  to={`/settings/${organization.slug}/projects/${project?.slug}/performance/`}
+                />
+              ),
+            }
+          )}
+        </Instruction>
+        {renderModalFields()}
+      </Body>
+      <Footer>
+        <Grid flow="column" align="center" gap="md">
+          <Button priority="default" onClick={handleReset} data-test-id="reset-all">
+            {t('Reset All')}
+          </Button>
+          <Button
+            aria-label={t('Apply')}
+            priority="primary"
+            onClick={handleApply}
+            data-test-id="apply-threshold"
+          >
+            {t('Apply')}
+          </Button>
+        </Grid>
+      </Footer>
+    </Fragment>
+  );
 }
 
 const Instruction = styled('div')`

--- a/static/app/views/performance/transactionSummary/useEventViewProject.ts
+++ b/static/app/views/performance/transactionSummary/useEventViewProject.ts
@@ -1,0 +1,15 @@
+import {useMemo} from 'react';
+
+import type {Project} from 'sentry/types/project';
+import type EventView from 'sentry/utils/discover/eventView';
+
+export function useEventViewProject(
+  projects: Project[],
+  eventView: EventView,
+  projectId = String(eventView.project[0])
+) {
+  return useMemo(
+    () => projects.find(project => project.id === projectId),
+    [projects, projectId]
+  );
+}


### PR DESCRIPTION
Extracts a shared `useEventViewProject` memo hook from the `TransactionThresholdButton` component as created in #109567.

Streamlines two things from the class component version:

* It was using dynamic `this.state[field]` setting with `lodash/set`; now it's direct `set*` hook setter calls
* `state.error` was never used for anything (errors are registered with `addErrorMessage`); now it's removed 

~Stacked on #109567. I'll keep this as a draft for reference for now.~ ✅ 

Fixes EXP-809