### PR TITLE
ref(performance): convert Table from class to function component

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -1,4 +1,4 @@
-import {Component, useEffect, type ReactNode} from 'react';
+import {useEffect, useRef, useState, type ReactNode} from 'react';
 import type {Theme} from '@emotion/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
@@ -41,7 +41,6 @@ import {
 import {getLandingDisplayFromParam} from 'sentry/views/performance/landing/utils';
 
 import {getMEPQueryParams} from './landing/widgets/utils';
-import type {TransactionThresholdMetric} from './transactionSummary/transactionThresholdModal';
 import TransactionThresholdModal, {
   modalCss,
 } from './transactionSummary/transactionThresholdModal';
@@ -77,14 +76,6 @@ type Props = {
   withStaticFilters: boolean;
   columnTitles?: ColumnTitle[];
   domainViewFilters?: DomainViewFilters;
-  summaryConditions?: string;
-};
-
-type State = {
-  transaction: string | undefined;
-  transactionThreshold: number | undefined;
-  transactionThresholdMetric: TransactionThresholdMetric | undefined;
-  widths: number[];
 };
 
 function getProjectFirstEventGroup(project: Project): '14d' | '30d' | '>30d' {
@@ -126,30 +117,36 @@ function TrackHasDataAnalytics({
   return children;
 }
 
-class _Table extends Component<Props, State> {
-  state: State = {
-    widths: [],
-    transaction: undefined,
-    transactionThreshold: undefined,
-    transactionThresholdMetric: undefined,
-  };
+type TransactionData = {
+  name: string;
+  threshold: number;
+};
 
-  componentDidMount(): void {
-    const {organization} = this.props;
-    if (!this.tableMetricSet) {
-      this.tableMetricSet = true;
-      trackAnalytics('performance_views.landing.table.seen', {
-        organization,
-      });
-    }
-  }
-  unparameterizedMetricSet = false;
-  tableMetricSet = false;
+export default function Table({
+  columnTitles = COLUMN_TITLES_OPTIONAL_TOOLTIP,
+  organization,
+  location,
+  withStaticFilters,
+  projects,
+  setError,
+  eventView,
+  theme,
+}: Props) {
+  const [widths, setWidths] = useState<number[]>([]);
+  const [transactionData, setTransactionData] = useState<TransactionData>();
+  const unparameterizedMetricProject = useRef<Project>(undefined);
 
-  sendUnparameterizedAnalytic(project: Project | undefined) {
-    const {organization, eventView} = this.props;
+  const domainViewFilters = useDomainViewFilters();
+
+  useEffect(() => {
+    trackAnalytics('performance_views.landing.table.seen', {
+      organization,
+    });
+  }, [organization]);
+
+  function sendUnparameterizedAnalytic(project: Project | undefined) {
     const statsPeriod = eventView.statsPeriod ?? 'other';
-    const projectMetadata = this.getProjectWithinMetadata(project);
+    const projectMetadata = getProjectWithinMetadata(project);
 
     trackAnalytics('performance_views.landing.table.unparameterized', {
       organization,
@@ -164,7 +161,7 @@ class _Table extends Component<Props, State> {
   /**
    * Used for cluster warning and analytics.
    */
-  getProjectWithinMetadata(project: Project | undefined) {
+  function getProjectWithinMetadata(project: Project | undefined) {
     let firstEventWithin: 'none' | '14d' | '30d' | '>30d' = 'none';
     if (!project) {
       return {
@@ -183,10 +180,11 @@ class _Table extends Component<Props, State> {
     };
   }
 
-  handleCellAction = (column: TableColumn<keyof TableDataRow>, dataRow: TableDataRow) => {
+  const handleCellAction = (
+    column: TableColumn<keyof TableDataRow>,
+    dataRow: TableDataRow
+  ) => {
     return (action: Actions, value: string | number) => {
-      const {eventView, location, organization, projects} = this.props;
-
       trackAnalytics('performance_views.overview.cellaction', {
         organization,
         action,
@@ -216,10 +214,9 @@ class _Table extends Component<Props, State> {
                   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                   metric !== project_threshold[0]
                 ) {
-                  this.setState({
-                    transaction: transactionName,
-                    transactionThreshold: threshold,
-                    transactionThresholdMetric: metric,
+                  setTransactionData({
+                    name: transactionName,
+                    threshold,
                   });
                 }
                 addSuccessMessage(
@@ -252,13 +249,11 @@ class _Table extends Component<Props, State> {
     };
   };
 
-  renderBodyCell(
+  function renderBodyCell(
     tableData: TableData | null,
     column: TableColumn<keyof TableDataRow>,
     dataRow: TableDataRow
   ): React.ReactNode {
-    const {eventView, organization, projects, location, withStaticFilters} = this.props;
-
     if (!tableData?.meta) {
       return dataRow[column.key];
     }
@@ -270,7 +265,7 @@ class _Table extends Component<Props, State> {
     const rendered = fieldRenderer(dataRow, {
       organization,
       location,
-      theme: this.props.theme,
+      theme,
       unit: tableMeta.units?.[column.key],
     });
 
@@ -313,11 +308,11 @@ class _Table extends Component<Props, State> {
 
       summaryView.query = existingQuery.formatString();
       summaryView.query = summaryView.getQueryWithAdditionalConditions();
-      if (isUnparameterizedRow && !this.unparameterizedMetricSet) {
-        this.sendUnparameterizedAnalytic(project);
-        this.unparameterizedMetricSet = true;
+      if (isUnparameterizedRow && !unparameterizedMetricProject.current) {
+        unparameterizedMetricProject.current = project;
+        sendUnparameterizedAnalytic(project);
       }
-      const {isInDomainView, view} = this.props.domainViewFilters ?? {};
+      const {isInDomainView, view} = domainViewFilters ?? {};
 
       const target = isUnparameterizedRow
         ? createUnnamedTransactionsDiscoverTarget({
@@ -336,12 +331,12 @@ class _Table extends Component<Props, State> {
         <CellAction
           column={column}
           dataRow={dataRow}
-          handleCellAction={this.handleCellAction(column, dataRow)}
+          handleCellAction={handleCellAction(column, dataRow)}
           allowActions={cellActions}
         >
           <Link
             to={target}
-            onClick={this.handleSummaryClick}
+            onClick={handleSummaryClick}
             style={{display: `block`, width: `100%`}}
           >
             {rendered}
@@ -354,7 +349,7 @@ class _Table extends Component<Props, State> {
       // don't display per cell actions for team_key_transaction
 
       const project = getProject(dataRow, projects);
-      const projectMetadata = this.getProjectWithinMetadata(project);
+      const projectMetadata = getProjectWithinMetadata(project);
       if (isUnparameterizedRow) {
         if (projectMetadata.firstEventWithin === '14d') {
           return (
@@ -394,7 +389,7 @@ class _Table extends Component<Props, State> {
           <CellAction
             column={column}
             dataRow={dataRow}
-            handleCellAction={this.handleCellAction(column, dataRow)}
+            handleCellAction={handleCellAction(column, dataRow)}
             allowActions={cellActions}
           >
             {rendered}
@@ -412,7 +407,7 @@ class _Table extends Component<Props, State> {
       <CellAction
         column={column}
         dataRow={dataRow}
-        handleCellAction={this.handleCellAction(column, dataRow)}
+        handleCellAction={handleCellAction(column, dataRow)}
         allowActions={cellActions}
       >
         {rendered}
@@ -420,15 +415,14 @@ class _Table extends Component<Props, State> {
     );
   }
 
-  renderBodyCellWithData = (tableData: TableData | null) => {
+  const renderBodyCellWithData = (tableData: TableData | null) => {
     return (
       column: TableColumn<keyof TableDataRow>,
       dataRow: TableDataRow
-    ): React.ReactNode => this.renderBodyCell(tableData, column, dataRow);
+    ): React.ReactNode => renderBodyCell(tableData, column, dataRow);
   };
 
-  onSortClick(currentSortKind?: string, currentSortField?: string) {
-    const {organization} = this.props;
+  function onSortClick(currentSortKind?: string, currentSortField?: string) {
     trackAnalytics('performance_views.landingv2.transactions.sort', {
       organization,
       field: currentSortField,
@@ -436,21 +430,18 @@ class _Table extends Component<Props, State> {
     });
   }
 
-  paginationAnalyticsEvent = (direction: string) => {
-    const {organization} = this.props;
+  const paginationAnalyticsEvent = (direction: string) => {
     trackAnalytics('performance_views.landingv3.table_pagination', {
       organization,
       direction,
     });
   };
 
-  renderHeadCell(
+  function renderHeadCell(
     tableMeta: TableData['meta'],
     column: TableColumn<keyof TableDataRow>,
     title: ColumnTitle
   ): React.ReactNode {
-    const {eventView, location} = this.props;
-
     const align = fieldAlignment(column.name, column.type, tableMeta);
     const field = {field: column.name, width: column.width};
     const aggregateAliasTableMeta: MetaType = {};
@@ -486,7 +477,7 @@ class _Table extends Component<Props, State> {
         direction={currentSortKind}
         canSort={canSort}
         generateSortLink={generateSortLink}
-        onClick={() => this.onSortClick(currentSortKind, currentSortField)}
+        onClick={() => onSortClick(currentSortKind, currentSortField)}
       />
     );
 
@@ -517,15 +508,12 @@ class _Table extends Component<Props, State> {
     );
   }
 
-  renderHeadCellWithMeta = (tableMeta: TableData['meta']) => {
-    const columnTitles = this.props.columnTitles ?? COLUMN_TITLES_OPTIONAL_TOOLTIP;
+  const renderHeadCellWithMeta = (tableMeta: TableData['meta']) => {
     return (column: TableColumn<keyof TableDataRow>, index: number): React.ReactNode =>
-      this.renderHeadCell(tableMeta, column, columnTitles[index]!);
+      renderHeadCell(tableMeta, column, columnTitles[index]!);
   };
 
-  renderPrependCellWithData = (tableData: TableData | null) => {
-    const {eventView} = this.props;
-
+  const renderPrependCellWithData = (tableData: TableData | null) => {
     const teamKeyTransactionColumn = eventView
       .getColumns()
       .find((col: TableColumn<string | number>) => col.name === 'team_key_transaction');
@@ -541,34 +529,33 @@ class _Table extends Component<Props, State> {
             />
           );
           return [
-            this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {title: star}),
+            renderHeadCell(tableData?.meta, teamKeyTransactionColumn, {title: star}),
           ];
         }
-        return [this.renderBodyCell(tableData, teamKeyTransactionColumn, dataRow)];
+        return [renderBodyCell(tableData, teamKeyTransactionColumn, dataRow)];
       }
       return [];
     };
   };
 
-  handleSummaryClick = () => {
-    const {organization, location, projects} = this.props;
+  const handleSummaryClick = () => {
     trackAnalytics('performance_views.overview.navigate.summary', {
       organization,
       project_platforms: getSelectedProjectPlatforms(location, projects),
     });
   };
 
-  handleResizeColumn = (columnIndex: number, nextColumn: GridColumn) => {
-    const widths: number[] = [...this.state.widths];
-    widths[columnIndex] = nextColumn.width
-      ? Number(nextColumn.width)
-      : COL_WIDTH_UNDEFINED;
-    this.setState({widths});
+  const handleResizeColumn = (columnIndex: number, nextColumn: GridColumn) => {
+    setWidths(previousWidths => {
+      const updatedWidths = [...previousWidths];
+      updatedWidths[columnIndex] = nextColumn.width
+        ? Number(nextColumn.width)
+        : COL_WIDTH_UNDEFINED;
+      return updatedWidths;
+    });
   };
 
-  getSortedEventView() {
-    const {eventView} = this.props;
-
+  function getSortedEventView() {
     return eventView.withSorts([
       {
         field: 'team_key_transaction',
@@ -578,101 +565,74 @@ class _Table extends Component<Props, State> {
     ]);
   }
 
-  render() {
-    const {eventView, organization, location, setError} = this.props;
-    const {widths, transaction, transactionThreshold} = this.state;
-    const columnOrder = eventView
-      .getColumns()
-      // remove team_key_transactions from the column order as we'll be rendering it
-      // via a prepended column
-      .filter(
-        (col: TableColumn<string | number>) =>
-          col.name !== 'team_key_transaction' &&
-          !col.name.startsWith('count_miserable') &&
-          col.name !== 'project_threshold_config'
-      )
-      .map((col: TableColumn<string | number>, i: number) => {
-        if (typeof widths[i] === 'number') {
-          return {...col, width: widths[i]};
-        }
-        return col;
-      });
+  const columnOrder = eventView
+    .getColumns()
+    // remove team_key_transactions from the column order as we'll be rendering it
+    // via a prepended column
+    .filter(
+      (col: TableColumn<string | number>) =>
+        col.name !== 'team_key_transaction' &&
+        !col.name.startsWith('count_miserable') &&
+        col.name !== 'project_threshold_config'
+    )
+    .map((col: TableColumn<string | number>, i: number) => {
+      if (typeof widths[i] === 'number') {
+        return {...col, width: widths[i]};
+      }
+      return col;
+    });
 
-    const sortedEventView = this.getSortedEventView();
-    const columnSortBy = sortedEventView.getSorts();
+  const sortedEventView = getSortedEventView();
+  const columnSortBy = sortedEventView.getSorts();
 
-    const prependColumnWidths = ['max-content'];
-    return (
-      <div data-test-id="performance-table">
-        <MEPConsumer>
-          {value => {
-            return (
-              <DiscoverQuery
-                eventView={sortedEventView}
-                orgSlug={organization.slug}
-                location={location}
-                setError={error => setError(error?.message)}
-                referrer="api.insights.landing-table"
-                transactionName={transaction}
-                transactionThreshold={transactionThreshold}
-                queryExtras={getMEPQueryParams(value)}
-              >
-                {({pageLinks, isLoading, tableData}) => (
-                  <TrackHasDataAnalytics isLoading={isLoading} tableData={tableData}>
-                    <VisuallyCompleteWithData
-                      id="PerformanceTable"
-                      hasData={
-                        !isLoading && !!tableData?.data && tableData.data.length > 0
-                      }
-                      isLoading={isLoading}
-                    >
-                      <GridEditable
-                        isLoading={isLoading}
-                        data={tableData ? tableData.data : []}
-                        columnOrder={columnOrder}
-                        columnSortBy={columnSortBy}
-                        bodyStyle={{overflow: 'visible'}}
-                        grid={{
-                          onResizeColumn: this.handleResizeColumn,
-                          renderHeadCell: this.renderHeadCellWithMeta(
-                            tableData?.meta
-                          ) as any,
-                          renderBodyCell: this.renderBodyCellWithData(tableData) as any,
-                          renderPrependColumns: this.renderPrependCellWithData(
-                            tableData
-                          ) as any,
-                          prependColumnWidths,
-                        }}
-                      />
-                    </VisuallyCompleteWithData>
-                    <Pagination
-                      pageLinks={pageLinks}
-                      paginationAnalyticsEvent={this.paginationAnalyticsEvent}
-                    />
-                  </TrackHasDataAnalytics>
-                )}
-              </DiscoverQuery>
-            );
-          }}
-        </MEPConsumer>
-      </div>
-    );
-  }
-}
-
-function Table(props: Omit<Props, 'summaryConditions'> & {summaryConditions?: string}) {
-  const summaryConditions =
-    props.summaryConditions ?? props.eventView.getQueryWithAdditionalConditions();
-
-  const domainViewFilters = useDomainViewFilters();
-
+  const prependColumnWidths = ['max-content'];
   return (
-    <_Table
-      {...props}
-      summaryConditions={summaryConditions}
-      domainViewFilters={domainViewFilters}
-    />
+    <div data-test-id="performance-table">
+      <MEPConsumer>
+        {value => {
+          return (
+            <DiscoverQuery
+              eventView={sortedEventView}
+              orgSlug={organization.slug}
+              location={location}
+              setError={error => setError(error?.message)}
+              referrer="api.insights.landing-table"
+              transactionName={transactionData?.name}
+              transactionThreshold={transactionData?.threshold}
+              queryExtras={getMEPQueryParams(value)}
+            >
+              {({pageLinks, isLoading, tableData}) => (
+                <TrackHasDataAnalytics isLoading={isLoading} tableData={tableData}>
+                  <VisuallyCompleteWithData
+                    id="PerformanceTable"
+                    hasData={!isLoading && !!tableData?.data && tableData.data.length > 0}
+                    isLoading={isLoading}
+                  >
+                    <GridEditable
+                      isLoading={isLoading}
+                      data={tableData ? tableData.data : []}
+                      columnOrder={columnOrder}
+                      columnSortBy={columnSortBy}
+                      bodyStyle={{overflow: 'visible'}}
+                      grid={{
+                        onResizeColumn: handleResizeColumn,
+                        renderHeadCell: renderHeadCellWithMeta(tableData?.meta),
+                        renderBodyCell: renderBodyCellWithData(tableData),
+                        renderPrependColumns: renderPrependCellWithData(tableData),
+                        prependColumnWidths,
+                      }}
+                    />
+                  </VisuallyCompleteWithData>
+                  <Pagination
+                    pageLinks={pageLinks}
+                    paginationAnalyticsEvent={paginationAnalyticsEvent}
+                  />
+                </TrackHasDataAnalytics>
+              )}
+            </DiscoverQuery>
+          );
+        }}
+      </MEPConsumer>
+    </div>
   );
 }
-
-export default Table;

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -34,10 +34,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
-import {
-  useDomainViewFilters,
-  type DomainViewFilters,
-} from 'sentry/views/insights/pages/useFilters';
+import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 import {getLandingDisplayFromParam} from 'sentry/views/performance/landing/utils';
 
 import {getMEPQueryParams} from './landing/widgets/utils';
@@ -75,7 +72,6 @@ type Props = {
   theme: Theme;
   withStaticFilters: boolean;
   columnTitles?: ColumnTitle[];
-  domainViewFilters?: DomainViewFilters;
 };
 
 function getProjectFirstEventGroup(project: Project): '14d' | '30d' | '>30d' {
@@ -134,15 +130,19 @@ export default function Table({
 }: Props) {
   const [widths, setWidths] = useState<number[]>([]);
   const [transactionData, setTransactionData] = useState<TransactionData>();
-  const unparameterizedMetricProject = useRef<Project>(undefined);
+  const [tableMetricSet, setTableMetricSet] = useState(false);
+  const unparameterizedMetricProject = useRef<{project?: Project | undefined}>(undefined);
 
   const domainViewFilters = useDomainViewFilters();
 
   useEffect(() => {
-    trackAnalytics('performance_views.landing.table.seen', {
-      organization,
-    });
-  }, [organization]);
+    if (!tableMetricSet) {
+      trackAnalytics('performance_views.landing.table.seen', {
+        organization,
+      });
+      setTableMetricSet(true);
+    }
+  }, [organization, tableMetricSet]);
 
   function sendUnparameterizedAnalytic(project: Project | undefined) {
     const statsPeriod = eventView.statsPeriod ?? 'other';
@@ -309,7 +309,7 @@ export default function Table({
       summaryView.query = existingQuery.formatString();
       summaryView.query = summaryView.getQueryWithAdditionalConditions();
       if (isUnparameterizedRow && !unparameterizedMetricProject.current) {
-        unparameterizedMetricProject.current = project;
+        unparameterizedMetricProject.current = {project};
         sendUnparameterizedAnalytic(project);
       }
       const {isInDomainView, view} = domainViewFilters ?? {};


### PR DESCRIPTION
Tested on /insights/frontend/ with the `insights-modules-use-eap` feature flag disabled (`useInsightsEap`). 💡 Tip to self: `?useEap=0`

`state.transactionThresholdMetric` was previously unused, so this PR removes it.

Fixes https://linear.app/getsentry/issue/EXP-810/convert-table-from-class-to-function-component