### PR TITLE
feat(tracemetrics): Use units in alerts metric selector UI

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -41,7 +41,7 @@ interface MetricSelectOption {
 }
 
 function makeMetricSelectValue(metric: TraceMetric): string {
-  return `${metric.name}||${metric.type}`;
+  return `${metric.name}||${metric.type}||${metric.unit ?? '-'}`;
 }
 
 export default function EAPMetricsField({

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -1,8 +1,9 @@
 import type {ReactNode} from 'react';
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 
@@ -11,8 +12,10 @@ import {t} from 'sentry/locale';
 import usePrevious from 'sentry/utils/usePrevious';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
 import {OPTIONS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
+import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {MetricTypeBadge} from 'sentry/views/explore/metrics/metricToolbar/metricOptionLabel';
+import {NONE_UNIT} from 'sentry/views/explore/metrics/metricToolbar/metricSelector';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,
@@ -34,6 +37,7 @@ interface MetricSelectOption {
   metricType: TraceMetricTypeValue;
   trailingItems: ReactNode;
   value: string;
+  metricUnit?: string;
 }
 
 function makeMetricSelectValue(metric: TraceMetric): string {
@@ -47,6 +51,7 @@ export default function EAPMetricsField({
   projectId,
   environment,
 }: Props) {
+  const hasMetricUnitsUI = useHasMetricUnitsUI();
   const [search, setSearch] = useState('');
   const {
     data: metricOptionsData,
@@ -64,18 +69,35 @@ export default function EAPMetricsField({
 
   const {aggregation, traceMetric} = parseMetricAggregate(aggregate);
 
-  const metricSelectValue = makeMetricSelectValue(traceMetric);
+  const metricSelectValue = makeMetricSelectValue(
+    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
+  );
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
       label: traceMetric.name || t('Select a metric'),
       value: metricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricName: traceMetric.name,
+      metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? NONE_UNIT) : undefined,
       trailingItems: (
-        <MetricTypeBadge metricType={traceMetric.type as TraceMetricTypeValue} />
+        <Fragment>
+          <MetricTypeBadge metricType={traceMetric.type as TraceMetricTypeValue} />
+          {hasMetricUnitsUI &&
+            traceMetric.unit &&
+            traceMetric.unit !== '-' &&
+            traceMetric.unit !== NONE_UNIT && (
+              <Tag variant="promotion">{traceMetric.unit}</Tag>
+            )}
+        </Fragment>
       ),
     }),
-    [metricSelectValue, traceMetric.name, traceMetric.type]
+    [
+      metricSelectValue,
+      traceMetric.name,
+      traceMetric.type,
+      traceMetric.unit,
+      hasMetricUnitsUI,
+    ]
   );
 
   const metricOptions = useMemo((): MetricSelectOption[] => {
@@ -91,15 +113,28 @@ export default function EAPMetricsField({
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
           type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,
+          unit: hasMetricUnitsUI
+            ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
+            : undefined,
         }),
         metricType: option[TraceMetricKnownFieldKey.METRIC_TYPE],
         metricName: option[TraceMetricKnownFieldKey.METRIC_NAME],
+        metricUnit: hasMetricUnitsUI
+          ? (option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT)
+          : undefined,
         trailingItems: (
-          <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
+          <Fragment>
+            <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
+            {hasMetricUnitsUI && option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
+              <Tag variant="promotion">
+                {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
+              </Tag>
+            )}
+          </Fragment>
         ),
       })) ?? []),
     ];
-  }, [metricOptionsData, optionFromTraceMetric, traceMetric.name]);
+  }, [metricOptionsData, optionFromTraceMetric, traceMetric.name, hasMetricUnitsUI]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedSetSearch = useCallback(
@@ -130,6 +165,7 @@ export default function EAPMetricsField({
       const newMetric: TraceMetric = {
         name: option.metricName,
         type: option.metricType,
+        unit: hasMetricUnitsUI ? (option.metricUnit ?? NONE_UNIT) : undefined,
       };
       const newMetricType = option.metricType?.toLowerCase() ?? '';
       const validOperations = OPTIONS_BY_TYPE[newMetricType] ?? [];
@@ -143,10 +179,12 @@ export default function EAPMetricsField({
       });
       onChange(newAggregate, {});
     },
-    [onChange]
+    [onChange, hasMetricUnitsUI]
   );
 
-  const traceMetricSelectValue = makeMetricSelectValue(traceMetric);
+  const traceMetricSelectValue = makeMetricSelectValue(
+    hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}
+  );
   const previousOptions = usePrevious(metricOptions ?? []);
 
   // Auto-select the first metric when API resolves and no metric is selected
@@ -159,11 +197,15 @@ export default function EAPMetricsField({
 
       const newAggregate = makeMetricsAggregate({
         aggregate: firstOperation,
-        traceMetric: {name: firstMetric.metricName, type: firstMetric.metricType},
+        traceMetric: {
+          name: firstMetric.metricName,
+          type: firstMetric.metricType,
+          unit: hasMetricUnitsUI ? (firstMetric.metricUnit ?? NONE_UNIT) : undefined,
+        },
       });
       onChange(newAggregate, {});
     }
-  }, [metricOptions, onChange, traceMetric.name]);
+  }, [metricOptions, onChange, traceMetric.name, hasMetricUnitsUI]);
 
   const hasNoMetrics = isMetricOptionsEmpty && !search;
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -99,7 +99,7 @@ export function MetricSelector({
         trailingItems: () => (
           <Fragment>
             <MetricTypeBadge metricType={option[TraceMetricKnownFieldKey.METRIC_TYPE]} />
-            {option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
+            {hasMetricUnitsUI && option[TraceMetricKnownFieldKey.METRIC_UNIT] && (
               <Tag variant="promotion">
                 {option[TraceMetricKnownFieldKey.METRIC_UNIT]}
               </Tag>


### PR DESCRIPTION
Allows for setting `unit` in the alerts UI. Everything is feature flagged and will only show `unit` tags and pass the unit along in the `events-stats` request if the flag is on.