### PR TITLE
ref(seer): Propagate viewer_context to code review Seer call sites

### DIFF
--- a/src/sentry/seer/code_review/webhooks/task.py
+++ b/src/sentry/seer/code_review/webhooks/task.py
@@ -16,6 +16,7 @@ from sentry.seer.code_review.models import (
     SeerCodeReviewTaskRequestForPrReview,
 )
 from sentry.seer.code_review.utils import transform_webhook_to_codegen_request
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_code_review_tasks
@@ -131,7 +132,10 @@ def process_github_webhook_event(
         if tags:
             sentry_sdk.set_tags(tags)
         path = get_seer_endpoint_for_event(github_event).value
-        make_seer_request(path=path, payload=event_payload)
+        viewer_context: SeerViewerContext | None = None
+        if tags and (org_id := tags.get("sentry_organization_id")):
+            viewer_context = SeerViewerContext(organization_id=int(org_id))
+        make_seer_request(path=path, payload=event_payload, viewer_context=viewer_context)
     except Exception as e:
         status = e.__class__.__name__
         # Retryable errors are automatically retried by taskworker.


### PR DESCRIPTION
Pass `SeerViewerContext` to the Seer API call site in the code review webhook task.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates `process_github_webhook_event()` to extract `sentry_organization_id` from the tags dict and construct a `SeerViewerContext` when available.

No behavior change — if tags are missing or don't contain the org ID, `viewer_context` remains `None`.

Co-Authored-By: Claude <noreply@anthropic.com>