### PR TITLE
feat(dashboards): Register Queues and Queue Summary prebuilt dashboards on backend

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -87,6 +87,8 @@ class PrebuiltDashboardId(IntEnum):
     LARAVEL_OVERVIEW = 23
     FRONTEND_ASSETS = 24
     FRONTEND_ASSETS_SUMMARY = 25
+    BACKEND_QUEUES = 26
+    BACKEND_QUEUE_SUMMARY = 27
 
 
 class PrebuiltDashboard(TypedDict):
@@ -203,6 +205,14 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.FRONTEND_ASSETS_SUMMARY,
         "title": "Frontend Assets Summary",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUES,
+        "title": "Queues",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY,
+        "title": "Queue Summary",
     },
 ]
 


### PR DESCRIPTION
Register two new prebuilt dashboards on the backend — Queues and Queue Summary.

Adds `BACKEND_QUEUES = 26` and `BACKEND_QUEUE_SUMMARY = 27` to the `PrebuiltDashboardId` enum and appends both entries to the `PREBUILT_DASHBOARDS` list in `organization_dashboards.py` with titles `"Queues"` and `"Queue Summary"` to match the frontend configs.

The companion frontend registration PR is: https://github.com/getsentry/sentry/pull/109594

Refs BROWSE-369