### PR TITLE
feat(insights): Add platformized cache module with conditional rendering

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/caches/caches.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/caches/caches.ts
@@ -1,10 +1,114 @@
+import {t} from 'sentry/locale';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/caches/settings';
+import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
+import {SpanFields} from 'sentry/views/insights/types';
+
+const BASE_CONDITION = `${SpanFields.SPAN_OP}:[cache.get,cache.get_item]`;
+
+const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
+  [
+    {
+      id: 'cache-hits-widget',
+      title: t('Miss Rate'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: '',
+          aggregates: [
+            `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
+          ],
+          columns: [],
+          fields: [
+            `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
+          ],
+          conditions: BASE_CONDITION,
+          orderby: `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
+          fieldMeta: [{valueType: 'percentage', valueUnit: null}],
+        },
+      ],
+    },
+    {
+      id: 'throughput-widget',
+      title: t('Throughput'),
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.SPANS,
+      interval: '5m',
+      queries: [
+        {
+          name: '',
+          aggregates: ['epm()'],
+          columns: [],
+          fields: ['epm()'],
+          conditions: BASE_CONDITION,
+          orderby: 'epm()',
+        },
+      ],
+    },
+  ],
+  0
+);
+
+const TRANSACTION_TABLE: Widget = {
+  id: 'transaction-table',
+  title: t('Transactions'),
+  displayType: DisplayType.TABLE,
+  widgetType: WidgetType.SPANS,
+  interval: '5m',
+  queries: [
+    {
+      name: '',
+      fields: [
+        SpanFields.TRANSACTION,
+        SpanFields.PROJECT,
+        `avg(${SpanFields.CACHE_ITEM_SIZE})`,
+        'epm()',
+        `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
+        `sum(${SpanFields.SPAN_DURATION})`,
+      ],
+      aggregates: [
+        `avg(${SpanFields.CACHE_ITEM_SIZE})`,
+        'epm()',
+        `equation|count_if(${SpanFields.CACHE_HIT},equals,false) / count(${SpanFields.SPAN_DURATION})`,
+        `sum(${SpanFields.SPAN_DURATION})`,
+      ],
+      columns: [SpanFields.TRANSACTION, SpanFields.PROJECT],
+      fieldAliases: [
+        t('Transaction'),
+        t('Project'),
+        t('Avg Value Size'),
+        t('Requests Per Minute'),
+        t('Miss Rate'),
+        t('Time Spent'),
+      ],
+      fieldMeta: [
+        null,
+        null,
+        null,
+        null,
+        {valueType: 'percentage', valueUnit: null},
+        null,
+      ],
+      conditions: BASE_CONDITION,
+      orderby: `-sum(${SpanFields.SPAN_DURATION})`,
+    },
+  ],
+  layout: {
+    x: 0,
+    y: 3,
+    w: 6,
+    h: 6,
+    minH: 6,
+  },
+};
 
 export const CACHES_PREBUILT_CONFIG: PrebuiltDashboard = {
   dateCreated: '',
   projects: [],
   title: DASHBOARD_TITLE,
   filters: {},
-  widgets: [],
+  widgets: [...FIRST_ROW_WIDGETS, TRANSACTION_TABLE],
 };

--- a/static/app/views/insights/cache/utils/useHasPlatformizedCaches.tsx
+++ b/static/app/views/insights/cache/utils/useHasPlatformizedCaches.tsx
@@ -1,0 +1,12 @@
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+
+export function useHasPlatformizedCaches() {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  return (
+    organization.features.includes('insights-cache-dashboard-migration') ||
+    location.query.usePlatformizedView === '1'
+  );
+}

--- a/static/app/views/insights/cache/views/cacheLandingPage.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.tsx
@@ -15,6 +15,8 @@ import {
 } from 'sentry/views/insights/cache/components/tables/transactionsTable';
 import {Referrer} from 'sentry/views/insights/cache/referrers';
 import {BASE_FILTERS} from 'sentry/views/insights/cache/settings';
+import {useHasPlatformizedCaches} from 'sentry/views/insights/cache/utils/useHasPlatformizedCaches';
+import {PlatformizedCachesOverview} from 'sentry/views/insights/cache/views/platformizedOverview';
 import {ModuleFeature} from 'sentry/views/insights/common/components/moduleFeature';
 import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLayout';
 import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modulePageFilterBar';
@@ -137,9 +139,14 @@ export function CacheLandingPage() {
 }
 
 function PageWithProviders() {
+  const hasPlatformizedCaches = useHasPlatformizedCaches();
   const maxPickableDays = useMaxPickableDays({
     dataCategories: [DataCategory.SPANS],
   });
+
+  if (hasPlatformizedCaches) {
+    return <PlatformizedCachesOverview />;
+  }
 
   return (
     <ModulePageProviders

--- a/static/app/views/insights/cache/views/platformizedOverview.tsx
+++ b/static/app/views/insights/cache/views/platformizedOverview.tsx
@@ -1,0 +1,20 @@
+import {DataCategory} from 'sentry/types/core';
+import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
+import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
+
+export function PlatformizedCachesOverview() {
+  const maxPickableDays = useMaxPickableDays({
+    dataCategories: [DataCategory.SPANS],
+  });
+
+  return (
+    <ModulePageProviders
+      moduleName="cache"
+      maxPickableDays={maxPickableDays.maxPickableDays}
+    >
+      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.BACKEND_CACHES} />
+    </ModulePageProviders>
+  );
+}


### PR DESCRIPTION
Scaffolds the platformized cache dashboard behind the `insights-cache-dashboard-migration` feature flag, following the same pattern used by the queues module. The insights cache module does some frontend joining under the hood, will implement some solution for that in a future pr.

- Adds `useHasPlatformizedCaches` hook that checks for the feature flag or the `usePlatformizedView=1` query param
- Adds `PlatformizedCachesOverview` component that renders the `BACKEND_CACHES` prebuilt dashboard
- Updates `PageWithProviders` in the cache landing page to conditionally render the platformized version when the flag is enabled
- Populates the `CACHES_PREBUILT_CONFIG` with miss rate, throughput, and transactions table widgets