### PR TITLE
feat(queues): Split transaction table into producer and consumer tables

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/queueSummary.ts
@@ -128,9 +128,9 @@ const FIRST_ROW_WIDGTS = spaceWidgetsEquallyOnRow(
 
 const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow([...QUEUE_CHARTS], 1);
 
-const TRANSACTIONS_TABLE: Widget = {
-  id: 'transactions-table',
-  title: t('Transactions Interacting with Destination'),
+const PRODUCER_TABLE: Widget = {
+  id: 'producer-table',
+  title: t('Producer Transactions'),
   displayType: DisplayType.TABLE,
   widgetType: WidgetType.SPANS,
   interval: '5m',
@@ -139,11 +139,45 @@ const TRANSACTIONS_TABLE: Widget = {
       name: '',
       fields: [
         SpanFields.TRANSACTION,
-        SpanFields.SPAN_OP,
+        `equation|1 - (count_if(${SpanFields.TRACE_STATUS},equals,ok) / count(${SpanFields.SPAN_DURATION}))`,
+        `count_if(${SpanFields.SPAN_OP},equals,queue.publish)`,
+        `sum(${SpanFields.SPAN_DURATION})`,
+      ],
+      aggregates: [
+        `equation|1 - (count_if(${SpanFields.TRACE_STATUS},equals,ok) / count(${SpanFields.SPAN_DURATION}))`,
+        `count_if(${SpanFields.SPAN_OP},equals,queue.publish)`,
+        `sum(${SpanFields.SPAN_DURATION})`,
+      ],
+      columns: [SpanFields.TRANSACTION],
+      fieldAliases: [t('Transaction'), t('Error rate'), t('Published'), t('Time spent')],
+      fieldMeta: [null, {valueType: 'percentage', valueUnit: null}, null, null],
+      conditions: `${SpanFields.SPAN_OP}:queue.publish`,
+      orderby: `-sum(${SpanFields.SPAN_DURATION})`,
+    },
+  ],
+  layout: {
+    x: 0,
+    y: 7,
+    w: 6,
+    h: 3,
+    minH: 3,
+  },
+};
+
+const CONSUMER_TABLE: Widget = {
+  id: 'consumer-table',
+  title: t('Consumer Transactions'),
+  displayType: DisplayType.TABLE,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  queries: [
+    {
+      name: '',
+      fields: [
+        SpanFields.TRANSACTION,
         `avg(${SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY})`,
         `avg_if(${SpanFields.SPAN_DURATION},${SpanFields.SPAN_OP},equals,queue.process)`,
         `equation|1 - (count_if(${SpanFields.TRACE_STATUS},equals,ok) / count(${SpanFields.SPAN_DURATION}))`,
-        `count_if(${SpanFields.SPAN_OP},equals,queue.publish)`,
         `count_if(${SpanFields.SPAN_OP},equals,queue.process)`,
         `sum(${SpanFields.SPAN_DURATION})`,
       ],
@@ -151,18 +185,15 @@ const TRANSACTIONS_TABLE: Widget = {
         `avg(${SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY})`,
         `avg_if(${SpanFields.SPAN_DURATION},${SpanFields.SPAN_OP},equals,queue.process)`,
         `equation|1 - (count_if(${SpanFields.TRACE_STATUS},equals,ok) / count(${SpanFields.SPAN_DURATION}))`,
-        `count_if(${SpanFields.SPAN_OP},equals,queue.publish)`,
         `count_if(${SpanFields.SPAN_OP},equals,queue.process)`,
         `sum(${SpanFields.SPAN_DURATION})`,
       ],
-      columns: [SpanFields.TRANSACTION, SpanFields.SPAN_OP],
+      columns: [SpanFields.TRANSACTION],
       fieldAliases: [
         t('Transaction'),
-        t('Type'),
         t('Avg time in queue'),
         t('Avg processing time'),
         t('Error rate'),
-        t('Published'),
         t('Processed'),
         t('Time spent'),
       ],
@@ -170,13 +201,11 @@ const TRANSACTIONS_TABLE: Widget = {
         null,
         null,
         null,
-        null,
         {valueType: 'percentage', valueUnit: null},
         null,
         null,
-        null,
       ],
-      conditions: SPAN_OP_FILTER,
+      conditions: `${SpanFields.SPAN_OP}:queue.process`,
       orderby: `-sum(${SpanFields.SPAN_DURATION})`,
     },
   ],
@@ -184,8 +213,8 @@ const TRANSACTIONS_TABLE: Widget = {
     x: 0,
     y: 4,
     w: 6,
-    h: 6,
-    minH: 6,
+    h: 3,
+    minH: 3,
   },
 };
 
@@ -194,5 +223,5 @@ export const QUEUE_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
   projects: [],
   title: SUMMARY_DASHBOARD_TITLE,
   filters: {},
-  widgets: [...FIRST_ROW_WIDGTS, ...SECOND_ROW_WIDGETS, TRANSACTIONS_TABLE],
+  widgets: [...FIRST_ROW_WIDGTS, ...SECOND_ROW_WIDGETS, CONSUMER_TABLE, PRODUCER_TABLE],
 };


### PR DESCRIPTION
Replace the single combined transactions table in the queue summary prebuilt dashboard with two separate tables — one for producer (`queue.publish`) operations and one for consumer (`queue.process`) operations.

The original combined table showed all fields regardless of relevance, including columns like "Avg time in queue" for producers (which don't receive messages) and "Published" for consumers. Splitting into dedicated tables removes the irrelevant fields and makes it clearer what metrics matter for each side of the queue.

Producer table fields: Transaction, Error rate, Published, Time spent
Consumer table fields: Transaction, Avg time in queue, Avg processing time, Error rate, Processed, Time spent

Refs DAIN-1239