### PR TITLE
ref(seer): Propagate viewer_context to Seer endpoint call sites

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_ranked.py
@@ -30,6 +30,7 @@ from sentry.search.eap.types import SearchResolverConfig, SupportedTraceItemType
 from sentry.search.eap.utils import can_expose_attribute, translate_internal_to_public_alias
 from sentry.search.events import fields
 from sentry.seer.endpoints.compare import compare_distributions
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils import snuba_rpc
@@ -104,6 +105,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             {"referrer": Referrer.API_TRACE_EXPLORER_STATS.value},
         )
 
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
         scored_attrs_rrr = compare_distributions(
             baseline=cohort_2_distribution,
             outliers=cohort_1_distribution,
@@ -116,6 +118,7 @@ class OrganizationTraceItemsAttributesRankedEndpoint(OrganizationEventsEndpointB
             meta={
                 "referrer": Referrer.API_TRACE_EXPLORER_STATS.value,
             },
+            viewer_context=viewer_context,
         )
         logger.info("scored_attrs_rrr: %s", scored_attrs_rrr)
 

--- a/src/sentry/seer/endpoints/compare.py
+++ b/src/sentry/seer/endpoints/compare.py
@@ -6,6 +6,7 @@ from typing import Any
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     CompareDistributionsRequest,
+    SeerViewerContext,
     make_compare_distributions_request,
 )
 from sentry.utils.json import JSONDecodeError
@@ -20,6 +21,7 @@ def compare_distributions(
     total_outliers: int,
     config: dict[str, Any],
     meta: dict[str, Any],
+    viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
     Sends a request to seer to compare two distributions and rank their attributes by suspisiouness
@@ -33,7 +35,7 @@ def compare_distributions(
         config=config,
         meta=meta,
     )
-    response = make_compare_distributions_request(body)
+    response = make_compare_distributions_request(body, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     try:

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -13,7 +13,11 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import LlmGenerateRequest, make_llm_generate_request
+from sentry.seer.signed_seer_api import (
+    LlmGenerateRequest,
+    SeerViewerContext,
+    make_llm_generate_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +35,9 @@ class IssueViewTitleGeneratePermission(OrganizationPermission):
     }
 
 
-def generate_title_from_query(query: str) -> str | None:
+def generate_title_from_query(
+    query: str, viewer_context: SeerViewerContext | None = None
+) -> str | None:
     truncated_query = query[:MAX_QUERY_LENGTH] if len(query) > MAX_QUERY_LENGTH else query
 
     body = LlmGenerateRequest(
@@ -43,7 +49,7 @@ def generate_title_from_query(query: str) -> str | None:
         temperature=0.3,
         max_tokens=50,
     )
-    response = make_llm_generate_request(body, timeout=10)
+    response = make_llm_generate_request(body, timeout=10, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     data = response.json()
@@ -81,7 +87,10 @@ class IssueViewTitleGenerateEndpoint(OrganizationEndpoint):
             )
 
         try:
-            title = generate_title_from_query(query)
+            viewer_context = SeerViewerContext(
+                organization_id=organization.id, user_id=request.user.id
+            )
+            title = generate_title_from_query(query, viewer_context=viewer_context)
             if not title:
                 return Response(
                     {"detail": "Failed to generate title"},

--- a/src/sentry/seer/endpoints/search_agent_start.py
+++ b/src/sentry/seer/endpoints/search_agent_start.py
@@ -18,7 +18,11 @@ from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplo
 from sentry.seer.explorer.client_utils import collect_user_org_context
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import SearchAgentStartRequest, make_search_agent_start_request
+from sentry.seer.signed_seer_api import (
+    SearchAgentStartRequest,
+    SeerViewerContext,
+    make_search_agent_start_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +67,7 @@ def send_search_agent_start_request(
     user_email: str | None = None,
     timezone: str | None = None,
     model_name: str | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> dict[str, Any]:
     """
     Sends a request to Seer to start an async search agent and returns a run_id for polling.
@@ -85,7 +90,7 @@ def send_search_agent_start_request(
     if options:
         body["options"] = options
 
-    response = make_search_agent_start_request(body, timeout=30)
+    response = make_search_agent_start_request(body, timeout=30, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -157,6 +162,9 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
         timezone = user_org_context.get("user_timezone")
 
         try:
+            viewer_context = SeerViewerContext(
+                organization_id=organization.id, user_id=request.user.id
+            )
             data = send_search_agent_start_request(
                 organization.id,
                 organization.slug,
@@ -166,6 +174,7 @@ class SearchAgentStartEndpoint(OrganizationEndpoint):
                 user_email=user_email,
                 timezone=timezone,
                 model_name=model_name,
+                viewer_context=viewer_context,
             )
 
             # Validate that run_id is present in the response

--- a/src/sentry/seer/endpoints/search_agent_state.py
+++ b/src/sentry/seer/endpoints/search_agent_state.py
@@ -17,19 +17,25 @@ from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import SearchAgentStateRequest, make_search_agent_state_request
+from sentry.seer.signed_seer_api import (
+    SearchAgentStateRequest,
+    SeerViewerContext,
+    make_search_agent_state_request,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def fetch_search_agent_state(run_id: int, organization_id: int) -> dict[str, Any]:
+def fetch_search_agent_state(
+    run_id: int, organization_id: int, viewer_context: SeerViewerContext | None = None
+) -> dict[str, Any]:
     """
     Fetch the current state of a search agent run from Seer.
 
     Calls POST /v1/assisted-query/state with the run_id and organization_id.
     """
     body = SearchAgentStateRequest(run_id=run_id, organization_id=organization_id)
-    response = make_search_agent_state_request(body, timeout=10)
+    response = make_search_agent_state_request(body, timeout=10, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -105,7 +111,12 @@ class SearchAgentStateEndpoint(OrganizationEndpoint):
             )
 
         try:
-            data = fetch_search_agent_state(run_id_int, organization.id)
+            viewer_context = SeerViewerContext(
+                organization_id=organization.id, user_id=request.user.id
+            )
+            data = fetch_search_agent_state(
+                run_id_int, organization.id, viewer_context=viewer_context
+            )
 
             # Return the session data directly from Seer
             return Response(data)

--- a/src/sentry/seer/endpoints/trace_explorer_ai_query.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_query.py
@@ -16,13 +16,21 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import TranslateQueryRequest, make_translate_query_request
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    TranslateQueryRequest,
+    make_translate_query_request,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def send_translate_request(
-    org_id: int, org_slug: str, project_ids: list[int], natural_language_query: str
+    org_id: int,
+    org_slug: str,
+    project_ids: list[int],
+    natural_language_query: str,
+    viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
     Sends a request to seer to create the initial cached prompt / setup the AI models
@@ -33,7 +41,7 @@ def send_translate_request(
         project_ids=project_ids,
         natural_language_query=natural_language_query,
     )
-    response = make_translate_query_request(body)
+    response = make_translate_query_request(body, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -102,8 +110,13 @@ class TraceExplorerAIQuery(OrganizationEndpoint):
                 {"detail": "Seer is not properly configured."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
         data = send_translate_request(
-            organization.id, organization.slug, project_ids, natural_language_query
+            organization.id,
+            organization.slug,
+            project_ids,
+            natural_language_query,
+            viewer_context=viewer_context,
         )
 
         responses = data.get("responses", [])[:limit]

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -15,7 +15,11 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
-from sentry.seer.signed_seer_api import CreateCacheRequest, make_create_cache_request
+from sentry.seer.signed_seer_api import (
+    CreateCacheRequest,
+    SeerViewerContext,
+    make_create_cache_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +33,14 @@ class OrganizationTraceExplorerAIPermission(OrganizationPermission):
     }
 
 
-def fire_setup_request(org_id: int, project_ids: list[int]) -> None:
+def fire_setup_request(
+    org_id: int, project_ids: list[int], viewer_context: SeerViewerContext | None = None
+) -> None:
     """
     Sends a request to seer to create the initial cached prompt / setup the AI models
     """
     body = CreateCacheRequest(org_id=org_id, project_ids=project_ids)
-    response = make_create_cache_request(body)
+    response = make_create_cache_request(body, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
 
@@ -91,6 +97,7 @@ class TraceExplorerAISetup(OrganizationEndpoint):
                 {"detail": "Seer is not properly configured."},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-        fire_setup_request(organization.id, validated_project_ids)
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
+        fire_setup_request(organization.id, validated_project_ids, viewer_context=viewer_context)
 
         return Response({"status": "ok"})

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -17,7 +17,11 @@ from sentry.models.organization import Organization
 from sentry.seer.endpoints.trace_explorer_ai_setup import OrganizationTraceExplorerAIPermission
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
-from sentry.seer.signed_seer_api import TranslateAgenticRequest, make_translate_agentic_request
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    TranslateAgenticRequest,
+    make_translate_agentic_request,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +64,7 @@ def send_translate_agentic_request(
     natural_language_query: str,
     strategy: str = "Traces",
     model_name: str | None = None,
+    viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
     Sends a request to seer to translate a natural language query using the agentic search API.
@@ -77,7 +82,7 @@ def send_translate_agentic_request(
     if options:
         body["options"] = options
 
-    response = make_translate_agentic_request(body)
+    response = make_translate_agentic_request(body, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
     return response.json()
@@ -134,6 +139,7 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+        viewer_context = SeerViewerContext(organization_id=organization.id, user_id=request.user.id)
         data = send_translate_agentic_request(
             organization.id,
             organization.slug,
@@ -141,5 +147,6 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             natural_language_query,
             strategy=strategy,
             model_name=model_name,
+            viewer_context=viewer_context,
         )
         return Response(data)

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_query.py
@@ -52,6 +52,10 @@ class TraceExplorerAIQueryTest(APITestCase):
             self.organization.slug,
             [self.project.id],
             "Find slow transactions",
+            viewer_context={
+                "organization_id": self.organization.id,
+                "user_id": self.user.id,
+            },
         )
 
     def test_query_missing_parameters(self) -> None:

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_setup.py
@@ -21,7 +21,14 @@ class TraceExplorerAISetupTest(APITestCase):
         )
 
         assert response.data == {"status": "ok"}
-        mock_fire_setup_request.assert_called_once_with(self.organization.id, [self.project.id])
+        mock_fire_setup_request.assert_called_once_with(
+            self.organization.id,
+            [self.project.id],
+            viewer_context={
+                "organization_id": self.organization.id,
+                "user_id": self.user.id,
+            },
+        )
 
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.seer.endpoints.trace_explorer_ai_setup.fire_setup_request")
@@ -69,7 +76,14 @@ class TraceExplorerAISetupTest(APITestCase):
         )
 
         assert response.data == {"status": "ok"}
-        mock_fire_setup_request.assert_called_once_with(self.organization.id, [])
+        mock_fire_setup_request.assert_called_once_with(
+            self.organization.id,
+            [],
+            viewer_context={
+                "organization_id": self.organization.id,
+                "user_id": self.user.id,
+            },
+        )
 
     def test_requires_feature_flag(self):
         self.login_as(self.user)

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
@@ -52,6 +52,10 @@ class SearchAgentTranslateEndpointTest(APITestCase):
             "Find slow transactions",
             strategy="Traces",
             model_name=None,
+            viewer_context={
+                "organization_id": self.organization.id,
+                "user_id": self.user.id,
+            },
         )
 
     def test_translate_missing_parameters(self) -> None:


### PR DESCRIPTION
Pass `SeerViewerContext` to Seer API wrapper call sites in various Seer endpoint modules.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates 8 files:

- `compare.py` + `organization_trace_item_attributes_ranked.py`: Compare distributions
- `issue_view_title_generate.py`: Title generation from query
- `search_agent_state.py`, `search_agent_start.py`: Search agent endpoints
- `trace_explorer_ai_query.py`, `trace_explorer_ai_translate_agentic.py`, `trace_explorer_ai_setup.py`: Trace explorer AI endpoints

All are API endpoints with both `organization_id` and `user_id` available. Intermediate functions thread `viewer_context` through to the underlying wrapper calls.

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>