### PR TITLE
ref(seer): Propagate viewer_context to breakpoints Seer call sites

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends_v2.py
+++ b/src/sentry/api/endpoints/organization_events_trends_v2.py
@@ -1,5 +1,6 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 
 import sentry_sdk
 from rest_framework.exceptions import ParseError
@@ -18,6 +19,7 @@ from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.constants import METRICS_GRANULARITIES
 from sentry.seer.breakpoints import detect_breakpoints
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba import metrics_performance
 from sentry.snuba.discover import create_result_key, zerofill
 from sentry.snuba.metrics_performance import query as metrics_query
@@ -75,6 +77,8 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
+
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -281,7 +285,12 @@ class OrganizationEventsNewTrendsStatsEndpoint(OrganizationEventsEndpointBase):
 
             # send the data to microservice
             with ThreadPoolExecutor(thread_name_prefix=__name__) as query_thread_pool:
-                results = list(query_thread_pool.map(detect_breakpoints, trends_requests))
+                results = list(
+                    query_thread_pool.map(
+                        partial(detect_breakpoints, viewer_context=viewer_context),
+                        trends_requests,
+                    )
+                )
             trend_results = []
 
             # append all the results

--- a/src/sentry/api/endpoints/organization_profiling_functions.py
+++ b/src/sentry/api/endpoints/organization_profiling_functions.py
@@ -20,6 +20,7 @@ from sentry.models.organization import Organization
 from sentry.search.events.builder.profile_functions import ProfileTopFunctionsTimeseriesQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig
 from sentry.seer.breakpoints import BreakpointData, BreakpointRequest, detect_breakpoints
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba import functions
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -80,6 +81,8 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsEndpointBase
     def get(self, request: Request, organization: Organization) -> Response:
         if not self.has_feature(organization, request):
             return Response(status=404)
+
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
 
         try:
             snuba_params = self.get_snuba_params(request, organization)
@@ -186,7 +189,7 @@ class OrganizationProfilingFunctionTrendsEndpoint(OrganizationEventsEndpointBase
                 "sort": data["trend"].as_sort(),
             }
 
-            return detect_breakpoints(trends_request)["data"]
+            return detect_breakpoints(trends_request, viewer_context=viewer_context)["data"]
 
         stats_data = self.get_event_stats_data(
             request,

--- a/src/sentry/seer/breakpoints.py
+++ b/src/sentry/seer/breakpoints.py
@@ -84,8 +84,11 @@ def make_breakpoint_detection_request(
     )
 
 
-def detect_breakpoints(breakpoint_request: BreakpointRequest) -> BreakpointResponse:
-    response = make_breakpoint_detection_request(breakpoint_request)
+def detect_breakpoints(
+    breakpoint_request: BreakpointRequest,
+    viewer_context: SeerViewerContext | None = None,
+) -> BreakpointResponse:
+    response = make_breakpoint_detection_request(breakpoint_request, viewer_context=viewer_context)
 
     if response.status >= 200 and response.status < 300:
         try:

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -30,6 +30,7 @@ from sentry.seer.breakpoints import (
     BreakpointTransaction,
     detect_breakpoints,
 )
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.statistical_detectors.algorithm import DetectorAlgorithm
 from sentry.statistical_detectors.base import DetectorPayload, DetectorState, TrendType
 from sentry.statistical_detectors.issue_platform_adapter import fingerprint_regression
@@ -221,6 +222,7 @@ class RegressionDetector(ABC):
         start: datetime,
         function: str,
         timeseries_per_batch=10,
+        viewer_context: SeerViewerContext | None = None,
     ) -> Generator[BreakpointData]:
         serializer = SnubaTSResultSerializer(None, None, None)
 
@@ -253,7 +255,7 @@ class RegressionDetector(ABC):
             }
 
             try:
-                yield from detect_breakpoints(request)["data"]
+                yield from detect_breakpoints(request, viewer_context=viewer_context)["data"]
             except Exception as e:
                 sentry_sdk.capture_exception(e)
                 metrics.incr(

--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -38,6 +38,7 @@ from sentry.profiles.utils import get_from_profiling_service
 from sentry.search.events.fields import resolve_datetime64
 from sentry.search.events.types import SnubaParams
 from sentry.seer.breakpoints import BreakpointData
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba import functions
@@ -393,8 +394,17 @@ def _detect_transaction_change_points(
         (projects_by_id[item[0]], item[1]) for item in transactions if item[0] in projects_by_id
     ]
 
+    viewer_context = None
+    if transaction_pairs:
+        project = transaction_pairs[0][0]
+        viewer_context = SeerViewerContext(organization_id=project.organization_id)
+
     regressions = EndpointRegressionDetector.detect_regressions(
-        transaction_pairs, start, "p95(transaction.duration)", TIMESERIES_PER_BATCH
+        transaction_pairs,
+        start,
+        "p95(transaction.duration)",
+        TIMESERIES_PER_BATCH,
+        viewer_context=viewer_context,
     )
     regressions = EndpointRegressionDetector.save_regressions_with_versions(regressions)
 
@@ -483,8 +493,13 @@ def _detect_function_change_points(
         (projects_by_id[item[0]], item[1]) for item in functions_list if item[0] in projects_by_id
     ]
 
+    viewer_context = None
+    if function_pairs:
+        project = function_pairs[0][0]
+        viewer_context = SeerViewerContext(organization_id=project.organization_id)
+
     regressions = FunctionRegressionDetector.detect_regressions(
-        function_pairs, start, "p95()", TIMESERIES_PER_BATCH
+        function_pairs, start, "p95()", TIMESERIES_PER_BATCH, viewer_context=viewer_context
     )
     regressions = FunctionRegressionDetector.save_regressions_with_versions(regressions)
 


### PR DESCRIPTION
Pass `SeerViewerContext` through breakpoint detection to all call sites.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR threads it through `detect_breakpoints()` and updates all callers:

- **Endpoints** (`organization_events_trends_v2`, `organization_profiling_functions`): Pass both `organization_id` and `user_id`
- **Statistical detector tasks**: Pass `organization_id` only (background task, no user)
- Uses `functools.partial` for `ThreadPoolExecutor.map` compatibility in trends endpoint

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>