### PR TITLE
fix(preprod): Return 404 instead of 500 for missing objectstore images

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from django.http import HttpResponse
+from objectstore_client.client import RequestError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -42,7 +43,18 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
 
             # Detect content type from the image data
             return HttpResponse(image_data, content_type=result.metadata.content_type)
-
+        except RequestError as e:
+            if e.status == 404:
+                return Response({"detail": "Image not found"}, status=404)
+            logger.exception(
+                "Unexpected error retrieving image",
+                extra={
+                    "organization_id": organization_id,
+                    "project_id": project_id,
+                    "image_id": image_id,
+                },
+            )
+            return Response({"detail": "Internal server error"}, status=500)
         except Exception:
             logger.exception(
                 "Unexpected error retrieving image",

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
+from objectstore_client.client import RequestError
 
 from sentry.testutils.cases import APITestCase
 
@@ -115,6 +116,20 @@ class ProjectPreprodArtifactImageTest(APITestCase):
             url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
         )
         assert response.status_code == 403
+
+    @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
+    def test_objectstore_404_returns_404(self, mock_get_session):
+        mock_session = MagicMock()
+        mock_session.get.side_effect = RequestError(message="Not Found", status=404, response="")
+        mock_get_session.return_value = mock_session
+
+        url = self._get_url()
+        response = self.client.get(
+            url, format="json", HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Image not found"}
 
     @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
     def test_error_handling_returns_json(self, mock_get_session):


### PR DESCRIPTION
The artifact image endpoint catches all exceptions with a blanket `except Exception`, logs at `exception` level (sending it to Sentry), and returns a 500. A missing image in objectstore is an expected condition — it should return 404, not generate noise in error monitoring.

This adds specific handling for `RequestError` from `objectstore_client`: status 404 returns a clean 404 response without logging, while other unexpected statuses still log and return 500. The generic `Exception` fallback is preserved for non-objectstore errors.

Fixes SENTRY-5KRY