### PR TITLE
Traces empty state callout

### DIFF
--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -72,6 +72,9 @@ describe('Testing new onboarding ui', () => {
     render(<Onboarding organization={organization} project={projectMock} />);
     expect(await screen.findByText('Query for Traces, Get Answers')).toBeInTheDocument();
     expect(await screen.findByText('Preview a Sentry Trace')).toBeInTheDocument();
+    expect(
+      await screen.findByText('OpenTelemetry Drains and Forwarders')
+    ).toBeInTheDocument();
 
     expect(
       await screen.findByText(

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -11,6 +11,7 @@ import tourTrace from 'sentry-images/spot/performance-tour-trace.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import {
   addErrorMessage,
@@ -86,6 +87,31 @@ const docsLink = (
     {t('Setup')}
   </LinkButton>
 );
+
+function TraceDrainsLink() {
+  return (
+    <TraceDrainsLinkWrapper>
+      <BodyTitle>{t('OpenTelemetry Drains and Forwarders')}</BodyTitle>
+      <SubTitle>
+        {tct(
+          'You can use [link:OpenTelemetry Drains] to send traces from platforms like [vercelLink:Vercel] and [herokuLink:Heroku], or via the [otlpLink:OpenTelemetry Collector].',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/product/drains/" />,
+            vercelLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/" />
+            ),
+            herokuLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/heroku/" />
+            ),
+            otlpLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/opentelemetry-collector/" />
+            ),
+          }
+        )}
+      </SubTitle>
+    </TraceDrainsLinkWrapper>
+  );
+}
 
 export const PERFORMANCE_TOUR_STEPS: TourStep[] = [
   {
@@ -389,7 +415,10 @@ function OnboardingPanel({
               </HeaderWrapper>
               <Divider />
               <Body>
-                <Setup>{children}</Setup>
+                <Setup>
+                  {children}
+                  <TraceDrainsLink />
+                </Setup>
                 <Preview>
                   <BodyTitle>{t('Preview a Sentry Trace')}</BodyTitle>
                   <Arcade
@@ -705,6 +734,10 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
 
 const SubTitle = styled('div')`
   margin-bottom: ${space(1)};
+`;
+
+const TraceDrainsLinkWrapper = styled('div')`
+  padding-top: ${space(2)};
 `;
 
 const Title = styled('div')`


### PR DESCRIPTION
Adds an OpenTelemetry drains callout to the traces page empty state.

This change provides a consistent user experience by mirroring the existing callout on the logs page, guiding users to relevant documentation for setting up OpenTelemetry drains when no trace data is present.
