### PR TITLE
ref(integrations): Refactor platform detection to composable framework definitions

### DIFF
--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -83,7 +83,7 @@ class DetectorRule(TypedDict, total=False):
 
 class FrameworkDef(TypedDict):
     platform: str  # Sentry platform ID, e.g. "javascript-nextjs"
-    sort: int  # Lower = higher priority (Vercel convention)
+    sort: int  # Lower = higher priority
     base_platform: str  # Language group, e.g. "javascript"
     every: NotRequired[list[DetectorRule]]  # ALL must match (AND)
     some: NotRequired[list[DetectorRule]]  # At least ONE must match (OR)
@@ -91,8 +91,6 @@ class FrameworkDef(TypedDict):
 
 
 # Each framework is a self-contained definition with composable detector rules.
-# Inspired by Vercel's framework detection:
-# github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
 #
 # The `sort` field controls priority for onboarding recommendations.
 # Lower sort = higher priority. Converted to `priority = 100 - sort` in output.
@@ -486,8 +484,7 @@ def detect_platforms(
     """
     Detect Sentry platforms for a GitHub repository.
 
-    Uses composable framework definitions (inspired by Vercel's detection)
-    with three signal types:
+    Uses composable framework definitions with three signal types:
     1. Config files — path-only rules (next.config.js, manage.py, etc.)
     2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
     3. Package dependencies — match_package rules (package.json, composer.json)

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -375,8 +375,8 @@ def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = 
         if ref:
             params["ref"] = ref
         response = client.get(f"/repos/{repo}/contents", params=params)
-        return {item["name"] for item in response if item.get("type") == "file"}
-    except (ApiError, AttributeError, KeyError, TypeError):
+        return {item["name"] for item in response if item.get("type") == "file" and "name" in item}
+    except (ApiError, AttributeError, TypeError):
         return set()
 
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -284,8 +284,8 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 10,
         "base_platform": "java",
         "some": [
-            {"path": "build.gradle", "match_content": r"spring-boot"},
-            {"path": "pom.xml", "match_content": r"spring-boot"},
+            {"path": "build.gradle", "match_content": r"(?i)spring-boot"},
+            {"path": "pom.xml", "match_content": r"(?i)spring-boot"},
         ],
     },
     {
@@ -293,8 +293,8 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 20,
         "base_platform": "java",
         "some": [
-            {"path": "build.gradle", "match_content": r"spring-framework"},
-            {"path": "pom.xml", "match_content": r"spring-framework"},
+            {"path": "build.gradle", "match_content": r"(?i)spring-framework"},
+            {"path": "pom.xml", "match_content": r"(?i)spring-framework"},
         ],
     },
     # --- Go ---

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -5,7 +5,7 @@ import re
 from base64 import b64decode
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
@@ -81,13 +81,13 @@ class DetectorRule(TypedDict, total=False):
     match_package: str  # Package name in package.json/composer.json deps
 
 
-class FrameworkDef(TypedDict, total=False):
+class FrameworkDef(TypedDict):
     platform: str  # Sentry platform ID, e.g. "javascript-nextjs"
     sort: int  # Lower = higher priority (Vercel convention)
     base_platform: str  # Language group, e.g. "javascript"
-    every: list[DetectorRule]  # ALL must match (AND)
-    some: list[DetectorRule]  # At least ONE must match (OR)
-    supersedes: list[str]  # Platform IDs this makes redundant
+    every: NotRequired[list[DetectorRule]]  # ALL must match (AND)
+    some: NotRequired[list[DetectorRule]]  # At least ONE must match (OR)
+    supersedes: NotRequired[list[str]]  # Platform IDs this makes redundant
 
 
 # Each framework is a self-contained definition with composable detector rules.
@@ -376,14 +376,14 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
         if manifest_file == "package.json":
             pkg = json.loads(content)
             return _PackageManifest(
-                dependencies=set(pkg.get("dependencies", {}).keys()),
-                dev_dependencies=set(pkg.get("devDependencies", {}).keys()),
+                dependencies=set((pkg.get("dependencies") or {}).keys()),
+                dev_dependencies=set((pkg.get("devDependencies") or {}).keys()),
             )
         elif manifest_file == "composer.json":
             composer = json.loads(content)
             return _PackageManifest(
-                dependencies=set(composer.get("require", {}).keys()),
-                dev_dependencies=set(composer.get("require-dev", {}).keys()),
+                dependencies=set((composer.get("require") or {}).keys()),
+                dev_dependencies=set((composer.get("require-dev") or {}).keys()),
             )
     except (json.JSONDecodeError, TypeError):
         pass

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -398,8 +398,10 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
     return None
 
 
-def _package_in_manifest(package_name: str, manifest: _PackageManifest) -> bool:
+def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -> bool:
     """Check if a package exists in a manifest's dependencies or devDependencies."""
+    if manifest is None:
+        return False
     all_deps = manifest["dependencies"] | manifest["dev_dependencies"]
     if package_name in all_deps:
         return True
@@ -417,8 +419,6 @@ def _rule_matches(
 ) -> bool:
     """Evaluate a single detector rule against repository state."""
     if "match_package" in rule:
-        if package_manifest is None:
-            return False
         return _package_in_manifest(rule["match_package"], package_manifest)
 
     path = rule.get("path")
@@ -448,11 +448,7 @@ def _framework_matches(
     if not every and not some:
         return False
 
-    every_pass = (
-        all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
-        if every
-        else True
-    )
+    every_pass = all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
     some_pass = (
         any(_rule_matches(r, root_files, file_contents, package_manifest) for r in some)
         if some
@@ -467,9 +463,9 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
 
     e.g. if Next.js is detected, React is redundant since Next.js includes it.
     """
-    detected_ids = {r["platform"] for r in results}
+    platform_ids = {r["platform"] for r in results}
     superseded: set[str] = set()
-    for platform_id in detected_ids:
+    for platform_id in platform_ids:
         for child_id in _SUPERSESSION_MAP.get(platform_id, []):
             superseded.add(child_id)
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -366,7 +366,7 @@ def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = 
             params["ref"] = ref
         response = client.get(f"/repos/{repo}/contents", params=params)
         return {item["name"] for item in response if item.get("type") == "file"}
-    except ApiError:
+    except (ApiError, AttributeError, KeyError, TypeError):
         return set()
 
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -363,11 +363,16 @@ def _get_repo_file_content(
         return None
 
 
-def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = None) -> set[str]:
+def _get_root_file_names(
+    client: GitHubBaseClient, repo: str, ref: str | None = None
+) -> set[str] | None:
     """Fetch the list of file names in the repository root directory.
 
     Uses the GitHub Contents API on the root path, which returns all
     top-level files and directories in a single API call.
+
+    Returns None on API failure so callers can fall back to fetching
+    files individually rather than assuming the repo root is empty.
     """
     try:
         params: dict[str, str] = {}
@@ -376,7 +381,7 @@ def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = 
         response = client.get(f"/repos/{repo}/contents", params=params)
         return {item["name"] for item in response if item.get("type") == "file" and "name" in item}
     except (ApiError, AttributeError, TypeError):
-        return set()
+        return None
 
 
 def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifest | None:
@@ -414,7 +419,7 @@ def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -
 
 def _rule_matches(
     rule: DetectorRule,
-    root_files: set[str],
+    root_files: set[str] | None,
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
 ) -> bool:
@@ -433,12 +438,15 @@ def _rule_matches(
         return bool(re.search(rule["match_content"], content))
 
     # path-only rule: check if file exists in root
+    # When root_files is None (API failed), we can't confirm existence
+    if root_files is None:
+        return False
     return path in root_files
 
 
 def _framework_matches(
     fw: FrameworkDef,
-    root_files: set[str],
+    root_files: set[str] | None,
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
 ) -> bool:
@@ -501,14 +509,16 @@ def detect_platforms(
         if base_platform is not None:
             active_platforms[base_platform].append((language, byte_count))
 
-    # Collect all file paths that need content fetching (path + match_content rules)
+    # Collect all file paths that need content fetching (path + match_content rules).
+    # When root_files is None (API failed), try all paths rather than skipping.
     needed_paths: set[str] = set()
     for base_platform in active_platforms:
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
             for rule in [*fw.get("every", []), *fw.get("some", [])]:
                 path = rule.get("path")
-                if path and "match_content" in rule and path in root_files:
-                    needed_paths.add(path)
+                if path and "match_content" in rule:
+                    if root_files is None or path in root_files:
+                        needed_paths.add(path)
 
     # Fetch file contents in one pass
     file_contents: dict[str, str] = {}
@@ -523,7 +533,7 @@ def detect_platforms(
         manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
         if manifest_file is None or manifest_file in package_manifests:
             continue
-        if manifest_file not in root_files:
+        if root_files is not None and manifest_file not in root_files:
             package_manifests[manifest_file] = None
             continue
         content = file_contents.get(manifest_file)

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -92,8 +92,9 @@ class FrameworkDef(TypedDict):
 
 # Each framework is a self-contained definition with composable detector rules.
 #
-# The `sort` field controls priority for onboarding recommendations.
+# The `sort` field controls priority within a language group for onboarding.
 # Lower sort = higher priority. Converted to `priority = 100 - sort` in output.
+# Across languages, byte count (language majority) is the primary ranking factor.
 #
 #   sort=1      Meta-frameworks         Next.js, Remix, Nuxt, SvelteKit
 #   sort=10     Primary frameworks      Django, Rails, Laravel, Spring Boot
@@ -485,7 +486,7 @@ def detect_platforms(
     2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
     3. Package dependencies — match_package rules (package.json, composer.json)
 
-    Results are ranked by priority (descending), then bytes (descending).
+    Results are ranked by bytes (descending), then priority (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
@@ -572,6 +573,6 @@ def detect_platforms(
             )
 
     results = _apply_supersession(results)
-    results.sort(key=lambda r: (r["priority"], r["bytes"]), reverse=True)
+    results.sort(key=lambda r: (r["bytes"], r["priority"]), reverse=True)
 
     return results

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -93,6 +93,16 @@ class FrameworkDef(TypedDict):
 # Each framework is a self-contained definition with composable detector rules.
 # Inspired by Vercel's framework detection:
 # github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
+#
+# The `sort` field controls priority for onboarding recommendations.
+# Lower sort = higher priority. Converted to `priority = 100 - sort` in output.
+#
+#   sort=1      Meta-frameworks         Next.js, Remix, Nuxt, SvelteKit
+#   sort=10     Primary frameworks      Django, Rails, Laravel, Spring Boot
+#   sort=20     Secondary frameworks    Flask, Go frameworks, PHP Symfony
+#   sort=30     UI / general            React, Vue, Angular, Svelte, Starlette
+#   sort=40     Server frameworks       Express, Koa
+#   sort=60     Utilities / background  Celery
 FRAMEWORKS: list[FrameworkDef] = [
     # --- JavaScript meta-frameworks (sort=1, highest priority) ---
     {

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
+import re
 from base64 import b64decode
+from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypedDict
 
 from sentry.shared_integrations.exceptions import ApiError
@@ -69,106 +72,269 @@ class DetectedPlatform(TypedDict):
     language: str  # GitHub Linguist name, e.g. "Python"
     bytes: int  # Bytes of code in that language
     confidence: str  # "high" (framework detected) or "medium" (language only)
+    priority: int  # Higher = more relevant for onboarding
 
 
-# Maps base_platform -> list of (manifest_file, {dependency_name: sentry_platform_id})
-FRAMEWORK_DETECTORS: dict[str, list[tuple[str, dict[str, str]]]] = {
-    "javascript": [
-        (
-            "package.json",
-            {
-                "next": "javascript-nextjs",
-                "react": "javascript-react",
-                "vue": "javascript-vue",
-                "@angular/core": "javascript-angular",
-                "svelte": "javascript-svelte",
-                "remix": "javascript-remix",
-                "nuxt": "javascript-nuxt",
-                "express": "node-express",
-                "hono": "node-hono",
-                "koa": "node-koa",
-            },
-        ),
-    ],
-    "python": [
-        (
-            "requirements.txt",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-        (
-            "pyproject.toml",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-        (
-            "Pipfile",
-            {
-                "django": "python-django",
-                "flask": "python-flask",
-                "fastapi": "python-fastapi",
-                "starlette": "python-starlette",
-                "celery": "python-celery",
-                "tornado": "python-tornado",
-            },
-        ),
-    ],
-    "ruby": [
-        (
-            "Gemfile",
-            {
-                "rails": "ruby-rails",
-            },
-        ),
-    ],
-    "php": [
-        (
-            "composer.json",
-            {
-                "laravel/framework": "php-laravel",
-                "symfony/": "php-symfony",
-            },
-        ),
-    ],
-    "java": [
-        (
-            "build.gradle",
-            {
-                "spring-boot": "java-spring-boot",
-                "spring-framework": "java-spring",
-            },
-        ),
-        (
-            "pom.xml",
-            {
-                "spring-boot": "java-spring-boot",
-                "spring-framework": "java-spring",
-            },
-        ),
-    ],
-    "go": [
-        (
-            "go.mod",
-            {
-                "echo": "go-echo",
-                "gin": "go-gin",
-                "fiber": "go-fiber",
-            },
-        ),
-    ],
+class DetectorRule(TypedDict, total=False):
+    path: str  # File must exist in root directory
+    match_content: str  # Regex pattern to match in file content (requires path)
+    match_package: str  # Package name in package.json/composer.json deps
+
+
+class FrameworkDef(TypedDict, total=False):
+    platform: str  # Sentry platform ID, e.g. "javascript-nextjs"
+    sort: int  # Lower = higher priority (Vercel convention)
+    base_platform: str  # Language group, e.g. "javascript"
+    every: list[DetectorRule]  # ALL must match (AND)
+    some: list[DetectorRule]  # At least ONE must match (OR)
+    supersedes: list[str]  # Platform IDs this makes redundant
+
+
+# Each framework is a self-contained definition with composable detector rules.
+# Inspired by Vercel's framework detection:
+# github.com/vercel/vercel/blob/main/packages/frameworks/src/frameworks.ts
+FRAMEWORKS: list[FrameworkDef] = [
+    # --- JavaScript meta-frameworks (sort=1, highest priority) ---
+    {
+        "platform": "javascript-nextjs",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "next"},
+            {"path": "next.config.js"},
+            {"path": "next.config.mjs"},
+            {"path": "next.config.ts"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-remix",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "remix"},
+            {"path": "remix.config.js"},
+            {"path": "remix.config.mjs"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-nuxt",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "nuxt"},
+            {"path": "nuxt.config.ts"},
+            {"path": "nuxt.config.js"},
+        ],
+        "supersedes": ["javascript-vue"],
+    },
+    # --- JavaScript UI frameworks (sort=30) ---
+    {
+        "platform": "javascript-react",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [{"match_package": "react"}],
+    },
+    {
+        "platform": "javascript-vue",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [{"match_package": "vue"}],
+    },
+    {
+        "platform": "javascript-angular",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "@angular/core"},
+            {"path": "angular.json"},
+        ],
+    },
+    {
+        "platform": "javascript-svelte",
+        "sort": 30,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "svelte"},
+            {"path": "svelte.config.js"},
+            {"path": "svelte.config.ts"},
+        ],
+    },
+    # --- JavaScript server frameworks (sort=40) ---
+    {
+        "platform": "node-express",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "express"}],
+    },
+    {
+        "platform": "node-hono",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "hono"}],
+    },
+    {
+        "platform": "node-koa",
+        "sort": 40,
+        "base_platform": "javascript",
+        "every": [{"match_package": "koa"}],
+    },
+    # --- Python frameworks ---
+    {
+        "platform": "python-django",
+        "sort": 10,
+        "base_platform": "python",
+        "some": [
+            {"path": "manage.py"},
+            {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bdjango\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bdjango\b"},
+        ],
+    },
+    {
+        "platform": "python-fastapi",
+        "sort": 10,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfastapi\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfastapi\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfastapi\b"},
+        ],
+    },
+    {
+        "platform": "python-flask",
+        "sort": 20,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bflask\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bflask\b"},
+        ],
+    },
+    {
+        "platform": "python-starlette",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bstarlette\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bstarlette\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bstarlette\b"},
+        ],
+    },
+    {
+        "platform": "python-tornado",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\btornado\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\btornado\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\btornado\b"},
+        ],
+    },
+    {
+        "platform": "python-celery",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bcelery\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bcelery\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bcelery\b"},
+        ],
+    },
+    # --- Ruby ---
+    {
+        "platform": "ruby-rails",
+        "sort": 10,
+        "base_platform": "ruby",
+        "some": [
+            {"path": "Gemfile", "match_content": r"(?i)\brails\b"},
+        ],
+    },
+    # --- PHP ---
+    {
+        "platform": "php-laravel",
+        "sort": 10,
+        "base_platform": "php",
+        "some": [
+            {"match_package": "laravel/framework"},
+            {"path": "artisan"},
+        ],
+    },
+    {
+        "platform": "php-symfony",
+        "sort": 20,
+        "base_platform": "php",
+        "some": [
+            {"match_package": "symfony/"},
+        ],
+    },
+    # --- Java ---
+    {
+        "platform": "java-spring-boot",
+        "sort": 10,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"spring-boot"},
+            {"path": "pom.xml", "match_content": r"spring-boot"},
+        ],
+    },
+    {
+        "platform": "java-spring",
+        "sort": 20,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"spring-framework"},
+            {"path": "pom.xml", "match_content": r"spring-framework"},
+        ],
+    },
+    # --- Go ---
+    {
+        "platform": "go-echo",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\becho\b"},
+        ],
+    },
+    {
+        "platform": "go-gin",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\bgin\b"},
+        ],
+    },
+    {
+        "platform": "go-fiber",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"(?i)\bfiber\b"},
+        ],
+    },
+]
+
+# Derived indexes built at module load
+_FRAMEWORKS_BY_PLATFORM: dict[str, list[FrameworkDef]] = defaultdict(list)
+for _fw in FRAMEWORKS:
+    _FRAMEWORKS_BY_PLATFORM[_fw["base_platform"]].append(_fw)
+
+_SUPERSESSION_MAP: dict[str, list[str]] = {}
+for _fw in FRAMEWORKS:
+    if "supersedes" in _fw:
+        _SUPERSESSION_MAP[_fw["platform"]] = _fw["supersedes"]
+
+# Package manifest files per base platform (for match_package rules)
+_PACKAGE_MANIFEST_FILES: dict[str, str] = {
+    "javascript": "package.json",
+    "php": "composer.json",
 }
+
+
+class _PackageManifest(TypedDict):
+    dependencies: set[str]
+    dev_dependencies: set[str]
 
 
 def _get_repo_file_content(
@@ -188,84 +354,118 @@ def _get_repo_file_content(
         return None
 
 
-def _detect_frameworks_from_content(
-    content: str,
-    manifest_file: str,
-    dependency_map: dict[str, str],
-) -> list[str]:
-    """Check manifest file content for known framework dependencies."""
-    detected: list[str] = []
+def _get_root_file_names(client: GitHubBaseClient, repo: str, ref: str | None = None) -> set[str]:
+    """Fetch the list of file names in the repository root directory.
 
-    if manifest_file == "package.json":
-        try:
+    Uses the GitHub Contents API on the root path, which returns all
+    top-level files and directories in a single API call.
+    """
+    try:
+        params: dict[str, str] = {}
+        if ref:
+            params["ref"] = ref
+        response = client.get(f"/repos/{repo}/contents", params=params)
+        return {item["name"] for item in response if item.get("type") == "file"}
+    except ApiError:
+        return set()
+
+
+def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifest | None:
+    """Parse a JSON package manifest into dependency sets."""
+    try:
+        if manifest_file == "package.json":
             pkg = json.loads(content)
-            all_deps: dict[str, str] = {}
-            all_deps.update(pkg.get("dependencies", {}))
-            all_deps.update(pkg.get("devDependencies", {}))
-            for dep_name, platform_id in dependency_map.items():
-                if dep_name in all_deps:
-                    detected.append(platform_id)
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    elif manifest_file == "composer.json":
-        try:
+            return _PackageManifest(
+                dependencies=set(pkg.get("dependencies", {}).keys()),
+                dev_dependencies=set(pkg.get("devDependencies", {}).keys()),
+            )
+        elif manifest_file == "composer.json":
             composer = json.loads(content)
-            all_deps = {}
-            all_deps.update(composer.get("require", {}))
-            all_deps.update(composer.get("require-dev", {}))
-            for dep_name, platform_id in dependency_map.items():
-                for pkg_name in all_deps:
-                    if pkg_name == dep_name or pkg_name.startswith(dep_name):
-                        detected.append(platform_id)
-                        break
-        except (json.JSONDecodeError, TypeError):
-            pass
-
-    else:
-        # Text-based manifest files: requirements.txt, Gemfile,
-        # pyproject.toml, build.gradle, pom.xml, go.mod
-        content_lower = content.lower()
-        for dep_name, platform_id in dependency_map.items():
-            if dep_name.lower() in content_lower:
-                detected.append(platform_id)
-
-    return detected
+            return _PackageManifest(
+                dependencies=set(composer.get("require", {}).keys()),
+                dev_dependencies=set(composer.get("require-dev", {}).keys()),
+            )
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return None
 
 
-def detect_framework(
-    client: GitHubBaseClient,
-    repo: str,
-    base_platform: str,
-    ref: str | None = None,
-) -> list[str]:
-    """
-    Refine a base platform (e.g. "python") into specific framework
-    platforms (e.g. "python-django") by reading manifest files.
+def _package_in_manifest(package_name: str, manifest: _PackageManifest) -> bool:
+    """Check if a package exists in a manifest's dependencies or devDependencies."""
+    all_deps = manifest["dependencies"] | manifest["dev_dependencies"]
+    if package_name in all_deps:
+        return True
+    # Prefix match for composer.json patterns like "symfony/"
+    if package_name.endswith("/"):
+        return any(dep.startswith(package_name) for dep in all_deps)
+    return False
 
-    Returns detected framework platform IDs, or an empty list if none found.
-    """
-    detectors = FRAMEWORK_DETECTORS.get(base_platform, [])
-    detected: list[str] = []
 
-    for manifest_file, dependency_map in detectors:
-        content = _get_repo_file_content(client, repo, manifest_file, ref)
+def _rule_matches(
+    rule: DetectorRule,
+    root_files: set[str],
+    file_contents: dict[str, str],
+    package_manifest: _PackageManifest | None,
+) -> bool:
+    """Evaluate a single detector rule against repository state."""
+    if "match_package" in rule:
+        if package_manifest is None:
+            return False
+        return _package_in_manifest(rule["match_package"], package_manifest)
+
+    path = rule.get("path")
+    if path is None:
+        return False
+
+    if "match_content" in rule:
+        content = file_contents.get(path)
         if content is None:
-            continue
-        frameworks = _detect_frameworks_from_content(content, manifest_file, dependency_map)
-        detected.extend(frameworks)
-        if detected:
-            break
+            return False
+        return bool(re.search(rule["match_content"], content))
 
-    # Deduplicate while preserving order
-    seen: set[str] = set()
-    unique: list[str] = []
-    for platform_id in detected:
-        if platform_id not in seen:
-            seen.add(platform_id)
-            unique.append(platform_id)
+    # path-only rule: check if file exists in root
+    return path in root_files
 
-    return unique
+
+def _framework_matches(
+    fw: FrameworkDef,
+    root_files: set[str],
+    file_contents: dict[str, str],
+    package_manifest: _PackageManifest | None,
+) -> bool:
+    """Evaluate whether a framework definition matches the repository."""
+    every: Sequence[DetectorRule] = fw.get("every", [])
+    some: Sequence[DetectorRule] = fw.get("some", [])
+
+    if not every and not some:
+        return False
+
+    every_pass = (
+        all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
+        if every
+        else True
+    )
+    some_pass = (
+        any(_rule_matches(r, root_files, file_contents, package_manifest) for r in some)
+        if some
+        else True
+    )
+
+    return every_pass and some_pass
+
+
+def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatform]:
+    """Remove platforms that are superseded by more specific ones.
+
+    e.g. if Next.js is detected, React is redundant since Next.js includes it.
+    """
+    detected_ids = {r["platform"] for r in results}
+    superseded: set[str] = set()
+    for platform_id in detected_ids:
+        for child_id in _SUPERSESSION_MAP.get(platform_id, []):
+            superseded.add(child_id)
+
+    return [r for r in results if r["platform"] not in superseded]
 
 
 def detect_platforms(
@@ -276,37 +476,85 @@ def detect_platforms(
     """
     Detect Sentry platforms for a GitHub repository.
 
-    Calls the GitHub Languages API, maps languages to Sentry platform IDs,
-    and attempts framework refinement via manifest file inspection.
+    Uses composable framework definitions (inspired by Vercel's detection)
+    with three signal types:
+    1. Config files — path-only rules (next.config.js, manage.py, etc.)
+    2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
+    3. Package dependencies — match_package rules (package.json, composer.json)
 
-    Returns platforms ordered by relevance (bytes of code, descending).
+    Results are ranked by priority (descending), then bytes (descending).
+    Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
+    root_files = _get_root_file_names(client, repo, ref)
 
-    results: list[DetectedPlatform] = []
-    seen_platforms: set[str] = set()
-
+    # Group languages by base platform
+    active_platforms: dict[str, list[tuple[str, int]]] = defaultdict(list)
     for language, byte_count in languages.items():
         if language in IGNORED_LANGUAGES:
             continue
-
         base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
-        if base_platform is None:
+        if base_platform is not None:
+            active_platforms[base_platform].append((language, byte_count))
+
+    # Collect all file paths that need content fetching (path + match_content rules)
+    needed_paths: set[str] = set()
+    for base_platform in active_platforms:
+        for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
+            for rule in [*fw.get("every", []), *fw.get("some", [])]:
+                path = rule.get("path")
+                if path and "match_content" in rule and path in root_files:
+                    needed_paths.add(path)
+
+    # Fetch file contents in one pass
+    file_contents: dict[str, str] = {}
+    for path in needed_paths:
+        content = _get_repo_file_content(client, repo, path, ref)
+        if content is not None:
+            file_contents[path] = content
+
+    # Parse package manifests for platforms that use match_package rules
+    package_manifests: dict[str, _PackageManifest | None] = {}
+    for base_platform in active_platforms:
+        manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
+        if manifest_file is None or manifest_file in package_manifests:
             continue
+        if manifest_file not in root_files:
+            package_manifests[manifest_file] = None
+            continue
+        content = file_contents.get(manifest_file)
+        if content is None:
+            content = _get_repo_file_content(client, repo, manifest_file, ref)
+            if content is not None:
+                file_contents[manifest_file] = content
+        package_manifests[manifest_file] = (
+            _parse_package_manifest(content, manifest_file) if content else None
+        )
 
-        frameworks = detect_framework(client, repo, base_platform, ref)
+    # Evaluate frameworks per base platform
+    results: list[DetectedPlatform] = []
+    seen_platforms: set[str] = set()
 
-        for framework_id in frameworks:
-            if framework_id not in seen_platforms:
-                seen_platforms.add(framework_id)
-                results.append(
-                    DetectedPlatform(
-                        platform=framework_id,
-                        language=language,
-                        bytes=byte_count,
-                        confidence="high",
+    for base_platform, lang_entries in active_platforms.items():
+        language, byte_count = max(lang_entries, key=lambda x: x[1])
+
+        manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
+        manifest = package_manifests.get(manifest_file) if manifest_file else None
+
+        for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
+            if _framework_matches(fw, root_files, file_contents, manifest):
+                platform_id = fw["platform"]
+                if platform_id not in seen_platforms:
+                    seen_platforms.add(platform_id)
+                    results.append(
+                        DetectedPlatform(
+                            platform=platform_id,
+                            language=language,
+                            bytes=byte_count,
+                            confidence="high",
+                            priority=100 - fw["sort"],
+                        )
                     )
-                )
 
         if base_platform not in seen_platforms:
             seen_platforms.add(base_platform)
@@ -316,7 +564,11 @@ def detect_platforms(
                     language=language,
                     bytes=byte_count,
                     confidence="medium",
+                    priority=1,
                 )
             )
+
+    results = _apply_supersession(results)
+    results.sort(key=lambda r: (r["priority"], r["bytes"]), reverse=True)
 
     return results

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -53,36 +53,23 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
             json={"Python": 50000, "JavaScript": 30000},
             status=200,
         )
-        # 404 for all manifest file lookups (no framework detection)
-        for manifest in ("requirements.txt", "pyproject.toml", "Pipfile", "package.json"):
-            responses.add(
-                method=responses.GET,
-                url=f"https://api.github.com/repos/Test-Organization/foo/contents/{manifest}",
-                json={"message": "Not Found"},
-                status=404,
-            )
+        # Root directory listing (no manifest files -> no framework detection)
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/repos/Test-Organization/foo/contents",
+            json=[],
+            status=200,
+        )
 
         with self.feature(FEATURE_FLAG):
             response = self.get_success_response(
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        assert response.data == {
-            "platforms": [
-                {
-                    "platform": "python",
-                    "language": "Python",
-                    "bytes": 50000,
-                    "confidence": "medium",
-                },
-                {
-                    "platform": "javascript",
-                    "language": "JavaScript",
-                    "bytes": 30000,
-                    "confidence": "medium",
-                },
-            ]
-        }
+        platforms = response.data["platforms"]
+        platform_ids = [p["platform"] for p in platforms]
+        assert "python" in platform_ids
+        assert "javascript" in platform_ids
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
@@ -114,28 +101,13 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        assert response.data == {
-            "platforms": [
-                {
-                    "platform": "python-django",
-                    "language": "Python",
-                    "bytes": 50000,
-                    "confidence": "high",
-                },
-                {
-                    "platform": "python-celery",
-                    "language": "Python",
-                    "bytes": 50000,
-                    "confidence": "high",
-                },
-                {
-                    "platform": "python",
-                    "language": "Python",
-                    "bytes": 50000,
-                    "confidence": "medium",
-                },
-            ]
-        }
+        platforms = response.data["platforms"]
+        platform_ids = [p["platform"] for p in platforms]
+        assert "python-django" in platform_ids
+        assert "python-celery" in platform_ids
+
+        django = next(p for p in platforms if p["platform"] == "python-django")
+        assert django["confidence"] == "high"
 
     def test_repo_not_found(self) -> None:
         with self.feature(FEATURE_FLAG):

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -66,19 +66,13 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
+        # Only the top language by bytes is returned
         assert response.data == {
             "platforms": [
                 {
                     "platform": "python",
                     "language": "Python",
                     "bytes": 50000,
-                    "confidence": "medium",
-                    "priority": 1,
-                },
-                {
-                    "platform": "javascript",
-                    "language": "JavaScript",
-                    "bytes": 30000,
                     "confidence": "medium",
                     "priority": 1,
                 },

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -66,13 +66,19 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        # Only the top language by bytes is returned
         assert response.data == {
             "platforms": [
                 {
                     "platform": "python",
                     "language": "Python",
                     "bytes": 50000,
+                    "confidence": "medium",
+                    "priority": 1,
+                },
+                {
+                    "platform": "javascript",
+                    "language": "JavaScript",
+                    "bytes": 30000,
                     "confidence": "medium",
                     "priority": 1,
                 },

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -66,10 +66,24 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        platforms = response.data["platforms"]
-        platform_ids = [p["platform"] for p in platforms]
-        assert "python" in platform_ids
-        assert "javascript" in platform_ids
+        assert response.data == {
+            "platforms": [
+                {
+                    "platform": "python",
+                    "language": "Python",
+                    "bytes": 50000,
+                    "confidence": "medium",
+                    "priority": 1,
+                },
+                {
+                    "platform": "javascript",
+                    "language": "JavaScript",
+                    "bytes": 30000,
+                    "confidence": "medium",
+                    "priority": 1,
+                },
+            ]
+        }
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
@@ -101,13 +115,31 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        platforms = response.data["platforms"]
-        platform_ids = [p["platform"] for p in platforms]
-        assert "python-django" in platform_ids
-        assert "python-celery" in platform_ids
-
-        django = next(p for p in platforms if p["platform"] == "python-django")
-        assert django["confidence"] == "high"
+        assert response.data == {
+            "platforms": [
+                {
+                    "platform": "python-django",
+                    "language": "Python",
+                    "bytes": 50000,
+                    "confidence": "high",
+                    "priority": 90,
+                },
+                {
+                    "platform": "python-celery",
+                    "language": "Python",
+                    "bytes": 50000,
+                    "confidence": "high",
+                    "priority": 40,
+                },
+                {
+                    "platform": "python",
+                    "language": "Python",
+                    "bytes": 50000,
+                    "confidence": "medium",
+                    "priority": 1,
+                },
+            ]
+        }
 
     def test_repo_not_found(self) -> None:
         with self.feature(FEATURE_FLAG):

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -303,6 +303,18 @@ class TestGetRootFileNames:
 
         client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
 
+    def test_returns_empty_on_malformed_item(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = [{"type": "file"}]  # missing "name" key
+
+        assert _get_root_file_names(client, "owner/repo") == set()
+
+    def test_returns_empty_on_non_list_response(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = {"message": "Not Found"}  # dict instead of list
+
+        assert _get_root_file_names(client, "owner/repo") == set()
+
 
 class TestApplySupersession:
     def test_nextjs_supersedes_react(self) -> None:

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from sentry.integrations.github.platform_detection import (
+    FRAMEWORKS,
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
     DetectorRule,
@@ -897,3 +898,172 @@ class TestDetectPlatforms:
 
         platforms = [r["platform"] for r in result]
         assert "go-gin" in platforms
+
+
+class TestFrameworksIntegrity:
+    """Validate the FRAMEWORKS list is internally consistent.
+
+    Catches typos and structural errors that would silently cause
+    framework definitions to never match at runtime.
+    """
+
+    def test_no_duplicate_platform_ids(self) -> None:
+        platform_ids = [fw["platform"] for fw in FRAMEWORKS]
+        duplicates = [p for p in platform_ids if platform_ids.count(p) > 1]
+        assert duplicates == [], f"Duplicate platform IDs: {set(duplicates)}"
+
+    def test_all_base_platforms_are_valid(self) -> None:
+        valid_base_platforms = set(GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.values())
+        for fw in FRAMEWORKS:
+            assert fw["base_platform"] in valid_base_platforms, (
+                f"{fw['platform']} has base_platform={fw['base_platform']!r} "
+                f"which is not a value in GITHUB_LANGUAGE_TO_SENTRY_PLATFORM"
+            )
+
+    def test_all_supersedes_targets_exist(self) -> None:
+        all_platform_ids = {fw["platform"] for fw in FRAMEWORKS}
+        all_base_platforms = set(GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.values())
+        valid_targets = all_platform_ids | all_base_platforms
+
+        for fw in FRAMEWORKS:
+            for target in fw.get("supersedes", []):
+                assert target in valid_targets, (
+                    f"{fw['platform']} supersedes {target!r} "
+                    f"which does not exist as a framework or base platform"
+                )
+
+    def test_every_framework_has_at_least_one_rule(self) -> None:
+        for fw in FRAMEWORKS:
+            has_rules = fw.get("every") or fw.get("some")
+            assert has_rules, f"{fw['platform']} has no detection rules (no every or some)"
+
+    def test_sort_values_are_positive_integers(self) -> None:
+        for fw in FRAMEWORKS:
+            assert isinstance(fw["sort"], int), (
+                f"{fw['platform']} sort={fw['sort']!r} is not an int"
+            )
+            assert 1 <= fw["sort"] <= 99, (
+                f"{fw['platform']} sort={fw['sort']} is outside valid range 1-99"
+            )
+
+    def test_no_rule_has_match_content_without_path(self) -> None:
+        for fw in FRAMEWORKS:
+            for rule in [*fw.get("every", []), *fw.get("some", [])]:
+                if "match_content" in rule:
+                    assert "path" in rule, (
+                        f"{fw['platform']} has match_content without path — "
+                        f"content matching requires a file to read"
+                    )
+
+
+class TestDetectPlatformsMultiStack:
+    """Test detection against a realistic multi-language, multi-framework repo.
+
+    Simulates a repo like a typical full-stack app with:
+    - Python backend (Django + Celery)
+    - JavaScript frontend (Next.js with React)
+    - Go microservice (Gin)
+    - Plus build/infra languages that should be ignored
+    """
+
+    def test_full_stack_repo(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {
+            "Python": 120000,
+            "JavaScript": 80000,
+            "TypeScript": 60000,
+            "Go": 40000,
+            "HTML": 15000,
+            "CSS": 10000,
+            "Shell": 5000,
+            "Makefile": 2000,
+            "Dockerfile": 1000,
+        }
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "manage.py", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                    {"name": "go.mod", "type": "file"},
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "Dockerfile", "type": "file"},
+                    {"name": "Makefile", "type": "file"},
+                    {"name": "src", "type": "dir"},
+                    {"name": "frontend", "type": "dir"},
+                    {"name": "services", "type": "dir"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response(
+                    "Django==4.2\ncelery>=5.3\ngunicorn\npsycopg2-binary\nredis\n"
+                )
+            if "package.json" in path:
+                return _make_b64_response(
+                    json.dumps(
+                        {
+                            "dependencies": {
+                                "next": "^14.0.0",
+                                "react": "^18.2.0",
+                                "react-dom": "^18.2.0",
+                            },
+                            "devDependencies": {
+                                "typescript": "^5.0.0",
+                                "eslint": "^8.0.0",
+                            },
+                        }
+                    )
+                )
+            if "go.mod" in path:
+                return _make_b64_response(
+                    "module github.com/myorg/myapp\n\n"
+                    "go 1.21\n\n"
+                    "require (\n"
+                    "\tgithub.com/gin-gonic/gin v1.9.1\n"
+                    "\tgithub.com/lib/pq v1.10.9\n"
+                    ")\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        platform_set = set(platforms)
+
+        # Frameworks detected with high confidence
+        assert "python-django" in platform_set
+        assert "python-celery" in platform_set
+        assert "javascript-nextjs" in platform_set
+        assert "go-gin" in platform_set
+
+        # Supersession: React removed because Next.js is present
+        assert "javascript-react" not in platform_set
+
+        # Base platforms as fallback
+        assert "python" in platform_set
+        assert "javascript" in platform_set
+        assert "go" in platform_set
+
+        # Ignored languages excluded entirely
+        for r in result:
+            assert r["language"] not in ("HTML", "CSS", "Shell", "Makefile", "Dockerfile")
+
+        # TypeScript deduplicates into javascript base platform
+        ts_results = [r for r in result if r["language"] == "TypeScript"]
+        assert ts_results == []
+
+        # Priority ordering: meta-frameworks first, then primary, then utilities, then base
+        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        django = next(r for r in result if r["platform"] == "python-django")
+        celery = next(r for r in result if r["platform"] == "python-celery")
+        python_base = next(r for r in result if r["platform"] == "python")
+
+        assert nextjs["priority"] > django["priority"] > celery["priority"]
+        assert celery["priority"] > python_base["priority"]
+        assert python_base["priority"] == 1
+
+        # Results are sorted by (priority, bytes) descending
+        for i in range(len(result) - 1):
+            a, b = result[i], result[i + 1]
+            assert (a["priority"], a["bytes"]) >= (b["priority"], b["bytes"])

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -552,7 +552,7 @@ class TestDetectPlatforms:
         python_result = next(r for r in result if r["platform"] == "python")
         assert python_result["confidence"] == "medium"
 
-    def test_results_sorted_by_priority_then_bytes(self) -> None:
+    def test_results_sorted_by_bytes_then_priority(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Python": 80000, "JavaScript": 30000}
 
@@ -574,11 +574,11 @@ class TestDetectPlatforms:
 
         result = detect_platforms(client, "owner/repo")
 
-        # Next.js (priority=99) > Flask (priority=80) > base platforms (priority=1)
+        # Python (80k bytes) > JavaScript (30k bytes); language majority wins
         platforms = [r["platform"] for r in result]
-        nextjs_idx = platforms.index("javascript-nextjs")
         flask_idx = platforms.index("python-flask")
-        assert nextjs_idx < flask_idx
+        nextjs_idx = platforms.index("javascript-nextjs")
+        assert flask_idx < nextjs_idx
 
     def test_nextjs_supersedes_react_in_full_flow(self) -> None:
         client = mock.MagicMock()
@@ -1053,7 +1053,7 @@ class TestDetectPlatformsMultiStack:
         ts_results = [r for r in result if r["language"] == "TypeScript"]
         assert ts_results == []
 
-        # Priority ordering: meta-frameworks first, then primary, then utilities, then base
+        # Priority ordering within a language: meta-frameworks > primary > utilities > base
         nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
         django = next(r for r in result if r["platform"] == "python-django")
         celery = next(r for r in result if r["platform"] == "python-celery")
@@ -1063,7 +1063,7 @@ class TestDetectPlatformsMultiStack:
         assert celery["priority"] > python_base["priority"]
         assert python_base["priority"] == 1
 
-        # Results are sorted by (priority, bytes) descending
+        # Results are sorted by (bytes, priority) descending — language majority first
         for i in range(len(result) - 1):
             a, b = result[i], result[i + 1]
-            assert (a["priority"], a["bytes"]) >= (b["priority"], b["bytes"])
+            assert (a["bytes"], a["priority"]) >= (b["bytes"], b["priority"])

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -67,6 +67,20 @@ class TestParsePackageManifest:
     def test_unsupported_manifest_returns_none(self) -> None:
         assert _parse_package_manifest("{}", "requirements.txt") is None
 
+    def test_null_dependencies_handled(self) -> None:
+        content = json.dumps({"dependencies": None, "devDependencies": None})
+        result = _parse_package_manifest(content, "package.json")
+        assert result is not None
+        assert result["dependencies"] == set()
+        assert result["dev_dependencies"] == set()
+
+    def test_null_composer_require_handled(self) -> None:
+        content = json.dumps({"require": None, "require-dev": None})
+        result = _parse_package_manifest(content, "composer.json")
+        assert result is not None
+        assert result["dependencies"] == set()
+        assert result["dev_dependencies"] == set()
+
 
 class TestPackageInManifest:
     def test_exact_match_in_dependencies(self) -> None:

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -8,9 +8,14 @@ import pytest
 from sentry.integrations.github.platform_detection import (
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
-    _detect_frameworks_from_content,
+    _apply_supersession,
+    _framework_matches,
     _get_repo_file_content,
-    detect_framework,
+    _get_root_file_names,
+    _package_in_manifest,
+    _PackageManifest,
+    _parse_package_manifest,
+    _rule_matches,
     detect_platforms,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -37,84 +42,370 @@ class TestGithubLanguageMapping:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get("Haskell") is None
 
 
-class TestDetectFrameworksFromContent:
-    def test_package_json_detects_next(self) -> None:
-        content = json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"next": "javascript-nextjs", "react": "javascript-react"}
+class TestParsePackageManifest:
+    def test_parses_package_json(self) -> None:
+        content = json.dumps(
+            {"dependencies": {"next": "^14.0.0"}, "devDependencies": {"jest": "^29.0.0"}}
         )
-        assert "javascript-nextjs" in result
-        assert "javascript-react" in result
+        result = _parse_package_manifest(content, "package.json")
+        assert result is not None
+        assert result["dependencies"] == {"next"}
+        assert result["dev_dependencies"] == {"jest"}
 
-    def test_package_json_checks_dev_dependencies(self) -> None:
-        content = json.dumps({"devDependencies": {"svelte": "^4.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"svelte": "javascript-svelte"}
+    def test_parses_composer_json(self) -> None:
+        content = json.dumps(
+            {"require": {"laravel/framework": "^10.0"}, "require-dev": {"phpunit/phpunit": "^10"}}
         )
-        assert result == ["javascript-svelte"]
+        result = _parse_package_manifest(content, "composer.json")
+        assert result is not None
+        assert result["dependencies"] == {"laravel/framework"}
+        assert result["dev_dependencies"] == {"phpunit/phpunit"}
 
-    def test_package_json_no_match(self) -> None:
-        content = json.dumps({"dependencies": {"lodash": "^4.0.0"}})
-        result = _detect_frameworks_from_content(
-            content, "package.json", {"next": "javascript-nextjs"}
+    def test_invalid_json_returns_none(self) -> None:
+        assert _parse_package_manifest("not json", "package.json") is None
+
+    def test_unsupported_manifest_returns_none(self) -> None:
+        assert _parse_package_manifest("{}", "requirements.txt") is None
+
+
+class TestPackageInManifest:
+    def test_exact_match_in_dependencies(self) -> None:
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _package_in_manifest("next", manifest) is True
+
+    def test_exact_match_in_dev_dependencies(self) -> None:
+        manifest = _PackageManifest(dependencies=set(), dev_dependencies={"jest"})
+        assert _package_in_manifest("jest", manifest) is True
+
+    def test_no_match(self) -> None:
+        manifest = _PackageManifest(dependencies={"react"}, dev_dependencies=set())
+        assert _package_in_manifest("vue", manifest) is False
+
+    def test_prefix_match_for_composer(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"symfony/framework-bundle"}, dev_dependencies=set()
         )
-        assert result == []
+        assert _package_in_manifest("symfony/", manifest) is True
 
-    def test_package_json_invalid_json(self) -> None:
-        result = _detect_frameworks_from_content(
-            "not valid json", "package.json", {"next": "javascript-nextjs"}
+    def test_prefix_no_match(self) -> None:
+        manifest = _PackageManifest(dependencies={"laravel/framework"}, dev_dependencies=set())
+        assert _package_in_manifest("symfony/", manifest) is False
+
+
+class TestRuleMatches:
+    def test_path_rule_matches_when_file_exists(self) -> None:
+        rule = {"path": "next.config.js"}
+        assert _rule_matches(rule, {"next.config.js", "package.json"}, {}, None) is True
+
+    def test_path_rule_no_match_when_file_missing(self) -> None:
+        rule = {"path": "next.config.js"}
+        assert _rule_matches(rule, {"package.json"}, {}, None) is False
+
+    def test_path_with_content_matches_regex(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert (
+            _rule_matches(rule, set(), {"requirements.txt": "Django==4.2\ncelery>=5.0\n"}, None)
+            is True
         )
-        assert result == []
 
-    def test_requirements_txt_detects_django(self) -> None:
-        content = "Django==4.2\ncelery>=5.0\nredis\n"
-        result = _detect_frameworks_from_content(
-            content,
-            "requirements.txt",
-            {"django": "python-django", "celery": "python-celery"},
+    def test_path_with_content_case_insensitive(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"}
+        assert _rule_matches(rule, set(), {"requirements.txt": "Flask==3.0\n"}, None) is True
+
+    def test_path_with_content_no_match(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert _rule_matches(rule, set(), {"requirements.txt": "flask==3.0\n"}, None) is False
+
+    def test_path_with_content_file_not_fetched(self) -> None:
+        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        assert _rule_matches(rule, set(), {}, None) is False
+
+    def test_match_package_finds_dependency(self) -> None:
+        rule = {"match_package": "next"}
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _rule_matches(rule, set(), {}, manifest) is True
+
+    def test_match_package_finds_dev_dependency(self) -> None:
+        rule = {"match_package": "svelte"}
+        manifest = _PackageManifest(dependencies=set(), dev_dependencies={"svelte"})
+        assert _rule_matches(rule, set(), {}, manifest) is True
+
+    def test_match_package_no_match(self) -> None:
+        rule = {"match_package": "next"}
+        manifest = _PackageManifest(dependencies={"react"}, dev_dependencies=set())
+        assert _rule_matches(rule, set(), {}, manifest) is False
+
+    def test_match_package_no_manifest(self) -> None:
+        rule = {"match_package": "next"}
+        assert _rule_matches(rule, set(), {}, None) is False
+
+    def test_match_package_prefix_match(self) -> None:
+        rule = {"match_package": "symfony/"}
+        manifest = _PackageManifest(
+            dependencies={"symfony/framework-bundle"}, dev_dependencies=set()
         )
-        assert "python-django" in result
-        assert "python-celery" in result
+        assert _rule_matches(rule, set(), {}, manifest) is True
 
-    def test_requirements_txt_case_insensitive(self) -> None:
-        content = "Flask==3.0\n"
-        result = _detect_frameworks_from_content(
-            content, "requirements.txt", {"flask": "python-flask"}
+    def test_rule_without_path_or_package_returns_false(self) -> None:
+        rule: dict = {}
+        assert _rule_matches(rule, {"file.txt"}, {}, None) is False
+
+
+class TestFrameworkMatches:
+    def test_some_rules_match_when_any_passes(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [
+                {"path": "missing.js"},
+                {"path": "found.js"},
+            ],
+        }
+        assert _framework_matches(fw, {"found.js"}, {}, None) is True
+
+    def test_some_rules_no_match_when_none_pass(self) -> None:
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [
+                {"path": "missing1.js"},
+                {"path": "missing2.js"},
+            ],
+        }
+        assert _framework_matches(fw, set(), {}, None) is False
+
+    def test_every_rules_match_when_all_pass(self) -> None:
+        manifest = _PackageManifest(dependencies={"express", "cors"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_package": "express"}],
+        }
+        assert _framework_matches(fw, set(), {}, manifest) is True
+
+    def test_every_rules_no_match_when_one_fails(self) -> None:
+        manifest = _PackageManifest(dependencies={"cors"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [
+                {"match_package": "express"},
+                {"match_package": "cors"},
+            ],
+        }
+        assert _framework_matches(fw, set(), {}, manifest) is False
+
+    def test_every_and_some_combined(self) -> None:
+        manifest = _PackageManifest(dependencies={"express"}, dev_dependencies=set())
+        fw = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_package": "express"}],
+            "some": [{"path": "app.js"}, {"path": "server.js"}],
+        }
+        # every passes, some passes (server.js exists)
+        assert _framework_matches(fw, {"server.js"}, {}, manifest) is True
+        # every passes, some fails (neither file exists)
+        assert _framework_matches(fw, set(), {}, manifest) is False
+
+    def test_empty_every_and_some_returns_false(self) -> None:
+        fw = {"platform": "test", "sort": 1, "base_platform": "test"}
+        assert _framework_matches(fw, set(), {}, None) is False
+
+    def test_nextjs_matches_from_package(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
+        manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
+        assert _framework_matches(nextjs, set(), {}, manifest) is True
+
+    def test_nextjs_matches_from_config_file(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
+        assert _framework_matches(nextjs, {"next.config.js"}, {}, None) is True
+
+    def test_django_matches_from_manage_py(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
+        assert _framework_matches(django, {"manage.py"}, {}, None) is True
+
+    def test_django_matches_from_requirements_content(self) -> None:
+        from sentry.integrations.github.platform_detection import FRAMEWORKS
+
+        django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
+        assert (
+            _framework_matches(
+                django, set(), {"requirements.txt": "Django==4.2\ncelery>=5.0\n"}, None
+            )
+            is True
         )
-        assert result == ["python-flask"]
 
-    def test_gemfile_detects_rails(self) -> None:
-        content = 'gem "rails", "~> 7.0"\ngem "pg"\n'
-        result = _detect_frameworks_from_content(content, "Gemfile", {"rails": "ruby-rails"})
-        assert result == ["ruby-rails"]
 
-    def test_composer_json_detects_laravel(self) -> None:
-        content = json.dumps({"require": {"laravel/framework": "^10.0"}})
-        result = _detect_frameworks_from_content(
-            content, "composer.json", {"laravel/framework": "php-laravel"}
-        )
-        assert result == ["php-laravel"]
+class TestGetRootFileNames:
+    def test_returns_file_names(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = [
+            {"name": "package.json", "type": "file"},
+            {"name": "next.config.js", "type": "file"},
+            {"name": "src", "type": "dir"},
+            {"name": "README.md", "type": "file"},
+        ]
 
-    def test_composer_json_prefix_match_symfony(self) -> None:
-        content = json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})
-        result = _detect_frameworks_from_content(
-            content, "composer.json", {"symfony/": "php-symfony"}
-        )
-        assert result == ["php-symfony"]
+        result = _get_root_file_names(client, "owner/repo")
 
-    def test_go_mod_detects_gin(self) -> None:
-        content = "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
-        result = _detect_frameworks_from_content(content, "go.mod", {"gin": "go-gin"})
-        assert result == ["go-gin"]
+        assert result == {"package.json", "next.config.js", "README.md"}
 
-    def test_build_gradle_detects_spring_boot(self) -> None:
-        content = (
-            "dependencies {\n    implementation 'org.springframework.boot:spring-boot-starter'\n}\n"
-        )
-        result = _detect_frameworks_from_content(
-            content, "build.gradle", {"spring-boot": "java-spring-boot"}
-        )
-        assert result == ["java-spring-boot"]
+    def test_excludes_directories(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = [
+            {"name": "src", "type": "dir"},
+            {"name": "lib", "type": "dir"},
+        ]
+
+        result = _get_root_file_names(client, "owner/repo")
+
+        assert result == set()
+
+    def test_returns_empty_on_api_error(self) -> None:
+        client = mock.MagicMock()
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = _get_root_file_names(client, "owner/repo")
+
+        assert result == set()
+
+    def test_passes_ref_param(self) -> None:
+        client = mock.MagicMock()
+        client.get.return_value = []
+
+        _get_root_file_names(client, "owner/repo", ref="main")
+
+        client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
+
+
+class TestApplySupersession:
+    def test_nextjs_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nextjs",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nextjs" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_nuxt_supersedes_vue(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nuxt",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-vue",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nuxt" in platforms
+        assert "javascript-vue" not in platforms
+
+    def test_remix_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-remix",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-remix" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_no_supersession_keeps_all(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+            DetectedPlatform(
+                platform="node-express",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=60,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        assert len(filtered) == 2
+
+    def test_supersession_does_not_affect_unrelated(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-nextjs",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="node-express",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=60,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-nextjs" in platforms
+        assert "node-express" in platforms
+        assert "javascript-react" not in platforms
 
 
 def _make_b64_response(content: str) -> dict:
@@ -164,70 +455,6 @@ class TestGetRepoFileContent:
         assert _get_repo_file_content(client, "owner/repo", "some-dir") is None
 
 
-class TestDetectFramework:
-    def test_detects_python_django(self) -> None:
-        client = mock.MagicMock()
-        client.get.return_value = _make_b64_response("Django==4.2\ncelery>=5.0\n")
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert "python-django" in result
-        assert "python-celery" in result
-
-    def test_falls_back_when_manifest_not_found(self) -> None:
-        client = mock.MagicMock()
-        client.get.side_effect = ApiError("Not Found", code=404)
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert result == []
-
-    def test_stops_after_first_manifest_with_results(self) -> None:
-        client = mock.MagicMock()
-        client.get.return_value = _make_b64_response("Django==4.2\n")
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert result == ["python-django"]
-        # Should have only called get() once (for requirements.txt),
-        # not continued to pyproject.toml
-        assert client.get.call_count == 1
-
-    def test_tries_next_manifest_when_first_has_no_match(self) -> None:
-        client = mock.MagicMock()
-
-        def side_effect(path, params=None):
-            if "requirements.txt" in path:
-                return _make_b64_response("some-unrelated-package\n")
-            if "pyproject.toml" in path:
-                return _make_b64_response('[project]\ndependencies = ["flask"]\n')
-            raise ApiError("Not Found", code=404)
-
-        client.get.side_effect = side_effect
-
-        result = detect_framework(client, "owner/repo", "python")
-
-        assert result == ["python-flask"]
-
-    def test_unknown_platform_returns_empty(self) -> None:
-        client = mock.MagicMock()
-        result = detect_framework(client, "owner/repo", "unknown-platform")
-        assert result == []
-        client.get.assert_not_called()
-
-    def test_deduplicates_results(self) -> None:
-        client = mock.MagicMock()
-        # package.json with both react in deps and devDeps
-        content = json.dumps(
-            {"dependencies": {"react": "^18.0.0"}, "devDependencies": {"react": "^18.0.0"}}
-        )
-        client.get.return_value = _make_b64_response(content)
-
-        result = detect_framework(client, "owner/repo", "javascript")
-
-        assert result.count("javascript-react") == 1
-
-
 class TestDetectPlatforms:
     def test_detects_single_language_repo(self) -> None:
         client = mock.MagicMock()
@@ -237,12 +464,11 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         assert len(result) == 1
-        assert result[0] == DetectedPlatform(
-            platform="python",
-            language="Python",
-            bytes=50000,
-            confidence="medium",
-        )
+        assert result[0]["platform"] == "python"
+        assert result[0]["language"] == "Python"
+        assert result[0]["bytes"] == 50000
+        assert result[0]["confidence"] == "medium"
+        assert result[0]["priority"] == 1
 
     def test_detects_multi_language_repo(self) -> None:
         client = mock.MagicMock()
@@ -278,6 +504,8 @@ class TestDetectPlatforms:
         client.get_languages.return_value = {"Python": 50000}
 
         def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "requirements.txt", "type": "file"}]
             if "requirements.txt" in path:
                 return _make_b64_response("Django==4.2\n")
             raise ApiError("Not Found", code=404)
@@ -292,17 +520,86 @@ class TestDetectPlatforms:
         python_result = next(r for r in result if r["platform"] == "python")
         assert python_result["confidence"] == "medium"
 
-    def test_preserves_github_ordering(self) -> None:
+    def test_results_sorted_by_priority_then_bytes(self) -> None:
         client = mock.MagicMock()
-        # GitHub returns languages ordered by bytes descending
-        client.get_languages.return_value = {"Python": 50000, "Go": 30000, "Ruby": 10000}
-        client.get.side_effect = ApiError("Not Found", code=404)
+        client.get_languages.return_value = {"Python": 80000, "JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "requirements.txt", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("flask==3.0\n")
+            if "package.json" in path:
+                return _make_b64_response(
+                    json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
-        assert result[0]["language"] == "Python"
-        assert result[1]["language"] == "Go"
-        assert result[2]["language"] == "Ruby"
+        # Next.js (priority=99) > Flask (priority=80) > base platforms (priority=1)
+        platforms = [r["platform"] for r in result]
+        nextjs_idx = platforms.index("javascript-nextjs")
+        flask_idx = platforms.index("python-flask")
+        assert nextjs_idx < flask_idx
+
+    def test_nextjs_supersedes_react_in_full_flow(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {"dependencies": {"next": "^14.0.0", "react": "^18.0.0", "express": "^4.0.0"}}
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-nextjs" in platforms
+        assert "node-express" in platforms
+        assert "javascript-react" not in platforms
+        assert "javascript" in platforms
+
+    def test_framework_sort_determines_ranking(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {
+                "dependencies": {"express": "^4.0.0"},
+                "devDependencies": {"svelte": "^4.0.0"},
+            }
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        svelte = next(r for r in result if r["platform"] == "javascript-svelte")
+        express = next(r for r in result if r["platform"] == "node-express")
+        # svelte sort=30 → priority=70, express sort=40 → priority=60
+        assert svelte["priority"] == 70
+        assert express["priority"] == 60
 
     def test_typescript_and_javascript_deduplicated(self) -> None:
         client = mock.MagicMock()
@@ -317,6 +614,7 @@ class TestDetectPlatforms:
     def test_empty_repo_returns_empty(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {}
+        client.get.return_value = []
 
         result = detect_platforms(client, "owner/repo")
 
@@ -325,10 +623,20 @@ class TestDetectPlatforms:
     def test_only_ignored_languages_returns_empty(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Shell": 5000, "Makefile": 1000}
+        client.get.return_value = []
 
         result = detect_platforms(client, "owner/repo")
 
         assert result == []
+
+    def test_priority_field_present_in_results(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert "priority" in result[0]
 
     @pytest.mark.parametrize(
         ("language", "expected_platform"),
@@ -357,3 +665,204 @@ class TestDetectPlatforms:
 
         assert len(result) >= 1
         assert result[0]["platform"] == expected_platform
+
+    def test_config_file_detects_nextjs_without_dep(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {"react": "^18.0.0"}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-nextjs" in platforms
+        # React is superseded by Next.js
+        assert "javascript-react" not in platforms
+
+    def test_config_file_sets_high_priority(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {"next": "^14.0.0"}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        # sort=1 → priority=99
+        assert nextjs["priority"] == 99
+
+    def test_config_file_only_detection(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "next.config.js", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        # sort=1 → priority=99 (same regardless of dep presence)
+        assert nextjs["priority"] == 99
+
+    def test_manage_py_detects_django(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "manage.py", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        django = next(r for r in result if r["platform"] == "python-django")
+        assert django["confidence"] == "high"
+        # sort=10 → priority=90
+        assert django["priority"] == 90
+
+    def test_base_platform_priority_is_one(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert result[0]["platform"] == "python"
+        assert result[0]["priority"] == 1
+
+    def test_multiple_frameworks_same_platform(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "manage.py", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\ncelery>=5.0\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-django" in platforms
+        assert "python-celery" in platforms
+        assert "python" in platforms
+
+    def test_no_root_files_only_base_platforms(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000, "JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return []
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert platforms == ["python", "javascript"] or set(platforms) == {
+            "python",
+            "javascript",
+        }
+        for r in result:
+            assert r["confidence"] == "medium"
+            assert r["priority"] == 1
+
+    def test_laravel_detected_from_artisan(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PHP": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "artisan", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "php-laravel" in platforms
+
+    def test_spring_boot_detected_from_build_gradle(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "build.gradle", "type": "file"}]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "dependencies {\n    implementation 'org.springframework.boot:spring-boot-starter'\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "java-spring-boot" in platforms
+
+    def test_go_gin_detected_from_go_mod(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Go": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "go.mod", "type": "file"}]
+            if "go.mod" in path:
+                return _make_b64_response(
+                    "module example.com/myapp\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "go-gin" in platforms

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -290,13 +290,13 @@ class TestGetRootFileNames:
 
         assert result == set()
 
-    def test_returns_empty_on_api_error(self) -> None:
+    def test_returns_none_on_api_error(self) -> None:
         client = mock.MagicMock()
         client.get.side_effect = ApiError("Not Found", code=404)
 
         result = _get_root_file_names(client, "owner/repo")
 
-        assert result == set()
+        assert result is None
 
     def test_passes_ref_param(self) -> None:
         client = mock.MagicMock()
@@ -315,11 +315,11 @@ class TestGetRootFileNames:
 
         assert _get_root_file_names(client, "owner/repo") == {"README.md"}
 
-    def test_returns_empty_on_non_list_response(self) -> None:
+    def test_returns_none_on_non_list_response(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = {"message": "Not Found"}  # dict instead of list
 
-        assert _get_root_file_names(client, "owner/repo") == set()
+        assert _get_root_file_names(client, "owner/repo") is None
 
 
 class TestApplySupersession:
@@ -842,6 +842,30 @@ class TestDetectPlatforms:
         for r in result:
             assert r["confidence"] == "medium"
             assert r["priority"] == 1
+
+    def test_root_listing_failure_still_detects_frameworks_via_manifest(self) -> None:
+        """When the root contents API fails, framework detection should fall
+        back to fetching manifest files individually rather than returning
+        only base platforms."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                raise ApiError("Server Error", code=500)
+            if path.endswith("/contents/requirements.txt"):
+                return {
+                    "content": b64encode(b"Django>=4.0\ncelery>=5.0").decode(),
+                    "encoding": "base64",
+                }
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-django" in platforms
 
     def test_laravel_detected_from_artisan(self) -> None:
         client = mock.MagicMock()

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -8,6 +8,8 @@ import pytest
 from sentry.integrations.github.platform_detection import (
     GITHUB_LANGUAGE_TO_SENTRY_PLATFORM,
     DetectedPlatform,
+    DetectorRule,
+    FrameworkDef,
     _apply_supersession,
     _framework_matches,
     _get_repo_file_content,
@@ -108,66 +110,66 @@ class TestPackageInManifest:
 
 class TestRuleMatches:
     def test_path_rule_matches_when_file_exists(self) -> None:
-        rule = {"path": "next.config.js"}
+        rule: DetectorRule = {"path": "next.config.js"}
         assert _rule_matches(rule, {"next.config.js", "package.json"}, {}, None) is True
 
     def test_path_rule_no_match_when_file_missing(self) -> None:
-        rule = {"path": "next.config.js"}
+        rule: DetectorRule = {"path": "next.config.js"}
         assert _rule_matches(rule, {"package.json"}, {}, None) is False
 
     def test_path_with_content_matches_regex(self) -> None:
-        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        rule: DetectorRule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
         assert (
             _rule_matches(rule, set(), {"requirements.txt": "Django==4.2\ncelery>=5.0\n"}, None)
             is True
         )
 
     def test_path_with_content_case_insensitive(self) -> None:
-        rule = {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"}
+        rule: DetectorRule = {"path": "requirements.txt", "match_content": r"(?i)\bflask\b"}
         assert _rule_matches(rule, set(), {"requirements.txt": "Flask==3.0\n"}, None) is True
 
     def test_path_with_content_no_match(self) -> None:
-        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        rule: DetectorRule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
         assert _rule_matches(rule, set(), {"requirements.txt": "flask==3.0\n"}, None) is False
 
     def test_path_with_content_file_not_fetched(self) -> None:
-        rule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
+        rule: DetectorRule = {"path": "requirements.txt", "match_content": r"(?i)\bdjango\b"}
         assert _rule_matches(rule, set(), {}, None) is False
 
     def test_match_package_finds_dependency(self) -> None:
-        rule = {"match_package": "next"}
+        rule: DetectorRule = {"match_package": "next"}
         manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
         assert _rule_matches(rule, set(), {}, manifest) is True
 
     def test_match_package_finds_dev_dependency(self) -> None:
-        rule = {"match_package": "svelte"}
+        rule: DetectorRule = {"match_package": "svelte"}
         manifest = _PackageManifest(dependencies=set(), dev_dependencies={"svelte"})
         assert _rule_matches(rule, set(), {}, manifest) is True
 
     def test_match_package_no_match(self) -> None:
-        rule = {"match_package": "next"}
+        rule: DetectorRule = {"match_package": "next"}
         manifest = _PackageManifest(dependencies={"react"}, dev_dependencies=set())
         assert _rule_matches(rule, set(), {}, manifest) is False
 
     def test_match_package_no_manifest(self) -> None:
-        rule = {"match_package": "next"}
+        rule: DetectorRule = {"match_package": "next"}
         assert _rule_matches(rule, set(), {}, None) is False
 
     def test_match_package_prefix_match(self) -> None:
-        rule = {"match_package": "symfony/"}
+        rule: DetectorRule = {"match_package": "symfony/"}
         manifest = _PackageManifest(
             dependencies={"symfony/framework-bundle"}, dev_dependencies=set()
         )
         assert _rule_matches(rule, set(), {}, manifest) is True
 
     def test_rule_without_path_or_package_returns_false(self) -> None:
-        rule: dict = {}
+        rule: DetectorRule = {}
         assert _rule_matches(rule, {"file.txt"}, {}, None) is False
 
 
 class TestFrameworkMatches:
     def test_some_rules_match_when_any_passes(self) -> None:
-        fw = {
+        fw: FrameworkDef = {
             "platform": "test",
             "sort": 1,
             "base_platform": "test",
@@ -179,7 +181,7 @@ class TestFrameworkMatches:
         assert _framework_matches(fw, {"found.js"}, {}, None) is True
 
     def test_some_rules_no_match_when_none_pass(self) -> None:
-        fw = {
+        fw: FrameworkDef = {
             "platform": "test",
             "sort": 1,
             "base_platform": "test",
@@ -192,7 +194,7 @@ class TestFrameworkMatches:
 
     def test_every_rules_match_when_all_pass(self) -> None:
         manifest = _PackageManifest(dependencies={"express", "cors"}, dev_dependencies=set())
-        fw = {
+        fw: FrameworkDef = {
             "platform": "test",
             "sort": 1,
             "base_platform": "test",
@@ -202,7 +204,7 @@ class TestFrameworkMatches:
 
     def test_every_rules_no_match_when_one_fails(self) -> None:
         manifest = _PackageManifest(dependencies={"cors"}, dev_dependencies=set())
-        fw = {
+        fw: FrameworkDef = {
             "platform": "test",
             "sort": 1,
             "base_platform": "test",
@@ -215,7 +217,7 @@ class TestFrameworkMatches:
 
     def test_every_and_some_combined(self) -> None:
         manifest = _PackageManifest(dependencies={"express"}, dev_dependencies=set())
-        fw = {
+        fw: FrameworkDef = {
             "platform": "test",
             "sort": 1,
             "base_platform": "test",
@@ -228,7 +230,7 @@ class TestFrameworkMatches:
         assert _framework_matches(fw, set(), {}, manifest) is False
 
     def test_empty_every_and_some_returns_false(self) -> None:
-        fw = {"platform": "test", "sort": 1, "base_platform": "test"}
+        fw: FrameworkDef = {"platform": "test", "sort": 1, "base_platform": "test"}
         assert _framework_matches(fw, set(), {}, None) is False
 
     def test_nextjs_matches_from_package(self) -> None:

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -305,11 +305,14 @@ class TestGetRootFileNames:
 
         client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
 
-    def test_returns_empty_on_malformed_item(self) -> None:
+    def test_skips_malformed_item_but_keeps_valid(self) -> None:
         client = mock.MagicMock()
-        client.get.return_value = [{"type": "file"}]  # missing "name" key
+        client.get.return_value = [
+            {"type": "file"},  # missing "name" key — skipped
+            {"name": "README.md", "type": "file"},  # valid — kept
+        ]
 
-        assert _get_root_file_names(client, "owner/repo") == set()
+        assert _get_root_file_names(client, "owner/repo") == {"README.md"}
 
     def test_returns_empty_on_non_list_response(self) -> None:
         client = mock.MagicMock()


### PR DESCRIPTION
## Summary

- Refactor flat framework detection into composable `FrameworkDef` / `DetectorRule` system
- Add three signal types: `path` (config file existence), `match_content` (regex on file content), `match_package` (dependency lookup in parsed manifests)
- Add `every` (AND) and `some` (OR) rule composition
- Add priority ranking (`sort` field) and supersession (e.g. Next.js supersedes React)
- Refactor file content fetching into a single batch pass to minimize API calls

No behavior change for existing detections, but the architecture now supports easy addition of new frameworks as data-only entries.

**Stack:**
- [PR 1](https://github.com/getsentry/sentry/pull/109699): Core detection + API endpoint
- **PR 2 (this):** Composable framework definitions refactor
- [PR 3](https://github.com/getsentry/sentry/pull/109701): Expanded coverage (98% of picker platforms)