### PR TITLE
ref(uptime): move test/suggest buttons into verification section

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -81,7 +81,7 @@ function createDefaultAssertionRoot(): UptimeAndOp {
 // XXX(epurkhiser): The types of the FormField render props are absolutely
 // abysmal, so we're leaving this untyped for now.
 
-function UptimeAssertionsControl({onChange, onBlur, value}: any) {
+function UptimeAssertionsControl({onChange, onBlur, value, trailingButtons}: any) {
   const previewCheckResult = usePreviewCheckResult();
 
   // value is an UptimeAssertion object from initialData or defaultValue.
@@ -103,11 +103,19 @@ function UptimeAssertionsControl({onChange, onBlur, value}: any) {
         onChange({root: op}, {});
         onBlur({root: op}, {});
       }}
+      trailingButtons={trailingButtons}
     />
   );
 }
 
-export function UptimeAssertionsField(props: Omit<FormFieldProps, 'children'>) {
+interface UptimeAssertionsFieldProps extends Omit<FormFieldProps, 'children'> {
+  trailingButtons?: React.ReactNode;
+}
+
+export function UptimeAssertionsField({
+  trailingButtons,
+  ...props
+}: UptimeAssertionsFieldProps) {
   return (
     <FormField
       defaultValue={{root: createDefaultAssertionRoot()}}
@@ -128,7 +136,9 @@ export function UptimeAssertionsField(props: Omit<FormFieldProps, 'children'>) {
         return {root: normalizeAssertion(value.root)};
       }}
     >
-      {({ref: _ref, ...fieldProps}) => <UptimeAssertionsControl {...fieldProps} />}
+      {({ref: _ref, ...fieldProps}) => (
+        <UptimeAssertionsControl {...fieldProps} trailingButtons={trailingButtons} />
+      )}
     </FormField>
   );
 }

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {CompositeSelect, type SelectOption} from '@sentry/scraps/compactSelect';
-import {Container, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -34,6 +34,7 @@ interface AssertionOpGroupProps {
   erroredOp?: UptimeOp;
   onRemove?: () => void;
   root?: boolean;
+  trailingButtons?: React.ReactNode;
 }
 
 const GROUP_TYPE_OPTIONS: Array<SelectOption<UptimeOpType.AND | UptimeOpType.OR>> = [
@@ -48,6 +49,7 @@ export function AssertionOpGroup({
   root,
   disableDropping,
   erroredOp,
+  trailingButtons,
 }: AssertionOpGroupProps) {
   const isNegated = value.op === UptimeOpType.NOT;
 
@@ -190,13 +192,14 @@ export function AssertionOpGroup({
       <AssertionsDndContext>
         <Stack gap="md">
           {opList}
-          <div>
+          <Flex align="center" gap="md">
             <AddOpButton
               triggerProps={{icon: <IconAdd />}}
               triggerLabel={t('Add Assertion')}
               onAddOp={handleAddOp}
             />
-          </div>
+            {trailingButtons}
+          </Flex>
         </Stack>
         <DropHandler rootOp={value} onChange={onChange} />
         <DragOverlay dropAnimation={null} />

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -10,7 +9,6 @@ import {
   PreviewCheckResultProvider,
   usePreviewCheckResult,
 } from 'sentry/views/alerts/rules/uptime/previewCheckContext';
-import {useUptimeAssertionFeatures} from 'sentry/views/alerts/rules/uptime/useUptimeAssertionFeatures';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {AssignSection} from 'sentry/views/detectors/components/forms/common/assignSection';
 import {DescribeSection} from 'sentry/views/detectors/components/forms/common/describeSection';
@@ -18,8 +16,6 @@ import {useSetAutomaticName} from 'sentry/views/detectors/components/forms/commo
 import type {DetectorBaseFields} from 'sentry/views/detectors/components/forms/detectorBaseFields';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
 import {NewDetectorLayout} from 'sentry/views/detectors/components/forms/newDetectorLayout';
-import {ConnectedAssertionSuggestionsButton} from 'sentry/views/detectors/components/forms/uptime/connectedAssertionSuggestionsButton';
-import {ConnectedTestUptimeMonitorButton} from 'sentry/views/detectors/components/forms/uptime/connectedTestUptimeMonitorButton';
 import {UptimeDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/uptime/detect';
 import {
   uptimeFormDataToEndpointPayload,
@@ -77,7 +73,6 @@ export function NewUptimeDetectorForm() {
 }
 
 function NewUptimeDetectorFormContent() {
-  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
   const previewCheckResult = usePreviewCheckResult();
 
   return (
@@ -86,14 +81,6 @@ function NewUptimeDetectorFormContent() {
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       initialFormData={{}}
       environment={ENVIRONMENT_CONFIG}
-      extraFooterButton={
-        hasRuntimeAssertions ? (
-          <Fragment>
-            {hasAiAssertionSuggestions && <ConnectedAssertionSuggestionsButton />}
-            <ConnectedTestUptimeMonitorButton />
-          </Fragment>
-        ) : undefined
-      }
       mapFormErrors={createMapFormErrors(previewCheckResult)}
     >
       <UptimeDetectorForm />
@@ -110,7 +97,6 @@ export function EditExistingUptimeDetectorForm({detector}: {detector: UptimeDete
 }
 
 function EditExistingUptimeDetectorFormContent({detector}: {detector: UptimeDetector}) {
-  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
   const previewCheckResult = usePreviewCheckResult();
 
   return (
@@ -119,16 +105,6 @@ function EditExistingUptimeDetectorFormContent({detector}: {detector: UptimeDete
       formDataToEndpointPayload={uptimeFormDataToEndpointPayload}
       savedDetectorToFormData={uptimeSavedDetectorToFormData}
       environment={ENVIRONMENT_CONFIG}
-      extraFooterButton={
-        hasRuntimeAssertions ? (
-          <Fragment>
-            {hasAiAssertionSuggestions && (
-              <ConnectedAssertionSuggestionsButton size="sm" />
-            )}
-            <ConnectedTestUptimeMonitorButton size="sm" />
-          </Fragment>
-        ) : undefined
-      }
       mapFormErrors={createMapFormErrors(previewCheckResult)}
     >
       <UptimeDetectorForm />

--- a/static/app/views/detectors/components/forms/uptime/verification.tsx
+++ b/static/app/views/detectors/components/forms/uptime/verification.tsx
@@ -3,10 +3,12 @@ import Section from 'sentry/components/workflowEngine/ui/section';
 import {t} from 'sentry/locale';
 import {UptimeAssertionsField} from 'sentry/views/alerts/rules/uptime/assertions/field';
 import {useUptimeAssertionFeatures} from 'sentry/views/alerts/rules/uptime/useUptimeAssertionFeatures';
+import {ConnectedAssertionSuggestionsButton} from 'sentry/views/detectors/components/forms/uptime/connectedAssertionSuggestionsButton';
+import {ConnectedTestUptimeMonitorButton} from 'sentry/views/detectors/components/forms/uptime/connectedTestUptimeMonitorButton';
 import {UptimeSectionGrid} from 'sentry/views/detectors/components/forms/uptime/styles';
 
 export function UptimeDetectorVerificationSection() {
-  const {hasRuntimeAssertions} = useUptimeAssertionFeatures();
+  const {hasRuntimeAssertions, hasAiAssertionSuggestions} = useUptimeAssertionFeatures();
 
   if (!hasRuntimeAssertions) {
     return null;
@@ -14,7 +16,10 @@ export function UptimeDetectorVerificationSection() {
 
   return (
     <Container>
-      <Section title={t('Verification')}>
+      <Section
+        title={t('Verification')}
+        trailingItems={<ConnectedTestUptimeMonitorButton size="xs" />}
+      >
         <UptimeSectionGrid>
           <UptimeAssertionsField
             name="assertion"
@@ -23,6 +28,11 @@ export function UptimeDetectorVerificationSection() {
               'Define conditions that must be met for the check to be considered successful.'
             )}
             flexibleControlStateSize
+            trailingButtons={
+              hasAiAssertionSuggestions ? (
+                <ConnectedAssertionSuggestionsButton size="sm" />
+              ) : undefined
+            }
           />
         </UptimeSectionGrid>
       </Section>


### PR DESCRIPTION
Moves the "Test Monitor" button to the Verification section header as a
trailing item, and moves the "Suggest Assertions" button next to the
"+ Add Assertion" button in the assertions field.

Fixes [NEW-763](https://linear.app/getsentry/issue/NEW-763)