### PR TITLE
ref(grouping): Expand datetime message parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -116,8 +116,21 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             # JavaScript
             ((?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s\d{2}\s\d{4}\s\d{2}:\d{2}:\d{2}\sGMT[+-]\d{4}(?:\s\([^)]+\))?)
             |
-            # Datetime:
-            (\d{4}-?[01]\d-?[0-3]\d\s[0-2]\d:[0-5]\d:[0-5]\d)(\.\d+)?
+            # Datetime with timezone offset (Z=UTC):
+            # (Note: These come before plain datetimes so the offset is seen as part of the time and
+            # not a separate int value.)
+            (
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d:?[0-5]\d\.\d+([+-][0-2]\d:?[0-5]\d|Z))| # decimal seconds
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d:?[0-5]\d([+-][0-2]\d:?[0-5]\d|Z))| # seconds
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d([+-][0-2]\d:?[0-5]\d|Z)) # no seconds
+            )
+            |
+            # Datetime
+            (
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d:?[0-5]\d\.\d+)| # decimal seconds
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d:?[0-5]\d)| # seconds
+                (\d{4}-?[01]\d-?[0-3]\d[\sT][0-2]\d:?[0-5]\d) # no seconds
+            )
             |
             # Kitchen
             ([1-9]\d?:\d{2}(:\d{2})?(?: [aApP][Mm])?)
@@ -129,11 +142,6 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             ([0-2]\d:[0-5]\d:[0-5]\d)
             |
             # Old Date Formats, TODO: possibly safe to remove?
-            (
-                (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|
-                (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))|
-                (\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))
-            ) |
             (
                 \b(?:(Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+)?
                 (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -63,9 +63,17 @@ standard_cases = [
     ("date - plain", "2006-01-02", "<date>"),
     ("date - long", "Jan 18, 2019", "<date>"),
     ("date - datetime space-separated", "2006-01-02 15:04:05", "<date>"),
+    ("date - datetime space-separated UTC", "2006-01-02 15:04:05Z", "<date>"),
+    ("date - datetime space-separated w offset", "2006-01-02 15:04:05+01:00", "<date>"),
     ("date - datetime T-separated", "2006-01-02T15:04:05", "<date>"),
     ("date - datetime T-separated UTC", "2006-01-02T15:04:05Z", "<date>"),
     ("date - datetime T-separated w offset", "2006-01-02T15:04:05+01:00", "<date>"),
+    ("date - datetime compressed space-separated", "20060102 150405", "<date>"),
+    ("date - datetime compressed space-separated UTC", "20060102 150405Z", "<date>"),
+    ("date - datetime compressed space-separated w offset", "20060102 150405+0100", "<date>"),
+    ("date - datetime compressed T-separated", "20060102T150405", "<date>"),
+    ("date - datetime compressed T-separated UTC", "20060102T150405Z", "<date>"),
+    ("date - datetime compressed T-separated w offset", "20060102T150405+0100", "<date>"),
     ("date - kitchen", "3:04PM", "<date>"),
     ("date - time", "15:04:05", "<date>"),
     ("date - basic", "Mon Jan 02, 1999", "<date>"),
@@ -200,54 +208,6 @@ def test_experimental_parameterization(
 # parameterization. (Remember to remove the last item in each tuple for the cases you fix.)
 incorrect_cases = [
     # ("name", "input", "desired", "actual")
-    (
-        "date - datetime space-separated UTC",
-        "2006-01-02 15:04:05Z",
-        "<date>",
-        "<date>Z",
-    ),
-    (
-        "date - datetime space-separated w offset",
-        "2006-01-02 15:04:05+01:00",
-        "<date>",
-        "<date>+<int>:<int>",
-    ),
-    (
-        "date - datetime compressed space-separated",
-        "20060102 150405",
-        "<date>",
-        "<hex> <int>",
-    ),
-    (
-        "date - datetime compressed space-separated UTC",
-        "20060102 150405Z",
-        "<date>",
-        "<hex> 150405Z",
-    ),
-    (
-        "date - datetime compressed space-separated w offset",
-        "20060102 150405+0100",
-        "<date>",
-        "<hex> <int>+<int>",
-    ),
-    (
-        "date - datetime compressed T-separated",
-        "20060102T150405",
-        "<date>",
-        "20060102T150405",
-    ),
-    (
-        "date - datetime compressed T-separated UTC",
-        "20060102T150405Z",
-        "<date>",
-        "20060102T150405Z",
-    ),
-    (
-        "date - datetime compressed T-separated w offset",
-        "20060102T150405+0100",
-        "<date>",
-        "20060102T150405+<int>",
-    ),
     (
         "git sha",
         "commit a93c7d2",


### PR DESCRIPTION
This refactors our datetime parameterization regexes to combine one set of the "old, potentially-removable" patterns (which has been spotted in the wild, so no, we can't remove it) with the current dash-optional pattern, and then expands the resulting pattern set so the colons in the time are optional as well. It then splits the set in two for greater readability. The resulting pattern set now handles the following:

- Date with or without dashes and time with or without colons

- Date and time separated either by a space or by `T`

- Decimal seconds, integer seconds, or no seconds

- Timezone information given as offset, as `Z` (UTC), or not given at all