### PR TITLE
fix(dashboards): Merge URL filters with saved filters instead of replacing them

### DIFF
--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -169,6 +169,37 @@ describe('FiltersBar', () => {
     expect(onDashboardFilterChange).not.toHaveBeenCalled();
   });
 
+  it('should not restore saved filters when URL filters are explicitly cleared', async () => {
+    const savedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'os.name', name: 'OS Name', kind: FieldKind.FIELD},
+      value: `os.name:[Windows]`,
+    };
+    // Empty string simulates cleared filters (handleChangeFilter stores [''])
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: '',
+      },
+    });
+
+    const onDashboardFilterChange = jest.fn();
+    renderFilterBar({
+      location: newLocation,
+      filters: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: [savedFilter],
+      },
+      onDashboardFilterChange,
+    });
+
+    // Wait for component to fully render
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'All Releases'})).toBeInTheDocument();
+    });
+
+    // Should NOT call onDashboardFilterChange — user cleared filters intentionally
+    expect(onDashboardFilterChange).not.toHaveBeenCalled();
+  });
+
   it('should not render save button on prebuilt dashboard', async () => {
     const newLocation = LocationFixture({
       query: {

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -5,7 +5,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReleaseFixture} from 'sentry-fixture/release';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import {FieldKind} from 'sentry/utils/fields';
@@ -101,6 +106,69 @@ describe('FiltersBar', () => {
     expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
   });
 
+  it('should sync merged filters to URL on mount', async () => {
+    const savedFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'os.name', name: 'OS Name', kind: FieldKind.FIELD},
+      value: `os.name:[Windows]`,
+    };
+    const urlFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+      value: `browser.name:[Chrome]`,
+    };
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify(urlFilter),
+      },
+    });
+
+    const onDashboardFilterChange = jest.fn();
+    renderFilterBar({
+      location: newLocation,
+      filters: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: [savedFilter],
+      },
+      onDashboardFilterChange,
+    });
+
+    // Should call onDashboardFilterChange on mount with merged filters
+    await waitFor(() => {
+      expect(onDashboardFilterChange).toHaveBeenCalledWith({
+        [DashboardFilterKeys.RELEASE]: [],
+        [DashboardFilterKeys.GLOBAL_FILTER]: [savedFilter, urlFilter],
+      });
+    });
+  });
+
+  it('should not sync filters to URL when no saved filters to merge', async () => {
+    const urlFilter: GlobalFilter = {
+      dataset: WidgetType.SPANS,
+      tag: {key: 'browser.name', name: 'Browser Name', kind: FieldKind.FIELD},
+      value: `browser.name:[Chrome]`,
+    };
+    const newLocation = LocationFixture({
+      query: {
+        [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify(urlFilter),
+      },
+    });
+
+    const onDashboardFilterChange = jest.fn();
+    renderFilterBar({
+      location: newLocation,
+      onDashboardFilterChange,
+    });
+
+    // Wait for any effects to settle
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: /browser\.name.*Chrome/i})
+      ).toBeInTheDocument();
+    });
+
+    expect(onDashboardFilterChange).not.toHaveBeenCalled();
+  });
+
   it('should not render save button on prebuilt dashboard', async () => {
     const newLocation = LocationFixture({
       query: {
@@ -167,6 +235,21 @@ const mockNetworkRequests = () => {
   MockApiClient.addMockResponse({
     url: `/organizations/org-slug/trace-items/attributes/browser.name/values/`,
     body: mockSearchResponse,
+    match: [MockApiClient.matchQuery({attributeType: 'string'})],
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/trace-items/attributes/os.name/values/`,
+    body: [
+      {
+        key: 'os.name',
+        value: 'Windows',
+        name: 'Windows',
+        first_seen: null,
+        last_seen: null,
+        times_seen: null,
+      },
+    ],
     match: [MockApiClient.matchQuery({attributeType: 'string'})],
   });
 };

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -188,6 +188,11 @@ export default function FiltersBar({
       return savedFilters;
     }
 
+    // Empty array means user explicitly cleared all filters — respect that
+    if (urlFilters.length === 0) {
+      return urlFilters;
+    }
+
     const nonOverlappingSaved = savedFilters.filter(
       saved => !urlFilters.some(url => globalFilterKeysAreEqual(saved, url))
     );
@@ -201,8 +206,12 @@ export default function FiltersBar({
   useEffect(() => {
     const urlFilters = dashboardFiltersFromURL?.[DashboardFilterKeys.GLOBAL_FILTER];
 
-    // Only sync if URL has filters AND saved filters were merged in
-    if (urlFilters && activeGlobalFilters.length > urlFilters.length) {
+    // Only sync if URL has non-empty filters AND saved filters were merged in
+    if (
+      urlFilters &&
+      urlFilters.length > 0 &&
+      activeGlobalFilters.length > urlFilters.length
+    ) {
       onDashboardFilterChange({
         [DashboardFilterKeys.RELEASE]: selectedReleases,
         [DashboardFilterKeys.GLOBAL_FILTER]: activeGlobalFilters,

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -195,6 +195,22 @@ export default function FiltersBar({
     return [...nonOverlappingSaved, ...urlFilters];
   });
 
+  // Sync merged filters to the URL on mount so widgets see the same filters
+  // as the filter bar. Without this, the filter bar shows merged [saved + URL]
+  // filters but widgets only query with raw URL filters.
+  useEffect(() => {
+    const urlFilters = dashboardFiltersFromURL?.[DashboardFilterKeys.GLOBAL_FILTER];
+
+    // Only sync if URL has filters AND saved filters were merged in
+    if (urlFilters && activeGlobalFilters.length > urlFilters.length) {
+      onDashboardFilterChange({
+        [DashboardFilterKeys.RELEASE]: selectedReleases,
+        [DashboardFilterKeys.GLOBAL_FILTER]: activeGlobalFilters,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const updateGlobalFilters = (newGlobalFilters: GlobalFilter[]) => {
     setActiveGlobalFilters(newGlobalFilters);
     onDashboardFilterChange({

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -181,11 +181,18 @@ export default function FiltersBar({
     [];
 
   const [activeGlobalFilters, setActiveGlobalFilters] = useState<GlobalFilter[]>(() => {
-    return (
-      dashboardFiltersFromURL?.[DashboardFilterKeys.GLOBAL_FILTER] ??
-      filters?.[DashboardFilterKeys.GLOBAL_FILTER] ??
-      []
+    const savedFilters = filters?.[DashboardFilterKeys.GLOBAL_FILTER] ?? [];
+    const urlFilters = dashboardFiltersFromURL?.[DashboardFilterKeys.GLOBAL_FILTER];
+
+    if (!urlFilters) {
+      return savedFilters;
+    }
+
+    const nonOverlappingSaved = savedFilters.filter(
+      saved => !urlFilters.some(url => globalFilterKeysAreEqual(saved, url))
     );
+
+    return [...nonOverlappingSaved, ...urlFilters];
   });
 
   const updateGlobalFilters = (newGlobalFilters: GlobalFilter[]) => {


### PR DESCRIPTION
When navigating to a dashboard via a linked dashboard URL (e.g. by clicking a table cell that links to another dashboard), any temporary filters in the URL were completely replacing the destination dashboard's permanent saved global filters.

The fix merges URL filters with the saved filters: for each URL filter, if a saved filter exists with the same `tag.key + dataset`, the URL version takes precedence. Saved filters that don't overlap with any URL filter are preserved as-is.

Before: destination dashboard permanent filters `[A, B]` + URL temporary filter `[C]` → `[C]`
After: destination dashboard permanent filters `[A, B]` + URL temporary filter `[C]` → `[A, B, C]`

If a temporary filter overlaps with a permanent one (same key/dataset), the temporary filter still wins for that key — only non-overlapping permanent filters are kept.