### PR TITLE
fix(CompactSelect): Adjust scrollbar gutter behavior based on overflow state

### DIFF
--- a/static/app/components/core/compactSelect/listBox/index.spec.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.spec.tsx
@@ -3,6 +3,86 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 
 describe('ListBox', () => {
+  it('does not reserve scrollbar gutter if the list never overflowed', async () => {
+    render(
+      <CompactSelect
+        search={{placeholder: 'Search here'}}
+        onChange={jest.fn()}
+        value={undefined}
+        options={[
+          {value: 'opt_one', label: 'Option One'},
+          {value: 'opt_two', label: 'Option Two'},
+          {value: 'opt_three', label: 'Option Three'},
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    const listBox = screen.getByRole('listbox');
+    const scrollContainer = listBox.parentElement?.parentElement;
+    expect(scrollContainer).toBeInTheDocument();
+
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      value: 100,
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      value: 60,
+      configurable: true,
+    });
+
+    await userEvent.type(screen.getByPlaceholderText('Search here'), 'Three');
+
+    expect(scrollContainer).not.toHaveStyle({scrollbarGutter: 'stable'});
+  });
+
+  it('keeps scrollbar gutter once the list has overflowed', async () => {
+    render(
+      <CompactSelect
+        search={{placeholder: 'Search here'}}
+        onChange={jest.fn()}
+        value={undefined}
+        options={[
+          {value: 'opt_one', label: 'Option One'},
+          {value: 'opt_two', label: 'Option Two'},
+          {value: 'opt_three', label: 'Option Three'},
+        ]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    const listBox = screen.getByRole('listbox');
+    const scrollContainer = listBox.parentElement?.parentElement;
+    expect(scrollContainer).toBeInTheDocument();
+
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      value: 60,
+      configurable: true,
+    });
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      value: 120,
+      configurable: true,
+    });
+
+    await userEvent.type(screen.getByPlaceholderText('Search here'), 'Option');
+
+    await waitFor(() => {
+      expect(scrollContainer).toHaveStyle({scrollbarGutter: 'stable'});
+    });
+
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      value: 50,
+      configurable: true,
+    });
+
+    await userEvent.clear(screen.getByPlaceholderText('Search here'));
+    await userEvent.type(screen.getByPlaceholderText('Search here'), 'Three');
+
+    expect(scrollContainer).toHaveStyle({scrollbarGutter: 'stable'});
+  });
+
   it('hides details overlay when mouse leaves the list', async () => {
     render(
       <CompactSelect

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef, useState} from 'react';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
 import {useListBox} from '@react-aria/listbox';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
@@ -143,6 +143,7 @@ export function ListBox<T extends ObjectLike>({
   ...props
 }: ListBoxProps<T>) {
   const listElementRef = useRef<HTMLUListElement>(null);
+  const [hasEverOverflowed, setHasEverOverflowed] = useState(false);
 
   const {listBoxProps, labelProps} = useListBox(
     {
@@ -186,16 +187,27 @@ export function ListBox<T extends ObjectLike>({
 
   const virtualizer = useVirtualizedItems({listItems, virtualized, size});
 
+  const refs = useMemo(() => {
+    const scrollContainerRef = (scrollContainer: HTMLDivElement | null) => {
+      if (hasEverOverflowed || listItems.length === 0 || !scrollContainer) {
+        return;
+      }
+
+      setHasEverOverflowed(scrollContainer.scrollHeight > scrollContainer.clientHeight);
+    };
+    return mergeRefs(scrollContainerRef, virtualizer.scrollElementRef);
+  }, [hasEverOverflowed, virtualizer.scrollElementRef, listItems]);
+
   return (
     <Fragment>
       {listItems.length !== 0 && <ListSeparator role="separator" />}
       {listItems.length !== 0 && label && <ListLabel {...labelProps}>{label}</ListLabel>}
       <Container
-        ref={virtualizer.scrollElementRef}
+        ref={refs}
         height="100%"
         overflowY="auto"
         className={className}
-        style={{scrollbarGutter: 'stable'}}
+        style={hasEverOverflowed ? {scrollbarGutter: 'stable'} : undefined}
       >
         <Container {...virtualizer.wrapperProps}>
           <ListWrap


### PR DESCRIPTION
we now reserve the scrollbar gutter only if we’ve had a scrollbar.

before:

<img width="339" height="261" alt="Screenshot 2026-03-02 at 11 29 14" src="https://github.com/user-attachments/assets/d37ccf3c-6450-4ed3-923b-07fdbee5744d" />

after:

<img width="434" height="210" alt="Screenshot 2026-03-02 at 11 28 10" src="https://github.com/user-attachments/assets/6c035576-a8c4-4649-9c53-08a6ec99ca57" />
