### PR TITLE
feat(explore): Exclude query-pinned attributes from stats breakdown

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -14,9 +14,16 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_trace_item_attributes import adjust_start_end_window
-from sentry.api.event_search import translate_escape_sequences
+from sentry.api.event_search import (
+    ParenExpression,
+    SearchBoolean,
+    SearchFilter,
+    parse_search_query,
+    translate_escape_sequences,
+)
 from sentry.api.serializers.base import serialize
 from sentry.api.utils import handle_query_errors
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.eap.constants import SUPPORTED_STATS_TYPES
 from sentry.search.eap.resolver import SearchResolver
@@ -34,6 +41,56 @@ logger = logging.getLogger(__name__)
 
 
 MAX_THREADS = 4
+
+
+def _contains_or(tokens):
+    for token in tokens:
+        if isinstance(token, str) and SearchBoolean.is_or_operator(token):
+            return True
+        if isinstance(token, ParenExpression) and _contains_or(token.children):
+            return True
+    return False
+
+
+def _collect_pinned(tokens, pinned):
+    for token in tokens:
+        if isinstance(token, SearchFilter):
+            if (
+                token.operator == "="
+                and not token.is_negation
+                and not token.is_in_filter
+                and isinstance(token.value.raw_value, str)
+                and token.value.raw_value != ""
+                and not token.value.is_wildcard()
+            ):
+                pinned.add(token.key.name)
+        elif isinstance(token, ParenExpression):
+            _collect_pinned(token.children, pinned)
+
+
+def get_pinned_attributes(query: str) -> set[str]:
+    """Return the set of attribute public aliases that are pinned to a single value in the query.
+
+    An attribute is "pinned" when it is filtered with ``=`` to a single non-wildcard value
+    (e.g. ``span.op:db``).  These attributes always show 100% one value in breakdown
+    results and should be excluded.
+
+    If the query contains any ``OR`` operator we conservatively return an empty set
+    because the pinned assumption no longer holds.
+    """
+    if not query:
+        return set()
+    try:
+        tokens = parse_search_query(query)
+    except InvalidSearchQuery:
+        return set()
+
+    if _contains_or(tokens):
+        return set()
+
+    pinned: set[str] = set()
+    _collect_pinned(tokens, pinned)
+    return pinned
 
 
 class TraceItemStatsPaginator:
@@ -161,6 +218,7 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
         def data_fn(offset: int, limit: int):
+            query_string = serialized.get("query", "")
             table_results = get_table_results()
             if not table_results["data"]:
                 return {"data": []}, 0
@@ -176,6 +234,8 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
             except (IndexError, KeyError):
                 return {"data": []}, 0
 
+            pinned_attributes = get_pinned_attributes(query_string)
+
             sanitized_keys = []
             for internal_name in internal_alias_attr_keys:
                 public_alias = SPANS_INTERNAL_TO_PUBLIC_ALIAS_MAPPINGS.get("string", {}).get(
@@ -183,6 +243,9 @@ class OrganizationTraceItemsStatsEndpoint(OrganizationEventsEndpointBase):
                 )
 
                 if public_alias in SPANS_STATS_EXCLUDED_ATTRIBUTES_PUBLIC_ALIAS:
+                    continue
+
+                if public_alias in pinned_attributes:
                     continue
 
                 if value_substring_match:

--- a/src/sentry/api/endpoints/organization_trace_item_stats.py
+++ b/src/sentry/api/endpoints/organization_trace_item_stats.py
@@ -15,15 +15,11 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.endpoints.organization_trace_item_attributes import adjust_start_end_window
 from sentry.api.event_search import (
-    ParenExpression,
-    SearchBoolean,
-    SearchFilter,
-    parse_search_query,
+    get_pinned_attributes,
     translate_escape_sequences,
 )
 from sentry.api.serializers.base import serialize
 from sentry.api.utils import handle_query_errors
-from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.search.eap.constants import SUPPORTED_STATS_TYPES
 from sentry.search.eap.resolver import SearchResolver
@@ -41,56 +37,6 @@ logger = logging.getLogger(__name__)
 
 
 MAX_THREADS = 4
-
-
-def _contains_or(tokens):
-    for token in tokens:
-        if isinstance(token, str) and SearchBoolean.is_or_operator(token):
-            return True
-        if isinstance(token, ParenExpression) and _contains_or(token.children):
-            return True
-    return False
-
-
-def _collect_pinned(tokens, pinned):
-    for token in tokens:
-        if isinstance(token, SearchFilter):
-            if (
-                token.operator == "="
-                and not token.is_negation
-                and not token.is_in_filter
-                and isinstance(token.value.raw_value, str)
-                and token.value.raw_value != ""
-                and not token.value.is_wildcard()
-            ):
-                pinned.add(token.key.name)
-        elif isinstance(token, ParenExpression):
-            _collect_pinned(token.children, pinned)
-
-
-def get_pinned_attributes(query: str) -> set[str]:
-    """Return the set of attribute public aliases that are pinned to a single value in the query.
-
-    An attribute is "pinned" when it is filtered with ``=`` to a single non-wildcard value
-    (e.g. ``span.op:db``).  These attributes always show 100% one value in breakdown
-    results and should be excluded.
-
-    If the query contains any ``OR`` operator we conservatively return an empty set
-    because the pinned assumption no longer holds.
-    """
-    if not query:
-        return set()
-    try:
-        tokens = parse_search_query(query)
-    except InvalidSearchQuery:
-        return set()
-
-    if _contains_or(tokens):
-        return set()
-
-    pinned: set[str] = set()
-    _collect_pinned(tokens, pinned)
-    return pinned
 
 
 class TraceItemStatsPaginator:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1898,7 +1898,8 @@ def _contains_or(tokens):
     return False
 
 
-def _collect_pinned(tokens, pinned):
+def _collect_pinned(tokens):
+    pinned: set[str] = set()
     for token in tokens:
         if isinstance(token, SearchFilter):
             if (
@@ -1911,7 +1912,8 @@ def _collect_pinned(tokens, pinned):
             ):
                 pinned.add(token.key.name)
         elif isinstance(token, ParenExpression):
-            _collect_pinned(token.children, pinned)
+            pinned.update(_collect_pinned(token.children))
+    return pinned
 
 
 def get_pinned_attributes(query: str) -> set[str]:
@@ -1933,6 +1935,4 @@ def get_pinned_attributes(query: str) -> set[str]:
     if _contains_or(tokens):
         return set()
 
-    pinned: set[str] = set()
-    _collect_pinned(tokens, pinned)
-    return pinned
+    return _collect_pinned(tokens)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1887,3 +1887,52 @@ def parse_search_query(
         get_field_type=get_field_type,
         get_function_result_type=get_function_result_type,
     ).visit(tree)
+
+
+def _contains_or(tokens):
+    for token in tokens:
+        if isinstance(token, str) and SearchBoolean.is_or_operator(token):
+            return True
+        if isinstance(token, ParenExpression) and _contains_or(token.children):
+            return True
+    return False
+
+
+def _collect_pinned(tokens, pinned):
+    for token in tokens:
+        if isinstance(token, SearchFilter):
+            if (
+                token.operator == "="
+                and not token.is_negation
+                and not token.is_in_filter
+                and isinstance(token.value.raw_value, str)
+                and token.value.raw_value != ""
+                and not token.value.is_wildcard()
+            ):
+                pinned.add(token.key.name)
+        elif isinstance(token, ParenExpression):
+            _collect_pinned(token.children, pinned)
+
+
+def get_pinned_attributes(query: str) -> set[str]:
+    """Return the set of attribute names that are pinned to a single value in the query.
+
+    An attribute is "pinned" when it is filtered with ``=`` to a single non-wildcard value
+    (e.g. ``span.op:db``).
+
+    If the query contains any ``OR`` operator we conservatively return an empty set
+    because the pinned assumption no longer holds.
+    """
+    if not query:
+        return set()
+    try:
+        tokens = parse_search_query(query)
+    except InvalidSearchQuery:
+        return set()
+
+    if _contains_or(tokens):
+        return set()
+
+    pinned: set[str] = set()
+    _collect_pinned(tokens, pinned)
+    return pinned

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1889,7 +1889,7 @@ def parse_search_query(
     ).visit(tree)
 
 
-def _contains_or(tokens):
+def _contains_or(tokens: Sequence[QueryToken]) -> bool:
     for token in tokens:
         if isinstance(token, str) and SearchBoolean.is_or_operator(token):
             return True
@@ -1898,7 +1898,7 @@ def _contains_or(tokens):
     return False
 
 
-def _collect_pinned(tokens):
+def _collect_pinned(tokens: Sequence[QueryToken]) -> set[str]:
     pinned: set[str] = set()
     for token in tokens:
         if isinstance(token, SearchFilter):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -21,6 +21,7 @@ from sentry.api.event_search import (
     default_config,
     flatten,
     gen_wildcard_value,
+    get_pinned_attributes,
     parse_search_query,
     translate_wildcard_as_clickhouse_pattern,
 )
@@ -1415,3 +1416,27 @@ def test_handles_ends_with_wildcard_op_translations(query, expected) -> None:
     assert isinstance(filters[0], SearchFilter)
     actual = filters[0].to_query_string()
     assert actual == expected
+
+
+class TestGetPinnedAttributes:
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            pytest.param("", set(), id="empty_query"),
+            pytest.param("span.op:db", {"span.op"}, id="single_pinned"),
+            pytest.param(
+                "span.op:db browser.name:chrome",
+                {"span.op", "browser.name"},
+                id="implicit_and",
+            ),
+            pytest.param("span.op:db OR browser.name:chrome", set(), id="or_operator"),
+            pytest.param("span.op:db*", set(), id="wildcard"),
+            pytest.param("!span.op:db", set(), id="negation"),
+            pytest.param("span.op:[db, http]", set(), id="in_filter"),
+            pytest.param("!has:span.op", set(), id="not_has"),
+            pytest.param("(a:1 OR b:2) AND c:3", set(), id="nested_or"),
+            pytest.param("(a:1 b:2) c:3", {"a", "b", "c"}, id="nested_and"),
+        ],
+    )
+    def test_get_pinned_attributes(self, query, expected):
+        assert get_pinned_attributes(query) == expected

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -1,7 +1,5 @@
-import pytest
 from django.urls import reverse
 
-from sentry.api.endpoints.organization_trace_item_stats import get_pinned_attributes
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
@@ -266,27 +264,3 @@ class OrganizationTraceItemsStatsEndpointTest(
                 links[attrs["rel"]] = attrs
 
             assert links["previous"]["results"] == "false"
-
-
-class TestGetPinnedAttributes:
-    @pytest.mark.parametrize(
-        ("query", "expected"),
-        [
-            pytest.param("", set(), id="empty_query"),
-            pytest.param("span.op:db", {"span.op"}, id="single_pinned"),
-            pytest.param(
-                "span.op:db browser.name:chrome",
-                {"span.op", "browser.name"},
-                id="implicit_and",
-            ),
-            pytest.param("span.op:db OR browser.name:chrome", set(), id="or_operator"),
-            pytest.param("span.op:db*", set(), id="wildcard"),
-            pytest.param("!span.op:db", set(), id="negation"),
-            pytest.param("span.op:[db, http]", set(), id="in_filter"),
-            pytest.param("!has:span.op", set(), id="not_has"),
-            pytest.param("(a:1 OR b:2) AND c:3", set(), id="nested_or"),
-            pytest.param("(a:1 b:2) c:3", {"a", "b", "c"}, id="nested_and"),
-        ],
-    )
-    def test_get_pinned_attributes(self, query, expected):
-        assert get_pinned_attributes(query) == expected

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -1,5 +1,7 @@
+import pytest
 from django.urls import reverse
 
+from sentry.api.endpoints.organization_trace_item_stats import get_pinned_attributes
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
@@ -237,3 +239,27 @@ class OrganizationTraceItemsStatsEndpointTest(
                 links[attrs["rel"]] = attrs
 
             assert links["previous"]["results"] == "false"
+
+
+class TestGetPinnedAttributes:
+    @pytest.mark.parametrize(
+        ("query", "expected"),
+        [
+            pytest.param("", set(), id="empty_query"),
+            pytest.param("span.op:db", {"span.op"}, id="single_pinned"),
+            pytest.param(
+                "span.op:db browser.name:chrome",
+                {"span.op", "browser.name"},
+                id="implicit_and",
+            ),
+            pytest.param("span.op:db OR browser.name:chrome", set(), id="or_operator"),
+            pytest.param("span.op:db*", set(), id="wildcard"),
+            pytest.param("!span.op:db", set(), id="negation"),
+            pytest.param("span.op:[db, http]", set(), id="in_filter"),
+            pytest.param("!has:span.op", set(), id="not_has"),
+            pytest.param("(a:1 OR b:2) AND c:3", set(), id="nested_or"),
+            pytest.param("(a:1 b:2) c:3", {"a", "b", "c"}, id="nested_and"),
+        ],
+    )
+    def test_get_pinned_attributes(self, query, expected):
+        assert get_pinned_attributes(query) == expected

--- a/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_stats.py
@@ -178,6 +178,33 @@ class OrganizationTraceItemsStatsEndpointTest(
             item["label"] == "mobile" or item["label"] == "tablet" for item in device_data
         )
 
+    def test_pinned_attribute_excluded_from_breakdown(self) -> None:
+        tags = [
+            ({"browser": "chrome", "device": "desktop"}, 100),
+            ({"browser": "chrome", "device": "mobile"}, 100),
+            ({"browser": "firefox", "device": "tablet"}, 100),
+        ]
+
+        for tag, duration in tags:
+            self._store_span(tags=tag, duration=duration)
+
+        response = self.do_request(
+            query={
+                "query": "browser:chrome",
+                "statsType": ["attributeDistributions"],
+            }
+        )
+        assert response.status_code == 200, response.data
+        assert len(response.data["data"]) == 1
+        attribute_distribution = response.data["data"][0]["attribute_distributions"]["data"]
+
+        # "browser" is pinned by the query filter, so it must be excluded
+        assert "browser" not in attribute_distribution
+        assert "sentry.browser" not in attribute_distribution
+
+        # "device" is not pinned, so it should still appear
+        assert "sentry.device" in attribute_distribution
+
     @override_options({"explore.trace-items.keys.max": 3})
     def test_pagination_with_limit(self) -> None:
         tags = [


### PR DESCRIPTION
When the Explore query filters an attribute to a single non-wildcard value
(e.g. `span.op:db`), that attribute will always show 100% one value in the
breakdown results — it's noise. This parses the query to detect these
"pinned" attributes and excludes them from the stats response.

The parsing logic (`get_pinned_attributes`) lives in `event_search.py`
alongside other query parsing utilities so it's reusable. If the query
contains any `OR` operators we conservatively skip exclusion since the
pinned assumption no longer holds.

Includes unit tests for the parser and an integration test verifying
end-to-end exclusion through the API.