### PR TITLE
ref(seer): Add typed wrappers for remaining Seer API callsites

### DIFF
--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -8,10 +8,9 @@ from parsimonious.exceptions import ParseError
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry.api.bases.organization_events import get_query_columns
-from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
-from sentry.seer.anomaly_detection.store_data import SeerMethod
+from sentry.seer.anomaly_detection.store_data import SeerMethod, make_store_data_request
 from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
     AnomalyDetectionConfig,
@@ -27,7 +26,6 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
@@ -246,11 +244,7 @@ def send_historical_data_to_seer(
         },
     )
     try:
-        response = make_signed_seer_api_request(
-            connection_pool=seer_anomaly_detection_connection_pool,
-            path=SEER_ANOMALY_DETECTION_STORE_DATA_URL,
-            body=json.dumps(body).encode("utf-8"),
-        )
+        response = make_store_data_request(body)
     # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -2,14 +2,12 @@ import logging
 from typing import Any
 
 import sentry_sdk
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from parsimonious.exceptions import ParseError
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry.api.bases.organization_events import get_query_columns
 from sentry.models.project import Project
-from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.store_data import SeerMethod, make_store_data_request
 from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
@@ -33,11 +31,6 @@ from sentry.workflow_engine.models import DataCondition, DataSource, DataSourceD
 from sentry.workflow_engine.types import DetectorException, DetectorPriorityLevel
 
 logger = logging.getLogger(__name__)
-
-seer_anomaly_detection_connection_pool = connection_from_url(
-    settings.SEER_ANOMALY_DETECTION_URL,
-    timeout=settings.SEER_ANOMALY_DETECTION_TIMEOUT,
-)
 
 
 def _fetch_related_models(

--- a/src/sentry/seer/anomaly_detection/types.py
+++ b/src/sentry/seer/anomaly_detection/types.py
@@ -124,6 +124,12 @@ class AnomalyThresholdDataPoint(TypedDict):
     yhat_upper: float
 
 
+class GetAnomalyThresholdDataRequest(TypedDict):
+    alert: AlertInSeer
+    start: float
+    end: float
+
+
 class SeerDetectorDataResponse(TypedDict):
     success: bool
     message: str | None

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from urllib3 import BaseHTTPResponse
 
 from sentry import features, quotas
 from sentry.api.serializers import EventSerializer, serialize
@@ -26,18 +27,20 @@ from sentry.seer.autofix.constants import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
-    autofix_connection_pool,
+    GetProjectPreferenceRequest,
     get_autofix_state,
     is_seer_autotriggered_autofix_rate_limited,
     is_seer_autotriggered_autofix_rate_limited_and_increment,
     is_seer_seat_based_tier_enabled,
+    make_get_project_preference_request,
 )
 from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.signed_seer_api import (
+    SummarizeIssueRequest,
     make_signed_seer_api_request,
-    seer_summarization_default_connection_pool,
+    make_summarize_issue_request,
 )
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
@@ -93,13 +96,8 @@ def _fetch_user_preference(project_id: int) -> str | None:
     Returns None if preference is not set or if the API call fails.
     """
     try:
-        path = "/v1/project-preference"
-        body = orjson.dumps({"project_id": project_id})
-
-        response = make_signed_seer_api_request(
-            autofix_connection_pool,
-            path,
-            body,
+        response = make_get_project_preference_request(
+            GetProjectPreferenceRequest(project_id=project_id),
             timeout=5,
         )
 
@@ -245,31 +243,20 @@ def _call_seer(
     serialized_event: dict[str, Any],
     trace_tree: dict[str, Any] | None,
 ):
-    path = "/v1/automation/summarize/issue"
-    body = orjson.dumps(
-        {
-            "group_id": group.id,
-            "issue": {
-                "id": group.id,
-                "title": group.title,
-                "short_id": group.qualified_short_id,
-                "events": [serialized_event],
-            },
-            "trace_tree": trace_tree,
-            "organization_slug": group.organization.slug,
-            "organization_id": group.organization.id,
-            "project_id": group.project.id,
+    body = SummarizeIssueRequest(
+        group_id=group.id,
+        issue={
+            "id": group.id,
+            "title": group.title,
+            "short_id": group.qualified_short_id,
+            "events": [serialized_event],
         },
-        option=orjson.OPT_NON_STR_KEYS,
+        trace_tree=trace_tree,
+        organization_slug=group.organization.slug,
+        organization_id=group.organization.id,
+        project_id=group.project.id,
     )
-
-    # Route to summarization URL
-    response = make_signed_seer_api_request(
-        seer_summarization_default_connection_pool,
-        path,
-        body,
-        timeout=30,
-    )
+    response = make_summarize_issue_request(body, timeout=30)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -283,24 +270,39 @@ fixability_connection_pool_gpu = connection_from_url(
 )
 
 
+class FixabilityScoreRequest(TypedDict):
+    group_id: int
+    organization_slug: str
+    organization_id: int
+    project_id: int
+    summary: NotRequired[str | None]
+
+
+def make_fixability_score_request(
+    body: FixabilityScoreRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        fixability_connection_pool_gpu,
+        "/v1/automation/summarize/fixability",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        timeout=timeout,
+    )
+
+
 def _generate_fixability_score(
     group: Group,
     summary: dict[str, Any] | None = None,
 ) -> SummarizeIssueResponse:
-    payload: dict[str, Any] = {
-        "group_id": group.id,
-        "organization_slug": group.organization.slug,
-        "organization_id": group.organization.id,
-        "project_id": group.project.id,
-    }
-    if summary is not None:
-        payload["summary"] = summary
-    response = make_signed_seer_api_request(
-        fixability_connection_pool_gpu,
-        "/v1/automation/summarize/fixability",
-        body=orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS),
-        timeout=settings.SEER_FIXABILITY_TIMEOUT,
+    body = FixabilityScoreRequest(
+        group_id=group.id,
+        organization_slug=group.organization.slug,
+        organization_id=group.organization.id,
+        project_id=group.project.id,
     )
+    if summary is not None:
+        body["summary"] = summary
+    response = make_fixability_score_request(body, timeout=settings.SEER_FIXABILITY_TIMEOUT)
     if response.status >= 400:
         raise Exception(f"Seer API error: {response.status}")
     response_data = orjson.loads(response.data)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -275,7 +275,7 @@ class FixabilityScoreRequest(TypedDict):
     organization_slug: str
     organization_id: int
     project_id: int
-    summary: NotRequired[str | None]
+    summary: NotRequired[dict[str, Any] | None]
 
 
 def make_fixability_score_request(

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1,14 +1,14 @@
 import logging
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import orjson
 import pydantic
 from django.conf import settings
 from pydantic import BaseModel
 from rest_framework import serializers
-from urllib3 import Retry
+from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
 from sentry import features, options, ratelimits
 from sentry.constants import DataCategory
@@ -28,7 +28,6 @@ from sentry.seer.models import (
     SeerRepoDefinition,
 )
 from sentry.seer.signed_seer_api import make_signed_seer_api_request
-from sentry.utils import json
 from sentry.utils.cache import cache
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -145,6 +144,182 @@ autofix_connection_pool = connection_from_url(
 )
 
 
+class GetProjectPreferenceRequest(TypedDict):
+    project_id: int
+
+
+class SetProjectPreferenceRequest(TypedDict):
+    preference: dict[str, Any]
+
+
+class BulkGetProjectPreferencesRequest(TypedDict):
+    organization_id: int
+    project_ids: list[int]
+
+
+class BulkSetProjectPreferencesRequest(TypedDict):
+    organization_id: int
+    preferences: list[dict[str, Any]]
+
+
+class GetAutofixStateRequest(TypedDict):
+    group_id: int | None
+    run_id: int | None
+    check_repo_access: bool
+    is_user_fetching: bool
+
+
+class GetAutofixStatePrRequest(TypedDict):
+    provider: str
+    pr_id: int
+
+
+class GetAutofixPromptRequest(TypedDict):
+    run_id: int
+    include_root_cause: bool
+    include_solution: bool
+
+
+class StoreCodingAgentStatesRequest(TypedDict):
+    run_id: int
+    coding_agent_states: list[dict[str, Any]]
+
+
+def make_get_project_preference_request(
+    body: GetProjectPreferenceRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/project-preference",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_set_project_preference_request(
+    body: SetProjectPreferenceRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/project-preference/set",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_bulk_get_project_preferences_request(
+    body: BulkGetProjectPreferencesRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/project-preference/bulk",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_bulk_set_project_preferences_request(
+    body: BulkSetProjectPreferencesRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/project-preference/bulk-set",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_get_autofix_state_request(
+    body: GetAutofixStateRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/state",
+        body=orjson.dumps(body),
+    )
+
+
+def make_get_autofix_state_pr_request(
+    body: GetAutofixStatePrRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/state/pr",
+        body=orjson.dumps(body),
+    )
+
+
+def make_get_autofix_prompt_request(
+    body: GetAutofixPromptRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/prompt",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_update_coding_agent_state_request(
+    body: CodingAgentStateUpdateRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/coding-agent/state/update",
+        body=orjson.dumps(body.dict(exclude_none=True)),
+        timeout=timeout,
+    )
+
+
+def make_autofix_start_request(
+    body: bytes,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/start",
+        body=body,
+    )
+
+
+def make_autofix_update_request(
+    body: bytes,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/update",
+        body=body,
+    )
+
+
+def make_store_coding_agent_states_request(
+    body: StoreCodingAgentStatesRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or autofix_connection_pool,
+        "/v1/automation/autofix/coding-agent/state/set",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
 class SeerAutofixSettingsSerializer(serializers.Serializer):
     """Base serializer for autofixAutomationTuning and automatedRunStoppingPoint"""
 
@@ -187,15 +362,9 @@ def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:
     Returns:
         SeerRawPreferenceResponse object if successful
     """
-    path = "/v1/project-preference"
-    body = orjson.dumps({"project_id": project_id})
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
+    response = make_get_project_preference_request(
+        GetProjectPreferenceRequest(project_id=project_id),
         timeout=5,
-        retries=Retry(total=2, backoff_factor=0.5),
     )
 
     if response.status == 200:
@@ -210,13 +379,8 @@ def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:
 
 def set_project_seer_preference(preference: SeerProjectPreference) -> None:
     """Set Seer project preference for a single project."""
-    path = "/v1/project-preference/set"
-    body = orjson.dumps({"preference": preference.dict()})
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
+    response = make_set_project_preference_request(
+        SetProjectPreferenceRequest(preference=preference.dict()),
         timeout=15,
     )
 
@@ -271,13 +435,8 @@ def has_project_connected_repos(
 
 def bulk_get_project_preferences(organization_id: int, project_ids: list[int]) -> dict[str, dict]:
     """Bulk fetch Seer project preferences. Returns dict mapping project ID (string) to preference dict."""
-    path = "/v1/project-preference/bulk"
-    body = orjson.dumps({"organization_id": organization_id, "project_ids": project_ids})
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
+    response = make_bulk_get_project_preferences_request(
+        BulkGetProjectPreferencesRequest(organization_id=organization_id, project_ids=project_ids),
         timeout=10,
     )
 
@@ -293,13 +452,8 @@ def bulk_set_project_preferences(organization_id: int, preferences: list[dict]) 
     if not preferences:
         return
 
-    path = "/v1/project-preference/bulk-set"
-    body = orjson.dumps({"organization_id": organization_id, "preferences": preferences})
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
+    response = make_bulk_set_project_preferences_request(
+        BulkSetProjectPreferencesRequest(organization_id=organization_id, preferences=preferences),
         timeout=15,
     )
 
@@ -346,21 +500,13 @@ def get_autofix_state(
     is_user_fetching: bool = False,
     organization_id: int,
 ) -> AutofixState | None:
-    path = "/v1/automation/autofix/state"
-    body = orjson.dumps(
-        {
-            "group_id": group_id,
-            "run_id": run_id,
-            "check_repo_access": check_repo_access,
-            "is_user_fetching": is_user_fetching,
-        }
+    body = GetAutofixStateRequest(
+        group_id=group_id,
+        run_id=run_id,
+        check_repo_access=check_repo_access,
+        is_user_fetching=is_user_fetching,
     )
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body,
-    )
+    response = make_get_autofix_state_request(body)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -385,19 +531,8 @@ def get_autofix_state(
 
 
 def get_autofix_state_from_pr_id(provider: str, pr_id: int) -> AutofixState | None:
-    path = "/v1/automation/autofix/state/pr"
-    body = json.dumps(
-        {
-            "provider": provider,
-            "pr_id": pr_id,
-        }
-    ).encode("utf-8")
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body,
-    )
+    body = GetAutofixStatePrRequest(provider=provider, pr_id=pr_id)
+    response = make_get_autofix_state_pr_request(body)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -615,21 +750,12 @@ def is_seer_autotriggered_autofix_rate_limited_and_increment(
 def get_autofix_prompt(run_id: int, include_root_cause: bool, include_solution: bool) -> str:
     """Get the autofix prompt from Seer API."""
 
-    path = "/v1/automation/autofix/prompt"
-    body = orjson.dumps(
-        {
-            "run_id": run_id,
-            "include_root_cause": include_root_cause,
-            "include_solution": include_solution,
-        }
+    body = GetAutofixPromptRequest(
+        run_id=run_id,
+        include_root_cause=include_root_cause,
+        include_solution=include_solution,
     )
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
-        timeout=15,
-    )
+    response = make_get_autofix_prompt_request(body, timeout=15)
 
     if response.status >= 400:
         raise SeerApiError(response.data.decode("utf-8"), response.status)
@@ -678,8 +804,6 @@ def update_coding_agent_state(
 
     Raises SeerApiError for non-2xx responses.
     """
-    path = "/v1/automation/autofix/coding-agent/state/update"
-
     updates = CodingAgentStateUpdate(
         status=status,
         agent_url=agent_url,
@@ -691,14 +815,7 @@ def update_coding_agent_state(
         updates=updates,
     )
 
-    body = orjson.dumps(update_data.dict(exclude_none=True))
-
-    response = make_signed_seer_api_request(
-        autofix_connection_pool,
-        path,
-        body=body,
-        timeout=30,
-    )
+    response = make_update_coding_agent_state_request(update_data, timeout=30)
 
     if response.status >= 400:
         raise SeerApiError(response.data.decode("utf-8"), response.status)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from pydantic import BaseModel
 from rest_framework import serializers
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+from urllib3.util.retry import Retry
 
 from sentry import features, options, ratelimits
 from sentry.constants import DataCategory
@@ -189,12 +190,14 @@ def make_get_project_preference_request(
     body: GetProjectPreferenceRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    retries: Retry | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/project-preference",
         body=orjson.dumps(body),
         timeout=timeout,
+        retries=retries,
     )
 
 
@@ -365,6 +368,7 @@ def get_project_seer_preferences(project_id: int) -> SeerRawPreferenceResponse:
     response = make_get_project_preference_request(
         GetProjectPreferenceRequest(project_id=project_id),
         timeout=5,
+        retries=Retry(total=2, backoff_factor=0.5),
     )
 
     if response.status == 200:

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -26,6 +26,8 @@ from .metrics import CodeReviewErrorType, record_webhook_handler_error
 
 logger = logging.getLogger(__name__)
 
+seer_code_review_connection_pool = connection_from_url(settings.SEER_PREVENT_AI_URL)
+
 
 class Log(enum.StrEnum):
     MISSING_INTEGRATION = "github.webhook.missing-integration"
@@ -104,7 +106,7 @@ def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
     """
     logger.info("seer.code_review.sending_request_to_seer")
     response = make_signed_seer_api_request(
-        connection_pool=connection_from_url(settings.SEER_PREVENT_AI_URL),
+        connection_pool=seer_code_review_connection_pool,
         path=path,
         body=orjson.dumps(payload),
     )

--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import orjson
-
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    make_signed_seer_api_request,
-    seer_anomaly_detection_default_connection_pool,
+    CompareDistributionsRequest,
+    make_compare_distributions_request,
 )
 from sentry.utils.json import JSONDecodeError
 
@@ -27,21 +25,15 @@ def compare_distributions(
     Sends a request to seer to compare two distributions and rank their attributes by suspisiouness
     """
 
-    body = orjson.dumps(
-        {
-            "baseline": baseline,
-            "outliers": outliers,
-            "total_baseline": total_baseline,
-            "total_outliers": total_outliers,
-            "config": config,
-            "meta": meta,
-        }
+    body = CompareDistributionsRequest(
+        baseline=baseline,
+        outliers=outliers,
+        total_baseline=total_baseline,
+        total_outliers=total_outliers,
+        config=config,
+        meta=meta,
     )
-    response = make_signed_seer_api_request(
-        seer_anomaly_detection_default_connection_pool,
-        "/v1/workflows/compare/cohort",
-        body,
-    )
+    response = make_compare_distributions_request(body)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     try:

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import orjson
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -19,10 +18,7 @@ from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplo
 from sentry.seer.explorer.client_utils import collect_user_org_context
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import (
-    make_signed_seer_api_request,
-    seer_autofix_default_connection_pool,
-)
+from sentry.seer.signed_seer_api import SearchAgentStartRequest, make_search_agent_start_request
 
 logger = logging.getLogger(__name__)
 
@@ -71,35 +67,25 @@ def send_search_agent_start_request(
     """
     Sends a request to Seer to start an async search agent and returns a run_id for polling.
     """
-    body_dict: dict[str, Any] = {
-        "org_id": org_id,
-        "org_slug": org_slug,
-        "project_ids": project_ids,
-        "natural_language_query": natural_language_query,
-        "strategy": strategy,
-    }
-
+    body = SearchAgentStartRequest(
+        org_id=org_id,
+        org_slug=org_slug,
+        project_ids=project_ids,
+        natural_language_query=natural_language_query,
+        strategy=strategy,
+    )
     if user_email:
-        body_dict["user_email"] = user_email
-
+        body["user_email"] = user_email
     if timezone:
-        body_dict["timezone"] = timezone
+        body["timezone"] = timezone
 
     options: dict[str, Any] = {}
     if model_name is not None:
         options["model_name"] = model_name
-
     if options:
-        body_dict["options"] = options
+        body["options"] = options
 
-    body = orjson.dumps(body_dict)
-
-    response = make_signed_seer_api_request(
-        seer_autofix_default_connection_pool,
-        "/v1/assisted-query/start",
-        body,
-        timeout=30,
-    )
+    response = make_search_agent_start_request(body, timeout=30)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -461,7 +461,12 @@ class SeerExplorerClient:
         )
 
         # Add optional filters
-        if only_current_user and self.user and hasattr(self.user, "id"):
+        if (
+            only_current_user
+            and self.user
+            and hasattr(self.user, "id")
+            and self.user.id is not None
+        ):
             runs_body["user_id"] = int(self.user.id)
         if category_key is not None:
             runs_body["category_key"] = category_key

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -462,7 +462,7 @@ class SeerExplorerClient:
 
         # Add optional filters
         if only_current_user and self.user and hasattr(self.user, "id"):
-            runs_body["user_id"] = self.user.id
+            runs_body["user_id"] = int(self.user.id)
         if category_key is not None:
             runs_body["category_key"] = category_key
         if category_value is not None:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -5,7 +5,6 @@ import time
 from datetime import datetime
 from typing import Any, Literal, overload
 
-import orjson
 from django.contrib.auth.models import AnonymousUser
 from pydantic import BaseModel
 from rest_framework.request import Request
@@ -15,9 +14,14 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.explorer.client_models import ExplorerRun, ExplorerRunWithPrs, SeerRunState
 from sentry.seer.explorer.client_utils import (
+    ExplorerChatRequest,
+    ExplorerRunsRequest,
+    ExplorerUpdateRequest,
     collect_user_org_context,
-    explorer_connection_pool,
     fetch_run_status,
+    make_explorer_chat_request,
+    make_explorer_runs_request,
+    make_explorer_update_request,
     poll_until_done,
 )
 from sentry.seer.explorer.coding_agent_handoff import launch_coding_agents
@@ -28,7 +32,6 @@ from sentry.seer.explorer.on_completion_hook import (
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.users.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -246,62 +249,56 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
-        path = "/v1/automation/explorer/chat"
-
-        payload: dict[str, Any] = {
-            "organization_id": self.organization.id,
-            "query": prompt,
-            "run_id": None,
-            "insert_index": None,
-            "on_page_context": on_page_context,
-            "user_org_context": collect_user_org_context(
+        chat_body: ExplorerChatRequest = ExplorerChatRequest(
+            organization_id=self.organization.id,
+            query=prompt,
+            run_id=None,
+            insert_index=None,
+            on_page_context=on_page_context,
+            user_org_context=collect_user_org_context(
                 self.user, self.organization, request=request
             ),
-            "intelligence_level": self.intelligence_level,
-            "is_interactive": self.is_interactive,
-            "enable_coding": self.enable_coding,
-        }
+            intelligence_level=self.intelligence_level,
+            is_interactive=self.is_interactive,
+            enable_coding=self.enable_coding,
+        )
 
         if self.project:
-            payload["project_id"] = self.project.id
+            chat_body["project_id"] = self.project.id
 
         if prompt_metadata:
-            payload["query_metadata"] = prompt_metadata
+            chat_body["query_metadata"] = prompt_metadata
 
         # Add artifact key and schema if provided
         if artifact_key and artifact_schema:
-            payload["artifact_key"] = artifact_key
-            payload["artifact_schema"] = artifact_schema.schema()
+            chat_body["artifact_key"] = artifact_key
+            chat_body["artifact_schema"] = artifact_schema.schema()
 
         # Extract and add custom tool definitions
         if self.custom_tools:
-            payload["custom_tools"] = [
+            chat_body["custom_tools"] = [
                 extract_tool_schema(tool).dict() for tool in self.custom_tools
             ]
 
         # Add on-completion hook if provided
         if self.on_completion_hook:
-            payload["on_completion_hook"] = extract_hook_definition(self.on_completion_hook).dict()
+            chat_body["on_completion_hook"] = extract_hook_definition(
+                self.on_completion_hook
+            ).dict()
 
         if self.category_key and self.category_value:
-            payload["category_key"] = self.category_key
-            payload["category_value"] = self.category_value
+            chat_body["category_key"] = self.category_key
+            chat_body["category_value"] = self.category_value
 
         if metadata:
-            payload["metadata"] = metadata
+            chat_body["metadata"] = metadata
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
         ):
-            payload["is_context_engine_enabled"] = True
+            chat_body["is_context_engine_enabled"] = True
 
-        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-
-        response = make_signed_seer_api_request(
-            explorer_connection_pool,
-            path,
-            body,
-        )
+        response = make_explorer_chat_request(chat_body)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -339,40 +336,32 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
-        path = "/v1/automation/explorer/chat"
-
-        payload: dict[str, Any] = {
-            "organization_id": self.organization.id,
-            "query": prompt,
-            "run_id": run_id,
-            "insert_index": insert_index,
-            "on_page_context": on_page_context,
-            "is_interactive": self.is_interactive,
-            "enable_coding": self.enable_coding,
-        }
+        chat_body: ExplorerChatRequest = ExplorerChatRequest(
+            organization_id=self.organization.id,
+            query=prompt,
+            run_id=run_id,
+            insert_index=insert_index,
+            on_page_context=on_page_context,
+            is_interactive=self.is_interactive,
+            enable_coding=self.enable_coding,
+        )
 
         if prompt_metadata:
-            payload["query_metadata"] = prompt_metadata
+            chat_body["query_metadata"] = prompt_metadata
 
         # Add artifact key and schema if provided
         if artifact_key and artifact_schema:
-            payload["artifact_key"] = artifact_key
-            payload["artifact_schema"] = artifact_schema.schema()
+            chat_body["artifact_key"] = artifact_key
+            chat_body["artifact_schema"] = artifact_schema.schema()
 
         if features.has(
             "organizations:seer-explorer-context-engine",
             self.organization,
             actor=self.user,
         ):
-            payload["is_context_engine_enabled"] = True
+            chat_body["is_context_engine_enabled"] = True
 
-        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-
-        response = make_signed_seer_api_request(
-            explorer_connection_pool,
-            path,
-            body,
-        )
+        response = make_explorer_chat_request(chat_body)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -467,39 +456,31 @@ class SeerExplorerClient:
         Raises:
             SeerApiError: If the Seer API request fails
         """
-        path = "/v1/automation/explorer/runs"
-
-        payload: dict[str, Any] = {
-            "organization_id": self.organization.id,
-        }
+        runs_body: ExplorerRunsRequest = ExplorerRunsRequest(
+            organization_id=self.organization.id,
+        )
 
         # Add optional filters
         if only_current_user and self.user and hasattr(self.user, "id"):
-            payload["user_id"] = self.user.id
+            runs_body["user_id"] = self.user.id
         if category_key is not None:
-            payload["category_key"] = category_key
+            runs_body["category_key"] = category_key
         if category_value is not None:
-            payload["category_value"] = category_value
+            runs_body["category_value"] = category_value
         if offset is not None:
-            payload["offset"] = offset
+            runs_body["offset"] = offset
         if project_ids is not None:
-            payload["project_ids"] = project_ids
+            runs_body["project_ids"] = project_ids
         if limit is not None:
-            payload["limit"] = limit
+            runs_body["limit"] = limit
         if expand is not None:
-            payload["expand"] = expand
+            runs_body["expand"] = expand
         if start is not None:
-            payload["start"] = start
+            runs_body["start"] = start
         if end is not None:
-            payload["end"] = end
+            runs_body["end"] = end
 
-        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-
-        response = make_signed_seer_api_request(
-            explorer_connection_pool,
-            path,
-            body,
-        )
+        response = make_explorer_runs_request(runs_body)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -536,21 +517,12 @@ class SeerExplorerClient:
             SeerApiError: If the Seer API request fails
         """
         # Trigger PR creation
-        path = "/v1/automation/explorer/update"
-        payload = {
-            "run_id": run_id,
-            "organization_id": self.organization.id,
-            "payload": {
-                "type": "create_pr",
-                "repo_name": repo_name,
-            },
-        }
-        body = orjson.dumps(payload, option=orjson.OPT_NON_STR_KEYS)
-        response = make_signed_seer_api_request(
-            explorer_connection_pool,
-            path,
-            body,
+        update_body = ExplorerUpdateRequest(
+            run_id=run_id,
+            organization_id=self.organization.id,
+            payload={"type": "create_pr", "repo_name": repo_name},
         )
+        response = make_explorer_update_request(update_body)
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from typing import Any, NotRequired, TypedDict
 
 import orjson
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
+from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
 from sentry import features
 from sentry.constants import ObjectStatus
@@ -36,6 +37,96 @@ logger = logging.getLogger(__name__)
 explorer_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL,
 )
+
+
+class ExplorerStateRequest(TypedDict):
+    run_id: int
+    organization_id: int
+
+
+class ExplorerChatRequest(TypedDict):
+    organization_id: int
+    query: str
+    run_id: int | None
+    insert_index: int | None
+    on_page_context: str | None
+    user_org_context: NotRequired[dict[str, Any] | None]
+    intelligence_level: NotRequired[str]
+    is_interactive: NotRequired[bool]
+    enable_coding: NotRequired[bool]
+    project_id: NotRequired[int]
+    query_metadata: NotRequired[dict[str, str]]
+    artifact_key: NotRequired[str]
+    artifact_schema: NotRequired[dict[str, Any]]
+    custom_tools: NotRequired[list[dict[str, Any]]]
+    on_completion_hook: NotRequired[dict[str, Any]]
+    category_key: NotRequired[str]
+    category_value: NotRequired[str]
+    metadata: NotRequired[dict[str, Any]]
+    is_context_engine_enabled: NotRequired[bool]
+
+
+class ExplorerRunsRequest(TypedDict):
+    organization_id: int
+    user_id: NotRequired[int]
+    category_key: NotRequired[str]
+    category_value: NotRequired[str]
+    offset: NotRequired[int]
+    project_ids: NotRequired[list[int]]
+    limit: NotRequired[int]
+    expand: NotRequired[str]
+    start: NotRequired[str]
+    end: NotRequired[str]
+
+
+class ExplorerUpdateRequest(TypedDict):
+    run_id: int
+    organization_id: int
+    payload: NotRequired[dict[str, Any]]
+
+
+def make_explorer_state_request(
+    body: ExplorerStateRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or explorer_connection_pool,
+        "/v1/automation/explorer/state",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+    )
+
+
+def make_explorer_chat_request(
+    body: ExplorerChatRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or explorer_connection_pool,
+        "/v1/automation/explorer/chat",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+    )
+
+
+def make_explorer_runs_request(
+    body: ExplorerRunsRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or explorer_connection_pool,
+        "/v1/automation/explorer/runs",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+    )
+
+
+def make_explorer_update_request(
+    body: ExplorerUpdateRequest,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        connection_pool or explorer_connection_pool,
+        "/v1/automation/explorer/update",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+    )
 
 
 def has_seer_explorer_access_with_detail(
@@ -126,21 +217,8 @@ def collect_user_org_context(
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
     """Fetch current run status from Seer."""
-    path = "/v1/automation/explorer/state"
-
-    body = orjson.dumps(
-        {
-            "run_id": run_id,
-            "organization_id": organization.id,
-        },
-        option=orjson.OPT_NON_STR_KEYS,
-    )
-
-    response = make_signed_seer_api_request(
-        explorer_connection_pool,
-        path,
-        body,
-    )
+    body = ExplorerStateRequest(run_id=run_id, organization_id=organization.id)
+    response = make_explorer_state_request(body)
 
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
 import orjson
@@ -75,8 +76,8 @@ class ExplorerRunsRequest(TypedDict):
     project_ids: NotRequired[list[int]]
     limit: NotRequired[int]
     expand: NotRequired[str]
-    start: NotRequired[str]
-    end: NotRequired[str]
+    start: NotRequired[datetime]
+    end: NotRequired[datetime]
 
 
 class ExplorerUpdateRequest(TypedDict):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -167,6 +167,206 @@ def make_llm_generate_request(
     )
 
 
+class SummarizeTraceRequest(TypedDict):
+    trace_id: str
+    only_transaction: bool
+    trace: dict[str, Any]
+
+
+class SummarizeIssueRequest(TypedDict):
+    group_id: int
+    issue: dict[str, Any]
+    trace_tree: NotRequired[dict[str, Any] | None]
+    organization_slug: str
+    organization_id: int
+    project_id: int
+
+
+class SupergroupsEmbeddingRequest(TypedDict):
+    organization_id: int
+    group_id: int
+    artifact_data: dict[str, Any]
+
+
+class ServiceMapUpdateRequest(TypedDict):
+    organization_id: int
+    nodes: list[dict[str, Any]]
+    edges: list[dict[str, Any]]
+
+
+class UnitTestGenerationRequest(TypedDict):
+    repo: dict[str, Any]
+    pr_id: int
+
+
+class SearchAgentStateRequest(TypedDict):
+    run_id: int
+    organization_id: int
+
+
+class TranslateQueryRequest(TypedDict):
+    org_id: int
+    org_slug: str
+    project_ids: list[int]
+    natural_language_query: str
+
+
+class SearchAgentStartRequest(TypedDict):
+    org_id: int
+    org_slug: str
+    project_ids: list[int]
+    natural_language_query: str
+    strategy: str
+    user_email: NotRequired[str]
+    timezone: NotRequired[str]
+    options: NotRequired[dict[str, Any]]
+
+
+class TranslateAgenticRequest(TypedDict):
+    org_id: int
+    org_slug: str
+    project_ids: list[int]
+    natural_language_query: str
+    strategy: str
+    options: NotRequired[dict[str, Any]]
+
+
+class CreateCacheRequest(TypedDict):
+    org_id: int
+    project_ids: list[int]
+
+
+class CompareDistributionsRequest(TypedDict):
+    baseline: list[dict[str, Any]]
+    outliers: list[dict[str, Any]]
+    total_baseline: int
+    total_outliers: int
+    config: dict[str, Any]
+    meta: dict[str, Any]
+
+
+def make_summarize_trace_request(
+    body: SummarizeTraceRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        "/v1/automation/summarize/trace",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        timeout=timeout,
+    )
+
+
+def make_summarize_issue_request(
+    body: SummarizeIssueRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_summarization_default_connection_pool,
+        "/v1/automation/summarize/issue",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        timeout=timeout,
+    )
+
+
+def make_supergroups_embedding_request(
+    body: SupergroupsEmbeddingRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v0/issues/supergroups",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_service_map_update_request(
+    body: ServiceMapUpdateRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/explorer/service-map/update",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_unit_test_generation_request(
+    body: UnitTestGenerationRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/automation/codegen/unit-tests",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+    )
+
+
+def make_search_agent_state_request(
+    body: SearchAgentStateRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/state",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_translate_query_request(
+    body: TranslateQueryRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate",
+        body=orjson.dumps(body),
+    )
+
+
+def make_search_agent_start_request(
+    body: SearchAgentStartRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/start",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_translate_agentic_request(
+    body: TranslateAgenticRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/translate-agentic",
+        body=orjson.dumps(body),
+    )
+
+
+def make_create_cache_request(
+    body: CreateCacheRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v1/assisted-query/create-cache",
+        body=orjson.dumps(body),
+    )
+
+
+def make_compare_distributions_request(
+    body: CompareDistributionsRequest,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_anomaly_detection_default_connection_pool,
+        "/v1/workflows/compare/cohort",
+        body=orjson.dumps(body),
+    )
+
+
 def sign_with_seer_secret(body: bytes) -> dict[str, str]:
     auth_headers: dict[str, str] = {}
     if settings.SEER_API_SHARED_SECRET:

--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import orjson
-
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
-    make_signed_seer_api_request,
-    seer_autofix_default_connection_pool,
+    SupergroupsEmbeddingRequest,
+    make_supergroups_embedding_request,
 )
 
 
@@ -14,20 +12,11 @@ def trigger_supergroups_embedding(
     group_id: int,
     artifact_data: dict,
 ) -> None:
-    path = "/v0/issues/supergroups"
-    body = orjson.dumps(
-        {
-            "organization_id": organization_id,
-            "group_id": group_id,
-            "artifact_data": artifact_data,
-        }
+    body = SupergroupsEmbeddingRequest(
+        organization_id=organization_id,
+        group_id=group_id,
+        artifact_data=artifact_data,
     )
-
-    response = make_signed_seer_api_request(
-        seer_autofix_default_connection_pool,
-        path,
-        body,
-        timeout=5,
-    )
+    response = make_supergroups_embedding_request(body, timeout=5)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -84,7 +84,7 @@ class TestGetAutofixStateFromPrId(TestCase):
         mock_request.assert_called_once()
         path = mock_request.call_args[0][1]
         assert path == "/v1/automation/autofix/state/pr"
-        body = orjson.loads(mock_request.call_args[0][2])
+        body = orjson.loads(mock_request.call_args[1]["body"])
         assert body == {"provider": "github", "pr_id": 1}
 
     @patch("sentry.seer.autofix.utils.make_signed_seer_api_request")
@@ -145,7 +145,7 @@ class TestGetAutofixState(TestCase):
         mock_request.assert_called_once()
         path = mock_request.call_args[0][1]
         assert path == "/v1/automation/autofix/state"
-        body = orjson.loads(mock_request.call_args[0][2])
+        body = orjson.loads(mock_request.call_args[1]["body"])
         assert body == {
             "group_id": 123,
             "run_id": None,
@@ -189,7 +189,7 @@ class TestGetAutofixState(TestCase):
         mock_request.assert_called_once()
         path = mock_request.call_args[0][1]
         assert path == "/v1/automation/autofix/state"
-        body = orjson.loads(mock_request.call_args[0][2])
+        body = orjson.loads(mock_request.call_args[1]["body"])
         assert body == {
             "group_id": None,
             "run_id": 456,

--- a/tests/sentry/incidents/endpoints/validators/test_validators.py
+++ b/tests/sentry/incidents/endpoints/validators/test_validators.py
@@ -300,9 +300,7 @@ class TestMetricAlertsCreateDetectorValidator(TestMetricAlertsDetectorValidator)
         )
         mock_schedule_update_project_config.assert_called_once_with(detector)
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_anomaly_detection(
         self, mock_audit: mock.MagicMock, mock_seer_request: mock.MagicMock
@@ -357,9 +355,7 @@ class TestMetricAlertsCreateDetectorValidator(TestMetricAlertsDetectorValidator)
         )
         assert not validator.is_valid()
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     def test_anomaly_detection__send_historical_data_fails(
         self, mock_seer_request: mock.MagicMock
     ) -> None:
@@ -870,9 +866,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         assert snuba_query.query_snapshot is None
 
     @mock.patch("sentry.seer.anomaly_detection.delete_rule.delete_rule_in_seer")
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_to_static(
         self,
@@ -910,9 +904,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
 
         assert mock_seer_delete_request.call_count == 1
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_from_static(
         self, mock_audit: mock.MagicMock, mock_seer_request: mock.MagicMock
@@ -972,9 +964,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             data=dynamic_detector.get_audit_log_data(),
         )
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_snuba_query_query(
         self, mock_audit: mock.MagicMock, mock_seer_request: mock.MagicMock
@@ -1042,9 +1032,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             data=dynamic_detector.get_audit_log_data(),
         )
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_snuba_query_aggregate(
         self, mock_audit: mock.MagicMock, mock_seer_request: mock.MagicMock
@@ -1112,9 +1100,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         )
 
     @mock.patch("sentry.seer.anomaly_detection.delete_rule.delete_rule_in_seer")
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_no_config(
         self,
@@ -1186,9 +1172,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             data=dynamic_detector.get_audit_log_data(),
         )
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.detector.create_audit_entry")
     def test_update_anomaly_detection_snuba_query_to_perf(
         self, mock_audit: mock.MagicMock, mock_seer_request: mock.MagicMock
@@ -1245,9 +1229,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             data=dynamic_detector.get_audit_log_data(),
         )
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     @mock.patch(
         "sentry.seer.anomaly_detection.store_data_workflow_engine.handle_send_historical_data_to_seer"
     )
@@ -1301,9 +1283,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
             [SnubaQueryEventType.EventType.TRANSACTION],
         )
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     def test_anomaly_detection__send_historical_data_update_fails(
         self, mock_seer_request: mock.MagicMock
     ) -> None:
@@ -1341,9 +1321,7 @@ class TestMetricAlertsUpdateDetectorValidator(TestMetricAlertsDetectorValidator)
         assert condition.comparison == 100
         assert condition.condition_result == DetectorPriorityLevel.HIGH
 
-    @mock.patch(
-        "sentry.seer.anomaly_detection.store_data_workflow_engine.seer_anomaly_detection_connection_pool.urlopen"
-    )
+    @mock.patch("sentry.seer.anomaly_detection.store_data_workflow_engine.make_store_data_request")
     def test_anomaly_detection__send_historical_data_snuba_update_fails(
         self, mock_seer_request: mock.MagicMock
     ) -> None:

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -200,8 +200,6 @@ class StoreCodingAgentStatesToSeerTest(APITestCase):
         from datetime import UTC, datetime
         from unittest.mock import MagicMock, patch
 
-        import orjson
-
         from sentry.seer.autofix.coding_agent import store_coding_agent_states_to_seer
         from sentry.seer.autofix.utils import (
             CodingAgentProviderType,
@@ -229,16 +227,13 @@ class StoreCodingAgentStatesToSeerTest(APITestCase):
         mocked_response.data = b"{}"
 
         with patch(
-            "sentry.seer.autofix.coding_agent.make_signed_seer_api_request",
+            "sentry.seer.autofix.coding_agent.make_store_coding_agent_states_request",
             return_value=mocked_response,
         ) as mocked_call:
             store_coding_agent_states_to_seer(run_id=5, coding_agent_states=[state1, state2])
 
             mocked_call.assert_called_once()
-            args, kwargs = mocked_call.call_args
-            # path is the second positional arg
-            assert args[1] == "/v1/automation/autofix/coding-agent/state/set"
-            body = orjson.loads(kwargs["body"]) if "body" in kwargs else orjson.loads(args[2])
+            body = mocked_call.call_args[0][0]
             assert body["run_id"] == 5
             assert isinstance(body["coding_agent_states"], list)
             assert len(body["coding_agent_states"]) == 2

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -1026,7 +1026,7 @@ class TestTriggerAutofixWithHideAiFeatures(APITestCase, SnubaTestCase):
 
 class TestCallAutofix(TestCase):
     @patch("sentry.seer.autofix.autofix._get_github_username_for_user")
-    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    @patch("sentry.seer.autofix.autofix.make_autofix_start_request")
     def test_call_autofix(self, mock_request, mock_get_username) -> None:
         """Tests the _call_autofix function makes the correct API call."""
         # Setup mocks
@@ -1080,12 +1080,9 @@ class TestCallAutofix(TestCase):
 
         # Verify the API call
         mock_request.assert_called_once()
-        # Verify path (second positional argument)
-        path = mock_request.call_args[0][1]
-        assert path == "/v1/automation/autofix/start"
 
-        # Verify the request body (third positional argument)
-        body = orjson.loads(mock_request.call_args[0][2])
+        # Verify the request body (first positional argument)
+        body = orjson.loads(mock_request.call_args[0][0])
         assert body["organization_id"] == 456
         assert body["project_id"] == 789
         assert body["repos"] == repos
@@ -1472,7 +1469,7 @@ class UpdateAutofixTest(TestCase):
         self.run_id = 123
         self.payload: AutofixSelectRootCausePayload = {"type": "select_root_cause", "cause_id": 1}
 
-    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    @patch("sentry.seer.autofix.autofix.make_autofix_update_request")
     def test_update_autofix_http_error(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 
@@ -1487,7 +1484,7 @@ class UpdateAutofixTest(TestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Failed to update autofix run"
 
-    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    @patch("sentry.seer.autofix.autofix.make_autofix_update_request")
     def test_update_autofix_json_decode_error(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 
@@ -1503,7 +1500,7 @@ class UpdateAutofixTest(TestCase):
         assert response.status_code == 500
         assert response.data["detail"] == "Seer returned an invalid response"
 
-    @patch("sentry.seer.autofix.autofix.make_signed_seer_api_request")
+    @patch("sentry.seer.autofix.autofix.make_autofix_update_request")
     def test_update_autofix_success(self, mock_request):
         from sentry.seer.autofix.autofix import update_autofix
 

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import orjson
 import pytest
 from pydantic import BaseModel
 
@@ -59,7 +58,7 @@ class TestSeerExplorerClient(TestCase):
         assert client.enable_coding is True
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_basic(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run collects user context"""
@@ -78,7 +77,7 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_request(self, mock_collect_context, mock_post, mock_access):
         """Test starting a new run passes request object to collect_user_org_context"""
@@ -98,7 +97,7 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_start_run_with_optional_params(self, mock_post, mock_access):
         """Test starting a run with optional parameters"""
         mock_access.return_value = (True, None)
@@ -115,7 +114,7 @@ class TestSeerExplorerClient(TestCase):
         assert call_args is not None
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_start_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
@@ -126,7 +125,7 @@ class TestSeerExplorerClient(TestCase):
             client.start_run("Test query")
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_categories(self, mock_collect_context, mock_post, mock_access):
         """Test starting a run with category fields"""
@@ -143,7 +142,7 @@ class TestSeerExplorerClient(TestCase):
         run_id = client.start_run("Fix bug")
 
         assert run_id == 999
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
@@ -184,7 +183,7 @@ class TestSeerExplorerClient(TestCase):
         assert client.intelligence_level == "medium"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_includes_intelligence_level(
         self, mock_collect_context, mock_post, mock_access
@@ -201,11 +200,11 @@ class TestSeerExplorerClient(TestCase):
         run_id = client.start_run("Test query")
 
         assert run_id == 555
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["intelligence_level"] == "low"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_basic(self, mock_post, mock_access):
         """Test continuing an existing run"""
         mock_access.return_value = (True, None)
@@ -221,7 +220,7 @@ class TestSeerExplorerClient(TestCase):
         assert mock_post.called
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_with_all_params(self, mock_post, mock_access):
         """Test continuing a run with all optional parameters"""
         mock_access.return_value = (True, None)
@@ -238,7 +237,7 @@ class TestSeerExplorerClient(TestCase):
         assert call_args is not None
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_http_error(self, mock_post, mock_access):
         """Test that HTTP errors are propagated"""
         mock_access.return_value = (True, None)
@@ -300,7 +299,7 @@ class TestSeerExplorerClient(TestCase):
             client.get_run(123)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_runs_request")
     def test_get_runs_basic(self, mock_post, mock_access):
         """Test getting runs with filters"""
         mock_access.return_value = (True, None)
@@ -325,7 +324,7 @@ class TestSeerExplorerClient(TestCase):
 
         assert len(runs) == 1
         assert runs[0].category_key == "bug-fixer"
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["category_key"] == "bug-fixer"
         assert body["category_value"] == "issue-123"
 
@@ -339,7 +338,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         self.organization = self.create_organization(owner=self.user)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_start_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
         """Test that artifact key and schema are serialized and sent to API"""
@@ -362,7 +361,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         assert run_id == 123
 
         # Verify artifact_key and artifact_schema were included in payload
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["artifact_key"] == "analysis"
         assert "artifact_schema" in body
         assert body["artifact_schema"]["type"] == "object"
@@ -370,7 +369,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
         assert "severity" in body["artifact_schema"]["properties"]
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_start_run_artifact_schema_requires_key(self, mock_post, mock_access):
         """Test that artifact_schema without artifact_key raises ValueError"""
         mock_access.return_value = (True, None)
@@ -385,7 +384,7 @@ class TestSeerExplorerClientArtifacts(TestCase):
             client.start_run("Analyze", artifact_schema=IssueAnalysis)
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     @patch("sentry.seer.explorer.client.collect_user_org_context")
     def test_continue_run_with_artifact_schema(self, mock_collect_context, mock_post, mock_access):
         """Test continuing a run with a new artifact key and schema"""
@@ -407,14 +406,14 @@ class TestSeerExplorerClientArtifacts(TestCase):
 
         assert run_id == 123
 
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["artifact_key"] == "solution"
         assert "artifact_schema" in body
         assert body["artifact_schema"]["type"] == "object"
         assert "description" in body["artifact_schema"]["properties"]
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_artifact_schema_requires_key(self, mock_post, mock_access):
         """Test that artifact_schema without artifact_key raises ValueError"""
         mock_access.return_value = (True, None)
@@ -646,7 +645,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_update_request")
     def test_push_changes_sends_correct_payload(self, mock_post, mock_fetch, mock_access):
         """Test that push_changes sends correct payload"""
         mock_access.return_value = (True, None)
@@ -668,7 +667,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
         client = SeerExplorerClient(self.organization, self.user, enable_coding=True)
         result = client.push_changes(123, repo_name="owner/repo")
 
-        body = orjson.loads(mock_post.call_args[0][2])
+        body = mock_post.call_args[0][0]
         assert body["run_id"] == 123
         assert body["payload"]["type"] == "create_pr"
         assert body["payload"]["repo_name"] == "owner/repo"
@@ -676,7 +675,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_update_request")
     @patch("sentry.seer.explorer.client.time.sleep")
     def test_push_changes_polls_until_complete(
         self, mock_sleep, mock_post, mock_fetch, mock_access
@@ -714,7 +713,7 @@ class TestSeerExplorerClientPushChanges(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")
-    @patch("sentry.seer.explorer.client.make_signed_seer_api_request")
+    @patch("sentry.seer.explorer.client.make_explorer_update_request")
     @patch("sentry.seer.explorer.client.time.sleep")
     @patch("sentry.seer.explorer.client.time.time")
     def test_push_changes_timeout(self, mock_time, mock_sleep, mock_post, mock_fetch, mock_access):

--- a/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
+++ b/tests/sentry/seer/explorer/test_explorer_service_map_utils.py
@@ -10,7 +10,6 @@ from typing import Any
 from unittest import mock
 from uuid import uuid4
 
-import orjson
 import pytest
 
 from sentry.search.events.types import SnubaParams
@@ -68,13 +67,13 @@ class TestSendToSeer(TestCase):
         mock_response.status = 200
 
         with mock.patch(
-            "sentry.seer.explorer.explorer_service_map_utils.make_signed_seer_api_request",
+            "sentry.seer.explorer.explorer_service_map_utils.make_service_map_update_request",
             return_value=mock_response,
         ) as mock_request:
             _send_to_seer(org.id, nodes, edges)
 
         mock_request.assert_called_once()
-        body = orjson.loads(mock_request.call_args[0][2])
+        body = mock_request.call_args[0][0]
         assert body["organization_id"] == org.id
         assert body["nodes"] == nodes
         assert body["edges"] == edges
@@ -112,12 +111,12 @@ class TestSendToSeer(TestCase):
         mock_response.status = 200
 
         with mock.patch(
-            "sentry.seer.explorer.explorer_service_map_utils.make_signed_seer_api_request",
+            "sentry.seer.explorer.explorer_service_map_utils.make_service_map_update_request",
             return_value=mock_response,
         ) as mock_request:
             _send_to_seer(org.id, nodes, edges)
 
-        body = orjson.loads(mock_request.call_args[0][2])
+        body = mock_request.call_args[0][0]
         assert len(body["nodes"]) == 1
         assert body["nodes"][0]["project_slug"] == "frontend"
         assert body["edges"] == []

--- a/tests/sentry/seer/test_supergroups.py
+++ b/tests/sentry/seer/test_supergroups.py
@@ -1,13 +1,11 @@
 from unittest.mock import patch
 
-import orjson
-
 from sentry.seer.supergroups import trigger_supergroups_embedding
 from sentry.testutils.cases import TestCase
 
 
 class TriggerSupergroupsEmbeddingTest(TestCase):
-    @patch("sentry.seer.supergroups.make_signed_seer_api_request")
+    @patch("sentry.seer.supergroups.make_supergroups_embedding_request")
     def test_calls_seer_with_correct_payload(self, mock_request):
         mock_request.return_value.status = 200
 
@@ -18,13 +16,11 @@ class TriggerSupergroupsEmbeddingTest(TestCase):
         )
 
         mock_request.assert_called_once()
-        # First arg is connection pool, second is path
         call_args = mock_request.call_args
-        assert "/v0/issues/supergroups" in call_args.args[1]
         assert call_args.kwargs["timeout"] == 5
 
-        # Third arg is the body (payload)
-        payload = orjson.loads(call_args.args[2])
+        # First positional arg is the typed dict body
+        payload = call_args.args[0]
         assert payload["organization_id"] == 1
         assert payload["group_id"] == 123
         assert payload["artifact_data"] == {"one_line_description": "Null pointer in auth module"}

--- a/tests/sentry/seer/test_test_generation.py
+++ b/tests/sentry/seer/test_test_generation.py
@@ -7,7 +7,7 @@ from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import control_silo_test
 
 
-@patch("sentry.seer.services.test_generation.impl.make_signed_seer_api_request")
+@patch("sentry.seer.services.test_generation.impl.make_unit_test_generation_request")
 @django_db_all
 @control_silo_test
 def test_start_unit_test_generation(mock_request: MagicMock) -> None:


### PR DESCRIPTION
Continues the work from #109589 to replace direct `make_signed_seer_api_request` calls with TypedDict request types and thin wrapper functions across all remaining callsites in `src/sentry/seer/`.

**Motivation:** The previous PR added typed wrappers for a few callsites. This completes the effort by covering ~40 remaining callsites across anomaly detection, autofix, explorer, breakpoints, similarity, code review, and the signed_seer_api connection pools. Each API endpoint now has a TypedDict for its request body and a wrapper function that handles serialization and routing, replacing untyped dicts with inline serialization and hardcoded paths.

**Pattern (unchanged from #109589):**
```python
class SomeRequest(TypedDict):
    field: int

def make_some_request(
    body: SomeRequest,
    connection_pool: HTTPConnectionPool | None = None,
    timeout: int | float | None = None,
) -> BaseHTTPResponse:
    return make_signed_seer_api_request(
        connection_pool or default_pool,
        "/v1/some/endpoint",
        body=orjson.dumps(body),
        timeout=timeout,
    )
```

**Scope:**
- ~30 new TypedDicts and ~30 new wrapper functions
- 28 source files updated (wrappers + callsites)
- 8 test files updated (mock targets changed from `make_signed_seer_api_request` to the new wrapper functions)
- `code_review/utils.py`: converted inline `connection_from_url()` to module-level singleton
- One exception: `organization_seer_explorer_update.py` kept as-is because it dynamically spreads `request.data`

No behavior changes — purely a typing/structure refactor.