### PR TITLE
fix(button): Restore focus ring on transparent LinkButton

### DIFF
--- a/static/app/components/core/button/linkButton.tsx
+++ b/static/app/components/core/button/linkButton.tsx
@@ -105,10 +105,6 @@ const StyledLinkButton = styled(
   }
 )<LinkButtonProps>`
   ${p => getLinkButtonStyles(p)}
-
-  &:focus-visible {
-    box-shadow: none;
-  }
 `;
 
 const getLinkButtonStyles = (p: LinkButtonProps) => {


### PR DESCRIPTION
Remove box shadow override from LinkButton