### PR TITLE
Increase sync_scim_team_privileges task timeout to 10 mins

### DIFF
--- a/src/sentry/tasks/scim/privilege_sync.py
+++ b/src/sentry/tasks/scim/privilege_sync.py
@@ -71,6 +71,7 @@ def update_privilege(
     namespace=auth_tasks,
     retry=Retry(times=3, on=(Exception,)),
     silo_mode=SiloMode.REGION,
+    processing_deadline_duration=600,  # 10 minutes
 )
 def sync_scim_team_privileges(
     team_slug: str,


### PR DESCRIPTION
10 seconds is way too short for this task. Since it doesn't run frequently, we can set it for much longer. 

Fixes: https://sentry.sentry.io/issues/7297018769/ 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
