### PR TITLE
feat(seer): Iterate on the instructions at the top of seer settings pages

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/agentSettings/cursorAgentSettings.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/agentSettings/cursorAgentSettings.tsx
@@ -30,7 +30,7 @@ export default function CursorAgentSettings({
       disabled={Boolean(disabledReason)}
       disabledReason={disabledReason}
       name="cursorAutoCreatePullRequests"
-      label={t('Auto-Create Pull Requests')}
+      label={t('Auto Create Pull Requests')}
       help={t(
         'When enabled, Cursor Cloud Agents will automatically create pull requests after hand off.'
       )}

--- a/static/gsApp/views/seerAutomation/components/projectDetails/agentSettings/seerAgentSettings.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/agentSettings/seerAgentSettings.tsx
@@ -34,7 +34,7 @@ export default function SeerAgentSettings({canWrite, preference, project}: Props
       disabled={Boolean(disabledReason)}
       disabledReason={disabledReason}
       name="automated_run_stopping_point"
-      label={t('Allow PR Auto Creation')}
+      label={t('Auto Create Pull Requests')}
       help={
         <Stack gap="sm">
           <span>

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
@@ -1,0 +1,34 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Stack} from '@sentry/scraps/layout';
+
+import {t} from 'sentry/locale';
+
+import SeerWizardSetupBanner from 'getsentry/views/seerAutomation/components/seerWizardSetupBanner';
+import SettingsPageTabs from 'getsentry/views/seerAutomation/components/settingsPageTabs';
+import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function SeerSettingsPageContent({children}: Props) {
+  const canWrite = useCanWriteSettings();
+
+  return (
+    <Stack gap="lg">
+      <SeerWizardSetupBanner />
+
+      <SettingsPageTabs />
+
+      {canWrite ? null : (
+        <Alert data-test-id="org-permission-alert" variant="warning">
+          {t(
+            'These settings can only be edited by users with the organization owner or manager role.'
+          )}
+        </Alert>
+      )}
+
+      {children}
+    </Stack>
+  );
+}

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageWrapper.tsx
@@ -1,22 +1,13 @@
 import {useEffect} from 'react';
 
-import {Alert} from '@sentry/scraps/alert';
-import {Stack} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
-
 import Feature from 'sentry/components/acl/feature';
 import {NoAccess} from 'sentry/components/noAccess';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import showNewSeer from 'sentry/utils/seer/showNewSeer';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
-
-import SeerWizardSetupBanner from 'getsentry/views/seerAutomation/components/seerWizardSetupBanner';
-import SettingsPageTabs from 'getsentry/views/seerAutomation/components/settingsPageTabs';
-import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 interface Props {
   children: React.ReactNode;
@@ -25,7 +16,6 @@ interface Props {
 export default function SeerSettingsPageWrapper({children}: Props) {
   const navigate = useNavigate();
   const organization = useOrganization();
-  const canWrite = useCanWriteSettings();
 
   useEffect(() => {
     // If the org is on the old-seer plan then they shouldn't be here on this new settings page
@@ -52,39 +42,8 @@ export default function SeerSettingsPageWrapper({children}: Props) {
       renderDisabled={NoAccess}
     >
       <SentryDocumentTitle title={t('Seer')} orgSlug={organization.slug} />
-      <SettingsPageHeader
-        title={t('Seer')}
-        subtitle={tct(
-          'Choose how Seer automatically triages and diagnoses incoming issues before you even notice them. Seer currently includes [rca:Root Cause Analysis], an agent that can root-cause issues and create pull requests, and [code_review:AI Code Review], an agent that will review your pull requests to detect issues before they happen. [read_the_docs:Learn what Seer can do from our docs]',
-          {
-            rca: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/issue-fix/#root-cause-analysis" />
-            ),
-            code_review: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/ai-code-review/" />
-            ),
-            read_the_docs: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
-            ),
-          }
-        )}
-      />
 
-      <Stack gap="lg">
-        <SeerWizardSetupBanner />
-
-        <SettingsPageTabs />
-
-        {canWrite ? null : (
-          <Alert data-test-id="org-permission-alert" variant="warning">
-            {t(
-              'These settings can only be edited by users with the organization owner or manager role.'
-            )}
-          </Alert>
-        )}
-
-        {children}
-      </Stack>
+      {children}
     </Feature>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -16,11 +16,8 @@ export default function SettingsPageTabs() {
 
   const tabs: Array<[string, Path]> = [
     [t('Settings'), `/settings/${organization.slug}/seer/`],
-    [
-      t('Projects (Root Cause Analysis & Agents)'),
-      `/settings/${organization.slug}/seer/projects/`,
-    ],
-    [t('Repos (Code Review)'), `/settings/${organization.slug}/seer/repos/`],
+    [t('Issue Autofix'), `/settings/${organization.slug}/seer/projects/`],
+    [t('Code Review'), `/settings/${organization.slug}/seer/repos/`],
   ];
 
   return (

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -40,11 +40,11 @@ function SeerProjectDetails() {
   return (
     <AnalyticsArea name="project-details">
       <SentryDocumentTitle
-        title={t('Project Seer Settings')}
+        title={t('Seer Autofix Settings')}
         projectSlug={project.slug}
       />
       <SettingsPageHeader
-        title={tct('Seer Settings for [projectName]', {
+        title={tct('Seer Autofix for [projectName]', {
           projectName: (
             <Text as="span" monospace>
               {project.slug}

--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -1,13 +1,12 @@
 import {Alert} from '@sentry/scraps/alert';
-import {LinkButton} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import {useProjectSeerPreferences} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
-import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
@@ -52,29 +51,14 @@ function SeerProjectDetails() {
             </Text>
           ),
         })}
-        subtitle={t(
-          'Choose how Seer automatically triages and diagnoses incoming issues, before you even notice them.'
+        subtitle={tct(
+          'Connect repositories to projects, and choose which Agent should automatically process issues. [read_the_docs:Read the docs] to learn what Seer can do',
+          {
+            read_the_docs: (
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+            ),
+          }
         )}
-        action={
-          <Flex gap="lg">
-            <FeedbackButton
-              size="md"
-              feedbackOptions={{
-                messagePlaceholder: t('How can we make Seer better for you?'),
-                tags: {
-                  ['feedback.source']: 'seer-settings-project-details',
-                  ['feedback.owner']: 'coding-workflows',
-                },
-              }}
-            />
-            <LinkButton
-              href="https://docs.sentry.io/product/ai-in-sentry/seer/issue-fix/"
-              external
-            >
-              {t('Read the docs')}
-            </LinkButton>
-          </Flex>
-        }
       />
       {canWrite ? null : (
         <Stack paddingBottom="xl">

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -15,7 +15,7 @@ export default function SeerAutomationProjects() {
         <SettingsPageHeader
           title={t('Seer Autofix')}
           subtitle={tct(
-            `Configure [rca:Issue Autofix] by connecting your repositories with projects. Connecting your source code is required and gives the coding agent context for Root Cause Analysis, Solution generation, and PR creation. Enable an Autofix Agent to automatically process and fix actionable issues as they are detected. [read_the_docs:Learn what Seer can do from our docs].`,
+            `Configure [rca:Issue Autofix] by connecting your repositories with projects. Connecting your source code is required and gives the coding agent context for Root Cause Analysis, Solution generation, and PR creation. Enable an Autofix Agent to automatically process and fix actionable issues as they are detected. [read_the_docs:Read the docs] to learn what Seer can do.`,
             {
               rca: (
                 <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#root-cause-analysis" />

--- a/static/gsApp/views/seerAutomation/projects.tsx
+++ b/static/gsApp/views/seerAutomation/projects.tsx
@@ -1,13 +1,34 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
 import AnalyticsArea from 'sentry/components/analyticsArea';
+import {t, tct} from 'sentry/locale';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import SeerProjectTable from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTable';
+import SeerSettingsPageContent from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationProjects() {
   return (
     <AnalyticsArea name="projects">
       <SeerSettingsPageWrapper>
-        <SeerProjectTable />
+        <SettingsPageHeader
+          title={t('Seer Autofix')}
+          subtitle={tct(
+            `Configure [rca:Issue Autofix] by connecting your repositories with projects. Connecting your source code is required and gives the coding agent context for Root Cause Analysis, Solution generation, and PR creation. Enable an Autofix Agent to automatically process and fix actionable issues as they are detected. [read_the_docs:Learn what Seer can do from our docs].`,
+            {
+              rca: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#root-cause-analysis" />
+              ),
+              read_the_docs: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+              ),
+            }
+          )}
+        />
+        <SeerSettingsPageContent>
+          <SeerProjectTable />
+        </SeerSettingsPageContent>
       </SeerSettingsPageWrapper>
     </AnalyticsArea>
   );

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -1,10 +1,10 @@
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import NotFound from 'sentry/components/errors/notFound';
 import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
-import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -67,7 +67,7 @@ export default function SeerRepoDetails() {
         projectSlug={repoWithSettings?.name}
       />
       <SettingsPageHeader
-        title={tct('Seer Settings for [repoName] [providerLink]', {
+        title={tct('Seer Code Review for [repoName] [providerLink]', {
           repoName: <code>{repoWithSettings?.name}</code>,
           providerLink: (
             <ExternalLink href={repoWithSettings?.url}>

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -15,7 +15,7 @@ export default function SeerAutomationRepos() {
         <SettingsPageHeader
           title={t('Seer Code Review')}
           subtitle={tct(
-            `Enable [code_review:Code-Review] on your repositories to automatically catch bugs before they're merged into production. Reviews can be triggered when a PR is ready for review, after each update to a PR, and always manually by tagging [code:@sentry review] in the comments. [read_the_docs:Learn what Seer can do from our docs].`,
+            `Enable [code_review:Code-Review] on your repositories to automatically catch bugs before they're merged into production. Reviews can be triggered when a PR is ready for review, after each update to a PR, and always manually by tagging [code:@sentry review] in the comments. [read_the_docs:Read the docs] to learn what Seer can do.`,
             {
               code: <code />,
               code_review: (

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -1,13 +1,35 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
 import AnalyticsArea from 'sentry/components/analyticsArea';
+import {t, tct} from 'sentry/locale';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
 import SeerRepoTable from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
+import SeerSettingsPageContent from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 
 export default function SeerAutomationRepos() {
   return (
     <AnalyticsArea name="repos">
       <SeerSettingsPageWrapper>
-        <SeerRepoTable />
+        <SettingsPageHeader
+          title={t('Seer Code Review')}
+          subtitle={tct(
+            `Enable [code_review:Code-Review] on your repositories to automatically catch bugs before they're merged into production. Reviews can be triggered when a PR is ready for review, after each update to a PR, and always manually by tagging [code:@sentry review] in the comments. [read_the_docs:Learn what Seer can do from our docs].`,
+            {
+              code: <code />,
+              code_review: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/ai-code-review/" />
+              ),
+              read_the_docs: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+              ),
+            }
+          )}
+        />
+        <SeerSettingsPageContent>
+          <SeerRepoTable />
+        </SeerSettingsPageContent>
       </SeerSettingsPageWrapper>
     </AnalyticsArea>
   );

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -24,7 +24,7 @@ export default function SeerAutomationSettings() {
       <SettingsPageHeader
         title={t('Seer')}
         subtitle={tct(
-          `Configure how Seer works with your codebase. Seer includes Issue Autofix and AI Code Review. Issue Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [read_the_docs:Learn what Seer can do from our docs].`,
+          `Configure how Seer works with your codebase. Seer includes [rca:Issue Autofix] and [code_review:AI Code Review]. Issue Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [read_the_docs:Read the docs] to learn what Seer can do.`,
           {
             rca: (
               <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#root-cause-analysis" />

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -22,7 +22,7 @@ export default function SeerAutomationSettings() {
   return (
     <SeerSettingsPageWrapper>
       <SettingsPageHeader
-        title={t('Seer')}
+        title={t('Seer Overview')}
         subtitle={tct(
           `Configure how Seer works with your codebase. Seer includes [rca:Issue Autofix] and [code_review:AI Code Review]. Issue Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [read_the_docs:Read the docs] to learn what Seer can do.`,
           {

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -9,7 +9,9 @@ import {t, tct} from 'sentry/locale';
 import {DEFAULT_CODE_REVIEW_TRIGGERS} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import useOrganization from 'sentry/utils/useOrganization';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 
+import SeerSettingsPageContent from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
 import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
 import useCanWriteSettings from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
@@ -19,180 +21,201 @@ export default function SeerAutomationSettings() {
 
   return (
     <SeerSettingsPageWrapper>
-      <Form
-        saveOnBlur
-        apiMethod="PUT"
-        apiEndpoint={`/organizations/${organization.slug}/`}
-        allowUndo
-        initialData={{
-          // Project<->Repo settings:
-          defaultAutofixAutomationTuning: organization.defaultAutofixAutomationTuning,
-          autoOpenPrs: organization.autoOpenPrs ?? false,
+      <SettingsPageHeader
+        title={t('Seer')}
+        subtitle={tct(
+          `Configure how Seer works with your codebase. Seer includes Issue Autofix and AI Code Review. Issue Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [read_the_docs:Learn what Seer can do from our docs].`,
+          {
+            rca: (
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#root-cause-analysis" />
+            ),
+            code_review: (
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/ai-code-review/" />
+            ),
+            read_the_docs: (
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+            ),
+          }
+        )}
+      />
+      <SeerSettingsPageContent>
+        <Form
+          saveOnBlur
+          apiMethod="PUT"
+          apiEndpoint={`/organizations/${organization.slug}/`}
+          allowUndo
+          initialData={{
+            // Project<->Repo settings:
+            defaultAutofixAutomationTuning: organization.defaultAutofixAutomationTuning,
+            autoOpenPrs: organization.autoOpenPrs ?? false,
 
-          // Second section
-          autoEnableCodeReview: organization.autoEnableCodeReview ?? true,
-          defaultCodeReviewTriggers:
-            organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS,
+            // Second section
+            autoEnableCodeReview: organization.autoEnableCodeReview ?? true,
+            defaultCodeReviewTriggers:
+              organization.defaultCodeReviewTriggers ?? DEFAULT_CODE_REVIEW_TRIGGERS,
 
-          // Third section
-          enableSeerEnhancedAlerts: organization.enableSeerEnhancedAlerts ?? true,
-          enableSeerCoding: organization.enableSeerCoding ?? true,
-        }}
-      >
-        <JsonForm
-          disabled={!canWrite}
-          forms={[
-            {
-              title: (
-                <Flex gap="md">
-                  <span>{t('Default automations for new projects')}</span>
-                  <QuestionTooltip
-                    isHoverable
-                    title={tct(
-                      'These settings apply as new projects are created. Any [link:existing projects] will not be affected.',
-                      {
-                        link: (
-                          <Link to={`/settings/${organization.slug}/seer/projects/`} />
-                        ),
-                      }
-                    )}
-                    size="xs"
-                    icon="info"
-                  />
-                </Flex>
-              ),
-              fields: [
-                {
-                  name: 'defaultAutofixAutomationTuning',
-                  label: t('Auto-Trigger Fixes by Default'),
-                  help: t(
-                    'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
-                  ),
-                  type: 'boolean',
-                  // Convert from between enum and boolean
-                  // All values other than 'off' are converted to 'medium'
-                  setValue: (
-                    value: Organization['defaultAutofixAutomationTuning']
-                  ): boolean => Boolean(value && value !== 'off'),
-                  getValue: (
-                    value: boolean
-                  ): Organization['defaultAutofixAutomationTuning'] =>
-                    value ? 'medium' : 'off',
-                },
-                {
-                  name: 'autoOpenPrs',
-                  label: t('Allow Root Cause Analysis to create PRs by Default'),
-                  help: (
-                    <Stack gap="sm">
-                      {t(
-                        'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+            // Third section
+            enableSeerEnhancedAlerts: organization.enableSeerEnhancedAlerts ?? true,
+            enableSeerCoding: organization.enableSeerCoding ?? true,
+          }}
+        >
+          <JsonForm
+            disabled={!canWrite}
+            forms={[
+              {
+                title: (
+                  <Flex gap="md">
+                    <span>{t('Default automations for new projects')}</span>
+                    <QuestionTooltip
+                      isHoverable
+                      title={tct(
+                        'These settings apply as new projects are created. Any [link:existing projects] will not be affected.',
+                        {
+                          link: (
+                            <Link to={`/settings/${organization.slug}/seer/projects/`} />
+                          ),
+                        }
                       )}
-                      {organization.enableSeerCoding === false && (
-                        <Alert variant="warning">
+                      size="xs"
+                      icon="info"
+                    />
+                  </Flex>
+                ),
+                fields: [
+                  {
+                    name: 'defaultAutofixAutomationTuning',
+                    label: t('Auto-Trigger Fixes by Default'),
+                    help: t(
+                      'For all new projects, Seer will automatically create a root cause analysis for highly actionable issues and propose a solution without a user needing to prompt it.'
+                    ),
+                    type: 'boolean',
+                    // Convert from between enum and boolean
+                    // All values other than 'off' are converted to 'medium'
+                    setValue: (
+                      value: Organization['defaultAutofixAutomationTuning']
+                    ): boolean => Boolean(value && value !== 'off'),
+                    getValue: (
+                      value: boolean
+                    ): Organization['defaultAutofixAutomationTuning'] =>
+                      value ? 'medium' : 'off',
+                  },
+                  {
+                    name: 'autoOpenPrs',
+                    label: t('Allow Root Cause Analysis to create PRs by Default'),
+                    help: (
+                      <Stack gap="sm">
+                        {t(
+                          'For all new projects with connected repos, Seer will be able to make pull requests for highly actionable issues.'
+                        )}
+                        {organization.enableSeerCoding === false && (
+                          <Alert variant="warning">
+                            {tct(
+                              '[settings:"Enable Code Generation"] must be enabled for Seer to create pull requests.',
+                              {
+                                settings: (
+                                  <Link
+                                    to={`/settings/${organization.slug}/seer/#enableSeerCoding`}
+                                  />
+                                ),
+                              }
+                            )}
+                          </Alert>
+                        )}
+                      </Stack>
+                    ),
+                    type: 'boolean',
+                    disabled: !canWrite || organization.enableSeerCoding === false,
+                    setValue: (value: boolean): boolean =>
+                      organization.enableSeerCoding === false ? false : value,
+                  },
+                ],
+              },
+              {
+                title: (
+                  <Flex gap="md">
+                    <span>{t('Default Code Review for New Repos')}</span>
+                    <QuestionTooltip
+                      isHoverable
+                      title={tct(
+                        'These settings apply as repos are newly connected. Any [link:existing repos] will not be affected.',
+                        {
+                          link: (
+                            <Link to={`/settings/${organization.slug}/seer/repos/`} />
+                          ),
+                        }
+                      )}
+                      size="xs"
+                      icon="info"
+                    />
+                  </Flex>
+                ),
+                fields: [
+                  {
+                    name: 'autoEnableCodeReview',
+                    label: t('Enable Code Review by Default'),
+                    help: t(
+                      'For all new repos connected, Seer will review your PRs and flag potential bugs.'
+                    ),
+                    type: 'boolean',
+                  },
+                  {
+                    name: 'defaultCodeReviewTriggers',
+                    label: t('Code Review Triggers'),
+                    help: tct(
+                      'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
+                      {code: <code />}
+                    ),
+                    type: 'choice',
+                    multiple: true,
+                    choices: [
+                      ['on_ready_for_review', t('On Ready for Review')],
+                      ['on_new_commit', t('On New Commit')],
+                    ],
+                    formatMessageValue: false,
+                  },
+                ],
+              },
+              {
+                title: t('Advanced Settings'),
+                fields: [
+                  {
+                    name: 'enableSeerEnhancedAlerts',
+                    label: t('Enable Seer Context in Alerts'),
+                    help: t('Seer will provide extra context in supported alerts.'),
+                    type: 'boolean',
+                  },
+                  {
+                    name: 'enableSeerCoding',
+                    label: t('Enable Code Generation'),
+                    help: (
+                      <Flex gap="sm">
+                        <span>
                           {tct(
-                            '[settings:"Enable Code Generation"] must be enabled for Seer to create pull requests.',
+                            'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. [docs:Read the docs] to learn more.',
                             {
-                              settings: (
-                                <Link
-                                  to={`/settings/${organization.slug}/seer/#enableSeerCoding`}
-                                />
+                              docs: (
+                                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#code-generation" />
                               ),
                             }
                           )}
-                        </Alert>
-                      )}
-                    </Stack>
-                  ),
-                  type: 'boolean',
-                  disabled: !canWrite || organization.enableSeerCoding === false,
-                  setValue: (value: boolean): boolean =>
-                    organization.enableSeerCoding === false ? false : value,
-                },
-              ],
-            },
-            {
-              title: (
-                <Flex gap="md">
-                  <span>{t('Default Code Review for New Repos')}</span>
-                  <QuestionTooltip
-                    isHoverable
-                    title={tct(
-                      'These settings apply as repos are newly connected. Any [link:existing repos] will not be affected.',
-                      {
-                        link: <Link to={`/settings/${organization.slug}/seer/repos/`} />,
-                      }
-                    )}
-                    size="xs"
-                    icon="info"
-                  />
-                </Flex>
-              ),
-              fields: [
-                {
-                  name: 'autoEnableCodeReview',
-                  label: t('Enable Code Review by Default'),
-                  help: t(
-                    'For all new repos connected, Seer will review your PRs and flag potential bugs.'
-                  ),
-                  type: 'boolean',
-                },
-                {
-                  name: 'defaultCodeReviewTriggers',
-                  label: t('Code Review Triggers'),
-                  help: tct(
-                    'Reviews can always run on demand by calling [code:@sentry review], whenever a PR is opened, or after each commit is pushed to a PR.',
-                    {code: <code />}
-                  ),
-                  type: 'choice',
-                  multiple: true,
-                  choices: [
-                    ['on_ready_for_review', t('On Ready for Review')],
-                    ['on_new_commit', t('On New Commit')],
-                  ],
-                  formatMessageValue: false,
-                },
-              ],
-            },
-            {
-              title: t('Advanced Settings'),
-              fields: [
-                {
-                  name: 'enableSeerEnhancedAlerts',
-                  label: t('Enable Seer Context in Alerts'),
-                  help: t('Seer will provide extra context in supported alerts.'),
-                  type: 'boolean',
-                },
-                {
-                  name: 'enableSeerCoding',
-                  label: t('Enable Code Generation'),
-                  help: (
-                    <Flex gap="sm">
-                      <span>
-                        {tct(
-                          'Enable Seer workflows that streamline creating code changes for your review, such as the ability to create pull requests or branches. [docs:Read the docs] to learn more.',
-                          {
-                            docs: (
-                              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/root-cause-analysis/#code-generation" />
-                            ),
-                          }
-                        )}
-                      </span>
-                      <QuestionTooltip
-                        size="xs"
-                        title={t(
-                          'This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input.'
-                        )}
-                      />
-                    </Flex>
-                  ),
-                  type: 'boolean',
-                  defaultValue: true, // See ENABLE_SEER_CODING_DEFAULT in sentry/src/sentry/constants.py
-                },
-              ],
-            },
-          ]}
-        />
-      </Form>
+                        </span>
+                        <QuestionTooltip
+                          size="xs"
+                          title={t(
+                            'This does not impact chat sessions where the agent will always be able to emit code snippets and examples while responding to your input.'
+                          )}
+                        />
+                      </Flex>
+                    ),
+                    type: 'boolean',
+                    defaultValue: true, // See ENABLE_SEER_CODING_DEFAULT in sentry/src/sentry/constants.py
+                  },
+                ],
+              },
+            ]}
+          />
+        </Form>
+      </SeerSettingsPageContent>
     </SeerSettingsPageWrapper>
   );
 }


### PR DESCRIPTION
**Before**
All pages had the same copy at the top, and the tab labels were messy
| Tab | Img |
| --- | --- |
| All tabs the same | <img width="779" height="220" alt="SCR-20260227-jhlr" src="https://github.com/user-attachments/assets/c25c63ab-2c40-41d0-b105-fe33848aaea5" />


**After**
more product centric, and trying to explain how things work
| Tab | Img |
| --- | --- |
| Settings | <img width="776" height="215" alt="Screenshot 2026-02-27 at 10 07 20 AM" src="https://github.com/user-attachments/assets/35575ce7-abed-46e1-b104-40535af4ae22" />
| Autofix | <img width="776" height="215" alt="Screenshot 2026-02-27 at 10 07 23 AM" src="https://github.com/user-attachments/assets/20d6bdc2-58c8-4b0a-a136-defcc7213478" />
| Code Review | <img width="776" height="215" alt="Screenshot 2026-02-27 at 10 09 35 AM" src="https://github.com/user-attachments/assets/425e38f3-5fbb-49ec-b433-4b30df4ff150" />
| Autofix for $project | <img width="974" height="351" alt="SCR-20260227-nxrz" src="https://github.com/user-attachments/assets/e3532637-22aa-4b96-b86a-496ccbfbc29a" />
| Code Review for $repo | <img width="975" height="266" alt="SCR-20260227-nxls" src="https://github.com/user-attachments/assets/00755ff5-a67b-4e94-8700-701a20b41c3b" />

Also i snuck in a copy change to align the copy for Create Pull Request checkbox
| Seer Agent | Cursor Agent |
| --- | --- |
| <img width="772" height="285" alt="Screenshot 2026-02-27 at 10 12 57 AM" src="https://github.com/user-attachments/assets/4426b776-9628-4fc9-8234-f135102d6344" /> | <img width="772" height="285" alt="Screenshot 2026-02-27 at 10 13 01 AM" src="https://github.com/user-attachments/assets/0f7c4f07-c1c4-4b64-b898-0323979ce9c7" />

