### PR TITLE
ref(seer): Propagate viewer_context to background tasks and utilities

### DIFF
--- a/src/sentry/seer/supergroups.py
+++ b/src/sentry/seer/supergroups.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
     SupergroupsEmbeddingRequest,
     make_supergroups_embedding_request,
 )
@@ -17,6 +18,7 @@ def trigger_supergroups_embedding(
         group_id=group_id,
         artifact_data=artifact_data,
     )
-    response = make_supergroups_embedding_request(body, timeout=5)
+    viewer_context = SeerViewerContext(organization_id=organization_id)
+    response = make_supergroups_embedding_request(body, timeout=5, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -50,7 +50,7 @@ def get_trace_summary(
         return convert_dict_key_case(cached_summary, snake_to_camel_case), 200
 
     viewer_context = SeerViewerContext(organization_id=organization.id)
-    if user is not None and not isinstance(user, AnonymousUser):
+    if not isinstance(user, AnonymousUser):
         viewer_context["user_id"] = user.id
 
     trace_summary = _call_seer(

--- a/src/sentry/seer/trace_summary.py
+++ b/src/sentry/seer/trace_summary.py
@@ -8,7 +8,11 @@ from sentry import features
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError, SummarizeTraceResponse
-from sentry.seer.signed_seer_api import SummarizeTraceRequest, make_summarize_trace_request
+from sentry.seer.signed_seer_api import (
+    SeerViewerContext,
+    SummarizeTraceRequest,
+    make_summarize_trace_request,
+)
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.cache import cache
@@ -45,10 +49,15 @@ def get_trace_summary(
     if cached_summary := cache.get(cache_key):
         return convert_dict_key_case(cached_summary, snake_to_camel_case), 200
 
+    viewer_context = SeerViewerContext(organization_id=organization.id)
+    if user is not None and not isinstance(user, AnonymousUser):
+        viewer_context["user_id"] = user.id
+
     trace_summary = _call_seer(
         traceSlug,
         traceTree,
         onlyTransaction,
+        viewer_context=viewer_context,
     )
 
     trace_summary_dict = trace_summary.dict()
@@ -62,13 +71,14 @@ def _call_seer(
     trace_id: str,
     trace_content: list[Any],
     only_transaction: bool = False,
+    viewer_context: SeerViewerContext | None = None,
 ) -> SummarizeTraceResponse:
     body = SummarizeTraceRequest(
         trace_id=trace_id,
         only_transaction=only_transaction,
         trace={"trace_id": trace_id, "trace": trace_content},
     )
-    response = make_summarize_trace_request(body)
+    response = make_summarize_trace_request(body, viewer_context=viewer_context)
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
 

--- a/src/sentry/tasks/context_engine_index.py
+++ b/src/sentry/tasks/context_engine_index.py
@@ -28,6 +28,7 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     OrgProjectKnowledgeIndexRequest,
     OrgProjectKnowledgeProjectData,
+    SeerViewerContext,
     make_org_project_knowledge_index_request,
 )
 from sentry.tasks.base import instrumented_task
@@ -104,10 +105,13 @@ def index_org_project_knowledge(org_id: int) -> None:
 
     payload = OrgProjectKnowledgeIndexRequest(org_id=org_id, projects=project_data)
 
+    viewer_context = SeerViewerContext(organization_id=org_id)
+
     try:
         response = make_org_project_knowledge_index_request(
             payload,
             timeout=30,
+            viewer_context=viewer_context,
         )
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -230,9 +230,9 @@ def run_explorer_index_for_projects(
     ]
     payload = ExplorerIndexRequest(projects=project_list)
 
-    # Use the org_id from the first project tuple for viewer context
-    _, first_org_id = projects[0]
-    viewer_context = SeerViewerContext(organization_id=first_org_id)
+    # Only set viewer_context when all projects in the batch share the same org
+    org_ids = {org_id for _, org_id in projects}
+    viewer_context = SeerViewerContext(organization_id=org_ids.pop()) if len(org_ids) == 1 else None
 
     try:
         response = make_explorer_index_request(

--- a/src/sentry/tasks/seer_explorer_index.py
+++ b/src/sentry/tasks/seer_explorer_index.py
@@ -15,6 +15,7 @@ from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
     ExplorerIndexProject,
     ExplorerIndexRequest,
+    SeerViewerContext,
     make_explorer_index_request,
 )
 from sentry.tasks.base import instrumented_task
@@ -229,10 +230,15 @@ def run_explorer_index_for_projects(
     ]
     payload = ExplorerIndexRequest(projects=project_list)
 
+    # Use the org_id from the first project tuple for viewer context
+    _, first_org_id = projects[0]
+    viewer_context = SeerViewerContext(organization_id=first_org_id)
+
     try:
         response = make_explorer_index_request(
             payload,
             timeout=30,
+            viewer_context=viewer_context,
         )
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)

--- a/tests/sentry/seer/test_trace_summary.py
+++ b/tests/sentry/seer/test_trace_summary.py
@@ -131,7 +131,15 @@ class TraceSummaryTest(TestCase, SnubaTestCase):
         )
         mock_has_feature.assert_called_once()
         mock_cache_get.assert_called_once()
-        mock_call_seer.assert_called_once_with(self.trace_id, self.trace_tree, False)
+        mock_call_seer.assert_called_once_with(
+            self.trace_id,
+            self.trace_tree,
+            False,
+            viewer_context={
+                "organization_id": self.organization.id,
+                "user_id": self.user.id,
+            },
+        )
         mock_cache_set.assert_called_once()
 
     @patch("sentry.seer.trace_summary._call_seer")


### PR DESCRIPTION
Pass `SeerViewerContext` to Seer API wrapper call sites in background tasks and utility modules.

PR #109697 added an optional `viewer_context` parameter to all Seer API wrapper functions. This PR updates:

- **`context_engine_index.py`**: Pass `organization_id` from `org_id` param
- **`seer_explorer_index.py`**: Pass `organization_id` from project tuples
- **`trace_summary.py`**: Pass `organization_id` + optional `user_id` (when user is not None/anonymous)
- **`supergroups.py`**: Pass `organization_id` from param
- **Skipped**: `seer_models.py` (no auth), `uptime/seer_assertions.py` (no context)

No behavior change — `viewer_context` defaults to `None` which preserves existing behavior.

Co-Authored-By: Claude <noreply@anthropic.com>