### PR TITLE
chore(grouping): remove grouphash cache expiry options

### DIFF
--- a/src/sentry/grouping/ingest/hashing.py
+++ b/src/sentry/grouping/ingest/hashing.py
@@ -37,6 +37,10 @@ from sentry.utils import metrics
 from sentry.utils.metrics import MutableTags
 from sentry.utils.tag_normalization import normalized_sdk_tag_from_event
 
+# How long we cache both the existence of secondary grouphashes and grouphashes themselves. We use a
+# minute because experimentation showed that anything more than that didn't improve hit rates.
+GROUPHASH_CACHE_EXPIRY_SECONDS = 60
+
 if TYPE_CHECKING:
     from sentry.event_manager import Job
     from sentry.services.eventstore.models import Event
@@ -215,14 +219,12 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
     """
     Check whether a given hash value has a corresponding `GroupHash` record in the database.
 
-    If `use_caching` is True, cache the boolean result. Cache retention is controlled by the
-    `grouping.ingest_grouphash_existence_cache_expiry` option.
+    If `use_caching` is True, cache the boolean result.
     """
     with metrics.timer(
         "grouping.get_or_create_grouphashes.check_secondary_hash_existence"
     ) as metrics_tags:
         cache_key = get_grouphash_existence_cache_key(hash_value, project.id)
-        cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
 
         if use_caching:
             grouphash_exists = cache.get(cache_key)
@@ -241,7 +243,7 @@ def _grouphash_exists_for_hash_value(hash_value: str, project: Project, use_cach
             metrics_tags["grouphash_exists"] = grouphash_exists
             metrics_tags["cache_set"] = True
 
-            cache.set(cache_key, grouphash_exists, cache_expiry)
+            cache.set(cache_key, grouphash_exists, GROUPHASH_CACHE_EXPIRY_SECONDS)
 
         return grouphash_exists
 
@@ -254,14 +256,12 @@ def _get_or_create_single_grouphash(
 
     If `use_caching` is true, and the resulting grouphash has an assigned group, cache the
     `GroupHash` object. (Grouphashes without a group aren't cached because their data is about to
-    change when a group is assigned.) Cache retention is controlled by the
-    `grouping.ingest_grouphash_object_cache_expiry` option.
+    change when a group is assigned.)
     """
     with metrics.timer(
         "grouping.get_or_create_grouphashes.get_or_create_grouphash"
     ) as metrics_tags:
         cache_key = get_grouphash_object_cache_key(hash_value, project.id)
-        cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
 
         if use_caching:
             grouphash = cache.get(cache_key)
@@ -279,7 +279,7 @@ def _get_or_create_single_grouphash(
         if use_caching and grouphash.group_id is not None:
             metrics_tags["cache_set"] = True
 
-            cache.set(cache_key, grouphash, cache_expiry)
+            cache.set(cache_key, grouphash, GROUPHASH_CACHE_EXPIRY_SECONDS)
 
         return (grouphash, created)
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3109,32 +3109,11 @@ register(
 # grouphashes we want to use ones which are already there but not create new ones, so we track the
 # boolean result of their `.exists()` check. For all existing grouphashes, secondary or not, we know
 # that if they already have a group assigned they won't be modified, so in that case we also cache
-# the full `GroupHash` object. The killswitch below controls both caches, but they have separate
-# expiry times because the secondary grouphash existence cache is used less frequently and has a
-# lighter memory footprint, so we can afford to cache things there for longer.
-#
-# TODO: Check hit/miss rates for both caches and adjust the two expiry options accordingly.
+# the full `GroupHash` object.
 register(
     "grouping.use_ingest_grouphash_caching",
     type=Bool,
     default=True,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# How long to cache a boolean indicating whether or not a grouphash exists for a given secondary
-# hash value
-register(
-    "grouping.ingest_grouphash_existence_cache_expiry",
-    type=Int,
-    default=60,  # seconds
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# How long to cache actual `GroupHash` objects
-register(
-    "grouping.ingest_grouphash_object_cache_expiry",
-    type=Int,
-    default=60,  # seconds
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -11,7 +11,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from django.core.cache import cache
 
-from sentry import audit_log, options
+from sentry import audit_log
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG, SENTRY_GROUPING_CONFIG_TRANSITION_DURATION
 from sentry.event_manager import _get_updated_group_title
 from sentry.eventtypes.base import DefaultEvent
@@ -23,6 +23,7 @@ from sentry.grouping.ingest.caching import (
 )
 from sentry.grouping.ingest.config import update_or_set_grouping_config_if_needed
 from sentry.grouping.ingest.hashing import (
+    GROUPHASH_CACHE_EXPIRY_SECONDS,
     find_grouphash_with_group,
     get_or_create_grouphashes,
 )
@@ -440,13 +441,11 @@ class GroupHashCachingTest(TestCase):
             grouping_config_id = "old_config"
             grouping_config_option = "sentry:secondary_grouping_config"
             cache_key = get_grouphash_existence_cache_key(hash_value, self.project.id)
-            cache_expiry = options.get("grouping.ingest_grouphash_existence_cache_expiry")
             cached_value: Any = grouphash_exists
         else:
             grouping_config_id = "new_config"
             grouping_config_option = "sentry:grouping_config"
             cache_key = get_grouphash_object_cache_key(hash_value, self.project.id)
-            cache_expiry = options.get("grouping.ingest_grouphash_object_cache_expiry")
             cached_value = grouphash
 
         self.project.update_option(grouping_config_option, grouping_config_id)
@@ -457,7 +456,7 @@ class GroupHashCachingTest(TestCase):
             # testing grouphash object handling)
             cache_get_spy, cache_set_spy, database_fn_spy = spies
             cache_get_args = [cache_key]
-            cache_set_args = [cache_key, cached_value, cache_expiry]
+            cache_set_args = [cache_key, cached_value, GROUPHASH_CACHE_EXPIRY_SECONDS]
             database_fn_kwargs = {"project": self.project, "hash": hash_value}
 
             assert cache_key not in cache

--- a/tests/sentry/models/test_grouphash.py
+++ b/tests/sentry/models/test_grouphash.py
@@ -2,13 +2,13 @@ from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 
-from sentry import options
 from sentry.grouping.ingest.caching import (
     get_grouphash_existence_cache_key,
     get_grouphash_object_cache_key,
     invalidate_grouphash_cache_on_save,
     invalidate_grouphash_caches_on_delete,
 )
+from sentry.grouping.ingest.hashing import GROUPHASH_CACHE_EXPIRY_SECONDS
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.testutils.cases import TestCase
@@ -123,7 +123,7 @@ class CacheInvalidationTest(TestCase):
     def test_removes_from_cache_on_queryset_update(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_expiry_seconds = GROUPHASH_CACHE_EXPIRY_SECONDS
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
         charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
@@ -155,7 +155,7 @@ class CacheInvalidationTest(TestCase):
     def test_removes_from_cache_on_model_update(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_expiry_seconds = GROUPHASH_CACHE_EXPIRY_SECONDS
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
         charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
@@ -188,7 +188,7 @@ class CacheInvalidationTest(TestCase):
     def test_removes_from_cache_on_model_save(self) -> None:
         project = self.project
         get_cache_key = get_grouphash_object_cache_key
-        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_expiry_seconds = GROUPHASH_CACHE_EXPIRY_SECONDS
 
         maisey_key = get_cache_key(hash_value="maisey", project_id=project.id)
         charlie_key = get_cache_key(hash_value="charlie", project_id=project.id)
@@ -224,7 +224,7 @@ class CacheInvalidationTest(TestCase):
         project = self.project
         get_object_cache_key = get_grouphash_object_cache_key
         get_existence_cache_key = get_grouphash_existence_cache_key
-        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_expiry_seconds = GROUPHASH_CACHE_EXPIRY_SECONDS
 
         maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
         charlie_object_key = get_object_cache_key(hash_value="charlie", project_id=project.id)
@@ -270,7 +270,7 @@ class CacheInvalidationTest(TestCase):
         project = self.project
         get_object_cache_key = get_grouphash_object_cache_key
         get_existence_cache_key = get_grouphash_existence_cache_key
-        cache_expiry_seconds = options.get("grouping.ingest_grouphash_existence_cache_expiry")
+        cache_expiry_seconds = GROUPHASH_CACHE_EXPIRY_SECONDS
 
         maisey_object_key = get_object_cache_key(hash_value="maisey", project_id=project.id)
         charlie_object_key = get_object_cache_key(hash_value="charlie", project_id=project.id)


### PR DESCRIPTION
The cache expiry values were experimentally verified in #108274 to not need tuning (1, 2, and 5 minute TTLs all had identical hit rates). Hardcode the 60s TTL directly and remove the options.
