### PR TITLE
feat(preprod): Add comparisonRunInfo data to response + new extra frontend models

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -24,6 +24,7 @@ from sentry.objectstore import get_preprod_session
 from sentry.preprod.analytics import PreprodArtifactApiGetSnapshotDetailsEvent
 from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsVcsInfo
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
+    SnapshotComparisonRunInfo,
     SnapshotDetailsApiResponse,
     SnapshotImageResponse,
 )
@@ -216,6 +217,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 comparison_manifest, images_by_file_name, base_manifest
             )
         else:
+            if comparison is not None:
+                base_artifact_id = str(comparison.base_snapshot_metrics.preprod_artifact_id)
             categorized = CategorizedComparison()
             pending_or_failed_state = (
                 PreprodSnapshotComparison.objects.filter(
@@ -231,9 +234,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 .first()
             )
             if pending_or_failed_state is not None:
-                comparison_state = PreprodSnapshotComparison.State(
-                    pending_or_failed_state
-                ).name.lower()
+                comparison_state = PreprodSnapshotComparison.State(pending_or_failed_state).name
 
         comparison_type = "diff" if comparison_manifest is not None else "solo"
 
@@ -261,16 +262,18 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             result["project_id"] = str(artifact.project_id)
             result["comparison_type"] = comparison_type
 
-            run_info: dict[str, Any] = {}
+            run_info: SnapshotComparisonRunInfo | None = None
             if comparison_state is not None:
-                run_info["state"] = comparison_state
+                run_info = SnapshotComparisonRunInfo(state=comparison_state)
             elif comparison is not None:
-                run_info["state"] = PreprodSnapshotComparison.State(comparison.state).name.lower()
-                run_info["completed_at"] = comparison.date_updated.isoformat()
                 duration = comparison.date_updated - comparison.date_added
-                run_info["duration_ms"] = int(duration.total_seconds() * 1000)
-            if run_info:
-                result["comparison_run_info"] = run_info
+                run_info = SnapshotComparisonRunInfo(
+                    state=PreprodSnapshotComparison.State(comparison.state).name,
+                    completed_at=comparison.date_updated.isoformat(),
+                    duration_ms=int(duration.total_seconds() * 1000),
+                )
+            if run_info is not None:
+                result["comparison_run_info"] = run_info.dict(exclude_none=True)
 
             return result
 

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -270,7 +270,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 errored=categorized.errored,
                 errored_count=len(categorized.errored),
                 comparison_run_info=run_info,
-            ).dict(exclude_none=True)
+            ).dict()
 
         return self.paginate(
             request=request,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -258,11 +258,19 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
 
             result = response.dict()
-            result["org_id"] = str(organization.id)
             result["project_id"] = str(artifact.project_id)
             result["comparison_type"] = comparison_type
+
+            run_info: dict[str, Any] = {}
             if comparison_state is not None:
-                result["comparison_state"] = comparison_state
+                run_info["state"] = comparison_state
+            elif comparison is not None:
+                run_info["state"] = PreprodSnapshotComparison.State(comparison.state).name.lower()
+                run_info["completed_at"] = comparison.date_updated.isoformat()
+                duration = comparison.date_updated - comparison.date_added
+                run_info["duration_ms"] = int(duration.total_seconds() * 1000)
+            if run_info:
+                result["comparison_run_info"] = run_info
 
             return result
 

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -238,10 +238,23 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         comparison_type = "diff" if comparison_manifest is not None else "solo"
 
+        run_info: SnapshotComparisonRunInfo | None = None
+        if comparison_state is not None:
+            run_info = SnapshotComparisonRunInfo(state=comparison_state)
+        elif comparison is not None:
+            duration = comparison.date_updated - comparison.date_added
+            run_info = SnapshotComparisonRunInfo(
+                state=PreprodSnapshotComparison.State(comparison.state).name,
+                completed_at=comparison.date_updated.isoformat(),
+                duration_ms=int(duration.total_seconds() * 1000),
+            )
+
         def on_results(images: list[SnapshotImageResponse]) -> dict[str, Any]:
-            response = SnapshotDetailsApiResponse(
+            return SnapshotDetailsApiResponse(
                 head_artifact_id=str(artifact.id),
                 base_artifact_id=base_artifact_id,
+                project_id=str(artifact.project_id),
+                comparison_type=comparison_type,
                 state=artifact.state,
                 vcs_info=vcs_info,
                 images=images,
@@ -256,26 +269,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 unchanged_count=len(categorized.unchanged),
                 errored=categorized.errored,
                 errored_count=len(categorized.errored),
-            )
-
-            result = response.dict()
-            result["project_id"] = str(artifact.project_id)
-            result["comparison_type"] = comparison_type
-
-            run_info: SnapshotComparisonRunInfo | None = None
-            if comparison_state is not None:
-                run_info = SnapshotComparisonRunInfo(state=comparison_state)
-            elif comparison is not None:
-                duration = comparison.date_updated - comparison.date_added
-                run_info = SnapshotComparisonRunInfo(
-                    state=PreprodSnapshotComparison.State(comparison.state).name,
-                    completed_at=comparison.date_updated.isoformat(),
-                    duration_ms=int(duration.total_seconds() * 1000),
-                )
-            if run_info is not None:
-                result["comparison_run_info"] = run_info.dict(exclude_none=True)
-
-            return result
+                comparison_run_info=run_info,
+            ).dict(exclude_none=True)
 
         return self.paginate(
             request=request,

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -11,6 +11,7 @@ from sentry.preprod.models import PreprodArtifact
 class SnapshotDiffSection(StrEnum):
     ADDED = "added"
     REMOVED = "removed"
+    RENAMED = "renamed"
     CHANGED = "changed"
     UNCHANGED = "unchanged"
     ERRORED = "errored"
@@ -34,6 +35,12 @@ class SnapshotDiffPair(BaseModel):
     diff: float | None = None
 
 
+class SnapshotComparisonRunInfo(BaseModel):
+    state: str | None = None
+    completed_at: str | None = None
+    duration_ms: int | None = None
+
+
 class SnapshotDetailsApiResponse(BaseModel):
     head_artifact_id: str
     base_artifact_id: str | None = None  # Only present for diffs
@@ -51,6 +58,9 @@ class SnapshotDetailsApiResponse(BaseModel):
     removed: list[SnapshotImageResponse] = []
     removed_count: int = 0
 
+    renamed: list[SnapshotImageResponse] = []
+    renamed_count: int = 0
+
     changed: list[SnapshotDiffPair] = []
     changed_count: int = 0
 
@@ -59,6 +69,8 @@ class SnapshotDetailsApiResponse(BaseModel):
 
     errored: list[SnapshotDiffPair] = []
     errored_count: int = 0
+
+    comparison_run_info: SnapshotComparisonRunInfo | None = None
 
 
 # TODO: POST request in the future when we migrate away from current schemas

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -43,7 +43,9 @@ class SnapshotComparisonRunInfo(BaseModel):
 
 class SnapshotDetailsApiResponse(BaseModel):
     head_artifact_id: str
-    base_artifact_id: str | None = None  # Only present for diffs
+    base_artifact_id: str | None = None
+    project_id: str
+    comparison_type: str
     state: PreprodArtifact.ArtifactState
     vcs_info: BuildDetailsVcsInfo
 


### PR DESCRIPTION
## Summary

Enhances the preprod snapshot API response and frontend types to support richer comparison metadata:

- **Comparison run info**: Adds `comparison_run_info` to the API response containing `state`, `completed_at`, and `duration_ms` from the `PreprodSnapshotComparison` model. Replaces the flat `comparison_state` field with a nested structure
- **Renamed section**: Adds a new `renamed` diff section to both backend models and frontend types for tracking renamed files in snapshot comparisons
- **Frontend type additions**: Adds `ComparisonState`, `DiffStatus`, and `SidebarItem` discriminated union types for upcoming sidebar UI refactor
- **Backward compat fix**: Defaults `errored` field in `ComparisonSummary` to `0` to handle manifests generated before the errored section existed
- **Removes `org_id`** from the API response (redundant — already in the URL)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.