### PR TITLE
fix(billing): Fix category display names in pending changes

### DIFF
--- a/static/gsAdmin/components/customers/pendingChanges.spec.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.spec.tsx
@@ -1,5 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
 import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
 import {PlanMigrationFixture} from 'getsentry-test/fixtures/planMigration';
 import {SeerReservedBudgetFixture} from 'getsentry-test/fixtures/reservedBudget';
@@ -300,7 +301,7 @@ describe('PendingChanges', () => {
     expect(container).toHaveTextContent(
       'Reserved performance units — 100,000 → 0 transactions'
     );
-    expect(container).toHaveTextContent('Reserved replays — 500 → 50 replays');
+    expect(container).toHaveTextContent('Reserved replays — 500 → 50 session replays');
     expect(container).toHaveTextContent('Reserved spans — 0 → 10,000,000 spans');
 
     // no actual changes
@@ -480,7 +481,7 @@ describe('PendingChanges', () => {
       'Reserved accepted spans — reserved budget → 10,000,000 spans'
     );
     expect(container).toHaveTextContent(
-      'Reserved stored spans — reserved budget → 0 spansIndexed'
+      'Reserved stored spans — reserved budget → 0 stored spans'
     );
     expect(container).not.toHaveTextContent('Reserved spans —');
     expect(container).not.toHaveTextContent('Reserved spansIndexed —');
@@ -489,7 +490,7 @@ describe('PendingChanges', () => {
       'Reserved cost-per-event for spans — $0.01000000 → None'
     );
     expect(container).toHaveTextContent(
-      'Reserved cost-per-event for spansIndexed — $0.02000000 → None'
+      'Reserved cost-per-event for stored spans — $0.02000000 → None'
     );
     expect(container).toHaveTextContent(
       'Reserved budgets — $0.00 for seer budget, $100,000.00 for spans budget → $0.00 for seer budget'
@@ -502,5 +503,31 @@ describe('PendingChanges', () => {
     });
     const {container} = render(<PendingChanges subscription={subscription} />);
     expect(container).not.toHaveTextContent('Reserved budgets —');
+  });
+
+  it('renders size analysis reserved changes with human-readable name', () => {
+    const subscription = SubscriptionFixture({
+      organization: OrganizationFixture(),
+      pendingChanges: PendingChangesFixture({
+        planDetails: PlanDetailsLookupFixture('am3_business'),
+        plan: 'am3_business',
+        planName: 'Business',
+        reserved: {
+          sizeAnalyses: 100,
+        },
+      }),
+    });
+    subscription.categories = {
+      ...subscription.categories,
+      sizeAnalyses: MetricHistoryFixture({
+        category: 'sizeAnalyses' as any,
+        reserved: 50,
+      }),
+    };
+
+    const {container} = render(<PendingChanges subscription={subscription} />);
+    expect(container).toHaveTextContent('Reserved size analysis builds');
+    expect(container).toHaveTextContent('50 → 100');
+    expect(container).not.toHaveTextContent('sizeAnalyses');
   });
 });

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -73,7 +73,7 @@ export function getPlanCategoryName({
       ? t('accepted spans')
       : displayNames
         ? displayNames.plural
-        : category;
+        : (getCategoryInfoFromPlural(category)?.titleName?.toLowerCase() ?? category);
   return title
     ? toTitleCase(categoryName, {allowInnerUpperCase: true})
     : capitalize
@@ -97,7 +97,8 @@ export function getSingularCategoryName({
       ? t('accepted span')
       : displayNames
         ? displayNames.singular
-        : category.substring(0, category.length - 1);
+        : (getCategoryInfoFromPlural(category)?.displayName ??
+          category.substring(0, category.length - 1));
   return title
     ? toTitleCase(categoryName, {allowInnerUpperCase: true})
     : capitalize

--- a/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
@@ -405,7 +405,7 @@ describe('Subscription > PendingChanges', () => {
     expect(screen.queryByText(/budget change/)).not.toBeInTheDocument();
   });
 
-  it('renders size analysis reserved changes with correct display name and units', () => {
+  it('renders size analysis reserved changes with correct display name', () => {
     const sub = SubscriptionFixture({
       organization,
       plan: 'am3_business',
@@ -428,7 +428,7 @@ describe('Subscription > PendingChanges', () => {
 
     render(<PendingChanges organization={organization} subscription={sub} />);
     expect(
-      screen.getByText('Reserved size analysis change to 100 builds')
+      screen.getByText('Reserved size analysis builds change to 100')
     ).toBeInTheDocument();
   });
 

--- a/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.spec.tsx
@@ -405,6 +405,33 @@ describe('Subscription > PendingChanges', () => {
     expect(screen.queryByText(/budget change/)).not.toBeInTheDocument();
   });
 
+  it('renders size analysis reserved changes with correct display name and units', () => {
+    const sub = SubscriptionFixture({
+      organization,
+      plan: 'am3_business',
+      pendingChanges: PendingChangesFixture({
+        planDetails: PlanDetailsLookupFixture('am3_business'),
+        plan: 'am3_business',
+        planName: 'Business',
+        reserved: {
+          sizeAnalyses: 100,
+        },
+      }),
+    });
+    sub.categories = {
+      ...sub.categories,
+      sizeAnalyses: MetricHistoryFixture({
+        category: 'sizeAnalyses' as any,
+        reserved: 50,
+      }),
+    };
+
+    render(<PendingChanges organization={organization} subscription={sub} />);
+    expect(
+      screen.getByText('Reserved size analysis change to 100 builds')
+    ).toBeInTheDocument();
+  });
+
   it('renders reserved budgets with existing budgets without dynamic sampling', () => {
     const sub = Am3DsEnterpriseSubscriptionFixture({
       organization,

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -21,9 +21,11 @@ import {
   hasPerformance,
 } from 'getsentry/utils/billing';
 import {
+  getCategoryInfoFromPlural,
   getPlanCategoryName,
   getReservedBudgetCategoryFromCategories,
   getReservedBudgetDisplayName,
+  isEmergeCategory,
 } from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {
@@ -173,14 +175,28 @@ function PendingChanges({organization, subscription}: Props) {
           pendingReserved !== RESERVED_BUDGET_QUOTA &&
           pendingReserved !== 0
         ) {
+          const formattedQuantity = formatReservedWithUnits(
+            pendingReserved ?? null,
+            category
+          );
+          const billedCategoryInfo = getCategoryInfoFromPlural(category);
+          const unitName = billedCategoryInfo?.shortenedUnitName;
+          let displayName = getPlanCategoryName({
+            plan: pendingChanges.planDetails,
+            category,
+            capitalize: false,
+          });
+          let quantityText = formattedQuantity;
+          if (isEmergeCategory(category) && unitName) {
+            // Strip unit from display name (e.g. "size analysis builds" → "size analysis")
+            displayName = displayName.replace(new RegExp(`\\s+${unitName}s?$`, 'i'), '');
+            const unitSuffix = pendingReserved === 1 ? unitName : `${unitName}s`;
+            quantityText = `${formattedQuantity} ${unitSuffix}`;
+          }
           results.push(
             tct('Reserved [displayName] change to [quantity]', {
-              displayName: getPlanCategoryName({
-                plan: pendingChanges.planDetails,
-                category,
-                capitalize: false,
-              }),
-              quantity: formatReservedWithUnits(pendingReserved ?? null, category),
+              displayName,
+              quantity: quantityText,
             })
           );
         }

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -21,11 +21,9 @@ import {
   hasPerformance,
 } from 'getsentry/utils/billing';
 import {
-  getCategoryInfoFromPlural,
   getPlanCategoryName,
   getReservedBudgetCategoryFromCategories,
   getReservedBudgetDisplayName,
-  isEmergeCategory,
 } from 'getsentry/utils/dataCategory';
 import formatCurrency from 'getsentry/utils/formatCurrency';
 import {
@@ -179,24 +177,15 @@ function PendingChanges({organization, subscription}: Props) {
             pendingReserved ?? null,
             category
           );
-          const billedCategoryInfo = getCategoryInfoFromPlural(category);
-          const unitName = billedCategoryInfo?.shortenedUnitName;
-          let displayName = getPlanCategoryName({
+          const displayName = getPlanCategoryName({
             plan: pendingChanges.planDetails,
             category,
             capitalize: false,
           });
-          let quantityText = formattedQuantity;
-          if (isEmergeCategory(category) && unitName) {
-            // Strip unit from display name (e.g. "size analysis builds" → "size analysis")
-            displayName = displayName.replace(new RegExp(`\\s+${unitName}s?$`, 'i'), '');
-            const unitSuffix = pendingReserved === 1 ? unitName : `${unitName}s`;
-            quantityText = `${formattedQuantity} ${unitSuffix}`;
-          }
           results.push(
             tct('Reserved [displayName] change to [quantity]', {
               displayName,
-              quantity: quantityText,
+              quantity: formattedQuantity,
             })
           );
         }


### PR DESCRIPTION
## Summary
- Fix `getPlanCategoryName` and `getSingularCategoryName` fallback to use human-readable `titleName`/`displayName` from `DATA_CATEGORY_INFO` instead of raw camelCase category keys (e.g. `sizeAnalyses`) when `categoryDisplayNames` is missing from the plan
- This fixes the pending changes display on both `/settings/billing/overview/` and `_admin` showing raw keys like "Reserved sizeAnalyses change to 100" instead of "Reserved size analysis builds change to 100"
- The fallback is triggered when `categoryDisplayNames` doesn't include a category, e.g. due to feature flag gating (`organizations:expose-category-size-analysis`)

## Test plan
- [x] Added test for size analysis pending changes in billing overview (`pendingChanges.spec.tsx` — 22 tests pass)
- [x] Added test for size analysis pending changes in admin view (`gsAdmin/pendingChanges.spec.tsx` — 13 tests pass)
- [x] Updated existing admin test assertions that previously expected raw category keys (`spansIndexed` → `stored spans`, `replays` → `session replays`)