### PR TITLE
ref(objectstore): Remove objectstore.force-stored-symbolication flag

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -27,7 +27,6 @@ from sentry.lang.native.utils import Backoff
 from sentry.models.project import Project
 from sentry.net.http import Session
 from sentry.objectstore import get_attachments_session, get_symbolicator_url
-from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 
 MAX_ATTEMPTS = 3
@@ -188,13 +187,6 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
 
-        force_stored_attachment = not minidump.stored_id and in_random_rollout(
-            "objectstore.force-stored-symbolication"
-        )
-        if force_stored_attachment:
-            session = get_attachments_session(self.project.organization_id, self.project.id)
-            minidump.stored_id = session.put(minidump.load_data(self.project))
-
         if minidump.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
             storage_url = get_symbolicator_url(session, minidump.stored_id)
@@ -209,13 +201,8 @@ class Symbolicator:
                     "rewrite_first_module": rewrite_first_module,
                 },
             }
-            try:
-                res = self._process("process_minidump", "symbolicate-any", json=json)
-                return process_response(res)
-            finally:
-                if force_stored_attachment:
-                    session.delete(minidump.stored_id)
-                    minidump.stored_id = None
+            res = self._process("process_minidump", "symbolicate-any", json=json)
+            return process_response(res)
 
         data = {
             "platform": orjson.dumps(platform).decode(),
@@ -233,13 +220,6 @@ class Symbolicator:
         (sources, process_response) = sources_for_symbolication(self.project)
         scraping_config = get_scraping_config(self.project)
 
-        force_stored_attachment = not report.stored_id and in_random_rollout(
-            "objectstore.force-stored-symbolication"
-        )
-        if force_stored_attachment:
-            session = get_attachments_session(self.project.organization_id, self.project.id)
-            report.stored_id = session.put(report.load_data(self.project))
-
         if report.stored_id:
             session = get_attachments_session(self.project.organization_id, self.project.id)
             storage_url = get_symbolicator_url(session, report.stored_id)
@@ -253,13 +233,8 @@ class Symbolicator:
                     "storage_url": storage_url,
                 },
             }
-            try:
-                res = self._process("process_applecrashreport", "symbolicate-any", json=json)
-                return process_response(res)
-            finally:
-                if force_stored_attachment:
-                    session.delete(report.stored_id)
-                    report.stored_id = None
+            res = self._process("process_applecrashreport", "symbolicate-any", json=json)
+            return process_response(res)
 
         data = {
             "platform": orjson.dumps(platform).decode(),

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3904,9 +3904,6 @@ register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMAT
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Fraction of attachments that are being stored on objectstore for processing and long-term storage.
 register("objectstore.enable_for.cached_attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# This forces symbolication to use the "stored attachment" codepath,
-# regardless of whether the attachment has already been stored.
-register("objectstore.force-stored-symbolication", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 
 # option used to enable/disable tracking

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -11,10 +11,9 @@ from sentry.models.eventattachment import EventAttachment
 from sentry.services import eventstore
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.factories import get_fixture_path
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
 from sentry.testutils.relay import RelayStoreHelper
-from sentry.testutils.skips import requires_kafka, requires_objectstore, requires_symbolicator
+from sentry.testutils.skips import requires_kafka, requires_symbolicator
 from sentry.testutils.thread_leaks.pytest import thread_leak_allowlist
 from sentry.utils.safe import get_path
 from tests.symbolicator import insta_snapshot_native_stacktrace_data, redact_location
@@ -201,16 +200,6 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
             assert minidump.name == "windows.dmp"
             assert minidump.sha1 == "74bb01c850e8d65d3ffbc5bad5cabc4668fce247"
 
-    @requires_objectstore
-    def test_reprocessing_with_objectstore(self) -> None:
-        with override_options(
-            {
-                "objectstore.force-stored-symbolication": 1,
-                "objectstore.enable_for.attachments": 1,
-            }
-        ):
-            self.test_reprocessing()
-
     def test_minidump_threadnames(self) -> None:
         self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
 
@@ -220,8 +209,3 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
 
         thread_name = get_path(event.data, "threads", "values", 1, "name")
         assert thread_name == "sentry-http"
-
-    @requires_objectstore
-    def test_force_stored_minidump(self) -> None:
-        with override_options({"objectstore.force-stored-symbolication": 1}):
-            self.test_minidump_threadnames()


### PR DESCRIPTION
Remove the `objectstore.force-stored-symbolication` rollout flag and all code that depended on it.

The flag was used to temporarily upload minidump and Apple crash report attachments to object storage when they weren't already stored, so that the stored-URL symbolication path (`symbolicate-any`) could be exercised during rollout. Now that the rollout is complete, the temporary upload/cleanup logic and its associated tests are no longer needed.

Requires https://github.com/getsentry/sentry-options-automator/pull/6654