### PR TITLE
refactor(onboarding): replace inline AI rules with sentry-for-ai skill prompts

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -82,42 +82,44 @@ export function getUploadSourceMapsStep({
   };
 }
 
-function CopyRulesButton({rules}: {rules: string}) {
+const SENTRY_FOR_AI_BASE_URL =
+  'https://github.com/getsentry/sentry-for-ai/blob/main/skills';
+
+function CopyPromptButton({prompt}: {prompt: string}) {
   const {copy} = useCopyToClipboard();
   return (
     <Button
       size="xs"
       icon={<IconCopy />}
-      onClick={() => copy(rules, {successMessage: t('Rules copied to clipboard')})}
+      onClick={() => copy(prompt, {successMessage: t('Prompt copied to clipboard')})}
     >
-      {t('Copy Rules')}
+      {t('Copy Prompt')}
     </Button>
   );
 }
 
-export function getAIRulesForCodeEditorStep({rules}: {rules: string}): OnboardingStep {
+export function getAISetupStep({skillPath}: {skillPath: string}): OnboardingStep {
+  const skillUrl = `${SENTRY_FOR_AI_BASE_URL}/${skillPath}/SKILL.md`;
+  const prompt = `Read and follow: ${skillUrl}`;
+
   return {
     collapsible: true,
-    title: t('AI Rules for Code Editors (Optional)'),
-    trailingItems: <CopyRulesButton rules={rules} />,
+    title: t('AI-Assisted Setup (Optional)'),
+    trailingItems: <CopyPromptButton prompt={prompt} />,
     content: [
       {
         type: 'text',
-        text: tct(
-          'Sentry provides a set of rules you can use to help your LLM use Sentry correctly. Copy this file and add it to your projects rules configuration. When created as a rules file this should be placed alongside other editor specific rule files. For example, if you are using Cursor, place this file in the [code:.cursorrules] directory.',
-          {
-            code: <code />,
-          }
+        text: t(
+          'If you want your AI coding assistant to help you set up Sentry, copy this prompt and paste it into your agent:'
         ),
       },
       {
         type: 'code',
         tabs: [
           {
-            label: 'Markdown',
-            language: 'md',
-            filename: 'rules.md',
-            code: rules,
+            label: 'Prompt',
+            language: 'text',
+            code: prompt,
           },
         ],
       },

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
@@ -6,7 +6,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {getAIRulesForCodeEditorStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
+import {getAISetupStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {t, tct} from 'sentry/locale';
 
 import {getInstallSnippet} from './utils';
@@ -57,138 +57,7 @@ export const onboarding: OnboardingConfig = {
         },
       ],
     },
-    getAIRulesForCodeEditorStep({
-      // ATTENTION: The rules defined here must match those in the documentation (see: https://github.com/getsentry/sentry-docs/blob/master/platform-includes/llm-rules-logs/javascript.nextjs.mdx).
-      // If you make any changes, please update the docs accordingly.
-      rules: `
-These examples should be used as guidance when configuring Sentry functionality within a project.
-
-# Exception Catching
-
-Use \`Sentry.captureException(error)\` to capture an exception and log the error in Sentry.
-Use this in try catch blocks or areas where exceptions are expected
-
-# Tracing Examples
-
-Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-Use the \`Sentry.startSpan\` function to create a span
-Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-The \`name\` and \`op\` properties should be meaninful for the activities in the call.
-Attach attributes based on relevant information and metrics from the request
-
-\`\`\`javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan(
-      {
-        op: "ui.click",
-        name: "Test Button Click",
-      },
-      (span) => {
-        const value = "some config";
-        const metric = "some metric";
-
-        // Metrics can be added to the span
-        span.setAttribute("config", value);
-        span.setAttribute("metric", metric);
-
-        doSomething();
-      },
-    );
-  };
-
-  return (
-    <button type="button" onClick={handleTestButtonClick}>
-      Test Sentry
-    </button>
-  );
-}
-\`\`\`
-
-## Custom span instrumentation in API calls
-
-The \`name\` and \`op\` properties should be meaninful for the activities in the call.
-Attach attributes based on relevant information and metrics from the request
-
-\`\`\`javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: \`GET /api/users/\${userId}\`,
-    },
-    async () => {
-      const response = await fetch(\`/api/users/\${userId}\`);
-      const data = await response.json();
-      return data;
-    },
-  );
-}
-\`\`\`
-
-# Logs
-
-Where logs are used, ensure Sentry is imported using \`import * as Sentry from "@sentry/nextjs"\`
-Enable logging in Sentry using \`Sentry.init({  enableLogs: true })\`
-Reference the logger using \`const { logger } = Sentry\`
-Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
-
-## Configuration
-
-In NextJS the client side Sentry initialization is in \`instrumentation-client.(js|ts)\`, the server initialization is in \`sentry.server.config.ts\` and the edge initialization is in \`sentry.edge.config.ts\`
-Initialization does not need to be repeated in other files, it only needs to happen the files mentioned above. You should use \`import * as Sentry from "@sentry/nextjs"\` to reference Sentry functionality
-
-### Baseline
-
-\`\`\`javascript
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-
-  enableLogs: true,
-});
-\`\`\`
-
-### Logger Integration
-
-\`\`\`javascript
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  integrations: [
-    // send console.log, console.warn, and console.error calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
-  ],
-});
-\`\`\`
-
-## Logger Examples
-
-\`logger.fmt\` is a template literal function that should be used to bring variables into the structured logs.
-
-\`\`\`javascript
-logger.trace("Starting database connection", { database: "users" });
-logger.debug(logger.fmt\`Cache miss for user: \${userId}\`);
-logger.info("Updated profile", { profileId: 345 });
-logger.warn("Rate limit reached for endpoint", {
-  endpoint: "/api/results/",
-  isEnterprise: false,
-});
-logger.error("Failed to process payment", {
-  orderId: "order_123",
-  amount: 99.99,
-});
-logger.fatal("Database connection pool exhausted", {
-  database: "users",
-  activeConnections: 100,
-});
-\`\`\`
-`,
-    }),
+    getAISetupStep({skillPath: 'sentry-nextjs-sdk'}),
   ],
   verify: () => [
     {

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
@@ -5,7 +5,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getAIRulesForCodeEditorStep,
+  getAISetupStep,
   getUploadSourceMapsStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {t, tct} from 'sentry/locale';
@@ -96,130 +96,7 @@ export const onboarding: OnboardingConfig = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/',
       ...params,
     }),
-    getAIRulesForCodeEditorStep({
-      // ATTENTION: The rules defined here must match those in the documentation (see: https://github.com/getsentry/sentry-docs/blob/master/platform-includes/llm-rules-logs/javascript.react.mdx).
-      // If you make any changes, please update the docs accordingly.
-      rules: `
-These examples should be used as guidance when configuring Sentry functionality within a project.
-
-# Error / Exception Tracking
-
-Use \`Sentry.captureException(error)\` to capture an exception and log the error in Sentry.
-Use this in try catch blocks or areas where exceptions are expected
-
-# Tracing Examples
-
-Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-Ensure you are creating custom spans with meaningful names and operations
-Use the \`Sentry.startSpan\` function to create a span
-Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-\`\`\`javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan(
-      {
-        op: "ui.click",
-        name: "Test Button Click",
-      },
-      (span) => {
-        const value = "some config";
-        const metric = "some metric";
-
-        // Metrics can be added to the span
-        span.setAttribute("config", value);
-        span.setAttribute("metric", metric);
-
-        doSomething();
-      },
-    );
-  };
-
-  return (
-    <button type="button" onClick={handleTestButtonClick}>
-      Test Sentry
-    </button>
-  );
-}
-\`\`\`
-
-## Custom span instrumentation in API calls
-
-\`\`\`javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: \`GET /api/users/\${userId}\`,
-    },
-    async () => {
-      const response = await fetch(\`/api/users/\${userId}\`);
-      const data = await response.json();
-      return data;
-    },
-  );
-}
-\`\`\`
-
-# Logs
-
-Where logs are used, ensure Sentry is imported using \`import * as Sentry from "@sentry/react"\`
-Enable logging in Sentry using \`Sentry.init({ enableLogs: true })\`
-Reference the logger using \`const { logger } = Sentry\`
-Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
-
-## Configuration
-
-### Baseline
-
-\`\`\`javascript
-import * as Sentry from "@sentry/react";
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-
-  enableLogs: true,
-});
-\`\`\`
-
-### Logger Integration
-
-\`\`\`javascript
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  integrations: [
-    // send console.log, console.warn, and console.error calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
-  ],
-});
-\`\`\`
-
-## Logger Examples
-
-\`logger.fmt\` is a template literal function that should be used to bring variables into the structured logs.
-
-\`\`\`javascript
-logger.trace("Starting database connection", { database: "users" });
-logger.debug(logger.fmt\`Cache miss for user: \${userId}\`);
-logger.info("Updated profile", { profileId: 345 });
-logger.warn("Rate limit reached for endpoint", {
-  endpoint: "/api/results/",
-  isEnterprise: false,
-});
-logger.error("Failed to process payment", {
-  orderId: "order_123",
-  amount: 99.99,
-});
-logger.fatal("Database connection pool exhausted", {
-  database: "users",
-  activeConnections: 100,
-});
-\`\`\`
-`,
-    }),
+    getAISetupStep({skillPath: 'sentry-react-sdk'}),
   ],
   verify: (params: DocsParams) => [
     {

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -10,7 +10,7 @@ import {
   type OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getAIRulesForCodeEditorStep,
+  getAISetupStep,
   getUploadSourceMapsStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {getFeedbackConfigOptions} from 'sentry/components/onboarding/gettingStartedDoc/utils/feedbackOnboarding';
@@ -174,140 +174,8 @@ const getVerifySnippetBlock = (params: Params): ContentBlock[] => [
   },
 ];
 
-export const getAiRulesConfig = (params: Params): OnboardingStep =>
-  getAIRulesForCodeEditorStep({
-    rules: `
-These examples should be used as guidance when configuring Sentry functionality within a project.
-
-# Error / Exception Tracking
-
-Use \`Sentry.captureException(error)\` to capture an exception and log the error in Sentry.
-Use this in try catch blocks or areas where exceptions are expected
-
-# Tracing Examples
-
-Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-Use the \`Sentry.startSpan\` function to create a span
-Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-Name custom spans with meaningful names and operations.
-Attach attributes based on relevant information and metrics from the request
-
-\`\`\`javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan(
-      {
-        op: "ui.click",
-        name: "Test Button Click",
-      },
-      (span) => {
-        const value = "some config";
-        const metric = "some metric";
-
-        // Metrics can be added to the span
-        span.setAttribute("config", value);
-        span.setAttribute("metric", metric);
-
-        doSomething();
-      },
-    );
-  };
-
-  return (
-    <button type="button" onClick={handleTestButtonClick}>
-      Test Sentry
-    </button>
-  );
-}
-\`\`\`
-
-## Custom span instrumentation in API calls
-
-Name custom spans with meaningful names and operations.
-Attach attributes based on relevant information and metrics from the request
-
-\`\`\`javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: \`GET /api/users/\${userId}\`,
-    },
-    async () => {
-      const response = await fetch(\`/api/users/\${userId}\`);
-      const data = await response.json();
-      return data;
-    },
-  );
-}
-\`\`\`
-
-# Logs
-
-Where logs are used, ensure Sentry is imported using \`import * as Sentry from "@sentry/browser"\`
-Enable logging in Sentry using \`Sentry.init({ _experiments: { enableLogs: true } })\`
-Reference the logger using \`const { logger } = Sentry\`
-Sentry offers a \`consoleLoggingIntegration\` that can be used to log specific console error types automatically without instrumenting the individual logger calls
-
-## Configuration
-
-### Baseline
-
-\`\`\`javascript
-import * as Sentry from "@sentry/browser";
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-
-  _experiments: {
-    enableLogs: true,
-  },
-});
-\`\`\`
-
-### Logger Integration
-
-\`\`\`javascript
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  integrations: [
-    // send console.log, console.warn, and console.error calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
-  ],
-});
-\`\`\`
-
-## Logger Examples
-
-\`logger.fmt\` is a template literal function that should be used to bring variables into the structured logs.
-
-\`\`\`javascript
-import * as Sentry from "@sentry/browser";
-
-const { logger } = Sentry;
-
-logger.trace("Starting database connection", { database: "users" });
-logger.debug(logger.fmt\`Cache miss for user: \${userId}\`);
-logger.info("Updated profile", { profileId: 345 });
-logger.warn("Rate limit reached for endpoint", {
-  endpoint: "/api/results/",
-  isEnterprise: false,
-});
-logger.error("Failed to process payment", {
-  orderId: "order_123",
-  amount: 99.99,
-});
-logger.fatal("Database connection pool exhausted", {
-  database: "users",
-  activeConnections: 100,
-});
-\`\`\`
-`,
-  });
+export const getAiRulesConfig = (): OnboardingStep =>
+  getAISetupStep({skillPath: 'sentry-sdk-setup'});
 
 const getVerifyConfig = (params: Params) => [
   {
@@ -442,7 +310,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
         }
       },
     },
-    getAiRulesConfig(params),
+    getAiRulesConfig(),
   ],
   verify: (params: Params) => getVerifyConfig(params),
   nextSteps: (params: Params) => {
@@ -561,7 +429,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/sourcemaps/',
       ...params,
     }),
-    getAiRulesConfig(params),
+    getAiRulesConfig(),
   ],
   verify: (params: Params) => getVerifyConfig(params),
   nextSteps: (params: Params) => {

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -174,7 +174,7 @@ const getVerifySnippetBlock = (params: Params): ContentBlock[] => [
   },
 ];
 
-export const getAiRulesConfig = (): OnboardingStep =>
+export const getAiSetupConfig = (): OnboardingStep =>
   getAISetupStep({skillPath: 'sentry-sdk-setup'});
 
 const getVerifyConfig = (params: Params) => [
@@ -310,7 +310,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
         }
       },
     },
-    getAiRulesConfig(),
+    getAiSetupConfig(),
   ],
   verify: (params: Params) => getVerifyConfig(params),
   nextSteps: (params: Params) => {
@@ -429,7 +429,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/sourcemaps/',
       ...params,
     }),
-    getAiRulesConfig(),
+    getAiSetupConfig(),
   ],
   verify: (params: Params) => getVerifyConfig(params),
   nextSteps: (params: Params) => {

--- a/static/app/gettingStartedDocs/node/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.tsx
@@ -6,7 +6,7 @@ import type {
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {
-  getAIRulesForCodeEditorStep,
+  getAISetupStep,
   getUploadSourceMapsStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {t, tct} from 'sentry/locale';
@@ -104,133 +104,7 @@ export const onboarding: OnboardingConfig = {
       guideLink: 'https://docs.sentry.io/platforms/javascript/guides/node/sourcemaps/',
       ...params,
     }),
-    getAIRulesForCodeEditorStep({
-      // ATTENTION: The rules defined here must match those in the documentation (see: https://github.com/getsentry/sentry-docs/blob/master/platform-includes/llm-rules-logs/javascript.node.mdx).
-      // If you make any changes, please update the docs accordingly.
-      rules: `
-These examples should be used as guidance when configuring Sentry functionality within a project.
-
-# Error / Exception Tracking
-
-Use \`Sentry.captureException(error)\` to capture an exception and log the error in Sentry.
-Use this in try catch blocks or areas where exceptions are expected
-
-# Tracing Examples
-
-Spans should be created for meaningful actions within an applications like button clicks, API calls, and function calls
-Ensure you are creating custom spans with meaningful names and operations
-Use the \`Sentry.startSpan\` function to create a span
-Child spans can exist within a parent span
-
-## Custom Span instrumentation in component actions
-
-\`\`\`javascript
-function TestComponent() {
-  const handleTestButtonClick = () => {
-    // Create a transaction/span to measure performance
-    Sentry.startSpan(
-      {
-        op: "ui.click",
-        name: "Test Button Click",
-      },
-      (span) => {
-        const value = "some config";
-        const metric = "some metric";
-
-        // Metrics can be added to the span
-        span.setAttribute("config", value);
-        span.setAttribute("metric", metric);
-
-        doSomething();
-      },
-    );
-  };
-
-  return (
-    <button type="button" onClick={handleTestButtonClick}>
-      Test Sentry
-    </button>
-  );
-}
-\`\`\`
-
-## Custom span instrumentation in API calls
-
-\`\`\`javascript
-async function fetchUserData(userId) {
-  return Sentry.startSpan(
-    {
-      op: "http.client",
-      name: \`GET /api/users/\${userId}\`,
-    },
-    async () => {
-      const response = await fetch(\`/api/users/\${userId}\`);
-      const data = await response.json();
-      return data;
-    },
-  );
-}
-\`\`\`
-
-# Logs
-
-Where logs are used, ensure they are imported using \`import * as Sentry from "@sentry/node"\`
-Enable logging in Sentry using \`Sentry.init({ enableLogs: true })\`
-Reference the logger using \`const { logger } = Sentry\`
-Sentry offers a consoleLoggingIntegration that can be used to log specific console error types automatically without instrumenting the individual logger calls
-
-## Configuration
-
-In Node.js the Sentry initialization is typically in \`instrumentation.ts\`
-
-### Baseline
-
-\`\`\`javascript
-import * as Sentry from "@sentry/node";
-
-Sentry.init({
-  dsn: "${params.dsn.public}",
-
-  // Send structured logs to Sentry
-  enableLogs: true,
-});
-\`\`\`
-
-### Logger Integration
-
-\`\`\`javascript
-Sentry.init({
-  dsn: "${params.dsn.public}",
-  integrations: [
-    // send console.log, console.warn, and console.error calls as logs to Sentry
-    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
-  ],
-});
-\`\`\`
-
-## Logger Examples
-
-\`logger.fmt\` is a template literal function that should be used to bring variables into the structured logs.
-
-\`\`\`javascript
-logger.trace("Starting database connection", { database: "users" });
-logger.debug(logger.fmt\`Cache miss for user: \${userId}\`);
-logger.info("Updated profile", { profileId: 345 });
-logger.warn("Rate limit reached for endpoint", {
-  endpoint: "/api/results/",
-  isEnterprise: false,
-});
-logger.error("Failed to process payment", {
-  orderId: "order_123",
-  amount: 99.99,
-});
-logger.fatal("Database connection pool exhausted", {
-  database: "users",
-  activeConnections: 100,
-});
-\`\`\`
-`,
-    }),
+    getAISetupStep({skillPath: 'sentry-sdk-setup'}),
   ],
   verify: (params: DocsParams) => [
     {


### PR DESCRIPTION
## Summary

Replace the Cursor-specific **AI Rules for Code Editors** onboarding step with an agent-agnostic **AI-Assisted Setup** step that links to skills in the [sentry-for-ai](https://github.com/getsentry/sentry-for-ai) repository.

## What changed

**Before:** Each SDK onboarding page embedded 100+ lines of raw rules markdown and instructed users to copy it into their `.cursorrules` directory. Cursor-specific.

**After:** Each page shows a one-line prompt pointing to the appropriate sentry-for-ai skill that users copy into *any* AI coding assistant:

```
Read and follow: https://github.com/getsentry/sentry-for-ai/blob/main/skills/sentry-nextjs-sdk/SKILL.md
```

### Platform → Skill mapping

| Onboarding | Skill |
|---|---|
| Next.js | `sentry-nextjs-sdk` |
| React | `sentry-react-sdk` |
| Vanilla JS (browser) | `sentry-sdk-setup` (router) |
| Node.js | `sentry-sdk-setup` (router) |

### UX changes

- Step title: "AI Rules for Code Editors (Optional)" → "AI-Assisted Setup (Optional)"
- Button: "Copy Rules" → "Copy Prompt"
- No more Cursor-specific language — works with any AI coding assistant
- Removes ~540 lines of duplicated inline rules content

### Files changed

- `static/app/components/onboarding/gettingStartedDoc/utils/index.tsx` — New `getAISetupStep()` replacing `getAIRulesForCodeEditorStep()`
- `static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx`
- `static/app/gettingStartedDocs/javascript-react/onboarding.tsx`
- `static/app/gettingStartedDocs/javascript/utils.tsx`
- `static/app/gettingStartedDocs/node/onboarding.tsx`