### PR TITLE
fix(alerts): user_misery eap validation error

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1857,6 +1857,7 @@ EAP_FUNCTIONS = [
     "failure_rate",
     "eps",
     "apdex",
+    "user_misery",
 ]
 
 

--- a/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_alert_rule.py
@@ -19,6 +19,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleTriggerAction,
 )
 from sentry.models.rule import Rule
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import ExtrapolationMode, SnubaQueryEventType
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.types.actor import Actor
@@ -175,6 +176,15 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         alert_rule = self.create_alert_rule(environment=self.environment)
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)
+
+    def test_eap_user_misery_aggregate(self) -> None:
+        alert_rule = self.create_alert_rule(
+            aggregate="user_misery(span.duration,300)",
+            dataset=Dataset.EventsAnalyticsPlatform,
+        )
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
+        assert result["aggregate"] == "user_misery(span.duration,300)"
 
     def test_created_by(self) -> None:
         user = self.create_user("foo@example.com")

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -270,3 +270,16 @@ class SnubaQueryValidatorTest(TestCase):
 
         assert validator.is_valid()
         assert validator.validated_data["group_by"] == ["project", "environment", "release", "user"]
+
+    def test_eap_user_misery_aggregate(self) -> None:
+        data = {
+            "dataset": Dataset.EventsAnalyticsPlatform.value,
+            "query": "",
+            "aggregate": "user_misery(span.duration,300)",
+            "timeWindow": 60,
+            "environment": self.environment.name,
+            "eventTypes": [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()],
+        }
+        validator = SnubaQueryValidator(data=data, context=self.context)
+        assert validator.is_valid(), validator.errors
+        assert validator.validated_data["aggregate"] == "user_misery(span.duration,300)"


### PR DESCRIPTION
Fixes [SENTRY-5KGJ](https://sentry.sentry.io/issues/7296730296/)

I had migrated all transaction alerts onto eap and i guess there were a couple of user misery alerts which hit discover function validation; EAP user_misery vs discover is different which is why the validation was failing. I've added user_misery to the list of eap functions so that it uses eap validation instead.