### PR TITLE
fix(ui): Filter null-tuple unhandled rejections

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -44,6 +44,39 @@ describe('initializeSdk', () => {
       })
     );
   });
+
+  it('filters malformed [null,null] unhandled rejections', () => {
+    initializeSdk({
+      ...window.__initialData,
+      apmSampling: 1,
+      sentryConfig: {
+        allowUrls: [],
+        dsn: '',
+        release: '',
+        tracePropagationTargets: [],
+      },
+    });
+
+    const initConfig = jest.mocked(Sentry.init).mock.calls.slice(-1)[0]?.[0];
+    expect(initConfig?.beforeSend).toBeDefined();
+
+    const event = {
+      message: '[null,null]',
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: ',',
+            mechanism: {
+              type: 'auto.browser.global_handlers.onunhandledrejection',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(initConfig?.beforeSend?.(event, {} as Sentry.EventHint)).toBeNull();
+  });
 });
 
 describe('isFilteredRequestErrorEvent', () => {

--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -73,7 +73,7 @@ describe('initializeSdk', () => {
           },
         ],
       },
-    };
+    } as Sentry.ErrorEvent;
 
     expect(initConfig?.beforeSend?.(event, {} as Sentry.EventHint)).toBeNull();
   });

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -203,7 +203,11 @@ export function initializeSdk(config: Config) {
     },
 
     beforeSend(event, hint) {
-      if (isFilteredRequestErrorEvent(event) || isEventWithFileUrl(event)) {
+      if (
+        isFilteredRequestErrorEvent(event) ||
+        isEventWithFileUrl(event) ||
+        isNullTupleUnhandledRejectionEvent(event)
+      ) {
         return null;
       }
 
@@ -296,6 +300,23 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
 
 export function isEventWithFileUrl(event: Event): boolean {
   return !!event.request?.url?.startsWith('file://');
+}
+
+/**
+ * Some unhandled rejections are serialized as `[null,null]`, which maps to
+ * an unhelpful `Error: ,` and is not actionable.
+ */
+function isNullTupleUnhandledRejectionEvent(event: Event): boolean {
+  if (event.message !== '[null,null]') {
+    return false;
+  }
+
+  const error = event.exception?.values?.at(-1);
+  return (
+    error?.type === 'Error' &&
+    error.value === ',' &&
+    error.mechanism?.type === 'auto.browser.global_handlers.onunhandledrejection'
+  );
 }
 
 /** Tag and set fingerprint for UndefinedResponseBodyError events */


### PR DESCRIPTION
Drop malformed unhandled rejection events that serialize as [null,null] because they are noisy and not actionable. Keep filtering strict by checking the error type, value, and mechanism in beforeSend.

silences https://sentry.sentry.io/issues/6235565924/
