### PR TITLE
feat(dashboards): Add maxFontSize prop to AutoSizedText and use it in details widget

### DIFF
--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -4,9 +4,10 @@ import * as Sentry from '@sentry/react';
 
 interface Props {
   children: React.ReactNode;
+  maxFontSize?: number;
 }
 
-export function AutoSizedText({children}: Props) {
+export function AutoSizedText({children, maxFontSize}: Props) {
   const childRef = useRef<HTMLDivElement>(null);
 
   const fontSize = useRef<number>(0);
@@ -47,7 +48,9 @@ export function AutoSizedText({children}: Props) {
 
       // Reset the iteration parameters
       fontSizeLowerBound.current = 0;
-      fontSizeUpperBound.current = parentDimensions.height;
+      fontSizeUpperBound.current = maxFontSize
+        ? Math.min(maxFontSize, parentDimensions.height)
+        : parentDimensions.height;
 
       let iterationCount = 0;
 
@@ -96,7 +99,7 @@ export function AutoSizedText({children}: Props) {
     return () => {
       observer.disconnect();
     };
-  }, []);
+  }, [maxFontSize]);
 
   const adjustFontSize = (childDimensions: Dimensions, parentDimensions: Dimensions) => {
     const childElement = childRef.current;

--- a/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization.tsx
@@ -65,7 +65,7 @@ export function DetailsWidgetVisualization(props: DetailsWidgetVisualizationProp
       return <ResourceImageVisualization spanGroup={spanGroup} projectId={projectId} />;
     }
 
-    return <Container padding="md xl">{spanDescription}</Container>;
+    return <Wrapper maxFontSize={64}>{spanDescription}</Wrapper>;
   }
 
   return <Wrapper>{`${spanOp} - ${spanDescription}`}</Wrapper>;
@@ -117,11 +117,17 @@ function HttpSpanVisualization(props: {
   );
 }
 
-function Wrapper({children}: any) {
+function Wrapper({
+  children,
+  maxFontSize,
+}: {
+  children: React.ReactNode;
+  maxFontSize?: number;
+}) {
   return (
     <GrowingWrapper>
       <AutoResizeParent>
-        <AutoSizedText>{children}</AutoSizedText>
+        <AutoSizedText maxFontSize={maxFontSize}>{children}</AutoSizedText>
       </AutoResizeParent>
     </GrowingWrapper>
   );


### PR DESCRIPTION
Adds an optional `maxFontSize` prop to `AutoSizedText` that caps the binary search upper bound, preventing the font from growing beyond the specified size regardless of available space.

Uses this in the details widget's resource span visualization to render span descriptions at up to 64px, scaling down to fit as needed rather than filling the full widget height.