### PR TITLE
fix(dashboards): Default axisRange to auto for existing widgets in builder

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -340,6 +340,7 @@ describe('add to dashboard modal', () => {
       query: '',
       sort: '',
       yAxis: 'count()',
+      axisRange: 'auto',
     });
   });
 
@@ -381,6 +382,7 @@ describe('add to dashboard modal', () => {
       legendAlias: '',
       statsPeriod: '1h',
       source: DashboardWidgetSource.DISCOVERV2,
+      axisRange: 'auto',
     });
   });
 
@@ -798,6 +800,7 @@ describe('add to dashboard modal', () => {
       project: ['2', '3'],
       environment: ['production', 'staging'],
       statsPeriod: '7d',
+      axisRange: 'auto',
     });
   });
 
@@ -851,6 +854,7 @@ describe('add to dashboard modal', () => {
       // Dashboard's saved filters should be used, not user's selection
       project: '1',
       statsPeriod: '1h',
+      axisRange: 'auto',
     });
   });
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -704,10 +704,7 @@ class DashboardDetail extends Component<Props, State> {
         pathname: path,
         query: {
           ...location.query,
-          ...convertWidgetToBuilderStateParams({
-            ...widget,
-            axisRange: widget.axisRange ?? 'auto',
-          }),
+          ...convertWidgetToBuilderStateParams(widget),
         },
       }),
       {preventScrollReset: true}

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -704,7 +704,10 @@ class DashboardDetail extends Component<Props, State> {
         pathname: path,
         query: {
           ...location.query,
-          ...convertWidgetToBuilderStateParams(widget),
+          ...convertWidgetToBuilderStateParams({
+            ...widget,
+            axisRange: widget.axisRange ?? 'auto',
+          }),
         },
       }),
       {preventScrollReset: true}

--- a/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertBuilderStateToWidget.spec.tsx
@@ -252,6 +252,18 @@ describe('convertBuilderStateToWidget', () => {
     expect(widget.axisRange).toBe('dataMin');
   });
 
+  it('preserves explicit auto axisRange on dataset with dataMin default', () => {
+    const mockState: WidgetBuilderState = {
+      dataset: WidgetType.PREPROD_APP_SIZE,
+      displayType: DisplayType.LINE,
+      axisRange: 'auto',
+    };
+
+    const widget = convertBuilderStateToWidget(mockState);
+
+    expect(widget.axisRange).toBe('auto');
+  });
+
   it('falls back to dataset config axisRange when state.axisRange is invalid', () => {
     const mockState: WidgetBuilderState = {
       dataset: WidgetType.PREPROD_APP_SIZE,

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -123,7 +123,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     );
   });
 
-  it('omits axisRange when widget axisRange is null', () => {
+  it('defaults axisRange to auto when widget axisRange is null', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: null,
@@ -132,10 +132,10 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBeUndefined();
+    expect(params.axisRange).toBe('auto');
   });
 
-  it('omits axisRange when widget axisRange is invalid', () => {
+  it('defaults axisRange to auto when widget axisRange is invalid', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: 'invalid',
@@ -144,7 +144,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBeUndefined();
+    expect(params.axisRange).toBe('auto');
   });
 
   describe('traceMetric', () => {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -123,7 +123,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     );
   });
 
-  it('returns undefined axisRange when widget axisRange is null', () => {
+  it('defaults axisRange to auto when widget axisRange is null', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: null,
@@ -132,10 +132,10 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBeUndefined();
+    expect(params.axisRange).toBe('auto');
   });
 
-  it('returns undefined axisRange when widget axisRange is invalid', () => {
+  it('defaults axisRange to auto when widget axisRange is invalid', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: 'invalid',
@@ -144,7 +144,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBeUndefined();
+    expect(params.axisRange).toBe('auto');
   });
 
   describe('traceMetric', () => {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.spec.tsx
@@ -123,7 +123,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     );
   });
 
-  it('defaults axisRange to auto when widget axisRange is null', () => {
+  it('returns undefined axisRange when widget axisRange is null', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: null,
@@ -132,10 +132,10 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBe('auto');
+    expect(params.axisRange).toBeUndefined();
   });
 
-  it('defaults axisRange to auto when widget axisRange is invalid', () => {
+  it('returns undefined axisRange when widget axisRange is invalid', () => {
     const widget = {
       ...getDefaultWidget(WidgetType.ERRORS),
       axisRange: 'invalid',
@@ -144,7 +144,7 @@ describe('convertWidgetToBuilderStateParams', () => {
     const params = convertWidgetToBuilderStateParams(
       widget as unknown as Parameters<typeof convertWidgetToBuilderStateParams>[0]
     );
-    expect(params.axisRange).toBe('auto');
+    expect(params.axisRange).toBeUndefined();
   });
 
   describe('traceMetric', () => {

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -76,6 +76,6 @@ export function convertWidgetToBuilderStateParams(
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
-    axisRange: getAxisRange(widget.axisRange),
+    axisRange: getAxisRange(widget.axisRange) ?? 'auto',
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
+++ b/static/app/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams.ts
@@ -76,6 +76,6 @@ export function convertWidgetToBuilderStateParams(
     selectedAggregate: firstWidgetQuery?.selectedAggregate,
     thresholds: widget.thresholds ? serializeThresholds(widget.thresholds) : undefined,
     traceMetric: traceMetric ? serializeTraceMetric(traceMetric) : undefined,
-    axisRange: getAxisRange(widget.axisRange) ?? 'auto',
+    axisRange: getAxisRange(widget.axisRange),
   };
 }

--- a/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
+++ b/static/app/views/dashboards/widgetBuilder/utils/getDefaultWidget.tsx
@@ -9,5 +9,6 @@ export function getDefaultWidget(widgetType: WidgetType): Widget {
     title: 'Custom Widget',
     widgetType,
     queries: [config.defaultWidgetQuery],
+    axisRange: config.axisRange,
   };
 }

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -872,6 +872,7 @@ describe('constructAddQueryToDashboardLink', () => {
         displayType: DisplayType.AREA,
         yAxis: ['count()', 'count_unique(user)'],
         source: DashboardWidgetSource.DISCOVERV2,
+        axisRange: 'auto',
       });
     });
     it('should construct a link with the correct params - topN', () => {
@@ -904,6 +905,7 @@ describe('constructAddQueryToDashboardLink', () => {
         yAxis: ['count()'],
         limit: 5,
         source: DashboardWidgetSource.DISCOVERV2,
+        axisRange: 'auto',
       });
     });
     it('should construct a link with the correct params - daily top N', () => {
@@ -936,6 +938,7 @@ describe('constructAddQueryToDashboardLink', () => {
         yAxis: ['count()'],
         limit: 5,
         source: DashboardWidgetSource.DISCOVERV2,
+        axisRange: 'auto',
       });
     });
   });

--- a/static/app/views/discover/utils.spec.tsx
+++ b/static/app/views/discover/utils.spec.tsx
@@ -872,7 +872,6 @@ describe('constructAddQueryToDashboardLink', () => {
         displayType: DisplayType.AREA,
         yAxis: ['count()', 'count_unique(user)'],
         source: DashboardWidgetSource.DISCOVERV2,
-        axisRange: 'auto',
       });
     });
     it('should construct a link with the correct params - topN', () => {
@@ -905,7 +904,6 @@ describe('constructAddQueryToDashboardLink', () => {
         yAxis: ['count()'],
         limit: 5,
         source: DashboardWidgetSource.DISCOVERV2,
-        axisRange: 'auto',
       });
     });
     it('should construct a link with the correct params - daily top N', () => {
@@ -938,7 +936,6 @@ describe('constructAddQueryToDashboardLink', () => {
         yAxis: ['count()'],
         limit: 5,
         source: DashboardWidgetSource.DISCOVERV2,
-        axisRange: 'auto',
       });
     });
   });


### PR DESCRIPTION
When editing an existing widget that was saved before the axisRange feature (#109390), the builder showed the dataset default (e.g. "Fit to data" for mobile app size) as checked, even though the widget was actually rendering with `auto` (Y-axis starting at 0). This created a mismatch between the builder UI and the actual chart behavior.

The fix normalizes missing `axisRange` to `'auto'` when loading an existing widget into the builder. This way `undefined` in builder state unambiguously means "new widget, apply dataset defaults" — existing widgets get an explicit value that matches their current rendering.

- Existing widgets: builder shows unchecked, matching actual rendering
- New widgets: dataset default still applies (e.g. `dataMin` for mobile app size)
- Existing widgets with explicit `axisRange`: no change

Refs EME-890