### PR TITLE
fix(grouping): Resolve mypy possibly-undefined errors in grouphash caching

### DIFF
--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -221,10 +221,10 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     with metrics.timer(
         "grouping.get_or_create_grouphashes.check_secondary_hash_existence"
     ) as metrics_tags:
-        if use_caching:
-            cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
-            cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
+        cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
+        if use_caching:
             grouphash_exists = cache.get(cache_key)
             got_cache_hit = grouphash_exists is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"
@@ -260,10 +260,10 @@ def _get_or_create_single_grouphash(
     with metrics.timer(
         "grouping.get_or_create_grouphashes.get_or_create_grouphash"
     ) as metrics_tags:
-        if use_caching:
-            cache_key = get_grouphash_object_cache_key(hash_value, project.id)
-            cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
+        cache_key = get_grouphash_object_cache_key(hash_value, project.id)
+        cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
 
+        if use_caching:
             grouphash = cache.get(cache_key)
             got_cache_hit = grouphash is not None
             metrics_tags["cache_result"] = "hit" if got_cache_hit else "miss"


### PR DESCRIPTION
Hoist `cache_key` and `cache_expiry` assignments out of the first `if use_caching:` block in `_grouphash_exists_for_hash_value` and `_get_or_create_single_grouphash`.

mypy's `--enable-error-code possibly-undefined` couldn't track that the variables were guaranteed to be assigned by the time the second `if use_caching:` block ran, since it treats each conditional independently. Both values are side-effect-free to compute (a string format and an options dict lookup), so computing them unconditionally has no meaningful impact on the non-caching path.