### PR TITLE
feat(preprod): Return snapshot URL in create snapshot response

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -38,7 +38,7 @@ from sentry.preprod.snapshots.manifest import ComparisonManifest, ImageMetadata,
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.preprod.snapshots.utils import find_base_snapshot_artifact
-from sentry.preprod.url_utils import get_preprod_snapshot_url
+from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
@@ -440,7 +440,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "artifactId": str(artifact.id),
                 "snapshotMetricsId": str(snapshot_metrics.id),
                 "imageCount": snapshot_metrics.image_count,
-                "snapshotUrl": get_preprod_snapshot_url(artifact),
+                "snapshotUrl": get_preprod_artifact_url(artifact, view_type="snapshots"),
             },
             status=200,
         )

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -38,6 +38,7 @@ from sentry.preprod.snapshots.manifest import ComparisonManifest, ImageMetadata,
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.preprod.snapshots.utils import find_base_snapshot_artifact
+from sentry.preprod.url_utils import get_preprod_snapshot_url
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import metrics
@@ -439,6 +440,7 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
                 "artifactId": str(artifact.id),
                 "snapshotMetricsId": str(snapshot_metrics.id),
                 "imageCount": snapshot_metrics.image_count,
+                "snapshotUrl": get_preprod_snapshot_url(artifact),
             },
             status=200,
         )

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -17,6 +17,18 @@ def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str =
     return organization.absolute_url(path, query=query)
 
 
+def get_preprod_snapshot_url(preprod_artifact: PreprodArtifact) -> str:
+    """
+    Build a region/customer-domain aware absolute URL for the snapshot UI.
+    """
+    organization: Organization = Organization.objects.get_from_cache(
+        id=preprod_artifact.project.organization_id
+    )
+    path = f"/organizations/{organization.slug}/preprod/snapshots/{preprod_artifact.id}"
+    query = f"project={preprod_artifact.project.id}"
+    return organization.absolute_url(path, query=query)
+
+
 def get_preprod_artifact_comparison_url(
     preprod_artifact: PreprodArtifact, base_artifact: PreprodArtifact, comparison_type: str = "size"
 ) -> str:

--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -17,18 +17,6 @@ def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str =
     return organization.absolute_url(path, query=query)
 
 
-def get_preprod_snapshot_url(preprod_artifact: PreprodArtifact) -> str:
-    """
-    Build a region/customer-domain aware absolute URL for the snapshot UI.
-    """
-    organization: Organization = Organization.objects.get_from_cache(
-        id=preprod_artifact.project.organization_id
-    )
-    path = f"/organizations/{organization.slug}/preprod/snapshots/{preprod_artifact.id}"
-    query = f"project={preprod_artifact.project.id}"
-    return organization.absolute_url(path, query=query)
-
-
 def get_preprod_artifact_comparison_url(
     preprod_artifact: PreprodArtifact, base_artifact: PreprodArtifact, comparison_type: str = "size"
 ) -> str:


### PR DESCRIPTION
## Summary
- Adds `snapshotUrl` to the POST `/preprodartifacts/snapshots/` response so sentry-cli can display a link to the snapshot after uploading

Requires companion sentry-cli PR to consume the new field.

Fixes EME-899