### PR TITLE
ref: Remove unused history/$historyId/ from KnownGetsentryApiUrls

### DIFF
--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -28,7 +28,6 @@ export type KnownGetsentryApiUrls =
   | '/customers/$organizationIdOrSlug/charges/'
   | '/customers/$organizationIdOrSlug/charges/$chargeId/'
   | '/customers/$organizationIdOrSlug/history/'
-  | '/customers/$organizationIdOrSlug/history/$historyId/'
   | '/customers/$organizationIdOrSlug/history/current/'
   | '/customers/$organizationIdOrSlug/invoices/'
   | '/customers/$organizationIdOrSlug/invoices/$invoiceId/'


### PR DESCRIPTION
The customer history detail endpoint is no longer needed in the known API URL type registry.
