### PR TITLE
feat(breadcrumbs): Make Seer drawer breadcrumbs open in new tabs

### DIFF
--- a/static/app/components/breadcrumbs.spec.tsx
+++ b/static/app/components/breadcrumbs.spec.tsx
@@ -48,4 +48,40 @@ describe('Breadcrumbs', () => {
     await userEvent.click(screen.getByText('Test 3'));
     expect(router.location.pathname).toBe(initialPathname);
   });
+
+  it('renders crumbs with openInNewTab as external links', () => {
+    render(
+      <Breadcrumbs
+        crumbs={[
+          {
+            label: 'Issue Link',
+            to: '/organizations/sentry/issues/123/',
+            openInNewTab: true,
+          },
+          {
+            label: 'Event Link',
+            to: '/organizations/sentry/issues/123/events/456/',
+            openInNewTab: true,
+          },
+          {
+            label: 'Current',
+          },
+        ]}
+      />
+    );
+
+    const links = screen.getAllByTestId('breadcrumb-link');
+    expect(links).toHaveLength(2);
+
+    expect(links[0]).toHaveAttribute('target', '_blank');
+    expect(links[0]).toHaveAttribute('rel', 'noreferrer noopener');
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('/issues/123/'));
+
+    expect(links[1]).toHaveAttribute('target', '_blank');
+    expect(links[1]).toHaveAttribute('rel', 'noreferrer noopener');
+    expect(links[1]).toHaveAttribute(
+      'href',
+      expect.stringContaining('/issues/123/events/456/')
+    );
+  });
 });

--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -2,12 +2,14 @@ import {Fragment} from 'react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
 import type {LinkProps} from '@sentry/scraps/link';
-import {Link} from '@sentry/scraps/link';
+import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {IconSlashForward} from 'sentry/icons';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {locationDescriptorToTo} from 'sentry/utils/reactRouter6Compat/location';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 
 export interface Crumb {
@@ -15,6 +17,11 @@ export interface Crumb {
    * Label of the crumb
    */
   label: NonNullable<React.ReactNode>;
+
+  /**
+   * If true, renders the link as an external link that opens in a new tab
+   */
+  openInNewTab?: boolean;
 
   /**
    * It will keep the page filter values (projects, environments, time) in the
@@ -87,6 +94,7 @@ function BreadCrumbItem(props: BreadCrumbItemProps) {
           <BreadcrumbLink
             to={props.crumb.to}
             preservePageFilters={props.crumb.preservePageFilters}
+            openInNewTab={props.crumb.openInNewTab}
             data-test-id="breadcrumb-link"
             onClick={onBreadcrumbLinkClick}
             {...styleProps}
@@ -112,11 +120,12 @@ function BreadCrumbItem(props: BreadCrumbItemProps) {
 
 interface BreadcrumbLinkProps extends LinkProps {
   children?: React.ReactNode;
+  openInNewTab?: boolean;
   preservePageFilters?: boolean;
 }
 
 function BreadcrumbLink(props: BreadcrumbLinkProps) {
-  const {preservePageFilters, to, ...rest} = props;
+  const {preservePageFilters, openInNewTab, to, ...rest} = props;
   const location = useLocation();
 
   if (!to) {
@@ -128,6 +137,16 @@ function BreadcrumbLink(props: BreadcrumbLinkProps) {
       ? {pathname: to, query: extractSelectionParameters(location.query)}
       : {...to, query: {...extractSelectionParameters(location.query), ...to.query}}
     : to;
+
+  if (openInNewTab) {
+    const normalized = normalizeUrl(toWithQuery);
+    const toObject = locationDescriptorToTo(normalized);
+    const href =
+      typeof toObject === 'string'
+        ? toObject
+        : `${toObject.pathname ?? ''}${toObject.search ?? ''}${toObject.hash ?? ''}`;
+    return <ExternalLink href={href} {...rest} />;
+  }
 
   return <Link to={toWithQuery} {...rest} />;
 }

--- a/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
+++ b/static/app/components/events/autofix/v2/explorerSeerDrawer.tsx
@@ -58,7 +58,12 @@ interface ExplorerSeerDrawerProps {
 /**
  * Common breadcrumbs for the drawer header.
  */
-const drawerBreadcrumbs = (group: Group, event: Event, project: Project) => [
+const drawerBreadcrumbs = (
+  group: Group,
+  event: Event,
+  project: Project,
+  orgSlug: string
+) => [
   {
     label: (
       <Flex align="center" gap="md">
@@ -66,8 +71,14 @@ const drawerBreadcrumbs = (group: Group, event: Event, project: Project) => [
         <ShortId>{group.shortId}</ShortId>
       </Flex>
     ),
+    to: `/organizations/${orgSlug}/issues/${group.id}/`,
+    openInNewTab: true,
   },
-  {label: getShortEventId(event.id)},
+  {
+    label: getShortEventId(event.id),
+    to: `/organizations/${orgSlug}/issues/${group.id}/events/${event.id}/`,
+    openInNewTab: true,
+  },
   {label: t('Seer')},
 ];
 
@@ -225,8 +236,8 @@ export function ExplorerSeerDrawer({
   }, [artifacts, group, event, copy]);
 
   const breadcrumbs = useMemo(
-    () => drawerBreadcrumbs(group, event, project),
-    [group, event, project]
+    () => drawerBreadcrumbs(group, event, project, organization.slug),
+    [group, event, project, organization.slug]
   );
 
   const hasArtifacts =

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -46,6 +46,32 @@ interface SeerDrawerProps {
   project: Project;
 }
 
+function seerDrawerBreadcrumbs(
+  group: Group,
+  event: Event,
+  project: Project,
+  orgSlug: string
+) {
+  return [
+    {
+      label: (
+        <Flex align="center" gap="md">
+          <ProjectAvatar project={project} />
+          <ShortId>{group.shortId}</ShortId>
+        </Flex>
+      ),
+      to: `/organizations/${orgSlug}/issues/${group.id}/`,
+      openInNewTab: true,
+    },
+    {
+      label: getShortEventId(event.id),
+      to: `/organizations/${orgSlug}/issues/${group.id}/events/${event.id}/`,
+      openInNewTab: true,
+    },
+    {label: t('Seer')},
+  ];
+}
+
 const AiSetupConfiguration = HookOrDefault({
   hookName: 'component:ai-setup-configuration',
   defaultComponent: ({
@@ -97,18 +123,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
       <SeerDrawerContainer className="seer-drawer-container">
         <SeerDrawerHeader>
           <NavigationCrumbs
-            crumbs={[
-              {
-                label: (
-                  <Flex align="center" gap="md">
-                    <ProjectAvatar project={project} />
-                    <ShortId>{group.shortId}</ShortId>
-                  </Flex>
-                ),
-              },
-              {label: getShortEventId(event.id)},
-              {label: t('Seer')},
-            ]}
+            crumbs={seerDrawerBreadcrumbs(group, event, project, organization.slug)}
           />
         </SeerDrawerHeader>
         <SeerDrawerBody>
@@ -148,18 +163,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
         <SeerDrawerContainer className="seer-drawer-container">
           <SeerDrawerHeader>
             <NavigationCrumbs
-              crumbs={[
-                {
-                  label: (
-                    <Flex align="center" gap="md">
-                      <ProjectAvatar project={project} />
-                      <ShortId>{group.shortId}</ShortId>
-                    </Flex>
-                  ),
-                },
-                {label: getShortEventId(event.id)},
-                {label: t('Seer')},
-              ]}
+              crumbs={seerDrawerBreadcrumbs(group, event, project, organization.slug)}
             />
           </SeerDrawerHeader>
           <SeerDrawerBody>
@@ -177,18 +181,7 @@ export function SeerDrawer({group, project, event}: SeerDrawerProps) {
       <SeerDrawerContainer className="seer-drawer-container">
         <SeerDrawerHeader>
           <NavigationCrumbs
-            crumbs={[
-              {
-                label: (
-                  <Flex align="center" gap="md">
-                    <ProjectAvatar project={project} />
-                    <ShortId>{group.shortId}</ShortId>
-                  </Flex>
-                ),
-              },
-              {label: getShortEventId(event.id)},
-              {label: t('Seer')},
-            ]}
+            crumbs={seerDrawerBreadcrumbs(group, event, project, organization.slug)}
           />
         </SeerDrawerHeader>
         <SeerDrawerBody>
@@ -364,18 +357,7 @@ function LegacySeerDrawer({group, project, event, aiConfig}: LegacySeerDrawerPro
     <SeerDrawerContainer className="seer-drawer-container">
       <SeerDrawerHeader>
         <NavigationCrumbs
-          crumbs={[
-            {
-              label: (
-                <Flex align="center" gap="md">
-                  <ProjectAvatar project={project} />
-                  <ShortId>{group.shortId}</ShortId>
-                </Flex>
-              ),
-            },
-            {label: getShortEventId(event.id)},
-            {label: t('Seer')},
-          ]}
+          crumbs={seerDrawerBreadcrumbs(group, event, project, organization.slug)}
         />
         <FeedbackWrapper>
           <AutofixFeedback />


### PR DESCRIPTION
## Summary
- Adds `openInNewTab` support to the `Breadcrumbs` component — when set, renders `ExternalLink` (`target="_blank"`) instead of the SPA `Link`
- Applies this to both the Explorer and Legacy Seer drawer breadcrumbs so clicking the issue shortId or event ID opens the corresponding page in a new tab without dismissing the drawer
- Extracts a `seerDrawerBreadcrumbs()` helper in the legacy drawer to eliminate 4 duplicated inline breadcrumb arrays

## Test plan
- [x] Added test in `breadcrumbs.spec.tsx` verifying `openInNewTab` crumbs render with `target="_blank"` and `rel="noreferrer noopener"`
- [x] All existing breadcrumb tests pass
- [x] Pre-commit passes on all modified files
- [x] Manually verify in dev: open Seer drawer on an issue, confirm issue/event breadcrumbs are clickable links that open in new tabs