### PR TITLE
ref(seer): Propagate viewer_context to explorer Seer call sites

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -32,6 +32,7 @@ from sentry.seer.explorer.on_completion_hook import (
 )
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.users.models.user import User
 
 logger = logging.getLogger(__name__)
@@ -207,6 +208,8 @@ class SeerExplorerClient:
 
         self.enable_coding = enable_coding
 
+        self.viewer_context = self._build_viewer_context()
+
         # Validate that category_key and category_value are provided together
         if category_key == "" or category_value == "":
             raise ValueError("category_key and category_value cannot be empty strings")
@@ -217,6 +220,12 @@ class SeerExplorerClient:
         has_access, error = has_seer_access_with_detail(organization, user)
         if not has_access:
             raise SeerPermissionError(error or "Access denied")
+
+    def _build_viewer_context(self) -> SeerViewerContext:
+        context = SeerViewerContext(organization_id=self.organization.id)
+        if self.user and hasattr(self.user, "id") and self.user.id is not None:
+            context["user_id"] = self.user.id
+        return context
 
     def start_run(
         self,
@@ -298,7 +307,7 @@ class SeerExplorerClient:
         ):
             chat_body["is_context_engine_enabled"] = True
 
-        response = make_explorer_chat_request(chat_body)
+        response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -361,7 +370,7 @@ class SeerExplorerClient:
         ):
             chat_body["is_context_engine_enabled"] = True
 
-        response = make_explorer_chat_request(chat_body)
+        response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -485,7 +494,7 @@ class SeerExplorerClient:
         if end is not None:
             runs_body["end"] = end
 
-        response = make_explorer_runs_request(runs_body)
+        response = make_explorer_runs_request(runs_body, viewer_context=self.viewer_context)
 
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
@@ -533,7 +542,7 @@ class SeerExplorerClient:
             organization_id=self.organization.id,
             payload=payload,
         )
-        response = make_explorer_update_request(update_body)
+        response = make_explorer_update_request(update_body, viewer_context=self.viewer_context)
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
 

--- a/src/sentry/seer/explorer/explorer_service_map_utils.py
+++ b/src/sentry/seer/explorer/explorer_service_map_utils.py
@@ -21,7 +21,11 @@ from sentry import options
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import ServiceMapUpdateRequest, make_service_map_update_request
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    ServiceMapUpdateRequest,
+    make_service_map_update_request,
+)
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 
@@ -308,6 +312,7 @@ def _send_to_seer(org_id: int, nodes: list[dict], edges: list[dict]) -> None:
         },
     )
 
-    response = make_service_map_update_request(body, timeout=30)
+    viewer_context = SeerViewerContext(organization_id=org_id)
+    response = make_service_map_update_request(body, timeout=30, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer service map update failed", response.status)


### PR DESCRIPTION
Pass `SeerViewerContext` to all Seer API wrapper call sites in the explorer module.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates the explorer module call sites:

- **SeerExplorerClient**: Builds context from `self.organization` and `self.user` in `__init__`, passes to `start_run`, `continue_run`, `get_runs`, `push_changes`
- **Service map utils** (`_send_to_seer`): Pass `organization_id` only (no user available)

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>