### PR TITLE
feat(integrations): Add GitHub repository platform detection

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -290,6 +290,9 @@ from sentry.integrations.api.endpoints.organization_repository_commits import (
 from sentry.integrations.api.endpoints.organization_repository_details import (
     OrganizationRepositoryDetailsEndpoint,
 )
+from sentry.integrations.api.endpoints.organization_repository_platforms import (
+    OrganizationRepositoryPlatformsEndpoint,
+)
 from sentry.integrations.api.endpoints.organization_repository_settings import (
     OrganizationRepositorySettingsEndpoint,
 )
@@ -2231,6 +2234,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/commits/$",
         OrganizationRepositoryCommitsEndpoint.as_view(),
         name="sentry-api-0-organization-repository-commits",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/repos/(?P<repo_id>[^/]+)/platforms/$",
+        OrganizationRepositoryPlatformsEndpoint.as_view(),
+        name="sentry-api-0-organization-repository-platforms",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/plugins/$",

--- a/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
+++ b/src/sentry/integrations/api/endpoints/organization_repository_platforms.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.integrations.github.client import GitHubApiClient
+from sentry.integrations.github.platform_detection import detect_platforms
+from sentry.integrations.services.integration import integration_service
+from sentry.models.organization import Organization
+from sentry.models.repository import Repository
+from sentry.shared_integrations.exceptions import ApiError
+
+logger = logging.getLogger(__name__)
+
+
+@region_silo_endpoint
+class OrganizationRepositoryPlatformsEndpoint(OrganizationEndpoint):
+    owner = ApiOwner.INTEGRATIONS
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (OrganizationIntegrationsPermission,)
+
+    def get(self, request: Request, organization: Organization, repo_id: int) -> Response:
+        try:
+            repo = Repository.objects.get(id=repo_id, organization_id=organization.id)
+        except Repository.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        if not repo.integration_id or not repo.provider or "github" not in repo.provider:
+            return Response(
+                {"detail": "Platform detection is only supported for GitHub repositories."},
+                status=400,
+            )
+
+        integration = integration_service.get_integration(integration_id=repo.integration_id)
+        if integration is None:
+            return Response({"detail": "GitHub integration not found."}, status=400)
+
+        org_integration = integration_service.get_organization_integration(
+            integration_id=repo.integration_id, organization_id=organization.id
+        )
+        if org_integration is None:
+            return Response(
+                {"detail": "GitHub integration is not configured for this organization."},
+                status=400,
+            )
+
+        client = GitHubApiClient(integration=integration, org_integration_id=org_integration.id)
+
+        try:
+            platforms = detect_platforms(client=client, repo=repo.name)
+        except ApiError:
+            logger.exception(
+                "integrations.github.platform_detection_failed",
+                extra={"repo_id": repo.id, "repo_name": repo.name},
+            )
+            return Response({"detail": "Failed to detect platforms from GitHub."}, status=502)
+
+        return Response({"platforms": platforms})

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -418,6 +418,16 @@ class GitHubBaseClient(
         """
         return self.get(f"/repos/{repo}")
 
+    def get_languages(self, repo: str) -> dict[str, int]:
+        """
+        https://docs.github.com/en/rest/repos/repos#list-repository-languages
+
+        :param repo: "owner/repo" format
+        :returns: {"Python": 50000, "JavaScript": 30000, ...}
+                  Keys are GitHub Linguist names, values are bytes of code.
+        """
+        return self.get(f"/repos/{repo}/languages")
+
     # https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28
     def get_rate_limit(self, specific_resource: str = "core") -> GithubRateLimitInfo:
         """This gives information of the current rate limit"""

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import logging
+from base64 import b64decode
+from typing import TYPE_CHECKING, TypedDict
+
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import json
+
+if TYPE_CHECKING:
+    from sentry.integrations.github.client import GitHubBaseClient
+
+logger = logging.getLogger(__name__)
+
+# GitHub Linguist name → Sentry base platform ID
+GITHUB_LANGUAGE_TO_SENTRY_PLATFORM: dict[str, str] = {
+    "Python": "python",
+    "JavaScript": "javascript",
+    "TypeScript": "javascript",
+    "Java": "java",
+    "Kotlin": "kotlin",
+    "Swift": "swift",
+    "Objective-C": "apple-ios",
+    "Objective-C++": "apple-ios",
+    "Go": "go",
+    "Ruby": "ruby",
+    "PHP": "php",
+    "Rust": "rust",
+    "C#": "dotnet",
+    "Dart": "dart",
+    "Elixir": "elixir",
+    "C": "native",
+    "C++": "native",
+    "Perl": "perl",
+}
+
+# Languages with no Sentry SDK — filtered out of detection results
+IGNORED_LANGUAGES = frozenset(
+    {
+        "Shell",
+        "Makefile",
+        "Dockerfile",
+        "HTML",
+        "CSS",
+        "SCSS",
+        "Less",
+        "Vim Script",
+        "Emacs Lisp",
+        "Nix",
+        "Starlark",
+        "HCL",
+        "Jsonnet",
+        "Batchfile",
+        "PowerShell",
+        "CMake",
+        "M4",
+        "Roff",
+        "TeX",
+        "XSLT",
+        "PLpgSQL",
+        "PLSQL",
+        "TSQL",
+    }
+)
+
+
+class DetectedPlatform(TypedDict):
+    platform: str  # Sentry platform ID, e.g. "python-django"
+    language: str  # GitHub Linguist name, e.g. "Python"
+    bytes: int  # Bytes of code in that language
+    confidence: str  # "high" (framework detected) or "medium" (language only)
+
+
+# Maps base_platform -> list of (manifest_file, {dependency_name: sentry_platform_id})
+FRAMEWORK_DETECTORS: dict[str, list[tuple[str, dict[str, str]]]] = {
+    "javascript": [
+        (
+            "package.json",
+            {
+                "next": "javascript-nextjs",
+                "react": "javascript-react",
+                "vue": "javascript-vue",
+                "@angular/core": "javascript-angular",
+                "svelte": "javascript-svelte",
+                "remix": "javascript-remix",
+                "nuxt": "javascript-nuxt",
+                "express": "node-express",
+                "hono": "node-hono",
+                "koa": "node-koa",
+            },
+        ),
+    ],
+    "python": [
+        (
+            "requirements.txt",
+            {
+                "django": "python-django",
+                "flask": "python-flask",
+                "fastapi": "python-fastapi",
+                "starlette": "python-starlette",
+                "celery": "python-celery",
+                "tornado": "python-tornado",
+            },
+        ),
+        (
+            "pyproject.toml",
+            {
+                "django": "python-django",
+                "flask": "python-flask",
+                "fastapi": "python-fastapi",
+                "starlette": "python-starlette",
+                "celery": "python-celery",
+                "tornado": "python-tornado",
+            },
+        ),
+        (
+            "Pipfile",
+            {
+                "django": "python-django",
+                "flask": "python-flask",
+                "fastapi": "python-fastapi",
+                "starlette": "python-starlette",
+                "celery": "python-celery",
+                "tornado": "python-tornado",
+            },
+        ),
+    ],
+    "ruby": [
+        (
+            "Gemfile",
+            {
+                "rails": "ruby-rails",
+            },
+        ),
+    ],
+    "php": [
+        (
+            "composer.json",
+            {
+                "laravel/framework": "php-laravel",
+                "symfony/": "php-symfony",
+            },
+        ),
+    ],
+    "java": [
+        (
+            "build.gradle",
+            {
+                "spring-boot": "java-spring-boot",
+                "spring-framework": "java-spring",
+            },
+        ),
+        (
+            "pom.xml",
+            {
+                "spring-boot": "java-spring-boot",
+                "spring-framework": "java-spring",
+            },
+        ),
+    ],
+    "go": [
+        (
+            "go.mod",
+            {
+                "echo": "go-echo",
+                "gin": "go-gin",
+                "fiber": "go-fiber",
+            },
+        ),
+    ],
+}
+
+
+def _get_repo_file_content(
+    client: GitHubBaseClient, repo: str, path: str, ref: str | None = None
+) -> str | None:
+    """Fetch a file's content from a GitHub repo. Returns None if not found."""
+    try:
+        params: dict[str, str] = {}
+        if ref:
+            params["ref"] = ref
+        response = client.get(
+            f"/repos/{repo}/contents/{path}",
+            params=params,
+        )
+        return b64decode(response["content"]).decode("utf-8")
+    except ApiError:
+        return None
+
+
+def _detect_frameworks_from_content(
+    content: str,
+    manifest_file: str,
+    dependency_map: dict[str, str],
+) -> list[str]:
+    """Check manifest file content for known framework dependencies."""
+    detected: list[str] = []
+
+    if manifest_file == "package.json":
+        try:
+            pkg = json.loads(content)
+            all_deps: dict[str, str] = {}
+            all_deps.update(pkg.get("dependencies", {}))
+            all_deps.update(pkg.get("devDependencies", {}))
+            for dep_name, platform_id in dependency_map.items():
+                if dep_name in all_deps:
+                    detected.append(platform_id)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    elif manifest_file == "composer.json":
+        try:
+            composer = json.loads(content)
+            all_deps = {}
+            all_deps.update(composer.get("require", {}))
+            all_deps.update(composer.get("require-dev", {}))
+            for dep_name, platform_id in dependency_map.items():
+                for pkg_name in all_deps:
+                    if pkg_name == dep_name or pkg_name.startswith(dep_name):
+                        detected.append(platform_id)
+                        break
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    else:
+        # Text-based manifest files: requirements.txt, Gemfile,
+        # pyproject.toml, build.gradle, pom.xml, go.mod
+        content_lower = content.lower()
+        for dep_name, platform_id in dependency_map.items():
+            if dep_name.lower() in content_lower:
+                detected.append(platform_id)
+
+    return detected
+
+
+def detect_framework(
+    client: GitHubBaseClient,
+    repo: str,
+    base_platform: str,
+    ref: str | None = None,
+) -> list[str]:
+    """
+    Refine a base platform (e.g. "python") into specific framework
+    platforms (e.g. "python-django") by reading manifest files.
+
+    Returns detected framework platform IDs, or an empty list if none found.
+    """
+    detectors = FRAMEWORK_DETECTORS.get(base_platform, [])
+    detected: list[str] = []
+
+    for manifest_file, dependency_map in detectors:
+        content = _get_repo_file_content(client, repo, manifest_file, ref)
+        if content is None:
+            continue
+        frameworks = _detect_frameworks_from_content(content, manifest_file, dependency_map)
+        detected.extend(frameworks)
+        if detected:
+            break
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for platform_id in detected:
+        if platform_id not in seen:
+            seen.add(platform_id)
+            unique.append(platform_id)
+
+    return unique
+
+
+def detect_platforms(
+    client: GitHubBaseClient,
+    repo: str,
+    ref: str | None = None,
+) -> list[DetectedPlatform]:
+    """
+    Detect Sentry platforms for a GitHub repository.
+
+    Calls the GitHub Languages API, maps languages to Sentry platform IDs,
+    and attempts framework refinement via manifest file inspection.
+
+    Returns platforms ordered by relevance (bytes of code, descending).
+    """
+    languages = client.get_languages(repo)
+
+    results: list[DetectedPlatform] = []
+    seen_platforms: set[str] = set()
+
+    for language, byte_count in languages.items():
+        if language in IGNORED_LANGUAGES:
+            continue
+
+        base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
+        if base_platform is None:
+            continue
+
+        frameworks = detect_framework(client, repo, base_platform, ref)
+
+        for framework_id in frameworks:
+            if framework_id not in seen_platforms:
+                seen_platforms.add(framework_id)
+                results.append(
+                    DetectedPlatform(
+                        platform=framework_id,
+                        language=language,
+                        bytes=byte_count,
+                        confidence="high",
+                    )
+                )
+
+        if base_platform not in seen_platforms:
+            seen_platforms.add(base_platform)
+            results.append(
+                DetectedPlatform(
+                    platform=base_platform,
+                    language=language,
+                    bytes=byte_count,
+                    confidence="medium",
+                )
+            )
+
+    return results

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -35,6 +35,7 @@ GITHUB_LANGUAGE_TO_SENTRY_PLATFORM: dict[str, str] = {
     "C": "native",
     "C++": "native",
     "Perl": "perl",
+    "PowerShell": "powershell",
 }
 
 # Languages with no Sentry SDK — filtered out of detection results
@@ -54,7 +55,6 @@ IGNORED_LANGUAGES = frozenset(
         "HCL",
         "Jsonnet",
         "Batchfile",
-        "PowerShell",
         "CMake",
         "M4",
         "Roff",
@@ -79,6 +79,8 @@ class DetectorRule(TypedDict, total=False):
     path: str  # File must exist in root directory
     match_content: str  # Regex pattern to match in file content (requires path)
     match_package: str  # Package name in package.json/composer.json deps
+    match_dir: str  # Directory must exist in root
+    match_ext: str  # File extension must exist in root (e.g., ".csproj")
 
 
 class FrameworkDef(TypedDict, total=False):
@@ -94,7 +96,9 @@ class FrameworkDef(TypedDict, total=False):
 # Inspired by Vercel's framework detection:
 # github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
 FRAMEWORKS: list[FrameworkDef] = [
-    # --- JavaScript meta-frameworks (sort=1, highest priority) ---
+    # ===================================================================
+    # JavaScript meta-frameworks (sort=1, highest priority)
+    # ===================================================================
     {
         "platform": "javascript-nextjs",
         "sort": 1,
@@ -129,7 +133,88 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
         "supersedes": ["javascript-vue"],
     },
-    # --- JavaScript UI frameworks (sort=30) ---
+    {
+        "platform": "javascript-astro",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "astro"},
+            {"path": "astro.config.mjs"},
+            {"path": "astro.config.ts"},
+            {"path": "astro.config.js"},
+        ],
+    },
+    {
+        "platform": "javascript-gatsby",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "gatsby"},
+            {"path": "gatsby-config.js"},
+            {"path": "gatsby-config.ts"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-sveltekit",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@sveltejs/kit"}],
+        "supersedes": ["javascript-svelte"],
+    },
+    {
+        "platform": "javascript-solidstart",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@solidjs/start"}],
+        "supersedes": ["javascript-solid"],
+    },
+    {
+        "platform": "javascript-tanstackstart-react",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@tanstack/react-start"}],
+        "supersedes": ["javascript-react"],
+    },
+    # --- Mobile / cross-platform (sort=1-10) ---
+    {
+        "platform": "react-native",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "react-native"}],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "electron",
+        "sort": 5,
+        "base_platform": "javascript",
+        "some": [{"match_package": "electron"}],
+    },
+    {
+        "platform": "capacitor",
+        "sort": 5,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@capacitor/core"}],
+    },
+    {
+        "platform": "javascript-react-router",
+        "sort": 5,
+        "base_platform": "javascript",
+        "every": [{"match_package": "react-router"}, {"match_package": "react"}],
+    },
+    {
+        "platform": "ionic",
+        "sort": 10,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "@ionic/angular"},
+            {"match_package": "@ionic/react"},
+            {"match_package": "@ionic/vue"},
+        ],
+    },
+    # ===================================================================
+    # JavaScript UI frameworks (sort=30)
+    # ===================================================================
     {
         "platform": "javascript-react",
         "sort": 30,
@@ -161,7 +246,24 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "svelte.config.ts"},
         ],
     },
-    # --- JavaScript server frameworks (sort=40) ---
+    {
+        "platform": "javascript-solid",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [{"match_package": "solid-js"}],
+    },
+    {
+        "platform": "javascript-ember",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "ember-source"},
+            {"path": "ember-cli-build.js"},
+        ],
+    },
+    # ===================================================================
+    # JavaScript server frameworks (sort=40)
+    # ===================================================================
     {
         "platform": "node-express",
         "sort": 40,
@@ -180,7 +282,72 @@ FRAMEWORKS: list[FrameworkDef] = [
         "base_platform": "javascript",
         "every": [{"match_package": "koa"}],
     },
-    # --- Python frameworks ---
+    {
+        "platform": "node-nestjs",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@nestjs/core"}],
+    },
+    {
+        "platform": "node-fastify",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "fastify"}],
+    },
+    {
+        "platform": "node-connect",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "connect"}],
+    },
+    {
+        "platform": "node-hapi",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@hapi/hapi"}],
+    },
+    # ===================================================================
+    # JavaScript serverless / edge (sort=50)
+    # ===================================================================
+    {
+        "platform": "node-awslambda",
+        "sort": 50,
+        "base_platform": "javascript",
+        "some": [{"path": "serverless.yml"}],
+    },
+    {
+        "platform": "node-gcpfunctions",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@google-cloud/functions-framework"}],
+    },
+    {
+        "platform": "node-azurefunctions",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [{"path": "host.json"}],
+    },
+    {
+        "platform": "node-cloudflare-pages",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [
+            {"path": "wrangler.toml", "match_content": r"pages_build_output_dir"},
+        ],
+        "supersedes": ["node-cloudflare-workers"],
+    },
+    {
+        "platform": "node-cloudflare-workers",
+        "sort": 50,
+        "base_platform": "javascript",
+        "some": [
+            {"path": "wrangler.toml"},
+            {"match_package": "wrangler"},
+        ],
+    },
+    # ===================================================================
+    # Python frameworks
+    # ===================================================================
     {
         "platform": "python-django",
         "sort": 10,
@@ -213,6 +380,66 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "python-aiohttp",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\baiohttp\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\baiohttp\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\baiohttp\b"},
+        ],
+    },
+    {
+        "platform": "python-bottle",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bbottle\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bbottle\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bbottle\b"},
+        ],
+    },
+    {
+        "platform": "python-falcon",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfalcon\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfalcon\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfalcon\b"},
+        ],
+    },
+    {
+        "platform": "python-pyramid",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bpyramid\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bpyramid\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bpyramid\b"},
+        ],
+    },
+    {
+        "platform": "python-quart",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bquart\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bquart\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bquart\b"},
+        ],
+    },
+    {
+        "platform": "python-sanic",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bsanic\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bsanic\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bsanic\b"},
+        ],
+    },
+    {
         "platform": "python-starlette",
         "sort": 30,
         "base_platform": "python",
@@ -233,6 +460,44 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "python-tryton",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\btrytond?\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\btrytond?\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\btrytond?\b"},
+        ],
+    },
+    {
+        "platform": "python-chalice",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bchalice\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bchalice\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bchalice\b"},
+        ],
+    },
+    # --- Python serverless (sort=50) ---
+    {
+        "platform": "python-awslambda",
+        "sort": 50,
+        "base_platform": "python",
+        "some": [{"path": "serverless.yml"}],
+    },
+    {
+        "platform": "python-gcpfunctions",
+        "sort": 50,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfunctions-framework\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfunctions-framework\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfunctions-framework\b"},
+        ],
+    },
+    # --- Python task queues / background (sort=60) ---
+    {
         "platform": "python-celery",
         "sort": 60,
         "base_platform": "python",
@@ -242,7 +507,19 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "Pipfile", "match_content": r"(?i)\bcelery\b"},
         ],
     },
-    # --- Ruby ---
+    {
+        "platform": "python-rq",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\brq\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\brq\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\brq\b"},
+        ],
+    },
+    # ===================================================================
+    # Ruby
+    # ===================================================================
     {
         "platform": "ruby-rails",
         "sort": 10,
@@ -251,7 +528,17 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "Gemfile", "match_content": r"(?i)\brails\b"},
         ],
     },
-    # --- PHP ---
+    {
+        "platform": "ruby-rack",
+        "sort": 30,
+        "base_platform": "ruby",
+        "some": [
+            {"path": "Gemfile", "match_content": r"(?i)\brack\b"},
+        ],
+    },
+    # ===================================================================
+    # PHP
+    # ===================================================================
     {
         "platform": "php-laravel",
         "sort": 10,
@@ -262,6 +549,12 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "php-wordpress",
+        "sort": 10,
+        "base_platform": "php",
+        "some": [{"path": "wp-config.php"}],
+    },
+    {
         "platform": "php-symfony",
         "sort": 20,
         "base_platform": "php",
@@ -269,7 +562,9 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"match_package": "symfony/"},
         ],
     },
-    # --- Java ---
+    # ===================================================================
+    # Java
+    # ===================================================================
     {
         "platform": "java-spring-boot",
         "sort": 10,
@@ -288,13 +583,33 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "pom.xml", "match_content": r"spring-framework"},
         ],
     },
-    # --- Go ---
+    {
+        "platform": "java-log4j2",
+        "sort": 60,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"log4j-core"},
+            {"path": "pom.xml", "match_content": r"log4j-core"},
+        ],
+    },
+    {
+        "platform": "java-logback",
+        "sort": 60,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"logback-core|logback-classic"},
+            {"path": "pom.xml", "match_content": r"logback-core|logback-classic"},
+        ],
+    },
+    # ===================================================================
+    # Go — using full module paths for precise matching
+    # ===================================================================
     {
         "platform": "go-echo",
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\becho\b"},
+            {"path": "go.mod", "match_content": r"github\.com/labstack/echo"},
         ],
     },
     {
@@ -302,7 +617,7 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\bgin\b"},
+            {"path": "go.mod", "match_content": r"github\.com/gin-gonic/gin"},
         ],
     },
     {
@@ -310,8 +625,77 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\bfiber\b"},
+            {"path": "go.mod", "match_content": r"github\.com/gofiber/fiber"},
         ],
+    },
+    {
+        "platform": "go-fasthttp",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/valyala/fasthttp"},
+        ],
+    },
+    {
+        "platform": "go-iris",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/kataras/iris"},
+        ],
+    },
+    {
+        "platform": "go-negroni",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/urfave/negroni"},
+        ],
+    },
+    # ===================================================================
+    # Dart / Flutter (requires pubspec.yaml manifest parsing)
+    # ===================================================================
+    {
+        "platform": "flutter",
+        "sort": 1,
+        "base_platform": "dart",
+        "some": [{"match_package": "flutter"}],
+    },
+    # ===================================================================
+    # Mobile / Desktop / Gaming — directory and extension-based detection
+    # ===================================================================
+    {
+        "platform": "unity",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_dir": "Assets"}, {"match_dir": "ProjectSettings"}],
+    },
+    {
+        "platform": "android",
+        "sort": 10,
+        "base_platform": "java",
+        "every": [
+            {"match_dir": "app"},
+            {"path": "build.gradle", "match_content": r"android"},
+        ],
+    },
+    {
+        "platform": "dotnet-aspnetcore",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "some": [{"match_ext": ".csproj"}],
+    },
+    {
+        "platform": "unreal",
+        "sort": 10,
+        "base_platform": "native",
+        "some": [{"match_ext": ".uproject"}],
+    },
+    {
+        "platform": "godot",
+        "sort": 10,
+        "base_platform": "native",
+        "some": [{"path": "project.godot"}],
     },
 ]
 
@@ -329,6 +713,9 @@ for _fw in FRAMEWORKS:
 _PACKAGE_MANIFEST_FILES: dict[str, str] = {
     "javascript": "package.json",
     "php": "composer.json",
+    "dart": "pubspec.yaml",
+    "ruby": "Gemfile",
+    "go": "go.mod",
 }
 
 
@@ -354,24 +741,31 @@ def _get_repo_file_content(
         return None
 
 
-def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = None) -> set[str]:
-    """Fetch the list of file names in the repository root directory.
+def _get_root_entries(
+    client: GitHubBaseClient, repo: str, ref: str | None = None
+) -> tuple[set[str], set[str]]:
+    """Fetch the file names and directory names in the repository root.
 
     Uses the GitHub Contents API on the root path, which returns all
     top-level files and directories in a single API call.
+
+    Returns:
+        Tuple of (file_names, dir_names).
     """
     try:
         params: dict[str, str] = {}
         if ref:
             params["ref"] = ref
         response = client.get(f"/repos/{repo}/contents", params=params)
-        return {item["name"] for item in response if item.get("type") == "file"}
+        files = {item["name"] for item in response if item.get("type") == "file"}
+        dirs = {item["name"] for item in response if item.get("type") == "dir"}
+        return files, dirs
     except ApiError:
-        return set()
+        return set(), set()
 
 
 def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifest | None:
-    """Parse a JSON package manifest into dependency sets."""
+    """Parse a package manifest into dependency sets."""
     try:
         if manifest_file == "package.json":
             pkg = json.loads(content)
@@ -385,9 +779,96 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
                 dependencies=set(composer.get("require", {}).keys()),
                 dev_dependencies=set(composer.get("require-dev", {}).keys()),
             )
+        elif manifest_file == "pubspec.yaml":
+            return _parse_pubspec_yaml(content)
+        elif manifest_file == "Gemfile":
+            return _parse_gemfile(content)
+        elif manifest_file == "go.mod":
+            return _parse_go_mod(content)
     except (json.JSONDecodeError, TypeError):
         pass
     return None
+
+
+def _parse_pubspec_yaml(content: str) -> _PackageManifest:
+    """Parse a pubspec.yaml file into dependency sets using line-based parsing.
+
+    Extracts package names from the dependencies: and dev_dependencies:
+    top-level sections. Direct dependencies are identified as lines indented
+    by exactly 2 spaces that contain a colon.
+    """
+    deps: set[str] = set()
+    dev_deps: set[str] = set()
+    section_re = re.compile(r"^(\w[\w_]*):")
+    dep_re = re.compile(r"^  (\w[\w_-]*):")
+
+    current_section: str | None = None
+    for line in content.splitlines():
+        section_match = section_re.match(line)
+        if section_match:
+            key = section_match.group(1)
+            if key == "dependencies":
+                current_section = "deps"
+            elif key == "dev_dependencies":
+                current_section = "dev_deps"
+            else:
+                current_section = None
+            continue
+
+        if current_section:
+            dep_match = dep_re.match(line)
+            if dep_match:
+                name = dep_match.group(1)
+                if current_section == "deps":
+                    deps.add(name)
+                else:
+                    dev_deps.add(name)
+
+    return _PackageManifest(dependencies=deps, dev_dependencies=dev_deps)
+
+
+def _parse_gemfile(content: str) -> _PackageManifest:
+    """Parse a Gemfile into dependency sets.
+
+    Extracts gem names from ``gem "name"`` or ``gem 'name'`` lines.
+    """
+    deps: set[str] = set()
+    gem_re = re.compile(r"""gem\s+['"]([^'"]+)['"]""")
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        match = gem_re.search(stripped)
+        if match:
+            deps.add(match.group(1))
+    return _PackageManifest(dependencies=deps, dev_dependencies=set())
+
+
+def _parse_go_mod(content: str) -> _PackageManifest:
+    """Parse a go.mod file into dependency sets.
+
+    Extracts module paths from ``require`` directives, both single-line
+    (``require path v1.0``) and block form (``require ( ... )``).
+    """
+    deps: set[str] = set()
+    in_require = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("require ("):
+            in_require = True
+            continue
+        if in_require:
+            if stripped == ")":
+                in_require = False
+                continue
+            parts = stripped.split()
+            if parts:
+                deps.add(parts[0])
+        elif stripped.startswith("require "):
+            parts = stripped.split()
+            if len(parts) >= 2:
+                deps.add(parts[1])
+    return _PackageManifest(dependencies=deps, dev_dependencies=set())
 
 
 def _package_in_manifest(package_name: str, manifest: _PackageManifest) -> bool:
@@ -398,6 +879,9 @@ def _package_in_manifest(package_name: str, manifest: _PackageManifest) -> bool:
     # Prefix match for composer.json patterns like "symfony/"
     if package_name.endswith("/"):
         return any(dep.startswith(package_name) for dep in all_deps)
+    # Go module version path matching: github.com/foo/bar matches github.com/foo/bar/v2
+    if "/" in package_name:
+        return any(dep.startswith(package_name + "/v") for dep in all_deps)
     return False
 
 
@@ -406,12 +890,22 @@ def _rule_matches(
     root_files: set[str],
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
+    root_dirs: set[str] | None = None,
 ) -> bool:
     """Evaluate a single detector rule against repository state."""
     if "match_package" in rule:
         if package_manifest is None:
             return False
         return _package_in_manifest(rule["match_package"], package_manifest)
+
+    if "match_dir" in rule:
+        if root_dirs is None:
+            return False
+        return rule["match_dir"] in root_dirs
+
+    if "match_ext" in rule:
+        ext = rule["match_ext"]
+        return any(f.endswith(ext) for f in root_files)
 
     path = rule.get("path")
     if path is None:
@@ -432,6 +926,7 @@ def _framework_matches(
     root_files: set[str],
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
+    root_dirs: set[str] | None = None,
 ) -> bool:
     """Evaluate whether a framework definition matches the repository."""
     every: Sequence[DetectorRule] = fw.get("every", [])
@@ -441,12 +936,12 @@ def _framework_matches(
         return False
 
     every_pass = (
-        all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
+        all(_rule_matches(r, root_files, file_contents, package_manifest, root_dirs) for r in every)
         if every
         else True
     )
     some_pass = (
-        any(_rule_matches(r, root_files, file_contents, package_manifest) for r in some)
+        any(_rule_matches(r, root_files, file_contents, package_manifest, root_dirs) for r in some)
         if some
         else True
     )
@@ -477,16 +972,18 @@ def detect_platforms(
     Detect Sentry platforms for a GitHub repository.
 
     Uses composable framework definitions (inspired by Vercel's detection)
-    with three signal types:
+    with five signal types:
     1. Config files — path-only rules (next.config.js, manage.py, etc.)
     2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
-    3. Package dependencies — match_package rules (package.json, composer.json)
+    3. Package dependencies — match_package rules (package.json, composer.json, etc.)
+    4. Root directories — match_dir rules (Assets/, app/, etc.)
+    5. File extensions — match_ext rules (.csproj, .uproject, etc.)
 
     Results are ranked by priority (descending), then bytes (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
-    root_files = _get_root_file_names(client, repo, ref)
+    root_files, root_dirs = _get_root_entries(client, repo, ref)
 
     # Group languages by base platform
     active_platforms: dict[str, list[tuple[str, int]]] = defaultdict(list)
@@ -542,7 +1039,7 @@ def detect_platforms(
         manifest = package_manifests.get(manifest_file) if manifest_file else None
 
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
-            if _framework_matches(fw, root_files, file_contents, manifest):
+            if _framework_matches(fw, root_files, file_contents, manifest, root_dirs):
                 platform_id = fw["platform"]
                 if platform_id not in seen_platforms:
                     seen_platforms.add(platform_id)

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -120,6 +120,35 @@ SUPERSEDED_BY: dict[str, list[str]] = {
     "javascript-nuxt": ["javascript-vue"],
 }
 
+# Priority bonus when a framework is detected via config file (strongest signal).
+# A config file like next.config.js is a definitive indicator vs. a dependency
+# which might be transitive or unused.
+CONFIG_FILE_BONUS = 20
+
+# Root-level config files that definitively indicate a specific framework.
+# Inspired by Vercel's framework detection: github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
+# Maps base_platform -> list of (config_filename, sentry_platform_id)
+CONFIG_FILE_DETECTORS: dict[str, list[tuple[str, str]]] = {
+    "javascript": [
+        ("next.config.js", "javascript-nextjs"),
+        ("next.config.mjs", "javascript-nextjs"),
+        ("next.config.ts", "javascript-nextjs"),
+        ("nuxt.config.ts", "javascript-nuxt"),
+        ("nuxt.config.js", "javascript-nuxt"),
+        ("svelte.config.js", "javascript-svelte"),
+        ("svelte.config.ts", "javascript-svelte"),
+        ("angular.json", "javascript-angular"),
+        ("remix.config.js", "javascript-remix"),
+        ("remix.config.mjs", "javascript-remix"),
+    ],
+    "python": [
+        ("manage.py", "python-django"),
+    ],
+    "php": [
+        ("artisan", "php-laravel"),
+    ],
+}
+
 
 class FrameworkMatch(TypedDict):
     platform: str
@@ -241,6 +270,40 @@ def _get_repo_file_content(
         return b64decode(response["content"]).decode("utf-8")
     except ApiError:
         return None
+
+
+def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = None) -> set[str]:
+    """Fetch the list of file names in the repository root directory.
+
+    Uses the GitHub Contents API on the root path, which returns all
+    top-level files and directories in a single API call.
+    """
+    try:
+        params: dict[str, str] = {}
+        if ref:
+            params["ref"] = ref
+        response = client.get(f"/repos/{repo}/contents/", params=params)
+        return {item["name"] for item in response if item.get("type") == "file"}
+    except ApiError:
+        return set()
+
+
+def _detect_from_config_files(
+    root_files: set[str],
+    base_platform: str,
+) -> list[str]:
+    """Detect frameworks from config file presence in root directory.
+
+    Returns a list of platform IDs detected via config files.
+    """
+    detectors = CONFIG_FILE_DETECTORS.get(base_platform, [])
+    detected: list[str] = []
+    seen: set[str] = set()
+    for config_file, platform_id in detectors:
+        if config_file in root_files and platform_id not in seen:
+            seen.add(platform_id)
+            detected.append(platform_id)
+    return detected
 
 
 def _detect_frameworks_from_content(
@@ -367,13 +430,16 @@ def detect_platforms(
     """
     Detect Sentry platforms for a GitHub repository.
 
-    Calls the GitHub Languages API, maps languages to Sentry platform IDs,
-    and attempts framework refinement via manifest file inspection.
+    Uses three signals (inspired by Vercel's framework detection):
+    1. Config files — strongest signal (next.config.js, manage.py, etc.)
+    2. Manifest dependencies — package.json, requirements.txt, etc.
+    3. Language bytes — from GitHub's Languages API
 
     Results are ranked by priority (descending), then bytes (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
+    root_files = _get_root_file_names(client, repo, ref)
 
     results: list[DetectedPlatform] = []
     seen_platforms: set[str] = set()
@@ -386,21 +452,33 @@ def detect_platforms(
         if base_platform is None:
             continue
 
-        framework_matches = detect_framework(client, repo, base_platform, ref)
+        # Signal 1: Config file detection (one check against cached root listing)
+        config_detected = set(_detect_from_config_files(root_files, base_platform))
 
-        for match in framework_matches:
-            framework_id = match["platform"]
+        # Signal 2: Dependency detection from manifest files
+        framework_matches = detect_framework(client, repo, base_platform, ref)
+        dep_map: dict[str, str] = {m["platform"]: m["dep_source"] for m in framework_matches}
+
+        # Merge signals: union of all detected framework platform IDs
+        all_framework_ids = config_detected | set(dep_map.keys())
+
+        for framework_id in all_framework_ids:
             if framework_id not in seen_platforms:
                 seen_platforms.add(framework_id)
                 base_priority = FRAMEWORK_PRIORITY.get(framework_id, 50)
-                dep_bonus = _DEP_SOURCE_BONUS.get(match["dep_source"], 0)
+                has_config = framework_id in config_detected
+                dep_source = dep_map.get(framework_id)
+
+                config_bonus = CONFIG_FILE_BONUS if has_config else 0
+                dep_bonus = _DEP_SOURCE_BONUS.get(dep_source, 0) if dep_source else 0
+
                 results.append(
                     DetectedPlatform(
                         platform=framework_id,
                         language=language,
                         bytes=byte_count,
                         confidence="high",
-                        priority=base_priority + dep_bonus,
+                        priority=base_priority + config_bonus + dep_bonus,
                     )
                 )
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+import re
 from base64 import b64decode
+from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypedDict
 
 from sentry.shared_integrations.exceptions import ApiError
@@ -72,187 +75,266 @@ class DetectedPlatform(TypedDict):
     priority: int  # Higher = more relevant for onboarding
 
 
-# Priority weights: higher = more specific/useful for onboarding
-FRAMEWORK_PRIORITY: dict[str, int] = {
-    # JS meta-frameworks (most specific, include routing/SSR)
-    "javascript-nextjs": 100,
-    "javascript-remix": 100,
-    "javascript-nuxt": 100,
-    # JS UI frameworks
-    "javascript-react": 70,
-    "javascript-vue": 70,
-    "javascript-angular": 70,
-    "javascript-svelte": 70,
-    # JS server frameworks
-    "node-express": 60,
-    "node-hono": 60,
-    "node-koa": 60,
-    # Python web frameworks
-    "python-django": 90,
-    "python-fastapi": 90,
-    "python-flask": 80,
-    "python-starlette": 70,
-    "python-tornado": 70,
-    # Python task queues (useful but secondary)
-    "python-celery": 40,
-    # Ruby
-    "ruby-rails": 90,
-    # PHP
-    "php-laravel": 90,
-    "php-symfony": 80,
-    # Java
-    "java-spring-boot": 90,
-    "java-spring": 80,
-    # Go
-    "go-echo": 80,
-    "go-gin": 80,
-    "go-fiber": 80,
+class DetectorRule(TypedDict, total=False):
+    path: str  # File must exist in root directory
+    match_content: str  # Regex pattern to match in file content (requires path)
+    match_package: str  # Package name in package.json/composer.json deps
+
+
+class FrameworkDef(TypedDict, total=False):
+    platform: str  # Sentry platform ID, e.g. "javascript-nextjs"
+    sort: int  # Lower = higher priority (Vercel convention)
+    base_platform: str  # Language group, e.g. "javascript"
+    every: list[DetectorRule]  # ALL must match (AND)
+    some: list[DetectorRule]  # At least ONE must match (OR)
+    supersedes: list[str]  # Platform IDs this makes redundant
+
+
+# Each framework is a self-contained definition with composable detector rules.
+# Inspired by Vercel's framework detection:
+# github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
+FRAMEWORKS: list[FrameworkDef] = [
+    # --- JavaScript meta-frameworks (sort=1, highest priority) ---
+    {
+        "platform": "javascript-nextjs",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "next"},
+            {"path": "next.config.js"},
+            {"path": "next.config.mjs"},
+            {"path": "next.config.ts"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-remix",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "remix"},
+            {"path": "remix.config.js"},
+            {"path": "remix.config.mjs"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-nuxt",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "nuxt"},
+            {"path": "nuxt.config.ts"},
+            {"path": "nuxt.config.js"},
+        ],
+        "supersedes": ["javascript-vue"],
+    },
+    # --- JavaScript UI frameworks (sort=30) ---
+    {
+        "platform": "javascript-react",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [{"match_package": "react"}],
+    },
+    {
+        "platform": "javascript-vue",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [{"match_package": "vue"}],
+    },
+    {
+        "platform": "javascript-angular",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "@angular/core"},
+            {"path": "angular.json"},
+        ],
+    },
+    {
+        "platform": "javascript-svelte",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "svelte"},
+            {"path": "svelte.config.js"},
+            {"path": "svelte.config.ts"},
+        ],
+    },
+    # --- JavaScript server frameworks (sort=40) ---
+    {
+        "platform": "node-express",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "express"}],
+    },
+    {
+        "platform": "node-hono",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "hono"}],
+    },
+    {
+        "platform": "node-koa",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "koa"}],
+    },
+    # --- Python frameworks ---
+    {
+        "platform": "python-django",
+        "sort": 10,
+        "base_platform": "python",
+        "some": [
+            {"path": "manage.py"},
+            {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bdjango\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bdjango\b"},
+        ],
+    },
+    {
+        "platform": "python-fastapi",
+        "sort": 10,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfastapi\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfastapi\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfastapi\b"},
+        ],
+    },
+    {
+        "platform": "python-flask",
+        "sort": 20,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bflask\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bflask\b"},
+        ],
+    },
+    {
+        "platform": "python-starlette",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bstarlette\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bstarlette\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bstarlette\b"},
+        ],
+    },
+    {
+        "platform": "python-tornado",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\btornado\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\btornado\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\btornado\b"},
+        ],
+    },
+    {
+        "platform": "python-celery",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bcelery\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bcelery\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bcelery\b"},
+        ],
+    },
+    # --- Ruby ---
+    {
+        "platform": "ruby-rails",
+        "sort": 10,
+        "base_platform": "ruby",
+        "some": [
+            {"path": "Gemfile", "match_content": r"(?i)\brails\b"},
+        ],
+    },
+    # --- PHP ---
+    {
+        "platform": "php-laravel",
+        "sort": 10,
+        "base_platform": "php",
+        "some": [
+            {"match_package": "laravel/framework"},
+            {"path": "artisan"},
+        ],
+    },
+    {
+        "platform": "php-symfony",
+        "sort": 20,
+        "base_platform": "php",
+        "some": [
+            {"match_package": "symfony/"},
+        ],
+    },
+    # --- Java ---
+    {
+        "platform": "java-spring-boot",
+        "sort": 10,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"spring-boot"},
+            {"path": "pom.xml", "match_content": r"spring-boot"},
+        ],
+    },
+    {
+        "platform": "java-spring",
+        "sort": 20,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"spring-framework"},
+            {"path": "pom.xml", "match_content": r"spring-framework"},
+        ],
+    },
+    # --- Go ---
+    {
+        "platform": "go-echo",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\becho\b"},
+        ],
+    },
+    {
+        "platform": "go-gin",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\bgin\b"},
+        ],
+    },
+    {
+        "platform": "go-fiber",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\bfiber\b"},
+        ],
+    },
+]
+
+# Derived indexes built at module load
+_FRAMEWORKS_BY_PLATFORM: dict[str, list[FrameworkDef]] = defaultdict(list)
+for _fw in FRAMEWORKS:
+    _FRAMEWORKS_BY_PLATFORM[_fw["base_platform"]].append(_fw)
+
+_SUPERSESSION_MAP: dict[str, list[str]] = {}
+for _fw in FRAMEWORKS:
+    if "supersedes" in _fw:
+        _SUPERSESSION_MAP[_fw["platform"]] = _fw["supersedes"]
+
+# Package manifest files per base platform (for match_package rules)
+_PACKAGE_MANIFEST_FILES: dict[str, str] = {
+    "javascript": "package.json",
+    "php": "composer.json",
 }
 
-# Base platform priority (used when no framework detected)
-BASE_PLATFORM_PRIORITY = 10
 
-# When a parent framework is detected, child frameworks are redundant.
-# e.g. Next.js includes React, so don't also suggest React.
-SUPERSEDED_BY: dict[str, list[str]] = {
-    "javascript-nextjs": ["javascript-react"],
-    "javascript-remix": ["javascript-react"],
-    "javascript-nuxt": ["javascript-vue"],
-}
-
-# Priority bonus when a framework is detected via config file (strongest signal).
-# A config file like next.config.js is a definitive indicator vs. a dependency
-# which might be transitive or unused.
-CONFIG_FILE_BONUS = 20
-
-# Root-level config files that definitively indicate a specific framework.
-# Inspired by Vercel's framework detection: github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
-# Maps base_platform -> list of (config_filename, sentry_platform_id)
-CONFIG_FILE_DETECTORS: dict[str, list[tuple[str, str]]] = {
-    "javascript": [
-        ("next.config.js", "javascript-nextjs"),
-        ("next.config.mjs", "javascript-nextjs"),
-        ("next.config.ts", "javascript-nextjs"),
-        ("nuxt.config.ts", "javascript-nuxt"),
-        ("nuxt.config.js", "javascript-nuxt"),
-        ("svelte.config.js", "javascript-svelte"),
-        ("svelte.config.ts", "javascript-svelte"),
-        ("angular.json", "javascript-angular"),
-        ("remix.config.js", "javascript-remix"),
-        ("remix.config.mjs", "javascript-remix"),
-    ],
-    "python": [
-        ("manage.py", "python-django"),
-    ],
-    "php": [
-        ("artisan", "php-laravel"),
-    ],
-}
-
-
-class FrameworkMatch(TypedDict):
-    platform: str
-    dep_source: str  # "dependencies", "devDependencies", or "unknown"
-
-
-# Maps base_platform -> list of (manifest_file, {dependency_name: sentry_platform_id})
-FRAMEWORK_DETECTORS: dict[str, list[tuple[str, dict[str, str]]]] = {
-    "javascript": [
-        (
-            "package.json",
-            {
-                "next": "javascript-nextjs",
-                "react": "javascript-react",
-                "vue": "javascript-vue",
-                "@angular/core": "javascript-angular",
-                "svelte": "javascript-svelte",
-                "remix": "javascript-remix",
-                "nuxt": "javascript-nuxt",
-                "express": "node-express",
-                "hono": "node-hono",
-                "koa": "node-koa",
-            },
-        ),
-    ],
-    "python": [
-        (
-            "requirements.txt",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-        (
-            "pyproject.toml",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-        (
-            "Pipfile",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-    ],
-    "ruby": [
-        (
-            "Gemfile",
-            {
-                "rails": "ruby-rails",
-            },
-        ),
-    ],
-    "php": [
-        (
-            "composer.json",
-            {
-                "laravel/framework": "php-laravel",
-                "symfony/": "php-symfony",
-            },
-        ),
-    ],
-    "java": [
-        (
-            "build.gradle",
-            {
-                "spring-boot": "java-spring-boot",
-                "spring-framework": "java-spring",
-            },
-        ),
-        (
-            "pom.xml",
-            {
-                "spring-boot": "java-spring-boot",
-                "spring-framework": "java-spring",
-            },
-        ),
-    ],
-    "go": [
-        (
-            "go.mod",
-            {
-                "echo": "go-echo",
-                "gin": "go-gin",
-                "fiber": "go-fiber",
-            },
-        ),
-    ],
-}
+class _PackageManifest(TypedDict):
+    dependencies: set[str]
+    dev_dependencies: set[str]
 
 
 def _get_repo_file_content(
@@ -282,122 +364,94 @@ def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = 
         params: dict[str, str] = {}
         if ref:
             params["ref"] = ref
-        response = client.get(f"/repos/{repo}/contents/", params=params)
+        response = client.get(f"/repos/{repo}/contents", params=params)
         return {item["name"] for item in response if item.get("type") == "file"}
     except ApiError:
         return set()
 
 
-def _detect_from_config_files(
-    root_files: set[str],
-    base_platform: str,
-) -> list[str]:
-    """Detect frameworks from config file presence in root directory.
-
-    Returns a list of platform IDs detected via config files.
-    """
-    detectors = CONFIG_FILE_DETECTORS.get(base_platform, [])
-    detected: list[str] = []
-    seen: set[str] = set()
-    for config_file, platform_id in detectors:
-        if config_file in root_files and platform_id not in seen:
-            seen.add(platform_id)
-            detected.append(platform_id)
-    return detected
-
-
-def _detect_frameworks_from_content(
-    content: str,
-    manifest_file: str,
-    dependency_map: dict[str, str],
-) -> list[FrameworkMatch]:
-    """Check manifest file content for known framework dependencies.
-
-    Returns FrameworkMatch objects that include which dependency section
-    the framework was found in (dependencies vs devDependencies).
-    """
-    detected: list[FrameworkMatch] = []
-
-    if manifest_file == "package.json":
-        try:
+def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifest | None:
+    """Parse a JSON package manifest into dependency sets."""
+    try:
+        if manifest_file == "package.json":
             pkg = json.loads(content)
-            prod_deps = set(pkg.get("dependencies", {}).keys())
-            dev_deps = set(pkg.get("devDependencies", {}).keys())
-            for dep_name, platform_id in dependency_map.items():
-                if dep_name in prod_deps:
-                    detected.append(FrameworkMatch(platform=platform_id, dep_source="dependencies"))
-                elif dep_name in dev_deps:
-                    detected.append(
-                        FrameworkMatch(platform=platform_id, dep_source="devDependencies")
-                    )
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    elif manifest_file == "composer.json":
-        try:
+            return _PackageManifest(
+                dependencies=set(pkg.get("dependencies", {}).keys()),
+                dev_dependencies=set(pkg.get("devDependencies", {}).keys()),
+            )
+        elif manifest_file == "composer.json":
             composer = json.loads(content)
-            prod_deps = set(composer.get("require", {}).keys())
-            dev_deps = set(composer.get("require-dev", {}).keys())
-            for dep_name, platform_id in dependency_map.items():
-                source = None
-                for pkg_name in prod_deps:
-                    if pkg_name == dep_name or pkg_name.startswith(dep_name):
-                        source = "dependencies"
-                        break
-                if source is None:
-                    for pkg_name in dev_deps:
-                        if pkg_name == dep_name or pkg_name.startswith(dep_name):
-                            source = "devDependencies"
-                            break
-                if source is not None:
-                    detected.append(FrameworkMatch(platform=platform_id, dep_source=source))
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    else:
-        # Text-based manifest files: requirements.txt, Gemfile,
-        # pyproject.toml, build.gradle, pom.xml, go.mod
-        content_lower = content.lower()
-        for dep_name, platform_id in dependency_map.items():
-            if dep_name.lower() in content_lower:
-                detected.append(FrameworkMatch(platform=platform_id, dep_source="unknown"))
-
-    return detected
+            return _PackageManifest(
+                dependencies=set(composer.get("require", {}).keys()),
+                dev_dependencies=set(composer.get("require-dev", {}).keys()),
+            )
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return None
 
 
-def detect_framework(
-    client: GitHubBaseClient,
-    repo: str,
-    base_platform: str,
-    ref: str | None = None,
-) -> list[FrameworkMatch]:
-    """
-    Refine a base platform (e.g. "python") into specific framework
-    platforms (e.g. "python-django") by reading manifest files.
+def _package_in_manifest(package_name: str, manifest: _PackageManifest) -> bool:
+    """Check if a package exists in a manifest's dependencies or devDependencies."""
+    all_deps = manifest["dependencies"] | manifest["dev_dependencies"]
+    if package_name in all_deps:
+        return True
+    # Prefix match for composer.json patterns like "symfony/"
+    if package_name.endswith("/"):
+        return any(dep.startswith(package_name) for dep in all_deps)
+    return False
 
-    Returns FrameworkMatch objects, or an empty list if none found.
-    """
-    detectors = FRAMEWORK_DETECTORS.get(base_platform, [])
-    detected: list[FrameworkMatch] = []
 
-    for manifest_file, dependency_map in detectors:
-        content = _get_repo_file_content(client, repo, manifest_file, ref)
+def _rule_matches(
+    rule: DetectorRule,
+    root_files: set[str],
+    file_contents: dict[str, str],
+    package_manifest: _PackageManifest | None,
+) -> bool:
+    """Evaluate a single detector rule against repository state."""
+    if "match_package" in rule:
+        if package_manifest is None:
+            return False
+        return _package_in_manifest(rule["match_package"], package_manifest)
+
+    path = rule.get("path")
+    if path is None:
+        return False
+
+    if "match_content" in rule:
+        content = file_contents.get(path)
         if content is None:
-            continue
-        frameworks = _detect_frameworks_from_content(content, manifest_file, dependency_map)
-        detected.extend(frameworks)
-        if detected:
-            break
+            return False
+        return bool(re.search(rule["match_content"], content))
 
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    unique: list[FrameworkMatch] = []
-    for match in detected:
-        if match["platform"] not in seen:
-            seen.add(match["platform"])
-            unique.append(match)
+    # path-only rule: check if file exists in root
+    return path in root_files
 
-    return unique
+
+def _framework_matches(
+    fw: FrameworkDef,
+    root_files: set[str],
+    file_contents: dict[str, str],
+    package_manifest: _PackageManifest | None,
+) -> bool:
+    """Evaluate whether a framework definition matches the repository."""
+    every: Sequence[DetectorRule] = fw.get("every", [])
+    some: Sequence[DetectorRule] = fw.get("some", [])
+
+    if not every and not some:
+        return False
+
+    every_pass = (
+        all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
+        if every
+        else True
+    )
+    some_pass = (
+        any(_rule_matches(r, root_files, file_contents, package_manifest) for r in some)
+        if some
+        else True
+    )
+
+    return every_pass and some_pass
 
 
 def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatform]:
@@ -408,18 +462,10 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
     detected_ids = {r["platform"] for r in results}
     superseded: set[str] = set()
     for platform_id in detected_ids:
-        for child_id in SUPERSEDED_BY.get(platform_id, []):
+        for child_id in _SUPERSESSION_MAP.get(platform_id, []):
             superseded.add(child_id)
 
     return [r for r in results if r["platform"] not in superseded]
-
-
-# Bonus priority for frameworks found in production dependencies vs devDependencies
-_DEP_SOURCE_BONUS = {
-    "dependencies": 10,
-    "devDependencies": 0,
-    "unknown": 5,
-}
 
 
 def detect_platforms(
@@ -430,10 +476,11 @@ def detect_platforms(
     """
     Detect Sentry platforms for a GitHub repository.
 
-    Uses three signals (inspired by Vercel's framework detection):
-    1. Config files — strongest signal (next.config.js, manage.py, etc.)
-    2. Manifest dependencies — package.json, requirements.txt, etc.
-    3. Language bytes — from GitHub's Languages API
+    Uses composable framework definitions (inspired by Vercel's detection)
+    with three signal types:
+    1. Config files — path-only rules (next.config.js, manage.py, etc.)
+    2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
+    3. Package dependencies — match_package rules (package.json, composer.json)
 
     Results are ranked by priority (descending), then bytes (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
@@ -441,46 +488,73 @@ def detect_platforms(
     languages = client.get_languages(repo)
     root_files = _get_root_file_names(client, repo, ref)
 
-    results: list[DetectedPlatform] = []
-    seen_platforms: set[str] = set()
-
+    # Group languages by base platform
+    active_platforms: dict[str, list[tuple[str, int]]] = defaultdict(list)
     for language, byte_count in languages.items():
         if language in IGNORED_LANGUAGES:
             continue
-
         base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
-        if base_platform is None:
+        if base_platform is not None:
+            active_platforms[base_platform].append((language, byte_count))
+
+    # Collect all file paths that need content fetching (path + match_content rules)
+    needed_paths: set[str] = set()
+    for base_platform in active_platforms:
+        for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
+            for rule in [*fw.get("every", []), *fw.get("some", [])]:
+                path = rule.get("path")
+                if path and "match_content" in rule and path in root_files:
+                    needed_paths.add(path)
+
+    # Fetch file contents in one pass
+    file_contents: dict[str, str] = {}
+    for path in needed_paths:
+        content = _get_repo_file_content(client, repo, path, ref)
+        if content is not None:
+            file_contents[path] = content
+
+    # Parse package manifests for platforms that use match_package rules
+    package_manifests: dict[str, _PackageManifest | None] = {}
+    for base_platform in active_platforms:
+        manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
+        if manifest_file is None or manifest_file in package_manifests:
             continue
+        if manifest_file not in root_files:
+            package_manifests[manifest_file] = None
+            continue
+        content = file_contents.get(manifest_file)
+        if content is None:
+            content = _get_repo_file_content(client, repo, manifest_file, ref)
+            if content is not None:
+                file_contents[manifest_file] = content
+        package_manifests[manifest_file] = (
+            _parse_package_manifest(content, manifest_file) if content else None
+        )
 
-        # Signal 1: Config file detection (one check against cached root listing)
-        config_detected = set(_detect_from_config_files(root_files, base_platform))
+    # Evaluate frameworks per base platform
+    results: list[DetectedPlatform] = []
+    seen_platforms: set[str] = set()
 
-        # Signal 2: Dependency detection from manifest files
-        framework_matches = detect_framework(client, repo, base_platform, ref)
-        dep_map: dict[str, str] = {m["platform"]: m["dep_source"] for m in framework_matches}
+    for base_platform, lang_entries in active_platforms.items():
+        language, byte_count = max(lang_entries, key=lambda x: x[1])
 
-        # Merge signals: union of all detected framework platform IDs
-        all_framework_ids = config_detected | set(dep_map.keys())
+        manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
+        manifest = package_manifests.get(manifest_file) if manifest_file else None
 
-        for framework_id in all_framework_ids:
-            if framework_id not in seen_platforms:
-                seen_platforms.add(framework_id)
-                base_priority = FRAMEWORK_PRIORITY.get(framework_id, 50)
-                has_config = framework_id in config_detected
-                dep_source = dep_map.get(framework_id)
-
-                config_bonus = CONFIG_FILE_BONUS if has_config else 0
-                dep_bonus = _DEP_SOURCE_BONUS.get(dep_source, 0) if dep_source else 0
-
-                results.append(
-                    DetectedPlatform(
-                        platform=framework_id,
-                        language=language,
-                        bytes=byte_count,
-                        confidence="high",
-                        priority=base_priority + config_bonus + dep_bonus,
+        for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
+            if _framework_matches(fw, root_files, file_contents, manifest):
+                platform_id = fw["platform"]
+                if platform_id not in seen_platforms:
+                    seen_platforms.add(platform_id)
+                    results.append(
+                        DetectedPlatform(
+                            platform=platform_id,
+                            language=language,
+                            bytes=byte_count,
+                            confidence="high",
+                            priority=100 - fw["sort"],
+                        )
                     )
-                )
 
         if base_platform not in seen_platforms:
             seen_platforms.add(base_platform)
@@ -490,7 +564,7 @@ def detect_platforms(
                     language=language,
                     bytes=byte_count,
                     confidence="medium",
-                    priority=BASE_PLATFORM_PRIORITY,
+                    priority=1,
                 )
             )
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -69,6 +69,61 @@ class DetectedPlatform(TypedDict):
     language: str  # GitHub Linguist name, e.g. "Python"
     bytes: int  # Bytes of code in that language
     confidence: str  # "high" (framework detected) or "medium" (language only)
+    priority: int  # Higher = more relevant for onboarding
+
+
+# Priority weights: higher = more specific/useful for onboarding
+FRAMEWORK_PRIORITY: dict[str, int] = {
+    # JS meta-frameworks (most specific, include routing/SSR)
+    "javascript-nextjs": 100,
+    "javascript-remix": 100,
+    "javascript-nuxt": 100,
+    # JS UI frameworks
+    "javascript-react": 70,
+    "javascript-vue": 70,
+    "javascript-angular": 70,
+    "javascript-svelte": 70,
+    # JS server frameworks
+    "node-express": 60,
+    "node-hono": 60,
+    "node-koa": 60,
+    # Python web frameworks
+    "python-django": 90,
+    "python-fastapi": 90,
+    "python-flask": 80,
+    "python-starlette": 70,
+    "python-tornado": 70,
+    # Python task queues (useful but secondary)
+    "python-celery": 40,
+    # Ruby
+    "ruby-rails": 90,
+    # PHP
+    "php-laravel": 90,
+    "php-symfony": 80,
+    # Java
+    "java-spring-boot": 90,
+    "java-spring": 80,
+    # Go
+    "go-echo": 80,
+    "go-gin": 80,
+    "go-fiber": 80,
+}
+
+# Base platform priority (used when no framework detected)
+BASE_PLATFORM_PRIORITY = 10
+
+# When a parent framework is detected, child frameworks are redundant.
+# e.g. Next.js includes React, so don't also suggest React.
+SUPERSEDED_BY: dict[str, list[str]] = {
+    "javascript-nextjs": ["javascript-react"],
+    "javascript-remix": ["javascript-react"],
+    "javascript-nuxt": ["javascript-vue"],
+}
+
+
+class FrameworkMatch(TypedDict):
+    platform: str
+    dep_source: str  # "dependencies", "devDependencies", or "unknown"
 
 
 # Maps base_platform -> list of (manifest_file, {dependency_name: sentry_platform_id})
@@ -192,33 +247,47 @@ def _detect_frameworks_from_content(
     content: str,
     manifest_file: str,
     dependency_map: dict[str, str],
-) -> list[str]:
-    """Check manifest file content for known framework dependencies."""
-    detected: list[str] = []
+) -> list[FrameworkMatch]:
+    """Check manifest file content for known framework dependencies.
+
+    Returns FrameworkMatch objects that include which dependency section
+    the framework was found in (dependencies vs devDependencies).
+    """
+    detected: list[FrameworkMatch] = []
 
     if manifest_file == "package.json":
         try:
             pkg = json.loads(content)
-            all_deps: dict[str, str] = {}
-            all_deps.update(pkg.get("dependencies", {}))
-            all_deps.update(pkg.get("devDependencies", {}))
+            prod_deps = set(pkg.get("dependencies", {}).keys())
+            dev_deps = set(pkg.get("devDependencies", {}).keys())
             for dep_name, platform_id in dependency_map.items():
-                if dep_name in all_deps:
-                    detected.append(platform_id)
+                if dep_name in prod_deps:
+                    detected.append(FrameworkMatch(platform=platform_id, dep_source="dependencies"))
+                elif dep_name in dev_deps:
+                    detected.append(
+                        FrameworkMatch(platform=platform_id, dep_source="devDependencies")
+                    )
         except (json.JSONDecodeError, TypeError):
             pass
 
     elif manifest_file == "composer.json":
         try:
             composer = json.loads(content)
-            all_deps = {}
-            all_deps.update(composer.get("require", {}))
-            all_deps.update(composer.get("require-dev", {}))
+            prod_deps = set(composer.get("require", {}).keys())
+            dev_deps = set(composer.get("require-dev", {}).keys())
             for dep_name, platform_id in dependency_map.items():
-                for pkg_name in all_deps:
+                source = None
+                for pkg_name in prod_deps:
                     if pkg_name == dep_name or pkg_name.startswith(dep_name):
-                        detected.append(platform_id)
+                        source = "dependencies"
                         break
+                if source is None:
+                    for pkg_name in dev_deps:
+                        if pkg_name == dep_name or pkg_name.startswith(dep_name):
+                            source = "devDependencies"
+                            break
+                if source is not None:
+                    detected.append(FrameworkMatch(platform=platform_id, dep_source=source))
         except (json.JSONDecodeError, TypeError):
             pass
 
@@ -228,7 +297,7 @@ def _detect_frameworks_from_content(
         content_lower = content.lower()
         for dep_name, platform_id in dependency_map.items():
             if dep_name.lower() in content_lower:
-                detected.append(platform_id)
+                detected.append(FrameworkMatch(platform=platform_id, dep_source="unknown"))
 
     return detected
 
@@ -238,15 +307,15 @@ def detect_framework(
     repo: str,
     base_platform: str,
     ref: str | None = None,
-) -> list[str]:
+) -> list[FrameworkMatch]:
     """
     Refine a base platform (e.g. "python") into specific framework
     platforms (e.g. "python-django") by reading manifest files.
 
-    Returns detected framework platform IDs, or an empty list if none found.
+    Returns FrameworkMatch objects, or an empty list if none found.
     """
     detectors = FRAMEWORK_DETECTORS.get(base_platform, [])
-    detected: list[str] = []
+    detected: list[FrameworkMatch] = []
 
     for manifest_file, dependency_map in detectors:
         content = _get_repo_file_content(client, repo, manifest_file, ref)
@@ -259,13 +328,35 @@ def detect_framework(
 
     # Deduplicate while preserving order
     seen: set[str] = set()
-    unique: list[str] = []
-    for platform_id in detected:
-        if platform_id not in seen:
-            seen.add(platform_id)
-            unique.append(platform_id)
+    unique: list[FrameworkMatch] = []
+    for match in detected:
+        if match["platform"] not in seen:
+            seen.add(match["platform"])
+            unique.append(match)
 
     return unique
+
+
+def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatform]:
+    """Remove platforms that are superseded by more specific ones.
+
+    e.g. if Next.js is detected, React is redundant since Next.js includes it.
+    """
+    detected_ids = {r["platform"] for r in results}
+    superseded: set[str] = set()
+    for platform_id in detected_ids:
+        for child_id in SUPERSEDED_BY.get(platform_id, []):
+            superseded.add(child_id)
+
+    return [r for r in results if r["platform"] not in superseded]
+
+
+# Bonus priority for frameworks found in production dependencies vs devDependencies
+_DEP_SOURCE_BONUS = {
+    "dependencies": 10,
+    "devDependencies": 0,
+    "unknown": 5,
+}
 
 
 def detect_platforms(
@@ -279,7 +370,8 @@ def detect_platforms(
     Calls the GitHub Languages API, maps languages to Sentry platform IDs,
     and attempts framework refinement via manifest file inspection.
 
-    Returns platforms ordered by relevance (bytes of code, descending).
+    Results are ranked by priority (descending), then bytes (descending).
+    Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
 
@@ -294,17 +386,21 @@ def detect_platforms(
         if base_platform is None:
             continue
 
-        frameworks = detect_framework(client, repo, base_platform, ref)
+        framework_matches = detect_framework(client, repo, base_platform, ref)
 
-        for framework_id in frameworks:
+        for match in framework_matches:
+            framework_id = match["platform"]
             if framework_id not in seen_platforms:
                 seen_platforms.add(framework_id)
+                base_priority = FRAMEWORK_PRIORITY.get(framework_id, 50)
+                dep_bonus = _DEP_SOURCE_BONUS.get(match["dep_source"], 0)
                 results.append(
                     DetectedPlatform(
                         platform=framework_id,
                         language=language,
                         bytes=byte_count,
                         confidence="high",
+                        priority=base_priority + dep_bonus,
                     )
                 )
 
@@ -316,7 +412,11 @@ def detect_platforms(
                     language=language,
                     bytes=byte_count,
                     confidence="medium",
+                    priority=BASE_PLATFORM_PRIORITY,
                 )
             )
+
+    results = _apply_supersession(results)
+    results.sort(key=lambda r: (r["priority"], r["bytes"]), reverse=True)
 
     return results

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -532,6 +532,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/repos/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/'
   | '/organizations/$organizationIdOrSlug/repos/$repoId/commits/'
+  | '/organizations/$organizationIdOrSlug/repos/$repoId/platforms/'
   | '/organizations/$organizationIdOrSlug/repos/settings/'
   | '/organizations/$organizationIdOrSlug/request-project-creation/'
   | '/organizations/$organizationIdOrSlug/sampling/admin-metrics/'

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models.repository import Repository
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationRepositoryPlatformsGetTest(APITestCase):
+    endpoint = "sentry-api-0-organization-repository-platforms"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+        ten_days = timezone.now() + timedelta(days=10)
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={
+                "access_token": "12345token",
+                "expires_at": ten_days.strftime("%Y-%m-%dT%H:%M:%S"),
+            },
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=self.integration.id,
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_detects_platforms(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"Python": 50000, "JavaScript": 30000},
+            status=200,
+        )
+        # Mock 404s for manifest file lookups (no framework detection)
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/requirements.txt",
+            json={"message": "Not Found"},
+            status=404,
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/pyproject.toml",
+            json={"message": "Not Found"},
+            status=404,
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/Pipfile",
+            json={"message": "Not Found"},
+            status=404,
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/package.json",
+            json={"message": "Not Found"},
+            status=404,
+        )
+
+        response = self.get_success_response(self.organization.slug, self.repo.id, status_code=200)
+
+        platforms = response.data["platforms"]
+        platform_ids = [p["platform"] for p in platforms]
+        assert "python" in platform_ids
+        assert "javascript" in platform_ids
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_detects_framework(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"Python": 50000},
+            status=200,
+        )
+
+        from base64 import b64encode
+
+        requirements_content = b64encode(b"Django==4.2\ncelery>=5.0\n").decode()
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/requirements.txt",
+            json={"content": requirements_content},
+            status=200,
+        )
+
+        response = self.get_success_response(self.organization.slug, self.repo.id, status_code=200)
+
+        platforms = response.data["platforms"]
+        platform_ids = [p["platform"] for p in platforms]
+        assert "python-django" in platform_ids
+        assert "python-celery" in platform_ids
+
+        django = next(p for p in platforms if p["platform"] == "python-django")
+        assert django["confidence"] == "high"
+
+    def test_repo_not_found(self) -> None:
+        response = self.get_response(self.organization.slug, 99999)
+        assert response.status_code == 404
+
+    def test_non_github_repo(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="non-github-repo",
+            provider="integrations:bitbucket",
+            external_id="456",
+        )
+
+        response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+        assert "only supported for GitHub" in response.data["detail"]
+
+    def test_repo_without_integration(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="orphan-repo",
+            provider="integrations:github",
+            external_id="789",
+            integration_id=None,
+        )
+
+        response = self.get_response(self.organization.slug, repo.id)
+        assert response.status_code == 400
+
+    def test_other_orgs_repo_not_accessible(self) -> None:
+        other_org = self.create_organization(name="other-org")
+        other_repo = Repository.objects.create(
+            organization_id=other_org.id,
+            name="Test-Organization/secret",
+            provider="integrations:github",
+            external_id="secret",
+            integration_id=self.integration.id,
+        )
+
+        response = self.get_response(self.organization.slug, other_repo.id)
+        assert response.status_code == 404
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_github_api_error_returns_502(self, get_jwt: mock.MagicMock) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/languages",
+            json={"message": "Server Error"},
+            status=500,
+        )
+
+        response = self.get_response(self.organization.slug, self.repo.id)
+        assert response.status_code == 502
+        assert "Failed to detect" in response.data["detail"]

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -46,37 +46,12 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             json={"Python": 50000, "JavaScript": 30000},
             status=200,
         )
-        # Root directory listing (no config files)
+        # Root directory listing (no manifest files → no framework detection)
         responses.add(
             method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/",
+            url="https://api.github.com/repos/Test-Organization/foo/contents",
             json=[],
             status=200,
-        )
-        # Mock 404s for manifest file lookups (no framework detection)
-        responses.add(
-            method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/requirements.txt",
-            json={"message": "Not Found"},
-            status=404,
-        )
-        responses.add(
-            method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/pyproject.toml",
-            json={"message": "Not Found"},
-            status=404,
-        )
-        responses.add(
-            method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/Pipfile",
-            json={"message": "Not Found"},
-            status=404,
-        )
-        responses.add(
-            method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/package.json",
-            json={"message": "Not Found"},
-            status=404,
         )
 
         response = self.get_success_response(self.organization.slug, self.repo.id, status_code=200)
@@ -95,11 +70,11 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             json={"Python": 50000},
             status=200,
         )
-        # Root directory listing (no config files)
+        # Root directory listing with requirements.txt so framework detection can find it
         responses.add(
             method=responses.GET,
-            url="https://api.github.com/repos/Test-Organization/foo/contents/",
-            json=[],
+            url="https://api.github.com/repos/Test-Organization/foo/contents",
+            json=[{"name": "requirements.txt", "type": "file"}],
             status=200,
         )
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -46,6 +46,13 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             json={"Python": 50000, "JavaScript": 30000},
             status=200,
         )
+        # Root directory listing (no config files)
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/",
+            json=[],
+            status=200,
+        )
         # Mock 404s for manifest file lookups (no framework detection)
         responses.add(
             method=responses.GET,
@@ -86,6 +93,13 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             method=responses.GET,
             url="https://api.github.com/repos/Test-Organization/foo/languages",
             json={"Python": 50000},
+            status=200,
+        )
+        # Root directory listing (no config files)
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents/",
+            json=[],
             status=200,
         )
 

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from base64 import b64encode
+from unittest import mock
+
+import pytest
+
+from sentry.integrations.github.platform_detection import (
+    GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
+    DetectedPlatform,
+    _detect_frameworks_from_content,
+    detect_framework,
+    detect_platforms,
+)
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import json
+
+
+class TestGithubLanguageMapping:
+    def test_python_maps_to_python(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["Python"] == "python"
+
+    def test_typescript_maps_to_javascript(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["TypeScript"] == "javascript"
+
+    def test_javascript_maps_to_javascript(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["JavaScript"] == "javascript"
+
+    def test_csharp_maps_to_dotnet(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["C#"] == "dotnet"
+
+    def test_objectivec_maps_to_apple_ios(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["Objective-C"] == "apple-ios"
+
+    def test_unmapped_language_returns_none(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get("Brainfuck") is None
+
+
+class TestDetectFrameworksFromContent:
+    def test_package_json_detects_next(self) -> None:
+        content = json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
+        result = _detect_frameworks_from_content(
+            content, "package.json", {"next": "javascript-nextjs", "react": "javascript-react"}
+        )
+        assert "javascript-nextjs" in result
+        assert "javascript-react" in result
+
+    def test_package_json_checks_dev_dependencies(self) -> None:
+        content = json.dumps({"devDependencies": {"svelte": "^4.0.0"}})
+        result = _detect_frameworks_from_content(
+            content, "package.json", {"svelte": "javascript-svelte"}
+        )
+        assert result == ["javascript-svelte"]
+
+    def test_package_json_no_match(self) -> None:
+        content = json.dumps({"dependencies": {"lodash": "^4.0.0"}})
+        result = _detect_frameworks_from_content(
+            content, "package.json", {"next": "javascript-nextjs"}
+        )
+        assert result == []
+
+    def test_package_json_invalid_json(self) -> None:
+        result = _detect_frameworks_from_content(
+            "not valid json", "package.json", {"next": "javascript-nextjs"}
+        )
+        assert result == []
+
+    def test_requirements_txt_detects_django(self) -> None:
+        content = "Django==4.2\ncelery>=5.0\nredis\n"
+        result = _detect_frameworks_from_content(
+            content,
+            "requirements.txt",
+            {"django": "python-django", "celery": "python-celery"},
+        )
+        assert "python-django" in result
+        assert "python-celery" in result
+
+    def test_requirements_txt_case_insensitive(self) -> None:
+        content = "Flask==3.0\n"
+        result = _detect_frameworks_from_content(
+            content, "requirements.txt", {"flask": "python-flask"}
+        )
+        assert result == ["python-flask"]
+
+    def test_gemfile_detects_rails(self) -> None:
+        content = 'gem "rails", "~> 7.0"\ngem "pg"\n'
+        result = _detect_frameworks_from_content(content, "Gemfile", {"rails": "ruby-rails"})
+        assert result == ["ruby-rails"]
+
+    def test_composer_json_detects_laravel(self) -> None:
+        content = json.dumps({"require": {"laravel/framework": "^10.0"}})
+        result = _detect_frameworks_from_content(
+            content, "composer.json", {"laravel/framework": "php-laravel"}
+        )
+        assert result == ["php-laravel"]
+
+    def test_composer_json_prefix_match_symfony(self) -> None:
+        content = json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})
+        result = _detect_frameworks_from_content(
+            content, "composer.json", {"symfony/": "php-symfony"}
+        )
+        assert result == ["php-symfony"]
+
+    def test_go_mod_detects_gin(self) -> None:
+        content = "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+        result = _detect_frameworks_from_content(content, "go.mod", {"gin": "go-gin"})
+        assert result == ["go-gin"]
+
+    def test_build_gradle_detects_spring_boot(self) -> None:
+        content = (
+            "dependencies {\n    implementation 'org.springframework.boot:spring-boot-starter'\n}\n"
+        )
+        result = _detect_frameworks_from_content(
+            content, "build.gradle", {"spring-boot": "java-spring-boot"}
+        )
+        assert result == ["java-spring-boot"]
+
+
+def _make_b64_response(content: str) -> dict:
+    """Helper to create a GitHub contents API response with base64-encoded content."""
+    return {"content": b64encode(content.encode()).decode()}
+
+
+class TestDetectFramework:
+    def test_detects_python_django(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = _make_b64_response("Django==4.2\ncelery>=5.0\n")
+
+        result = detect_framework(client, "owner/repo", "python")
+
+        assert "python-django" in result
+        assert "python-celery" in result
+
+    def test_falls_back_when_manifest_not_found(self) -> None:
+        client = mock.MagicMock()
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_framework(client, "owner/repo", "python")
+
+        assert result == []
+
+    def test_stops_after_first_manifest_with_results(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = _make_b64_response("Django==4.2\n")
+
+        result = detect_framework(client, "owner/repo", "python")
+
+        assert result == ["python-django"]
+        # Should have only called get() once (for requirements.txt),
+        # not continued to pyproject.toml
+        assert client.get.call_count == 1
+
+    def test_tries_next_manifest_when_first_has_no_match(self) -> None:
+        client = mock.MagicMock()
+
+        def side_effect(path, params=None):
+            if "requirements.txt" in path:
+                return _make_b64_response("some-unrelated-package\n")
+            if "pyproject.toml" in path:
+                return _make_b64_response('[project]\ndependencies = ["flask"]\n')
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = side_effect
+
+        result = detect_framework(client, "owner/repo", "python")
+
+        assert result == ["python-flask"]
+
+    def test_unknown_platform_returns_empty(self) -> None:
+        client = mock.MagicMock()
+        result = detect_framework(client, "owner/repo", "unknown-platform")
+        assert result == []
+        client.get.assert_not_called()
+
+    def test_deduplicates_results(self) -> None:
+        client = mock.MagicMock()
+        # package.json with both react in deps and devDeps
+        content = json.dumps(
+            {"dependencies": {"react": "^18.0.0"}, "devDependencies": {"react": "^18.0.0"}}
+        )
+        client.get.return_value = _make_b64_response(content)
+
+        result = detect_framework(client, "owner/repo", "javascript")
+
+        assert result.count("javascript-react") == 1
+
+
+class TestDetectPlatforms:
+    def test_detects_single_language_repo(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert len(result) == 1
+        assert result[0] == DetectedPlatform(
+            platform="python",
+            language="Python",
+            bytes=50000,
+            confidence="medium",
+        )
+
+    def test_detects_multi_language_repo(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000, "JavaScript": 30000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python" in platforms
+        assert "javascript" in platforms
+
+    def test_filters_ignored_languages(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {
+            "Python": 50000,
+            "Shell": 5000,
+            "Makefile": 1000,
+            "Dockerfile": 500,
+        }
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        languages = [r["language"] for r in result]
+        assert "Python" in languages
+        assert "Shell" not in languages
+        assert "Makefile" not in languages
+        assert "Dockerfile" not in languages
+
+    def test_framework_detection_gives_high_confidence(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        django_result = next(r for r in result if r["platform"] == "python-django")
+        assert django_result["confidence"] == "high"
+
+        python_result = next(r for r in result if r["platform"] == "python")
+        assert python_result["confidence"] == "medium"
+
+    def test_preserves_github_ordering(self) -> None:
+        client = mock.MagicMock()
+        # GitHub returns languages ordered by bytes descending
+        client.get_languages.return_value = {"Python": 50000, "Go": 30000, "Ruby": 10000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert result[0]["language"] == "Python"
+        assert result[1]["language"] == "Go"
+        assert result[2]["language"] == "Ruby"
+
+    def test_typescript_and_javascript_deduplicated(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"TypeScript": 40000, "JavaScript": 10000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert platforms.count("javascript") == 1
+
+    def test_empty_repo_returns_empty(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {}
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert result == []
+
+    def test_only_ignored_languages_returns_empty(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Shell": 5000, "Makefile": 1000}
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert result == []
+
+    @pytest.mark.parametrize(
+        ("language", "expected_platform"),
+        [
+            ("Python", "python"),
+            ("JavaScript", "javascript"),
+            ("TypeScript", "javascript"),
+            ("Java", "java"),
+            ("Kotlin", "kotlin"),
+            ("Swift", "swift"),
+            ("Go", "go"),
+            ("Ruby", "ruby"),
+            ("PHP", "php"),
+            ("Rust", "rust"),
+            ("C#", "dotnet"),
+            ("Dart", "dart"),
+            ("Elixir", "elixir"),
+        ],
+    )
+    def test_all_mapped_languages_detected(self, language: str, expected_platform: str) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {language: 10000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert len(result) >= 1
+        assert result[0]["platform"] == expected_platform

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -6,16 +6,15 @@ from unittest import mock
 import pytest
 
 from sentry.integrations.github.platform_detection import (
-    BASE_PLATFORM_PRIORITY,
-    CONFIG_FILE_BONUS,
-    FRAMEWORK_PRIORITY,
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
     _apply_supersession,
-    _detect_frameworks_from_content,
-    _detect_from_config_files,
+    _framework_matches,
     _get_root_file_names,
-    detect_framework,
+    _package_in_manifest,
+    _PackageManifest,
+    _parse_package_manifest,
+    _rule_matches,
     detect_platforms,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -42,205 +41,210 @@ class TestGithubLanguageMapping:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get("Brainfuck") is None
 
 
-class TestDetectFrameworksFromContent:
-    def test_package_json_detects_next(self) -> None:
-        content = json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"next": "javascript-nextjs", "react": "javascript-react"}
-        )
-        platforms = [m["platform"] for m in result]
-        assert "javascript-nextjs" in platforms
-        assert "javascript-react" in platforms
-        # Both are in prod deps
-        for m in result:
-            assert m["dep_source"] == "dependencies"
-
-    def test_package_json_checks_dev_dependencies(self) -> None:
-        content = json.dumps({"devDependencies": {"svelte": "^4.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"svelte": "javascript-svelte"}
-        )
-        assert len(result) == 1
-        assert result[0]["platform"] == "javascript-svelte"
-        assert result[0]["dep_source"] == "devDependencies"
-
-    def test_package_json_prefers_prod_over_dev(self) -> None:
+class TestParsePackageManifest:
+    def test_parses_package_json(self) -> None:
         content = json.dumps(
-            {"dependencies": {"react": "^18.0.0"}, "devDependencies": {"react": "^18.0.0"}}
+            {"dependencies": {"next": "^14.0.0"}, "devDependencies": {"jest": "^29.0.0"}}
         )
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"react": "javascript-react"}
-        )
-        assert len(result) == 1
-        assert result[0]["dep_source"] == "dependencies"
+        result = _parse_package_manifest(content, "package.json")
+        assert result is not None
+        assert result["dependencies"] == {"next"}
+        assert result["dev_dependencies"] == {"jest"}
 
-    def test_package_json_no_match(self) -> None:
-        content = json.dumps({"dependencies": {"lodash": "^4.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"next": "javascript-nextjs"}
-        )
-        assert result == []
-
-    def test_package_json_invalid_json(self) -> None:
-        result = _detect_frameworks_from_content(
-            "not valid json", "package.json", {"next": "javascript-nextjs"}
-        )
-        assert result == []
-
-    def test_requirements_txt_detects_django(self) -> None:
-        content = "Django==4.2\ncelery>=5.0\nredis\n"
-        result = _detect_frameworks_from_content(
-            content,
-            "requirements.txt",
-            {"django": "python-django", "celery": "python-celery"},
-        )
-        platforms = [m["platform"] for m in result]
-        assert "python-django" in platforms
-        assert "python-celery" in platforms
-        for m in result:
-            assert m["dep_source"] == "unknown"
-
-    def test_requirements_txt_case_insensitive(self) -> None:
-        content = "Flask==3.0\n"
-        result = _detect_frameworks_from_content(
-            content, "requirements.txt", {"flask": "python-flask"}
-        )
-        assert len(result) == 1
-        assert result[0]["platform"] == "python-flask"
-
-    def test_gemfile_detects_rails(self) -> None:
-        content = 'gem "rails", "~> 7.0"\ngem "pg"\n'
-        result = _detect_frameworks_from_content(content, "Gemfile", {"rails": "ruby-rails"})
-        assert len(result) == 1
-        assert result[0]["platform"] == "ruby-rails"
-
-    def test_composer_json_detects_laravel(self) -> None:
-        content = json.dumps({"require": {"laravel/framework": "^10.0"}})
-        result = _detect_frameworks_from_content(
-            content, "composer.json", {"laravel/framework": "php-laravel"}
-        )
-        assert len(result) == 1
-        assert result[0]["platform"] == "php-laravel"
-        assert result[0]["dep_source"] == "dependencies"
-
-    def test_composer_json_prefix_match_symfony(self) -> None:
-        content = json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})
-        result = _detect_frameworks_from_content(
-            content, "composer.json", {"symfony/": "php-symfony"}
-        )
-        assert len(result) == 1
-        assert result[0]["platform"] == "php-symfony"
-
-    def test_composer_json_dev_dependency(self) -> None:
-        content = json.dumps({"require-dev": {"laravel/framework": "^10.0"}})
-        result = _detect_frameworks_from_content(
-            content, "composer.json", {"laravel/framework": "php-laravel"}
-        )
-        assert len(result) == 1
-        assert result[0]["dep_source"] == "devDependencies"
-
-    def test_go_mod_detects_gin(self) -> None:
-        content = "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
-        result = _detect_frameworks_from_content(content, "go.mod", {"gin": "go-gin"})
-        assert len(result) == 1
-        assert result[0]["platform"] == "go-gin"
-
-    def test_build_gradle_detects_spring_boot(self) -> None:
-        content = (
-            "dependencies {\n    implementation 'org.springframework.boot:spring-boot-starter'\n}\n"
-        )
-        result = _detect_frameworks_from_content(
-            content, "build.gradle", {"spring-boot": "java-spring-boot"}
-        )
-        assert len(result) == 1
-        assert result[0]["platform"] == "java-spring-boot"
-
-
-def _make_b64_response(content: str) -> dict:
-    """Helper to create a GitHub contents API response with base64-encoded content."""
-    return {"content": b64encode(content.encode()).decode()}
-
-
-class TestDetectFramework:
-    def test_detects_python_django(self) -> None:
-        client = mock.MagicMock()
-        client.get.return_value = _make_b64_response("Django==4.2\ncelery>=5.0\n")
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        platforms = [m["platform"] for m in result]
-        assert "python-django" in platforms
-        assert "python-celery" in platforms
-
-    def test_falls_back_when_manifest_not_found(self) -> None:
-        client = mock.MagicMock()
-        client.get.side_effect = ApiError("Not Found", code=404)
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert result == []
-
-    def test_stops_after_first_manifest_with_results(self) -> None:
-        client = mock.MagicMock()
-        client.get.return_value = _make_b64_response("Django==4.2\n")
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert len(result) == 1
-        assert result[0]["platform"] == "python-django"
-        # Should have only called get() once (for requirements.txt),
-        # not continued to pyproject.toml
-        assert client.get.call_count == 1
-
-    def test_tries_next_manifest_when_first_has_no_match(self) -> None:
-        client = mock.MagicMock()
-
-        def side_effect(path, params=None):
-            if "requirements.txt" in path:
-                return _make_b64_response("some-unrelated-package\n")
-            if "pyproject.toml" in path:
-                return _make_b64_response('[project]\ndependencies = ["flask"]\n')
-            raise ApiError("Not Found", code=404)
-
-        client.get.side_effect = side_effect
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert len(result) == 1
-        assert result[0]["platform"] == "python-flask"
-
-    def test_unknown_platform_returns_empty(self) -> None:
-        client = mock.MagicMock()
-        result = detect_framework(client, "owner/repo", "unknown-platform")
-        assert result == []
-        client.get.assert_not_called()
-
-    def test_deduplicates_results(self) -> None:
-        client = mock.MagicMock()
-        # package.json with both react in deps and devDeps
+    def test_parses_composer_json(self) -> None:
         content = json.dumps(
-            {"dependencies": {"react": "^18.0.0"}, "devDependencies": {"react": "^18.0.0"}}
+            {"require": {"laravel/framework": "^10.0"}, "require-dev": {"phpunit/phpunit": "^10"}}
         )
-        client.get.return_value = _make_b64_response(content)
+        result = _parse_package_manifest(content, "composer.json")
+        assert result is not None
+        assert result["dependencies"] == {"laravel/framework"}
+        assert result["dev_dependencies"] == {"phpunit/phpunit"}
 
-        result = detect_framework(client, "owner/repo", "javascript")
+    def test_invalid_json_returns_none(self) -> None:
+        assert _parse_package_manifest("not json", "package.json") is None
 
-        react_matches = [m for m in result if m["platform"] == "javascript-react"]
-        assert len(react_matches) == 1
-        # Should prefer prod dep
-        assert react_matches[0]["dep_source"] == "dependencies"
+    def test_unsupported_manifest_returns_none(self) -> None:
+        assert _parse_package_manifest("{}", "requirements.txt") is None
 
-    def test_returns_framework_match_objects(self) -> None:
-        client = mock.MagicMock()
-        content = json.dumps({"dependencies": {"next": "^14.0.0"}})
-        client.get.return_value = _make_b64_response(content)
 
-        result = detect_framework(client, "owner/repo", "javascript")
+class TestPackageInManifest:
+    def test_exact_match_in_dependencies(self) -> None:
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _package_in_manifest("next", manifest) is True
 
-        assert len(result) >= 1
-        match = result[0]
-        assert "platform" in match
-        assert "dep_source" in match
+    def test_exact_match_in_dev_dependencies(self) -> None:
+        manifest = _PackageManifest(dependencies=set(), dev_dependencies={"jest"})
+        assert _package_in_manifest("jest", manifest) is True
+
+    def test_no_match(self) -> None:
+        manifest = _PackageManifest(dependencies={"react"}, dev_dependencies=set())
+        assert _package_in_manifest("vue", manifest) is False
+
+    def test_prefix_match_for_composer(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"symfony/framework-bundle"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("symfony/", manifest) is True
+
+    def test_prefix_no_match(self) -> None:
+        manifest = _PackageManifest(dependencies={"laravel/framework"}, dev_dependencies=set())
+        assert _package_in_manifest("symfony/", manifest) is False
+
+
+class TestRuleMatches:
+    def test_path_rule_matches_when_file_exists(self) -> None:
+        rule = {"path": "next.config.js"}
+        assert _rule_matches(rule, {"next.config.js", "package.json"}, {}, None) is True
+
+    def test_path_rule_no_match_when_file_missing(self) -> None:
+        rule = {"path": "next.config.js"}
+        assert _rule_matches(rule, {"package.json"}, {}, None) is False
+
+    def test_path_with_content_matches_regex(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert (
+            _rule_matches(rule, set(), {"requirements.txt": "Django==4.2\ncelery>=5.0\n"}, None)
+            is True
+        )
+
+    def test_path_with_content_case_insensitive(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"}
+        assert _rule_matches(rule, set(), {"requirements.txt": "Flask==3.0\n"}, None) is True
+
+    def test_path_with_content_no_match(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert _rule_matches(rule, set(), {"requirements.txt": "flask==3.0\n"}, None) is False
+
+    def test_path_with_content_file_not_fetched(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert _rule_matches(rule, set(), {}, None) is False
+
+    def test_match_package_finds_dependency(self) -> None:
+        rule = {"match_package": "next"}
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _rule_matches(rule, set(), {}, manifest) is True
+
+    def test_match_package_finds_dev_dependency(self) -> None:
+        rule = {"match_package": "svelte"}
+        manifest = _PackageManifest(dependencies=set(), dev_dependencies={"svelte"})
+        assert _rule_matches(rule, set(), {}, manifest) is True
+
+    def test_match_package_no_match(self) -> None:
+        rule = {"match_package": "next"}
+        manifest = _PackageManifest(dependencies={"react"}, dev_dependencies=set())
+        assert _rule_matches(rule, set(), {}, manifest) is False
+
+    def test_match_package_no_manifest(self) -> None:
+        rule = {"match_package": "next"}
+        assert _rule_matches(rule, set(), {}, None) is False
+
+    def test_match_package_prefix_match(self) -> None:
+        rule = {"match_package": "symfony/"}
+        manifest = _PackageManifest(
+            dependencies={"symfony/framework-bundle"}, dev_dependencies=set()
+        )
+        assert _rule_matches(rule, set(), {}, manifest) is True
+
+    def test_rule_without_path_or_package_returns_false(self) -> None:
+        rule: dict = {}
+        assert _rule_matches(rule, {"file.txt"}, {}, None) is False
+
+
+class TestFrameworkMatches:
+    def test_some_rules_match_when_any_passes(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [
+                {"path": "missing.js"},
+                {"path": "found.js"},
+            ],
+        }
+        assert _framework_matches(fw, {"found.js"}, {}, None) is True
+
+    def test_some_rules_no_match_when_none_pass(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [
+                {"path": "missing1.js"},
+                {"path": "missing2.js"},
+            ],
+        }
+        assert _framework_matches(fw, set(), {}, None) is False
+
+    def test_every_rules_match_when_all_pass(self) -> None:
+        manifest = _PackageManifest(dependencies={"express", "cors"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_package": "express"}],
+        }
+        assert _framework_matches(fw, set(), {}, manifest) is True
+
+    def test_every_rules_no_match_when_one_fails(self) -> None:
+        manifest = _PackageManifest(dependencies={"cors"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [
+                {"match_package": "express"},
+                {"match_package": "cors"},
+            ],
+        }
+        assert _framework_matches(fw, set(), {}, manifest) is False
+
+    def test_every_and_some_combined(self) -> None:
+        manifest = _PackageManifest(dependencies={"express"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_package": "express"}],
+            "some": [{"path": "app.js"}, {"path": "server.js"}],
+        }
+        # every passes, some passes (server.js exists)
+        assert _framework_matches(fw, {"server.js"}, {}, manifest) is True
+        # every passes, some fails (neither file exists)
+        assert _framework_matches(fw, set(), {}, manifest) is False
+
+    def test_empty_every_and_some_returns_false(self) -> None:
+        fw = {"platform": "test", "sort": 1, "base_platform": "test"}
+        assert _framework_matches(fw, set(), {}, None) is False
+
+    def test_nextjs_matches_from_package(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _framework_matches(nextjs, set(), {}, manifest) is True
+
+    def test_nextjs_matches_from_config_file(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
+        assert _framework_matches(nextjs, {"next.config.js"}, {}, None) is True
+
+    def test_django_matches_from_manage_py(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
+        assert _framework_matches(django, {"manage.py"}, {}, None) is True
+
+    def test_django_matches_from_requirements_content(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
+        assert (
+            _framework_matches(
+                django, set(), {"requirements.txt": "Django==4.2\ncelery>=5.0\n"}, None
+            )
+            is True
+        )
 
 
 class TestGetRootFileNames:
@@ -282,44 +286,7 @@ class TestGetRootFileNames:
 
         _get_root_file_names(client, "owner/repo", ref="main")
 
-        client.get.assert_called_once_with("/repos/owner/repo/contents/", params={"ref": "main"})
-
-
-class TestDetectFromConfigFiles:
-    def test_detects_nextjs_from_config(self) -> None:
-        root_files = {"next.config.js", "package.json", "README.md"}
-        result = _detect_from_config_files(root_files, "javascript")
-        assert "javascript-nextjs" in result
-
-    def test_detects_nuxt_from_config(self) -> None:
-        root_files = {"nuxt.config.ts", "package.json"}
-        result = _detect_from_config_files(root_files, "javascript")
-        assert "javascript-nuxt" in result
-
-    def test_detects_django_from_manage_py(self) -> None:
-        root_files = {"manage.py", "requirements.txt"}
-        result = _detect_from_config_files(root_files, "python")
-        assert "python-django" in result
-
-    def test_detects_laravel_from_artisan(self) -> None:
-        root_files = {"artisan", "composer.json"}
-        result = _detect_from_config_files(root_files, "php")
-        assert "php-laravel" in result
-
-    def test_no_match_returns_empty(self) -> None:
-        root_files = {"README.md", "setup.py"}
-        result = _detect_from_config_files(root_files, "javascript")
-        assert result == []
-
-    def test_unknown_platform_returns_empty(self) -> None:
-        root_files = {"next.config.js"}
-        result = _detect_from_config_files(root_files, "unknown")
-        assert result == []
-
-    def test_deduplicates_multiple_config_variants(self) -> None:
-        root_files = {"next.config.js", "next.config.mjs"}
-        result = _detect_from_config_files(root_files, "javascript")
-        assert result.count("javascript-nextjs") == 1
+        client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
 
 
 class TestApplySupersession:
@@ -330,7 +297,7 @@ class TestApplySupersession:
                 language="JavaScript",
                 bytes=50000,
                 confidence="high",
-                priority=100,
+                priority=99,
             ),
             DetectedPlatform(
                 platform="javascript-react",
@@ -352,7 +319,7 @@ class TestApplySupersession:
                 language="JavaScript",
                 bytes=50000,
                 confidence="high",
-                priority=100,
+                priority=99,
             ),
             DetectedPlatform(
                 platform="javascript-vue",
@@ -374,7 +341,7 @@ class TestApplySupersession:
                 language="JavaScript",
                 bytes=50000,
                 confidence="high",
-                priority=100,
+                priority=99,
             ),
             DetectedPlatform(
                 platform="javascript-react",
@@ -416,7 +383,7 @@ class TestApplySupersession:
                 language="JavaScript",
                 bytes=50000,
                 confidence="high",
-                priority=100,
+                priority=99,
             ),
             DetectedPlatform(
                 platform="node-express",
@@ -440,6 +407,11 @@ class TestApplySupersession:
         assert "javascript-react" not in platforms
 
 
+def _make_b64_response(content: str) -> dict:
+    """Helper to create a GitHub contents API response with base64-encoded content."""
+    return {"content": b64encode(content.encode()).decode()}
+
+
 class TestDetectPlatforms:
     def test_detects_single_language_repo(self) -> None:
         client = mock.MagicMock()
@@ -453,7 +425,7 @@ class TestDetectPlatforms:
         assert result[0]["language"] == "Python"
         assert result[0]["bytes"] == 50000
         assert result[0]["confidence"] == "medium"
-        assert result[0]["priority"] == BASE_PLATFORM_PRIORITY
+        assert result[0]["priority"] == 1
 
     def test_detects_multi_language_repo(self) -> None:
         client = mock.MagicMock()
@@ -489,6 +461,8 @@ class TestDetectPlatforms:
         client.get_languages.return_value = {"Python": 50000}
 
         def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "requirements.txt", "type": "file"}]
             if "requirements.txt" in path:
                 return _make_b64_response("Django==4.2\n")
             raise ApiError("Not Found", code=404)
@@ -505,10 +479,14 @@ class TestDetectPlatforms:
 
     def test_results_sorted_by_priority_then_bytes(self) -> None:
         client = mock.MagicMock()
-        # Python has more bytes but framework detection gives JS higher priority
         client.get_languages.return_value = {"Python": 80000, "JavaScript": 30000}
 
         def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "requirements.txt", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
             if "requirements.txt" in path:
                 return _make_b64_response("flask==3.0\n")
             if "package.json" in path:
@@ -521,7 +499,7 @@ class TestDetectPlatforms:
 
         result = detect_platforms(client, "owner/repo")
 
-        # Next.js (priority 110) > Django (95) > base platforms (10)
+        # Next.js (priority=99) > Flask (priority=80) > base platforms (priority=1)
         platforms = [r["platform"] for r in result]
         nextjs_idx = platforms.index("javascript-nextjs")
         flask_idx = platforms.index("python-flask")
@@ -536,9 +514,11 @@ class TestDetectPlatforms:
         )
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
-                return []
-            return _make_b64_response(content)
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
 
         client.get.side_effect = get_side_effect
 
@@ -550,7 +530,7 @@ class TestDetectPlatforms:
         assert "javascript-react" not in platforms
         assert "javascript" in platforms
 
-    def test_prod_dep_ranks_higher_than_dev_dep(self) -> None:
+    def test_framework_sort_determines_ranking(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"JavaScript": 50000}
 
@@ -562,22 +542,21 @@ class TestDetectPlatforms:
         )
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
-                return []
-            return _make_b64_response(content)
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
 
         client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
-        express = next(r for r in result if r["platform"] == "node-express")
         svelte = next(r for r in result if r["platform"] == "javascript-svelte")
-        # express: priority 60 + 10 (prod) = 70
-        # svelte: priority 70 + 0 (dev) = 70
-        # Same priority, but express has same bytes, so order may vary.
-        # The key thing is both are present and have correct priorities.
-        assert express["priority"] == FRAMEWORK_PRIORITY["node-express"] + 10
-        assert svelte["priority"] == FRAMEWORK_PRIORITY["javascript-svelte"] + 0
+        express = next(r for r in result if r["platform"] == "node-express")
+        # svelte sort=30 → priority=70, express sort=40 → priority=60
+        assert svelte["priority"] == 70
+        assert express["priority"] == 60
 
     def test_typescript_and_javascript_deduplicated(self) -> None:
         client = mock.MagicMock()
@@ -649,7 +628,7 @@ class TestDetectPlatforms:
         client.get_languages.return_value = {"JavaScript": 50000}
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
+            if path.endswith("/contents"):
                 return [
                     {"name": "next.config.js", "type": "file"},
                     {"name": "package.json", "type": "file"},
@@ -667,12 +646,12 @@ class TestDetectPlatforms:
         # React is superseded by Next.js
         assert "javascript-react" not in platforms
 
-    def test_config_file_gets_priority_bonus(self) -> None:
+    def test_config_file_sets_high_priority(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"JavaScript": 50000}
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
+            if path.endswith("/contents"):
                 return [
                     {"name": "next.config.js", "type": "file"},
                     {"name": "package.json", "type": "file"},
@@ -686,17 +665,15 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
-        # base priority (100) + config bonus (20) + prod dep bonus (10) = 130
-        assert (
-            nextjs["priority"] == FRAMEWORK_PRIORITY["javascript-nextjs"] + CONFIG_FILE_BONUS + 10
-        )
+        # sort=1 → priority=99
+        assert nextjs["priority"] == 99
 
-    def test_config_file_only_gets_config_bonus_without_dep(self) -> None:
+    def test_config_file_only_detection(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"JavaScript": 50000}
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
+            if path.endswith("/contents"):
                 return [
                     {"name": "next.config.js", "type": "file"},
                     {"name": "package.json", "type": "file"},
@@ -710,15 +687,15 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
-        # base priority (100) + config bonus (20) + no dep bonus (0) = 120
-        assert nextjs["priority"] == FRAMEWORK_PRIORITY["javascript-nextjs"] + CONFIG_FILE_BONUS
+        # sort=1 → priority=99 (same regardless of dep presence)
+        assert nextjs["priority"] == 99
 
     def test_manage_py_detects_django(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Python": 50000}
 
         def get_side_effect(path, params=None):
-            if path.endswith("/contents/"):
+            if path.endswith("/contents"):
                 return [
                     {"name": "manage.py", "type": "file"},
                     {"name": "requirements.txt", "type": "file"},
@@ -733,5 +710,116 @@ class TestDetectPlatforms:
 
         django = next(r for r in result if r["platform"] == "python-django")
         assert django["confidence"] == "high"
-        # base priority (90) + config bonus (20) + unknown dep bonus (5) = 115
-        assert django["priority"] == FRAMEWORK_PRIORITY["python-django"] + CONFIG_FILE_BONUS + 5
+        # sort=10 → priority=90
+        assert django["priority"] == 90
+
+    def test_base_platform_priority_is_one(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert result[0]["platform"] == "python"
+        assert result[0]["priority"] == 1
+
+    def test_multiple_frameworks_same_platform(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "manage.py", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\ncelery>=5.0\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-django" in platforms
+        assert "python-celery" in platforms
+        assert "python" in platforms
+
+    def test_no_root_files_only_base_platforms(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000, "JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return []
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert platforms == ["python", "javascript"] or set(platforms) == {
+            "python",
+            "javascript",
+        }
+        for r in result:
+            assert r["confidence"] == "medium"
+            assert r["priority"] == 1
+
+    def test_laravel_detected_from_artisan(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PHP": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "artisan", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "php-laravel" in platforms
+
+    def test_spring_boot_detected_from_build_gradle(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "build.gradle", "type": "file"}]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "dependencies {\n    implementation 'org.springframework.boot:spring-boot-starter'\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "java-spring-boot" in platforms
+
+    def test_go_gin_detected_from_go_mod(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Go": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "go.mod", "type": "file"}]
+            if "go.mod" in path:
+                return _make_b64_response(
+                    "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "go-gin" in platforms

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -10,10 +10,13 @@ from sentry.integrations.github.platform_detection import (
     DetectedPlatform,
     _apply_supersession,
     _framework_matches,
-    _get_root_file_names,
+    _get_root_entries,
     _package_in_manifest,
     _PackageManifest,
+    _parse_gemfile,
+    _parse_go_mod,
     _parse_package_manifest,
+    _parse_pubspec_yaml,
     _rule_matches,
     detect_platforms,
 )
@@ -36,6 +39,9 @@ class TestGithubLanguageMapping:
 
     def test_objectivec_maps_to_apple_ios(self) -> None:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["Objective-C"] == "apple-ios"
+
+    def test_powershell_maps_to_powershell(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["PowerShell"] == "powershell"
 
     def test_unmapped_language_returns_none(self) -> None:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get("Brainfuck") is None
@@ -66,6 +72,101 @@ class TestParsePackageManifest:
     def test_unsupported_manifest_returns_none(self) -> None:
         assert _parse_package_manifest("{}", "requirements.txt") is None
 
+    def test_delegates_to_pubspec_yaml(self) -> None:
+        content = "dependencies:\n  flutter:\n    sdk: flutter\n  http: ^0.13.5\n"
+        result = _parse_package_manifest(content, "pubspec.yaml")
+        assert result is not None
+        assert "flutter" in result["dependencies"]
+        assert "http" in result["dependencies"]
+
+    def test_delegates_to_gemfile(self) -> None:
+        content = 'gem "rails", "~> 7.0"\ngem "puma"\n'
+        result = _parse_package_manifest(content, "Gemfile")
+        assert result is not None
+        assert "rails" in result["dependencies"]
+        assert "puma" in result["dependencies"]
+
+    def test_delegates_to_go_mod(self) -> None:
+        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+        result = _parse_package_manifest(content, "go.mod")
+        assert result is not None
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+
+
+class TestParsePubspecYaml:
+    def test_extracts_dependencies(self) -> None:
+        content = (
+            "name: my_app\n"
+            "dependencies:\n"
+            "  flutter:\n"
+            "    sdk: flutter\n"
+            "  http: ^0.13.5\n"
+            "  cupertino_icons: ^1.0.2\n"
+            "dev_dependencies:\n"
+            "  flutter_test:\n"
+            "    sdk: flutter\n"
+            "  flutter_lints: ^2.0.0\n"
+        )
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == {"flutter", "http", "cupertino_icons"}
+        assert result["dev_dependencies"] == {"flutter_test", "flutter_lints"}
+
+    def test_empty_sections(self) -> None:
+        content = "name: my_app\ndependencies:\ndev_dependencies:\n"
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == set()
+        assert result["dev_dependencies"] == set()
+
+    def test_no_dev_dependencies(self) -> None:
+        content = "name: my_app\ndependencies:\n  http: ^0.13.5\n"
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == {"http"}
+        assert result["dev_dependencies"] == set()
+
+
+class TestParseGemfile:
+    def test_extracts_gem_names(self) -> None:
+        content = (
+            'source "https://rubygems.org"\n'
+            'gem "rails", "~> 7.0"\n'
+            "gem 'puma', '~> 6.0'\n"
+            'gem "rack"\n'
+        )
+        result = _parse_gemfile(content)
+        assert result["dependencies"] == {"rails", "puma", "rack"}
+
+    def test_ignores_comments(self) -> None:
+        content = '# gem "not-this"\ngem "real-gem"\n'
+        result = _parse_gemfile(content)
+        assert result["dependencies"] == {"real-gem"}
+
+    def test_empty_gemfile(self) -> None:
+        result = _parse_gemfile("")
+        assert result["dependencies"] == set()
+
+
+class TestParseGoMod:
+    def test_single_require(self) -> None:
+        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+        result = _parse_go_mod(content)
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+
+    def test_require_block(self) -> None:
+        content = (
+            "module example.com/app\n\n"
+            "require (\n"
+            "\tgithub.com/gin-gonic/gin v1.9.1\n"
+            "\tgithub.com/labstack/echo/v4 v4.11.0\n"
+            ")\n"
+        )
+        result = _parse_go_mod(content)
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+        assert "github.com/labstack/echo/v4" in result["dependencies"]
+
+    def test_empty_go_mod(self) -> None:
+        result = _parse_go_mod("module example.com/app\n\ngo 1.21\n")
+        assert result["dependencies"] == set()
+
 
 class TestPackageInManifest:
     def test_exact_match_in_dependencies(self) -> None:
@@ -89,6 +190,18 @@ class TestPackageInManifest:
     def test_prefix_no_match(self) -> None:
         manifest = _PackageManifest(dependencies={"laravel/framework"}, dev_dependencies=set())
         assert _package_in_manifest("symfony/", manifest) is False
+
+    def test_go_module_version_path_match(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"github.com/labstack/echo/v4"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("github.com/labstack/echo", manifest) is True
+
+    def test_go_module_exact_match(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"github.com/gin-gonic/gin"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("github.com/gin-gonic/gin", manifest) is True
 
 
 class TestRuleMatches:
@@ -148,6 +261,30 @@ class TestRuleMatches:
     def test_rule_without_path_or_package_returns_false(self) -> None:
         rule: dict = {}
         assert _rule_matches(rule, {"file.txt"}, {}, None) is False
+
+    def test_match_dir_matches_when_dir_exists(self) -> None:
+        rule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs={"Assets", "src"}) is True
+
+    def test_match_dir_no_match_when_dir_missing(self) -> None:
+        rule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs={"src", "lib"}) is False
+
+    def test_match_dir_no_match_when_root_dirs_none(self) -> None:
+        rule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs=None) is False
+
+    def test_match_ext_matches_when_extension_exists(self) -> None:
+        rule = {"match_ext": ".csproj"}
+        assert _rule_matches(rule, {"MyApp.csproj", "README.md"}, {}, None) is True
+
+    def test_match_ext_no_match_when_extension_missing(self) -> None:
+        rule = {"match_ext": ".csproj"}
+        assert _rule_matches(rule, {"README.md", "package.json"}, {}, None) is False
+
+    def test_match_ext_uproject(self) -> None:
+        rule = {"match_ext": ".uproject"}
+        assert _rule_matches(rule, {"MyGame.uproject"}, {}, None) is True
 
 
 class TestFrameworkMatches:
@@ -216,6 +353,31 @@ class TestFrameworkMatches:
         fw = {"platform": "test", "sort": 1, "base_platform": "test"}
         assert _framework_matches(fw, set(), {}, None) is False
 
+    def test_match_dir_in_every(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_dir": "Assets"}, {"match_dir": "ProjectSettings"}],
+        }
+        assert (
+            _framework_matches(
+                fw, set(), {}, None, root_dirs={"Assets", "ProjectSettings", "Packages"}
+            )
+            is True
+        )
+        assert _framework_matches(fw, set(), {}, None, root_dirs={"Assets"}) is False
+
+    def test_match_ext_in_some(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [{"match_ext": ".csproj"}],
+        }
+        assert _framework_matches(fw, {"MyApp.csproj"}, {}, None) is True
+        assert _framework_matches(fw, {"README.md"}, {}, None) is False
+
     def test_nextjs_matches_from_package(self) -> None:
         from sentry.integrations.github.platform_detection import FRAMEWORKS
 
@@ -246,9 +408,35 @@ class TestFrameworkMatches:
             is True
         )
 
+    def test_unity_matches_from_directories(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
 
-class TestGetRootFileNames:
-    def test_returns_file_names(self) -> None:
+        unity = next(fw for fw in FRAMEWORKS if fw["platform"] == "unity")
+        assert (
+            _framework_matches(
+                unity, set(), {}, None, root_dirs={"Assets", "ProjectSettings", "Packages"}
+            )
+            is True
+        )
+        assert _framework_matches(unity, set(), {}, None, root_dirs={"Assets"}) is False
+
+    def test_flutter_matches_from_pubspec(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        flutter = next(fw for fw in FRAMEWORKS if fw["platform"] == "flutter")
+        manifest = _PackageManifest(dependencies={"flutter", "http"}, dev_dependencies=set())
+        assert _framework_matches(flutter, set(), {}, manifest) is True
+
+    def test_dotnet_aspnetcore_matches_from_csproj(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        aspnet = next(fw for fw in FRAMEWORKS if fw["platform"] == "dotnet-aspnetcore")
+        assert _framework_matches(aspnet, {"MyApp.csproj"}, {}, None) is True
+        assert _framework_matches(aspnet, {"README.md"}, {}, None) is False
+
+
+class TestGetRootEntries:
+    def test_returns_files_and_dirs(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = [
             {"name": "package.json", "type": "file"},
@@ -257,34 +445,37 @@ class TestGetRootFileNames:
             {"name": "README.md", "type": "file"},
         ]
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result == {"package.json", "next.config.js", "README.md"}
+        assert files == {"package.json", "next.config.js", "README.md"}
+        assert dirs == {"src"}
 
-    def test_excludes_directories(self) -> None:
+    def test_excludes_directories_from_files(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = [
             {"name": "src", "type": "dir"},
             {"name": "lib", "type": "dir"},
         ]
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result == set()
+        assert files == set()
+        assert dirs == {"src", "lib"}
 
     def test_returns_empty_on_api_error(self) -> None:
         client = mock.MagicMock()
         client.get.side_effect = ApiError("Not Found", code=404)
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result == set()
+        assert files == set()
+        assert dirs == set()
 
     def test_passes_ref_param(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = []
 
-        _get_root_file_names(client, "owner/repo", ref="main")
+        _get_root_entries(client, "owner/repo", ref="main")
 
         client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
 
@@ -355,6 +546,94 @@ class TestApplySupersession:
         platforms = [r["platform"] for r in filtered]
         assert "javascript-remix" in platforms
         assert "javascript-react" not in platforms
+
+    def test_sveltekit_supersedes_svelte(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-sveltekit",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-svelte",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-sveltekit" in platforms
+        assert "javascript-svelte" not in platforms
+
+    def test_gatsby_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-gatsby",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-gatsby" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_react_native_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="react-native",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "react-native" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_cloudflare_pages_supersedes_workers(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="node-cloudflare-pages",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=50,
+            ),
+            DetectedPlatform(
+                platform="node-cloudflare-workers",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=50,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "node-cloudflare-pages" in platforms
+        assert "node-cloudflare-workers" not in platforms
 
     def test_no_supersession_keeps_all(self) -> None:
         results = [
@@ -455,6 +734,16 @@ class TestDetectPlatforms:
         assert "Shell" not in languages
         assert "Makefile" not in languages
         assert "Dockerfile" not in languages
+
+    def test_powershell_detected_as_base_platform(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PowerShell": 20000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert len(result) == 1
+        assert result[0]["platform"] == "powershell"
 
     def test_framework_detection_gives_high_confidence(self) -> None:
         client = mock.MagicMock()
@@ -611,6 +900,7 @@ class TestDetectPlatforms:
             ("C#", "dotnet"),
             ("Dart", "dart"),
             ("Elixir", "elixir"),
+            ("PowerShell", "powershell"),
         ],
     )
     def test_all_mapped_languages_detected(self, language: str, expected_platform: str) -> None:
@@ -823,3 +1113,372 @@ class TestDetectPlatforms:
 
         platforms = [r["platform"] for r in result]
         assert "go-gin" in platforms
+
+    def test_react_native_detected_and_supersedes_react(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"react-native": "^0.72.0", "react": "^18.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "react-native" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_electron_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"electron": "^28.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "electron" in platforms
+
+    def test_flutter_detected_from_pubspec(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Dart": 50000}
+
+        pubspec_content = (
+            "name: my_app\ndependencies:\n  flutter:\n    sdk: flutter\n  http: ^0.13.5\n"
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "pubspec.yaml", "type": "file"}]
+            if "pubspec.yaml" in path:
+                return _make_b64_response(pubspec_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "flutter" in platforms
+
+    def test_unity_detected_from_directories(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "Assets", "type": "dir"},
+                    {"name": "ProjectSettings", "type": "dir"},
+                    {"name": "Packages", "type": "dir"},
+                    {"name": "README.md", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "unity" in platforms
+
+    def test_android_detected_from_build_gradle_and_app_dir(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "app", "type": "dir"},
+                    {"name": "build.gradle", "type": "file"},
+                    {"name": "settings.gradle", "type": "file"},
+                ]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "buildscript {\n}\n\nallprojects {\n}\n\nandroid {\n    compileSdk 34\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "android" in platforms
+
+    def test_dotnet_aspnetcore_detected_from_csproj(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyApp.csproj", "type": "file"},
+                    {"name": "Program.cs", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-aspnetcore" in platforms
+
+    def test_unreal_detected_from_uproject(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyGame.uproject", "type": "file"},
+                    {"name": "Source", "type": "dir"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "unreal" in platforms
+
+    def test_godot_detected_from_project_file(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "project.godot", "type": "file"},
+                    {"name": "scenes", "type": "dir"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "godot" in platforms
+
+    def test_wordpress_detected_from_wp_config(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PHP": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "wp-config.php", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "php-wordpress" in platforms
+
+    def test_ruby_rack_detected_from_gemfile(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Ruby": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Gemfile", "type": "file"}]
+            if "Gemfile" in path:
+                return _make_b64_response('gem "rack"\ngem "puma"\n')
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "ruby-rack" in platforms
+
+    def test_python_aiohttp_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "requirements.txt", "type": "file"}]
+            if "requirements.txt" in path:
+                return _make_b64_response("aiohttp==3.9.0\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-aiohttp" in platforms
+
+    def test_java_log4j2_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "build.gradle", "type": "file"}]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "dependencies {\n    implementation 'org.apache.logging.log4j:log4j-core:2.20'\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "java-log4j2" in platforms
+
+    def test_astro_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"astro": "^4.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-astro" in platforms
+
+    def test_sveltekit_supersedes_svelte_in_full_flow(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {
+                "dependencies": {},
+                "devDependencies": {"@sveltejs/kit": "^2.0.0", "svelte": "^4.0.0"},
+            }
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-sveltekit" in platforms
+        assert "javascript-svelte" not in platforms
+
+    def test_nestjs_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"TypeScript": 50000}
+
+        content = json.dumps({"dependencies": {"@nestjs/core": "^10.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-nestjs" in platforms
+
+    def test_cloudflare_workers_detected_from_wrangler(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "wrangler.toml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-cloudflare-workers" in platforms
+
+    def test_cloudflare_pages_supersedes_workers(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "wrangler.toml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "wrangler.toml" in path:
+                return _make_b64_response(
+                    'name = "my-pages-app"\npages_build_output_dir = "./dist"\n'
+                )
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-cloudflare-pages" in platforms
+        assert "node-cloudflare-workers" not in platforms
+
+    def test_serverless_yml_detects_awslambda(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "serverless.yml", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-awslambda" in platforms

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -7,11 +7,14 @@ import pytest
 
 from sentry.integrations.github.platform_detection import (
     BASE_PLATFORM_PRIORITY,
+    CONFIG_FILE_BONUS,
     FRAMEWORK_PRIORITY,
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
     _apply_supersession,
     _detect_frameworks_from_content,
+    _detect_from_config_files,
+    _get_root_file_names,
     detect_framework,
     detect_platforms,
 )
@@ -240,6 +243,85 @@ class TestDetectFramework:
         assert "dep_source" in match
 
 
+class TestGetRootFileNames:
+    def test_returns_file_names(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = [
+            {"name": "package.json", "type": "file"},
+            {"name": "next.config.js", "type": "file"},
+            {"name": "src", "type": "dir"},
+            {"name": "README.md", "type": "file"},
+        ]
+
+        result = _get_root_file_names(client, "owner/repo")
+
+        assert result == {"package.json", "next.config.js", "README.md"}
+
+    def test_excludes_directories(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = [
+            {"name": "src", "type": "dir"},
+            {"name": "lib", "type": "dir"},
+        ]
+
+        result = _get_root_file_names(client, "owner/repo")
+
+        assert result == set()
+
+    def test_returns_empty_on_api_error(self) -> None:
+        client = mock.MagicMock()
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = _get_root_file_names(client, "owner/repo")
+
+        assert result == set()
+
+    def test_passes_ref_param(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = []
+
+        _get_root_file_names(client, "owner/repo", ref="main")
+
+        client.get.assert_called_once_with("/repos/owner/repo/contents/", params={"ref": "main"})
+
+
+class TestDetectFromConfigFiles:
+    def test_detects_nextjs_from_config(self) -> None:
+        root_files = {"next.config.js", "package.json", "README.md"}
+        result = _detect_from_config_files(root_files, "javascript")
+        assert "javascript-nextjs" in result
+
+    def test_detects_nuxt_from_config(self) -> None:
+        root_files = {"nuxt.config.ts", "package.json"}
+        result = _detect_from_config_files(root_files, "javascript")
+        assert "javascript-nuxt" in result
+
+    def test_detects_django_from_manage_py(self) -> None:
+        root_files = {"manage.py", "requirements.txt"}
+        result = _detect_from_config_files(root_files, "python")
+        assert "python-django" in result
+
+    def test_detects_laravel_from_artisan(self) -> None:
+        root_files = {"artisan", "composer.json"}
+        result = _detect_from_config_files(root_files, "php")
+        assert "php-laravel" in result
+
+    def test_no_match_returns_empty(self) -> None:
+        root_files = {"README.md", "setup.py"}
+        result = _detect_from_config_files(root_files, "javascript")
+        assert result == []
+
+    def test_unknown_platform_returns_empty(self) -> None:
+        root_files = {"next.config.js"}
+        result = _detect_from_config_files(root_files, "unknown")
+        assert result == []
+
+    def test_deduplicates_multiple_config_variants(self) -> None:
+        root_files = {"next.config.js", "next.config.mjs"}
+        result = _detect_from_config_files(root_files, "javascript")
+        assert result.count("javascript-nextjs") == 1
+
+
 class TestApplySupersession:
     def test_nextjs_supersedes_react(self) -> None:
         results = [
@@ -452,7 +534,13 @@ class TestDetectPlatforms:
         content = json.dumps(
             {"dependencies": {"next": "^14.0.0", "react": "^18.0.0", "express": "^4.0.0"}}
         )
-        client.get.return_value = _make_b64_response(content)
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return []
+            return _make_b64_response(content)
+
+        client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
@@ -472,7 +560,13 @@ class TestDetectPlatforms:
                 "devDependencies": {"svelte": "^4.0.0"},
             }
         )
-        client.get.return_value = _make_b64_response(content)
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return []
+            return _make_b64_response(content)
+
+        client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
@@ -498,6 +592,7 @@ class TestDetectPlatforms:
     def test_empty_repo_returns_empty(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {}
+        client.get.return_value = []
 
         result = detect_platforms(client, "owner/repo")
 
@@ -506,6 +601,7 @@ class TestDetectPlatforms:
     def test_only_ignored_languages_returns_empty(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Shell": 5000, "Makefile": 1000}
+        client.get.return_value = []
 
         result = detect_platforms(client, "owner/repo")
 
@@ -547,3 +643,95 @@ class TestDetectPlatforms:
 
         assert len(result) >= 1
         assert result[0]["platform"] == expected_platform
+
+    def test_config_file_detects_nextjs_without_dep(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {"react": "^18.0.0"}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-nextjs" in platforms
+        # React is superseded by Next.js
+        assert "javascript-react" not in platforms
+
+    def test_config_file_gets_priority_bonus(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {"next": "^14.0.0"}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        # base priority (100) + config bonus (20) + prod dep bonus (10) = 130
+        assert (
+            nextjs["priority"] == FRAMEWORK_PRIORITY["javascript-nextjs"] + CONFIG_FILE_BONUS + 10
+        )
+
+    def test_config_file_only_gets_config_bonus_without_dep(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        # base priority (100) + config bonus (20) + no dep bonus (0) = 120
+        assert nextjs["priority"] == FRAMEWORK_PRIORITY["javascript-nextjs"] + CONFIG_FILE_BONUS
+
+    def test_manage_py_detects_django(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents/"):
+                return [
+                    {"name": "manage.py", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        django = next(r for r in result if r["platform"] == "python-django")
+        assert django["confidence"] == "high"
+        # base priority (90) + config bonus (20) + unknown dep bonus (5) = 115
+        assert django["priority"] == FRAMEWORK_PRIORITY["python-django"] + CONFIG_FILE_BONUS + 5

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -6,8 +6,11 @@ from unittest import mock
 import pytest
 
 from sentry.integrations.github.platform_detection import (
+    BASE_PLATFORM_PRIORITY,
+    FRAMEWORK_PRIORITY,
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
+    _apply_supersession,
     _detect_frameworks_from_content,
     detect_framework,
     detect_platforms,
@@ -42,15 +45,31 @@ class TestDetectFrameworksFromContent:
         result = _detect_frameworks_from_content(
             content, "package.json", {"next": "javascript-nextjs", "react": "javascript-react"}
         )
-        assert "javascript-nextjs" in result
-        assert "javascript-react" in result
+        platforms = [m["platform"] for m in result]
+        assert "javascript-nextjs" in platforms
+        assert "javascript-react" in platforms
+        # Both are in prod deps
+        for m in result:
+            assert m["dep_source"] == "dependencies"
 
     def test_package_json_checks_dev_dependencies(self) -> None:
         content = json.dumps({"devDependencies": {"svelte": "^4.0.0"}})
         result = _detect_frameworks_from_content(
             content, "package.json", {"svelte": "javascript-svelte"}
         )
-        assert result == ["javascript-svelte"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "javascript-svelte"
+        assert result[0]["dep_source"] == "devDependencies"
+
+    def test_package_json_prefers_prod_over_dev(self) -> None:
+        content = json.dumps(
+            {"dependencies": {"react": "^18.0.0"}, "devDependencies": {"react": "^18.0.0"}}
+        )
+        result = _detect_frameworks_from_content(
+            content, "package.json", {"react": "javascript-react"}
+        )
+        assert len(result) == 1
+        assert result[0]["dep_source"] == "dependencies"
 
     def test_package_json_no_match(self) -> None:
         content = json.dumps({"dependencies": {"lodash": "^4.0.0"}})
@@ -72,39 +91,56 @@ class TestDetectFrameworksFromContent:
             "requirements.txt",
             {"django": "python-django", "celery": "python-celery"},
         )
-        assert "python-django" in result
-        assert "python-celery" in result
+        platforms = [m["platform"] for m in result]
+        assert "python-django" in platforms
+        assert "python-celery" in platforms
+        for m in result:
+            assert m["dep_source"] == "unknown"
 
     def test_requirements_txt_case_insensitive(self) -> None:
         content = "Flask==3.0\n"
         result = _detect_frameworks_from_content(
             content, "requirements.txt", {"flask": "python-flask"}
         )
-        assert result == ["python-flask"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "python-flask"
 
     def test_gemfile_detects_rails(self) -> None:
         content = 'gem "rails", "~> 7.0"\ngem "pg"\n'
         result = _detect_frameworks_from_content(content, "Gemfile", {"rails": "ruby-rails"})
-        assert result == ["ruby-rails"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "ruby-rails"
 
     def test_composer_json_detects_laravel(self) -> None:
         content = json.dumps({"require": {"laravel/framework": "^10.0"}})
         result = _detect_frameworks_from_content(
             content, "composer.json", {"laravel/framework": "php-laravel"}
         )
-        assert result == ["php-laravel"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "php-laravel"
+        assert result[0]["dep_source"] == "dependencies"
 
     def test_composer_json_prefix_match_symfony(self) -> None:
         content = json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})
         result = _detect_frameworks_from_content(
             content, "composer.json", {"symfony/": "php-symfony"}
         )
-        assert result == ["php-symfony"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "php-symfony"
+
+    def test_composer_json_dev_dependency(self) -> None:
+        content = json.dumps({"require-dev": {"laravel/framework": "^10.0"}})
+        result = _detect_frameworks_from_content(
+            content, "composer.json", {"laravel/framework": "php-laravel"}
+        )
+        assert len(result) == 1
+        assert result[0]["dep_source"] == "devDependencies"
 
     def test_go_mod_detects_gin(self) -> None:
         content = "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
         result = _detect_frameworks_from_content(content, "go.mod", {"gin": "go-gin"})
-        assert result == ["go-gin"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "go-gin"
 
     def test_build_gradle_detects_spring_boot(self) -> None:
         content = (
@@ -113,7 +149,8 @@ class TestDetectFrameworksFromContent:
         result = _detect_frameworks_from_content(
             content, "build.gradle", {"spring-boot": "java-spring-boot"}
         )
-        assert result == ["java-spring-boot"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "java-spring-boot"
 
 
 def _make_b64_response(content: str) -> dict:
@@ -128,8 +165,9 @@ class TestDetectFramework:
 
         result = detect_framework(client, "owner/repo", "python")
 
-        assert "python-django" in result
-        assert "python-celery" in result
+        platforms = [m["platform"] for m in result]
+        assert "python-django" in platforms
+        assert "python-celery" in platforms
 
     def test_falls_back_when_manifest_not_found(self) -> None:
         client = mock.MagicMock()
@@ -145,7 +183,8 @@ class TestDetectFramework:
 
         result = detect_framework(client, "owner/repo", "python")
 
-        assert result == ["python-django"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "python-django"
         # Should have only called get() once (for requirements.txt),
         # not continued to pyproject.toml
         assert client.get.call_count == 1
@@ -164,7 +203,8 @@ class TestDetectFramework:
 
         result = detect_framework(client, "owner/repo", "python")
 
-        assert result == ["python-flask"]
+        assert len(result) == 1
+        assert result[0]["platform"] == "python-flask"
 
     def test_unknown_platform_returns_empty(self) -> None:
         client = mock.MagicMock()
@@ -182,7 +222,140 @@ class TestDetectFramework:
 
         result = detect_framework(client, "owner/repo", "javascript")
 
-        assert result.count("javascript-react") == 1
+        react_matches = [m for m in result if m["platform"] == "javascript-react"]
+        assert len(react_matches) == 1
+        # Should prefer prod dep
+        assert react_matches[0]["dep_source"] == "dependencies"
+
+    def test_returns_framework_match_objects(self) -> None:
+        client = mock.MagicMock()
+        content = json.dumps({"dependencies": {"next": "^14.0.0"}})
+        client.get.return_value = _make_b64_response(content)
+
+        result = detect_framework(client, "owner/repo", "javascript")
+
+        assert len(result) >= 1
+        match = result[0]
+        assert "platform" in match
+        assert "dep_source" in match
+
+
+class TestApplySupersession:
+    def test_nextjs_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nextjs",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=100,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nextjs" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_nuxt_supersedes_vue(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nuxt",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=100,
+            ),
+            DetectedPlatform(
+                platform="javascript-vue",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nuxt" in platforms
+        assert "javascript-vue" not in platforms
+
+    def test_remix_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-remix",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=100,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-remix" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_no_supersession_keeps_all(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+            DetectedPlatform(
+                platform="node-express",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=60,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        assert len(filtered) == 2
+
+    def test_supersession_does_not_affect_unrelated(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nextjs",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=100,
+            ),
+            DetectedPlatform(
+                platform="node-express",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=60,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nextjs" in platforms
+        assert "node-express" in platforms
+        assert "javascript-react" not in platforms
 
 
 class TestDetectPlatforms:
@@ -194,12 +367,11 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         assert len(result) == 1
-        assert result[0] == DetectedPlatform(
-            platform="python",
-            language="Python",
-            bytes=50000,
-            confidence="medium",
-        )
+        assert result[0]["platform"] == "python"
+        assert result[0]["language"] == "Python"
+        assert result[0]["bytes"] == 50000
+        assert result[0]["confidence"] == "medium"
+        assert result[0]["priority"] == BASE_PLATFORM_PRIORITY
 
     def test_detects_multi_language_repo(self) -> None:
         client = mock.MagicMock()
@@ -249,17 +421,69 @@ class TestDetectPlatforms:
         python_result = next(r for r in result if r["platform"] == "python")
         assert python_result["confidence"] == "medium"
 
-    def test_preserves_github_ordering(self) -> None:
+    def test_results_sorted_by_priority_then_bytes(self) -> None:
         client = mock.MagicMock()
-        # GitHub returns languages ordered by bytes descending
-        client.get_languages.return_value = {"Python": 50000, "Go": 30000, "Ruby": 10000}
-        client.get.side_effect = ApiError("Not Found", code=404)
+        # Python has more bytes but framework detection gives JS higher priority
+        client.get_languages.return_value = {"Python": 80000, "JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if "requirements.txt" in path:
+                return _make_b64_response("flask==3.0\n")
+            if "package.json" in path:
+                return _make_b64_response(
+                    json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
-        assert result[0]["language"] == "Python"
-        assert result[1]["language"] == "Go"
-        assert result[2]["language"] == "Ruby"
+        # Next.js (priority 110) > Django (95) > base platforms (10)
+        platforms = [r["platform"] for r in result]
+        nextjs_idx = platforms.index("javascript-nextjs")
+        flask_idx = platforms.index("python-flask")
+        assert nextjs_idx < flask_idx
+
+    def test_nextjs_supersedes_react_in_full_flow(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {"dependencies": {"next": "^14.0.0", "react": "^18.0.0", "express": "^4.0.0"}}
+        )
+        client.get.return_value = _make_b64_response(content)
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-nextjs" in platforms
+        assert "node-express" in platforms
+        assert "javascript-react" not in platforms
+        assert "javascript" in platforms
+
+    def test_prod_dep_ranks_higher_than_dev_dep(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {
+                "dependencies": {"express": "^4.0.0"},
+                "devDependencies": {"svelte": "^4.0.0"},
+            }
+        )
+        client.get.return_value = _make_b64_response(content)
+
+        result = detect_platforms(client, "owner/repo")
+
+        express = next(r for r in result if r["platform"] == "node-express")
+        svelte = next(r for r in result if r["platform"] == "javascript-svelte")
+        # express: priority 60 + 10 (prod) = 70
+        # svelte: priority 70 + 0 (dev) = 70
+        # Same priority, but express has same bytes, so order may vary.
+        # The key thing is both are present and have correct priorities.
+        assert express["priority"] == FRAMEWORK_PRIORITY["node-express"] + 10
+        assert svelte["priority"] == FRAMEWORK_PRIORITY["javascript-svelte"] + 0
 
     def test_typescript_and_javascript_deduplicated(self) -> None:
         client = mock.MagicMock()
@@ -286,6 +510,15 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         assert result == []
+
+    def test_priority_field_present_in_results(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert "priority" in result[0]
 
     @pytest.mark.parametrize(
         ("language", "expected_platform"),


### PR DESCRIPTION
Automatic platform detection from GitHub repository languages to support the onboarding flow redesign (VDY-15). The goal is to eliminate the manual 28+ platform picker by detecting platforms directly from a connected GitHub repo.

## What this does

Adds a new endpoint `GET /api/0/organizations/{org}/repos/{repo_id}/platforms/` that detects Sentry platforms for a GitHub repository using composable framework definitions inspired by [Vercel's framework detection](https://github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts).

Each framework is a self-contained definition with three rule types composed via `every` (AND) / `some` (OR) logic:

1. **`path`** - File must exist in root directory (e.g. `next.config.js`, `manage.py`, `artisan`)
2. **`path` + `match_content`** - File must exist and content must match a regex (e.g. `requirements.txt` containing `django`)
3. **`match_package`** - Package must be in `package.json` or `composer.json` dependencies

Results are ranked by `sort` priority (lower = more specific), with superseded frameworks removed (e.g. React when Next.js is present). Base platforms are always included as a fallback.

## Architecture

Detection runs through a single `FRAMEWORKS` list of `FrameworkDef` entries, replacing 6 separate data structures from the initial implementation. The algorithm:

1. Fetch language stats from GitHub Languages API to determine active base platforms
2. Fetch root directory listing (single API call) to gate all file-based checks
3. Pre-fetch file contents needed by active framework detectors
4. Parse package manifests (`package.json`, `composer.json`) once per platform
5. Evaluate frameworks per base platform using composable `every`/`some` rules
6. Apply supersession, sort by priority descending then bytes descending

### Comparison with Vercel

The core data structures (`FrameworkDef`, `DetectorRule`, `every`/`some` composition, `supersedes`) directly mirror Vercel's `Framework` and `FrameworkDetectionItem` types. Key adaptations for Sentry's use case:

- **Language scoping** - GitHub Languages API narrows which frameworks to test, avoiding irrelevant checks
- **Multi-language detection** - Returns platforms for all detected languages (not just one winner)
- **Remote filesystem** - Uses root file listing as negative cache + batch content fetching to minimize GitHub API calls (vs Vercel's local FS with Promise-level caching)
- **Base platform fallback** - Always returns the base platform even if no framework matches
- **Composer.json support** - Extends `match_package` beyond `package.json` with prefix matching for patterns like `symfony/`

## Files added/modified

- `src/sentry/integrations/github/platform_detection.py` - Core detection module: `FRAMEWORKS` list, `_rule_matches`, `_framework_matches`, `detect_platforms`
- `src/sentry/integrations/github/client.py` - Added `get_languages()` method to GitHubBaseClient
- `src/sentry/integrations/api/endpoints/organization_repository_platforms.py` - REST endpoint with IDOR prevention
- `src/sentry/api/urls.py` - URL registration
- `tests/` - 87 tests (80 unit + 7 integration)

## Coverage

- 18 GitHub languages mapped to Sentry platform IDs
- 24 ignored languages (Shell, Makefile, Dockerfile, etc.)
- 23 framework definitions across 6 base platforms (JS, Python, Ruby, PHP, Java, Go)
- Framework supersession (Next.js > React, Nuxt > Vue, Remix > React)

Refs VDY-15