### PR TITLE
perf(build): Add vendor chunk splitting for heavy stable dependencies

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -581,8 +581,8 @@ const appConfig: Configuration = {
     assetModuleFilename: 'assets/[name].[contenthash][ext]',
   },
   optimization: {
-    chunkIds: 'named',
-    moduleIds: 'named',
+    chunkIds: IS_PRODUCTION ? 'deterministic' : 'named',
+    moduleIds: IS_PRODUCTION ? 'deterministic' : 'named',
     splitChunks: {
       // Only affect async chunks, otherwise webpack could potentially split our initial chunks
       // Which means the app will not load because we'd need these additional chunks to be loaded in our

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -589,8 +589,40 @@ const appConfig: Configuration = {
       // django template.
       chunks: 'async',
       maxInitialRequests: 10, // (default: 30)
-      maxAsyncRequests: 10, // (default: 30)
-      cacheGroups: localeChunkGroups,
+      maxAsyncRequests: 30, // raised from 10; HTTP/2 handles parallel requests well
+      cacheGroups: {
+        ...localeChunkGroups,
+        // Extract stable, heavy dependencies into named vendor chunks so they
+        // can be cached independently of app code changes.
+        vendorReact: {
+          name: 'vendor-react',
+          chunks: 'all',
+          test: /[\\/]node_modules[\\/](react|react-dom|react-router-dom|@remix-run|framer-motion|@react-aria|@react-stately|@react-types)[\\/]/,
+          priority: 30,
+          enforce: true,
+        },
+        vendorEmotion: {
+          name: 'vendor-emotion',
+          chunks: 'all',
+          test: /[\\/]node_modules[\\/]@emotion[\\/]/,
+          priority: 20,
+          enforce: true,
+        },
+        vendorTanstack: {
+          name: 'vendor-tanstack',
+          chunks: 'all',
+          test: /[\\/]node_modules[\\/]@tanstack[\\/]/,
+          priority: 20,
+          enforce: true,
+        },
+        vendorEcharts: {
+          name: 'vendor-echarts',
+          chunks: 'all',
+          test: /[\\/]node_modules[\\/](echarts|zrender)[\\/]/,
+          priority: 20,
+          enforce: true,
+        },
+      },
     },
 
     // This only runs in production mode

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -597,15 +597,8 @@ const appConfig: Configuration = {
         vendorReact: {
           name: 'vendor-react',
           chunks: 'all',
-          test: /[\\/]node_modules[\\/](react|react-dom|react-router-dom|@remix-run|framer-motion|@react-aria|@react-stately|@react-types)[\\/]/,
+          test: /[\\/]node_modules[\\/](react|react-dom|react-router-dom|@remix-run|framer-motion|@react-aria|@react-stately|@react-types|@emotion)[\\/]/,
           priority: 30,
-          enforce: true,
-        },
-        vendorEmotion: {
-          name: 'vendor-emotion',
-          chunks: 'all',
-          test: /[\\/]node_modules[\\/]@emotion[\\/]/,
-          priority: 20,
           enforce: true,
         },
         vendorTanstack: {


### PR DESCRIPTION
Stacked on #109631.

Without explicit cache groups, stable heavy dependencies get mixed into app chunks and their browser-cached copies are invalidated on every app code deploy — even when the library versions haven't changed.

This adds vendor cache groups for three groups of packages:

- **vendor-react** — React, React DOM, React Router, framer-motion, React Aria/Stately/Types, and all `@emotion/*` packages. The full UI rendering ecosystem. These are used across hundreds of files but change only when deps are bumped.
- **vendor-tanstack** — TanStack Query, Form, Virtual, Pacer. Stable API/data layer.
- **vendor-echarts** — echarts + zrender. Largest single dependency (~400KB min), statically imported in 162 files with no dynamic imports anywhere.

Also raises `maxAsyncRequests` from 10 → 30. The cap was preventing legitimate async chunk splits on complex routes; with HTTP/2 multiplexing the rspack default of 30 is appropriate.

Co-Authored-By: Claude <noreply@anthropic.com>