### PR TITLE
fix(counter): Handle empty Redis pipeline result in increment_project_counter_in_cache

### DIFF
--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -60,8 +60,14 @@ def increment_project_counter_in_cache(project, using="default") -> int:
     with redis.pipeline() as pipe:
         pipe.lpop(redis_key)
         pipe.llen(redis_key)
-        short_id_from_redis, remaining = pipe.execute()
-        short_id_from_redis = int(short_id_from_redis) if short_id_from_redis is not None else None
+        result = pipe.execute()
+
+    if len(result) == 2:
+        short_id_from_redis = int(result[0]) if result[0] is not None else None
+        remaining = result[1]
+    else:
+        short_id_from_redis = None
+        remaining = 0
 
     if short_id_from_redis is None:  # fallback if not populated in Redis
         metrics.incr("counter.increment_project_counter_in_cache.fallback")

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -290,6 +290,25 @@ def test_fallback_to_database(default_project, redis_mock) -> None:
 
 
 @django_db_all
+def test_increment_project_counter_in_cache_empty_pipeline_result(default_project, redis_mock):
+    """When Redis pipeline returns an empty list (e.g. during cluster failover),
+    fall back to the database path instead of crashing with ValueError."""
+    pipeline_mock = MagicMock()
+    pipeline_mock.__enter__.return_value = pipeline_mock
+    pipeline_mock.__exit__.return_value = None
+    with patch.object(redis_mock, "pipeline", return_value=pipeline_mock):
+        pipeline_mock.execute.return_value = []
+        with patch("sentry.models.counter.refill_cached_short_ids.delay") as mock_refill:
+            with patch(
+                "sentry.models.counter.increment_project_counter_in_database", return_value=42
+            ) as mock_db:
+                result = increment_project_counter_in_cache(default_project, using="default")
+                assert result == 42
+                mock_db.assert_called_once_with(default_project, using="default")
+                mock_refill.assert_called_once()
+
+
+@django_db_all
 def test_preallocation_end_to_end(default_project) -> None:
     # The first increment should trigger a refill
     with TaskRunner():


### PR DESCRIPTION
During Redis cluster failover, pipe.execute() can return an empty list, causing a ValueError on unpacking. Check the result length before unpacking and fall back to the existing database path when results are missing.

I'm fairly confident we can fix this upstream in https://github.com/getsentry/sentry-redis-tools but that is a much bigger change with a significantly larger blast radius - given how infrequently we hit these I'm not sure it's worth the effort yet

Fixes SENTRY-5HQ2