### PR TITLE
fix(dashboards): Ignore stale limit on Table widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -282,6 +282,10 @@ function WidgetViewerModal(props: Props) {
   const tableWidget = {
     ...cloneDeep({...widget, queries: [sortedQueries[selectedQueryIndex]!]}),
     displayType: DisplayType.TABLE,
+    // Strip `limit` for Table widgets to avoid stale values from previous display types
+    // (e.g., a widget that was previously a chart with limit 3). The viewer's own
+    // FULL_TABLE_ITEM_LIMIT / HALF_TABLE_ITEM_LIMIT will be used instead.
+    limit: isTableWidget ? undefined : widget.limit,
   };
   const {aggregates, columns} = tableWidget.queries[0]!;
   const {orderby} = widget.queries[0]!;

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -19,6 +19,7 @@ import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import {DashboardsMEPProvider} from './widgetCard/dashboardsMEPContext';
 import {Toolbar} from './widgetCard/toolbar';
 import {
+  DisplayType,
   WidgetType,
   type DashboardFilters,
   type DashboardPermissions,
@@ -148,7 +149,10 @@ function SortableWidget(props: Props) {
     },
     isMobile,
     windowWidth,
-    tableItemLimit: widget.limit ?? TABLE_ITEM_LIMIT,
+    tableItemLimit:
+      widget.displayType === DisplayType.TABLE
+        ? TABLE_ITEM_LIMIT
+        : (widget.limit ?? TABLE_ITEM_LIMIT),
     onWidgetTableSort,
     onWidgetTableResizeColumn,
     useTimeseriesVisualization,


### PR DESCRIPTION
Table widgets on dashboards were showing too few rows (3 or 5 instead of 20) and the Widget Viewer showed inconsistent pagination results.

PR #107954 changed `sortableWidget.tsx` to pass `widget.limit ?? TABLE_ITEM_LIMIT` instead of the previous hardcoded `TABLE_ITEM_LIMIT` (20). This was needed for categorical bar widgets to use their custom limit, but it had the unintended side effect of exposing stale `limit` values on Table widgets — values left over from when a widget was previously a different chart type (e.g., Top N with `limit: 3`). Before that PR, those stale values were harmlessly ignored.

This fix:
- **`sortableWidget.tsx`**: For `DisplayType.TABLE`, always use `TABLE_ITEM_LIMIT` (20) instead of `widget.limit`. Other display types still use `widget.limit` as intended.
- **`widgetViewerModal.tsx`**: Strip `limit` from the derived `tableWidget` when the source widget is a Table, so the viewer consistently uses `FULL_TABLE_ITEM_LIMIT` (20) from the first load instead of inheriting a stale value that gets replaced on pagination.

Fixes DAIN-1240
Fixes DAIN-1246
Fixes DAIN-1252
Fixes DAIN-1254