### PR TITLE
fix(grouping): Fix hex parameterization lookahead bug

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -180,13 +180,15 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             # then the <int> pattern would already have caught it. Given that we're here, it didn't,
             # so the only thing we need the lookahead to guard against is it being all letters.
             #
-            # Each regex consists of two parts:
-            # (?=.*[0-9])             The aforementioned lookahead - at least one `0-9` is present
-            # [0-9a-f/A-F]{8 | 16,64}   8 or 16-128 hex characters
-            (\b(?=.*[0-9])[0-9a-f]{8}\b) |
-            (\b(?=.*[0-9])[0-9a-f]{16,128}\b) |
-            (\b(?=.*[0-9])[0-9A-F]{8}\b) |
-            (\b(?=.*[0-9])[0-9A-F]{16,128}\b)
+            # Each regex consists of two parts, the lookahead and the hex characters themselves. For
+            # example, for the lowercase 8-character pattern we have:
+            #     (?=[a-f]*[0-9])     The lookahead - there must be a digit, which may or may not be
+            #                         preceded by some number of hex letters
+            #     [0-9a-f]{8}         The matcher itself - 8 hex characters
+            (\b(?=[a-f]*[0-9])[0-9a-f]{8}\b) |
+            (\b(?=[a-f]*[0-9])[0-9a-f]{16,128}\b) |
+            (\b(?=[A-F]*[0-9])[0-9A-F]{8}\b) |
+            (\b(?=[A-F]*[0-9])[0-9A-F]{16,128}\b)
         """,
     ),
     ParameterizationRegex(name="float", raw_pattern=r"""-\d+\.\d+\b | \b\d+\.\d+\b"""),

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -119,6 +119,8 @@ standard_cases = [
     ("hex without prefix - uppercase, 128 digits", "B0" * 64, "<hex>"),
     ("hex without prefix - lowercase, no numbers", "deadbeef", "deadbeef"),
     ("hex without prefix - uppercase, no numbers", "DEADBEEF", "DEADBEEF"),
+    ("hex without prefix - lowercase, no numbers until later", "deadbeef 123", "deadbeef <int>"),
+    ("hex without prefix - uppercase, no numbers until later", "DEADBEEF 123", "DEADBEEF <int>"),
     ("hex without prefix - no letters, < 8 digits", "1234567", "<int>"),
     ("hex without prefix - no letters, 8+ digits", "12345678", "<hex>"),
     ("git sha - all letters", "commit deadbeef", "commit deadbeef"),
@@ -253,18 +255,6 @@ incorrect_cases = [
         "commit a93c7d2",
         "commit <git_sha>",
         "commit a93c7d2",
-    ),
-    (
-        "hex without prefix - lowercase, no numbers until later",
-        "deadbeef 123",
-        "deadbeef <int>",
-        "<hex> <int>",
-    ),
-    (
-        "hex without prefix - uppercase, no numbers until later",
-        "DEADBEEF 123",
-        "DEADBEEF <int>",
-        "<hex> <int>",
     ),
     (
         "int - number in word",


### PR DESCRIPTION
When we parameterize messages for grouping, and we encounter a value we suspect might be hex (but which lacks the `0x` prefix), we only parameterize it as hex if it contains a number, to prevent parameterizing words that happen to consist of only hex letters. To enforce this, our regex pattern set uses a lookahead like this: `(?=.*[0-9])` - there can be other stuff first, but there must be a number. This turns out to be too permissive, though, in that the "other stuff first" can include the end of the hex value and any amount of other stuff before we get to the number. Thus in a string like `deadbeef dogs are number 1`, we'll match `deadbeef` as hex even though it contains only letters.

To fix this problem, this PR changes the lookahead to be `(?=[a-f]*[0-9])` - there can be other _hex letters_ first, but there must be a number.  This prevents the lookahead from consuming anything past the hex string we're trying to match, and thus correctly recognizes `deadbeef` as not matching the pattern.