### PR TITLE
fix(explorer): use sentry org for conversations url and rename slash cmd

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -298,7 +298,7 @@ function BlockComponent({
           block_message: block.message.content.slice(0, 100),
           langfuse_url: getLangfuseUrl(runId),
           explorer_url: getExplorerUrl(runId),
-          conversations_url: getConversationsUrl(organization.slug, runId),
+          conversations_url: getConversationsUrl('sentry', runId),
         });
         setFeedbackSubmitted(true); // disable button for rest of the session
       }

--- a/static/app/views/seerExplorer/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/explorerMenu.tsx
@@ -10,6 +10,15 @@ import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 type MenuMode = 'slash-commands-keyboard' | 'session-history' | 'pr-widget' | 'hidden';
 
+interface SlashCommandHandlers {
+  onConversations: () => void;
+  onFeedback: (() => void) | undefined;
+  onLangfuse: () => void;
+  onMaxSize: () => void;
+  onMedSize: () => void;
+  onNew: () => void;
+}
+
 interface ExplorerMenuProps {
   clearInput: () => void;
   focusInput: () => void;
@@ -17,14 +26,7 @@ interface ExplorerMenuProps {
   onChangeSession: (runId: number) => void;
   panelSize: 'max' | 'med';
   panelVisible: boolean;
-  slashCommandHandlers: {
-    onFeedback: (() => void) | undefined;
-    onLangfuse: () => void;
-    onMaxSize: () => void;
-    onMedSize: () => void;
-    onNew: () => void;
-    onSentryTrace: () => void;
-  };
+  slashCommandHandlers: SlashCommandHandlers;
   textAreaRef: React.RefObject<HTMLTextAreaElement | null>;
   inputAnchorRef?: React.RefObject<HTMLElement | null>;
   menuAnchorRef?: React.RefObject<HTMLElement | null>;
@@ -348,15 +350,8 @@ function useSlashCommands({
   onNew,
   onFeedback,
   onLangfuse,
-  onSentryTrace,
-}: {
-  onFeedback: (() => void) | undefined;
-  onLangfuse: () => void;
-  onMaxSize: () => void;
-  onMedSize: () => void;
-  onNew: () => void;
-  onSentryTrace: () => void;
-}): MenuItemProps[] {
+  onConversations,
+}: SlashCommandHandlers): MenuItemProps[] {
   const isSentryEmployee = useIsSentryEmployee();
 
   return useMemo(
@@ -404,15 +399,23 @@ function useSlashCommands({
               handler: onLangfuse,
             },
             {
-              title: '/sentry-conversation',
-              key: '/sentry-conversation',
-              description: 'Open Sentry AI trace (conversation view)',
-              handler: onSentryTrace,
+              title: '/conversations',
+              key: '/conversations',
+              description: 'Open Sentry AI trace (conversations view)',
+              handler: onConversations,
             },
           ]
         : []),
     ],
-    [onNew, onMaxSize, onMedSize, onFeedback, onLangfuse, onSentryTrace, isSentryEmployee]
+    [
+      onNew,
+      onMaxSize,
+      onMedSize,
+      onFeedback,
+      onLangfuse,
+      onConversations,
+      isSentryEmployee,
+    ]
   );
 }
 

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -328,10 +328,7 @@ function ExplorerPanel() {
   }, [setFocusedBlockIndex, textareaRef, setIsMinimized]);
 
   const langfuseUrl = runId ? getLangfuseUrl(runId) : undefined;
-  const conversationsUrl =
-    runId && organization?.slug
-      ? getConversationsUrl(organization.slug, runId)
-      : undefined;
+  const conversationsUrl = runId ? getConversationsUrl('sentry', runId) : undefined;
 
   const handleOpenLangfuse = useCallback(() => {
     // Command handler. Disabled in slash command menu for non-employees
@@ -340,7 +337,7 @@ function ExplorerPanel() {
     }
   }, [langfuseUrl]);
 
-  const handleOpenSentryTrace = useCallback(() => {
+  const handleOpenConversations = useCallback(() => {
     // Command handler. Disabled in slash command menu for non-employees
     if (conversationsUrl) {
       window.open(conversationsUrl, '_blank');
@@ -381,7 +378,7 @@ function ExplorerPanel() {
         onNew: startNewSession,
         onFeedback: openFeedbackForm ? handleFeedback : undefined,
         onLangfuse: handleOpenLangfuse,
-        onSentryTrace: handleOpenSentryTrace,
+        onConversations: handleOpenConversations,
       },
       onChangeSession: switchToRun,
       menuAnchorRef: sessionHistoryButtonRef,


### PR DESCRIPTION
in explorer we use this for internal tagging and slash cmd so slug should always be sentry

also renames the cmd and refactors a type