### PR TITLE
feat(dashboards): Add 'datamin' support to Mobile Session Health dashboard

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileSessionHealth.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileSessionHealth.ts
@@ -69,6 +69,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       displayType: DisplayType.LINE,
       widgetType: WidgetType.RELEASE,
       interval: '5m',
+      axisRange: 'dataMin',
       queries: [
         {
           aggregates: ['crash_free_rate(session)'],
@@ -86,6 +87,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       displayType: DisplayType.LINE,
       widgetType: WidgetType.RELEASE,
       interval: '5m',
+      axisRange: 'dataMin',
       queries: [
         {
           fields: ['crash_free_rate(user)'],


### PR DESCRIPTION
This adds 'datamin' feature to Crash Free Users and Crash Free Sessions widgets in the Mobile Session Health Dashboard.

Fixes DAIN-1250

Before
<img width="1442" height="528" alt="Monosnap Mobile Session Health — sentry — Sentry 2026-02-27 14-59-21" src="https://github.com/user-attachments/assets/9633e734-d087-4535-ab5a-ee7bac7a0d3c" />

After
<img width="1444" height="525" alt="Monosnap Mobile Session Health — sentry — Sentry 2026-02-27 14-59-41" src="https://github.com/user-attachments/assets/cfa9543c-0b77-4c9d-a12e-9c190af70392" />