### PR TITLE
ref(seer): Propagate viewer_context to feedback Seer call sites

### DIFF
--- a/src/sentry/feedback/endpoints/organization_feedback_categories.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_categories.py
@@ -26,6 +26,7 @@ from sentry.feedback.lib.seer_api import (
 from sentry.grouping.utils import hash_from_values
 from sentry.models.organization import Organization
 from sentry.seer.seer_setup import has_seer_access
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,8 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI categorization is not available for this organization."}, status=403
             )
+
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             start, end = get_date_range_from_stats_period(
@@ -192,6 +195,7 @@ class OrganizationFeedbackCategoriesEndpoint(OrganizationEndpoint):
                     seer_request,
                     timeout=SEER_TIMEOUT_S,
                     retries=SEER_RETRIES,
+                    viewer_context=viewer_context,
                 )
             except Exception:
                 logger.exception("Seer failed to generate user feedback label groups")

--- a/src/sentry/feedback/endpoints/organization_feedback_summary.py
+++ b/src/sentry/feedback/endpoints/organization_feedback_summary.py
@@ -18,6 +18,7 @@ from sentry.issues.grouptype import FeedbackGroup
 from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.seer.seer_setup import has_seer_access
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 
@@ -35,13 +36,17 @@ SEER_TIMEOUT_S = 30
 SEER_RETRIES = Retry(total=1, backoff_factor=3)  # 1 retry after a 3 second delay.
 
 
-def get_summary_from_seer(feedback_msgs: list[str]) -> str | None:
+def get_summary_from_seer(
+    feedback_msgs: list[str],
+    viewer_context: SeerViewerContext | None = None,
+) -> str | None:
     request_body = SummarizeFeedbacksRequest(feedbacks=feedback_msgs)
     try:
         response = make_summarize_feedbacks_request(
             request_body,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
+            viewer_context=viewer_context,
         )
     except Exception:
         logger.exception(
@@ -89,6 +94,8 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
             return Response(
                 {"detail": "AI summaries are not available for this organization."}, status=403
             )
+
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             start, end = get_date_range_from_stats_period(
@@ -155,7 +162,7 @@ class OrganizationFeedbackSummaryEndpoint(OrganizationEndpoint):
         if len(feedback_msgs) < MIN_FEEDBACKS_TO_SUMMARIZE:
             logger.error("Too few feedbacks to summarize after enforcing the character limit")
 
-        summary = get_summary_from_seer(feedback_msgs)
+        summary = get_summary_from_seer(feedback_msgs, viewer_context=viewer_context)
         if summary is None:
             return Response(
                 {"detail": "Failed to generate a summary for a list of feedbacks"}, status=500

--- a/src/sentry/feedback/usecases/ingest/create_feedback.py
+++ b/src/sentry/feedback/usecases/ingest/create_feedback.py
@@ -27,6 +27,7 @@ from sentry.issues.status_change_message import StatusChangeMessage
 from sentry.models.group import GroupStatus
 from sentry.models.project import Project
 from sentry.seer.seer_setup import has_seer_access
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.signals import first_feedback_received, first_new_feedback_received
 from sentry.types.group import GroupSubStatus
 from sentry.utils import json, metrics
@@ -270,12 +271,16 @@ def create_feedback_issue(
 
     feedback_message = event["contexts"]["feedback"]["message"]
 
+    viewer_context = SeerViewerContext(organization_id=project.organization_id)
+
     # Spam detection.
     is_message_spam = None
     is_spam_enabled = spam_detection_enabled(project)
     if is_spam_enabled:
         # Will be None if the request fails
-        is_message_spam = is_spam_seer(feedback_message, project.organization_id)
+        is_message_spam = is_spam_seer(
+            feedback_message, project.organization_id, viewer_context=viewer_context
+        )
 
         metrics.incr(
             "feedback.create_feedback_issue.seer_spam_detection",
@@ -300,7 +305,12 @@ def create_feedback_issue(
 
     use_ai_title = should_query_seer
     title = truncate_feedback_title(
-        get_feedback_title(feedback_message, project.organization_id, use_ai_title)
+        get_feedback_title(
+            feedback_message,
+            project.organization_id,
+            use_ai_title,
+            viewer_context=viewer_context,
+        )
     )
 
     # Set feedback summary to the title without the "User Feedback: " prefix
@@ -335,7 +345,9 @@ def create_feedback_issue(
     # Generating labels using Seer, which will later be used to categorize feedbacks
     if should_query_seer:
         try:
-            labels = generate_labels(feedback_message, project.organization_id)
+            labels = generate_labels(
+                feedback_message, project.organization_id, viewer_context=viewer_context
+            )
             # This will rarely happen unless the user writes a really long feedback message
             if len(labels) > MAX_AI_LABELS:
                 logger.info(

--- a/src/sentry/feedback/usecases/label_generation.py
+++ b/src/sentry/feedback/usecases/label_generation.py
@@ -1,6 +1,7 @@
 import logging
 
 from sentry.feedback.lib.seer_api import LabelGenerationRequest, make_label_generation_request
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -17,7 +18,11 @@ SEER_RETRIES = 0  # Do not retry since this is called in ingest.
 
 
 @metrics.wraps("feedback.generate_labels")
-def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
+def generate_labels(
+    feedback_message: str,
+    organization_id: int,
+    viewer_context: SeerViewerContext | None = None,
+) -> list[str]:
     """
     Generate labels for a feedback message.
 
@@ -33,6 +38,7 @@ def generate_labels(feedback_message: str, organization_id: int) -> list[str]:
             request,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
+            viewer_context=viewer_context,
         )
     except Exception:
         logger.exception("Seer failed to generate user feedback labels")

--- a/src/sentry/feedback/usecases/spam_detection.py
+++ b/src/sentry/feedback/usecases/spam_detection.py
@@ -4,6 +4,7 @@ from sentry import features
 from sentry.feedback.lib.seer_api import SpamDetectionRequest, make_spam_detection_request
 from sentry.models.project import Project
 from sentry.seer.seer_setup import has_seer_access
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -13,7 +14,11 @@ SEER_RETRIES = 0
 
 
 @metrics.wraps("feedback.spam_detection_seer")
-def is_spam_seer(message: str, organization_id: int) -> bool | None:
+def is_spam_seer(
+    message: str,
+    organization_id: int,
+    viewer_context: SeerViewerContext | None = None,
+) -> bool | None:
     """
     Check if a message is spam using Seer.
 
@@ -30,6 +35,7 @@ def is_spam_seer(message: str, organization_id: int) -> bool | None:
             seer_request,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
+            viewer_context=viewer_context,
         )
     except Exception:
         logger.exception("Seer failed to check if message is spam")

--- a/src/sentry/feedback/usecases/title_generation.py
+++ b/src/sentry/feedback/usecases/title_generation.py
@@ -6,6 +6,7 @@ from sentry.feedback.lib.seer_api import (
     GenerateFeedbackTitleRequest,
     make_title_generation_request,
 )
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,11 @@ def truncate_feedback_title(title: str, max_words: int = 10) -> str:
 
 
 @metrics.wraps("feedback.ai_title_generation")
-def get_feedback_title_from_seer(feedback_message: str, organization_id: int) -> str | None:
+def get_feedback_title_from_seer(
+    feedback_message: str,
+    organization_id: int,
+    viewer_context: SeerViewerContext | None = None,
+) -> str | None:
     """
     Generate an AI-powered title for user feedback using Seer, or None if generation fails.
 
@@ -67,6 +72,7 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
             seer_request,
             timeout=SEER_TIMEOUT_S,
             retries=SEER_RETRIES,
+            viewer_context=viewer_context,
         )
     except Exception:
         return None
@@ -88,11 +94,19 @@ def get_feedback_title_from_seer(feedback_message: str, organization_id: int) ->
         return None
 
 
-def get_feedback_title(feedback_message: str, organization_id: int, use_seer: bool) -> str:
+def get_feedback_title(
+    feedback_message: str,
+    organization_id: int,
+    use_seer: bool,
+    viewer_context: SeerViewerContext | None = None,
+) -> str:
     if use_seer:
         # Message is fallback if Seer fails.
         raw_title = (
-            get_feedback_title_from_seer(feedback_message, organization_id) or feedback_message
+            get_feedback_title_from_seer(
+                feedback_message, organization_id, viewer_context=viewer_context
+            )
+            or feedback_message
         )
     else:
         raw_title = feedback_message

--- a/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
+++ b/tests/sentry/feedback/usecases/ingest/test_create_feedback.py
@@ -779,7 +779,10 @@ def test_create_feedback_issue_title(
     create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     mock_get_feedback_title.assert_called_once_with(
-        long_message, default_project.organization_id, False
+        long_message,
+        default_project.organization_id,
+        False,
+        viewer_context={"organization_id": default_project.organization_id},
     )
     assert mock_produce_occurrence_to_kafka.call_count == 1
     call_args = mock_produce_occurrence_to_kafka.call_args
@@ -812,7 +815,10 @@ def test_create_feedback_issue_title_from_seer(
     create_feedback_issue(event, default_project, FeedbackCreationSource.NEW_FEEDBACK_ENVELOPE)
 
     mock_get_feedback_title.assert_called_once_with(
-        "The login button is broken and the UI is slow", default_project.organization_id, True
+        "The login button is broken and the UI is slow",
+        default_project.organization_id,
+        True,
+        viewer_context={"organization_id": default_project.organization_id},
     )
 
     assert mock_produce_occurrence_to_kafka.call_count == 1


### PR DESCRIPTION
Pass `SeerViewerContext` to all Seer API wrapper call sites in the feedback module.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates the call sites in the feedback module to construct and pass `SeerViewerContext` from available org/user data:

- **Endpoints** (`organization_feedback_categories`, `organization_feedback_summary`): Pass both `organization_id` and `user_id`
- **Ingest** (`create_feedback`): Pass `organization_id` only (no user in ingest context)
- **Intermediate functions** (`spam_detection`, `label_generation`, `title_generation`): Thread `viewer_context` parameter through to underlying API calls

No behavior change — `viewer_context` defaults to `None` which preserves the existing behavior of not sending the header.

Co-Authored-By: Claude <noreply@anthropic.com>