### PR TITLE
Heroku integration content

### DIFF
--- a/static/app/views/performance/onboarding.spec.tsx
+++ b/static/app/views/performance/onboarding.spec.tsx
@@ -72,6 +72,9 @@ describe('Testing new onboarding ui', () => {
     render(<Onboarding organization={organization} project={projectMock} />);
     expect(await screen.findByText('Query for Traces, Get Answers')).toBeInTheDocument();
     expect(await screen.findByText('Preview a Sentry Trace')).toBeInTheDocument();
+    expect(
+      await screen.findByText('OpenTelemetry Drains and Forwarders')
+    ).toBeInTheDocument();
 
     expect(
       await screen.findByText(

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -11,6 +11,7 @@ import tourTrace from 'sentry-images/spot/performance-tour-trace.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 
 import {
   addErrorMessage,
@@ -86,6 +87,31 @@ const docsLink = (
     {t('Setup')}
   </LinkButton>
 );
+
+function TraceDrainsLink() {
+  return (
+    <TraceDrainsLinkWrapper>
+      <BodyTitle>{t('OpenTelemetry Drains and Forwarders')}</BodyTitle>
+      <SubTitle>
+        {tct(
+          'You can use [link:OpenTelemetry Drains] to send traces from platforms like [vercelLink:Vercel] and [herokuLink:Heroku], or via the [otlpLink:OpenTelemetry Collector].',
+          {
+            link: <ExternalLink href="https://docs.sentry.io/product/drains/" />,
+            vercelLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/" />
+            ),
+            herokuLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/heroku/" />
+            ),
+            otlpLink: (
+              <ExternalLink href="https://docs.sentry.io/product/drains/integration/opentelemetry-collector/" />
+            ),
+          }
+        )}
+      </SubTitle>
+    </TraceDrainsLinkWrapper>
+  );
+}
 
 export const PERFORMANCE_TOUR_STEPS: TourStep[] = [
   {
@@ -389,7 +415,10 @@ function OnboardingPanel({
               </HeaderWrapper>
               <Divider />
               <Body>
-                <Setup>{children}</Setup>
+                <Setup>
+                  {children}
+                  <TraceDrainsLink />
+                </Setup>
                 <Preview>
                   <BodyTitle>{t('Preview a Sentry Trace')}</BodyTitle>
                   <Arcade
@@ -705,6 +734,10 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
 
 const SubTitle = styled('div')`
   margin-bottom: ${space(1)};
+`;
+
+const TraceDrainsLinkWrapper = styled('div')`
+  padding-top: ${space(2)};
 `;
 
 const Title = styled('div')`

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -94,14 +94,11 @@ function TraceDrainsLink() {
       <BodyTitle>{t('OpenTelemetry Drains and Forwarders')}</BodyTitle>
       <SubTitle>
         {tct(
-          'You can use [link:OpenTelemetry Drains] to send traces from platforms like [vercelLink:Vercel] and [herokuLink:Heroku], or via the [otlpLink:OpenTelemetry Collector].',
+          'You can use [link:OpenTelemetry Drains] to send traces from platforms like [vercelLink:Vercel], or via the [otlpLink:OpenTelemetry Collector].',
           {
             link: <ExternalLink href="https://docs.sentry.io/product/drains/" />,
             vercelLink: (
               <ExternalLink href="https://docs.sentry.io/product/drains/integration/vercel/" />
-            ),
-            herokuLink: (
-              <ExternalLink href="https://docs.sentry.io/product/drains/integration/heroku/" />
             ),
             otlpLink: (
               <ExternalLink href="https://docs.sentry.io/product/drains/integration/opentelemetry-collector/" />


### PR DESCRIPTION
<!-- Describe your PR here. -->
Removes the Heroku example from the OpenTelemetry Drains callout on the traces empty state page, as Heroku is no longer a relevant platform for this context.

The callout now reads: "You can use OpenTelemetry Drains to send traces from platforms like Vercel, or via the OpenTelemetry Collector."

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
[Slack Thread](https://sentry.slack.com/archives/G6MCDB51U/p1772222037295879?thread_ts=1772222037.295879&cid=G6MCDB51U)

<p><a href="https://cursor.com/agents/bc-f6ef5aef-6c76-5269-9523-30587904c70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6ef5aef-6c76-5269-9523-30587904c70e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

