### PR TITLE
feat(integrations): Expand platform detection to 98% picker coverage

### DIFF
--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1176,14 +1176,21 @@ def detect_platforms(
     languages = client.get_languages(repo)
     root_files, root_dirs = _get_root_entries(client, repo, ref)
 
-    # Group languages by base platform
-    active_platforms: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    # Find the top language and only process its base platform to limit
+    # API calls — only one suggestion is shown to the user anyway.
+    top_language: str | None = None
+    top_bytes = 0
     for language, byte_count in languages.items():
         if language in IGNORED_LANGUAGES:
             continue
-        base_platform = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language)
-        if base_platform is not None:
-            active_platforms[base_platform].append((language, byte_count))
+        if GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get(language) is not None and byte_count > top_bytes:
+            top_language = language
+            top_bytes = byte_count
+
+    active_platforms: dict[str, list[tuple[str, int]]] = {}
+    if top_language is not None:
+        bp = GITHUB_LANGUAGE_TO_SENTRY_PLATFORM[top_language]
+        active_platforms[bp] = [(top_language, top_bytes)]
 
     # Collect all file paths that need content fetching.
     # When root_files is None (API failed), try all paths rather than skipping.

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, NotRequired, TypedDict
 
+from yaml import YAMLError
+
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
 from sentry.utils.yaml import safe_load
@@ -983,7 +985,7 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
             return _parse_gemfile(content)
         elif manifest_file == "go.mod":
             return _parse_go_mod(content)
-    except Exception:
+    except (json.JSONDecodeError, YAMLError, ValueError, KeyError, TypeError, AttributeError):
         pass
     return None
 
@@ -1027,7 +1029,7 @@ def _parse_go_mod(content: str) -> _PackageManifest:
         stripped = line.strip()
         if not stripped or stripped.startswith("//"):
             continue
-        if stripped.startswith("require ("):
+        if stripped.startswith("require (") or stripped.startswith("require("):
             in_require = True
             continue
         if in_require:

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -378,7 +378,6 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": ".node-version"},
             {"path": "nodemon.json"},
             {"path": "Procfile", "match_content": r"\bnode\b"},
-            {"path": "package.json", "match_content": r'"engines"\s*:\s*\{[^}]*"node"'},
         ],
     },
     # ===================================================================

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1249,31 +1249,16 @@ def detect_platforms(
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
             if _framework_matches(fw, root_files, file_contents, manifest, root_dirs):
                 platform_id = fw["platform"]
-                if platform_id not in seen_platforms:
-                    seen_platforms.add(platform_id)
-                    results.append(
-                        DetectedPlatform(
-                            platform=platform_id,
-                            language=language,
-                            bytes=byte_count,
-                            confidence="high",
-                            priority=100 - fw["sort"],
-                        )
+                seen_platforms.add(platform_id)
+                results.append(
+                    DetectedPlatform(
+                        platform=platform_id,
+                        language=language,
+                        bytes=byte_count,
+                        confidence="high",
+                        priority=100 - fw["sort"],
                     )
-                else:
-                    # Same platform detected via a different base_platform
-                    # (e.g. android under both java and kotlin, or apple-ios
-                    # under both swift and objective-c).  Always upgrade to
-                    # framework confidence/priority, and keep the higher
-                    # byte count so sorting reflects the dominant language.
-                    for r in results:
-                        if r["platform"] == platform_id:
-                            r["confidence"] = "high"
-                            r["priority"] = max(r["priority"], 100 - fw["sort"])
-                            if byte_count > r["bytes"]:
-                                r["bytes"] = byte_count
-                                r["language"] = language
-                            break
+                )
 
         if base_platform not in seen_platforms:
             seen_platforms.add(base_platform)

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1262,6 +1262,8 @@ def detect_platforms(
                         if r["platform"] == platform_id and byte_count > r["bytes"]:
                             r["bytes"] = byte_count
                             r["language"] = language
+                            r["confidence"] = "high"
+                            r["priority"] = 100 - fw["sort"]
                             break
 
         if base_platform not in seen_platforms:

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -906,7 +906,6 @@ for _fw in FRAMEWORKS:
 # detection) but are not selectable in the frontend project creation picker.
 _NON_SELECTABLE_PLATFORMS = frozenset(
     {
-        "perl",  # no Perl onboarding doc in Sentry
         "php-wordpress",  # WordPress uses the base PHP SDK
         "swift",  # picker uses apple-ios / apple-macos instead
     }

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -35,6 +35,7 @@ GITHUB_LANGUAGE_TO_SENTRY_PLATFORM: dict[str, str] = {
     "Elixir": "elixir",
     "C": "native",
     "C++": "native",
+    "GDScript": "godot",
     "PowerShell": "powershell",
 }
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -349,7 +349,6 @@ FRAMEWORKS: list[FrameworkDef] = [
         "base_platform": "javascript",
         "every": [
             {"path": "host.json", "match_content": r'"extensionBundle"'},
-            {"path": "local.settings.json"},
         ],
     },
     {
@@ -747,7 +746,6 @@ FRAMEWORKS: list[FrameworkDef] = [
         "some": [
             {"path": "Package.swift", "match_content": r"\.iOS\s*\("},
             {"path": "Podfile", "match_content": r"platform\s*:ios\b"},
-            {"match_ext": ".xcodeproj"},
             {"match_dir": ".xcodeproj"},
         ],
     },
@@ -904,6 +902,7 @@ _SUPERSESSION_MAP: dict[str, list[str]] = {}
 for _fw in FRAMEWORKS:
     if "supersedes" in _fw:
         _SUPERSESSION_MAP[_fw["platform"]] = _fw["supersedes"]
+del _fw
 
 # Platforms that are detected internally (as base platforms for framework
 # detection) but are not selectable in the frontend project creation picker.
@@ -1031,6 +1030,13 @@ def _parse_go_mod(content: str) -> _PackageManifest:
             continue
         if stripped.startswith("require (") or stripped.startswith("require("):
             in_require = True
+            # Handle single-line block: require (github.com/foo/bar v1.0)
+            if stripped.endswith(")"):
+                inner = stripped.split("(", 1)[1].rstrip(")")
+                parts = inner.strip().split()
+                if parts:
+                    deps.add(parts[0])
+                in_require = False
             continue
         if in_require:
             if stripped == ")":
@@ -1256,16 +1262,17 @@ def detect_platforms(
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
             if _framework_matches(fw, root_files, file_contents, manifest, root_dirs):
                 platform_id = fw["platform"]
-                seen_platforms.add(platform_id)
-                results.append(
-                    DetectedPlatform(
-                        platform=platform_id,
-                        language=language,
-                        bytes=byte_count,
-                        confidence="high",
-                        priority=100 - fw["sort"],
+                if platform_id not in seen_platforms:
+                    seen_platforms.add(platform_id)
+                    results.append(
+                        DetectedPlatform(
+                            platform=platform_id,
+                            language=language,
+                            bytes=byte_count,
+                            confidence="high",
+                            priority=100 - fw["sort"],
+                        )
                     )
-                )
 
         if base_platform not in seen_platforms:
             seen_platforms.add(base_platform)

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -824,7 +824,7 @@ FRAMEWORKS: list[FrameworkDef] = [
     {
         "platform": "godot",
         "sort": 10,
-        "base_platform": "native",
+        "base_platform": "godot",
         "some": [{"path": "project.godot"}],
     },
     # ===================================================================

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, NotRequired, TypedDict
 
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
+from sentry.utils.yaml import safe_load
 
 if TYPE_CHECKING:
     from sentry.integrations.github.client import GitHubBaseClient
@@ -981,45 +982,18 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
             return _parse_gemfile(content)
         elif manifest_file == "go.mod":
             return _parse_go_mod(content)
-    except (json.JSONDecodeError, TypeError):
+    except Exception:
         pass
     return None
 
 
 def _parse_pubspec_yaml(content: str) -> _PackageManifest:
-    """Parse a pubspec.yaml file into dependency sets using line-based parsing.
-
-    Extracts package names from the dependencies: and dev_dependencies:
-    top-level sections. Direct dependencies are identified as lines indented
-    by exactly 2 spaces that contain a colon.
-    """
-    deps: set[str] = set()
-    dev_deps: set[str] = set()
-    section_re = re.compile(r"^(\w[\w_]*):")
-    dep_re = re.compile(r"^  (\w[\w_-]*):")
-
-    current_section: str | None = None
-    for line in content.splitlines():
-        section_match = section_re.match(line)
-        if section_match:
-            key = section_match.group(1)
-            if key == "dependencies":
-                current_section = "deps"
-            elif key == "dev_dependencies":
-                current_section = "dev_deps"
-            else:
-                current_section = None
-            continue
-
-        if current_section:
-            dep_match = dep_re.match(line)
-            if dep_match:
-                name = dep_match.group(1)
-                if current_section == "deps":
-                    deps.add(name)
-                else:
-                    dev_deps.add(name)
-
+    """Parse a pubspec.yaml file into dependency sets using PyYAML."""
+    data = safe_load(content)
+    if not isinstance(data, dict):
+        return _PackageManifest(dependencies=set(), dev_dependencies=set())
+    deps = set((data.get("dependencies") or {}).keys())
+    dev_deps = set((data.get("dev_dependencies") or {}).keys())
     return _PackageManifest(dependencies=deps, dev_dependencies=dev_deps)
 
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -919,7 +919,6 @@ _PACKAGE_MANIFEST_FILES: dict[str, str] = {
     "php": "composer.json",
     "dart": "pubspec.yaml",
     "ruby": "Gemfile",
-    "go": "go.mod",
 }
 
 
@@ -982,8 +981,6 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
             return _parse_pubspec_yaml(content)
         elif manifest_file == "Gemfile":
             return _parse_gemfile(content)
-        elif manifest_file == "go.mod":
-            return _parse_go_mod(content)
     except (json.JSONDecodeError, YAMLError, ValueError, KeyError, TypeError, AttributeError):
         pass
     return None
@@ -1016,42 +1013,6 @@ def _parse_gemfile(content: str) -> _PackageManifest:
     return _PackageManifest(dependencies=deps, dev_dependencies=set())
 
 
-def _parse_go_mod(content: str) -> _PackageManifest:
-    """Parse a go.mod file into dependency sets.
-
-    Extracts module paths from ``require`` directives, both single-line
-    (``require path v1.0``) and block form (``require ( ... )``).
-    """
-    deps: set[str] = set()
-    in_require = False
-    for line in content.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("//"):
-            continue
-        if stripped.startswith("require (") or stripped.startswith("require("):
-            in_require = True
-            # Handle single-line block: require (github.com/foo/bar v1.0)
-            if stripped.endswith(")"):
-                inner = stripped.split("(", 1)[1].rstrip(")")
-                parts = inner.strip().split()
-                if parts:
-                    deps.add(parts[0])
-                in_require = False
-            continue
-        if in_require:
-            if stripped == ")":
-                in_require = False
-                continue
-            parts = stripped.split()
-            if parts:
-                deps.add(parts[0])
-        elif stripped.startswith("require "):
-            parts = stripped.split()
-            if len(parts) >= 2:
-                deps.add(parts[1])
-    return _PackageManifest(dependencies=deps, dev_dependencies=set())
-
-
 def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -> bool:
     """Check if a package exists in a manifest's dependencies or devDependencies."""
     if manifest is None:
@@ -1062,17 +1023,6 @@ def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -
     # Prefix match for composer.json patterns like "symfony/"
     if package_name.endswith("/"):
         return any(dep.startswith(package_name) for dep in all_deps)
-    # Go module version path matching: github.com/foo/bar matches github.com/foo/bar/v2
-    # Only applies to Go module paths (contain a dot from the domain name),
-    # not npm scoped packages (@nestjs/core) or composer packages (laravel/framework).
-    if "." in package_name and "/" in package_name:
-        version_prefix = package_name + "/v"
-        return any(
-            dep.startswith(version_prefix)
-            and len(dep) > len(version_prefix)
-            and dep[len(version_prefix)].isdigit()
-            for dep in all_deps
-        )
     return False
 
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1255,14 +1255,17 @@ def detect_platforms(
                     )
                 else:
                     # Same platform detected via a different base_platform
-                    # (e.g. android under both java and kotlin).  Keep the
-                    # higher byte count so sorting reflects the dominant language.
+                    # (e.g. android under both java and kotlin, or apple-ios
+                    # under both swift and objective-c).  Always upgrade to
+                    # framework confidence/priority, and keep the higher
+                    # byte count so sorting reflects the dominant language.
                     for r in results:
-                        if r["platform"] == platform_id and byte_count > r["bytes"]:
-                            r["bytes"] = byte_count
-                            r["language"] = language
+                        if r["platform"] == platform_id:
                             r["confidence"] = "high"
-                            r["priority"] = 100 - fw["sort"]
+                            r["priority"] = max(r["priority"], 100 - fw["sort"])
+                            if byte_count > r["bytes"]:
+                                r["bytes"] = byte_count
+                                r["language"] = language
                             break
 
         if base_platform not in seen_platforms:

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -615,6 +615,7 @@ FRAMEWORKS: list[FrameworkDef] = [
         "platform": "php-laravel",
         "sort": 10,
         "base_platform": "php",
+        "supersedes": ["php-symfony"],
         "some": [
             {"match_package": "laravel/framework"},
             {"path": "artisan"},
@@ -624,6 +625,7 @@ FRAMEWORKS: list[FrameworkDef] = [
         "platform": "php-wordpress",
         "sort": 10,
         "base_platform": "php",
+        "supersedes": ["php-symfony"],
         "some": [{"path": "wp-config.php"}],
     },
     {

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -1153,9 +1153,12 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
     """Remove platforms that are superseded by more specific ones.
 
     e.g. if Next.js is detected, React is redundant since Next.js includes it.
+    Non-selectable platforms (like php-wordpress) are excluded from superseding
+    because they will be filtered out later, which would drop valid detections.
     """
     detected = {r["platform"] for r in results}
-    superseded = {child for pid in detected for child in _SUPERSESSION_MAP.get(pid, [])}
+    selectable = detected - _NON_SELECTABLE_PLATFORMS
+    superseded = {child for pid in selectable for child in _SUPERSESSION_MAP.get(pid, [])}
     return [r for r in results if r["platform"] not in superseded]
 
 

--- a/src/sentry/integrations/github/platform_detection.py
+++ b/src/sentry/integrations/github/platform_detection.py
@@ -34,7 +34,7 @@ GITHUB_LANGUAGE_TO_SENTRY_PLATFORM: dict[str, str] = {
     "Elixir": "elixir",
     "C": "native",
     "C++": "native",
-    "Perl": "perl",
+    "PowerShell": "powershell",
 }
 
 # Languages with no Sentry SDK — filtered out of detection results
@@ -54,7 +54,6 @@ IGNORED_LANGUAGES = frozenset(
         "HCL",
         "Jsonnet",
         "Batchfile",
-        "PowerShell",
         "CMake",
         "M4",
         "Roff",
@@ -79,6 +78,8 @@ class DetectorRule(TypedDict, total=False):
     path: str  # File must exist in root directory
     match_content: str  # Regex pattern to match in file content (requires path)
     match_package: str  # Package name in package.json/composer.json deps
+    match_dir: str  # Directory must exist in root
+    match_ext: str  # File extension must exist in root (e.g., ".csproj")
 
 
 class FrameworkDef(TypedDict):
@@ -96,14 +97,16 @@ class FrameworkDef(TypedDict):
 # Lower sort = higher priority. Converted to `priority = 100 - sort` in output.
 # Across languages, byte count (language majority) is the primary ranking factor.
 #
-#   sort=1      Meta-frameworks         Next.js, Remix, Nuxt, SvelteKit
-#   sort=10     Primary frameworks      Django, Rails, Laravel, Spring Boot
-#   sort=20     Secondary frameworks    Flask, Go frameworks, PHP Symfony
-#   sort=30     UI / general            React, Vue, Angular, Svelte, Starlette
-#   sort=40     Server frameworks       Express, Koa
-#   sort=60     Utilities / background  Celery
+#   sort=1      Meta / cross-platform   Next.js, Remix, React Native, Electron, Flutter
+#   sort=10     Primary frameworks      Django, Rails, React, Vue, Angular, Spring Boot
+#   sort=20     Secondary frameworks    Flask, Express, Go frameworks, PHP Symfony
+#   sort=30     Niche frameworks        Starlette, Tornado, Bottle, Rack
+#   sort=50     Serverless / edge       AWS Lambda, GCP Functions, Cloudflare Workers
+#   sort=60     Utilities / runtimes    Celery, RQ, Log4j, Node, Bun, Deno
 FRAMEWORKS: list[FrameworkDef] = [
-    # --- JavaScript meta-frameworks (sort=1, highest priority) ---
+    # ===================================================================
+    # JavaScript meta-frameworks (sort=1, highest priority)
+    # ===================================================================
     {
         "platform": "javascript-nextjs",
         "sort": 1,
@@ -138,22 +141,113 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
         "supersedes": ["javascript-vue"],
     },
-    # --- JavaScript UI frameworks (sort=30) ---
+    {
+        "platform": "javascript-astro",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "astro"},
+            {"path": "astro.config.mjs"},
+            {"path": "astro.config.ts"},
+            {"path": "astro.config.js"},
+        ],
+    },
+    {
+        "platform": "javascript-gatsby",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "gatsby"},
+            {"path": "gatsby-config.js"},
+            {"path": "gatsby-config.ts"},
+        ],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "javascript-sveltekit",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@sveltejs/kit"}],
+        "supersedes": ["javascript-svelte"],
+    },
+    {
+        "platform": "javascript-solidstart",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@solidjs/start"}],
+        "supersedes": ["javascript-solid"],
+    },
+    {
+        "platform": "javascript-tanstackstart-react",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@tanstack/react-start"}],
+        "supersedes": ["javascript-react"],
+    },
+    # --- Mobile / cross-platform / routing meta-frameworks (sort=1) ---
+    {
+        "platform": "react-native",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "react-native"}],
+        "supersedes": ["javascript-react"],
+    },
+    {
+        "platform": "electron",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "electron"}],
+    },
+    {
+        "platform": "capacitor",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [{"match_package": "@capacitor/core"}],
+    },
+    {
+        "platform": "javascript-react-router",
+        "sort": 1,
+        "base_platform": "javascript",
+        "every": [{"match_package": "react-router"}, {"match_package": "react"}],
+    },
+    {
+        "platform": "ionic",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "@ionic/angular"},
+            {"match_package": "@ionic/react"},
+            {"match_package": "@ionic/vue"},
+        ],
+    },
+    {
+        "platform": "cordova",
+        "sort": 1,
+        "base_platform": "javascript",
+        "some": [
+            {"path": "config.xml", "match_content": r"cordova\.apache\.org"},
+            {"match_package": "cordova-android"},
+            {"match_package": "cordova-ios"},
+        ],
+    },
+    # ===================================================================
+    # JavaScript UI frameworks (sort=10)
+    # ===================================================================
     {
         "platform": "javascript-react",
-        "sort": 30,
+        "sort": 10,
         "base_platform": "javascript",
         "some": [{"match_package": "react"}],
     },
     {
         "platform": "javascript-vue",
-        "sort": 30,
+        "sort": 10,
         "base_platform": "javascript",
         "some": [{"match_package": "vue"}],
     },
     {
         "platform": "javascript-angular",
-        "sort": 30,
+        "sort": 10,
         "base_platform": "javascript",
         "some": [
             {"match_package": "@angular/core"},
@@ -162,7 +256,7 @@ FRAMEWORKS: list[FrameworkDef] = [
     },
     {
         "platform": "javascript-svelte",
-        "sort": 30,
+        "sort": 10,
         "base_platform": "javascript",
         "some": [
             {"match_package": "svelte"},
@@ -170,26 +264,124 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "svelte.config.ts"},
         ],
     },
-    # --- JavaScript server frameworks (sort=40) ---
+    {
+        "platform": "javascript-solid",
+        "sort": 10,
+        "base_platform": "javascript",
+        "some": [{"match_package": "solid-js"}],
+    },
+    {
+        "platform": "javascript-ember",
+        "sort": 10,
+        "base_platform": "javascript",
+        "some": [
+            {"match_package": "ember-source"},
+            {"path": "ember-cli-build.js"},
+        ],
+    },
+    # ===================================================================
+    # JavaScript server frameworks (sort=20)
+    # ===================================================================
     {
         "platform": "node-express",
-        "sort": 40,
+        "sort": 20,
         "base_platform": "javascript",
         "every": [{"match_package": "express"}],
     },
     {
         "platform": "node-hono",
-        "sort": 40,
+        "sort": 20,
         "base_platform": "javascript",
         "every": [{"match_package": "hono"}],
     },
     {
         "platform": "node-koa",
-        "sort": 40,
+        "sort": 20,
         "base_platform": "javascript",
         "every": [{"match_package": "koa"}],
     },
-    # --- Python frameworks ---
+    {
+        "platform": "node-nestjs",
+        "sort": 20,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@nestjs/core"}],
+    },
+    {
+        "platform": "node-fastify",
+        "sort": 20,
+        "base_platform": "javascript",
+        "every": [{"match_package": "fastify"}],
+    },
+    {
+        "platform": "node-connect",
+        "sort": 20,
+        "base_platform": "javascript",
+        "every": [{"match_package": "connect"}],
+    },
+    {
+        "platform": "node-hapi",
+        "sort": 20,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@hapi/hapi"}],
+    },
+    # ===================================================================
+    # JavaScript serverless / edge (sort=50)
+    # ===================================================================
+    {
+        "platform": "node-awslambda",
+        "sort": 50,
+        "base_platform": "javascript",
+        "some": [{"path": "serverless.yml", "match_content": r"runtime:\s*nodejs"}],
+    },
+    {
+        "platform": "node-gcpfunctions",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [{"match_package": "@google-cloud/functions-framework"}],
+    },
+    {
+        "platform": "node-azurefunctions",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [
+            {"path": "host.json", "match_content": r'"extensionBundle"'},
+            {"path": "local.settings.json"},
+        ],
+    },
+    {
+        "platform": "node-cloudflare-pages",
+        "sort": 50,
+        "base_platform": "javascript",
+        "every": [
+            {"path": "wrangler.toml", "match_content": r"pages_build_output_dir"},
+        ],
+        "supersedes": ["node-cloudflare-workers"],
+    },
+    {
+        "platform": "node-cloudflare-workers",
+        "sort": 50,
+        "base_platform": "javascript",
+        "some": [
+            {"path": "wrangler.toml"},
+            {"match_package": "wrangler"},
+        ],
+    },
+    # --- Node.js base (sort=60, low priority fallback) ---
+    {
+        "platform": "node",
+        "sort": 60,
+        "base_platform": "javascript",
+        "some": [
+            {"path": ".nvmrc"},
+            {"path": ".node-version"},
+            {"path": "nodemon.json"},
+            {"path": "Procfile", "match_content": r"\bnode\b"},
+            {"path": "package.json", "match_content": r'"engines"\s*:\s*\{[^}]*"node"'},
+        ],
+    },
+    # ===================================================================
+    # Python frameworks
+    # ===================================================================
     {
         "platform": "python-django",
         "sort": 10,
@@ -222,6 +414,66 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "python-aiohttp",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\baiohttp\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\baiohttp\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\baiohttp\b"},
+        ],
+    },
+    {
+        "platform": "python-bottle",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bbottle\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bbottle\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bbottle\b"},
+        ],
+    },
+    {
+        "platform": "python-falcon",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfalcon\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfalcon\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfalcon\b"},
+        ],
+    },
+    {
+        "platform": "python-pyramid",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bpyramid\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bpyramid\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bpyramid\b"},
+        ],
+    },
+    {
+        "platform": "python-quart",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bquart\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bquart\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bquart\b"},
+        ],
+    },
+    {
+        "platform": "python-sanic",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bsanic\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bsanic\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bsanic\b"},
+        ],
+    },
+    {
         "platform": "python-starlette",
         "sort": 30,
         "base_platform": "python",
@@ -242,6 +494,80 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "python-tryton",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\btrytond?\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\btrytond?\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\btrytond?\b"},
+        ],
+    },
+    {
+        "platform": "python-chalice",
+        "sort": 30,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bchalice\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bchalice\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bchalice\b"},
+        ],
+    },
+    # --- Python serverless (sort=50) ---
+    {
+        "platform": "python-awslambda",
+        "sort": 50,
+        "base_platform": "python",
+        "some": [{"path": "serverless.yml", "match_content": r"runtime:\s*python"}],
+    },
+    {
+        "platform": "python-gcpfunctions",
+        "sort": 50,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\bfunctions-framework\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\bfunctions-framework\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\bfunctions-framework\b"},
+        ],
+    },
+    # --- Python ASGI / WSGI servers (sort=60) ---
+    {
+        "platform": "python-asgi",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {
+                "path": "requirements.txt",
+                "match_content": r"(?i)\b(?:uvicorn|daphne|hypercorn)\b",
+            },
+            {
+                "path": "pyproject.toml",
+                "match_content": r"(?i)\b(?:uvicorn|daphne|hypercorn)\b",
+            },
+            {
+                "path": "Pipfile",
+                "match_content": r"(?i)\b(?:uvicorn|daphne|hypercorn)\b",
+            },
+        ],
+    },
+    {
+        "platform": "python-wsgi",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {
+                "path": "requirements.txt",
+                "match_content": r"(?i)\b(?:gunicorn|uwsgi)\b",
+            },
+            {
+                "path": "pyproject.toml",
+                "match_content": r"(?i)\b(?:gunicorn|uwsgi)\b",
+            },
+            {"path": "Pipfile", "match_content": r"(?i)\b(?:gunicorn|uwsgi)\b"},
+        ],
+    },
+    # --- Python task queues / background (sort=60) ---
+    {
         "platform": "python-celery",
         "sort": 60,
         "base_platform": "python",
@@ -251,16 +577,39 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "Pipfile", "match_content": r"(?i)\bcelery\b"},
         ],
     },
-    # --- Ruby ---
+    {
+        "platform": "python-rq",
+        "sort": 60,
+        "base_platform": "python",
+        "some": [
+            {"path": "requirements.txt", "match_content": r"(?i)\brq\b"},
+            {"path": "pyproject.toml", "match_content": r"(?i)\brq\b"},
+            {"path": "Pipfile", "match_content": r"(?i)\brq\b"},
+        ],
+    },
+    # ===================================================================
+    # Ruby
+    # ===================================================================
     {
         "platform": "ruby-rails",
         "sort": 10,
         "base_platform": "ruby",
         "some": [
-            {"path": "Gemfile", "match_content": r"(?i)\brails\b"},
+            {"match_package": "rails"},
+        ],
+        "supersedes": ["ruby-rack"],
+    },
+    {
+        "platform": "ruby-rack",
+        "sort": 30,
+        "base_platform": "ruby",
+        "some": [
+            {"match_package": "rack"},
         ],
     },
-    # --- PHP ---
+    # ===================================================================
+    # PHP
+    # ===================================================================
     {
         "platform": "php-laravel",
         "sort": 10,
@@ -271,6 +620,12 @@ FRAMEWORKS: list[FrameworkDef] = [
         ],
     },
     {
+        "platform": "php-wordpress",
+        "sort": 10,
+        "base_platform": "php",
+        "some": [{"path": "wp-config.php"}],
+    },
+    {
         "platform": "php-symfony",
         "sort": 20,
         "base_platform": "php",
@@ -278,7 +633,9 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"match_package": "symfony/"},
         ],
     },
-    # --- Java ---
+    # ===================================================================
+    # Java
+    # ===================================================================
     {
         "platform": "java-spring-boot",
         "sort": 10,
@@ -297,13 +654,33 @@ FRAMEWORKS: list[FrameworkDef] = [
             {"path": "pom.xml", "match_content": r"(?i)spring-framework"},
         ],
     },
-    # --- Go ---
+    {
+        "platform": "java-log4j2",
+        "sort": 60,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"log4j-core"},
+            {"path": "pom.xml", "match_content": r"log4j-core"},
+        ],
+    },
+    {
+        "platform": "java-logback",
+        "sort": 60,
+        "base_platform": "java",
+        "some": [
+            {"path": "build.gradle", "match_content": r"logback-core|logback-classic"},
+            {"path": "pom.xml", "match_content": r"logback-core|logback-classic"},
+        ],
+    },
+    # ===================================================================
+    # Go — using full module paths for precise matching
+    # ===================================================================
     {
         "platform": "go-echo",
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\becho\b"},
+            {"path": "go.mod", "match_content": r"github\.com/labstack/echo"},
         ],
     },
     {
@@ -311,7 +688,7 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\bgin\b"},
+            {"path": "go.mod", "match_content": r"github\.com/gin-gonic/gin"},
         ],
     },
     {
@@ -319,7 +696,196 @@ FRAMEWORKS: list[FrameworkDef] = [
         "sort": 20,
         "base_platform": "go",
         "some": [
-            {"path": "go.mod", "match_content": r"(?i)\bfiber\b"},
+            {"path": "go.mod", "match_content": r"github\.com/gofiber/fiber"},
+        ],
+    },
+    {
+        "platform": "go-fasthttp",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/valyala/fasthttp"},
+        ],
+    },
+    {
+        "platform": "go-iris",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/kataras/iris"},
+        ],
+    },
+    {
+        "platform": "go-negroni",
+        "sort": 20,
+        "base_platform": "go",
+        "some": [
+            {"path": "go.mod", "match_content": r"github\.com/urfave/negroni"},
+        ],
+    },
+    # ===================================================================
+    # Dart / Flutter (requires pubspec.yaml manifest parsing)
+    # ===================================================================
+    {
+        "platform": "flutter",
+        "sort": 1,
+        "base_platform": "dart",
+        "some": [{"match_package": "flutter"}],
+    },
+    # ===================================================================
+    # Swift — iOS vs macOS differentiation
+    # ===================================================================
+    {
+        "platform": "apple-ios",
+        "sort": 10,
+        "base_platform": "swift",
+        "some": [
+            {"path": "Package.swift", "match_content": r"\.iOS\s*\("},
+            {"path": "Podfile", "match_content": r"platform\s*:ios\b"},
+            {"match_ext": ".xcodeproj"},
+            {"match_dir": ".xcodeproj"},
+        ],
+    },
+    {
+        "platform": "apple-macos",
+        "sort": 20,
+        "base_platform": "swift",
+        "some": [
+            {"path": "Package.swift", "match_content": r"\.macOS\s*\("},
+            {"path": "Podfile", "match_content": r"platform\s*:osx\b"},
+        ],
+    },
+    # ===================================================================
+    # Native (C/C++) — Qt framework detection
+    # ===================================================================
+    {
+        "platform": "native-qt",
+        "sort": 10,
+        "base_platform": "native",
+        "some": [
+            {"match_ext": ".qrc"},
+            {
+                "path": "CMakeLists.txt",
+                "match_content": r"find_package\s*\(\s*Qt[56]|qt_add_executable|Qt[56]::\w+",
+            },
+        ],
+    },
+    # ===================================================================
+    # Mobile / Desktop / Gaming — directory and extension-based detection
+    # ===================================================================
+    {
+        "platform": "unity",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_dir": "Assets"}, {"match_dir": "ProjectSettings"}],
+    },
+    {
+        "platform": "android",
+        "sort": 10,
+        "base_platform": "java",
+        "every": [
+            {"match_dir": "app"},
+        ],
+        "some": [
+            {"path": "build.gradle", "match_content": r"android"},
+            {"path": "build.gradle.kts", "match_content": r"android"},
+        ],
+    },
+    {
+        "platform": "android",
+        "sort": 10,
+        "base_platform": "kotlin",
+        "every": [
+            {"match_dir": "app"},
+        ],
+        "some": [
+            {"path": "build.gradle", "match_content": r"android"},
+            {"path": "build.gradle.kts", "match_content": r"android"},
+        ],
+    },
+    {
+        "platform": "dotnet-aspnetcore",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [
+            {"match_ext": ".csproj"},
+            {"path": "appsettings.json"},
+        ],
+    },
+    {
+        "platform": "unreal",
+        "sort": 10,
+        "base_platform": "native",
+        "some": [{"match_ext": ".uproject"}],
+    },
+    {
+        "platform": "godot",
+        "sort": 10,
+        "base_platform": "native",
+        "some": [{"path": "project.godot"}],
+    },
+    # ===================================================================
+    # JavaScript runtimes (sort=60, low priority — these are runtimes, not frameworks)
+    # ===================================================================
+    {
+        "platform": "bun",
+        "sort": 60,
+        "base_platform": "javascript",
+        "some": [{"path": "bunfig.toml"}, {"path": "bun.lockb"}],
+    },
+    {
+        "platform": "deno",
+        "sort": 60,
+        "base_platform": "javascript",
+        "some": [{"path": "deno.json"}, {"path": "deno.jsonc"}],
+    },
+    # ===================================================================
+    # .NET variants — detected via .csproj content inspection
+    # ===================================================================
+    {
+        "platform": "dotnet-maui",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_ext": ".csproj", "match_content": r"Microsoft\.Maui"}],
+    },
+    {
+        "platform": "dotnet-wpf",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_ext": ".csproj", "match_content": r"UseWPF"}],
+    },
+    {
+        "platform": "dotnet-winforms",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_ext": ".csproj", "match_content": r"UseWindowsForms"}],
+    },
+    {
+        "platform": "dotnet-xamarin",
+        "sort": 10,
+        "base_platform": "dotnet",
+        "every": [{"match_ext": ".csproj", "match_content": r"Xamarin\."}],
+    },
+    {
+        "platform": "dotnet-aspnet",
+        "sort": 20,
+        "base_platform": "dotnet",
+        "every": [
+            {"match_ext": ".csproj", "match_content": r"Microsoft\.AspNet(?!Core)"},
+        ],
+    },
+    {
+        "platform": "dotnet-awslambda",
+        "sort": 50,
+        "base_platform": "dotnet",
+        "every": [{"match_ext": ".csproj", "match_content": r"Amazon\.Lambda"}],
+    },
+    {
+        "platform": "dotnet-gcpfunctions",
+        "sort": 50,
+        "base_platform": "dotnet",
+        "every": [
+            {"match_ext": ".csproj", "match_content": r"Google\.Cloud\.Functions"},
         ],
     },
 ]
@@ -334,10 +900,23 @@ for _fw in FRAMEWORKS:
     if "supersedes" in _fw:
         _SUPERSESSION_MAP[_fw["platform"]] = _fw["supersedes"]
 
+# Platforms that are detected internally (as base platforms for framework
+# detection) but are not selectable in the frontend project creation picker.
+_NON_SELECTABLE_PLATFORMS = frozenset(
+    {
+        "perl",  # no Perl onboarding doc in Sentry
+        "php-wordpress",  # WordPress uses the base PHP SDK
+        "swift",  # picker uses apple-ios / apple-macos instead
+    }
+)
+
 # Package manifest files per base platform (for match_package rules)
 _PACKAGE_MANIFEST_FILES: dict[str, str] = {
     "javascript": "package.json",
     "php": "composer.json",
+    "dart": "pubspec.yaml",
+    "ruby": "Gemfile",
+    "go": "go.mod",
 }
 
 
@@ -346,46 +925,43 @@ class _PackageManifest(TypedDict):
     dev_dependencies: set[str]
 
 
+def _ref_params(ref: str | None) -> dict[str, str]:
+    return {"ref": ref} if ref else {}
+
+
 def _get_repo_file_content(
     client: GitHubBaseClient, repo: str, path: str, ref: str | None = None
 ) -> str | None:
     """Fetch a file's content from a GitHub repo. Returns None if not found."""
     try:
-        params: dict[str, str] = {}
-        if ref:
-            params["ref"] = ref
         response = client.get(
             f"/repos/{repo}/contents/{path}",
-            params=params,
+            params=_ref_params(ref),
         )
         return b64decode(response["content"]).decode("utf-8")
     except (ApiError, KeyError, TypeError, UnicodeDecodeError, ValueError):
         return None
 
 
-def _get_root_file_names(
+def _get_root_entries(
     client: GitHubBaseClient, repo: str, ref: str | None = None
-) -> set[str] | None:
-    """Fetch the list of file names in the repository root directory.
+) -> tuple[set[str] | None, set[str] | None]:
+    """Fetch the root-level file and directory names in a single API call.
 
-    Uses the GitHub Contents API on the root path, which returns all
-    top-level files and directories in a single API call.
-
-    Returns None on API failure so callers can fall back to fetching
-    files individually rather than assuming the repo root is empty.
+    Returns (None, None) on API failure so callers can fall back to
+    fetching files individually rather than assuming the repo root is empty.
     """
     try:
-        params: dict[str, str] = {}
-        if ref:
-            params["ref"] = ref
-        response = client.get(f"/repos/{repo}/contents", params=params)
-        return {item["name"] for item in response if item.get("type") == "file" and "name" in item}
+        response = client.get(f"/repos/{repo}/contents", params=_ref_params(ref))
+        files = {item["name"] for item in response if item.get("type") == "file" and "name" in item}
+        dirs = {item["name"] for item in response if item.get("type") == "dir" and "name" in item}
+        return files, dirs
     except (ApiError, AttributeError, TypeError):
-        return None
+        return None, None
 
 
 def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifest | None:
-    """Parse a JSON package manifest into dependency sets."""
+    """Parse a package manifest into dependency sets."""
     try:
         if manifest_file == "package.json":
             pkg = json.loads(content)
@@ -399,9 +975,98 @@ def _parse_package_manifest(content: str, manifest_file: str) -> _PackageManifes
                 dependencies=set((composer.get("require") or {}).keys()),
                 dev_dependencies=set((composer.get("require-dev") or {}).keys()),
             )
+        elif manifest_file == "pubspec.yaml":
+            return _parse_pubspec_yaml(content)
+        elif manifest_file == "Gemfile":
+            return _parse_gemfile(content)
+        elif manifest_file == "go.mod":
+            return _parse_go_mod(content)
     except (json.JSONDecodeError, TypeError):
         pass
     return None
+
+
+def _parse_pubspec_yaml(content: str) -> _PackageManifest:
+    """Parse a pubspec.yaml file into dependency sets using line-based parsing.
+
+    Extracts package names from the dependencies: and dev_dependencies:
+    top-level sections. Direct dependencies are identified as lines indented
+    by exactly 2 spaces that contain a colon.
+    """
+    deps: set[str] = set()
+    dev_deps: set[str] = set()
+    section_re = re.compile(r"^(\w[\w_]*):")
+    dep_re = re.compile(r"^  (\w[\w_-]*):")
+
+    current_section: str | None = None
+    for line in content.splitlines():
+        section_match = section_re.match(line)
+        if section_match:
+            key = section_match.group(1)
+            if key == "dependencies":
+                current_section = "deps"
+            elif key == "dev_dependencies":
+                current_section = "dev_deps"
+            else:
+                current_section = None
+            continue
+
+        if current_section:
+            dep_match = dep_re.match(line)
+            if dep_match:
+                name = dep_match.group(1)
+                if current_section == "deps":
+                    deps.add(name)
+                else:
+                    dev_deps.add(name)
+
+    return _PackageManifest(dependencies=deps, dev_dependencies=dev_deps)
+
+
+def _parse_gemfile(content: str) -> _PackageManifest:
+    """Parse a Gemfile into dependency sets.
+
+    Extracts gem names from ``gem "name"`` or ``gem 'name'`` lines.
+    """
+    deps: set[str] = set()
+    gem_re = re.compile(r"""gem\s+['"]([^'"]+)['"]""")
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        match = gem_re.search(stripped)
+        if match:
+            deps.add(match.group(1))
+    return _PackageManifest(dependencies=deps, dev_dependencies=set())
+
+
+def _parse_go_mod(content: str) -> _PackageManifest:
+    """Parse a go.mod file into dependency sets.
+
+    Extracts module paths from ``require`` directives, both single-line
+    (``require path v1.0``) and block form (``require ( ... )``).
+    """
+    deps: set[str] = set()
+    in_require = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        if stripped.startswith("require ("):
+            in_require = True
+            continue
+        if in_require:
+            if stripped == ")":
+                in_require = False
+                continue
+            parts = stripped.split()
+            if parts:
+                deps.add(parts[0])
+        elif stripped.startswith("require "):
+            parts = stripped.split()
+            if len(parts) >= 2:
+                deps.add(parts[1])
+    return _PackageManifest(dependencies=deps, dev_dependencies=set())
 
 
 def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -> bool:
@@ -414,6 +1079,17 @@ def _package_in_manifest(package_name: str, manifest: _PackageManifest | None) -
     # Prefix match for composer.json patterns like "symfony/"
     if package_name.endswith("/"):
         return any(dep.startswith(package_name) for dep in all_deps)
+    # Go module version path matching: github.com/foo/bar matches github.com/foo/bar/v2
+    # Only applies to Go module paths (contain a dot from the domain name),
+    # not npm scoped packages (@nestjs/core) or composer packages (laravel/framework).
+    if "." in package_name and "/" in package_name:
+        version_prefix = package_name + "/v"
+        return any(
+            dep.startswith(version_prefix)
+            and len(dep) > len(version_prefix)
+            and dep[len(version_prefix)].isdigit()
+            for dep in all_deps
+        )
     return False
 
 
@@ -422,10 +1098,36 @@ def _rule_matches(
     root_files: set[str] | None,
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
+    root_dirs: set[str] | None = None,
 ) -> bool:
     """Evaluate a single detector rule against repository state."""
     if "match_package" in rule:
         return _package_in_manifest(rule["match_package"], package_manifest)
+
+    if "match_dir" in rule:
+        if root_dirs is None:
+            return False
+        dirname = rule["match_dir"]
+        if dirname.startswith("."):
+            return any(d.endswith(dirname) for d in root_dirs)
+        return dirname in root_dirs
+
+    if "match_ext" in rule:
+        if root_files is None:
+            return False
+        ext = rule["match_ext"]
+        matching_files = [f for f in root_files if f.endswith(ext)]
+        if not matching_files:
+            return False
+        if "match_content" not in rule:
+            return True
+        # match_ext + match_content: search content of extension-matched files
+        pattern = rule["match_content"]
+        for f in matching_files:
+            content = file_contents.get(f)
+            if content and re.search(pattern, content):
+                return True
+        return False
 
     path = rule.get("path")
     if path is None:
@@ -449,6 +1151,7 @@ def _framework_matches(
     root_files: set[str] | None,
     file_contents: dict[str, str],
     package_manifest: _PackageManifest | None,
+    root_dirs: set[str] | None = None,
 ) -> bool:
     """Evaluate whether a framework definition matches the repository."""
     every: Sequence[DetectorRule] = fw.get("every", [])
@@ -457,9 +1160,11 @@ def _framework_matches(
     if not every and not some:
         return False
 
-    every_pass = all(_rule_matches(r, root_files, file_contents, package_manifest) for r in every)
+    every_pass = all(
+        _rule_matches(r, root_files, file_contents, package_manifest, root_dirs) for r in every
+    )
     some_pass = (
-        any(_rule_matches(r, root_files, file_contents, package_manifest) for r in some)
+        any(_rule_matches(r, root_files, file_contents, package_manifest, root_dirs) for r in some)
         if some
         else True
     )
@@ -472,12 +1177,8 @@ def _apply_supersession(results: list[DetectedPlatform]) -> list[DetectedPlatfor
 
     e.g. if Next.js is detected, React is redundant since Next.js includes it.
     """
-    platform_ids = {r["platform"] for r in results}
-    superseded: set[str] = set()
-    for platform_id in platform_ids:
-        for child_id in _SUPERSESSION_MAP.get(platform_id, []):
-            superseded.add(child_id)
-
+    detected = {r["platform"] for r in results}
+    superseded = {child for pid in detected for child in _SUPERSESSION_MAP.get(pid, [])}
     return [r for r in results if r["platform"] not in superseded]
 
 
@@ -489,16 +1190,18 @@ def detect_platforms(
     """
     Detect Sentry platforms for a GitHub repository.
 
-    Uses composable framework definitions with three signal types:
+    Uses composable framework definitions with five signal types:
     1. Config files — path-only rules (next.config.js, manage.py, etc.)
     2. Manifest content — path + match_content rules (requirements.txt, go.mod, etc.)
-    3. Package dependencies — match_package rules (package.json, composer.json)
+    3. Package dependencies — match_package rules (package.json, composer.json, etc.)
+    4. Root directories — match_dir rules (Assets/, app/, etc.)
+    5. File extensions — match_ext rules (.csproj, .uproject, etc.)
 
     Results are ranked by bytes (descending), then priority (descending).
     Superseded frameworks (e.g. React when Next.js is present) are removed.
     """
     languages = client.get_languages(repo)
-    root_files = _get_root_file_names(client, repo, ref)
+    root_files, root_dirs = _get_root_entries(client, repo, ref)
 
     # Group languages by base platform
     active_platforms: dict[str, list[tuple[str, int]]] = defaultdict(list)
@@ -509,16 +1212,28 @@ def detect_platforms(
         if base_platform is not None:
             active_platforms[base_platform].append((language, byte_count))
 
-    # Collect all file paths that need content fetching (path + match_content rules).
+    # Collect all file paths that need content fetching.
     # When root_files is None (API failed), try all paths rather than skipping.
     needed_paths: set[str] = set()
     for base_platform in active_platforms:
+        # Include manifest files for match_package rules
+        manifest_file = _PACKAGE_MANIFEST_FILES.get(base_platform)
+        if manifest_file and (root_files is None or manifest_file in root_files):
+            needed_paths.add(manifest_file)
+        # Include files for match_content rules
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
             for rule in [*fw.get("every", []), *fw.get("some", [])]:
+                if "match_content" not in rule:
+                    continue
                 path = rule.get("path")
-                if path and "match_content" in rule:
+                if path:
                     if root_files is None or path in root_files:
                         needed_paths.add(path)
+                elif "match_ext" in rule and root_files is not None:
+                    ext = rule["match_ext"]
+                    for f in root_files:
+                        if f.endswith(ext):
+                            needed_paths.add(f)
 
     # Fetch file contents in one pass
     file_contents: dict[str, str] = {}
@@ -537,10 +1252,6 @@ def detect_platforms(
             package_manifests[manifest_file] = None
             continue
         content = file_contents.get(manifest_file)
-        if content is None:
-            content = _get_repo_file_content(client, repo, manifest_file, ref)
-            if content is not None:
-                file_contents[manifest_file] = content
         package_manifests[manifest_file] = (
             _parse_package_manifest(content, manifest_file) if content else None
         )
@@ -556,7 +1267,7 @@ def detect_platforms(
         manifest = package_manifests.get(manifest_file) if manifest_file else None
 
         for fw in _FRAMEWORKS_BY_PLATFORM.get(base_platform, []):
-            if _framework_matches(fw, root_files, file_contents, manifest):
+            if _framework_matches(fw, root_files, file_contents, manifest, root_dirs):
                 platform_id = fw["platform"]
                 if platform_id not in seen_platforms:
                     seen_platforms.add(platform_id)
@@ -569,6 +1280,15 @@ def detect_platforms(
                             priority=100 - fw["sort"],
                         )
                     )
+                else:
+                    # Same platform detected via a different base_platform
+                    # (e.g. android under both java and kotlin).  Keep the
+                    # higher byte count so sorting reflects the dominant language.
+                    for r in results:
+                        if r["platform"] == platform_id and byte_count > r["bytes"]:
+                            r["bytes"] = byte_count
+                            r["language"] = language
+                            break
 
         if base_platform not in seen_platforms:
             seen_platforms.add(base_platform)
@@ -583,6 +1303,7 @@ def detect_platforms(
             )
 
     results = _apply_supersession(results)
+    results = [r for r in results if r["platform"] not in _NON_SELECTABLE_PLATFORMS]
     results.sort(key=lambda r: (r["bytes"], r["priority"]), reverse=True)
 
     return results

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -66,19 +66,13 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
+        # Only the top language by bytes is returned
         assert response.data == {
             "platforms": [
                 {
                     "platform": "python",
                     "language": "Python",
                     "bytes": 50000,
-                    "confidence": "medium",
-                    "priority": 1,
-                },
-                {
-                    "platform": "javascript",
-                    "language": "JavaScript",
-                    "bytes": 30000,
                     "confidence": "medium",
                     "priority": 1,
                 },

--- a/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repository_platforms.py
@@ -66,13 +66,19 @@ class OrganizationRepositoryPlatformsGetTest(APITestCase):
                 self.organization.slug, self.repo.id, status_code=200
             )
 
-        # Only the top language by bytes is returned
         assert response.data == {
             "platforms": [
                 {
                     "platform": "python",
                     "language": "Python",
                     "bytes": 50000,
+                    "confidence": "medium",
+                    "priority": 1,
+                },
+                {
+                    "platform": "javascript",
+                    "language": "JavaScript",
+                    "bytes": 30000,
                     "confidence": "medium",
                     "priority": 1,
                 },

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1466,7 +1466,10 @@ class TestDetectPlatforms:
 
         def get_side_effect(path, params=None):
             if path.endswith("/contents"):
-                return [{"name": "wp-config.php", "type": "file"}]
+                return [
+                    {"name": "wp-config.php", "type": "file"},
+                    {"name": "composer.json", "type": "file"},
+                ]
             if "composer.json" in path:
                 return _make_b64_response(
                     json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1653,7 +1653,7 @@ class TestDetectPlatforms:
         assert "node-cloudflare-pages" in platforms
         assert "node-cloudflare-workers" not in platforms
 
-    def test_azurefunctions_detected_from_host_and_local_settings(self) -> None:
+    def test_azurefunctions_detected_from_host_json(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"JavaScript": 50000}
 
@@ -1663,7 +1663,6 @@ class TestDetectPlatforms:
             if path.endswith("/contents"):
                 return [
                     {"name": "host.json", "type": "file"},
-                    {"name": "local.settings.json", "type": "file"},
                     {"name": "package.json", "type": "file"},
                 ]
             if "host.json" in path:
@@ -1689,7 +1688,6 @@ class TestDetectPlatforms:
             if path.endswith("/contents"):
                 return [
                     {"name": "host.json", "type": "file"},
-                    {"name": "local.settings.json", "type": "file"},
                     {"name": "package.json", "type": "file"},
                 ]
             if "host.json" in path:

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1459,6 +1459,28 @@ class TestDetectPlatforms:
         assert "php-wordpress" not in platforms
         assert "php" in platforms
 
+    def test_wordpress_does_not_supersede_symfony(self) -> None:
+        """Non-selectable platforms should not supersede selectable ones."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PHP": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "wp-config.php", "type": "file"}]
+            if "composer.json" in path:
+                return _make_b64_response(
+                    json.dumps({"require": {"symfony/framework-bundle": "^6.0"}})
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "php-wordpress" not in platforms
+        assert "php-symfony" in platforms
+
     def test_ruby_rack_detected_from_gemfile(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Ruby": 50000}

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -14,10 +14,13 @@ from sentry.integrations.github.platform_detection import (
     _apply_supersession,
     _framework_matches,
     _get_repo_file_content,
-    _get_root_file_names,
+    _get_root_entries,
     _package_in_manifest,
     _PackageManifest,
+    _parse_gemfile,
+    _parse_go_mod,
     _parse_package_manifest,
+    _parse_pubspec_yaml,
     _rule_matches,
     detect_platforms,
 )
@@ -40,6 +43,9 @@ class TestGithubLanguageMapping:
 
     def test_objectivec_maps_to_apple_ios(self) -> None:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["Objective-C"] == "apple-ios"
+
+    def test_powershell_maps_to_powershell(self) -> None:
+        assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM["PowerShell"] == "powershell"
 
     def test_unmapped_language_returns_none(self) -> None:
         assert GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.get("Haskell") is None
@@ -84,6 +90,121 @@ class TestParsePackageManifest:
         assert result["dependencies"] == set()
         assert result["dev_dependencies"] == set()
 
+    def test_delegates_to_pubspec_yaml(self) -> None:
+        content = "dependencies:\n  flutter:\n    sdk: flutter\n  http: ^0.13.5\n"
+        result = _parse_package_manifest(content, "pubspec.yaml")
+        assert result is not None
+        assert "flutter" in result["dependencies"]
+        assert "http" in result["dependencies"]
+
+    def test_delegates_to_gemfile(self) -> None:
+        content = 'gem "rails", "~> 7.0"\ngem "puma"\n'
+        result = _parse_package_manifest(content, "Gemfile")
+        assert result is not None
+        assert "rails" in result["dependencies"]
+        assert "puma" in result["dependencies"]
+
+    def test_delegates_to_go_mod(self) -> None:
+        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+        result = _parse_package_manifest(content, "go.mod")
+        assert result is not None
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+
+
+class TestParsePubspecYaml:
+    def test_extracts_dependencies(self) -> None:
+        content = (
+            "name: my_app\n"
+            "dependencies:\n"
+            "  flutter:\n"
+            "    sdk: flutter\n"
+            "  http: ^0.13.5\n"
+            "  cupertino_icons: ^1.0.2\n"
+            "dev_dependencies:\n"
+            "  flutter_test:\n"
+            "    sdk: flutter\n"
+            "  flutter_lints: ^2.0.0\n"
+        )
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == {"flutter", "http", "cupertino_icons"}
+        assert result["dev_dependencies"] == {"flutter_test", "flutter_lints"}
+
+    def test_empty_sections(self) -> None:
+        content = "name: my_app\ndependencies:\ndev_dependencies:\n"
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == set()
+        assert result["dev_dependencies"] == set()
+
+    def test_no_dev_dependencies(self) -> None:
+        content = "name: my_app\ndependencies:\n  http: ^0.13.5\n"
+        result = _parse_pubspec_yaml(content)
+        assert result["dependencies"] == {"http"}
+        assert result["dev_dependencies"] == set()
+
+
+class TestParseGemfile:
+    def test_extracts_gem_names(self) -> None:
+        content = (
+            'source "https://rubygems.org"\n'
+            'gem "rails", "~> 7.0"\n'
+            "gem 'puma', '~> 6.0'\n"
+            'gem "rack"\n'
+        )
+        result = _parse_gemfile(content)
+        assert result["dependencies"] == {"rails", "puma", "rack"}
+
+    def test_ignores_comments(self) -> None:
+        content = '# gem "not-this"\ngem "real-gem"\n'
+        result = _parse_gemfile(content)
+        assert result["dependencies"] == {"real-gem"}
+
+    def test_empty_gemfile(self) -> None:
+        result = _parse_gemfile("")
+        assert result["dependencies"] == set()
+
+
+class TestParseGoMod:
+    def test_single_require(self) -> None:
+        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+        result = _parse_go_mod(content)
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+
+    def test_require_block(self) -> None:
+        content = (
+            "module example.com/app\n\n"
+            "require (\n"
+            "\tgithub.com/gin-gonic/gin v1.9.1\n"
+            "\tgithub.com/labstack/echo/v4 v4.11.0\n"
+            ")\n"
+        )
+        result = _parse_go_mod(content)
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+        assert "github.com/labstack/echo/v4" in result["dependencies"]
+
+    def test_empty_go_mod(self) -> None:
+        result = _parse_go_mod("module example.com/app\n\ngo 1.21\n")
+        assert result["dependencies"] == set()
+
+    def test_skips_commented_lines_in_require_block(self) -> None:
+        content = (
+            "module example.com/app\n\n"
+            "require (\n"
+            "\tgithub.com/gin-gonic/gin v1.9.1\n"
+            "\t// github.com/old/dep v0.1.0\n"
+            "\tgithub.com/labstack/echo/v4 v4.11.0\n"
+            ")\n"
+        )
+        result = _parse_go_mod(content)
+        assert "github.com/gin-gonic/gin" in result["dependencies"]
+        assert "github.com/labstack/echo/v4" in result["dependencies"]
+        assert "//" not in result["dependencies"]
+        assert "github.com/old/dep" not in result["dependencies"]
+
+    def test_skips_commented_single_require(self) -> None:
+        content = "module example.com/app\n\n// require github.com/old/dep v0.1.0\n"
+        result = _parse_go_mod(content)
+        assert result["dependencies"] == set()
+
 
 class TestPackageInManifest:
     def test_exact_match_in_dependencies(self) -> None:
@@ -107,6 +228,29 @@ class TestPackageInManifest:
     def test_prefix_no_match(self) -> None:
         manifest = _PackageManifest(dependencies={"laravel/framework"}, dev_dependencies=set())
         assert _package_in_manifest("symfony/", manifest) is False
+
+    def test_go_module_version_path_match(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"github.com/labstack/echo/v4"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("github.com/labstack/echo", manifest) is True
+
+    def test_go_module_exact_match(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"github.com/gin-gonic/gin"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("github.com/gin-gonic/gin", manifest) is True
+
+    def test_go_module_version_no_false_positive_on_similar_path(self) -> None:
+        manifest = _PackageManifest(
+            dependencies={"github.com/foo/bar/validator"}, dev_dependencies=set()
+        )
+        assert _package_in_manifest("github.com/foo/bar", manifest) is False
+
+    def test_npm_scoped_package_no_go_version_matching(self) -> None:
+        manifest = _PackageManifest(dependencies={"@nestjs/core"}, dev_dependencies=set())
+        assert _package_in_manifest("@nestjs/core", manifest) is True
+        assert _package_in_manifest("@nestjs/missing", manifest) is False
 
 
 class TestRuleMatches:
@@ -166,6 +310,53 @@ class TestRuleMatches:
     def test_rule_without_path_or_package_returns_false(self) -> None:
         rule: DetectorRule = {}
         assert _rule_matches(rule, {"file.txt"}, {}, None) is False
+
+    def test_match_dir_matches_when_dir_exists(self) -> None:
+        rule: DetectorRule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs={"Assets", "src"}) is True
+
+    def test_match_dir_no_match_when_dir_missing(self) -> None:
+        rule: DetectorRule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs={"src", "lib"}) is False
+
+    def test_match_dir_no_match_when_root_dirs_none(self) -> None:
+        rule: DetectorRule = {"match_dir": "Assets"}
+        assert _rule_matches(rule, set(), {}, None, root_dirs=None) is False
+
+    def test_match_ext_matches_when_extension_exists(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj"}
+        assert _rule_matches(rule, {"MyApp.csproj", "README.md"}, {}, None) is True
+
+    def test_match_ext_no_match_when_extension_missing(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj"}
+        assert _rule_matches(rule, {"README.md", "package.json"}, {}, None) is False
+
+    def test_match_ext_uproject(self) -> None:
+        rule: DetectorRule = {"match_ext": ".uproject"}
+        assert _rule_matches(rule, {"MyGame.uproject"}, {}, None) is True
+
+    def test_match_ext_with_match_content_matches(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj", "match_content": r"Microsoft\.Maui"}
+        files = {"MyApp.csproj", "README.md"}
+        contents = {"MyApp.csproj": '<PackageReference Include="Microsoft.Maui" />'}
+        assert _rule_matches(rule, files, contents, None) is True
+
+    def test_match_ext_with_match_content_no_content_match(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj", "match_content": r"Microsoft\.Maui"}
+        files = {"MyApp.csproj", "README.md"}
+        contents = {"MyApp.csproj": '<PackageReference Include="Newtonsoft.Json" />'}
+        assert _rule_matches(rule, files, contents, None) is False
+
+    def test_match_ext_with_match_content_no_ext_match(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj", "match_content": r"Microsoft\.Maui"}
+        files = {"README.md", "package.json"}
+        assert _rule_matches(rule, files, {}, None) is False
+
+    def test_match_ext_with_match_content_no_fetched_content(self) -> None:
+        rule: DetectorRule = {"match_ext": ".csproj", "match_content": r"Microsoft\.Maui"}
+        files = {"MyApp.csproj"}
+        # File exists but content wasn't fetched
+        assert _rule_matches(rule, files, {}, None) is False
 
 
 class TestFrameworkMatches:
@@ -234,28 +425,45 @@ class TestFrameworkMatches:
         fw: FrameworkDef = {"platform": "test", "sort": 1, "base_platform": "test"}
         assert _framework_matches(fw, set(), {}, None) is False
 
-    def test_nextjs_matches_from_package(self) -> None:
-        from sentry.integrations.github.platform_detection import FRAMEWORKS
+    def test_match_dir_in_every(self) -> None:
+        fw: FrameworkDef = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "every": [{"match_dir": "Assets"}, {"match_dir": "ProjectSettings"}],
+        }
+        assert (
+            _framework_matches(
+                fw, set(), {}, None, root_dirs={"Assets", "ProjectSettings", "Packages"}
+            )
+            is True
+        )
+        assert _framework_matches(fw, set(), {}, None, root_dirs={"Assets"}) is False
 
+    def test_match_ext_in_some(self) -> None:
+        fw: FrameworkDef = {
+            "platform": "test",
+            "sort": 1,
+            "base_platform": "test",
+            "some": [{"match_ext": ".csproj"}],
+        }
+        assert _framework_matches(fw, {"MyApp.csproj"}, {}, None) is True
+        assert _framework_matches(fw, {"README.md"}, {}, None) is False
+
+    def test_nextjs_matches_from_package(self) -> None:
         nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
         manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
         assert _framework_matches(nextjs, set(), {}, manifest) is True
 
     def test_nextjs_matches_from_config_file(self) -> None:
-        from sentry.integrations.github.platform_detection import FRAMEWORKS
-
         nextjs = next(fw for fw in FRAMEWORKS if fw["platform"] == "javascript-nextjs")
         assert _framework_matches(nextjs, {"next.config.js"}, {}, None) is True
 
     def test_django_matches_from_manage_py(self) -> None:
-        from sentry.integrations.github.platform_detection import FRAMEWORKS
-
         django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
         assert _framework_matches(django, {"manage.py"}, {}, None) is True
 
     def test_django_matches_from_requirements_content(self) -> None:
-        from sentry.integrations.github.platform_detection import FRAMEWORKS
-
         django = next(fw for fw in FRAMEWORKS if fw["platform"] == "python-django")
         assert (
             _framework_matches(
@@ -264,9 +472,36 @@ class TestFrameworkMatches:
             is True
         )
 
+    def test_unity_matches_from_directories(self) -> None:
+        unity = next(fw for fw in FRAMEWORKS if fw["platform"] == "unity")
+        assert (
+            _framework_matches(
+                unity, set(), {}, None, root_dirs={"Assets", "ProjectSettings", "Packages"}
+            )
+            is True
+        )
+        assert _framework_matches(unity, set(), {}, None, root_dirs={"Assets"}) is False
 
-class TestGetRootFileNames:
-    def test_returns_file_names(self) -> None:
+    def test_flutter_matches_from_pubspec(self) -> None:
+        flutter = next(fw for fw in FRAMEWORKS if fw["platform"] == "flutter")
+        manifest = _PackageManifest(dependencies={"flutter", "http"}, dev_dependencies=set())
+        assert _framework_matches(flutter, set(), {}, manifest) is True
+
+    def test_dotnet_aspnetcore_matches_with_csproj_and_appsettings(self) -> None:
+        aspnet = next(fw for fw in FRAMEWORKS if fw["platform"] == "dotnet-aspnetcore")
+        assert _framework_matches(aspnet, {"MyApp.csproj", "appsettings.json"}, {}, None) is True
+
+    def test_dotnet_aspnetcore_no_match_csproj_only(self) -> None:
+        aspnet = next(fw for fw in FRAMEWORKS if fw["platform"] == "dotnet-aspnetcore")
+        assert _framework_matches(aspnet, {"MyApp.csproj"}, {}, None) is False
+
+    def test_dotnet_aspnetcore_no_match_appsettings_only(self) -> None:
+        aspnet = next(fw for fw in FRAMEWORKS if fw["platform"] == "dotnet-aspnetcore")
+        assert _framework_matches(aspnet, {"appsettings.json"}, {}, None) is False
+
+
+class TestGetRootEntries:
+    def test_returns_files_and_dirs(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = [
             {"name": "package.json", "type": "file"},
@@ -275,34 +510,37 @@ class TestGetRootFileNames:
             {"name": "README.md", "type": "file"},
         ]
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result == {"package.json", "next.config.js", "README.md"}
+        assert files == {"package.json", "next.config.js", "README.md"}
+        assert dirs == {"src"}
 
-    def test_excludes_directories(self) -> None:
+    def test_excludes_directories_from_files(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = [
             {"name": "src", "type": "dir"},
             {"name": "lib", "type": "dir"},
         ]
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result == set()
+        assert files == set()
+        assert dirs == {"src", "lib"}
 
     def test_returns_none_on_api_error(self) -> None:
         client = mock.MagicMock()
         client.get.side_effect = ApiError("Not Found", code=404)
 
-        result = _get_root_file_names(client, "owner/repo")
+        files, dirs = _get_root_entries(client, "owner/repo")
 
-        assert result is None
+        assert files is None
+        assert dirs is None
 
     def test_passes_ref_param(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = []
 
-        _get_root_file_names(client, "owner/repo", ref="main")
+        _get_root_entries(client, "owner/repo", ref="main")
 
         client.get.assert_called_once_with("/repos/owner/repo/contents", params={"ref": "main"})
 
@@ -313,13 +551,15 @@ class TestGetRootFileNames:
             {"name": "README.md", "type": "file"},  # valid — kept
         ]
 
-        assert _get_root_file_names(client, "owner/repo") == {"README.md"}
+        files, dirs = _get_root_entries(client, "owner/repo")
+        assert files == {"README.md"}
+        assert dirs == set()
 
     def test_returns_none_on_non_list_response(self) -> None:
         client = mock.MagicMock()
         client.get.return_value = {"message": "Not Found"}  # dict instead of list
 
-        assert _get_root_file_names(client, "owner/repo") is None
+        assert _get_root_entries(client, "owner/repo") == (None, None)
 
 
 class TestApplySupersession:
@@ -388,6 +628,94 @@ class TestApplySupersession:
         platforms = [r["platform"] for r in filtered]
         assert "javascript-remix" in platforms
         assert "javascript-react" not in platforms
+
+    def test_sveltekit_supersedes_svelte(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-sveltekit",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-svelte",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-sveltekit" in platforms
+        assert "javascript-svelte" not in platforms
+
+    def test_gatsby_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="javascript-gatsby",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "javascript-gatsby" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_react_native_supersedes_react(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="react-native",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=99,
+            ),
+            DetectedPlatform(
+                platform="javascript-react",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=70,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "react-native" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_cloudflare_pages_supersedes_workers(self) -> None:
+        results = [
+            DetectedPlatform(
+                platform="node-cloudflare-pages",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=50,
+            ),
+            DetectedPlatform(
+                platform="node-cloudflare-workers",
+                language="JavaScript",
+                bytes=50000,
+                confidence="high",
+                priority=50,
+            ),
+        ]
+        filtered = _apply_supersession(results)
+        platforms = [r["platform"] for r in filtered]
+        assert "node-cloudflare-pages" in platforms
+        assert "node-cloudflare-workers" not in platforms
 
     def test_no_supersession_keeps_all(self) -> None:
         results = [
@@ -531,6 +859,16 @@ class TestDetectPlatforms:
         assert "Makefile" not in languages
         assert "Dockerfile" not in languages
 
+    def test_powershell_detected_as_base_platform(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PowerShell": 20000}
+        client.get.side_effect = ApiError("Not Found", code=404)
+
+        result = detect_platforms(client, "owner/repo")
+
+        assert len(result) == 1
+        assert result[0]["platform"] == "powershell"
+
     def test_framework_detection_gives_high_confidence(self) -> None:
         client = mock.MagicMock()
         client.get_languages.return_value = {"Python": 50000}
@@ -629,9 +967,9 @@ class TestDetectPlatforms:
 
         svelte = next(r for r in result if r["platform"] == "javascript-svelte")
         express = next(r for r in result if r["platform"] == "node-express")
-        # svelte sort=30 → priority=70, express sort=40 → priority=60
-        assert svelte["priority"] == 70
-        assert express["priority"] == 60
+        # svelte sort=10 → priority=90, express sort=20 → priority=80
+        assert svelte["priority"] == 90
+        assert express["priority"] == 80
 
     def test_typescript_and_javascript_deduplicated(self) -> None:
         client = mock.MagicMock()
@@ -678,7 +1016,6 @@ class TestDetectPlatforms:
             ("TypeScript", "javascript"),
             ("Java", "java"),
             ("Kotlin", "kotlin"),
-            ("Swift", "swift"),
             ("Go", "go"),
             ("Ruby", "ruby"),
             ("PHP", "php"),
@@ -686,6 +1023,7 @@ class TestDetectPlatforms:
             ("C#", "dotnet"),
             ("Dart", "dart"),
             ("Elixir", "elixir"),
+            ("PowerShell", "powershell"),
         ],
     )
     def test_all_mapped_languages_detected(self, language: str, expected_platform: str) -> None:
@@ -923,6 +1261,962 @@ class TestDetectPlatforms:
         platforms = [r["platform"] for r in result]
         assert "go-gin" in platforms
 
+    def test_react_native_detected_and_supersedes_react(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"react-native": "^0.72.0", "react": "^18.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "react-native" in platforms
+        assert "javascript-react" not in platforms
+
+    def test_electron_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"electron": "^28.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "electron" in platforms
+
+    def test_flutter_detected_from_pubspec(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Dart": 50000}
+
+        pubspec_content = (
+            "name: my_app\ndependencies:\n  flutter:\n    sdk: flutter\n  http: ^0.13.5\n"
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "pubspec.yaml", "type": "file"}]
+            if "pubspec.yaml" in path:
+                return _make_b64_response(pubspec_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "flutter" in platforms
+
+    def test_unity_detected_from_directories(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "Assets", "type": "dir"},
+                    {"name": "ProjectSettings", "type": "dir"},
+                    {"name": "Packages", "type": "dir"},
+                    {"name": "README.md", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "unity" in platforms
+
+    def test_android_detected_from_build_gradle_and_app_dir(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "app", "type": "dir"},
+                    {"name": "build.gradle", "type": "file"},
+                    {"name": "settings.gradle", "type": "file"},
+                ]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "buildscript {\n}\n\nallprojects {\n}\n\nandroid {\n    compileSdk 34\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "android" in platforms
+
+    def test_dotnet_aspnetcore_detected_with_csproj_and_appsettings(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyApp.csproj", "type": "file"},
+                    {"name": "Program.cs", "type": "file"},
+                    {"name": "appsettings.json", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-aspnetcore" in platforms
+
+    def test_dotnet_csproj_without_appsettings_falls_back_to_base(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyApp.csproj", "type": "file"},
+                    {"name": "Program.cs", "type": "file"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-aspnetcore" not in platforms
+        assert "dotnet" in platforms
+
+    def test_unreal_detected_from_uproject(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyGame.uproject", "type": "file"},
+                    {"name": "Source", "type": "dir"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "unreal" in platforms
+
+    def test_godot_detected_from_project_file(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "project.godot", "type": "file"},
+                    {"name": "scenes", "type": "dir"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "godot" in platforms
+
+    def test_wordpress_filtered_as_non_selectable(self) -> None:
+        """WordPress is detected internally but filtered from results as non-selectable."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"PHP": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "wp-config.php", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "php-wordpress" not in platforms
+        assert "php" in platforms
+
+    def test_ruby_rack_detected_from_gemfile(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Ruby": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Gemfile", "type": "file"}]
+            if "Gemfile" in path:
+                return _make_b64_response('gem "rack"\ngem "puma"\n')
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "ruby-rack" in platforms
+
+    def test_python_aiohttp_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "requirements.txt", "type": "file"}]
+            if "requirements.txt" in path:
+                return _make_b64_response("aiohttp==3.9.0\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-aiohttp" in platforms
+
+    def test_java_log4j2_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Java": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "build.gradle", "type": "file"}]
+            if "build.gradle" in path:
+                return _make_b64_response(
+                    "dependencies {\n    implementation 'org.apache.logging.log4j:log4j-core:2.20'\n}\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "java-log4j2" in platforms
+
+    def test_astro_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps({"dependencies": {"astro": "^4.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-astro" in platforms
+
+    def test_sveltekit_supersedes_svelte_in_full_flow(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        content = json.dumps(
+            {
+                "dependencies": {},
+                "devDependencies": {"@sveltejs/kit": "^2.0.0", "svelte": "^4.0.0"},
+            }
+        )
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "javascript-sveltekit" in platforms
+        assert "javascript-svelte" not in platforms
+
+    def test_nestjs_detected(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"TypeScript": 50000}
+
+        content = json.dumps({"dependencies": {"@nestjs/core": "^10.0.0"}})
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-nestjs" in platforms
+
+    def test_cloudflare_workers_detected_from_wrangler(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "wrangler.toml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-cloudflare-workers" in platforms
+
+    def test_cloudflare_pages_supersedes_workers(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "wrangler.toml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "wrangler.toml" in path:
+                return _make_b64_response(
+                    'name = "my-pages-app"\npages_build_output_dir = "./dist"\n'
+                )
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-cloudflare-pages" in platforms
+        assert "node-cloudflare-workers" not in platforms
+
+    def test_azurefunctions_detected_from_host_and_local_settings(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        host_json = '{"version": "2.0", "extensionBundle": {"id": "Microsoft.Azure.Functions.ExtensionBundle"}}'
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "host.json", "type": "file"},
+                    {"name": "local.settings.json", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "host.json" in path:
+                return _make_b64_response(host_json)
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-azurefunctions" in platforms
+
+    def test_azurefunctions_not_detected_without_extension_bundle(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 50000}
+
+        host_json = '{"version": "2.0"}'
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "host.json", "type": "file"},
+                    {"name": "local.settings.json", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "host.json" in path:
+                return _make_b64_response(host_json)
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "node-azurefunctions" not in platforms
+
+    def test_serverless_yml_detects_awslambda(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 50000}
+
+        serverless_content = b64encode(
+            b"service: my-service\nprovider:\n  runtime: python3.11\n"
+        ).decode()
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "serverless.yml", "type": "file"},
+                    {"name": "requirements.txt", "type": "file"},
+                ]
+            if path.endswith("/contents/serverless.yml"):
+                return {"content": serverless_content}
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+
+        platforms = [r["platform"] for r in result]
+        assert "python-awslambda" in platforms
+
+    def test_bun_detected_from_bunfig(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"TypeScript": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "bunfig.toml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "bun" in platforms
+
+    def test_bun_detected_from_lockfile(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "bun.lockb", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "bun" in platforms
+
+    def test_deno_detected_from_config(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"TypeScript": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "deno.json", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "deno" in platforms
+
+    def test_dotnet_maui_detected_from_csproj_content(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 60000}
+
+        csproj_content = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0" />
+  </ItemGroup>
+</Project>"""
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyApp.csproj", "type": "file"},
+                    {"name": "MauiProgram.cs", "type": "file"},
+                ]
+            if "MyApp.csproj" in path:
+                return _make_b64_response(csproj_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-maui" in platforms
+
+    def test_dotnet_wpf_detected_from_csproj_content(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 50000}
+
+        csproj_content = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+</Project>"""
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "WpfApp.csproj", "type": "file"},
+                ]
+            if "WpfApp.csproj" in path:
+                return _make_b64_response(csproj_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-wpf" in platforms
+
+    def test_dotnet_awslambda_detected_from_csproj_content(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 30000}
+
+        csproj_content = """<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+  </ItemGroup>
+</Project>"""
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "LambdaFunc.csproj", "type": "file"},
+                ]
+            if "LambdaFunc.csproj" in path:
+                return _make_b64_response(csproj_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-awslambda" in platforms
+
+    def test_dotnet_aspnet_legacy_detected_not_core(self) -> None:
+        """dotnet-aspnet detects legacy ASP.NET but not ASP.NET Core."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 40000}
+
+        csproj_content = """<Project>
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNet.Mvc" />
+  </ItemGroup>
+</Project>"""
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "WebApp.csproj", "type": "file"},
+                ]
+            if "WebApp.csproj" in path:
+                return _make_b64_response(csproj_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "dotnet-aspnet" in platforms
+
+    def test_dotnet_aspnetcore_not_detected_as_legacy_aspnet(self) -> None:
+        """ASP.NET Core references should NOT match the legacy dotnet-aspnet pattern."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C#": 40000}
+
+        csproj_content = """<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>"""
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "WebApp.csproj", "type": "file"},
+                    {"name": "appsettings.json", "type": "file"},
+                ]
+            if "WebApp.csproj" in path:
+                return _make_b64_response(csproj_content)
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        # Should detect aspnetcore (via existing rule), not legacy aspnet
+        assert "dotnet-aspnetcore" in platforms
+        assert "dotnet-aspnet" not in platforms
+
+    def test_apple_ios_detected_from_package_swift(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Package.swift", "type": "file"}]
+            if "Package.swift" in path:
+                return _make_b64_response("let package = Package(\n  platforms: [.iOS(.v14)],\n)")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "apple-ios" in platforms
+
+    def test_apple_ios_detected_from_podfile(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Podfile", "type": "file"}]
+            if "Podfile" in path:
+                return _make_b64_response("platform :ios, '14.0'\npod 'Alamofire'\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "apple-ios" in platforms
+
+    def test_apple_ios_higher_priority_than_macos(self) -> None:
+        """When both iOS and macOS are in Package.swift, iOS should rank higher."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Package.swift", "type": "file"}]
+            if "Package.swift" in path:
+                return _make_b64_response(
+                    "let package = Package(\n  platforms: [.iOS(.v14), .macOS(.v11)],\n)"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "apple-ios" in platforms
+        assert "apple-macos" in platforms
+        # iOS (sort=3, priority=97) should come before macOS (sort=5, priority=95)
+        assert platforms.index("apple-ios") < platforms.index("apple-macos")
+
+    def test_swift_without_ios_signals_returns_empty(self) -> None:
+        """Plain Swift repo with no framework signals returns empty results.
+
+        Swift is a non-selectable platform (the picker uses apple-ios / apple-macos),
+        so it gets filtered out when no framework-specific signals are found.
+        """
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "README.md", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        assert result == []
+
+    def test_apple_macos_detected_from_package_swift(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Package.swift", "type": "file"}]
+            if "Package.swift" in path:
+                return _make_b64_response(
+                    'let package = Package(\n  platforms: [.macOS("12.0")],\n)'
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "apple-macos" in platforms
+
+    def test_apple_macos_detected_from_podfile(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Swift": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "Podfile", "type": "file"}]
+            if "Podfile" in path:
+                return _make_b64_response("platform :osx, '12.0'\npod 'Alamofire'\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "apple-macos" in platforms
+
+    def test_native_qt_detected_from_qrc(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "resources.qrc", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "native-qt" in platforms
+
+    def test_native_qt_detected_from_cmake(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"C++": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "CMakeLists.txt", "type": "file"}]
+            if "CMakeLists.txt" in path:
+                return _make_b64_response(
+                    "cmake_minimum_required(VERSION 3.16)\nfind_package(Qt6 REQUIRED)\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "native-qt" in platforms
+
+    def test_cordova_detected_from_config_xml(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 20000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "config.xml", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "config.xml" in path:
+                return _make_b64_response(
+                    '<widget xmlns="http://cordova.apache.org/ns/1.0">\n'
+                    "  <name>MyApp</name>\n"
+                    "</widget>\n"
+                )
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "cordova" in platforms
+
+    def test_cordova_detected_from_package_json(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 20000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(
+                    json.dumps({"dependencies": {"cordova-android": "^12.0.0"}})
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "cordova" in platforms
+
+    def test_node_detected_from_nvmrc(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": ".nvmrc", "type": "file"},
+                    {"name": "package.json", "type": "file"},
+                ]
+            if "package.json" in path:
+                return _make_b64_response(json.dumps({"dependencies": {}}))
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "node" in platforms
+
+    def test_node_detected_from_engines_field(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"JavaScript": 30000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "package.json", "type": "file"}]
+            if "package.json" in path:
+                return _make_b64_response(
+                    json.dumps(
+                        {
+                            "engines": {"node": ">=18.0.0"},
+                            "dependencies": {},
+                        }
+                    )
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "node" in platforms
+
+    def test_go_base_platform_when_no_framework(self) -> None:
+        """Go with no framework should emit plain 'go'."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Go": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "main.go", "type": "file"}]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "go" in platforms
+
+    def test_go_with_framework_emits_framework_and_base(self) -> None:
+        """Go with a framework should emit both the framework and base 'go' platform."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Go": 50000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "go.mod", "type": "file"}]
+            if "go.mod" in path:
+                return _make_b64_response(
+                    "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
+                )
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "go-gin" in platforms
+        assert "go" in platforms
+
+    def test_python_asgi_detected_from_uvicorn(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [{"name": "requirements.txt", "type": "file"}]
+            if "requirements.txt" in path:
+                return _make_b64_response("fastapi\nuvicorn\npydantic\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "python-asgi" in platforms
+        assert "python-fastapi" in platforms
+
+    def test_python_wsgi_detected_from_gunicorn(self) -> None:
+        client = mock.MagicMock()
+        client.get_languages.return_value = {"Python": 40000}
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "requirements.txt", "type": "file"},
+                    {"name": "manage.py", "type": "file"},
+                ]
+            if "requirements.txt" in path:
+                return _make_b64_response("Django==4.2\ngunicorn\npsycopg2\n")
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        platforms = [r["platform"] for r in result]
+        assert "python-wsgi" in platforms
+        assert "python-django" in platforms
+
 
 class TestFrameworksIntegrity:
     """Validate the FRAMEWORKS list is internally consistent.
@@ -931,10 +2225,16 @@ class TestFrameworksIntegrity:
     framework definitions to never match at runtime.
     """
 
-    def test_no_duplicate_platform_ids(self) -> None:
-        platform_ids = [fw["platform"] for fw in FRAMEWORKS]
-        duplicates = [p for p in platform_ids if platform_ids.count(p) > 1]
-        assert duplicates == [], f"Duplicate platform IDs: {set(duplicates)}"
+    def test_no_unintentional_duplicate_platform_ids(self) -> None:
+        # Some platforms intentionally have multiple entries with different
+        # base_platforms (e.g. android has both java and kotlin entries).
+        # Duplicates are only valid when each entry has a distinct base_platform.
+        from collections import Counter
+
+        entries = [(fw["platform"], fw["base_platform"]) for fw in FRAMEWORKS]
+        entry_counts = Counter(entries)
+        exact_dupes = [e for e, count in entry_counts.items() if count > 1]
+        assert exact_dupes == [], f"Duplicate (platform, base_platform) pairs: {exact_dupes}"
 
     def test_all_base_platforms_are_valid(self) -> None:
         valid_base_platforms = set(GITHUB_LANGUAGE_TO_SENTRY_PLATFORM.values())
@@ -970,13 +2270,13 @@ class TestFrameworksIntegrity:
                 f"{fw['platform']} sort={fw['sort']} is outside valid range 1-99"
             )
 
-    def test_no_rule_has_match_content_without_path(self) -> None:
+    def test_no_rule_has_match_content_without_file_source(self) -> None:
         for fw in FRAMEWORKS:
             for rule in [*fw.get("every", []), *fw.get("some", [])]:
                 if "match_content" in rule:
-                    assert "path" in rule, (
-                        f"{fw['platform']} has match_content without path — "
-                        f"content matching requires a file to read"
+                    assert "path" in rule or "match_ext" in rule, (
+                        f"{fw['platform']} has match_content without path or match_ext — "
+                        f"content matching requires a file source to read"
                     )
 
 
@@ -1058,6 +2358,7 @@ class TestDetectPlatformsMultiStack:
         # Frameworks detected with high confidence
         assert "python-django" in platform_set
         assert "python-celery" in platform_set
+        assert "python-wsgi" in platform_set  # gunicorn in requirements.txt
         assert "javascript-nextjs" in platform_set
         assert "go-gin" in platform_set
 

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -18,7 +18,6 @@ from sentry.integrations.github.platform_detection import (
     _package_in_manifest,
     _PackageManifest,
     _parse_gemfile,
-    _parse_go_mod,
     _parse_package_manifest,
     _parse_pubspec_yaml,
     _rule_matches,
@@ -104,12 +103,6 @@ class TestParsePackageManifest:
         assert "rails" in result["dependencies"]
         assert "puma" in result["dependencies"]
 
-    def test_delegates_to_go_mod(self) -> None:
-        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
-        result = _parse_package_manifest(content, "go.mod")
-        assert result is not None
-        assert "github.com/gin-gonic/gin" in result["dependencies"]
-
 
 class TestParsePubspecYaml:
     def test_extracts_dependencies(self) -> None:
@@ -163,49 +156,6 @@ class TestParseGemfile:
         assert result["dependencies"] == set()
 
 
-class TestParseGoMod:
-    def test_single_require(self) -> None:
-        content = "module example.com/app\n\nrequire github.com/gin-gonic/gin v1.9.1\n"
-        result = _parse_go_mod(content)
-        assert "github.com/gin-gonic/gin" in result["dependencies"]
-
-    def test_require_block(self) -> None:
-        content = (
-            "module example.com/app\n\n"
-            "require (\n"
-            "\tgithub.com/gin-gonic/gin v1.9.1\n"
-            "\tgithub.com/labstack/echo/v4 v4.11.0\n"
-            ")\n"
-        )
-        result = _parse_go_mod(content)
-        assert "github.com/gin-gonic/gin" in result["dependencies"]
-        assert "github.com/labstack/echo/v4" in result["dependencies"]
-
-    def test_empty_go_mod(self) -> None:
-        result = _parse_go_mod("module example.com/app\n\ngo 1.21\n")
-        assert result["dependencies"] == set()
-
-    def test_skips_commented_lines_in_require_block(self) -> None:
-        content = (
-            "module example.com/app\n\n"
-            "require (\n"
-            "\tgithub.com/gin-gonic/gin v1.9.1\n"
-            "\t// github.com/old/dep v0.1.0\n"
-            "\tgithub.com/labstack/echo/v4 v4.11.0\n"
-            ")\n"
-        )
-        result = _parse_go_mod(content)
-        assert "github.com/gin-gonic/gin" in result["dependencies"]
-        assert "github.com/labstack/echo/v4" in result["dependencies"]
-        assert "//" not in result["dependencies"]
-        assert "github.com/old/dep" not in result["dependencies"]
-
-    def test_skips_commented_single_require(self) -> None:
-        content = "module example.com/app\n\n// require github.com/old/dep v0.1.0\n"
-        result = _parse_go_mod(content)
-        assert result["dependencies"] == set()
-
-
 class TestPackageInManifest:
     def test_exact_match_in_dependencies(self) -> None:
         manifest = _PackageManifest(dependencies={"next", "react"}, dev_dependencies=set())
@@ -229,25 +179,7 @@ class TestPackageInManifest:
         manifest = _PackageManifest(dependencies={"laravel/framework"}, dev_dependencies=set())
         assert _package_in_manifest("symfony/", manifest) is False
 
-    def test_go_module_version_path_match(self) -> None:
-        manifest = _PackageManifest(
-            dependencies={"github.com/labstack/echo/v4"}, dev_dependencies=set()
-        )
-        assert _package_in_manifest("github.com/labstack/echo", manifest) is True
-
-    def test_go_module_exact_match(self) -> None:
-        manifest = _PackageManifest(
-            dependencies={"github.com/gin-gonic/gin"}, dev_dependencies=set()
-        )
-        assert _package_in_manifest("github.com/gin-gonic/gin", manifest) is True
-
-    def test_go_module_version_no_false_positive_on_similar_path(self) -> None:
-        manifest = _PackageManifest(
-            dependencies={"github.com/foo/bar/validator"}, dev_dependencies=set()
-        )
-        assert _package_in_manifest("github.com/foo/bar", manifest) is False
-
-    def test_npm_scoped_package_no_go_version_matching(self) -> None:
+    def test_npm_scoped_package_match(self) -> None:
         manifest = _PackageManifest(dependencies={"@nestjs/core"}, dev_dependencies=set())
         assert _package_in_manifest("@nestjs/core", manifest) is True
         assert _package_in_manifest("@nestjs/missing", manifest) is False

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1424,7 +1424,7 @@ class TestDetectPlatforms:
 
     def test_godot_detected_from_project_file(self) -> None:
         client = mock.MagicMock()
-        client.get_languages.return_value = {"C++": 50000}
+        client.get_languages.return_value = {"GDScript": 50000}
 
         def get_side_effect(path, params=None):
             if path.endswith("/contents"):

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -830,7 +830,8 @@ class TestDetectPlatforms:
         assert result[0]["confidence"] == "medium"
         assert result[0]["priority"] == 1
 
-    def test_detects_multi_language_repo(self) -> None:
+    def test_only_top_language_platform_detected(self) -> None:
+        """Only the top language's base platform is processed."""
         client = mock.MagicMock()
         client.get_languages.return_value = {"Python": 50000, "JavaScript": 30000}
         client.get.side_effect = ApiError("Not Found", code=404)
@@ -839,7 +840,7 @@ class TestDetectPlatforms:
 
         platforms = [r["platform"] for r in result]
         assert "python" in platforms
-        assert "javascript" in platforms
+        assert "javascript" not in platforms
 
     def test_filters_ignored_languages(self) -> None:
         client = mock.MagicMock()
@@ -891,32 +892,29 @@ class TestDetectPlatforms:
         assert python_result["confidence"] == "medium"
 
     def test_results_sorted_by_bytes_then_priority(self) -> None:
+        """Frameworks for the top language are sorted by (bytes, priority)."""
         client = mock.MagicMock()
-        client.get_languages.return_value = {"Python": 80000, "JavaScript": 30000}
+        client.get_languages.return_value = {"Python": 80000}
 
         def get_side_effect(path, params=None):
             if path.endswith("/contents"):
                 return [
                     {"name": "requirements.txt", "type": "file"},
-                    {"name": "package.json", "type": "file"},
+                    {"name": "manage.py", "type": "file"},
                 ]
             if "requirements.txt" in path:
-                return _make_b64_response("flask==3.0\n")
-            if "package.json" in path:
-                return _make_b64_response(
-                    json.dumps({"dependencies": {"next": "^14.0.0", "react": "^18.0.0"}})
-                )
+                return _make_b64_response("flask==3.0\ncelery>=5.0\n")
             raise ApiError("Not Found", code=404)
 
         client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
 
-        # Python (80k bytes) > JavaScript (30k bytes); language majority wins
         platforms = [r["platform"] for r in result]
+        # Flask (sort=10, priority=90) should rank above Celery (sort=50, priority=50)
         flask_idx = platforms.index("python-flask")
-        nextjs_idx = platforms.index("javascript-nextjs")
-        assert flask_idx < nextjs_idx
+        celery_idx = platforms.index("python-celery")
+        assert flask_idx < celery_idx
 
     def test_nextjs_supersedes_react_in_full_flow(self) -> None:
         client = mock.MagicMock()
@@ -1173,13 +1171,9 @@ class TestDetectPlatforms:
         result = detect_platforms(client, "owner/repo")
 
         platforms = [r["platform"] for r in result]
-        assert platforms == ["python", "javascript"] or set(platforms) == {
-            "python",
-            "javascript",
-        }
-        for r in result:
-            assert r["confidence"] == "medium"
-            assert r["priority"] == 1
+        assert platforms == ["python"]
+        assert result[0]["confidence"] == "medium"
+        assert result[0]["priority"] == 1
 
     def test_root_listing_failure_still_detects_frameworks_via_manifest(self) -> None:
         """When the root contents API fails, framework detection should fall
@@ -1940,10 +1934,10 @@ class TestDetectPlatforms:
         platforms = [r["platform"] for r in result]
         assert "apple-ios" in platforms
 
-    def test_cross_base_dedup_upgrades_confidence(self) -> None:
-        """When apple-ios is first added as a base platform (via Objective-C)
-        and then matched as a framework (via Swift + .xcodeproj), the entry
-        should be upgraded to high confidence even if Obj-C has more bytes."""
+    def test_objc_dominant_repo_returns_apple_ios_base(self) -> None:
+        """When Objective-C dominates, apple-ios is returned as the base
+        platform (medium confidence) since framework detection for apple-ios
+        runs under the swift base platform which isn't processed."""
         client = mock.MagicMock()
         client.get_languages.return_value = {
             "Objective-C": 80000,
@@ -1961,8 +1955,7 @@ class TestDetectPlatforms:
 
         result = detect_platforms(client, "owner/repo")
         ios_entry = next(r for r in result if r["platform"] == "apple-ios")
-        assert ios_entry["confidence"] == "high"
-        assert ios_entry["priority"] == 90
+        assert ios_entry["confidence"] == "medium"
         assert ios_entry["bytes"] == 80000
 
     def test_apple_ios_higher_priority_than_macos(self) -> None:
@@ -2318,7 +2311,9 @@ class TestDetectPlatformsMultiStack:
     - Plus build/infra languages that should be ignored
     """
 
-    def test_full_stack_repo(self) -> None:
+    def test_full_stack_repo_only_detects_top_language(self) -> None:
+        """In a multi-language repo, only the top language's platform is
+        processed. Only one suggestion is shown to the user."""
         client = mock.MagicMock()
         client.get_languages.return_value = {
             "Python": 120000,
@@ -2350,73 +2345,35 @@ class TestDetectPlatformsMultiStack:
                 return _make_b64_response(
                     "Django==4.2\ncelery>=5.3\ngunicorn\npsycopg2-binary\nredis\n"
                 )
-            if "package.json" in path:
-                return _make_b64_response(
-                    json.dumps(
-                        {
-                            "dependencies": {
-                                "next": "^14.0.0",
-                                "react": "^18.2.0",
-                                "react-dom": "^18.2.0",
-                            },
-                            "devDependencies": {
-                                "typescript": "^5.0.0",
-                                "eslint": "^8.0.0",
-                            },
-                        }
-                    )
-                )
-            if "go.mod" in path:
-                return _make_b64_response(
-                    "module github.com/myorg/myapp\n\n"
-                    "go 1.21\n\n"
-                    "require (\n"
-                    "\tgithub.com/gin-gonic/gin v1.9.1\n"
-                    "\tgithub.com/lib/pq v1.10.9\n"
-                    ")\n"
-                )
             raise ApiError("Not Found", code=404)
 
         client.get.side_effect = get_side_effect
 
         result = detect_platforms(client, "owner/repo")
-        platforms = [r["platform"] for r in result]
-        platform_set = set(platforms)
+        platform_set = {r["platform"] for r in result}
 
-        # Frameworks detected with high confidence
+        # Only Python frameworks detected (top language)
         assert "python-django" in platform_set
         assert "python-celery" in platform_set
-        assert "python-wsgi" in platform_set  # gunicorn in requirements.txt
-        assert "javascript-nextjs" in platform_set
-        assert "go-gin" in platform_set
-
-        # Supersession: React removed because Next.js is present
-        assert "javascript-react" not in platform_set
-
-        # Base platforms as fallback
+        assert "python-wsgi" in platform_set
         assert "python" in platform_set
-        assert "javascript" in platform_set
-        assert "go" in platform_set
 
-        # Ignored languages excluded entirely
-        for r in result:
-            assert r["language"] not in ("HTML", "CSS", "Shell", "Makefile", "Dockerfile")
+        # Other languages not processed
+        assert "javascript-nextjs" not in platform_set
+        assert "go-gin" not in platform_set
+        assert "javascript" not in platform_set
+        assert "go" not in platform_set
 
-        # TypeScript deduplicates into javascript base platform
-        ts_results = [r for r in result if r["language"] == "TypeScript"]
-        assert ts_results == []
-
-        # Priority ordering within a language: meta-frameworks > primary > utilities > base
-        nextjs = next(r for r in result if r["platform"] == "javascript-nextjs")
+        # Priority ordering within Python: frameworks > utilities > base
         django = next(r for r in result if r["platform"] == "python-django")
         celery = next(r for r in result if r["platform"] == "python-celery")
         python_base = next(r for r in result if r["platform"] == "python")
 
-        assert nextjs["priority"] > django["priority"] > celery["priority"]
+        assert django["priority"] > celery["priority"]
         assert celery["priority"] > python_base["priority"]
         assert python_base["priority"] == 1
 
-        # Results are sorted by (bytes, priority) descending — language majority first
+        # Results are sorted by (bytes, priority) descending
         for i in range(len(result) - 1):
             a, b = result[i], result[i + 1]
             assert (a["bytes"], a["priority"]) >= (b["bytes"], b["priority"])

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -1940,6 +1940,31 @@ class TestDetectPlatforms:
         platforms = [r["platform"] for r in result]
         assert "apple-ios" in platforms
 
+    def test_cross_base_dedup_upgrades_confidence(self) -> None:
+        """When apple-ios is first added as a base platform (via Objective-C)
+        and then matched as a framework (via Swift + .xcodeproj), the entry
+        should be upgraded to high confidence even if Obj-C has more bytes."""
+        client = mock.MagicMock()
+        client.get_languages.return_value = {
+            "Objective-C": 80000,
+            "Swift": 20000,
+        }
+
+        def get_side_effect(path, params=None):
+            if path.endswith("/contents"):
+                return [
+                    {"name": "MyApp.xcodeproj", "type": "dir"},
+                ]
+            raise ApiError("Not Found", code=404)
+
+        client.get.side_effect = get_side_effect
+
+        result = detect_platforms(client, "owner/repo")
+        ios_entry = next(r for r in result if r["platform"] == "apple-ios")
+        assert ios_entry["confidence"] == "high"
+        assert ios_entry["priority"] == 90
+        assert ios_entry["bytes"] == 80000
+
     def test_apple_ios_higher_priority_than_macos(self) -> None:
         """When both iOS and macOS are in Package.swift, iOS should rank higher."""
         client = mock.MagicMock()

--- a/tests/sentry/integrations/github/test_platform_detection.py
+++ b/tests/sentry/integrations/github/test_platform_detection.py
@@ -2117,7 +2117,9 @@ class TestDetectPlatforms:
         platforms = [r["platform"] for r in result]
         assert "node" in platforms
 
-    def test_node_detected_from_engines_field(self) -> None:
+    def test_engines_node_alone_does_not_trigger_node(self) -> None:
+        """engines.node is too common in JS ecosystem (even browser libs set it)
+        so it should not by itself trigger Node detection."""
         client = mock.MagicMock()
         client.get_languages.return_value = {"JavaScript": 30000}
 
@@ -2139,7 +2141,8 @@ class TestDetectPlatforms:
 
         result = detect_platforms(client, "owner/repo")
         platforms = [r["platform"] for r in result]
-        assert "node" in platforms
+        assert "node" not in platforms
+        assert "javascript" in platforms
 
     def test_go_base_platform_when_no_framework(self) -> None:
         """Go with no framework should emit plain 'go'."""


### PR DESCRIPTION
Expand the composable framework detection system to cover 97/100 (97%) of selectable platforms in the picker, up from the ~36 platforms in PR 2.

**Infrastructure additions:**
- `match_ext` + `match_content` combo rules -- find files by extension, then search content (needed for .csproj inspection where filenames vary)
- `_NON_SELECTABLE_PLATFORMS` filter -- platforms detected internally for ranking (e.g. preventing WordPress from being misidentified as Symfony) but not shown to users because they lack onboarding docs or map to other platforms (perl, php-wordpress, swift)
- Dual `base_platform` entries for Android (java + kotlin) so Kotlin-first projects are correctly detected

**61 new framework definitions:**
- **JavaScript (22):** astro, gatsby, sveltekit, solidstart, solid, ember, tanstackstart-react, react-router, react-native, electron, capacitor, ionic, cordova, node, nestjs, fastify, connect, hapi, awslambda, gcpfunctions, azurefunctions, cloudflare-workers, cloudflare-pages
- **Python (13):** aiohttp, bottle, falcon, pyramid, quart, sanic, tryton, chalice, asgi, wsgi, awslambda, gcpfunctions, rq
- **Go (4):** fasthttp, iris, negroni
- **Java (2):** log4j2, logback
- **Ruby (1):** rack
- **PHP (2):** wordpress (non-selectable), symfony
- **Dart (1):** flutter
- **Swift (1):** apple-macos
- **Native (1):** native-qt
- **.NET (7):** maui, wpf, winforms, xamarin, aspnet, awslambda, gcpfunctions
- **Mobile/Gaming (5):** unity, android, dotnet-aspnetcore, unreal, godot
- **Other (3):** bun, deno, PowerShell (base platform)

**Only 3 platforms remain undetectable:** `go-http` (stdlib net/http, no manifest signal), `minidump` (crash dump format, not a project type), and `python-serverless` (too generic, overlaps with awslambda/gcpfunctions).

**Note on `go-http`:** Plain Go repos now intentionally return `go` as the base platform instead of `go-http`. There is no reliable way to distinguish a net/http project from any other Go project without a framework dependency, so the generic `go` platform is the correct fallback.

**Stack:**
- [PR 1](https://github.com/getsentry/sentry/pull/109699): Core detection + API endpoint
- [PR 2](https://github.com/getsentry/sentry/pull/109700): Composable framework definitions refactor
- **PR 3 (this):** Expanded coverage (97% of picker platforms)