### PR TITLE
fix(eslint): replace untyped default-case and consistent-return with typed switch-exhaustiveness-check

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -310,8 +310,6 @@ export default typescript.config([
     rules: {
       'array-callback-return': 'error',
       'block-scoped-var': 'error',
-      'consistent-return': 'error',
-      'default-case': 'error',
       'dot-notation': 'error',
       eqeqeq: 'error',
       'guard-for-in': 'off', // TODO(ryan953): Fix violations and enable this rule
@@ -604,6 +602,10 @@ export default typescript.config([
           '@typescript-eslint/no-for-in-array': 'error',
           '@typescript-eslint/no-unnecessary-template-expression': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+          '@typescript-eslint/switch-exhaustiveness-check': [
+            'error',
+            {considerDefaultExhaustiveForUnions: true},
+          ],
           '@typescript-eslint/only-throw-error': 'error',
           '@typescript-eslint/prefer-optional-chain': 'error',
           '@typescript-eslint/prefer-promise-reject-errors': 'error',

--- a/static/app/components/avatarChooser/avatarCropper.tsx
+++ b/static/app/components/avatarChooser/avatarCropper.tsx
@@ -332,7 +332,6 @@ function AvatarCropper({maxDimension, minDimension, updateDataUrlState, dataUrl}
     document.addEventListener('mousemove', updateSize);
     document.addEventListener('mouseup', stopResize);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       document.removeEventListener('mousemove', updateSize);
       document.removeEventListener('mouseup', stopResize);

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -361,7 +361,6 @@ export function useChartXRangeSelection({
 
     document.body.addEventListener('click', handleInsideSelectionClick, true);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       document.body.removeEventListener('click', handleInsideSelectionClick, true);
     };
@@ -422,7 +421,6 @@ export function useChartXRangeSelection({
       enableBrushMode();
     });
 
-    // eslint-disable-next-line consistent-return
     return () => {
       if (brushStateSyncFrameRef.current) {
         cancelAnimationFrame(brushStateSyncFrameRef.current);

--- a/static/app/components/events/contexts/platformContext/utils.tsx
+++ b/static/app/components/events/contexts/platformContext/utils.tsx
@@ -54,8 +54,6 @@ export function getPlatformContextIcon({
     case PlatformContextKeys.SPRING:
       platformIconName = 'java-spring';
       break;
-    default:
-      break;
   }
 
   if (platformIconName.length === 0) {

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -355,8 +355,6 @@ export function getContextIcon({
     case 'gpu':
       iconName = generateIconName(value?.vendor_name ? value?.vendor_name : value?.name);
       break;
-    default:
-      break;
   }
   if (iconName.length === 0) {
     return null;
@@ -567,8 +565,6 @@ export function getContextSummary({
         subtitle = data?.version;
         subtitleType = t('Version');
       }
-      break;
-    default:
       break;
   }
   return {

--- a/static/app/components/events/highlights/util.tsx
+++ b/static/app/components/events/highlights/util.tsx
@@ -181,7 +181,6 @@ export function getRuntimeLabelAndTooltip(
     return null;
   }
 
-  // eslint-disable-next-line default-case
   switch (event.contexts.runtime?.name || '') {
     case 'node':
       return {label: t('Backend'), tooltip: t('Error from Node.js Server Runtime')};

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -278,7 +278,7 @@ export function parseAssembly(assembly: string | null) {
   for (let i = 1; i < pieces.length; i++) {
     const [key, value] = pieces[i]!.trim().split('=');
 
-    // eslint-disable-next-line default-case
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (key) {
       case 'Version':
         version = value;

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -198,8 +198,6 @@ export function usePipeline<
             error: new Error((response.data?.detail as string) ?? 'Pipeline error'),
           });
           break;
-        default:
-          break;
       }
     },
     onError: (error: Error, _variables, context) => {

--- a/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
@@ -114,8 +114,6 @@ export function useSearchTokenCombobox<T>(
       case 'ArrowRight':
         state.selectionManager.setFocusedKey(null);
         break;
-      default:
-        break;
     }
   };
 

--- a/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
+++ b/static/app/views/alerts/list/rules/alertLastIncidentActivationInfo.tsx
@@ -79,7 +79,6 @@ function LastMetricAlertIncident({rule}: {rule: MetricAlert}) {
 }
 
 export function AlertLastIncidentActivationInfo({rule}: Props) {
-  // eslint-disable-next-line default-case
   switch (rule.type) {
     case CombinedAlertType.UPTIME:
       return <LastUptimeIncident rule={rule} />;

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1176,8 +1176,6 @@ export function useWidgetBuilderState(): {
           setTextContent(action.payload);
           break;
         }
-        default:
-          break;
       }
     },
     [

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.stories.tsx
@@ -386,8 +386,6 @@ function onTriggerCellAction(actions: Actions, value: string | number) {
     case Actions.EXCLUDE:
       setFilter(filter.filter(_value => _value !== value));
       break;
-    default:
-      break;
   }
 }
         `}

--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -317,8 +317,6 @@ function getInternalLinkActionLabel(field: string): string {
       return t('Open issue');
     case FieldKey.REPLAY_ID:
       return t('Open replay');
-    default:
-      break;
   }
   return t('Open link');
 }

--- a/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
+++ b/static/app/views/explore/hooks/useAttributeBreakdownsTooltip.tsx
@@ -65,8 +65,6 @@ export function useAttributeBreakdownsTooltipAction(): TooltipActions['onAction'
         case Actions.COPY_TO_CLIPBOARD:
           copyToClipboard.copy(value);
           break;
-        default:
-          break;
       }
     },
     [addSearchFilter, setGroupBys, copyToClipboard]
@@ -136,7 +134,6 @@ export function useAttributeBreakdownsTooltip({
     dom.addEventListener('click', handleClickAnywhere);
     dom.addEventListener('mouseleave', handleMouseLeave);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       dom.removeEventListener('click', handleClickAnywhere);
       dom.removeEventListener('mouseleave', handleMouseLeave);
@@ -185,7 +182,6 @@ export function useAttributeBreakdownsTooltip({
     document.addEventListener('mouseover', handleMouseOver);
     document.addEventListener('mouseout', handleMouseOut);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       document.removeEventListener('click', handleClickActions);
       document.removeEventListener('mouseover', handleMouseOver);

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -30,8 +30,6 @@ export function useCrossEventQueries() {
         case 'logs':
           logQuery.push(crossEvent.query);
           break;
-        default:
-          break;
       }
     }
 

--- a/static/app/views/issueDetails/groupEventCarousel.tsx
+++ b/static/app/views/issueDetails/groupEventCarousel.tsx
@@ -230,8 +230,6 @@ function EventNavigationDropdown({group, event, isDisabled}: GroupEventNavigatio
             });
             break;
           }
-          default:
-            break;
         }
       }}
     />

--- a/static/app/views/issueList/editableIssueViewHeader.tsx
+++ b/static/app/views/issueList/editableIssueViewHeader.tsx
@@ -101,8 +101,6 @@ function EditingViewTitle({
       case 'Escape':
         stopEditing();
         break;
-      default:
-        break;
     }
   };
 

--- a/static/app/views/navigation/navigationTour.tsx
+++ b/static/app/views/navigation/navigationTour.tsx
@@ -208,8 +208,6 @@ export function NavigationTourProvider({children}: {children: React.ReactNode}) 
             navigate(target, {replace: true});
           }
           break;
-        default:
-          break;
       }
     },
     [activeGroup, navigate, organization]

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -360,7 +360,6 @@ function getInsightsModuleBreadcrumbs(
       });
       break;
 
-    case ModuleName.CACHE:
     default:
       break;
   }

--- a/static/app/views/replays/detail/network/truncateJson/completeJson.ts
+++ b/static/app/views/replays/detail/network/truncateJson/completeJson.ts
@@ -37,7 +37,7 @@ export function completeJson(incompleteJson: string, stack: JsonToken[]): string
   for (let i = lastPos; i >= 0; i--) {
     const step = stack[i];
 
-    // eslint-disable-next-line default-case
+    // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
     switch (step) {
       case OBJ:
         json = `${json}}`;

--- a/static/app/views/replays/detail/network/truncateJson/evaluateJson.ts
+++ b/static/app/views/replays/detail/network/truncateJson/evaluateJson.ts
@@ -41,7 +41,6 @@ function _evaluateJsonPos(stack: JsonToken[], json: string, pos: number): void {
     return;
   }
 
-  // eslint-disable-next-line default-case
   switch (char) {
     case '{':
       _handleObj(stack, curStep);

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -181,8 +181,6 @@ export function AttributeField({
         case 'Escape':
           setShowSuggestions(false);
           break;
-        default:
-          break;
       }
     },
     [showSuggestions, filteredSuggestions, activeSuggestion, handleClickSuggestion]

--- a/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
@@ -112,12 +112,12 @@ function isReactFragment(nameNode: TSESTree.JSXTagNameExpression) {
  */
 function getDisplayName(node: TSESTree.JSXTagNameExpression): string {
   switch (node.type) {
+    case AST_NODE_TYPES.JSXIdentifier:
+      return node.name;
     case AST_NODE_TYPES.JSXMemberExpression:
       return `${getDisplayName(node.object)}.${node.property.name}`;
     case AST_NODE_TYPES.JSXNamespacedName:
       return `${node.namespace.name}:${node.name.name}`;
-    default:
-      return node.name;
   }
 }
 

--- a/static/gsAdmin/components/customers/organizationStatus.tsx
+++ b/static/gsAdmin/components/customers/organizationStatus.tsx
@@ -24,8 +24,6 @@ export function OrganizationStatus({orgStatus}: Props) {
     case 'deletion_in_progress':
       message = 'This organization in the process of being deleted.';
       break;
-    default:
-      break;
   }
 
   if (!message) {

--- a/static/gsAdmin/components/relocationBadge.tsx
+++ b/static/gsAdmin/components/relocationBadge.tsx
@@ -26,8 +26,6 @@ export function RelocationBadge({data}: Props) {
       text = 'Paused';
       theme = 'warning';
       break;
-    default:
-      break;
   }
 
   if (


### PR DESCRIPTION
Following up on https://github.com/getsentry/sentry/pull/109725#discussion_r2874708881: our lint rules that attempt to enforce exhaustive logical handling aren't set up right. We're using ESLint's core rules that are not type-aware and so are actually buggy / problematic:

* [`consistent-return`](https://eslint.org/docs/latest/rules/consistent-return): Requires `return` statements to either always or never specify values. This can be thought of as a safety point (never accidentally implicitly returning `undefined`) or a stylistic point (clearly indicating returned values). TypeScript handles the safety point.
* [`default-case`](https://eslint.org/docs/latest/rules/default-case): Requires `default` cases in `switch` statements. This doesn't factor in type information for union types, resulting in a need to add a `default` even if the `switch` is already exhaustive or (e.g. for finite unions) or cannot be (e.g. for primitive types).

This PR switches from them to the type-aware [`@typescript-eslint/switch-exhaustiveness-check`](https://typescript-eslint.io/rules/switch-exhaustiveness-check). That rule knows to only enforce asking for handling all cases  when the `switch` is over a union type.

In other words, for a `switch (value)`, if a `value` is...

* `string`: nothing will require a `default:`
* `"a" | "b"`: then if there isn't both `case "a":` and `case "b":`, there will need to be `default:`