### PR TITLE
build(ui): Use deterministic chunk/module IDs in production

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -581,8 +581,8 @@ const appConfig: Configuration = {
     assetModuleFilename: 'assets/[name].[contenthash][ext]',
   },
   optimization: {
-    chunkIds: 'named',
-    moduleIds: 'named',
+    chunkIds: IS_PRODUCTION ? 'deterministic' : 'named',
+    moduleIds: IS_PRODUCTION ? 'deterministic' : 'named',
     splitChunks: {
       // Only affect async chunks, otherwise webpack could potentially split our initial chunks
       // Which means the app will not load because we'd need these additional chunks to be loaded in our


### PR DESCRIPTION
Use deterministic chunk and module IDs for production rspack builds. The rspack default is `named` for dev and `deterministic` for production

Named causes cache invalidation whenever unrelated modules are added or removed (because insertion order affects IDs).

Switching to `'deterministic'` in production gives short, stable numeric hashes that don't change unless the module itself changes, which improves long-term browser cache hit rates. `'named'` is kept in development for readable chunk names during debugging.

saves ~ 2.2mb (non gzip) from initial page load just because of the shorter file names. Fairly negligible change w/ gzip.

before (total size non gzip)

<img width="440" height="206" alt="Screenshot 2026-03-02 at 10 14 12 AM" src="https://github.com/user-attachments/assets/1aaec557-0c9c-463e-abc6-6af8e17f6f03" />

 after

<img width="441" height="198" alt="Screenshot 2026-03-02 at 10 16 18 AM" src="https://github.com/user-attachments/assets/6b400ebf-35af-4fbe-9d26-26c74ffb2fe2" />

