### PR TITLE
chore: enable @typescript-eslint/no-duplicate-type-constituents

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -588,6 +588,7 @@ export default typescript.config([
           '@typescript-eslint/consistent-type-exports': 'error',
           '@typescript-eslint/no-array-delete': 'error',
           '@typescript-eslint/no-base-to-string': 'error',
+          '@typescript-eslint/no-duplicate-type-constituents': 'error',
           '@typescript-eslint/no-for-in-array': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
           '@typescript-eslint/only-throw-error': 'error',

--- a/static/app/components/events/eventStatisticalDetector/eventDifferentialFlamegraph.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventDifferentialFlamegraph.tsx
@@ -290,9 +290,7 @@ function paginationReducer(
 
 interface DifferentialFlamegraphChangedFunctionsProps {
   flamegraph: DifferentialFlamegraphModel;
-  functions:
-    | DifferentialFlamegraphModel['increasedFrames']
-    | DifferentialFlamegraphModel['newFrames'];
+  functions: FlamegraphFrame[];
   loading: boolean;
   makeFunctionLink: (frame: FlamegraphFrame) => LocationDescriptor;
   subtitle: string;

--- a/static/app/components/pageFilters/parse.tsx
+++ b/static/app/components/pageFilters/parse.tsx
@@ -6,7 +6,7 @@ import moment from 'moment-timezone';
 
 import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import type {IntervalPeriod, PageFilters} from 'sentry/types/core';
+import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import toArray from 'sentry/utils/array/toArray';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
@@ -31,7 +31,7 @@ const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?(-\\w+)?$';
  * parseStatsPeriod("30m") // returns { period: "30", periodLength: "m" }
  * parseStatsPeriod("invalid") // returns undefined
  */
-export function parseStatsPeriod(input: string | IntervalPeriod) {
+export function parseStatsPeriod(input: string) {
   const result = input.match(STATS_PERIOD_PATTERN);
 
   if (!result) {

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -232,7 +232,7 @@ export class VideoReplayer {
    * Pause timer only if replay is running. Otherwise, no need to
    * pause if timer is not already running.
    */
-  private pauseTimer(videoOffsetMs?: number | undefined) {
+  private pauseTimer(videoOffsetMs?: number) {
     // This is valid to run when replay is not playing (seeking to
     // a place in the replay). Due to ReplayContext and maintaining
     // compatibility with rrweb player, we need to update the time
@@ -381,7 +381,7 @@ export class VideoReplayer {
     };
   }
 
-  protected getSegment(index?: number | undefined): VideoEvent | undefined {
+  protected getSegment(index?: number): VideoEvent | undefined {
     if (index === undefined) {
       return undefined;
     }

--- a/static/app/components/replays/videoReplayer.tsx
+++ b/static/app/components/replays/videoReplayer.tsx
@@ -381,7 +381,7 @@ export class VideoReplayer {
     };
   }
 
-  protected getSegment(index?: number): VideoEvent | undefined {
+  protected getSegment(index: number | undefined): VideoEvent | undefined {
     if (index === undefined) {
       return undefined;
     }

--- a/static/app/components/teamRoleSelect.tsx
+++ b/static/app/components/teamRoleSelect.tsx
@@ -4,7 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 import type {ControlProps} from '@sentry/scraps/select';
 
 import RoleSelectControl from 'sentry/components/roleSelectControl';
-import type {Organization, Team, TeamMember, TeamRole} from 'sentry/types/organization';
+import type {Organization, Team, TeamMember} from 'sentry/types/organization';
 import {
   hasOrgRoleOverwrite,
   RoleOverwriteIcon,
@@ -12,7 +12,7 @@ import {
 
 interface Props {
   member: TeamMember;
-  onChangeTeamRole: (newRole: TeamRole['id'] | string) => void;
+  onChangeTeamRole: (newRole: string) => void;
   organization: Organization;
   team: Team;
   disabled?: boolean;

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1401,7 +1401,7 @@ const alignedTypes: ColumnValueType[] = [
 
 export function fieldAlignment(
   columnName: string,
-  columnType?: undefined | ColumnValueType,
+  columnType?: ColumnValueType,
   metadata?: Record<string, ColumnValueType>
 ): Alignments {
   let align: Alignments = 'left';

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -27,6 +27,7 @@ import {
   createFrameIndex,
   createSentrySampleProfileFrameIndex,
   wrapWithSpan,
+  type FrameIndex,
 } from './utils';
 
 interface ImportOptions {
@@ -562,10 +563,7 @@ function importSingleProfile(
     | Profiling.EventedProfile
     | Profiling.SampledProfile
     | JSSelfProfiling.Trace,
-  frameIndex:
-    | ReturnType<typeof createFrameIndex>
-    | ReturnType<typeof createContinuousProfileFrameIndex>
-    | ReturnType<typeof createSentrySampleProfileFrameIndex>,
+  frameIndex: FrameIndex,
   {span, type, frameFilter, profiles}: ImportOptions
 ): Profile {
   if (isSentryContinuousProfile(profile)) {

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -5,7 +5,7 @@ import {defined} from 'sentry/utils';
 import type {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {Frame} from 'sentry/utils/profiling/frame';
 
-type FrameIndex = Record<string | number, Frame>;
+export type FrameIndex = Record<string | number, Frame>;
 
 export function createContinuousProfileFrameIndex(
   frames: Profiling.SentryContinousProfileChunk['profile']['frames'],

--- a/static/app/utils/url/safeURL.tsx
+++ b/static/app/utils/url/safeURL.tsx
@@ -2,7 +2,7 @@
  * Does not throw error on invalid input and returns the parsed URL object
  * if the input is a valid URL, otherwise returns undefined.
  */
-export function safeURL(input: string | URL, base?: string | undefined): URL | undefined {
+export function safeURL(input: string | URL, base?: string): URL | undefined {
   try {
     return new globalThis.URL(input, base);
   } catch {

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -11,7 +11,6 @@ import type {
   IssueAlertRuleAction,
   IssueAlertRuleActionTemplate,
   IssueAlertRuleCondition,
-  IssueAlertRuleConditionTemplate,
 } from 'sentry/types/alerts';
 import {IssueAlertActionType, IssueAlertConditionType} from 'sentry/types/alerts';
 import type {Organization} from 'sentry/types/organization';
@@ -37,9 +36,7 @@ type Props = {
    * All available actions or conditions
    */
   nodes: IssueAlertConfiguration[keyof IssueAlertConfiguration] | null;
-  onAddRow: (
-    value: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate
-  ) => void;
+  onAddRow: (value: IssueAlertRuleActionTemplate) => void;
   onDeleteRow: (ruleIndex: number) => void;
   onPropertyChange: (ruleIndex: number, prop: string, val: string) => void;
   onResetRow: (ruleIndex: number, name: string, value: string) => void;
@@ -105,10 +102,7 @@ const groupLabels = {
  */
 const groupSelectOptions = (actions: IssueAlertRuleActionTemplate[]) => {
   const grouped = actions.reduce<
-    Record<
-      keyof typeof groupLabels,
-      IssueAlertRuleActionTemplate[] | IssueAlertRuleConditionTemplate[]
-    >
+    Record<keyof typeof groupLabels, IssueAlertRuleActionTemplate[]>
   >(
     (acc, curr) => {
       if (curr.actionType === 'ticket') {

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -340,16 +340,16 @@ export function getDatasetConfig<T extends WidgetType | undefined>(
                 ? typeof MobileAppSizeConfig
                 : typeof ErrorsAndTransactionsConfig;
 
-export function getDatasetConfig(
-  widgetType?: WidgetType
-):
+export function getDatasetConfig(widgetType?: WidgetType):
   | typeof IssuesConfig
   | typeof ReleasesConfig
   | typeof ErrorsAndTransactionsConfig
+  /* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
   | typeof ErrorsConfig
   | typeof TransactionsConfig
   | typeof LogsConfig
   | typeof SpansConfig
+  /* eslint-enable @typescript-eslint/no-duplicate-type-constituents */
   | typeof TraceMetricsConfig
   | typeof MobileAppSizeConfig {
   switch (widgetType) {

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -58,7 +58,7 @@ interface SelectRowProps {
   source: string;
   columnFilterMethod?: (
     option: FieldValueOption,
-    fieldValue?: QueryFieldValue | undefined
+    fieldValue?: QueryFieldValue
   ) => boolean;
   disabled?: boolean;
   error?: Record<string, any>;

--- a/static/app/views/dashboards/widgets/common/typePredicates.tsx
+++ b/static/app/views/dashboards/widgets/common/typePredicates.tsx
@@ -20,7 +20,7 @@ export function isAUnitConvertibleFieldType(
 }
 
 export function isAPlottableTimeSeriesValueType(
-  timeSeriesValueType?: string | undefined | null
+  timeSeriesValueType?: string | null
 ): timeSeriesValueType is PlottableTimeSeriesValueType {
   if (!defined(timeSeriesValueType)) {
     return false;

--- a/static/app/views/insights/mobile/screenload/constants.ts
+++ b/static/app/views/insights/mobile/screenload/constants.ts
@@ -27,7 +27,7 @@ export enum YAxis {
   FRAMES_DELAY = 10,
 }
 
-export const YAXIS_COLUMNS: Readonly<Record<YAxis, SpanProperty | SpanProperty>> = {
+export const YAXIS_COLUMNS: Readonly<Record<YAxis, SpanProperty>> = {
   [YAxis.WARM_START]: 'avg(measurements.app_start_warm)',
   [YAxis.COLD_START]: 'avg(measurements.app_start_cold)',
   [YAxis.TTID]: 'avg(measurements.time_to_initial_display)',

--- a/static/app/views/insights/mobile/screens/utils.ts
+++ b/static/app/views/insights/mobile/screens/utils.ts
@@ -4,7 +4,7 @@ import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import type {SpanProperty} from 'sentry/views/insights/types';
 import {VitalState} from 'sentry/views/performance/vitalDetail/utils';
 
-const formatMetricValue = (metric: MetricValue, field?: string | undefined): string => {
+const formatMetricValue = (metric: MetricValue, field?: string): string => {
   if (metric.value === undefined || metric.value === null) {
     return '-';
   }
@@ -54,7 +54,7 @@ type GenericVitalItem<T extends 'spansMetrics' | 'metrics'> = {
   description: string;
   docs: React.ReactNode;
   field: SpanProperty;
-  getStatus: (value: MetricValue, field?: string | undefined) => VitalStatus;
+  getStatus: (value: MetricValue, field?: string) => VitalStatus;
   platformDocLinks: Record<string, string>;
   sdkDocLinks: Record<string, string>;
   setup: React.ReactNode | undefined;
@@ -139,7 +139,7 @@ export function getWarmAppStartPerformance(metric: MetricValue): VitalStatus {
 
 export function getDefaultMetricPerformance(
   metric: MetricValue,
-  field?: string | undefined
+  field?: string
 ): VitalStatus {
   return {
     description: undefined,

--- a/static/app/views/insights/pages/backend/backendTable.tsx
+++ b/static/app/views/insights/pages/backend/backendTable.tsx
@@ -197,7 +197,7 @@ export function BackendOverviewTable({response, sort}: Props) {
   );
 }
 
-function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+function renderPrependColumns(isHeader: boolean, row?: Row) {
   if (isHeader) {
     return [<IconStar key="star" variant="warning" isSolid />];
   }

--- a/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewTable.tsx
@@ -224,7 +224,7 @@ export function FrontendOverviewTable({displayPerfScore, response, sort}: Props)
   );
 }
 
-function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+function renderPrependColumns(isHeader: boolean, row?: Row) {
   if (isHeader) {
     return [<IconStar key="star" variant="warning" isSolid />];
   }

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -178,7 +178,7 @@ export function MobileOverviewTable({response, sort}: Props) {
   );
 }
 
-function renderPrependColumns(isHeader: boolean, row?: Row | undefined) {
+function renderPrependColumns(isHeader: boolean, row?: Row) {
   if (isHeader) {
     return [<IconStar key="star" variant="warning" isSolid />];
   }

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -144,7 +144,6 @@ export function getChartProps({
     | 'chartDateStartDisplay'
     | 'chartDateTimezoneDisplay'
     | 'chartDateEndDisplay'
-    | 'chartStats'
     | 'cardStats'
   >;
   dataCategory: DataCategory;
@@ -324,7 +323,7 @@ export interface UsageStatsOrganizationProps {
     ) => void;
     orgStats: UseApiQueryResult<UsageSeries | undefined, RequestError>;
     usageChart: React.ReactNode;
-  }) => React.ReactNode | React.ReactNode;
+  }) => React.ReactNode;
   clientDiscard?: boolean;
   clock24Hours?: boolean;
   endpointQuery?: ReturnType<typeof getEndpointQuery>;

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -46,7 +46,7 @@ const LANDING_DISPLAYS = [
 ];
 
 export function excludeTransaction(
-  transaction: string | string | number,
+  transaction: string | number,
   props: {eventView: EventView; location: Location}
 ) {
   const {eventView, location} = props;

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -31,7 +31,7 @@ import {EAP_QUERY_PARAMS} from 'sentry/views/performance/landing/widgets/widgets
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToArea>;
-  overall: WidgetDataResult & ReturnType<typeof transformDiscoverToSingleValue>;
+  overall: WidgetDataResult;
 };
 
 export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {

--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -157,7 +157,7 @@ describe('ChangePlanAction', () => {
 
     // Verify tab change changes categories displayed
     expect(screen.getAllByRole('textbox')).toHaveLength(
-      PlanDetailsLookupFixture('am2_business')!.checkoutCategories.length + 2 // +2 for audit fields
+      PlanDetailsLookupFixture('am2_business').checkoutCategories.length + 2 // +2 for audit fields
     );
     expect(screen.getByRole('textbox', {name: 'Performance units'})).toBeInTheDocument();
     expect(screen.queryByRole('textbox', {name: 'Transactions'})).not.toBeInTheDocument();

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1021,7 +1021,7 @@ describe('isNewPayingCustomer', () => {
 });
 
 describe('getOnDemandCategories', () => {
-  const plan = PlanDetailsLookupFixture('am1_business')!;
+  const plan = PlanDetailsLookupFixture('am1_business');
   it('filters out unconfigurable categories for per-category budget mode', () => {
     const categories = getOnDemandCategories({
       plan,
@@ -1046,7 +1046,7 @@ describe('getOnDemandCategories', () => {
 
 describe('getOnDemandCategories - AM2 logBytes support', () => {
   it('does not include logBytes in getOnDemandCategories for AM2 plans in per-category mode', () => {
-    const plan = PlanDetailsLookupFixture('am2_business')!;
+    const plan = PlanDetailsLookupFixture('am2_business');
     const categories = getOnDemandCategories({
       plan,
       budgetMode: OnDemandBudgetMode.PER_CATEGORY,
@@ -1055,7 +1055,7 @@ describe('getOnDemandCategories - AM2 logBytes support', () => {
   });
 
   it('includes logBytes in getOnDemandCategories for AM2 plans in shared mode', () => {
-    const plan = PlanDetailsLookupFixture('am2_business')!;
+    const plan = PlanDetailsLookupFixture('am2_business');
     const categories = getOnDemandCategories({
       plan,
       budgetMode: OnDemandBudgetMode.SHARED,

--- a/static/gsApp/utils/dataCategory.spec.tsx
+++ b/static/gsApp/utils/dataCategory.spec.tsx
@@ -377,7 +377,7 @@ describe('listDisplayNames', () => {
   it('should list categories in order given', () => {
     expect(
       listDisplayNames({
-        plan: plan!,
+        plan,
         categories: [
           DataCategory.SPANS,
           DataCategory.TRANSACTIONS,
@@ -393,8 +393,8 @@ describe('listDisplayNames', () => {
   it('should hide stored spans for no DS', () => {
     expect(
       listDisplayNames({
-        plan: plan!,
-        categories: plan!.checkoutCategories,
+        plan,
+        categories: plan.checkoutCategories,
         hadCustomDynamicSampling: false,
       })
     ).toBe(
@@ -405,8 +405,8 @@ describe('listDisplayNames', () => {
   it('should include stored spans and use accepted spans for DS', () => {
     expect(
       listDisplayNames({
-        plan: plan!,
-        categories: plan!.checkoutCategories,
+        plan,
+        categories: plan.checkoutCategories,
         hadCustomDynamicSampling: true,
       })
     ).toBe(

--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -49,7 +49,7 @@ describe('Cart', () => {
       ...Object.fromEntries(
         Object.entries(businessPlan.planCategories).map(([category, buckets]) => [
           category,
-          buckets[0]!.events,
+          buckets[0].events,
         ])
       ),
       seerAutofix: 0,

--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -39,9 +39,9 @@ describe('Cart', () => {
     ...routerProps,
     navigate: jest.fn(),
   };
-  const businessPlan = PlanDetailsLookupFixture('am3_business')!;
-  const teamPlanAnnual = PlanDetailsLookupFixture('am3_team_auf')!;
-  const legacyTeamPlan = PlanDetailsLookupFixture('am2_team')!;
+  const businessPlan = PlanDetailsLookupFixture('am3_business');
+  const teamPlanAnnual = PlanDetailsLookupFixture('am3_team_auf');
+  const legacyTeamPlan = PlanDetailsLookupFixture('am2_team');
 
   const defaultFormData: CheckoutFormData = {
     plan: 'am3_business',

--- a/static/gsApp/views/amCheckout/components/cartDiff.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cartDiff.spec.tsx
@@ -14,8 +14,8 @@ import CartDiff from 'getsentry/views/amCheckout/components/cartDiff';
 import {type CheckoutFormData} from 'getsentry/views/amCheckout/types';
 
 describe('CartDiff', () => {
-  const bizPlan = PlanDetailsLookupFixture('am3_business')!;
-  const teamAnnualPlan = PlanDetailsLookupFixture('am3_team_auf')!;
+  const bizPlan = PlanDetailsLookupFixture('am3_business');
+  const teamAnnualPlan = PlanDetailsLookupFixture('am3_team_auf');
   const org = OrganizationFixture();
   const sub = SubscriptionFixture({
     organization: org,

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.spec.tsx
@@ -9,7 +9,7 @@ import {PreviewDataFixture} from 'getsentry/__fixtures__/previewData';
 import CheckoutSuccess from 'getsentry/views/amCheckout/components/checkoutSuccess';
 
 describe('CheckoutSuccess', () => {
-  const bizPlan = PlanDetailsLookupFixture('am3_business')!;
+  const bizPlan = PlanDetailsLookupFixture('am3_business');
   const mockDate = new Date('2025-01-01');
 
   beforeEach(() => {

--- a/static/gsApp/views/amCheckout/components/planFeatures.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/planFeatures.spec.tsx
@@ -4,9 +4,9 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import PlanFeatures from 'getsentry/views/amCheckout/components/planFeatures';
 
 describe('PlanFeatures', () => {
-  const freePlan = PlanDetailsLookupFixture('am3_f')!;
-  const teamPlan = PlanDetailsLookupFixture('am3_team')!;
-  const businessPlan = PlanDetailsLookupFixture('am3_business')!;
+  const freePlan = PlanDetailsLookupFixture('am3_f');
+  const teamPlan = PlanDetailsLookupFixture('am3_team');
+  const businessPlan = PlanDetailsLookupFixture('am3_business');
   const planOptions = [freePlan, teamPlan, businessPlan];
 
   it('renders for team plan', () => {

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -75,8 +75,8 @@ describe('ReserveAdditionalVolume', () => {
 
     const billingConfig = BillingConfigFixture(PlanTier.AM2);
     billingConfig.planList = billingConfig.planList.filter(plan => plan.userSelectable);
-    const am2BizPlanMonthly = PlanDetailsLookupFixture('am2_business')!;
-    const am2TeamPlanAnnual = PlanDetailsLookupFixture('am2_team_auf')!;
+    const am2BizPlanMonthly = PlanDetailsLookupFixture('am2_business');
+    const am2TeamPlanAnnual = PlanDetailsLookupFixture('am2_team_auf');
 
     const stepProps = {
       checkoutTier: PlanTier.AM2,
@@ -210,7 +210,7 @@ describe('ReserveAdditionalVolume', () => {
     let subscription: Subscription;
 
     const billingConfig = BillingConfigFixture(PlanTier.AM3);
-    const bizPlanMonthly = PlanDetailsLookupFixture('am3_business')!;
+    const bizPlanMonthly = PlanDetailsLookupFixture('am3_business');
 
     const stepProps: any = {
       checkoutTier: PlanTier.AM3,

--- a/static/gsApp/views/amCheckout/utils.spec.tsx
+++ b/static/gsApp/views/amCheckout/utils.spec.tsx
@@ -5,8 +5,8 @@ import * as utils from 'getsentry/views/amCheckout/utils';
 import {getCheckoutAPIData} from 'getsentry/views/amCheckout/utils';
 
 describe('utils', () => {
-  const teamPlan = PlanDetailsLookupFixture('am1_team')!;
-  const bizPlan = PlanDetailsLookupFixture('am1_business')!;
+  const teamPlan = PlanDetailsLookupFixture('am1_team');
+  const bizPlan = PlanDetailsLookupFixture('am1_business');
   const DEFAULT_ADDONS = {
     [AddOnCategory.LEGACY_SEER]: {
       enabled: false,

--- a/static/gsApp/views/subscriptionPage/overview.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.spec.tsx
@@ -74,7 +74,7 @@ describe('Subscription > Overview', () => {
         onDemandMaxSpend: 0,
         effectiveDate: '2021-09-01',
         onDemandEffectiveDate: '2021-09-01',
-        planDetails: PlanDetailsLookupFixture('mm2_a_100k')!,
+        planDetails: PlanDetailsLookupFixture('mm2_a_100k'),
       }),
     });
 

--- a/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.spec.tsx
@@ -212,7 +212,7 @@ describe('Subscription > UsageAlert', () => {
   it('renders am1 all data categories exceeded request upgrade', () => {
     const organization = OrganizationFixture({access: []});
     const plan_id = 'am1_f';
-    const planDetails = PlanDetailsLookupFixture(plan_id)!;
+    const planDetails = PlanDetailsLookupFixture(plan_id);
     const subCategories = {};
 
     planDetails.categories.forEach(category => {
@@ -255,7 +255,7 @@ describe('Subscription > UsageAlert', () => {
   it('renders am2 all data categories exceeded request upgrade', () => {
     const organization = OrganizationFixture({access: []});
     const plan_id = 'am2_f';
-    const planDetails = PlanDetailsLookupFixture(plan_id)!;
+    const planDetails = PlanDetailsLookupFixture(plan_id);
     const subCategories = {};
 
     planDetails.categories.forEach(category => {
@@ -298,7 +298,7 @@ describe('Subscription > UsageAlert', () => {
   it('renders am3 all data categories exceeded request upgrade', () => {
     const organization = OrganizationFixture({access: []});
     const plan_id = 'am3_f';
-    const planDetails = PlanDetailsLookupFixture(plan_id)!;
+    const planDetails = PlanDetailsLookupFixture(plan_id);
     const subCategories = {};
 
     planDetails.categories.forEach(category => {

--- a/tests/js/getsentry-test/fixtures/am1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am1Plans.ts
@@ -122,7 +122,7 @@ const commonFields = {
   availableReservedBudgetTypes: AM1_AVAILABLE_RESERVED_BUDGET_TYPES,
 };
 
-const AM1_PLANS: Record<string, Plan> = {
+const AM1_PLANS = {
   am1_f: {
     ...commonFields,
     allowAdditionalReservedEvents: false,
@@ -2765,6 +2765,6 @@ const AM1_PLANS: Record<string, Plan> = {
     dashboardLimit: -1,
     metricDetectorLimit: -1,
   },
-};
+} as const satisfies Record<string, Plan>;
 
 export default AM1_PLANS;

--- a/tests/js/getsentry-test/fixtures/am2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am2Plans.ts
@@ -133,7 +133,7 @@ const commonFields = {
 };
 
 // TODO: Update with correct pricing and structure
-const AM2_PLANS: Record<string, Plan> = {
+const AM2_PLANS = {
   am2_business: {
     ...commonFields,
     id: 'am2_business',
@@ -5174,6 +5174,6 @@ const AM2_PLANS: Record<string, Plan> = {
     metricDetectorLimit: -1,
     hasOnDemandModes: false,
   },
-};
+} as const satisfies Record<string, Plan>;
 
 export default AM2_PLANS;

--- a/tests/js/getsentry-test/fixtures/am3Plans.ts
+++ b/tests/js/getsentry-test/fixtures/am3Plans.ts
@@ -292,7 +292,7 @@ const commonFieldsForDs = {
   availableReservedBudgetTypes: AM3_DS_AVAILABLE_RESERVED_BUDGET_TYPES,
 };
 
-const AM3_PLANS: Record<string, Plan> = {
+const AM3_PLANS = {
   am3_business: {
     ...commonFields,
     id: 'am3_business',
@@ -3523,6 +3523,6 @@ const AM3_PLANS: Record<string, Plan> = {
       ],
     },
   },
-};
+} as const satisfies Record<string, Plan>;
 
 export default AM3_PLANS;

--- a/tests/js/getsentry-test/fixtures/billingConfig.ts
+++ b/tests/js/getsentry-test/fixtures/billingConfig.ts
@@ -96,12 +96,13 @@ export function BillingConfigFixture(tier: PlanTier): BillingConfig {
         uptime: 1,
       },
       annualDiscount: 0.1,
-      planList: Object.values(MM1_PLANS).concat(
-        Object.values(MM2_PLANS),
-        Object.values(AM1_PLANS),
-        Object.values(AM2_PLANS),
-        Object.values(AM3_PLANS)
-      ),
+      planList: [
+        ...Object.values(MM1_PLANS),
+        ...Object.values(MM2_PLANS),
+        ...Object.values(AM1_PLANS),
+        ...Object.values(AM2_PLANS),
+        ...Object.values(AM3_PLANS),
+      ],
       featureList: FeatureListFixture(),
     };
   }

--- a/tests/js/getsentry-test/fixtures/billingHistory.ts
+++ b/tests/js/getsentry-test/fixtures/billingHistory.ts
@@ -1,5 +1,8 @@
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
-import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {
+  PlanDetailsLookupFixture,
+  type PlanIds,
+} from 'getsentry-test/fixtures/planDetailsLookup';
 
 import {DataCategory} from 'sentry/types/core';
 
@@ -10,7 +13,7 @@ export function BillingHistoryFixture(
   params: Partial<TBillingHistory> = {}
 ): TBillingHistory {
   const planData = {plan: 'am1_f', ...params};
-  const planDetails = PlanDetailsLookupFixture(planData.plan);
+  const planDetails = PlanDetailsLookupFixture(planData.plan as PlanIds);
 
   return {
     id: '625529670',
@@ -18,9 +21,9 @@ export function BillingHistoryFixture(
     onDemandMaxSpend: 0,
     onDemandSpend: 0,
     onDemandBudgetMode: OnDemandBudgetMode.SHARED,
-    plan: planDetails!.id,
-    planName: planDetails!.name,
-    planDetails: planDetails!,
+    plan: planDetails.id,
+    planName: planDetails.name,
+    planDetails,
     periodStart: '2018-01-01',
     periodEnd: '2018-01-31',
     categories: {

--- a/tests/js/getsentry-test/fixtures/mm1Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm1Plans.ts
@@ -22,7 +22,7 @@ const commonFields = {
   availableReservedBudgetTypes: {},
 };
 
-const MM1_PLANS: Record<string, Plan> = {
+const MM1_PLANS = {
   e1_ac: {
     ...commonFields,
     isTestPlan: false,
@@ -442,6 +442,6 @@ const MM1_PLANS: Record<string, Plan> = {
     dashboardLimit: 0,
     metricDetectorLimit: 0,
   },
-};
+} as const satisfies Record<string, Plan>;
 
 export default MM1_PLANS;

--- a/tests/js/getsentry-test/fixtures/mm2Plans.ts
+++ b/tests/js/getsentry-test/fixtures/mm2Plans.ts
@@ -25,7 +25,7 @@ const commonFields = {
   availableReservedBudgetTypes: {},
 };
 
-const MM2_PLANS: Record<string, Plan> = {
+const MM2_PLANS = {
   mm2_a_100k: {
     ...commonFields,
     isTestPlan: false,
@@ -653,6 +653,6 @@ const MM2_PLANS: Record<string, Plan> = {
     dashboardLimit: 0,
     metricDetectorLimit: 0,
   },
-};
+} as const satisfies Record<string, Plan>;
 
 export default MM2_PLANS;

--- a/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
+++ b/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
@@ -8,11 +8,7 @@ import MM2_PLANS from 'getsentry-test/fixtures/mm2Plans';
 
 import {PlanTier} from 'getsentry/types';
 
-type PlanIds = keyof typeof AM1_PLANS &
-  keyof typeof AM2_PLANS &
-  keyof typeof AM3_PLANS &
-  keyof typeof MM1_PLANS &
-  keyof typeof MM2_PLANS;
+type PlanIds = string;
 
 // Pass a planId to get back details for that particular plan, or 'all'
 // to get a list of all plan detail objects for a plan tier.

--- a/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
+++ b/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
@@ -8,16 +8,25 @@ import MM2_PLANS from 'getsentry-test/fixtures/mm2Plans';
 
 import {PlanTier} from 'getsentry/types';
 
-type PlanIds =
+export type PlanIds =
   | keyof typeof AM1_PLANS
   | keyof typeof AM2_PLANS
   | keyof typeof AM3_PLANS
   | keyof typeof MM1_PLANS
   | keyof typeof MM2_PLANS;
 
+type AllPlans = typeof AM1_PLANS &
+  typeof AM2_PLANS &
+  typeof AM3_PLANS &
+  typeof MM1_PLANS &
+  typeof MM2_PLANS;
+
 // Pass a planId to get back details for that particular plan, or 'all'
 // to get a list of all plan detail objects for a plan tier.
-export function PlanDetailsLookupFixture(planId: PlanIds, tier?: PlanTier) {
+export function PlanDetailsLookupFixture<PlanId extends PlanIds>(
+  planId: PlanId,
+  tier?: PlanTier
+): AllPlans[PlanId] {
   if (!planId) {
     throw new Error('Must provide a planId or `all`');
   }
@@ -33,5 +42,5 @@ export function PlanDetailsLookupFixture(planId: PlanIds, tier?: PlanTier) {
             ? MM2_PLANS[planId as keyof typeof MM2_PLANS]
             : MM1_PLANS[planId as keyof typeof MM1_PLANS];
 
-  return cloneDeep(planData);
+  return cloneDeep(planData) as AllPlans[PlanId];
 }

--- a/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
+++ b/tests/js/getsentry-test/fixtures/planDetailsLookup.ts
@@ -8,7 +8,12 @@ import MM2_PLANS from 'getsentry-test/fixtures/mm2Plans';
 
 import {PlanTier} from 'getsentry/types';
 
-type PlanIds = string;
+type PlanIds =
+  | keyof typeof AM1_PLANS
+  | keyof typeof AM2_PLANS
+  | keyof typeof AM3_PLANS
+  | keyof typeof MM1_PLANS
+  | keyof typeof MM2_PLANS;
 
 // Pass a planId to get back details for that particular plan, or 'all'
 // to get a list of all plan detail objects for a plan tier.
@@ -19,14 +24,14 @@ export function PlanDetailsLookupFixture(planId: PlanIds, tier?: PlanTier) {
 
   const planData =
     (tier ?? planId.startsWith(PlanTier.AM3))
-      ? AM3_PLANS[planId]
+      ? AM3_PLANS[planId as keyof typeof AM3_PLANS]
       : planId.startsWith(PlanTier.AM1)
-        ? AM1_PLANS[planId]
+        ? AM1_PLANS[planId as keyof typeof AM1_PLANS]
         : planId.startsWith(PlanTier.AM2)
-          ? AM2_PLANS[planId]
+          ? AM2_PLANS[planId as keyof typeof AM2_PLANS]
           : planId.startsWith(PlanTier.MM2)
-            ? MM2_PLANS[planId]
-            : MM1_PLANS[planId];
+            ? MM2_PLANS[planId as keyof typeof MM2_PLANS]
+            : MM1_PLANS[planId as keyof typeof MM1_PLANS];
 
   return cloneDeep(planData);
 }

--- a/tests/js/getsentry-test/fixtures/subscription.ts
+++ b/tests/js/getsentry-test/fixtures/subscription.ts
@@ -1,5 +1,8 @@
 import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
-import {PlanDetailsLookupFixture} from 'getsentry-test/fixtures/planDetailsLookup';
+import {
+  PlanDetailsLookupFixture,
+  type PlanIds,
+} from 'getsentry-test/fixtures/planDetailsLookup';
 import {
   DynamicSamplingReservedBudgetFixture,
   ReservedBudgetMetricHistoryFixture,
@@ -22,7 +25,7 @@ export function SubscriptionFixture(props: Props): TSubscription {
 
   // Use planDetails from params if provided, otherwise look it up
   const planDetails = (planData.planDetails ||
-    PlanDetailsLookupFixture(planData.plan)) as Plan;
+    PlanDetailsLookupFixture(planData.plan as PlanIds)) as Plan;
 
   const hasPerformance = planDetails?.categories?.includes(DataCategory.TRANSACTIONS);
   const hasReplays = planDetails?.categories?.includes(DataCategory.REPLAYS);
@@ -337,7 +340,7 @@ export function SubscriptionWithLegacySeerFixture(props: Props): TSubscription {
 
 export function InvoicedSubscriptionFixture(props: Props): TSubscription {
   const planData = {plan: 'am2_business_ent_auf', planTier: 'am2', ...props};
-  const planDetails = PlanDetailsLookupFixture(planData.plan);
+  const planDetails = PlanDetailsLookupFixture(planData.plan as PlanIds);
   const subscription = SubscriptionFixture({
     ...props,
     planDetails,


### PR DESCRIPTION
Enables [`@typescript-eslint/no-duplicate-type-constituents`](https://typescript-eslint.io/rules/no-duplicate-type-constituents), which detects "constituents" (possible types) that are duplicates in intersections and unions.

Fixes ENG-7007.