### PR TITLE
feat(ci): add getsentry/codecov-action to backend coverage workflow

### DIFF
--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -127,6 +127,8 @@ jobs:
       contents: read
       id-token: write
       actions: read # used for DIM metadata
+      statuses: write # for codecov status checks
+      pull-requests: write # for codecov PR comments
     needs: [check-existing-coverage, backend-test-with-cov-context, calculate-shards]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -173,6 +175,21 @@ jobs:
           fi
 
           mv .coverage ".coverage.combined"
+
+      - name: Generate Cobertura XML report
+        run: |
+          uvx --with covdefaults --with sentry-covdefaults-disable-branch-coverage \
+            coverage xml -i --data-file=.coverage.combined -o coverage.xml
+
+      - name: Upload coverage to Codecov
+        uses: getsentry/codecov-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./coverage.xml
+          coverage-format: cobertura
+          flags: backend
+          name: backend-coverage
+          fail-ci-if-error: false
 
       - name: Authenticate to Google Cloud
         id: gcloud-auth


### PR DESCRIPTION
## Summary

- Adds `getsentry/codecov-action@v1` to the `backend-with-coverage.yml` workflow to report backend test coverage using GitHub Artifacts (no external Codecov token required)
- Generates a Cobertura XML report from the combined `.coverage.combined` SQLite database before uploading
- Adds `statuses: write` and `pull-requests: write` permissions needed by the action for commit status checks and PR comments
- Preserves the existing GCS upload which is still used for selective testing

## How it works

After all test shards produce coverage and the `combine-coverage` job merges them:

1. **New step**: `coverage xml -i` converts the combined coverage database to `coverage.xml` (Cobertura format)
2. **New step**: `getsentry/codecov-action@v1` uploads the XML report, tagging it with `flags: backend`
3. **Existing steps**: GCS upload continues unchanged for selective testing

The action uses `${{ secrets.GITHUB_TOKEN }}` and stores results as GitHub Artifacts — no external service or Codecov token is needed.