### PR TITLE
feat(seer): Add tooltip to ResponseDot showing step status

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -7,6 +7,7 @@ import {Button} from '@sentry/scraps/button';
 import {inlineCodeStyles} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
 import {IconChevron, IconLink, IconThumb} from 'sentry/icons';
@@ -525,7 +526,42 @@ const BlockChevronIcon = styled(IconChevron)`
   flex-shrink: 0;
 `;
 
-const ResponseDot = styled('div')<{
+function getStatusTooltipText(
+  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending'
+): string {
+  switch (status) {
+    case 'loading':
+      return t('Running...');
+    case 'pending':
+      return t('Waiting for approval');
+    case 'content':
+      return t('Response received');
+    case 'success':
+      return t('Completed successfully');
+    case 'failure':
+      return t('Completed with errors');
+    case 'mixed':
+      return t('Completed with partial errors');
+    default:
+      return '';
+  }
+}
+
+function ResponseDot({
+  status,
+  hasOnlyTools,
+}: {
+  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending';
+  hasOnlyTools?: boolean;
+}) {
+  return (
+    <Tooltip title={getStatusTooltipText(status)}>
+      <ResponseDotIndicator status={status} hasOnlyTools={hasOnlyTools} />
+    </Tooltip>
+  );
+}
+
+const ResponseDotIndicator = styled('div')<{
   status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending';
   hasOnlyTools?: boolean;
 }>`


### PR DESCRIPTION
Add a Tooltip to the ResponseDot component in the Seer Explorer that
explains what each colored dot status means (running, waiting for
approval, completed successfully, completed with errors, etc.).

This resolves: JAVASCRIPT-37MV

Agent transcript: https://claudescope.sentry.dev/share/6VEU5dMf1StM03aLgpQZ4AGkKZMZToqTy_TYNoKbzU4


https://github.com/user-attachments/assets/a2e1e8d5-110d-4ff3-96b3-8d8c9a834160
