### PR TITLE
ref(seer): Add typed wrappers for Seer API callsites

### DIFF
--- a/src/sentry/api/endpoints/seer_models.py
+++ b/src/sentry/api/endpoints/seer_models.py
@@ -14,10 +14,7 @@ from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import (
-    make_signed_seer_api_request,
-    seer_autofix_default_connection_pool,
-)
+from sentry.seer.signed_seer_api import make_seer_models_request
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.cache import cache
 
@@ -82,16 +79,8 @@ class SeerModelsEndpoint(Endpoint):
         if cached_data is not None:
             return Response(cached_data, status=200)
 
-        path = "/v1/models"
-
         try:
-            response = make_signed_seer_api_request(
-                seer_autofix_default_connection_pool,
-                path,
-                b"",
-                timeout=5,
-                method="GET",
-            )
+            response = make_seer_models_request(timeout=5)
             if response.status >= 400:
                 raise SeerApiError("Seer request failed", response.status)
 

--- a/src/sentry/feedback/lib/seer_api.py
+++ b/src/sentry/feedback/lib/seer_api.py
@@ -1,6 +1,11 @@
+from typing import TypedDict
+
+import orjson
 from django.conf import settings
+from urllib3 import BaseHTTPResponse, Retry
 
 from sentry.net.http import connection_from_url
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 
 # Shared connection pool for feedback AI usecases. No timeout or retries by default, but requests can override these params.
 seer_summarization_connection_pool = connection_from_url(
@@ -9,3 +14,102 @@ seer_summarization_connection_pool = connection_from_url(
     retries=0,
     maxsize=10,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
 )
+
+
+class SpamDetectionRequest(TypedDict):
+    organization_id: int
+    feedback_message: str
+
+
+class LabelGenerationRequest(TypedDict):
+    organization_id: int
+    feedback_message: str
+
+
+class GenerateFeedbackTitleRequest(TypedDict):
+    organization_id: int
+    feedback_message: str
+
+
+class LabelGroupFeedbacksContext(TypedDict):
+    feedback: str
+    labels: list[str]
+
+
+class LabelGroupsRequest(TypedDict):
+    labels: list[str]
+    feedbacks_context: list[LabelGroupFeedbacksContext]
+
+
+class SummarizeFeedbacksRequest(TypedDict):
+    feedbacks: list[str]
+
+
+def make_spam_detection_request(
+    body: SpamDetectionRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/feedback/spam-detection",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_label_generation_request(
+    body: LabelGenerationRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/feedback/labels",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_title_generation_request(
+    body: GenerateFeedbackTitleRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/feedback/title",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_label_groups_request(
+    body: LabelGroupsRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/feedback/label-groups",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_summarize_feedbacks_request(
+    body: SummarizeFeedbacksRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/feedback/summarize",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -1,24 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
 
-from sentry.feedback.lib.seer_api import seer_summarization_connection_pool
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.utils import json, metrics
+from sentry.feedback.lib.seer_api import (
+    GenerateFeedbackTitleRequest,
+    make_title_generation_request,
+)
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
-SEER_TITLE_GENERATION_ENDPOINT_PATH = "/v1/automation/summarize/feedback/title"
 SEER_TIMEOUT_S = 15
 SEER_RETRIES = 0  # Do not retry since this is called in ingest.
-
-
-class GenerateFeedbackTitleRequest(TypedDict):
-    """Corresponds to GenerateFeedbackTitleRequest in Seer."""
-
-    organization_id: int
-    feedback_message: str
 
 
 def truncate_feedback_title(title: str, max_words: int = 10) -> str:
@@ -70,10 +63,8 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
     )
 
     try:
-        response = make_signed_seer_api_request(
-            connection_pool=seer_summarization_connection_pool,
-            path=SEER_TITLE_GENERATION_ENDPOINT_PATH,
-            body=json.dumps(seer_request).encode("utf-8"),
+        response = make_title_generation_request(
+            seer_request,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
         )

--- a/src/sentry/replays/lib/seer_api.py
+++ b/src/sentry/replays/lib/seer_api.py
@@ -1,6 +1,11 @@
+from typing import NotRequired, TypedDict
+
+import orjson
 from django.conf import settings
+from urllib3 import BaseHTTPResponse, Retry
 
 from sentry.net.http import connection_from_url
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 
 # Shared connection pool for replay AI usecases. No timeout or retries by default, but requests can override these params.
 seer_summarization_connection_pool = connection_from_url(
@@ -9,3 +14,67 @@ seer_summarization_connection_pool = connection_from_url(
     retries=0,
     maxsize=20,  # Max persisted connections. If the number of concurrent requests exceeds this, temporary connections are created.
 )
+
+
+class ReplaySummaryStartRequest(TypedDict):
+    replay_id: str
+    replay_start: str | None
+    replay_end: str | None
+    num_segments: int
+    organization_id: int
+    project_id: int
+    temperature: NotRequired[float | None]
+
+
+class ReplaySummaryStateRequest(TypedDict):
+    replay_id: str
+    organization_id: int
+    project_id: int
+
+
+class ReplayDeleteSeerDataRequest(TypedDict):
+    replay_ids: list[str]
+    organization_id: int
+    project_id: int
+
+
+def make_replay_summary_start_request(
+    body: ReplaySummaryStartRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/replay/breadcrumbs/start",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_replay_summary_state_request(
+    body: ReplaySummaryStateRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/replay/breadcrumbs/state",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )
+
+
+def make_replay_delete_request(
+    body: ReplayDeleteSeerDataRequest,
+    timeout: int | float | None = None,
+    retries: int | None | Retry = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_connection_pool,
+        "/v1/automation/summarize/replay/breadcrumbs/delete",
+        body=orjson.dumps(body),
+        timeout=timeout,
+        retries=retries,
+    )

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -75,7 +75,7 @@ class OrgProjectKnowledgeProjectData(TypedDict):
     transaction_count: int
     instrumentation: list[str]
     top_transactions: list[str]
-    top_span_operations: list[str]
+    top_span_operations: list[tuple[str, str]]
 
 
 class OrgProjectKnowledgeIndexRequest(TypedDict):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -1,9 +1,10 @@
 import hashlib
 import hmac
 import logging
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import urlparse
 
+import orjson
 import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
@@ -64,6 +65,106 @@ def make_signed_seer_api_request(
             headers={"content-type": "application/json;charset=utf-8", **auth_headers},
             **options,
         )
+
+
+class OrgProjectKnowledgeProjectData(TypedDict):
+    project_id: int
+    slug: str
+    sdk_name: str
+    error_count: int
+    transaction_count: int
+    instrumentation: list[str]
+    top_transactions: list[str]
+    top_span_operations: list[str]
+
+
+class OrgProjectKnowledgeIndexRequest(TypedDict):
+    org_id: int
+    projects: list[OrgProjectKnowledgeProjectData]
+
+
+class RemoveRepositoryRequest(TypedDict):
+    organization_id: int
+    repo_provider: str
+    repo_external_id: str
+
+
+class ExplorerIndexProject(TypedDict):
+    org_id: int
+    project_id: int
+
+
+class ExplorerIndexRequest(TypedDict):
+    projects: list[ExplorerIndexProject]
+
+
+class LlmGenerateRequest(TypedDict):
+    provider: str
+    model: str
+    referrer: str
+    prompt: str
+    system_prompt: str
+    temperature: float
+    max_tokens: int
+    response_schema: NotRequired[dict[str, Any]]
+
+
+def make_org_project_knowledge_index_request(
+    body: OrgProjectKnowledgeIndexRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/automation/explorer/index/org-project-knowledge",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_remove_repository_request(
+    body: RemoveRepositoryRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/project-preference/remove-repository",
+        body=orjson.dumps(body),
+    )
+
+
+def make_explorer_index_request(
+    body: ExplorerIndexRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/automation/explorer/index",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_seer_models_request(
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/models",
+        body=b"",
+        timeout=timeout,
+        method="GET",
+    )
+
+
+def make_llm_generate_request(
+    body: LlmGenerateRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/llm/generate",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
 
 
 def sign_with_seer_secret(body: bytes) -> dict[str, str]:

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -5,9 +5,11 @@ import random
 from datetime import UTC, datetime
 from uuid import uuid4
 
+import orjson
 import sentry_sdk
 from django.conf import settings
 from pydantic import BaseModel, Field
+from urllib3 import BaseHTTPResponse
 
 from sentry import features, options
 from sentry.constants import VALID_PLATFORMS
@@ -20,7 +22,6 @@ from sentry.seer.explorer.utils import normalize_description
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
-from sentry.utils import json
 from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
@@ -101,6 +102,24 @@ class IssueDetectionRequest(BaseModel):
     organization_id: int
     project_id: int
     org_slug: str
+
+
+def make_issue_detection_request(
+    request: IssueDetectionRequest,
+    timeout: int | float | None = None,
+    retries: int | None = None,
+) -> BaseHTTPResponse:
+    extra_kwargs: dict[str, int | float | None] = {}
+    if timeout is not None:
+        extra_kwargs["timeout"] = timeout
+    if retries is not None:
+        extra_kwargs["retries"] = retries
+    return make_signed_seer_api_request(
+        seer_issue_detection_connection_pool,
+        SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
+        body=orjson.dumps(request.dict()),
+        **extra_kwargs,
+    )
 
 
 def get_base_platform(platform: str | None) -> str | None:
@@ -299,10 +318,8 @@ def detect_llm_issues_for_project(project_id: int) -> None:
         org_slug=organization_slug,
     )
 
-    response = make_signed_seer_api_request(
-        connection_pool=seer_issue_detection_connection_pool,
-        path=SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
-        body=json.dumps(seer_request.dict()).encode("utf-8"),
+    response = make_issue_detection_request(
+        seer_request,
         timeout=SEER_TIMEOUT_S,
         retries=0,
     )

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 import orjson
@@ -109,7 +110,7 @@ def make_issue_detection_request(
     timeout: int | float | None = None,
     retries: int | None = None,
 ) -> BaseHTTPResponse:
-    extra_kwargs: dict[str, int | float | None] = {}
+    extra_kwargs: dict[str, Any] = {}
     if timeout is not None:
         extra_kwargs["timeout"] = timeout
     if retries is not None:

--- a/tests/sentry/api/endpoints/test_seer_models.py
+++ b/tests/sentry/api/endpoints/test_seer_models.py
@@ -13,7 +13,7 @@ class TestSeerModels(APITestCase):
         super().setUp()
         self.url = "/api/0/seer/models/"
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_successful(self, mock_request: MagicMock) -> None:
         """Test successful retrieval of models from Seer."""
         mock_request.return_value.status = 200
@@ -27,7 +27,7 @@ class TestSeerModels(APITestCase):
         assert response.data == {"models": ["gpt-4", "claude-3", "gemini-pro"]}
         mock_request.assert_called_once()
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_no_authentication_required(self, mock_request: MagicMock) -> None:
         """Test that the endpoint works without authentication."""
         mock_request.return_value.status = 200
@@ -37,7 +37,7 @@ class TestSeerModels(APITestCase):
 
         assert response.status_code == status.HTTP_200_OK
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_timeout(self, mock_request: MagicMock) -> None:
         """Test handling of timeout errors."""
         mock_request.side_effect = TimeoutError("Request timed out")
@@ -47,7 +47,7 @@ class TestSeerModels(APITestCase):
         assert response.status_code == status.HTTP_504_GATEWAY_TIMEOUT
         assert response.data == {"detail": "Request to Seer timed out"}
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_request_exception(self, mock_request: MagicMock) -> None:
         """Test handling of request exceptions."""
         mock_request.side_effect = SeerApiError("Connection error", 500)
@@ -57,7 +57,7 @@ class TestSeerModels(APITestCase):
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
         assert response.data == {"detail": "Failed to fetch models from Seer"}
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_http_error(self, mock_request: MagicMock) -> None:
         """Test handling of HTTP errors from Seer."""
         mock_request.return_value.status = 500
@@ -67,7 +67,7 @@ class TestSeerModels(APITestCase):
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
         assert response.data == {"detail": "Failed to fetch models from Seer"}
 
-    @patch("sentry.api.endpoints.seer_models.make_signed_seer_api_request")
+    @patch("sentry.api.endpoints.seer_models.make_seer_models_request")
     def test_get_models_empty_response(self, mock_request: MagicMock) -> None:
         """Test handling of empty models list."""
         mock_request.return_value.status = 200

--- a/tests/sentry/feedback/endpoints/test_organization_feedback_categories.py
+++ b/tests/sentry/feedback/endpoints/test_organization_feedback_categories.py
@@ -31,7 +31,7 @@ class OrganizationFeedbackCategoriesTest(APITestCase):
             return_value=True,
         )
         self.mock_make_signed_seer_api_request_patcher = patch(
-            "sentry.feedback.endpoints.organization_feedback_categories.make_signed_seer_api_request"
+            "sentry.feedback.endpoints.organization_feedback_categories.make_label_groups_request"
         )
         self.mock_threshold_to_get_associated_labels_patcher = patch(
             "sentry.feedback.endpoints.organization_feedback_categories.THRESHOLD_TO_GET_ASSOCIATED_LABELS",

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -822,7 +822,7 @@ def test_create_feedback_issue_title_from_seer(
 
 
 @django_db_all
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_create_feedback_issue_title_does_not_throw(
     mock_make_signed_seer_api_request,
     default_project,
@@ -839,7 +839,7 @@ def test_create_feedback_issue_title_does_not_throw(
 
 
 @django_db_all
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_create_feedback_issue_title_from_seer_skips_if_spam(
     mock_make_signed_seer_api_request,
     default_project,

--- a/tests/sentry/feedback/usecases/test_label_generation.py
+++ b/tests/sentry/feedback/usecases/test_label_generation.py
@@ -4,11 +4,10 @@ import pytest
 import requests
 
 from sentry.feedback.usecases.label_generation import generate_labels
-from sentry.utils import json
 from tests.sentry.feedback import MockSeerResponse
 
 
-@patch("sentry.feedback.usecases.label_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.label_generation.make_label_generation_request")
 def test_generate_labels_success_response(mock_make_seer_request) -> None:
     mock_response = MockSeerResponse(
         200,
@@ -21,7 +20,7 @@ def test_generate_labels_success_response(mock_make_seer_request) -> None:
     )
 
     mock_make_seer_request.assert_called_once()
-    request_body = json.loads(mock_make_seer_request.call_args[1]["body"].decode("utf-8"))
+    request_body = mock_make_seer_request.call_args[0][0]
     expected_request = {
         "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
         "organization_id": 1,
@@ -31,7 +30,7 @@ def test_generate_labels_success_response(mock_make_seer_request) -> None:
     assert labels == ["User Interface", "Navigation", "Right Sidebar"]
 
 
-@patch("sentry.feedback.usecases.label_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.label_generation.make_label_generation_request")
 def test_generate_labels_failed_response(mock_make_seer_request) -> None:
     mock_response = MockSeerResponse(
         500,
@@ -45,7 +44,7 @@ def test_generate_labels_failed_response(mock_make_seer_request) -> None:
         )
 
     mock_make_seer_request.assert_called_once()
-    request_body = json.loads(mock_make_seer_request.call_args[1]["body"].decode("utf-8"))
+    request_body = mock_make_seer_request.call_args[0][0]
     expected_request = {
         "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
         "organization_id": 1,
@@ -53,7 +52,7 @@ def test_generate_labels_failed_response(mock_make_seer_request) -> None:
     assert request_body == expected_request
 
 
-@patch("sentry.feedback.usecases.label_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.label_generation.make_label_generation_request")
 def test_generate_labels_network_error(mock_make_seer_request) -> None:
     mock_make_seer_request.side_effect = requests.exceptions.Timeout("Request timed out")
 
@@ -63,7 +62,7 @@ def test_generate_labels_network_error(mock_make_seer_request) -> None:
         )
 
     assert mock_make_seer_request.call_count == 1
-    request_body = json.loads(mock_make_seer_request.call_args[1]["body"].decode("utf-8"))
+    request_body = mock_make_seer_request.call_args[0][0]
     expected_request = {
         "feedback_message": "I don't like the new right sidebar, it makes navigating everywhere hard!",
         "organization_id": 1,

--- a/tests/sentry/feedback/usecases/test_spam_detection.py
+++ b/tests/sentry/feedback/usecases/test_spam_detection.py
@@ -7,7 +7,7 @@ from tests.sentry.feedback import MockSeerResponse
 
 
 @pytest.mark.parametrize("response_is_spam", [True, False])
-@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.spam_detection.make_spam_detection_request")
 def test_is_spam_seer_success(mock_make_seer_request, response_is_spam):
     mock_make_seer_request.return_value = MockSeerResponse(200, {"is_spam": response_is_spam})
     if response_is_spam:
@@ -17,7 +17,7 @@ def test_is_spam_seer_success(mock_make_seer_request, response_is_spam):
     mock_make_seer_request.assert_called_once()
 
 
-@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.spam_detection.make_spam_detection_request")
 def test_is_spam_seer_exception(mock_make_seer_request):
     mock_make_seer_request.side_effect = Exception("Network error")
     assert is_spam_seer("Test feedback message", 1) is None
@@ -25,7 +25,7 @@ def test_is_spam_seer_exception(mock_make_seer_request):
 
 
 @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 502, 503, 504])
-@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.spam_detection.make_spam_detection_request")
 def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
     mock_make_seer_request.return_value = MockSeerResponse(status_code, {})
     assert is_spam_seer("Test feedback message", 1) is None
@@ -43,7 +43,7 @@ def test_is_spam_seer_http_error(mock_make_seer_request, status_code):
         pytest.param({}, id="empty_dict"),
     ],
 )
-@patch("sentry.feedback.usecases.spam_detection.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.spam_detection.make_spam_detection_request")
 def test_is_spam_seer_invalid_response(mock_make_seer_request, invalid_response):
     mock_make_seer_request.return_value = MockSeerResponse(200, invalid_response)
     assert is_spam_seer("Test feedback message", 1) is None

--- a/tests/sentry/feedback/usecases/test_title_generation.py
+++ b/tests/sentry/feedback/usecases/test_title_generation.py
@@ -41,7 +41,7 @@ from tests.sentry.feedback import MockSeerResponse
         ),
     ],
 )
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_get_feedback_title_from_seer_invalid_response(
     mock_make_seer_request, status_code, json_data
 ):
@@ -52,7 +52,7 @@ def test_get_feedback_title_from_seer_invalid_response(
     mock_make_seer_request.assert_called_once()
 
 
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_get_feedback_title_from_seer_http_error(mock_make_seer_request):
     """Test the get_feedback_title_from_seer function with HTTP error response."""
     mock_response = MockSeerResponse(500, {})
@@ -61,7 +61,7 @@ def test_get_feedback_title_from_seer_http_error(mock_make_seer_request):
     mock_make_seer_request.assert_called_once()
 
 
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_get_feedback_title_from_seer_exception(mock_make_seer_request):
     """Test the get_feedback_title_from_seer function with exception during API call."""
     mock_make_seer_request.side_effect = Exception("Network error")
@@ -69,7 +69,7 @@ def test_get_feedback_title_from_seer_exception(mock_make_seer_request):
     assert mock_make_seer_request.call_count == 1
 
 
-@patch("sentry.feedback.usecases.title_generation.make_signed_seer_api_request")
+@patch("sentry.feedback.usecases.title_generation.make_title_generation_request")
 def test_get_feedback_title_from_seer_success(mock_make_seer_request):
     """Test the get_feedback_title_from_seer function with successful response."""
     mock_response = MockSeerResponse(200, {"title": "Login Button Issue"})

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -7,10 +7,6 @@ import requests
 from django.conf import settings
 from django.urls import reverse
 
-from sentry.replays.endpoints.project_replay_summary import (
-    SEER_POLL_STATE_ENDPOINT_PATH,
-    SEER_START_TASK_ENDPOINT_PATH,
-)
 from sentry.replays.testutils import mock_replay
 from sentry.testutils.cases import SnubaTestCase, TransactionTestCase
 from sentry.utils import json
@@ -98,30 +94,27 @@ class ProjectReplaySummaryTestCase(
                 )
                 assert response.status_code == 403, method
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_get_simple(self, mock_make_seer_api_request: Mock) -> None:
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_state_request")
+    def test_get_simple(self, mock_seer_request: Mock) -> None:
         mock_response = MockSeerResponse(200, json_data={"hello": "world"})
-        mock_make_seer_api_request.return_value = mock_response
+        mock_seer_request.return_value = mock_response
 
         with self.feature(self.features):
             response = self.client.get(self.url)
             assert response.status_code == 200
             assert response.json() == {"hello": "world"}
 
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        assert call_args[1]["path"] == SEER_POLL_STATE_ENDPOINT_PATH
-        assert json.loads(call_args[1]["body"].decode()) == {
+        mock_seer_request.assert_called_once()
+        body = mock_seer_request.call_args[0][0]
+        assert body == {
             "replay_id": self.replay_id,
             "organization_id": self.organization.id,
             "project_id": self.project.id,
         }
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_simple(self, mock_make_seer_api_request: Mock) -> None:
-        mock_make_seer_api_request.return_value = MockSeerResponse(
-            200, json_data={"hello": "world"}
-        )
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    def test_post_simple(self, mock_seer_request: Mock) -> None:
+        mock_seer_request.return_value = MockSeerResponse(200, json_data={"hello": "world"})
 
         start = datetime.now(UTC) - timedelta(days=3)
         end = datetime.now(UTC) - timedelta(days=2, hours=23)
@@ -136,20 +129,16 @@ class ProjectReplaySummaryTestCase(
         assert response.status_code == 200
         assert response.json() == {"hello": "world"}
 
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
-        request_body = json.loads(call_args[1]["body"].decode())
+        mock_seer_request.assert_called_once()
+        body = mock_seer_request.call_args[0][0]
 
-        assert request_body["replay_id"] == self.replay_id
-        assert abs(datetime.fromisoformat(request_body["replay_start"]) - start) <= timedelta(
-            seconds=1
-        )
-        assert abs(datetime.fromisoformat(request_body["replay_end"]) - end) <= timedelta(seconds=1)
-        assert request_body["num_segments"] == 2
-        assert request_body["organization_id"] == self.organization.id
-        assert request_body["project_id"] == self.project.id
-        assert request_body["temperature"] is None
+        assert body["replay_id"] == self.replay_id
+        assert abs(datetime.fromisoformat(body["replay_start"]) - start) <= timedelta(seconds=1)
+        assert abs(datetime.fromisoformat(body["replay_end"]) - end) <= timedelta(seconds=1)
+        assert body["num_segments"] == 2
+        assert body["organization_id"] == self.organization.id
+        assert body["project_id"] == self.project.id
+        assert body.get("temperature") is None
 
     def test_post_replay_not_found(self) -> None:
         with self.feature(self.features):
@@ -159,11 +148,9 @@ class ProjectReplaySummaryTestCase(
             assert response.status_code == 404
 
     @patch("sentry.replays.endpoints.project_replay_summary.MAX_SEGMENTS_TO_SUMMARIZE", 1)
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_max_segments_exceeded(self, mock_make_seer_api_request: Mock) -> None:
-        mock_make_seer_api_request.return_value = MockSeerResponse(
-            200, json_data={"hello": "world"}
-        )
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    def test_post_max_segments_exceeded(self, mock_seer_request: Mock) -> None:
+        mock_seer_request.return_value = MockSeerResponse(200, json_data={"hello": "world"})
         self.store_replay()
 
         with self.feature(self.features):
@@ -173,17 +160,13 @@ class ProjectReplaySummaryTestCase(
 
         assert response.status_code == 200
 
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
-        request_body = json.loads(call_args[1]["body"].decode())
-        assert request_body["num_segments"] == 1
+        mock_seer_request.assert_called_once()
+        body = mock_seer_request.call_args[0][0]
+        assert body["num_segments"] == 1
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_post_with_temperature(self, mock_make_seer_api_request: Mock) -> None:
-        mock_make_seer_api_request.return_value = MockSeerResponse(
-            200, json_data={"hello": "world"}
-        )
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    def test_post_with_temperature(self, mock_seer_request: Mock) -> None:
+        mock_seer_request.return_value = MockSeerResponse(200, json_data={"hello": "world"})
         self.store_replay()
 
         with self.feature(self.features):
@@ -195,18 +178,16 @@ class ProjectReplaySummaryTestCase(
 
         assert response.status_code == 200
 
-        mock_make_seer_api_request.assert_called_once()
-        call_args = mock_make_seer_api_request.call_args
-        assert call_args[1]["path"] == SEER_START_TASK_ENDPOINT_PATH
-        request_body = json.loads(call_args[1]["body"].decode())
-        assert request_body["temperature"] == 0.73
+        mock_seer_request.assert_called_once()
+        body = mock_seer_request.call_args[0][0]
+        assert body["temperature"] == 0.73
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_seer_timeout(self, mock_make_seer_api_request: Mock) -> None:
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_state_request")
+    def test_seer_timeout(self, mock_state_request: Mock, mock_start_request: Mock) -> None:
         for method in ["GET", "POST"]:
-            mock_make_seer_api_request.side_effect = requests.exceptions.Timeout(
-                "Request timed out"
-            )
+            mock_state_request.side_effect = requests.exceptions.Timeout("Request timed out")
+            mock_start_request.side_effect = requests.exceptions.Timeout("Request timed out")
             self.store_replay()
 
             with self.feature(self.features):
@@ -220,12 +201,14 @@ class ProjectReplaySummaryTestCase(
 
             assert response.status_code == 500, method
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_seer_connection_error(self, mock_make_seer_api_request: Mock) -> None:
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_state_request")
+    def test_seer_connection_error(
+        self, mock_state_request: Mock, mock_start_request: Mock
+    ) -> None:
         for method in ["GET", "POST"]:
-            mock_make_seer_api_request.side_effect = requests.exceptions.ConnectionError(
-                "Connection error"
-            )
+            mock_state_request.side_effect = requests.exceptions.ConnectionError("Connection error")
+            mock_start_request.side_effect = requests.exceptions.ConnectionError("Connection error")
             self.store_replay()
 
             with self.feature(self.features):
@@ -239,10 +222,14 @@ class ProjectReplaySummaryTestCase(
 
             assert response.status_code == 500, method
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_seer_request_error(self, mock_make_seer_api_request: Mock) -> None:
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_state_request")
+    def test_seer_request_error(self, mock_state_request: Mock, mock_start_request: Mock) -> None:
         for method in ["GET", "POST"]:
-            mock_make_seer_api_request.side_effect = requests.exceptions.RequestException(
+            mock_state_request.side_effect = requests.exceptions.RequestException(
+                "Generic request error"
+            )
+            mock_start_request.side_effect = requests.exceptions.RequestException(
                 "Generic request error"
             )
             self.store_replay()
@@ -257,15 +244,17 @@ class ProjectReplaySummaryTestCase(
                 )
             assert response.status_code == 500, method
 
-    @patch("sentry.replays.endpoints.project_replay_summary.make_signed_seer_api_request")
-    def test_seer_http_errors(self, mock_make_seer_api_request: Mock) -> None:
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_state_request")
+    def test_seer_http_errors(self, mock_state_request: Mock, mock_start_request: Mock) -> None:
         for method in ["GET", "POST"]:
             for status in [400, 401, 403, 404, 429, 500, 502, 503, 504]:
                 mock_response = MockSeerResponse(
                     status=status,
                     json_data={"error": "Test error"},
                 )
-                mock_make_seer_api_request.return_value = mock_response
+                mock_state_request.return_value = mock_response
+                mock_start_request.return_value = mock_response
                 self.store_replay()
 
                 with self.feature(self.features):

--- a/tests/sentry/replays/unit/usecases/test_delete_seer_replay_data.py
+++ b/tests/sentry/replays/unit/usecases/test_delete_seer_replay_data.py
@@ -1,47 +1,43 @@
 from unittest.mock import MagicMock, Mock, patch
 
 from sentry.replays.usecases.delete import delete_seer_replay_data
-from sentry.utils import json
 
 
-@patch("sentry.replays.usecases.delete.make_signed_seer_api_request")
-def test_delete_seer_replay_data_success(mock_make_seer_api_request: MagicMock) -> None:
+@patch("sentry.replays.usecases.delete.make_replay_delete_request")
+def test_delete_seer_replay_data_success(mock_seer_request: MagicMock) -> None:
     """Test successful deletion of replay data from Seer."""
     mock_response = Mock()
     mock_response.status = 200
     mock_response.data = "Success"
-    mock_make_seer_api_request.return_value = mock_response
+    mock_seer_request.return_value = mock_response
 
     replay_ids = ["replay-1", "replay-2", "replay-3"]
 
     assert delete_seer_replay_data(456, 123, replay_ids) is True
 
-    mock_make_seer_api_request.assert_called_once()
-    call_args = mock_make_seer_api_request.call_args
-    assert call_args[1]["path"] == "/v1/automation/summarize/replay/breadcrumbs/delete"
-
-    request_body = json.loads(call_args[1]["body"].decode("utf-8"))
-    assert request_body == {"replay_ids": replay_ids, "organization_id": 456, "project_id": 123}
+    mock_seer_request.assert_called_once()
+    body = mock_seer_request.call_args[0][0]
+    assert body == {"replay_ids": replay_ids, "organization_id": 456, "project_id": 123}
 
 
-@patch("sentry.replays.usecases.delete.make_signed_seer_api_request")
-def test_delete_seer_replay_data_network_exception(mock_make_seer_api_request: MagicMock) -> None:
+@patch("sentry.replays.usecases.delete.make_replay_delete_request")
+def test_delete_seer_replay_data_network_exception(mock_seer_request: MagicMock) -> None:
     """Test handling of network/timeout exceptions during Seer API call."""
-    mock_make_seer_api_request.side_effect = Exception("Network timeout")
+    mock_seer_request.side_effect = Exception("Network timeout")
     assert delete_seer_replay_data(456, 123, ["replay-1", "replay-2"]) is False
     # Should be called once (retries happen at urllib3 level, invisible to application layer)
-    assert mock_make_seer_api_request.call_count == 1
+    assert mock_seer_request.call_count == 1
 
 
-@patch("sentry.replays.usecases.delete.make_signed_seer_api_request")
-def test_delete_seer_replay_data_non_200_status(mock_make_seer_api_request: MagicMock) -> None:
+@patch("sentry.replays.usecases.delete.make_replay_delete_request")
+def test_delete_seer_replay_data_non_200_status(mock_seer_request: MagicMock) -> None:
     """Test handling of non-200 status codes from Seer API."""
     for status in [400, 401, 403, 404, 500, 502, 503, 504]:
-        mock_make_seer_api_request.reset_mock()
+        mock_seer_request.reset_mock()
         mock_response = Mock()
         mock_response.status = status
         mock_response.data = "Internal Server Error"
-        mock_make_seer_api_request.return_value = mock_response
+        mock_seer_request.return_value = mock_response
 
         assert delete_seer_replay_data(456, 123, ["replay-1"]) is False
-        mock_make_seer_api_request.assert_called_once()
+        mock_seer_request.assert_called_once()

--- a/tests/sentry/uptime/test_seer_assertions.py
+++ b/tests/sentry/uptime/test_seer_assertions.py
@@ -288,7 +288,7 @@ class GenerateAssertionSuggestionsTest(TestCase):
         assert suggestions is None
         assert debug is not None and "No status_code" in debug
 
-    @patch("sentry.uptime.seer_assertions.make_signed_seer_api_request")
+    @patch("sentry.uptime.seer_assertions.make_llm_generate_request")
     def test_seer_request_failure(self, mock_request):
         from sentry.seer.models import SeerApiError
 
@@ -310,7 +310,7 @@ class GenerateAssertionSuggestionsTest(TestCase):
         assert suggestions is None
         assert debug is not None and "request failed" in debug
 
-    @patch("sentry.uptime.seer_assertions.make_signed_seer_api_request")
+    @patch("sentry.uptime.seer_assertions.make_llm_generate_request")
     def test_successful_generation(self, mock_request):
         mock_request.return_value.status = 200
         mock_request.return_value.json.return_value = {
@@ -335,7 +335,7 @@ class GenerateAssertionSuggestionsTest(TestCase):
         assert suggestions.suggestions[0].assertion_type == "status_code"
         assert debug is None
 
-    @patch("sentry.uptime.seer_assertions.make_signed_seer_api_request")
+    @patch("sentry.uptime.seer_assertions.make_llm_generate_request")
     def test_empty_seer_content(self, mock_request):
         mock_request.return_value.status = 200
         mock_request.return_value.json.return_value = {"content": ""}


### PR DESCRIPTION
Add TypedDict request types and typed wrapper functions for all callsites
outside `src/sentry/seer/` that call `make_signed_seer_api_request` directly.

Previously these callsites constructed inline dicts, manually serialized
with `json`/`orjson`, and hardcoded API paths. This follows the pattern
established in `event_manager.py` where a TypedDict, a typed wrapper, and
a module-level connection pool are colocated.

Wrappers grouped by connection pool:

- **`seer/signed_seer_api.py`** (autofix pool): `make_org_project_knowledge_index_request`, `make_remove_repository_request`, `make_explorer_index_request`, `make_seer_models_request`, `make_llm_generate_request`
- **`feedback/lib/seer_api.py`** (summarization pool): `make_spam_detection_request`, `make_label_generation_request`, `make_title_generation_request`, `make_label_groups_request`, `make_summarize_feedbacks_request`
- **`replays/lib/seer_api.py`** (summarization pool): `make_replay_summary_start_request`, `make_replay_summary_state_request`, `make_replay_delete_request`
- **`tasks/llm_issue_detection/detection.py`** (issue detection pool): `make_issue_detection_request`

Each callsite now imports the TypedDict + wrapper instead of manually
constructing dicts and calling the low-level function. No behavior change.