### PR TITLE
ref(components): convert StackedAreaChart from class to function component

### DIFF
--- a/static/app/components/charts/stackedAreaChart.tsx
+++ b/static/app/components/charts/stackedAreaChart.tsx
@@ -1,12 +1,8 @@
-import {Component} from 'react';
-
 import type {AreaChartProps} from 'sentry/components/charts/areaChart';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 
-class StackedAreaChart extends Component<AreaChartProps> {
-  render() {
-    return <AreaChart tooltip={{filter: val => val > 0}} {...this.props} stacked />;
-  }
+function StackedAreaChart(props: AreaChartProps) {
+  return <AreaChart tooltip={{filter: val => val > 0}} {...props} stacked />;
 }
 
 export default StackedAreaChart;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -124,9 +124,7 @@ class ReleaseSessionsChart extends Component<Props> {
     }
   }
 
-  getChart():
-    | React.ComponentType<StackedAreaChart['props']>
-    | React.ComponentType<AreaChartProps> {
+  getChart(): React.ComponentType<AreaChartProps> {
     const {chartType} = this.props;
     switch (chartType) {
       case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:


### PR DESCRIPTION
This is a 5-liner. If it causes any bugs I will be amazed.

Fixes https://linear.app/getsentry/issue/EXP-813/convert-stackedareachart-from-class-to-function-component