### PR TITLE
fix(grouping): Fix ip parameterization false positives

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -57,6 +57,10 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
     ParameterizationRegex(
         name="ip",
         raw_pattern=r"""
+            # This negative lookbehind ensures two things (depending on the pattern):
+            #     - We don't match starting in the middle of a valid set of initial characters
+            #     - We don't match things like `::` when they appear in expressions like `SomeClass::someMethod()`
+            (?<![0-9a-zA-Z_])
             (
                 ([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|
                 ([0-9a-fA-F]{1,4}:){1,7}:|
@@ -74,7 +78,12 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
                 ([0-9a-fA-F]{1,4}:){1,4}:
                 ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
                 (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\b
-            ) |
+            )
+            # This negative lookahead works with the negative lookbehind above to block false
+            # positives on expressions of the form `SomeClass::someMethod()`, ensuring that even if
+            # the class name is valid hex, the method name being invalid will block the match
+            (?![0-9a-zA-Z])
+            |
             (
                 \b((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}
                 (25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\b

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -24,6 +24,8 @@ standard_cases = [
     ("hostname - tld", "example.com", "<hostname>"),
     ("hostname - subdomain", "www.example.net", "<hostname>"),
     ("ip", "0.0.0.0", "<ip>"),
+    ("ip - double colon object property", "Option::unwrap()", "Option::unwrap()"),
+    ("ip - double colon object property including hex", "Bee::buzz()", "Bee::buzz()"),
     (
         "traceparent - header",
         "traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
@@ -277,18 +279,6 @@ incorrect_cases = [
         "4,150,908",
         "<int>",
         "<int>,<int>,<int>",
-    ),
-    (
-        "ip - double colon object property",
-        "Option::unwrap()",
-        "Option::unwrap()",
-        "Option<ip>unwrap()",
-    ),
-    (
-        "ip - double colon object property including hex",
-        "Bee::buzz()",
-        "Bee::buzz()",
-        "<ip>buzz()",
     ),
     (
         "json - double quotes",


### PR DESCRIPTION
Right now, the regex we use to match IP addresses when parameterizing messages for grouping is too permissive, and doesn't restrict what can come immediately before or after what it sees as valid IP addresses. Since `::` by itself is technically a valid IPv6 address, that means we end up matching things we shouldn't, specifically places where `::` is used as part of the language syntax. For example, C++ and Rust use it for class attribute access, and Ruby uses it to access identifiers within a module. In these cases, we're (unfortunately) turning `SomeClass::someMethod` into `SomeClass<ip>someMethod`.

This PR fixes that by adding a negative lookbehind and a negative lookahead to either side of our IPv6 regex patterns, respectively, so that the patterns are now all of the form `<word boundary><negative lookbehind ensuring only valid IPv6 characters><IPv6 pattern><negative lookahead ensuring only valid IPv6 characters><word boundary>`. That way, since `s` is not a valid IPv6 character, the double colon in `SomeClass::someMethod` is not longer matched.

This partially addresses the problems detailed in https://github.com/getsentry/sentry/issues/109301. A second PR, preventing us from parameterizing the message when it's used in a custom title, will fix the rest.