### PR TITLE
feat(occurrences): Preprocess redirects

### DIFF
--- a/src/sentry/snuba/occurrences_rpc.py
+++ b/src/sentry/snuba/occurrences_rpc.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from re import finditer
 from typing import Any
 
 import sentry_sdk
@@ -12,6 +13,7 @@ from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import AdditionalQueries, EAPResponse, SearchResolverConfig
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
+from sentry.services.eventstore.query_preprocessing import get_all_merged_group_ids
 from sentry.snuba import rpc_dataset_common
 from sentry.utils.snuba import process_value
 
@@ -55,7 +57,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
     ) -> EAPResponse:
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(
-                query_string=query_string,
+                query_string=cls._update_eap_query_string_with_merged_group_ids(query_string),
                 selected_columns=selected_columns,
                 equations=equations,
                 orderby=orderby,
@@ -117,7 +119,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
 
         return cls._run_table_query(
             rpc_dataset_common.TableQuery(
-                query_string=query_string,
+                query_string=cls._update_eap_query_string_with_merged_group_ids(query_string),
                 selected_columns=selected_columns,
                 equations=equations,
                 orderby=orderby,
@@ -182,7 +184,7 @@ class Occurrences(rpc_dataset_common.RPCBase):
         rpc_request, _aggregates, groupbys_resolved = cls.get_timeseries_query(
             search_resolver=search_resolver,
             params=params,
-            query_string=query_string,
+            query_string=cls._update_eap_query_string_with_merged_group_ids(query_string),
             y_axes=y_axes,
             groupby=groupby,
             referrer=referrer,
@@ -261,3 +263,40 @@ class Occurrences(rpc_dataset_common.RPCBase):
             )
 
         return None
+
+    @staticmethod
+    def _update_eap_query_string_with_merged_group_ids(qs: str) -> str:
+        matches = finditer(r"group_id:(\d+|\[(\d(, )?)+\])", qs)
+        pieces = []
+        i = 0
+        for m in matches:
+            match_start, match_end = m.span()
+            if match_start != i:
+                pieces.append(qs[i:match_start])
+
+            match = qs[match_start:match_end]
+            if "[" in match:
+                group_ids = match.split("[")[1][:-1].split(", ")
+                all_group_ids = get_all_merged_group_ids({int(gid) for gid in group_ids})
+
+                # Only need to update in the "new matches found" case.
+                if len(all_group_ids) > len(group_ids):
+                    pieces.append(f"group_id:[{', '.join(str(gid) for gid in all_group_ids)}]")
+                else:
+                    pieces.append(match)
+
+            else:
+                group_id = match.split(":")[1]
+                all_group_ids = get_all_merged_group_ids({int(group_id)})
+
+                # Only need to update in the "new matches found" case.
+                if len(all_group_ids) > 1:
+                    pieces.append(f"group_id:[{', '.join(str(gid) for gid in all_group_ids)}]")
+                else:
+                    pieces.append(match)
+
+            i = match_end
+
+        pieces.append(qs[i:])
+
+        return "".join(pieces)

--- a/tests/sentry/snuba/test_occurrences_rpc.py
+++ b/tests/sentry/snuba/test_occurrences_rpc.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
@@ -19,6 +19,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
 )
 
 from sentry.exceptions import InvalidSearchQuery
+from sentry.models.groupredirect import GroupRedirect
 from sentry.search.eap.occurrences.definitions import OCCURRENCE_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import SearchResolverConfig
@@ -224,6 +225,47 @@ class OccurrencesRPCTest(TestCase):
             )
         )
         assert having is None
+
+    def test_update_eap_query_string_with_merged_group_ids(self) -> None:
+        self.g1 = self.create_group(id=1)
+        self.g2 = self.create_group(id=2)
+        self.g3 = self.create_group(id=3)
+        self.g4 = self.create_group(id=4)
+
+        self.gr31 = GroupRedirect.objects.create(
+            id=10001,
+            organization_id=self.g1.project.organization_id,
+            group_id=self.g1.id,
+            previous_group_id=self.g3.id,
+            date_added=datetime.now(UTC) - timedelta(hours=4),
+        )
+        self.gr21 = GroupRedirect.objects.create(
+            id=10002,
+            organization_id=self.g1.project.organization_id,
+            group_id=self.g1.id,
+            previous_group_id=self.g2.id,
+            date_added=datetime.now(UTC) - timedelta(hours=1),
+        )
+
+        assert Occurrences._update_eap_query_string_with_merged_group_ids("foo:bar") == "foo:bar"
+        assert (
+            Occurrences._update_eap_query_string_with_merged_group_ids("group_id:1")
+            == "group_id:[1, 2, 3]"
+        )
+        assert (
+            Occurrences._update_eap_query_string_with_merged_group_ids("group_id:3")
+            == "group_id:[1, 3]"
+        )
+        assert (
+            Occurrences._update_eap_query_string_with_merged_group_ids("group_id:[3, 4]")
+            == "group_id:[1, 3, 4]"
+        )
+        assert (
+            Occurrences._update_eap_query_string_with_merged_group_ids(
+                "group_id:1 foo:bar group_id:[3, 4]"
+            )
+            == "group_id:[1, 2, 3] foo:bar group_id:[1, 3, 4]"
+        )
 
 
 class OccurrencesTimeseriesTest(TestCase):


### PR DESCRIPTION
We do not update EAP in the event of a group merge. Instead, we track the merge in our "Group Redirect" table.

This PR preprocesses EAP queries to account for the redirects, so users can always query and get all their relevant groups.
