### PR TITLE
ref(attachments): Clean up objectstore rollout options

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -165,12 +165,11 @@ x-sentry-service-config:
       description: Kafka consumer for uptime monitoring results
 
   modes:
-    default: [snuba, postgres, relay, spotlight]
+    default: [snuba, postgres, relay, spotlight, objectstore]
     migrations: [postgres, redis]
     acceptance-ci: [postgres, snuba, chartcuterie]
     chartcuterie: [postgres, snuba, chartcuterie, spotlight]
     launchpad: [snuba, postgres, launchpad, taskbroker, taskworker, objectstore]
-    objectstore: [snuba, postgres, relay, spotlight, objectstore]
     taskbroker: [snuba, postgres, relay, spotlight, taskbroker]
     taskworker:
       [snuba, postgres, relay, taskbroker, spotlight, taskworker, taskworker-scheduler]
@@ -248,6 +247,7 @@ x-sentry-service-config:
         postgres,
         relay,
         spotlight,
+        objectstore,
         taskbroker,
         taskworker,
         ingest-events,
@@ -297,6 +297,7 @@ x-sentry-service-config:
         process-spans,
         relay,
         symbolicator,
+        objectstore,
         snuba,
         spotlight,
         taskbroker,

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 import zstandard
 
 from sentry.objectstore import get_attachments_session
-from sentry.options.rollout import in_random_rollout
 from sentry.utils import metrics
 from sentry.utils.json import prune_empty_keys
 
@@ -145,13 +144,7 @@ class BaseAttachmentCache:
             if attachment.chunks is not None or attachment.stored_id is not None:
                 continue
 
-            # otherwise, store it in objectstore or the attachments cache:
-            if in_random_rollout("objectstore.enable_for.cached_attachments"):
-                assert project
-                session = get_attachments_session(project.organization_id, project.id)
-                attachment.stored_id = session.put(attachment.load_data(project))
-                continue
-
+            # otherwise, store it in the attachment cache:
             metrics_tags = {"type": attachment.type}
             self.set_unchunked_data(
                 key=key,

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -80,8 +80,6 @@ class EventAttachment(Model):
       The default :func:`get_storage` is used as the backing store.
       The attachment data is not chunked or deduplicated in this case.
       However, it is `zstd` compressed.
-    - When the `blob_path` field has a `v2/` prefix:
-      The objectstore is used as the backing store.
     """
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -80,6 +80,8 @@ class EventAttachment(Model):
       The default :func:`get_storage` is used as the backing store.
       The attachment data is not chunked or deduplicated in this case.
       However, it is `zstd` compressed.
+    - When the `blob_path` field has a `v2/` prefix:
+      The objectstore is used as the backing store.
     """
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3897,8 +3897,6 @@ register(
 
 # Fraction of attachments that are being stored exclusively in the new objectstore.
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
-# Fraction of attachments that are being stored on objectstore for processing and long-term storage.
-register("objectstore.enable_for.cached_attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 
 # option used to enable/disable tracking

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -414,27 +414,21 @@ def _maybe_copy_attachment_into_cache(
     stored_id = None
     chunks = None
 
-    if in_random_rollout("objectstore.enable_for.attachments"):
-        blob_path = attachment.blob_path or ""
-        if blob_path.startswith(V2_PREFIX):
-            # in case the attachment is already stored in objectstore, there is nothing to do
-            stored_id = blob_path.removeprefix(V2_PREFIX)
-        else:
-            # otherwise, we store it in objectstore
-            with attachment.getfile() as fp:
-                stored_id = get_attachments_session(project.organization_id, project.id).put(fp)
-            # but we then also make that storage permanent, as otherwise
-            # the codepaths won’t be cleaning up this stored file.
-            # essentially this means we are moving the file from the previous storage
-            # into objectstore at this point.
-            attachment.blob_path = V2_PREFIX + stored_id
-            attachment.save()
-            if blob_path.startswith(V1_PREFIX):
-                storage = get_storage()
-                storage.delete(blob_path)
-
+    blob_path = attachment.blob_path or ""
+    if blob_path.startswith(V2_PREFIX):
+        # attachment is already in objectstore (regardless of flag)
+        stored_id = blob_path.removeprefix(V2_PREFIX)
+    elif in_random_rollout("objectstore.enable_for.attachments"):
+        # move the attachment into objectstore and update the record
+        with attachment.getfile() as fp:
+            stored_id = get_attachments_session(project.organization_id, project.id).put(fp)
+        attachment.blob_path = V2_PREFIX + stored_id
+        attachment.save()
+        if blob_path.startswith(V1_PREFIX):
+            storage = get_storage()
+            storage.delete(blob_path)
     else:
-        # when not using objectstore, store chunks in the attachment cache
+        # store chunks in the attachment cache
         with attachment.getfile() as fp:
             chunk_index = 0
             size = 0

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -165,6 +165,7 @@ def pytest_configure(config: pytest.Config) -> None:
 
     # enable draft features
     settings.SENTRY_OPTIONS["mail.enable-replies"] = True
+    settings.SENTRY_OPTIONS["objectstore.enable_for.attachments"] = 1.0
 
     settings.SENTRY_ALLOW_ORIGIN = "*"
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -348,10 +348,8 @@ def test_deobfuscate_view_hierarchy(default_project, task_runner, live_server) -
 @pytest.mark.symbolicator
 @thread_leak_allowlist(reason="django dev server", issue=97036)
 def test_deobfuscate_view_hierarchy_objectstore(default_project, task_runner, live_server) -> None:
-    with override_options(
-        {"system.url-prefix": live_server.url, "objectstore.enable_for.cached_attachments": 1}
-    ):
-        # this stores the attachment during processing because of the feature flag above:
+    with override_options({"system.url-prefix": live_server.url}):
+        # this stores the attachment during processing in objectstore:
         do_process_view_hierarchy(default_project, task_runner)
         # this passes an already stored attachment to the ingest consumer:
         do_process_view_hierarchy(default_project, task_runner, use_objectstore=True)


### PR DESCRIPTION
Remove cached-attachment objectstore rollout options now that migration is complete, keeping only the single `enable_for.attachments` flag that gates whether new attachments land in objectstore or legacy storage. Note that ingestion via Relay is controlled separately.

Reprocessing is updated to always handle attachments that are already in objectstore (regardless of the flag), while still migrating V1 attachments into objectstore during reprocessing when the flag is on.

Objectstore is also added to the default devservices mode so it starts alongside the rest of the stack without needing a separate mode.

Refs FS-281