### PR TITLE
build(deps): Fix GHSA-23c5-xmqv-rm74 vulnerable minimatch in api-docs

### DIFF
--- a/api-docs/package.json
+++ b/api-docs/package.json
@@ -25,7 +25,8 @@
   "pnpm": {
     "overrides": {
       "lodash": ">=4.17.23",
-      "form-data": ">=4.0.2"
+      "form-data": ">=4.0.2",
+      "glob>minimatch": "5.1.9"
     }
   }
 }

--- a/api-docs/pnpm-lock.yaml
+++ b/api-docs/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   lodash: '>=4.17.23'
   form-data: '>=4.0.2'
+  glob>minimatch: 5.1.9
 
 importers:
 
@@ -469,8 +470,8 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
   minimist@1.2.8:
@@ -948,7 +949,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.6
+      minimatch: 5.1.9
       once: 1.4.0
 
   gopd@1.0.1:
@@ -1096,7 +1097,7 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  minimatch@5.1.6:
+  minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.0.1
 


### PR DESCRIPTION
Resolves the ReDoS vulnerability [GHSA-23c5-xmqv-rm74](https://github.com/advisories/GHSA-23c5-xmqv-rm74) in `minimatch` (<5.1.7) within the `api-docs` workspace.

The vulnerable `minimatch@5.1.6` is introduced transitively via `openapi-examples-validator@6.0.3` → `glob@8.1.0` → `minimatch@5.1.6`. Since `openapi-examples-validator` is already at the latest version, bumping it is not an option.

The fix adds a scoped pnpm override `"glob>minimatch": "5.1.9"` in `api-docs/package.json`, targeting only glob's minimatch dependency to avoid unintended side effects on other packages. This resolves `minimatch` to `5.1.9` (latest 5.x).

Co-Authored-By: Claude <noreply@anthropic.com>