### PR TITLE
feat(dashboards): Register backend caches prebuilt dashboard module

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -89,6 +89,7 @@ class PrebuiltDashboardId(IntEnum):
     FRONTEND_ASSETS_SUMMARY = 25
     BACKEND_QUEUES = 26
     BACKEND_QUEUE_SUMMARY = 27
+    BACKEND_CACHES = 28
 
 
 class PrebuiltDashboard(TypedDict):
@@ -213,6 +214,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_QUEUE_SUMMARY,
         "title": "Queue Summary",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.BACKEND_CACHES,
+        "title": "Caches",
     },
 ]
 


### PR DESCRIPTION
Adds the `BACKEND_CACHES` entry (id 28) to the `PrebuiltDashboardId` enum and registers a "Caches" prebuilt dashboard in `PREBUILT_DASHBOARDS`. This allows the frontend to discover and render the caches module dashboard.

Refs BROWSE-380