### PR TITLE
perf(scim): Bulk add/remove members in SCIM team patch operations 

### DIFF
--- a/src/sentry/core/endpoints/scim/constants.py
+++ b/src/sentry/core/endpoints/scim/constants.py
@@ -43,6 +43,11 @@ SCIM_400_UNSUPPORTED_ATTRIBUTE = {
     "detail": "Invalid Replace attr. Only displayName and members supported.",
 }
 
+SCIM_400_INVALID_PAYLOAD = {
+    "schemas": [SCIM_API_ERROR],
+    "detail": "Invalid SCIM payload.",
+}
+
 SCIM_400_INVALID_PATCH = "Invalid Patch Operation."
 
 

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -49,6 +49,7 @@ from sentry.utils.snowflake import MaxSnowflakeRetryError
 from .constants import (
     SCIM_400_INTEGRITY_ERROR,
     SCIM_400_INVALID_FILTER,
+    SCIM_400_INVALID_PAYLOAD,
     SCIM_400_TOO_MANY_PATCH_OPS_ERROR,
     SCIM_400_UNSUPPORTED_ATTRIBUTE,
     SCIM_404_GROUP_RES,
@@ -67,6 +68,13 @@ from .utils import (
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 logger = logging.getLogger(__name__)
+
+
+def _parse_member_ids(operation_value: list[dict[str, Any]]) -> set[int]:
+    try:
+        return {int(v["value"]) for v in operation_value}
+    except (KeyError, TypeError, ValueError):
+        raise ParseError(detail=SCIM_400_INVALID_PAYLOAD)
 
 
 @extend_schema_serializer(many=True)
@@ -467,13 +475,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                     op = operation["op"].lower()
 
                     if op == TeamPatchOps.ADD and operation["path"] == "members":
-                        try:
-                            member_ids = [int(v["value"]) for v in operation["value"]]
-                        except (KeyError, TypeError, ValueError):
-                            return Response(
-                                {"detail": "Invalid member value format in add operation"},
-                                status=400,
-                            )
+                        member_ids = _parse_member_ids(operation["value"])
                         members = list(
                             OrganizationMember.objects.filter(
                                 organization=team.organization, id__in=member_ids
@@ -517,7 +519,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                                         team_id=team.id
                                     ).select_related("organizationmember")
                                 }
-                                desired_member_ids = {int(v["value"]) for v in operation["value"]}
+                                desired_member_ids = _parse_member_ids(operation["value"])
                                 existing_member_ids = set(existing_omts.keys())
 
                                 # Remove members no longer in the replace list
@@ -557,6 +559,8 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                         else:
                             return Response(SCIM_400_UNSUPPORTED_ATTRIBUTE, status=400)
 
+        except ParseError as e:
+            return Response(e.detail, status=400)
         except OrganizationMember.DoesNotExist:
             raise ResourceDoesNotExist(detail=SCIM_404_USER_RES)
         except IntegrityError as e:

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -485,21 +485,38 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                         path = operation.get("path")
 
                         if path == "members":
-                            # delete all the current team members
-                            # and replace with the ones in the operation list
                             with transaction.atomic(router.db_for_write(OrganizationMember)):
-                                # TODO: We're not removing the members's privileges if they're removed here.
-                                # We should probably find the removed members list by diff-ing the
-                                # existing members and the members in this replace operation.
-                                existing_members = list(
-                                    OrganizationMemberTeam.objects.filter(team_id=team.id)
-                                )
-                                OrganizationMemberTeam.objects.bulk_delete(existing_members)
+                                existing_omts = {
+                                    omt.organizationmember_id: omt
+                                    for omt in OrganizationMemberTeam.objects.filter(
+                                        team_id=team.id
+                                    ).select_related("organizationmember")
+                                }
+                                desired_member_ids = {int(v["value"]) for v in operation["value"]}
+                                existing_member_ids = set(existing_omts.keys())
 
-                                added_members = self._add_members_operation(
-                                    request, operation, team
-                                )
-                                members_to_grant_privileges.extend(added_members)
+                                # Remove members no longer in the replace list
+                                for member_id in existing_member_ids - desired_member_ids:
+                                    omt = existing_omts[member_id]
+                                    if omt.organizationmember.user_id:
+                                        user_ids_to_revoke.append(omt.organizationmember.user_id)
+                                    self._remove_member_operation(request, member_id, team)
+
+                                # Only add members not already on the team
+                                member_ids_to_add = desired_member_ids - existing_member_ids
+                                if member_ids_to_add:
+                                    add_op = {
+                                        **operation,
+                                        "value": [
+                                            v
+                                            for v in operation["value"]
+                                            if int(v["value"]) in member_ids_to_add
+                                        ],
+                                    }
+                                    added_members = self._add_members_operation(
+                                        request, add_op, team
+                                    )
+                                    members_to_grant_privileges.extend(added_members)
 
                         # azure and okta handle team name change operation differently
                         elif path is None:

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -9,7 +9,7 @@ from django.http.response import HttpResponseBase
 from django.utils.text import slugify
 from drf_spectacular.utils import extend_schema, extend_schema_serializer, inline_serializer
 from rest_framework import serializers, status
-from rest_framework.exceptions import ParseError
+from rest_framework.exceptions import APIException, ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -68,6 +68,13 @@ from .utils import (
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 logger = logging.getLogger(__name__)
+
+
+class UnsupportedAttributeError(APIException):
+    status_code = 400
+
+    def __init__(self, detail=None):
+        super().__init__(detail=detail)
 
 
 def _parse_member_ids(operation_value: list[dict[str, Any]]) -> set[int]:
@@ -388,15 +395,15 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                 [OrganizationMemberTeam(team=team, organizationmember=m) for m in members]
             )
 
-        for omt in new_omts:
-            self.create_audit_entry(
-                request=request,
-                organization=team.organization,
-                target_object=omt.id,
-                target_user_id=omt.organizationmember.user_id,
-                event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
-                data=omt.get_audit_log_data(),
-            )
+            for omt in new_omts:
+                self.create_audit_entry(
+                    request=request,
+                    organization=team.organization,
+                    target_object=omt.id,
+                    target_user_id=omt.organizationmember.user_id,
+                    event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
+                    data=omt.get_audit_log_data(),
+                )
 
     def _remove_members_operation(
         self,
@@ -437,6 +444,102 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             data=team.get_audit_log_data(),
         )
 
+    def _handle_add_members_patch_op(
+        self,
+        request: Request,
+        operation: dict[str, Any],
+        team: Team,
+    ) -> list[OrganizationMember]:
+        member_ids = _parse_member_ids(operation["value"])
+        members = list(
+            OrganizationMember.objects.filter(organization=team.organization, id__in=member_ids)
+        )
+        if len(members) != len(member_ids):
+            raise OrganizationMember.DoesNotExist
+        existing = set(
+            OrganizationMemberTeam.objects.filter(
+                team=team, organizationmember__in=members
+            ).values_list("organizationmember_id", flat=True)
+        )
+        new_members = [m for m in members if m.id not in existing]
+        self._add_members_operation(request, new_members, team)
+        return new_members
+
+    def _handle_remove_member_patch_op(
+        self,
+        request: Request,
+        operation: dict[str, Any],
+        team: Team,
+    ) -> int | None:
+        member_id = self._get_member_id_for_remove_op(operation)
+        omt = (
+            OrganizationMemberTeam.objects.filter(
+                team=team,
+                organizationmember__organization=team.organization,
+                organizationmember_id=member_id,
+            )
+            .select_related("organizationmember")
+            .first()
+        )
+        if omt is not None:
+            self._remove_members_operation(request, [omt], team)
+            return omt.organizationmember.user_id
+
+        # If the member is not on the team, we will just gracefully ignore the operation
+        return None
+
+    def _handle_replace_patch_op(
+        self,
+        request: Request,
+        operation: dict[str, Any],
+        team: Team,
+    ) -> tuple[list[OrganizationMember], list[int]] | None:
+        path = operation.get("path")
+
+        if path == "members":
+            with transaction.atomic(router.db_for_write(OrganizationMember)):
+                existing_omts = {
+                    omt.organizationmember_id: omt
+                    for omt in OrganizationMemberTeam.objects.filter(
+                        team_id=team.id
+                    ).select_related("organizationmember")
+                }
+                desired_member_ids = _parse_member_ids(operation["value"])
+                existing_member_ids = set(existing_omts.keys())
+
+                # Remove members no longer in the replace list
+                omts_to_remove = []
+                revoked_user_ids = []
+                for member_id in existing_member_ids - desired_member_ids:
+                    omt = existing_omts[member_id]
+                    omts_to_remove.append(omt)
+                    if omt.organizationmember.user_id is not None:
+                        revoked_user_ids.append(omt.organizationmember.user_id)
+                self._remove_members_operation(request, omts_to_remove, team)
+
+                # Only add members not already on the team
+                new_members = []
+                member_ids_to_add = desired_member_ids - existing_member_ids
+                if member_ids_to_add:
+                    new_members = list(
+                        OrganizationMember.objects.filter(
+                            organization=team.organization,
+                            id__in=member_ids_to_add,
+                        )
+                    )
+                    if len(new_members) != len(member_ids_to_add):
+                        raise OrganizationMember.DoesNotExist
+                    self._add_members_operation(request, new_members, team)
+            return new_members, revoked_user_ids
+
+        elif path is None:
+            self._rename_team_operation(request, operation["value"]["displayName"], team)
+        elif path == "displayName":
+            self._rename_team_operation(request, operation["value"], team)
+        else:
+            raise UnsupportedAttributeError(detail=SCIM_400_UNSUPPORTED_ATTRIBUTE)
+        return None
+
     @extend_schema(
         operation_id="Update a Team's Attributes",
         parameters=[GlobalParams.ORG_ID_OR_SLUG, GlobalParams.TEAM_ID_OR_SLUG],
@@ -463,7 +566,6 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             return Response(SCIM_400_TOO_MANY_PATCH_OPS_ERROR, status=400)
 
         user_ids_to_revoke_privileges: list[int] = []
-
         members_to_grant_privileges: list[OrganizationMember] = []
 
         try:
@@ -475,91 +577,30 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                     op = operation["op"].lower()
 
                     if op == TeamPatchOps.ADD and operation["path"] == "members":
-                        member_ids = _parse_member_ids(operation["value"])
-                        members = list(
-                            OrganizationMember.objects.filter(
-                                organization=team.organization, id__in=member_ids
-                            )
-                        )
-                        if len(members) != len(member_ids):
-                            raise OrganizationMember.DoesNotExist
-                        existing = set(
-                            OrganizationMemberTeam.objects.filter(
-                                team=team, organizationmember__in=members
-                            ).values_list("organizationmember_id", flat=True)
-                        )
-                        new_members = [m for m in members if m.id not in existing]
-                        self._add_members_operation(request, new_members, team)
+                        new_members = self._handle_add_members_patch_op(request, operation, team)
                         members_to_grant_privileges.extend(new_members)
 
                     elif op == TeamPatchOps.REMOVE and "members" in operation["path"]:
-                        member_id = self._get_member_id_for_remove_op(operation)
-                        omt = (
-                            OrganizationMemberTeam.objects.filter(
-                                team=team,
-                                organizationmember__organization=team.organization,
-                                organizationmember_id=member_id,
-                            )
-                            .select_related("organizationmember")
-                            .first()
+                        revoked_user_id = self._handle_remove_member_patch_op(
+                            request, operation, team
                         )
-                        if omt is not None:
-                            if omt.organizationmember.user_id:
-                                user_ids_to_revoke_privileges.append(omt.organizationmember.user_id)
-                            self._remove_members_operation(request, [omt], team)
+                        if revoked_user_id is not None:
+                            user_ids_to_revoke_privileges.append(revoked_user_id)
 
                     elif op == TeamPatchOps.REPLACE:
-                        path = operation.get("path")
-
-                        if path == "members":
-                            with transaction.atomic(router.db_for_write(OrganizationMember)):
-                                existing_omts = {
-                                    omt.organizationmember_id: omt
-                                    for omt in OrganizationMemberTeam.objects.filter(
-                                        team_id=team.id
-                                    ).select_related("organizationmember")
-                                }
-                                desired_member_ids = _parse_member_ids(operation["value"])
-                                existing_member_ids = set(existing_omts.keys())
-
-                                # Remove members no longer in the replace list
-                                omts_to_remove = []
-                                for member_id in existing_member_ids - desired_member_ids:
-                                    omt = existing_omts[member_id]
-                                    if omt.organizationmember.user_id:
-                                        user_ids_to_revoke_privileges.append(
-                                            omt.organizationmember.user_id
-                                        )
-                                    omts_to_remove.append(omt)
-                                self._remove_members_operation(request, omts_to_remove, team)
-
-                                # Only add members not already on the team
-                                member_ids_to_add = desired_member_ids - existing_member_ids
-                                if member_ids_to_add:
-                                    new_members = list(
-                                        OrganizationMember.objects.filter(
-                                            organization=team.organization,
-                                            id__in=member_ids_to_add,
-                                        )
-                                    )
-                                    if len(new_members) != len(member_ids_to_add):
-                                        raise OrganizationMember.DoesNotExist
-                                    self._add_members_operation(request, new_members, team)
-                                    members_to_grant_privileges.extend(new_members)
-
-                        # azure and okta handle team name change operation differently
-                        elif path is None:
-                            # for okta
-                            self._rename_team_operation(
-                                request, operation["value"]["displayName"], team
-                            )
-                        elif path == "displayName":
-                            # for azure
-                            self._rename_team_operation(request, operation["value"], team)
-                        else:
-                            return Response(SCIM_400_UNSUPPORTED_ATTRIBUTE, status=400)
+                        replaced_output = self._handle_replace_patch_op(
+                            request,
+                            operation,
+                            team,
+                        )
+                        if replaced_output is not None:
+                            new_members, revoked_users = replaced_output
+                            members_to_grant_privileges.extend(new_members)
+                            user_ids_to_revoke_privileges.extend(revoked_users)
 
         except ParseError as e:
+            return Response(e.detail, status=400)
+        except UnsupportedAttributeError as e:
             return Response(e.detail, status=400)
         except OrganizationMember.DoesNotExist:
             raise ResourceDoesNotExist(detail=SCIM_404_USER_RES)

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -366,53 +366,50 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             )
         )
 
-    def _add_members_operation(self, request: Request, operation, team) -> list[OrganizationMember]:
-        added_members = []
-
-        for member_data in operation["value"]:
-            member = OrganizationMember.objects.get(
-                organization=team.organization, id=member_data["value"]
-            )
-            if OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists():
-                continue
-
-            with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
-                omt = OrganizationMemberTeam.objects.create(team=team, organizationmember=member)
-                self.create_audit_entry(
-                    request=request,
-                    organization=team.organization,
-                    target_object=omt.id,
-                    target_user_id=member.user_id,
-                    event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
-                    data=omt.get_audit_log_data(),
-                )
-
-            added_members.append(member)
-
-        return added_members
-
-    def _remove_member_operation(
-        self, request: Request, member_id, team
-    ) -> OrganizationMember | None:
-        member = OrganizationMember.objects.get(organization=team.organization, id=member_id)
+    def _add_members_operation(
+        self,
+        request: Request,
+        members: list[OrganizationMember],
+        team: Team,
+    ) -> None:
+        if not members:
+            return
 
         with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
-            try:
-                omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
-            except OrganizationMemberTeam.DoesNotExist:
-                return None
+            new_omts = OrganizationMemberTeam.objects.bulk_create(
+                [OrganizationMemberTeam(team=team, organizationmember=m) for m in members]
+            )
 
+        for omt in new_omts:
             self.create_audit_entry(
                 request=request,
                 organization=team.organization,
                 target_object=omt.id,
-                target_user_id=member.user_id,
-                event=audit_log.get_event_id("MEMBER_LEAVE_TEAM"),
+                target_user_id=omt.organizationmember.user_id,
+                event=audit_log.get_event_id("MEMBER_JOIN_TEAM"),
                 data=omt.get_audit_log_data(),
             )
-            omt.delete()
 
-        return member
+    def _remove_members_operation(
+        self,
+        request: Request,
+        omts: list[OrganizationMemberTeam],
+        team: Team,
+    ) -> None:
+        if not omts:
+            return
+
+        with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
+            for omt in omts:
+                self.create_audit_entry(
+                    request=request,
+                    organization=team.organization,
+                    target_object=omt.id,
+                    target_user_id=omt.organizationmember.user_id,
+                    event=audit_log.get_event_id("MEMBER_LEAVE_TEAM"),
+                    data=omt.get_audit_log_data(),
+                )
+            OrganizationMemberTeam.objects.bulk_delete(omts)
 
     def _rename_team_operation(self, request: Request, new_name, team):
         serializer = TeamSerializer(
@@ -457,9 +454,10 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         if len(operations) > 100:
             return Response(SCIM_400_TOO_MANY_PATCH_OPS_ERROR, status=400)
 
-        user_ids_to_revoke: list[int] = []
+        user_ids_to_revoke_privileges: list[int] = []
 
         members_to_grant_privileges: list[OrganizationMember] = []
+
         try:
             with transaction.atomic(router.db_for_write(OrganizationMemberTeam)):
                 team.idp_provisioned = True
@@ -469,17 +467,44 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                     op = operation["op"].lower()
 
                     if op == TeamPatchOps.ADD and operation["path"] == "members":
-                        added_members = self._add_members_operation(request, operation, team)
-                        members_to_grant_privileges.extend(added_members)
+                        try:
+                            member_ids = [int(v["value"]) for v in operation["value"]]
+                        except (KeyError, TypeError, ValueError):
+                            return Response(
+                                {"detail": "Invalid member value format in add operation"},
+                                status=400,
+                            )
+                        members = list(
+                            OrganizationMember.objects.filter(
+                                organization=team.organization, id__in=member_ids
+                            )
+                        )
+                        if len(members) != len(member_ids):
+                            raise OrganizationMember.DoesNotExist
+                        existing = set(
+                            OrganizationMemberTeam.objects.filter(
+                                team=team, organizationmember__in=members
+                            ).values_list("organizationmember_id", flat=True)
+                        )
+                        new_members = [m for m in members if m.id not in existing]
+                        self._add_members_operation(request, new_members, team)
+                        members_to_grant_privileges.extend(new_members)
 
                     elif op == TeamPatchOps.REMOVE and "members" in operation["path"]:
                         member_id = self._get_member_id_for_remove_op(operation)
-                        member = OrganizationMember.objects.get(
-                            organization=team.organization, id=member_id
+                        omt = (
+                            OrganizationMemberTeam.objects.filter(
+                                team=team,
+                                organizationmember__organization=team.organization,
+                                organizationmember_id=member_id,
+                            )
+                            .select_related("organizationmember")
+                            .first()
                         )
-                        if member.user_id:
-                            user_ids_to_revoke.append(member.user_id)
-                        self._remove_member_operation(request, member_id, team)
+                        if omt is not None:
+                            if omt.organizationmember.user_id:
+                                user_ids_to_revoke_privileges.append(omt.organizationmember.user_id)
+                            self._remove_members_operation(request, [omt], team)
 
                     elif op == TeamPatchOps.REPLACE:
                         path = operation.get("path")
@@ -496,27 +521,29 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                                 existing_member_ids = set(existing_omts.keys())
 
                                 # Remove members no longer in the replace list
+                                omts_to_remove = []
                                 for member_id in existing_member_ids - desired_member_ids:
                                     omt = existing_omts[member_id]
                                     if omt.organizationmember.user_id:
-                                        user_ids_to_revoke.append(omt.organizationmember.user_id)
-                                    self._remove_member_operation(request, member_id, team)
+                                        user_ids_to_revoke_privileges.append(
+                                            omt.organizationmember.user_id
+                                        )
+                                    omts_to_remove.append(omt)
+                                self._remove_members_operation(request, omts_to_remove, team)
 
                                 # Only add members not already on the team
                                 member_ids_to_add = desired_member_ids - existing_member_ids
                                 if member_ids_to_add:
-                                    add_op = {
-                                        **operation,
-                                        "value": [
-                                            v
-                                            for v in operation["value"]
-                                            if int(v["value"]) in member_ids_to_add
-                                        ],
-                                    }
-                                    added_members = self._add_members_operation(
-                                        request, add_op, team
+                                    new_members = list(
+                                        OrganizationMember.objects.filter(
+                                            organization=team.organization,
+                                            id__in=member_ids_to_add,
+                                        )
                                     )
-                                    members_to_grant_privileges.extend(added_members)
+                                    if len(new_members) != len(member_ids_to_add):
+                                        raise OrganizationMember.DoesNotExist
+                                    self._add_members_operation(request, new_members, team)
+                                    members_to_grant_privileges.extend(new_members)
 
                         # azure and okta handle team name change operation differently
                         elif path is None:
@@ -544,7 +571,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
                 team_slug=team.slug,
                 organization_id=team.organization.id,
                 user_ids_to_grant=user_ids_to_grant,
-                user_ids_to_revoke=user_ids_to_revoke,
+                user_ids_to_revoke=user_ids_to_revoke_privileges,
             )
 
         metrics.incr("sentry.scim.team.update", tags={"organization": organization})

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -343,6 +343,70 @@ class SCIMDetailPatchTest(SCIMTestCase):
             "scimType": "invalidFilter",
         }
 
+    def test_add_members_invalid_value_format(self) -> None:
+        self.base_data["Operations"] = [
+            {
+                "op": "add",
+                "path": "members",
+                "value": [{"bad_key": "not_a_value"}],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=400
+        )
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail": "Invalid SCIM payload.",
+        }
+
+    def test_add_members_non_numeric_value(self) -> None:
+        self.base_data["Operations"] = [
+            {
+                "op": "add",
+                "path": "members",
+                "value": [{"value": "not_a_number"}],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=400
+        )
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail": "Invalid SCIM payload.",
+        }
+
+    def test_replace_members_invalid_value_format(self) -> None:
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [{"bad_key": "not_a_value"}],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=400
+        )
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail": "Invalid SCIM payload.",
+        }
+
+    def test_replace_members_non_numeric_value(self) -> None:
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [{"value": "not_a_number"}],
+            }
+        ]
+        response = self.get_error_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=400
+        )
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail": "Invalid SCIM payload.",
+        }
+
     def test_rename_team_azure_request(self) -> None:
         self.base_data["Operations"] = [
             {"op": "Replace", "path": "displayName", "value": "theNewName"}

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -226,6 +226,74 @@ class SCIMDetailPatchTest(SCIMTestCase):
         ).exists()
         assert Team.objects.get(id=self.team.id).idp_provisioned
 
+    def test_replace_members_keeps_overlapping_members(self) -> None:
+        # member_on_team is already on the team; replacing with member_on_team + member_one
+        # should keep member_on_team untouched and only add member_one
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [
+                    {
+                        "value": self.member_on_team.id,
+                        "display": "existing@example.com",
+                    },
+                    {
+                        "value": self.member_one.id,
+                        "display": "new@example.com",
+                    },
+                ],
+            }
+        ]
+        self.get_success_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=204
+        )
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_on_team.id
+        ).exists()
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_one.id
+        ).exists()
+        assert not OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_two.id
+        ).exists()
+
+    def test_replace_members_with_identical_list_is_noop(self) -> None:
+        # Replacing with the same member already on the team should change nothing
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [
+                    {
+                        "value": self.member_on_team.id,
+                        "display": "already@example.com",
+                    },
+                ],
+            }
+        ]
+        self.get_success_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=204
+        )
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_on_team.id
+        ).exists()
+        assert OrganizationMemberTeam.objects.filter(team_id=self.team.id).count() == 1
+
+    def test_replace_members_with_empty_list(self) -> None:
+        # Replacing with an empty list should remove all members
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [],
+            }
+        ]
+        self.get_success_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=204
+        )
+        assert not OrganizationMemberTeam.objects.filter(team_id=self.team.id).exists()
+
     def test_team_member_doesnt_exist_add_to_team(self) -> None:
         self.base_data["Operations"] = [
             {
@@ -510,6 +578,10 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
                 organization=self.organization, slug="snty-staff", idp_provisioned=True
             )
 
+            self.user_one.is_staff = True
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                self.user_one.save()
+
             OrganizationMemberTeam.objects.create(
                 team=staff_team, organizationmember=self.member_one
             )
@@ -535,6 +607,10 @@ class SCIMPrivilegeManagementTest(SCIMTestCase):
             # The new member gets granted staff
             self.user_two.refresh_from_db()
             assert self.user_two.is_staff
+
+            # The removed member gets staff revoked
+            self.user_one.refresh_from_db()
+            assert not self.user_one.is_staff
 
     def test_adding_to_superuser_write_group_dispatches_task(self) -> None:
         from sentry.users.models.userpermission import UserPermission

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -329,6 +329,65 @@ class SCIMDetailPatchTest(SCIMTestCase):
         ).exists()
         assert OrganizationMemberTeam.objects.filter(team_id=self.team.id).count() == 1
 
+    def test_replace_members_query_count(self) -> None:
+        """The replace-members path should use a bounded number of core data
+        queries regardless of member count: 1 SELECT existing OMTs,
+        1 SELECT new OrgMembers, 1 bulk DELETE, 1 bulk INSERT.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [
+                    {
+                        "value": self.member_one.id,
+                        "display": "test.user@okta.local",
+                    },
+                    {
+                        "value": self.member_two.id,
+                        "display": "test.user2@okta.local",
+                    },
+                ],
+            }
+        ]
+
+        # Removes 1 existing member (member_on_team), adds 2 new members.
+        with CaptureQueriesContext(connection) as ctx:
+            self.get_success_response(
+                self.organization.slug, self.team.id, **self.base_data, status_code=204
+            )
+
+        # Count the core replace-path queries:
+        # - SELECT on OMT with JOIN to OM (fetch existing with select_related)
+        # - DELETE on OMT (bulk delete removed members)
+        # - SELECT on OM with IN clause (batch fetch new members)
+        # - INSERT on OMT (bulk create new memberships)
+        # Exclude: auth lookups, outbox replication callbacks, savepoints,
+        # audit logs, bulk_delete pre-fetches, and sequence nextval calls.
+        core_queries = []
+        for q in ctx.captured_queries:
+            sql = q["sql"]
+            is_fetch_existing = "INNER JOIN" in sql and "sentry_organizationmember_teams" in sql
+            is_bulk_delete = sql.startswith("DELETE") and "sentry_organizationmember_teams" in sql
+            is_fetch_new = (
+                sql.startswith("SELECT")
+                and '"sentry_organizationmember"' in sql
+                and "IN" in sql
+                and "sentry_organizationmember_teams" not in sql
+            )
+            is_bulk_insert = sql.startswith("INSERT") and "sentry_organizationmember_teams" in sql
+            if is_fetch_existing or is_bulk_delete or is_fetch_new or is_bulk_insert:
+                core_queries.append(sql)
+
+        # Exactly 4 core queries, none of which scale with member count
+        assert len(core_queries) <= 4, (
+            f"Expected at most 4 core member queries, got {len(core_queries)}:\n"
+            + "\n".join(f"  {i + 1}. {q[:120]}" for i, q in enumerate(core_queries))
+        )
+
     def test_replace_members_with_empty_list(self) -> None:
         # Replacing with an empty list should remove all members
         self.base_data["Operations"] = [

--- a/tests/sentry/core/endpoints/scim/test_scim_team_details.py
+++ b/tests/sentry/core/endpoints/scim/test_scim_team_details.py
@@ -258,6 +258,55 @@ class SCIMDetailPatchTest(SCIMTestCase):
             team_id=self.team.id, organizationmember_id=self.member_two.id
         ).exists()
 
+    def test_add_multiple_members(self) -> None:
+        self.base_data["Operations"] = [
+            {
+                "op": "add",
+                "path": "members",
+                "value": [
+                    {"value": self.member_one.id, "display": "one@example.com"},
+                    {"value": self.member_two.id, "display": "two@example.com"},
+                ],
+            },
+        ]
+        self.get_success_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=204
+        )
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_one.id
+        ).exists()
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_two.id
+        ).exists()
+
+    def test_replace_members_preserves_overlapping_membership_row(self) -> None:
+        original_omt = OrganizationMemberTeam.objects.get(
+            team_id=self.team.id, organizationmember_id=self.member_on_team.id
+        )
+        self.base_data["Operations"] = [
+            {
+                "op": "replace",
+                "path": "members",
+                "value": [
+                    {"value": self.member_on_team.id, "display": "existing@example.com"},
+                    {"value": self.member_one.id, "display": "new@example.com"},
+                ],
+            }
+        ]
+        self.get_success_response(
+            self.organization.slug, self.team.id, **self.base_data, status_code=204
+        )
+        # The overlapping member's row is the same DB object, not deleted and re-created
+        assert OrganizationMemberTeam.objects.filter(id=original_omt.id).exists()
+        # New member was added
+        assert OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_one.id
+        ).exists()
+        # member_two was not in the replace list and should not be on the team
+        assert not OrganizationMemberTeam.objects.filter(
+            team_id=self.team.id, organizationmember_id=self.member_two.id
+        ).exists()
+
     def test_replace_members_with_identical_list_is_noop(self) -> None:
         # Replacing with the same member already on the team should change nothing
         self.base_data["Operations"] = [


### PR DESCRIPTION
I've added a bunch of performance related updates, as well as fixing the privilege revocation for the `REPLACE` SCIM operation.

## Summary
                                                                                                                                                             
  - Refactor SCIM team replace-members to use a diff-based approach instead of delete-all/re-add-all, preserving existing memberships for overlapping members
  - The refactored diff-based approach makes it possible to do privilege revocation for members removed from a REPLACE operation
  - Refactor `_add_members_operation` to accept pre-fetched `OrganizationMember` objects and use `bulk_create` instead of per-member `create()` calls                                   
  - Refactor `_remove_members_operation` to accept `OrganizationMemberTeam` objects and use a single bulk `filter(id__in=...).delete()` query                                           
  - Both callers (standalone add/remove ops and replace-members path) now batch-fetch members with `filter(id__in=...)` to eliminate per-member DB round trips                          
                                                            
  ### Replace-members diff approach

  The replace-members path now computes the diff between existing and desired members:
  - **Overlapping members** are left untouched (no spurious leave/join audit entries, no unnecessary outbox churn)
  - **Removed members** are bulk-deleted in a single query
  - **Added members** are bulk-created in a single query

  ### Query reduction

  **Before (per-member):**
  - Add: `.get()` + `.exists()` + `.create()` = 3 queries per member
  - Remove: `.get()` + `.get()` + `.delete()` = 3 queries per member

  **After (bulk):**
  - Add: 1 `filter(id__in=...)` + 1 `filter(...).values_list(...)` + 1 `bulk_create` = 3 queries total
  - Remove: 1 `filter(id__in=...).delete()` = 1 query total

  For replace-members with N existing and M desired members sharing K overlap, audit writes drop from N+M to (N-K)+(M-K).

