### PR TITLE
ref(seer): Add viewer_context passthrough to all Seer API wrappers

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -120,7 +120,7 @@ from sentry.quotas.base import index_data_category
 from sentry.receivers.features import record_event_processed
 from sentry.receivers.onboarding import record_release_received
 from sentry.reprocessing2 import is_reprocessed_event
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.services.eventstore.processing import event_processing_store
 from sentry.signals import (
     first_event_received,
@@ -1979,6 +1979,7 @@ def make_severity_score_request(
     body: SeverityScoreRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     payload: SeverityScoreRequest = {**body}
     if options.get("processing.severity-backlog-test.timeout"):
@@ -1990,6 +1991,7 @@ def make_severity_score_request(
         "/v0/issues/severity-score",
         body=orjson.dumps(payload),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/feedback/lib/seer_api.py
+++ b/src/sentry/feedback/lib/seer_api.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from urllib3 import BaseHTTPResponse, Retry
 
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 
 # Shared connection pool for feedback AI usecases. No timeout or retries by default, but requests can override these params.
 seer_summarization_connection_pool = connection_from_url(
@@ -49,6 +49,7 @@ def make_spam_detection_request(
     body: SpamDetectionRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -56,6 +57,7 @@ def make_spam_detection_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -63,6 +65,7 @@ def make_label_generation_request(
     body: LabelGenerationRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -70,6 +73,7 @@ def make_label_generation_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -77,6 +81,7 @@ def make_title_generation_request(
     body: GenerateFeedbackTitleRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -84,6 +89,7 @@ def make_title_generation_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -91,6 +97,7 @@ def make_label_groups_request(
     body: LabelGroupsRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -98,6 +105,7 @@ def make_label_groups_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -105,6 +113,7 @@ def make_summarize_feedbacks_request(
     body: SummarizeFeedbacksRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -112,4 +121,5 @@ def make_summarize_feedbacks_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )

--- a/src/sentry/replays/lib/seer_api.py
+++ b/src/sentry/replays/lib/seer_api.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from urllib3 import BaseHTTPResponse, Retry
 
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 
 # Shared connection pool for replay AI usecases. No timeout or retries by default, but requests can override these params.
 seer_summarization_connection_pool = connection_from_url(
@@ -42,6 +42,7 @@ def make_replay_summary_start_request(
     body: ReplaySummaryStartRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -49,6 +50,7 @@ def make_replay_summary_start_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -56,6 +58,7 @@ def make_replay_summary_state_request(
     body: ReplaySummaryStateRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -63,6 +66,7 @@ def make_replay_summary_state_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -70,6 +74,7 @@ def make_replay_delete_request(
     body: ReplayDeleteSeerDataRequest,
     timeout: int | float | None = None,
     retries: int | None | Retry = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_connection_pool,
@@ -77,4 +82,5 @@ def make_replay_delete_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )

--- a/src/sentry/seer/anomaly_detection/delete_rule.py
+++ b/src/sentry/seer/anomaly_detection/delete_rule.py
@@ -11,7 +11,7 @@ from sentry.conf.server import SEER_ALERT_DELETION_URL
 from sentry.models.organization import Organization
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import AlertInSeer, DataSourceType, DeleteAlertDataRequest
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
@@ -25,11 +25,13 @@ seer_anomaly_detection_connection_pool = connection_from_url(
 def make_delete_alert_data_request(
     body: DeleteAlertDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ALERT_DELETION_URL,
         body=json.dumps(body).encode("utf-8"),
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -25,7 +25,7 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import get_aggregate_type, translate_direction
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
@@ -67,24 +67,28 @@ SEER_RETRIES = Retry(
 def make_detect_anomalies_request(
     body: DetectAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
+        viewer_context=viewer_context,
     )
 
 
 def make_get_anomaly_threshold_data_request(
     body: GetAnomalyThresholdDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or SEER_ANOMALY_DETECTION_CONNECTION_POOL,
         SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -15,7 +15,7 @@ from sentry.seer.anomaly_detection.types import (
     DetectHistoricalAnomaliesRequest,
     TimeSeriesPoint,
 )
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.utils import json
 from sentry.utils.json import JSONDecodeError
 
@@ -37,12 +37,14 @@ SEER_RETRIES = Retry(
 def make_detect_historical_anomalies_request(
     body: DetectHistoricalAnomaliesRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_ENDPOINT_URL,
         body=json.dumps(body).encode("utf-8"),
         retries=SEER_RETRIES,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -31,7 +31,7 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
@@ -48,11 +48,13 @@ MIN_DAYS = 7
 def make_store_data_request(
     body: StoreDataRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_anomaly_detection_connection_pool,
         SEER_ANOMALY_DETECTION_STORE_DATA_URL,
         body=json.dumps(body).encode("utf-8"),
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -38,6 +38,7 @@ from sentry.seer.entrypoints.cache import SeerOperatorAutofixCache
 from sentry.seer.entrypoints.operator import SeerOperator
 from sentry.seer.models import SummarizeIssueResponse
 from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
     SummarizeIssueRequest,
     make_signed_seer_api_request,
     make_summarize_issue_request,
@@ -281,12 +282,14 @@ class FixabilityScoreRequest(TypedDict):
 def make_fixability_score_request(
     body: FixabilityScoreRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         fixability_connection_pool_gpu,
         "/v1/automation/summarize/fixability",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -28,7 +28,7 @@ from sentry.seer.models import (
     SeerRawPreferenceResponse,
     SeerRepoDefinition,
 )
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.utils.cache import cache
 from sentry.utils.outcomes import Outcome, track_outcome
 
@@ -191,6 +191,7 @@ def make_get_project_preference_request(
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
     retries: Retry | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
@@ -198,6 +199,7 @@ def make_get_project_preference_request(
         body=orjson.dumps(body),
         timeout=timeout,
         retries=retries,
+        viewer_context=viewer_context,
     )
 
 
@@ -205,12 +207,14 @@ def make_set_project_preference_request(
     body: SetProjectPreferenceRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/project-preference/set",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
@@ -218,12 +222,14 @@ def make_bulk_get_project_preferences_request(
     body: BulkGetProjectPreferencesRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/project-preference/bulk",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
@@ -231,34 +237,40 @@ def make_bulk_set_project_preferences_request(
     body: BulkSetProjectPreferencesRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/project-preference/bulk-set",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_get_autofix_state_request(
     body: GetAutofixStateRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/state",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
 def make_get_autofix_state_pr_request(
     body: GetAutofixStatePrRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/state/pr",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
@@ -266,12 +278,14 @@ def make_get_autofix_prompt_request(
     body: GetAutofixPromptRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/prompt",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
@@ -279,34 +293,40 @@ def make_update_coding_agent_state_request(
     body: CodingAgentStateUpdateRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/coding-agent/state/update",
         body=orjson.dumps(body.dict(exclude_none=True)),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_autofix_start_request(
     body: bytes,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/start",
         body=body,
+        viewer_context=viewer_context,
     )
 
 
 def make_autofix_update_request(
     body: bytes,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/update",
         body=body,
+        viewer_context=viewer_context,
     )
 
 
@@ -314,12 +334,14 @@ def make_store_coding_agent_states_request(
     body: StoreCodingAgentStatesRequest,
     connection_pool: HTTPConnectionPool | None = None,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or autofix_connection_pool,
         "/v1/automation/autofix/coding-agent/state/set",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/breakpoints.py
+++ b/src/sentry/seer/breakpoints.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -74,11 +74,13 @@ SnubaTSEntry = tuple[int, tuple[SnubaMetadata]]
 def make_breakpoint_detection_request(
     body: BreakpointRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_breakpoint_connection_pool,
         "/trends/breakpoint-detector",
         body=json.dumps(body).encode("utf-8"),
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -20,7 +20,7 @@ from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.net.http import connection_from_url
 from sentry.seer.code_review.models import SeerCodeReviewRequestType, SeerCodeReviewTrigger
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 
 from .metrics import CodeReviewErrorType, record_webhook_handler_error
 
@@ -89,13 +89,18 @@ def get_seer_endpoint_for_event(github_event: str) -> SeerEndpoint:
     return SeerEndpoint.OVERWATCH_REQUEST
 
 
-def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
+def make_seer_request(
+    path: str,
+    payload: Mapping[str, Any],
+    viewer_context: SeerViewerContext | None = None,
+) -> bytes:
     """
     Make a request to the Seer API and return the response data.
 
     Args:
         path: The path to the Seer API
         payload: The payload to send to the Seer API
+        viewer_context: Optional viewer context for access control
 
     Raises:
         HTTPError: If the Seer API returns a retryable status
@@ -109,6 +114,7 @@ def make_seer_request(path: str, payload: Mapping[str, Any]) -> bytes:
         connection_pool=seer_code_review_connection_pool,
         path=path,
         body=orjson.dumps(payload),
+        viewer_context=viewer_context,
     )
     # Retry on server errors (5xx) and rate limits (429), but not client errors (4xx)
     if response.status >= 500 or response.status == 429:

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -27,7 +27,7 @@ from sentry.net.http import connection_from_url
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.users.models.user import User as SentryUser
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user_option import user_option_service
@@ -89,44 +89,52 @@ class ExplorerUpdateRequest(TypedDict):
 def make_explorer_state_request(
     body: ExplorerStateRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or explorer_connection_pool,
         "/v1/automation/explorer/state",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
     )
 
 
 def make_explorer_chat_request(
     body: ExplorerChatRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or explorer_connection_pool,
         "/v1/automation/explorer/chat",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
     )
 
 
 def make_explorer_runs_request(
     body: ExplorerRunsRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or explorer_connection_pool,
         "/v1/automation/explorer/runs",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
     )
 
 
 def make_explorer_update_request(
     body: ExplorerUpdateRequest,
     connection_pool: HTTPConnectionPool | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or explorer_connection_pool,
         "/v1/automation/explorer/update",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -135,39 +135,46 @@ class LlmGenerateRequest(TypedDict):
 def make_org_project_knowledge_index_request(
     body: OrgProjectKnowledgeIndexRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/automation/explorer/index/org-project-knowledge",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_remove_repository_request(
     body: RemoveRepositoryRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/project-preference/remove-repository",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
 def make_explorer_index_request(
     body: ExplorerIndexRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/automation/explorer/index",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_seer_models_request(
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
@@ -175,18 +182,21 @@ def make_seer_models_request(
         body=b"",
         timeout=timeout,
         method="GET",
+        viewer_context=viewer_context,
     )
 
 
 def make_llm_generate_request(
     body: LlmGenerateRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/llm/generate",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
@@ -271,122 +281,144 @@ class CompareDistributionsRequest(TypedDict):
 def make_summarize_trace_request(
     body: SummarizeTraceRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_default_connection_pool,
         "/v1/automation/summarize/trace",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_summarize_issue_request(
     body: SummarizeIssueRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_summarization_default_connection_pool,
         "/v1/automation/summarize/issue",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_supergroups_embedding_request(
     body: SupergroupsEmbeddingRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v0/issues/supergroups",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_service_map_update_request(
     body: ServiceMapUpdateRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/explorer/service-map/update",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_unit_test_generation_request(
     body: UnitTestGenerationRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/automation/codegen/unit-tests",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        viewer_context=viewer_context,
     )
 
 
 def make_search_agent_state_request(
     body: SearchAgentStateRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/assisted-query/state",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_translate_query_request(
     body: TranslateQueryRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/assisted-query/translate",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
 def make_search_agent_start_request(
     body: SearchAgentStartRequest,
     timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/assisted-query/start",
         body=orjson.dumps(body),
         timeout=timeout,
+        viewer_context=viewer_context,
     )
 
 
 def make_translate_agentic_request(
     body: TranslateAgenticRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/assisted-query/translate-agentic",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
 def make_create_cache_request(
     body: CreateCacheRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v1/assisted-query/create-cache",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 
 def make_compare_distributions_request(
     body: CompareDistributionsRequest,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         seer_anomaly_detection_default_connection_pool,
         "/v1/workflows/compare/cohort",
         body=orjson.dumps(body),
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -15,7 +15,7 @@ from sentry.conf.server import (
 )
 from sentry.models.grouphashmetadata import GroupHashMetadata
 from sentry.net.http import connection_from_url
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.seer.similarity.types import (
     IncompleteSeerDataError,
     SeerSimilarIssueData,
@@ -42,6 +42,7 @@ def make_similar_issues_request(
     retries: int | None = None,
     timeout: int | float | None = None,
     metric_tags: dict[str, str | int | bool] | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     return make_signed_seer_api_request(
         connection_pool or seer_grouping_connection_pool,
@@ -50,6 +51,7 @@ def make_similar_issues_request(
         retries=retries,
         timeout=timeout,
         metric_tags=metric_tags,
+        viewer_context=viewer_context,
     )
 
 

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -20,7 +20,7 @@ from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.seer.explorer.utils import normalize_description
-from sentry.seer.signed_seer_api import make_signed_seer_api_request
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
 from sentry.utils.redis import redis_clusters
@@ -109,6 +109,7 @@ def make_issue_detection_request(
     request: IssueDetectionRequest,
     timeout: int | float | None = None,
     retries: int | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> BaseHTTPResponse:
     extra_kwargs: dict[str, Any] = {}
     if timeout is not None:
@@ -119,6 +120,7 @@ def make_issue_detection_request(
         seer_issue_detection_connection_pool,
         SEER_ANALYZE_ISSUE_ENDPOINT_PATH,
         body=orjson.dumps(request.dict()),
+        viewer_context=viewer_context,
         **extra_kwargs,
     )
 


### PR DESCRIPTION
## Summary
- Propagates the optional `viewer_context: SeerViewerContext | None` kwarg through all 51 wrapper functions across 15 files that call `make_signed_seer_api_request()`
- Enables callers to pass organization and user context which gets HMAC-signed into `X-Viewer-Context` / `X-Viewer-Context-Signature` headers for Seer access control
- All new params default to `None` — no call sites are changed yet

Builds on #109626 which added `viewer_context` support to `make_signed_seer_api_request()`.

## Test plan
- All changes are additive (new optional param defaulting to `None`), so existing behavior is unchanged
- Pre-commit passes on all 15 modified files
- CI should validate no regressions