### PR TITLE
feat(admin): add Last Active column and sort to user search

### DIFF
--- a/src/sentry/users/api/endpoints/user_index.py
+++ b/src/sentry/users/api/endpoints/user_index.py
@@ -74,6 +74,7 @@ class UserIndexEndpoint(Endpoint):
 
         sort_by = request.GET.get("sortBy", "date")
         if sort_by == "lastActive":
+            queryset = queryset.exclude(last_active__isnull=True)
             order_by = "-last_active"
         else:
             order_by = "-date_joined"

--- a/src/sentry/users/api/endpoints/user_index.py
+++ b/src/sentry/users/api/endpoints/user_index.py
@@ -72,7 +72,11 @@ class UserIndexEndpoint(Endpoint):
         elif status == "disabled":
             queryset = queryset.filter(is_active=False)
 
-        order_by = "-date_joined"
+        sort_by = request.GET.get("sortBy", "date")
+        if sort_by == "lastActive":
+            order_by = "-last_active"
+        else:
+            order_by = "-date_joined"
         paginator_cls = DateTimePaginator
 
         return self.paginate(

--- a/static/gsAdmin/views/users.tsx
+++ b/static/gsAdmin/views/users.tsx
@@ -29,6 +29,9 @@ const getRow = (row: any) => [
   <td key="joined" style={{textAlign: 'right'}}>
     {moment(row.dateJoined).fromNow()}
   </td>,
+  <td key="lastActive" style={{textAlign: 'right'}}>
+    {row.lastActive ? moment(row.lastActive).fromNow() : '—'}
+  </td>,
 ];
 
 export default function Users() {
@@ -51,6 +54,9 @@ export default function Users() {
           <th key="joined" style={{width: 200, textAlign: 'right'}}>
             Joined
           </th>,
+          <th key="lastActive" style={{width: 200, textAlign: 'right'}}>
+            Last Active
+          </th>,
         ]}
         columnsForRow={getRow}
         hasSearch
@@ -63,7 +69,7 @@ export default function Users() {
             ],
           },
         }}
-        sortOptions={[['date', 'Date Joined']]}
+        sortOptions={[['date', 'Date Joined'], ['lastActive', 'Last Active']]}
         defaultSort="date"
       />
     </div>

--- a/static/gsAdmin/views/users.tsx
+++ b/static/gsAdmin/views/users.tsx
@@ -69,7 +69,10 @@ export default function Users() {
             ],
           },
         }}
-        sortOptions={[['date', 'Date Joined'], ['lastActive', 'Last Active']]}
+        sortOptions={[
+          ['date', 'Date Joined'],
+          ['lastActive', 'Last Active'],
+        ]}
         defaultSort="date"
       />
     </div>


### PR DESCRIPTION
Adds a "Last Active" column to the /_admin/users/ user search table and a "Last Active" sort option, backed by the existing last_active field on the User model.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
