### PR TITLE
fix(stories): Fix HMR for .stories.tsx and .mdx files in Scraps

### DIFF
--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -9,7 +9,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconChevron} from 'sentry/icons';
 import {IconSearch} from 'sentry/icons/iconSearch';
-import * as Storybook from 'sentry/stories';
+import {Section} from 'sentry/stories/layout';
 import {fzf} from 'sentry/utils/search/fzf';
 
 interface APIReferenceProps {
@@ -21,7 +21,7 @@ export function APIReference(props: APIReferenceProps) {
   const nodes = usePropTree(props.componentProps?.props ?? {}, query);
 
   return (
-    <Storybook.Section>
+    <Section>
       {props.componentProps?.description && <p>{props.componentProps.description}</p>}
       <Container marginBottom="md">
         <InputGroup>
@@ -87,7 +87,7 @@ export function APIReference(props: APIReferenceProps) {
           </tbody>
         </StoryTypesTable>
       </StoryTableContainer>
-    </Storybook.Section>
+    </Section>
   );
 }
 

--- a/static/app/stories/storybook.tsx
+++ b/static/app/stories/storybook.tsx
@@ -4,10 +4,14 @@ import {Children, Fragment, useEffect} from 'react';
 import {Container} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
-import {makeStorybookDocumentTitle} from 'sentry/stories/view/storyExports';
 import {StoryHeading} from 'sentry/stories/view/storyHeading';
 
-import * as Storybook from './';
+import {APIReference} from './apiReference';
+import {Section, SideBySide} from './layout';
+
+function makeStorybookDocumentTitle(title: string | undefined): string {
+  return title ? `${title} — Scraps` : 'Scraps';
+}
 
 type StoryRenderFunction = () => ReactNode | ReactNode[];
 type StoryContext = (storyName: string, story: StoryRenderFunction) => void;
@@ -47,7 +51,7 @@ export function story(title: string, setup: SetupFunction): StoryRenderFunction 
           <Story key={name + idx} name={name} render={render} />
         ))}
         {APIDocumentation.map((documentation, i) => (
-          <Storybook.APIReference key={i} componentProps={documentation} />
+          <APIReference key={i} componentProps={documentation} />
         ))}
       </Fragment>
     );
@@ -59,13 +63,13 @@ function Story(props: {name: string; render: StoryRenderFunction}) {
   const isOneChild = Children.count(children) === 1;
 
   return (
-    <Storybook.Section>
+    <Section>
       <Container borderBottom="primary">
         <StoryHeading as="h2" size="2xl">
           {props.name}
         </StoryHeading>
       </Container>
-      {isOneChild ? children : <Storybook.SideBySide>{children}</Storybook.SideBySide>}
-    </Storybook.Section>
+      {isOneChild ? children : <SideBySide>{children}</SideBySide>}
+    </Section>
   );
 }

--- a/static/app/stories/view/storyExports.tsx
+++ b/static/app/stories/view/storyExports.tsx
@@ -64,7 +64,7 @@ function StoryLayout() {
   );
 }
 
-export function makeStorybookDocumentTitle(title: string | undefined): string {
+function makeStorybookDocumentTitle(title: string | undefined): string {
   return title ? `${title} — Scraps` : 'Scraps';
 }
 

--- a/static/app/stories/view/useStoriesLoader.tsx
+++ b/static/app/stories/view/useStoriesLoader.tsx
@@ -1,10 +1,56 @@
 import type React from 'react';
-import {useMemo} from 'react';
+import {useMemo, useSyncExternalStore} from 'react';
 
 import {useQuery, type UseQueryResult} from 'sentry/utils/queryClient';
 
-const context = require.context('sentry', true, /\.stories.tsx$/, 'lazy');
-const mdxContext = require.context('sentry', true, /\.mdx$/, 'lazy');
+let context = import.meta.webpackContext('sentry', {
+  recursive: true,
+  regExp: /\.stories.tsx$/,
+  mode: 'lazy',
+});
+let mdxContext = import.meta.webpackContext('sentry', {
+  recursive: true,
+  regExp: /\.mdx$/,
+  mode: 'lazy',
+});
+
+// External store that increments whenever HMR replaces a story or mdx file.
+// Accepting context module IDs creates proper HMR boundaries — without this,
+// updates are silently dropped or cause "unexpected require from disposed module".
+let _storiesHmrVersion = 0;
+const _storiesHmrListeners = new Set<() => void>();
+
+if (process.env.NODE_ENV === 'development' && import.meta.webpackHot) {
+  const onUpdate = () => {
+    // Re-capture and re-register after each replacement — the old context
+    // reference is stale and its replacement won't have accept handlers.
+    context = import.meta.webpackContext('sentry', {
+      recursive: true,
+      regExp: /\.stories.tsx$/,
+      mode: 'lazy',
+    });
+    mdxContext = import.meta.webpackContext('sentry', {
+      recursive: true,
+      regExp: /\.mdx$/,
+      mode: 'lazy',
+    });
+    import.meta.webpackHot!.accept(context.id as string, onUpdate);
+    import.meta.webpackHot!.accept(mdxContext.id as string, onUpdate);
+    _storiesHmrVersion++;
+    _storiesHmrListeners.forEach(l => l());
+  };
+  import.meta.webpackHot.accept(context.id as string, onUpdate);
+  import.meta.webpackHot.accept(mdxContext.id as string, onUpdate);
+}
+
+function subscribeToStoriesHmr(listener: () => void) {
+  _storiesHmrListeners.add(listener);
+  return () => _storiesHmrListeners.delete(listener);
+}
+
+function getStoriesHmrVersion() {
+  return _storiesHmrVersion;
+}
 
 export interface StoryResources {
   a11y?: Record<string, string>;
@@ -78,8 +124,9 @@ interface UseStoriesLoaderOptions {
 export function useStoriesLoader(
   options: UseStoriesLoaderOptions
 ): UseQueryResult<StoryDescriptor[], Error> {
+  const hmrVersion = useSyncExternalStore(subscribeToStoriesHmr, getStoriesHmrVersion);
   return useQuery({
-    queryKey: [options.files],
+    queryKey: [options.files, hmrVersion],
     queryFn: (): Promise<StoryDescriptor[]> => {
       return Promise.all(options.files.map(importStory));
     },


### PR DESCRIPTION
Two separate problems were causing hot reload to break in the Scraps storybook.

**Circular dependency crash**

`storybook.tsx` was self-importing via the barrel (`import * as Storybook from './'`) and importing `makeStorybookDocumentTitle` from `storyExports.tsx`, which itself imports the barrel. This cycle (`barrel → storybook → barrel`, `storybook → storyExports → barrel → storybook`) caused rspack's HMR to surface a crash on reload:

```
TypeError: Cannot read properties of undefined (reading 'ThemeSwitcher')
```

Fixed by replacing barrel imports in `storybook.tsx` and `apiReference.tsx` with direct imports from the modules they actually need. The `view/` layer files (`storyExports.tsx`, `storyHeader.tsx`) are not part of any cycle because the barrel doesn't re-export from `view/`.

**HMR only working once**

The context references were `const`, so after the first HMR cycle the captured module reference became stale. The new context module had no accept handler registered, causing all subsequent saves to be silently dropped:

```
HMR Ignored an update to unaccepted module ./app/components/core/checkbox/checkbox.mdx
```

or in some cases triggering "unexpected require from disposed module".

Fixed by switching from `require.context` to `import.meta.webpackContext` (rspack's recommended ESM API) with `let` references. On each HMR update the `onUpdate` callback re-captures fresh context references and re-registers accept handlers against the new context IDs — otherwise after the first replacement the old handler is gone and HMR goes dead.

A `useSyncExternalStore`-based version counter threads the HMR signal into React Query, so the active story refetches cleanly after each save rather than requiring a manual page refresh.