### PR TITLE
ref(ui): Hoist inline regexes in initializeSdk to module-level constants

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -32,7 +32,6 @@ export function getLastEventId(): string | undefined {
   return lastEventId;
 }
 
-// Pre-compiled regex and lookup map for isFilteredRequestErrorEvent.
 // Each error type maps to the set of HTTP status codes it should be filtered for.
 const FILTERED_STATUSES_BY_ERROR_TYPE: Readonly<Record<string, ReadonlySet<string>>> = {
   RequestError: new Set(['200', '400', '401', '403', '404', '429']),
@@ -44,7 +43,6 @@ const FILTERED_STATUSES_BY_ERROR_TYPE: Readonly<Record<string, ReadonlySet<strin
 };
 const FILTERED_REQUEST_ERROR_VALUE_REGEX = /^(GET|POST|PUT|DELETE) .* (\d+)$/;
 
-// Pre-compiled regex for addEndpointTagToRequestError.
 const ENDPOINT_TAG_REGEX = /^([A-Za-z]+ (\/[^/]+)+\/) \d+$/;
 
 // We don't care about recording breadcrumbs for these hosts. These typically

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -32,6 +32,21 @@ export function getLastEventId(): string | undefined {
   return lastEventId;
 }
 
+// Pre-compiled regex and lookup map for isFilteredRequestErrorEvent.
+// Each error type maps to the set of HTTP status codes it should be filtered for.
+const FILTERED_STATUSES_BY_ERROR_TYPE: Readonly<Record<string, ReadonlySet<string>>> = {
+  RequestError: new Set(['200', '400', '401', '403', '404', '429']),
+  BadRequestError: new Set(['400']),
+  UnauthorizedError: new Set(['401']),
+  ForbiddenError: new Set(['403']),
+  NotFoundError: new Set(['404']),
+  TooManyRequestsError: new Set(['429']),
+};
+const FILTERED_REQUEST_ERROR_VALUE_REGEX = /^(GET|POST|PUT|DELETE) .* (\d+)$/;
+
+// Pre-compiled regex for addEndpointTagToRequestError.
+const ENDPOINT_TAG_REGEX = /^([A-Za-z]+ (\/[^/]+)+\/) \d+$/;
+
 // We don't care about recording breadcrumbs for these hosts. These typically
 // pollute our breadcrumbs since they may occur a LOT.
 //
@@ -268,26 +283,12 @@ export function isFilteredRequestErrorEvent(event: Event): boolean {
   for (const error of mainAndMaybeCauseErrors) {
     const {type = '', value = ''} = error;
 
-    const is200 =
-      ['RequestError'].includes(type) && !!value.match('(GET|POST|PUT|DELETE) .* 200');
-    const is400 =
-      ['BadRequestError', 'RequestError'].includes(type) &&
-      !!value.match('(GET|POST|PUT|DELETE) .* 400');
-    const is401 =
-      ['UnauthorizedError', 'RequestError'].includes(type) &&
-      !!value.match('(GET|POST|PUT|DELETE) .* 401');
-    const is403 =
-      ['ForbiddenError', 'RequestError'].includes(type) &&
-      !!value.match('(GET|POST|PUT|DELETE) .* 403');
-    const is404 =
-      ['NotFoundError', 'RequestError'].includes(type) &&
-      !!value.match('(GET|POST|PUT|DELETE) .* 404');
-    const is429 =
-      ['TooManyRequestsError', 'RequestError'].includes(type) &&
-      !!value.match('(GET|POST|PUT|DELETE) .* 429');
-
-    if (is200 || is400 || is401 || is403 || is404 || is429) {
-      return true;
+    const allowedStatuses = FILTERED_STATUSES_BY_ERROR_TYPE[type];
+    if (allowedStatuses) {
+      const match = FILTERED_REQUEST_ERROR_VALUE_REGEX.exec(value);
+      if (match && allowedStatuses.has(match[2]!)) {
+        return true;
+      }
     }
   }
 
@@ -319,8 +320,7 @@ export function addEndpointTagToRequestError(event: Event): void {
   const errorMessage = event.exception?.values?.[0]!.value || '';
 
   // The capturing group here turns `GET /dogs/are/great 500` into just `GET /dogs/are/great`
-  const requestErrorRegex = new RegExp('^([A-Za-z]+ (/[^/]+)+/) \\d+$');
-  const messageMatch = requestErrorRegex.exec(errorMessage);
+  const messageMatch = ENDPOINT_TAG_REGEX.exec(errorMessage);
 
   if (messageMatch) {
     event.tags = {...event.tags, endpoint: messageMatch[1]};


### PR DESCRIPTION
The goal was mostly to clean up the sdk init a little bit, but i've included some quick benchmarks

Benchmark (500k iterations, Node.js):

| Scenario | Before (ops/s) | After (ops/s) | Speedup |
|---|---|---|---|
| isFilteredRequestErrorEvent (matching, RequestError 404) | 1,441,697 | 15,824,329 | **11x** |
| isFilteredRequestErrorEvent (matching, chained NotFoundError) | 7,967,498 | 15,573,211 | **2x** |
| isFilteredRequestErrorEvent (no match, unknown type) | 32,164,683 | 50,715,726 | **1.6x** |
| addEndpointTagToRequestError (matching message) | 6,188,132 | 11,652,782 | **1.9x** |
| addEndpointTagToRequestError (non-matching message) | 7,883,404 | 18,463,527 | **2.3x** |