### PR TITLE
(span-repro): add logging for advancing deadline

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -317,21 +317,20 @@ class SpansBuffer:
 
                 zadd_items = queue_adds.setdefault(queue_key, {})
 
-                # Debug logging: read old deadline before updating
-                old_deadline = None
-                if self._debug_trace_logger is None:
-                    self._debug_trace_logger = DebugTraceLogger(self.client)
-                if self._debug_trace_logger._should_log_trace(project_and_trace):
-                    old_deadline_score = self.client.zscore(queue_key, segment_key)
-                    old_deadline = (
-                        int(old_deadline_score) if old_deadline_score is not None else None
-                    )
-
                 new_deadline = now + offset
                 zadd_items[segment_key] = new_deadline
 
-                # Debug logging: log deadline update
+                # Debug logging
                 try:
+                    old_deadline = None
+                    if self._debug_trace_logger is None:
+                        self._debug_trace_logger = DebugTraceLogger(self.client)
+                    if self._debug_trace_logger._should_log_trace(project_and_trace):
+                        old_deadline_score = self.client.zscore(queue_key, segment_key)
+                        old_deadline = (
+                            int(old_deadline_score) if old_deadline_score is not None else None
+                        )
+
                     self._debug_trace_logger.log_deadline_update(
                         segment_key=segment_key,
                         project_and_trace=project_and_trace,

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -581,6 +581,21 @@ class SpansBuffer:
             )
             num_has_root_spans += int(has_root_span)
 
+            try:
+                if self._debug_trace_logger is None:
+                    self._debug_trace_logger = DebugTraceLogger(self.client)
+                self._debug_trace_logger.log_flush_info(
+                    segment_key,
+                    segment_span_id,
+                    has_root_span,
+                    len(segment),
+                    shard,
+                    queue_key,
+                    now,
+                )
+            except Exception:
+                logger.exception("flush_segments: Failed to log debug trace flush info")
+
             if flusher_logger_enabled and segment:
                 project_id, trace_id, _ = parse_segment_key(segment_key)
                 project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -582,34 +582,16 @@ class SpansBuffer:
             )
             num_has_root_spans += int(has_root_span)
 
-            try:
-                if self._debug_trace_logger is None:
-                    self._debug_trace_logger = DebugTraceLogger(self.client)
-                self._debug_trace_logger.log_flush_info(
-                    segment_key,
-                    segment_span_id,
-                    has_root_span,
-                    len(segment),
-                    shard,
-                    queue_key,
-                    now,
-                )
-            except Exception:
-                logger.exception("flush_segments: Failed to log debug trace flush info")
-
-            if flusher_logger_enabled:
-                if segment:
-                    project_id, trace_id, _ = parse_segment_key(segment_key)
-                    project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-                    flusher_log_entries.append(
-                        FlusherLogEntry(
-                            project_and_trace,
-                            len(segment),
-                            sum(len(s) for s in segment),
-                        )
+            if flusher_logger_enabled and segment:
+                project_id, trace_id, _ = parse_segment_key(segment_key)
+                project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                flusher_log_entries.append(
+                    FlusherLogEntry(
+                        project_and_trace,
+                        len(segment),
+                        sum(len(s) for s in segment),
                     )
-                else:
-                    metrics.incr("spans.buffer.flush_segments.no_segment")
+                )
 
         if flusher_logger_enabled and flusher_log_entries:
             self._flusher_logger.log(

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -156,6 +156,7 @@ class SpansBuffer:
         self._buffer_logger = BufferLogger()
         self._flusher_logger = FlusherLogger()
         self._debug_trace_logger: DebugTraceLogger | None = None
+        self.empty_flush_segment_calls = 0
 
     @cached_property
     def client(self) -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -617,6 +618,22 @@ class SpansBuffer:
 
         metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
         metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
+
+        if not return_segments:
+            self.empty_flush_segment_calls += 1
+        else:
+            if self.empty_flush_segment_calls > 0:
+                try:
+                    if self._debug_trace_logger is None:
+                        self._debug_trace_logger = DebugTraceLogger(self.client)
+                    self._debug_trace_logger.logger.info(
+                        "flush_segments.empty_calls",
+                        extra={"empty_flush_count": self.empty_flush_segment_calls},
+                    )
+                except Exception:
+                    logger.exception("flush_segments: Failed to log empty flush count")
+                finally:
+                    self.empty_flush_segment_calls = 0
 
         self.any_shard_at_limit = any_shard_at_limit
         return return_segments

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -626,10 +626,7 @@ class SpansBuffer:
                 try:
                     if self._debug_trace_logger is None:
                         self._debug_trace_logger = DebugTraceLogger(self.client)
-                    self._debug_trace_logger.logger.info(
-                        "flush_segments.empty_calls",
-                        extra={"empty_flush_count": self.empty_flush_segment_calls},
-                    )
+                    self._debug_trace_logger.log_empty_segments(self.empty_flush_segment_calls)
                 except Exception:
                     logger.exception("flush_segments: Failed to log empty flush count")
                 finally:

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -316,7 +316,32 @@ class SpansBuffer:
                     offset = timeout
 
                 zadd_items = queue_adds.setdefault(queue_key, {})
-                zadd_items[segment_key] = now + offset
+
+                # Debug logging: read old deadline before updating
+                old_deadline = None
+                if self._debug_trace_logger is None:
+                    self._debug_trace_logger = DebugTraceLogger(self.client)
+                if self._debug_trace_logger._should_log_trace(project_and_trace):
+                    old_deadline_score = self.client.zscore(queue_key, segment_key)
+                    old_deadline = (
+                        int(old_deadline_score) if old_deadline_score is not None else None
+                    )
+
+                new_deadline = now + offset
+                zadd_items[segment_key] = new_deadline
+
+                # Debug logging: log deadline update
+                try:
+                    self._debug_trace_logger.log_deadline_update(
+                        segment_key=segment_key,
+                        project_and_trace=project_and_trace,
+                        old_deadline=old_deadline,
+                        new_deadline=new_deadline,
+                        message_timestamp=now,
+                        has_root_span=has_root_span,
+                    )
+                except Exception:
+                    logger.exception("process_spans: Failed to log deadline update")
 
                 subsegment_spans = trees[project_and_trace, parent_span_id]
                 delete_set = queue_deletes.setdefault(queue_key, set())

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -597,16 +597,19 @@ class SpansBuffer:
             except Exception:
                 logger.exception("flush_segments: Failed to log debug trace flush info")
 
-            if flusher_logger_enabled and segment:
-                project_id, trace_id, _ = parse_segment_key(segment_key)
-                project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
-                flusher_log_entries.append(
-                    FlusherLogEntry(
-                        project_and_trace,
-                        len(segment),
-                        sum(len(s) for s in segment),
+            if flusher_logger_enabled:
+                if segment:
+                    project_id, trace_id, _ = parse_segment_key(segment_key)
+                    project_and_trace = f"{project_id.decode('ascii')}:{trace_id.decode('ascii')}"
+                    flusher_log_entries.append(
+                        FlusherLogEntry(
+                            project_and_trace,
+                            len(segment),
+                            sum(len(s) for s in segment),
+                        )
                     )
-                )
+                else:
+                    metrics.incr("spans.buffer.flush_segments.no_segment")
 
         if flusher_logger_enabled and flusher_log_entries:
             self._flusher_logger.log(

--- a/src/sentry/spans/debug_trace_logger.py
+++ b/src/sentry/spans/debug_trace_logger.py
@@ -153,7 +153,7 @@ class DebugTraceLogger:
 
         segment_span_id = segment_key.split(b":")[-1].decode("ascii")
 
-        deadline_advanced_by = (new_deadline - old_deadline) if old_deadline else None
+        deadline_advanced_by = (new_deadline - old_deadline) if old_deadline is not None else None
         is_new_segment = old_deadline is None
 
         logger.info(

--- a/src/sentry/spans/debug_trace_logger.py
+++ b/src/sentry/spans/debug_trace_logger.py
@@ -173,3 +173,16 @@ class DebugTraceLogger:
                 "new_ttl_remaining_seconds": new_deadline - message_timestamp,
             },
         )
+
+    def log_empty_segments(self, empty_flush_count: int) -> None:
+        """
+        Log the number of consecutive empty flush_segments calls.
+
+        Args:
+            empty_flush_count: Number of consecutive calls to flush_segments
+                              that returned no segments
+        """
+        logger.info(
+            "spans.buffer.debug_empty_flushes",
+            extra={"empty_flush_count": empty_flush_count},
+        )

--- a/src/sentry/spans/debug_trace_logger.py
+++ b/src/sentry/spans/debug_trace_logger.py
@@ -29,6 +29,11 @@ class DebugTraceLogger:
     def _get_debug_traces(self) -> set[str]:
         return set(options.get("spans.buffer.debug-traces"))
 
+    def _should_log_trace(self, project_and_trace: str) -> bool:
+        """Check if a trace should be logged based on debug-traces option."""
+        _, _, trace_id = project_and_trace.partition(":")
+        return trace_id in self._get_debug_traces()
+
     def _get_span_key(self, project_and_trace: str, span_id: str) -> bytes:
         return f"span-buf:s:{{{project_and_trace}}}:{span_id}".encode("ascii")
 
@@ -116,8 +121,55 @@ class DebugTraceLogger:
                 "root_span_in_segment": root_span_in_segment,
                 "num_spans": num_spans,
                 "shard_id": shard_id,
-                "flusher_now": now,
+                "flusher_timestamp": now,
                 "segment_deadline": deadline,
                 "ttl_remaining_seconds": ttl_remaining,
+            },
+        )
+
+    def log_deadline_update(
+        self,
+        segment_key: SegmentKey,
+        project_and_trace: str,
+        old_deadline: int | None,
+        new_deadline: int,
+        message_timestamp: int,
+        has_root_span: bool,
+    ) -> None:
+        """
+        Log when a segment's deadline is set or updated.
+
+        Args:
+            segment_key: Redis key for the segment
+            project_and_trace: String like "123:trace-id"
+            old_deadline: Previous deadline timestamp (None if new segment)
+            new_deadline: New deadline timestamp being set
+            message_timestamp: Kafka message timestamp from current batch
+            has_root_span: Whether segment has root span (determines timeout)
+        """
+        _, _, trace_id = project_and_trace.partition(":")
+        if trace_id not in self._get_debug_traces():
+            return
+
+        segment_span_id = segment_key.split(b":")[-1].decode("ascii")
+
+        deadline_advanced_by = (new_deadline - old_deadline) if old_deadline else None
+        is_new_segment = old_deadline is None
+
+        logger.info(
+            "spans.buffer.debug_deadline_update",
+            extra={
+                "project_and_trace": project_and_trace,
+                "segment_span_id": segment_span_id,
+                "is_new_segment": is_new_segment,
+                "has_root_span": has_root_span,
+                "old_deadline": old_deadline,
+                "new_deadline": new_deadline,
+                "deadline_advanced_by_seconds": deadline_advanced_by,
+                "message_timestamp": message_timestamp,
+                "old_ttl_remaining_seconds": (old_deadline - message_timestamp)
+                if old_deadline
+                else None,
+                "new_ttl_remaining_seconds": new_deadline - message_timestamp,
             },
         )

--- a/tests/sentry/spans/test_debug_trace_logger.py
+++ b/tests/sentry/spans/test_debug_trace_logger.py
@@ -174,7 +174,7 @@ class TestDebugTraceLogger:
         assert extra["root_span_in_segment"] is True
         assert extra["num_spans"] == 5
         assert extra["shard_id"] == 0
-        assert extra["flusher_now"] == 1705320600
+        assert extra["flusher_timestamp"] == 1705320600
         assert extra["segment_deadline"] == 1705320610
         assert extra["ttl_remaining_seconds"] == 10
 
@@ -210,7 +210,7 @@ class TestDebugTraceLogger:
         assert extra["root_span_in_segment"] is False
         assert extra["num_spans"] == 3
         assert extra["shard_id"] == 7
-        assert extra["flusher_now"] == 1705320600
+        assert extra["flusher_timestamp"] == 1705320600
         assert extra["segment_deadline"] == 1705320660
         assert extra["ttl_remaining_seconds"] == 60
 
@@ -238,3 +238,16 @@ class TestDebugTraceLogger:
         mock_logger.info.assert_not_called()
         mock_client.exists.assert_not_called()
         mock_client.zscore.assert_not_called()
+
+    @mock.patch("sentry.spans.debug_trace_logger.logger")
+    def test_should_log_trace(self, mock_logger):
+        """Test _should_log_trace helper method."""
+        mock_client = mock.MagicMock()
+
+        with override_options({"spans.buffer.debug-traces": ["trace123", "trace456"]}):
+            debug_logger = DebugTraceLogger(mock_client)
+
+            assert debug_logger._should_log_trace("123:trace123") is True
+            assert debug_logger._should_log_trace("456:trace456") is True
+            assert debug_logger._should_log_trace("789:trace789") is False
+            assert debug_logger._should_log_trace("123:other_trace") is False


### PR DESCRIPTION
#proj-span-buffer
trying to understand why sometimes flusher flushes prematurely when there's new spans arriving to segments