### PR TITLE
ref(attachments): Remove objectstore double-write code

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -6,7 +6,6 @@ from hashlib import sha1
 from io import BytesIO
 from typing import IO, Any
 
-import sentry_sdk
 import zstandard
 from django.core.cache import cache
 from django.db import models
@@ -21,7 +20,6 @@ from sentry.models.files.utils import get_size_and_checksum, get_storage
 from sentry.objectstore import get_attachments_session
 from sentry.objectstore.metrics import measure_storage_operation
 from sentry.options.rollout import in_random_rollout
-from sentry.utils import metrics
 
 # Attachment file types that are considered a crash report (PII relevant)
 CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport")
@@ -79,7 +77,7 @@ class EventAttachment(Model):
       It is saved inline in `blob_path` following the `:` prefix.
       This happens for "small" and ASCII-only (see `can_store_inline`) attachments.
     - When the `blob_path` field has a `eventattachments/v1/` prefix:
-      In this case, the default :func:`get_storage` is used as the backing store.
+      The default :func:`get_storage` is used as the backing store.
       The attachment data is not chunked or deduplicated in this case.
       However, it is `zstd` compressed.
     """
@@ -131,17 +129,6 @@ class EventAttachment(Model):
                 with measure_storage_operation("delete", "attachments"):
                     storage.delete(self.blob_path)
 
-                # delete double-written attachments
-                blob_path = self.blob_path.removeprefix(V1_PREFIX)
-                if blob_path.startswith(V2_PREFIX):
-                    try:
-                        organization_id = _get_organization(self.project_id)
-                        get_attachments_session(organization_id, self.project_id).delete(
-                            blob_path.removeprefix(V2_PREFIX)
-                        )
-                    except Exception:
-                        sentry_sdk.capture_exception()
-
             elif self.blob_path.startswith(V2_PREFIX):
                 organization_id = _get_organization(self.project_id)
                 get_attachments_session(organization_id, self.project_id).delete(
@@ -183,9 +170,9 @@ class EventAttachment(Model):
     def get_blob_stream(self, accept_encoding: list[str]) -> BlobStream:
         """Return a streamable blob, negotiating content-encoding for V2 blobs.
 
-        For pure V2 blobs, passes ``accept_encoding`` to the objectstore so compressed
+        For V2 blobs, passes ``accept_encoding`` to the objectstore so compressed
         bytes can be transferred directly to the client. For all other blob types
-        (inline, V1, V1+V2 double-write), delegates to :meth:`getfile`.
+        (inline, V1), delegates to :meth:`getfile`.
         """
         if self.blob_path and self.blob_path.startswith(V2_PREFIX):
             key = self.blob_path.removeprefix(V2_PREFIX)
@@ -218,16 +205,7 @@ class EventAttachment(Model):
             from sentry.models.files import FileBlob
 
             object_key = FileBlob.generate_unique_path()
-            blob_path = V1_PREFIX
-            if in_random_rollout("objectstore.double_write.attachments"):
-                try:
-                    organization_id = _get_organization(project_id)
-                    get_attachments_session(organization_id, project_id).put(data, key=object_key)
-                    metrics.incr("storage.attachments.double_write")
-                    blob_path += V2_PREFIX
-                except Exception:
-                    sentry_sdk.capture_exception()
-            blob_path += object_key
+            blob_path = V1_PREFIX + object_key
 
             storage = get_storage()
             with measure_storage_operation("put", "attachments", size) as metric_emitter:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3897,9 +3897,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Fraction of attachments that are double-written to the new objectstore alongside the existing attachments store.
-# This is mutually exclusive with the below setting.
-register("objectstore.double_write.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Fraction of attachments that are being stored exclusively in the new objectstore.
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 # Fraction of attachments that are being stored on objectstore for processing and long-term storage.

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -3,8 +3,7 @@ from django.test import override_settings
 
 from sentry.attachments.base import CachedAttachment
 from sentry.models.activity import Activity
-from sentry.models.eventattachment import V1_PREFIX, V2_PREFIX, EventAttachment
-from sentry.objectstore import get_attachments_session
+from sentry.models.eventattachment import EventAttachment
 from sentry.testutils.cases import APITestCase, PermissionTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -85,31 +84,6 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.get("Content-Length") == str(self.attachment.size)
         assert response.get("Content-Type") == "image/png"
         assert close_streaming_response(response) == ATTACHMENT_CONTENT
-
-    @with_feature("organizations:event-attachments")
-    @requires_objectstore
-    def test_doublewrite_objectstore(self) -> None:
-        self.login_as(user=self.user)
-
-        with override_options({"objectstore.double_write.attachments": 1}):
-            attachment = self.create_attachment()
-
-            assert attachment.blob_path is not None
-            object_key = attachment.blob_path.removeprefix(V1_PREFIX + V2_PREFIX)
-            # the file should also be available in objectstore
-            os_response = get_attachments_session(self.organization.id, self.project.id).get(
-                object_key
-            )
-            assert os_response.payload.read() == ATTACHMENT_CONTENT
-
-            path1 = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{attachment.id}/?download"
-            response = self.client.get(path1)
-
-            assert response.status_code == 200, response.content
-            assert response.get("Content-Disposition") == 'attachment; filename="hello.png"'
-            assert response.get("Content-Length") == str(attachment.size)
-            assert response.get("Content-Type") == "image/png"
-            assert close_streaming_response(response) == ATTACHMENT_CONTENT
 
     @with_feature("organizations:event-attachments")
     @requires_objectstore


### PR DESCRIPTION
The `objectstore.double_write.attachments` migration path wrote attachments to both V1 file storage and the V2 objectstore simultaneously, allowing a gradual rollout of the new backend. This migration is complete and the double-write path is no longer needed.

Removes the feature option registration, the write/delete logic in `EventAttachment.putfile` and `EventAttachment.delete`, and the corresponding test. V1 and V2 storage paths are fully preserved.

Ref FS-281