### PR TITLE
feat(dashboards): Register Queues and Queue Summary prebuilt dashboards on frontend

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs.tsx
+++ b/static/app/views/dashboards/utils/prebuiltConfigs.tsx
@@ -21,6 +21,8 @@ import {MOBILE_VITALS_SCREEN_RENDERING_PREBUILT_CONFIG} from 'sentry/views/dashb
 import {NEXTJS_FRONTEND_OVERVIEW_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview';
 import {QUERIES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/queries';
 import {QUERIES_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queries/querySummary';
+import {QUEUES_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queues';
+import {QUEUE_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queueSummary';
 import {SESSION_HEALTH_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/sessionHealth';
 import {WEB_VITALS_SUMMARY_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary';
 import {WEB_VITALS_PREBUILT_CONFIG} from 'sentry/views/dashboards/utils/prebuiltConfigs/webVitals/webVitals';
@@ -51,6 +53,8 @@ export enum PrebuiltDashboardId {
   LARAVEL_OVERVIEW = 23,
   FRONTEND_ASSETS = 24,
   FRONTEND_ASSETS_SUMMARY = 25,
+  BACKEND_QUEUES = 26,
+  BACKEND_QUEUE_SUMMARY = 27,
 }
 
 export type PrebuiltDashboard = Omit<DashboardDetails, 'id'>;
@@ -87,4 +91,6 @@ export const PREBUILT_DASHBOARDS: Record<PrebuiltDashboardId, PrebuiltDashboard>
   [PrebuiltDashboardId.LARAVEL_OVERVIEW]: LARAVEL_OVERVIEW_PREBUILT_CONFIG,
   [PrebuiltDashboardId.FRONTEND_ASSETS]: FRONTEND_ASSETS_PREBUILT_CONFIG,
   [PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY]: FRONTEND_ASSETS_SUMMARY_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.BACKEND_QUEUES]: QUEUES_PREBUILT_CONFIG,
+  [PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY]: QUEUE_SUMMARY_PREBUILT_CONFIG,
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueSummary.ts
@@ -1,0 +1,10 @@
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {SUMMARY_DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/settings';
+
+export const QUEUE_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: SUMMARY_DASHBOARD_TITLE,
+  filters: {},
+  widgets: [],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/queues.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/queues.ts
@@ -1,0 +1,10 @@
+import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/settings';
+
+export const QUEUES_PREBUILT_CONFIG: PrebuiltDashboard = {
+  dateCreated: '',
+  projects: [],
+  title: DASHBOARD_TITLE,
+  filters: {},
+  widgets: [],
+};

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/settings.ts
@@ -1,0 +1,4 @@
+import {t} from 'sentry/locale';
+
+export const DASHBOARD_TITLE = t('Queues');
+export const SUMMARY_DASHBOARD_TITLE = t('Queue Summary');


### PR DESCRIPTION
Register two new prebuilt dashboards — Queues and Queue Summary — in the frontend dashboard registry.

Adds a `queues/` folder under `prebuiltConfigs/` with:
- `settings.ts` with shared title constants (`Queues`, `Queue Summary`)
- `queues.ts` with the `QUEUES_PREBUILT_CONFIG` (empty widgets, to be filled in a follow-up)
- `queueSummary.ts` with the `QUEUE_SUMMARY_PREBUILT_CONFIG` (empty widgets)

Registers both configs as `BACKEND_QUEUES = 26` and `BACKEND_QUEUE_SUMMARY = 27` in the `PrebuiltDashboardId` enum and `PREBUILT_DASHBOARDS` record in `prebuiltConfigs.tsx`.

The companion backend registration PR is: dominikbuszowiecki/browse-369-register-on-backend

Refs BROWSE-370