### PR TITLE
ref(seer): Propagate viewer_context to anomaly detection Seer call sites

### DIFF
--- a/src/sentry/seer/anomaly_detection/delete_rule.py
+++ b/src/sentry/seer/anomaly_detection/delete_rule.py
@@ -81,8 +81,9 @@ def delete_rule_in_seer(source_id: int, organization: Organization) -> bool:
     extra_data = {
         "source_id": source_id,
     }
+    viewer_context = SeerViewerContext(organization_id=organization.id)
     try:
-        response = make_delete_alert_data_request(body)
+        response = make_delete_alert_data_request(body, viewer_context=viewer_context)
     except (TimeoutError, MaxRetryError):
         logger.warning(
             "Timeout error when hitting Seer delete rule data endpoint",

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -143,7 +143,10 @@ def get_anomaly_data_from_seer(
     extra_data["dataset"] = snuba_query.dataset
     try:
         logger.info("Sending subscription update data to Seer", extra=extra_data)
-        response = make_detect_anomalies_request(detect_anomalies_request)
+        viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
+        response = make_detect_anomalies_request(
+            detect_anomalies_request, viewer_context=viewer_context
+        )
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
         return None
@@ -226,8 +229,9 @@ def get_anomaly_threshold_data_from_seer(
         start=start,
         end=end,
     )
+    viewer_context = SeerViewerContext(organization_id=subscription.project.organization_id)
     try:
-        response = make_get_anomaly_threshold_data_request(body)
+        response = make_get_anomaly_threshold_data_request(body, viewer_context=viewer_context)
     except (TimeoutError, MaxRetryError):
         logger.warning("anomaly_threshold.timeout_error_hitting_seer_endpoint")
         return None

--- a/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
+++ b/src/sentry/seer/anomaly_detection/get_historical_anomalies.py
@@ -136,8 +136,9 @@ def get_historical_anomaly_data_from_seer_preview(
         "config": config,
         "context": context,
     }
+    viewer_context = SeerViewerContext(organization_id=organization_id)
     try:
-        response = make_detect_historical_anomalies_request(body)
+        response = make_detect_historical_anomalies_request(body, viewer_context=viewer_context)
     except (TimeoutError, MaxRetryError):
         logger.warning("Timeout error when hitting anomaly detection endpoint", extra=extra_data)
         return None

--- a/src/sentry/seer/anomaly_detection/store_data.py
+++ b/src/sentry/seer/anomaly_detection/store_data.py
@@ -243,8 +243,9 @@ def send_historical_data_to_seer_legacy(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
+    viewer_context = SeerViewerContext(organization_id=alert_rule.organization.id)
     try:
-        response = make_store_data_request(body)
+        response = make_store_data_request(body, viewer_context=viewer_context)
     # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(

--- a/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
+++ b/src/sentry/seer/anomaly_detection/store_data_workflow_engine.py
@@ -24,6 +24,7 @@ from sentry.seer.anomaly_detection.utils import (
     get_event_types,
     translate_direction,
 )
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.utils import json, metrics
 from sentry.utils.json import JSONDecodeError
@@ -236,8 +237,9 @@ def send_historical_data_to_seer(
             "meta": json.dumps(historical_data.data.get("meta", {}).get("fields", {})),
         },
     )
+    viewer_context = SeerViewerContext(organization_id=project.organization.id)
     try:
-        response = make_store_data_request(body)
+        response = make_store_data_request(body, viewer_context=viewer_context)
     # See SEER_ANOMALY_DETECTION_TIMEOUT in sentry.conf.server.py
     except (TimeoutError, MaxRetryError):
         logger.warning(


### PR DESCRIPTION
Pass `SeerViewerContext` to all Seer API wrapper call sites in anomaly detection.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR constructs context at each call site from available org data:

- `get_anomaly_data.py`: From `subscription.project.organization_id`
- `store_data.py`: From `alert_rule.organization.id`
- `store_data_workflow_engine.py`: From `project.organization.id`
- `delete_rule.py`: From `organization.id`
- `get_historical_anomalies.py`: From `organization_id` parameter

All are background/task contexts with org only (no user).

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>