### PR TITLE
docs(sentry-apps): Add sentryAppId to sentry-app-installations API schema

### DIFF
--- a/api-docs/paths/integration-platform/sentry-app-installations.json
+++ b/api-docs/paths/integration-platform/sentry-app-installations.json
@@ -27,13 +27,16 @@
                 "properties": {
                   "app": {
                     "type": "object",
-                    "required": ["uuid", "slug"],
+                    "required": ["uuid", "slug", "sentryAppId"],
                     "properties": {
                       "uuid": {
                         "type": "string"
                       },
                       "slug": {
                         "type": "string"
+                      },
+                      "sentryAppId": {
+                        "type": "integer"
                       }
                     }
                   },
@@ -59,7 +62,8 @@
               {
                 "app": {
                   "uuid": "a9988ad6-meow-4905-bb93-f7cbf4c96bbb",
-                  "slug": "cat-75c19a"
+                  "slug": "cat-75c19a",
+                  "sentryAppId": 1
                 },
                 "organization": {
                   "slug": "sentry"


### PR DESCRIPTION
The installations endpoint now returns sentryAppId in the app object, which is required when building metric alert trigger actions via the API. Update the OpenAPI schema and regenerate the derefed spec.

See screenshot: 
<img width="1254" height="665" alt="image" src="https://github.com/user-attachments/assets/9b27e459-beb6-4bf1-ba6f-89090ed4ee7b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the OpenAPI contract for a single endpoint; primary risk is downstream client expectations around the new required field.
> 
> **Overview**
> Updates the OpenAPI response schema for `GET` `integration-platform/sentry-app-installations` so the returned `app` object now includes a required integer `sentryAppId` field.
> 
> The response example is updated accordingly to show `sentryAppId` alongside `uuid` and `slug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b38012370a50854e6c3d959536622637bef78c74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->