### PR TITLE
ref(seer): Propagate viewer_context to autofix Seer call sites

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -37,6 +37,7 @@ from sentry.seer.autofix.utils import (
     make_autofix_update_request,
 )
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.ourlogs import OurLogs
@@ -465,7 +466,11 @@ def _call_autofix(
         option=orjson.OPT_NON_STR_KEYS,
     )
 
-    response = make_autofix_start_request(body)
+    viewer_context = SeerViewerContext(organization_id=group.organization.id)
+    if not isinstance(user, AnonymousUser):
+        viewer_context["user_id"] = user.id
+
+    response = make_autofix_start_request(body, viewer_context=viewer_context)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -717,7 +722,8 @@ def update_autofix(
 
     data = AutofixUpdateRequest(organization_id=organization_id, run_id=run_id, payload=payload)
     body = orjson.dumps(data)
-    response = make_autofix_update_request(body)
+    viewer_context = SeerViewerContext(organization_id=organization_id)
+    response = make_autofix_update_request(body, viewer_context=viewer_context)
 
     if response.status >= 400:
         return Response({"detail": "Failed to update autofix run"}, status=500)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -257,7 +257,8 @@ def _call_seer(
         organization_id=group.organization.id,
         project_id=group.project.id,
     )
-    response = make_summarize_issue_request(body, timeout=30)
+    viewer_context = SeerViewerContext(organization_id=group.organization.id)
+    response = make_summarize_issue_request(body, timeout=30, viewer_context=viewer_context)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")
@@ -305,7 +306,10 @@ def _generate_fixability_score(
     )
     if summary is not None:
         body["summary"] = summary
-    response = make_fixability_score_request(body, timeout=settings.SEER_FIXABILITY_TIMEOUT)
+    viewer_context = SeerViewerContext(organization_id=group.organization.id)
+    response = make_fixability_score_request(
+        body, timeout=settings.SEER_FIXABILITY_TIMEOUT, viewer_context=viewer_context
+    )
     if response.status >= 400:
         raise Exception(f"Seer API error: {response.status}")
     response_data = orjson.loads(response.data)

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -461,9 +461,11 @@ def has_project_connected_repos(
 
 def bulk_get_project_preferences(organization_id: int, project_ids: list[int]) -> dict[str, dict]:
     """Bulk fetch Seer project preferences. Returns dict mapping project ID (string) to preference dict."""
+    viewer_context = SeerViewerContext(organization_id=organization_id)
     response = make_bulk_get_project_preferences_request(
         BulkGetProjectPreferencesRequest(organization_id=organization_id, project_ids=project_ids),
         timeout=10,
+        viewer_context=viewer_context,
     )
 
     if response.status >= 400:
@@ -478,9 +480,11 @@ def bulk_set_project_preferences(organization_id: int, preferences: list[dict]) 
     if not preferences:
         return
 
+    viewer_context = SeerViewerContext(organization_id=organization_id)
     response = make_bulk_set_project_preferences_request(
         BulkSetProjectPreferencesRequest(organization_id=organization_id, preferences=preferences),
         timeout=15,
+        viewer_context=viewer_context,
     )
 
     if response.status >= 400:
@@ -532,7 +536,8 @@ def get_autofix_state(
         check_repo_access=check_repo_access,
         is_user_fetching=is_user_fetching,
     )
-    response = make_get_autofix_state_request(body)
+    viewer_context = SeerViewerContext(organization_id=organization_id)
+    response = make_get_autofix_state_request(body, viewer_context=viewer_context)
 
     if response.status >= 400:
         raise Exception(f"Seer request failed with status {response.status}")

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -21,7 +21,7 @@ from sentry.seer.autofix.utils import (
     make_set_project_preference_request,
 )
 from sentry.seer.models import PreferenceResponse, SeerApiError, SeerProjectPreference
-from sentry.seer.signed_seer_api import seer_autofix_default_connection_pool
+from sentry.seer.signed_seer_api import SeerViewerContext, seer_autofix_default_connection_pool
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -140,8 +140,13 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
                 }
             ).dict(),
         )
+        viewer_context = SeerViewerContext(
+            organization_id=project.organization.id, user_id=request.user.id
+        )
         response = make_set_project_preference_request(
-            body, connection_pool=seer_autofix_default_connection_pool
+            body,
+            connection_pool=seer_autofix_default_connection_pool,
+            viewer_context=viewer_context,
         )
 
         if response.status >= 400:
@@ -151,8 +156,13 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
 
     def get(self, request: Request, project: Project) -> Response:
         body = GetProjectPreferenceRequest(project_id=project.id)
+        viewer_context = SeerViewerContext(
+            organization_id=project.organization.id, user_id=request.user.id
+        )
         response = make_get_project_preference_request(
-            body, connection_pool=seer_autofix_default_connection_pool
+            body,
+            connection_pool=seer_autofix_default_connection_pool,
+            viewer_context=viewer_context,
         )
 
         if response.status >= 400:

--- a/src/sentry/tasks/seer.py
+++ b/src/sentry/tasks/seer.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import logging
 
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import RemoveRepositoryRequest, make_remove_repository_request
+from sentry.seer.signed_seer_api import (
+    RemoveRepositoryRequest,
+    SeerViewerContext,
+    make_remove_repository_request,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
@@ -33,8 +37,9 @@ def cleanup_seer_repository_preferences(
         repo_external_id=repo_external_id,
     )
 
+    viewer_context = SeerViewerContext(organization_id=organization_id)
     try:
-        response = make_remove_repository_request(body)
+        response = make_remove_repository_request(body, viewer_context=viewer_context)
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
         logger.info(


### PR DESCRIPTION
Pass `SeerViewerContext` to all Seer API wrapper call sites in the autofix module.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates autofix call sites:

- **`_call_autofix()`**: Pass `organization_id` + `user_id` (when not anonymous)
- **`update_autofix()`**: Pass `organization_id` only
- **`utils.py`** (`get_autofix_state`, `bulk_get/set_project_preferences`): Pass `organization_id` only
- **`issue_summary.py`** (`_call_seer`, `_generate_fixability_score`): Pass `organization_id` from group
- **`project_seer_preferences` endpoint**: Pass both `organization_id` and `user_id`
- **`tasks/seer.py`** (`cleanup_seer_repository_preferences`): Pass `organization_id` only
- **Skipped**: `_fetch_user_preference` (only has `project_id`, no org context)

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>