### PR TITLE
ref(seer): Propagate viewer_context to similarity Seer call sites

### DIFF
--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -16,6 +16,7 @@ from sentry.grouping.ingest.grouphash_metadata import (
 from sentry.grouping.variants import BaseVariant
 from sentry.models.grouphash import GroupHash
 from sentry.models.project import Project
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.similarity.config import (
     get_grouping_model_version,
     get_new_model_version,
@@ -347,9 +348,11 @@ def get_seer_similar_issues(
 
     request_data, seer_request_metric_tags = _build_seer_request(event, variants)
 
+    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
     seer_results = get_similarity_data_from_seer(
         request_data,
         {**seer_request_metric_tags, "hybrid_fingerprint": event_has_hybrid_fingerprint},
+        viewer_context=viewer_context,
     )
 
     # All of these will get overridden if we find a usable match
@@ -415,7 +418,9 @@ def get_seer_similar_issues(
 
         # We only want this for the side effect, and we know it'll return no matches, so we don't
         # bother to capture the return value.
-        get_similarity_data_from_seer(request_data, seer_request_metric_tags)
+        get_similarity_data_from_seer(
+            request_data, seer_request_metric_tags, viewer_context=viewer_context
+        )
 
     is_hybrid_fingerprint_case = (
         event_has_hybrid_fingerprint
@@ -644,8 +649,11 @@ def maybe_send_seer_for_new_model_training(
 
     request_data, metric_tags = _build_seer_request(event, variants, training_mode=True)
 
+    viewer_context = SeerViewerContext(organization_id=event.project.organization_id)
     try:
-        get_similarity_data_from_seer(request_data, metric_tags, raise_on_error=True)
+        get_similarity_data_from_seer(
+            request_data, metric_tags, raise_on_error=True, viewer_context=viewer_context
+        )
     except Exception as e:
         sentry_sdk.capture_exception(
             e,

--- a/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
+++ b/src/sentry/issues/endpoints/group_similar_issues_embeddings.py
@@ -18,6 +18,7 @@ from sentry.grouping.grouping_info import get_grouping_info_from_variants_legacy
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.models.group import Group
 from sentry.models.grouphash import GroupHash
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.similarity.config import get_grouping_model_version
 from sentry.seer.similarity.similar_issues import get_similarity_data_from_seer
 from sentry.seer.similarity.types import SeerSimilarIssueData, SimilarIssuesEmbeddingsRequest
@@ -138,7 +139,12 @@ class GroupSimilarIssuesEmbeddingsEndpoint(GroupEndpoint):
 
         logger.info("Similar issues embeddings parameters", extra=similar_issues_params)
 
-        results = get_similarity_data_from_seer(similar_issues_params)
+        viewer_context = SeerViewerContext(
+            organization_id=group.project.organization.id, user_id=request.user.id
+        )
+        results = get_similarity_data_from_seer(
+            similar_issues_params, viewer_context=viewer_context
+        )
 
         analytics.record(
             GroupSimilarIssuesEmbeddingsCountEvent(

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -15,6 +15,11 @@ from sentry.utils import metrics
 
 class SeerViewerContext(TypedDict, total=False):
     organization_id: int
+    # TODO(jeremy.stanley): user_id is int | None as a temporary state while
+    # consolidating viewer context across call sites. Some pass request.user.id
+    # (which can be None for anonymous users), others omit the key entirely.
+    # Once all call sites are wired up, tighten this to int and ensure callers
+    # only set user_id when an authenticated user is present.
     user_id: int | None
 
 

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -60,6 +60,7 @@ def get_similarity_data_from_seer(
     similar_issues_request: SimilarIssuesEmbeddingsRequest,
     metric_tags: Mapping[str, str | int | bool] | None = None,
     raise_on_error: bool = False,
+    viewer_context: SeerViewerContext | None = None,
 ) -> list[SeerSimilarIssueData]:
     """
     Request similar issues data from seer and normalize the results. Returns similar groups
@@ -93,6 +94,7 @@ def get_similarity_data_from_seer(
             retries=options.get("seer.similarity.grouping-ingest-retries"),
             timeout=options.get("seer.similarity.grouping-ingest-timeout"),
             metric_tags={"referrer": referrer} if referrer else {},
+            viewer_context=viewer_context,
         )
     except (TimeoutError, MaxRetryError) as e:
         logger.warning("get_seer_similar_issues.request_error", extra=logger_extra)

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -117,6 +117,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "training_mode": False,
                 "hybrid_fingerprint": False,
             },
+            viewer_context={"organization_id": self.project.organization_id},
         )
 
     @patch("sentry.grouping.ingest.seer.metrics.incr")
@@ -165,6 +166,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                 "training_mode": False,
             }
 
+            viewer_ctx = {"organization_id": self.project.organization_id}
             assert mock_get_similarity_data.call_count == 2
             assert mock_get_similarity_data.mock_calls == [
                 # Initial call to Seer
@@ -181,6 +183,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "training_mode": False,
                         "hybrid_fingerprint": False,
                     },
+                    viewer_context=viewer_ctx,
                 ),
                 # Second call to store the event's data since the match that came back from Seer
                 # wasn't usable
@@ -196,6 +199,7 @@ class GetSeerSimilarIssuesTest(TestCase):
                         "model_version": "v1",
                         "training_mode": False,
                     },
+                    viewer_context=viewer_ctx,
                 ),
             ]
 

--- a/tests/sentry/grouping/seer_similarity/test_seer.py
+++ b/tests/sentry/grouping/seer_similarity/test_seer.py
@@ -69,6 +69,7 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                 "training_mode": False,
                 "hybrid_fingerprint": False,
             },
+            viewer_context={"organization_id": self.project.organization_id},
         )
 
     @patch("sentry.grouping.ingest.seer.record_did_call_seer_metric")
@@ -206,4 +207,5 @@ class MaybeCheckSeerForMatchingGroupHashTest(TestCase):
                     "training_mode": False,
                     "hybrid_fingerprint": False,
                 },
+                viewer_context={"organization_id": self.project.organization_id},
             )


### PR DESCRIPTION
Pass `SeerViewerContext` through similarity/grouping code to all Seer call sites.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR threads it through `get_similarity_data_from_seer()` and updates all callers:

- **Endpoint** (`group_similar_issues_embeddings`): Pass both `organization_id` and `user_id`
- **Grouping ingest** (`seer.py`): Pass `organization_id` only from `event.project` (no user in ingest context)

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>