### PR TITLE
feat(billing): admin page for contract information

### DIFF
--- a/.agents/skills/warden-lint-judge/SKILL.md
+++ b/.agents/skills/warden-lint-judge/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: warden-lint-judge
+description: "Warden skill: evaluates first-pass findings and proposes deterministic lint rules that could permanently catch the same patterns. Requires Warden's multi-pass pipeline (phase 2)."
+allowed-tools: Read Grep Glob
+---
+
+# Lint Judge
+
+You are a second-pass Warden skill. Your job: turn AI findings into deterministic lint rules.
+
+The bar is high. Only propose a rule when you can guarantee it catches the exact pattern through AST structure, not heuristics. A rule that fires on `eval(anything)` is deterministic. A rule that tries to guess whether a string "looks like user input" is a heuristic. Only the first kind belongs here.
+
+## Step 1: Detect the linter
+
+Before evaluating any findings, determine what linter system the project uses. Use `Glob` and `Read` to check for:
+
+- `.oxlintrc.json` / `oxlint.json` (oxlint)
+- `.eslintrc.*` / `eslint.config.*` / `"eslintConfig"` in package.json (eslint)
+- `clippy.toml` / `.clippy.toml` (Rust clippy)
+- `.pylintrc` / `pyproject.toml` with `[tool.pylint]` (pylint)
+- `.flake8` / `setup.cfg` with `[flake8]` (flake8)
+- `biome.json` / `biome.jsonc` (biome)
+
+Also check whether the linter supports custom/plugin rules:
+
+- oxlint: check for `jsPlugins` in config and an existing plugins directory
+- eslint: check for local plugins or `eslint-plugin-*` deps
+- biome: no custom rule support, existing rules only
+
+If custom rules exist, read them. Before proposing a new custom rule in Step 2, verify no existing rule already covers the same pattern. If one does, skip it silently.
+
+If the project has no linter, return an empty findings array. You cannot propose rules for a tool that doesn't exist.
+
+## Step 2: Evaluate prior findings
+
+For each prior finding that has a `suggestedFix`, ask: can this exact pattern be caught by a deterministic AST check in the linter we found?
+
+**Deterministic means:**
+
+- The rule matches a specific syntactic pattern in the AST (node type, property name, call signature)
+- Zero or near-zero false positives -- if the AST matches, the code is wrong
+- No guessing about intent, data flow, variable contents, or runtime behavior
+- Examples: banning `eval()`, requiring `===` over `==`, disallowing `execSync` with template literal arguments, flagging `new Function()` calls
+
+**Not deterministic (skip these):**
+
+- "This variable might contain user input" (data flow analysis)
+- "This function name suggests it handles sensitive data" (naming heuristic)
+- "This pattern is usually a bug" (probabilistic)
+- Anything that requires understanding what a variable contains at runtime
+
+**Only report if ALL of these are true:**
+
+1. You can identify a specific existing rule by name, OR you can write a complete working custom rule
+2. The rule is deterministic: it matches AST structure, not heuristics
+3. The project's linter actually supports this
+
+## What to skip silently
+
+- Findings without `suggestedFix`
+- Patterns that need type information the linter can't access, cross-file context, or runtime knowledge
+- Patterns where the rule would need to guess or use heuristics
+- Cases where you're not confident the rule is correct and complete
+
+Return an empty findings array when nothing qualifies. That's the expected common case.
+
+## Output format
+
+**Do NOT set a `location` field.** These findings target linter config and plugin files, not the source code where the original issue was found. Omitting location ensures they appear as top-level review comments, not inline on unrelated source lines.
+
+**The `description` is the primary output.** Write each finding's description as a prompt you could copy-paste directly into a local coding agent. It should be a clear, complete instruction that an agent can act on without additional context. Example: "Add `\"no-eval\": \"error\"` to the `rules` object in `.oxlintrc.json` to ban all `eval()` calls."
+
+The `suggestedFix` carries the machine-readable diff for local application via `warden --fix`. It is not shown in PR comments.
+
+For existing rules:
+
+- **title**: The rule name (e.g., `no-eval`)
+- **severity**: `low`
+- **description**: A copy-pasteable prompt: which config file to edit, what to add, and why.
+- **suggestedFix**: A diff enabling the rule in the project's linter config file
+
+For custom rules:
+
+- **title**: `custom: <rule-name>` (e.g., `custom: no-execsync-interpolation`)
+- **severity**: `low`
+- **description**: A copy-pasteable prompt: what plugin file to create, what AST pattern it matches, and how to wire it into the linter config.
+- **suggestedFix**: The complete rule implementation file AND the config diff to wire it up. Match the conventions of existing custom rules in the project.

--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -20,6 +20,7 @@ export type KnownGetsentryApiUrls =
   | '/copilot/'
   | '/copilot/webhook/'
   | '/customers/'
+  | '/_admin/customers/$organizationIdOrSlug/contract/'
   | '/customers/$organizationIdOrSlug/'
   | '/customers/$organizationIdOrSlug/balancechanges/'
   | '/customers/$organizationIdOrSlug/billing-config/'

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -7,6 +7,7 @@ import BillingAdmins from 'admin/views/billingAdmins';
 import BillingPlans from 'admin/views/billingPlans';
 import BroadcastDetails from 'admin/views/broadcastDetails';
 import Broadcasts from 'admin/views/broadcasts';
+import CustomerContractDetails from 'admin/views/customerContractDetails';
 import CustomerDetails from 'admin/views/customerDetails';
 import Customers from 'admin/views/customers';
 import CustomerUpgradeRequest from 'admin/views/customerUpgradeRequest';
@@ -92,6 +93,10 @@ function buildRoutes() {
               {
                 path: 'upgrade-request/',
                 component: CustomerUpgradeRequest,
+              },
+              {
+                path: 'contract/',
+                component: CustomerContractDetails,
               },
               {
                 path: 'projects/:projectId/',

--- a/static/gsAdmin/views/customerContractDetails.spec.tsx
+++ b/static/gsAdmin/views/customerContractDetails.spec.tsx
@@ -1,0 +1,156 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import CustomerContractDetails from 'admin/views/customerContractDetails';
+
+const MOCK_CONTRACT = {
+  metadata: {id: 'contract-123', organizationId: 'org-456'},
+  billingConfig: {
+    billingType: 'BILLING_TYPE_CREDIT_CARD',
+    channel: 'CHANNEL_SALES',
+    address: {countryCode: 'US'},
+    contractStartDate: {year: 2024, month: 1, day: 1},
+    contractEndDate: {year: 2025, month: 1, day: 1},
+  },
+  pricingConfig: {
+    skuConfigs: [
+      {
+        sku: 'SKU_ERRORS',
+        basePriceCents: '10000',
+        paygBudgetCents: '5000',
+        reservedVolume: '100000',
+        reservedRate: {tiers: [{ratePerUnitCpe: '100'}]},
+        paygRate: {tiers: [{ratePerUnitCpe: '200'}]},
+      },
+    ],
+    sharedSkuBudgets: [],
+    billingPeriodStartDate: {year: 2024, month: 1, day: 1},
+    billingPeriodEndDate: {year: 2024, month: 2, day: 1},
+    maxSpendCents: '50000',
+    basePriceCents: '10000',
+  },
+};
+
+const ROUTER_CONFIG = {
+  location: {pathname: '/_admin/customers/test-org/contract/'},
+  route: '/_admin/customers/:orgId/contract/',
+};
+
+describe('CustomerContractDetails', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders contract data', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/customers/test-org/contract/',
+      body: MOCK_CONTRACT,
+    });
+
+    render(<CustomerContractDetails />, {
+      initialRouterConfig: ROUTER_CONFIG,
+    });
+
+    expect(await screen.findByText('Contract Overview')).toBeInTheDocument();
+
+    expect(screen.getByText('Billing Period:')).toBeInTheDocument();
+    expect(screen.getByText('Contract Period:')).toBeInTheDocument();
+    expect(screen.getByText('Base Price:')).toBeInTheDocument();
+    expect(screen.getByText('Max Spend:')).toBeInTheDocument();
+    expect(screen.getByText('Contract ID:')).toBeInTheDocument();
+    expect(screen.getByText('Type:')).toBeInTheDocument();
+    expect(screen.getByText('Channel:')).toBeInTheDocument();
+    expect(screen.getByText('Billing Country:')).toBeInTheDocument();
+
+    expect(screen.getByText('contract-123')).toBeInTheDocument();
+    expect(screen.getByText('Credit Card')).toBeInTheDocument();
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.getByText('United States')).toBeInTheDocument();
+
+    expect(screen.getByText('SKU Pricing')).toBeInTheDocument();
+    expect(screen.getByText('Errors')).toBeInTheDocument();
+    expect(screen.getByText('Reserved Volume:')).toBeInTheDocument();
+    expect(screen.getByText('100,000')).toBeInTheDocument();
+  });
+
+  it('renders loading state', () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/customers/test-org/contract/',
+      body: MOCK_CONTRACT,
+      statusCode: 200,
+    });
+
+    // The component will show loading indicator briefly before data loads.
+    // We verify it doesn't crash by checking the final rendered state.
+    render(<CustomerContractDetails />, {
+      initialRouterConfig: ROUTER_CONFIG,
+    });
+
+    expect(document.body).toBeInTheDocument();
+  });
+
+  it('renders error state', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/customers/test-org/contract/',
+      body: {detail: 'Not found'},
+      statusCode: 404,
+    });
+
+    render(<CustomerContractDetails />, {
+      initialRouterConfig: ROUTER_CONFIG,
+    });
+
+    expect(
+      await screen.findByText('There was an error loading data.')
+    ).toBeInTheDocument();
+  });
+
+  it('renders shared budgets when present', async () => {
+    const contractWithBudgets = {
+      ...MOCK_CONTRACT,
+      pricingConfig: {
+        ...MOCK_CONTRACT.pricingConfig,
+        sharedSkuBudgets: [
+          {
+            skus: ['SKU_ERRORS', 'SKU_TRANSACTIONS'],
+            reservedBudgetCents: '20000',
+            paygBudgetCents: '10000',
+          },
+        ],
+      },
+    };
+
+    MockApiClient.addMockResponse({
+      url: '/_admin/customers/test-org/contract/',
+      body: contractWithBudgets,
+    });
+
+    render(<CustomerContractDetails />, {
+      initialRouterConfig: ROUTER_CONFIG,
+    });
+
+    expect(await screen.findByText('Shared Budgets')).toBeInTheDocument();
+    expect(screen.getByText('Errors, Transactions')).toBeInTheDocument();
+    expect(screen.getByText('Reserved Budget:')).toBeInTheDocument();
+    expect(screen.getByText('PAYG Budget:')).toBeInTheDocument();
+  });
+
+  it('handles missing optional fields gracefully', async () => {
+    const minimalContract = {
+      metadata: {},
+      billingConfig: {},
+      pricingConfig: {},
+    };
+
+    MockApiClient.addMockResponse({
+      url: '/_admin/customers/test-org/contract/',
+      body: minimalContract,
+    });
+
+    render(<CustomerContractDetails />, {
+      initialRouterConfig: ROUTER_CONFIG,
+    });
+
+    expect(await screen.findByText('Contract Overview')).toBeInTheDocument();
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/views/customerContractDetails.tsx
+++ b/static/gsAdmin/views/customerContractDetails.tsx
@@ -1,0 +1,262 @@
+import {Fragment} from 'react';
+import moment from 'moment-timezone';
+
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useParams} from 'sentry/utils/useParams';
+
+import DetailLabel from 'admin/components/detailLabel';
+import DetailList from 'admin/components/detailList';
+import DetailsContainer from 'admin/components/detailsContainer';
+import PageHeader from 'admin/components/pageHeader';
+import {getCountryByCode} from 'getsentry/utils/ISO3166codes';
+import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
+
+type ContractDate = {day?: number; month?: number; year?: number};
+
+type PricingTier = {end?: string; ratePerUnitCpe?: string; start?: string};
+type TieredPricingRate = {tiers?: PricingTier[]};
+
+type SKUConfig = {
+  basePriceCents?: string;
+  paygBudgetCents?: string;
+  paygRate?: TieredPricingRate;
+  reservedRate?: TieredPricingRate;
+  reservedVolume?: string;
+  sku?: string;
+};
+
+type SharedSKUBudget = {
+  paygBudgetCents?: string;
+  reservedBudgetCents?: string;
+  skus?: string[];
+};
+
+type ContractData = {
+  billingConfig?: {
+    address?: {countryCode?: string};
+    billingType?: string;
+    channel?: string;
+    contractEndDate?: ContractDate;
+    contractStartDate?: ContractDate;
+  };
+  metadata?: {id?: string; organizationId?: string};
+  pricingConfig?: {
+    basePriceCents?: string;
+    billingPeriodEndDate?: ContractDate;
+    billingPeriodStartDate?: ContractDate;
+    maxSpendCents?: string;
+    sharedSkuBudgets?: SharedSKUBudget[];
+    skuConfigs?: SKUConfig[];
+  };
+};
+
+function parseCents(value?: string): number {
+  if (!value) {
+    return 0;
+  }
+  const n = parseInt(value, 10);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatContractDate(d?: ContractDate): string {
+  if (!d?.year || !d?.month || !d?.day) {
+    return 'N/A';
+  }
+  return moment({year: d.year, month: d.month - 1, day: d.day}).format('ll');
+}
+
+function formatEnumLabel(enumStr: string | undefined, prefix: string): string {
+  if (!enumStr) {
+    return 'N/A';
+  }
+  const stripped = enumStr.startsWith(prefix) ? enumStr.slice(prefix.length) : enumStr;
+  return stripped
+    .toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function formatPrice(cents: number): string {
+  return displayPriceWithCents({cents});
+}
+
+function formatPricePrecise(cents: number): string {
+  return displayPriceWithCents({
+    cents,
+    minimumFractionDigits: 8,
+    maximumFractionDigits: 8,
+  });
+}
+
+function ContractOverview({data}: {data: ContractData}) {
+  const {metadata, billingConfig, pricingConfig} = data;
+  const maxSpend = parseCents(pricingConfig?.maxSpendCents);
+
+  return (
+    <Panel>
+      <PanelHeader>Contract Overview</PanelHeader>
+      <PanelBody withPadding>
+        <DetailsContainer>
+          <div>
+            <h6>Subscription</h6>
+            <DetailList>
+              <DetailLabel title="Billing Period">
+                {`${formatContractDate(pricingConfig?.billingPeriodStartDate)} › ${formatContractDate(pricingConfig?.billingPeriodEndDate)}`}
+              </DetailLabel>
+              <DetailLabel title="Contract Period">
+                {`${formatContractDate(billingConfig?.contractStartDate)} › ${formatContractDate(billingConfig?.contractEndDate)}`}
+              </DetailLabel>
+              <DetailLabel title="Base Price">
+                {formatPrice(parseCents(pricingConfig?.basePriceCents))}
+              </DetailLabel>
+              <DetailLabel title="Max Spend">
+                {maxSpend > 0 ? formatPrice(maxSpend) : 'None'}
+              </DetailLabel>
+            </DetailList>
+          </div>
+          <div>
+            <DetailList>
+              <DetailLabel title="Contract ID">{metadata?.id || 'N/A'}</DetailLabel>
+              <DetailLabel title="Type">
+                {formatEnumLabel(billingConfig?.billingType, 'BILLING_TYPE_')}
+              </DetailLabel>
+              <DetailLabel title="Channel">
+                {formatEnumLabel(billingConfig?.channel, 'CHANNEL_')}
+              </DetailLabel>
+              <DetailLabel title="Billing Country">
+                {billingConfig?.address?.countryCode
+                  ? (getCountryByCode(billingConfig.address.countryCode)?.name ??
+                    billingConfig.address.countryCode)
+                  : 'N/A'}
+              </DetailLabel>
+            </DetailList>
+          </div>
+        </DetailsContainer>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function SKUPricing({skuConfigs}: {skuConfigs: SKUConfig[]}) {
+  if (skuConfigs.length === 0) {
+    return null;
+  }
+
+  return (
+    <Panel>
+      <PanelHeader>SKU Pricing</PanelHeader>
+      <PanelBody withPadding>
+        {skuConfigs.map((skuConfig, idx) => {
+          const reservedTier = skuConfig.reservedRate?.tiers?.[0];
+          const paygTier = skuConfig.paygRate?.tiers?.[0];
+          const paygBudget = parseCents(skuConfig.paygBudgetCents);
+
+          return (
+            <Fragment key={skuConfig.sku ?? idx}>
+              <h6>{formatEnumLabel(skuConfig.sku, 'SKU_')}</h6>
+              <DetailList>
+                <DetailLabel title="Reserved Volume">
+                  {parseInt(skuConfig.reservedVolume ?? '0', 10).toLocaleString()}
+                </DetailLabel>
+                <DetailLabel title="Base Price">
+                  {formatPrice(parseCents(skuConfig.basePriceCents))}
+                </DetailLabel>
+                <DetailLabel title="PAYG Budget">
+                  {paygBudget > 0 ? formatPrice(paygBudget) : 'None'}
+                </DetailLabel>
+                <DetailLabel title="Reserved CPE">
+                  {reservedTier?.ratePerUnitCpe
+                    ? formatPricePrecise(parseCents(reservedTier.ratePerUnitCpe))
+                    : 'N/A'}
+                </DetailLabel>
+                <DetailLabel title="PAYG CPE">
+                  {paygTier?.ratePerUnitCpe
+                    ? formatPricePrecise(parseCents(paygTier.ratePerUnitCpe))
+                    : 'N/A'}
+                </DetailLabel>
+              </DetailList>
+            </Fragment>
+          );
+        })}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+function SharedBudgets({budgets}: {budgets: SharedSKUBudget[]}) {
+  if (budgets.length === 0) {
+    return null;
+  }
+
+  return (
+    <Panel>
+      <PanelHeader>Shared Budgets</PanelHeader>
+      <PanelBody withPadding>
+        {budgets.map((budget, idx) => {
+          const skuNames = (budget.skus ?? [])
+            .map(sku => formatEnumLabel(sku, 'SKU_'))
+            .join(', ');
+
+          return (
+            <Fragment key={idx}>
+              <h6>{skuNames || 'Unknown SKUs'}</h6>
+              <DetailList>
+                <DetailLabel title="Reserved Budget">
+                  {formatPrice(parseCents(budget.reservedBudgetCents))}
+                </DetailLabel>
+                <DetailLabel title="PAYG Budget">
+                  {formatPrice(parseCents(budget.paygBudgetCents))}
+                </DetailLabel>
+              </DetailList>
+            </Fragment>
+          );
+        })}
+      </PanelBody>
+    </Panel>
+  );
+}
+
+export default function CustomerContractDetails() {
+  const {orgId} = useParams<{orgId: string}>();
+  const {data, isPending, isError, refetch} = useApiQuery<ContractData>(
+    [
+      getApiUrl(`/_admin/customers/$organizationIdOrSlug/contract/`, {
+        path: {organizationIdOrSlug: orgId},
+      }),
+    ],
+    {
+      staleTime: 0,
+    }
+  );
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    return <LoadingError onRetry={refetch} />;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const skuConfigs = data.pricingConfig?.skuConfigs ?? [];
+  const sharedBudgets = data.pricingConfig?.sharedSkuBudgets ?? [];
+
+  return (
+    <Fragment>
+      <PageHeader title="Customers" breadcrumbs={[orgId, 'Contract']} />
+      <ContractOverview data={data} />
+      <SKUPricing skuConfigs={skuConfigs} />
+      <SharedBudgets budgets={sharedBudgets} />
+    </Fragment>
+  );
+}

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -3,6 +3,8 @@ import cloneDeep from 'lodash/cloneDeep';
 import some from 'lodash/some';
 import scrollToElement from 'scroll-to-element';
 
+import {Link} from '@sentry/scraps/link';
+
 import {
   addErrorMessage,
   addLoadingMessage,
@@ -923,6 +925,14 @@ export default function CustomerDetails() {
           {
             noPanel: true,
             content: <CustomerPolicies orgId={orgId} />,
+          },
+          {
+            name: 'Contract',
+            content: (
+              <Link to={`/_admin/customers/${orgId}/contract/`}>
+                View Contract Details
+              </Link>
+            ),
           },
         ]}
       />


### PR DESCRIPTION
Added an admin page to display contract information, calling a contract admin endpoint that is created here: https://github.com/getsentry/getsentry/pull/19461. This page displays overlapping info from the contract object and the current customer overview page in admin, linked by a button on the admin page. 