### PR TITLE
fix(replay): Fix tooltips on timestamps in replay index

### DIFF
--- a/static/app/components/replays/replayBadge.tsx
+++ b/static/app/components/replays/replayBadge.tsx
@@ -93,7 +93,9 @@ export default function ReplayBadge({replay}: Props) {
           <Text size="sm" variant="muted">
             {events.getShortEventId(replay.id)}
           </Text>
-          <Flex gap="xs" align="center">
+          {/* z-index lifts the timestamp above the row's ::before click target
+             (from SimpleTable.rowLinkStyle) so the TimeSince tooltip can trigger */}
+          <Flex gap="xs" align="center" position="relative" style={{zIndex: 1}}>
             <IconCalendar variant="muted" size="xs" />
             <Text size="sm" variant="muted">
               {timestampType === 'absolute' ? (


### PR DESCRIPTION
Need a z-index on the timestamp component so that the mouse target for the tooltip is raised above the row click target.
