### PR TITLE
feat(ACI): Make ProjectRulesEndpoint GET method backwards compatible

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -728,7 +728,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             queryset = Workflow.objects.filter(
                 detectorworkflow__detector__project=project,
                 status=ObjectStatus.ACTIVE,
-                enabled=True,
             ).distinct()
             serializer = WorkflowEngineRuleSerializer(expand=expand, project_slug=project.slug)
         else:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -726,7 +726,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         serializer: WorkflowEngineRuleSerializer | RuleSerializer
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
             queryset = Workflow.objects.filter(
-                detectorworkflow__detector__project=project, status=ObjectStatus.ACTIVE
+                detectorworkflow__detector__project=project,
+                status=ObjectStatus.ACTIVE,
+                enabled=True,
             ).distinct()
             serializer = WorkflowEngineRuleSerializer(expand=expand, project_slug=project.slug)
         else:

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -17,7 +17,11 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.rule import RuleSerializer, RuleSerializerResponse
+from sentry.api.serializers.models.rule import (
+    RuleSerializer,
+    RuleSerializerResponse,
+    WorkflowEngineRuleSerializer,
+)
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
 from sentry.api.serializers.rest_framework.rule import RuleSerializer as DrfRuleSerializer
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
@@ -34,6 +38,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.rules.processing.processor import is_condition_slow
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_created
+from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -714,22 +719,28 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
-        queryset = Rule.objects.filter(
-            project=project,
-            status=ObjectStatus.ACTIVE,
-        ).select_related("project")
-        # Mark that we're using legacy Rule models
-        report_used_legacy_models()
-
         expand = request.GET.getlist("expand", ["lastTriggered"])
+
+        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+            queryset = Workflow.objects.filter(
+                organization=project.organization,
+                status=ObjectStatus.ACTIVE,
+            )
+            serializer = WorkflowEngineRuleSerializer(expand=expand, project_slug=project.slug)
+        else:
+            queryset = Rule.objects.filter(
+                project=project,
+                status=ObjectStatus.ACTIVE,
+            ).select_related("project")
+            # Mark that we're using legacy Rule models
+            report_used_legacy_models()
+            serializer = RuleSerializer(expand=expand, project_slug=project.slug)
 
         return self.paginate(
             request=request,
             queryset=queryset,
             order_by="-id",
-            on_results=lambda x: serialize(
-                x, request.user, RuleSerializer(expand=expand, project_slug=project.slug)
-            ),
+            on_results=lambda x: serialize(x, request.user, serializer),
         )
 
     @extend_schema(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -723,9 +723,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
 
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
             queryset = Workflow.objects.filter(
-                organization=project.organization,
-                status=ObjectStatus.ACTIVE,
-            )
+                detectorworkflow__detector__project=project, status=ObjectStatus.ACTIVE
+            ).distinct()
             serializer = WorkflowEngineRuleSerializer(expand=expand, project_slug=project.slug)
         else:
             queryset = Rule.objects.filter(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -29,6 +29,7 @@ from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import ObjectStatus
+from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
 from sentry.models.project import Project
@@ -721,6 +722,8 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         """
         expand = request.GET.getlist("expand", ["lastTriggered"])
 
+        queryset: BaseQuerySet[Workflow, Workflow] | BaseQuerySet[Rule, Rule]
+        serializer: WorkflowEngineRuleSerializer | RuleSerializer
         if features.has("organizations:workflow-engine-rule-serializers", project.organization):
             queryset = Workflow.objects.filter(
                 detectorworkflow__detector__project=project, status=ObjectStatus.ACTIVE

--- a/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
+++ b/src/sentry/workflow_engine/migration_helpers/rule_conditions.py
@@ -312,6 +312,7 @@ def translate_to_rule_condition_filters(
 ) -> ConditionAndFilters:
     translator = data_condition_to_rule_condition_mapping.get(Condition(data_condition.type))
     if not translator:
-        raise ValueError(f"Unsupported condition: {data_condition.type}")
+        # return nothing rather than crash when we encounter a condition from a single written workflow that we can't represent in the old UI
+        return {}, []
 
     return translator(data_condition, is_filter)

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -127,7 +127,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         workflow_resp_1 = response.data[0]
         workflow_resp_2 = response.data[1]
 
-        if workflow_resp_1["id"] == self.rule.id:
+        if workflow_resp_1["id"] == str(self.rule.id):
             is_rule_resp = True
 
         if not is_rule_resp:
@@ -196,6 +196,19 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
             == ExistingHighPriorityIssueCondition.id
         )
         assert len(issue_resolved_trigger_resp["filters"]) == 1
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_only_fetch_workflows_in_project(self) -> None:
+        another_rule = self.create_project_rule(
+            project=self.create_project(), name="other project rule"
+        )
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+        for resp in response.data:
+            assert not resp["name"] == another_rule.label
 
 
 class GetMaxAlertsTest(ProjectRuleBaseTestCase):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -13,18 +13,23 @@ from slack_sdk.web import SlackResponse
 
 from sentry.api.endpoints.project_rules import get_max_alerts
 from sentry.constants import ObjectStatus
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
+from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.user import User
+from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.models.workflow import Workflow
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
 
-class ProjectRuleBaseTestCase(APITestCase):
+class ProjectRuleBaseTestCase(APITestCase, BaseWorkflowTest):
     endpoint = "sentry-api-0-project-rules"
 
     def setUp(self) -> None:
@@ -69,6 +74,33 @@ class ProjectRuleBaseTestCase(APITestCase):
                 "input_channel_id": self.channel_id,
             }
         ]
+        # create single written workflow
+        self.detector = self.create_detector()
+        self.workflow_triggers = self.create_data_condition_group()
+        self.workflow = self.create_workflow(
+            when_condition_group=self.workflow_triggers,
+            organization=self.detector.project.organization,
+        )
+        self.detector_workflow = self.create_detector_workflow(
+            detector=self.detector, workflow=self.workflow
+        )
+        self.create_data_condition(  # trigger condition
+            condition_group=self.workflow_triggers,
+            type=Condition.EVENT_FREQUENCY_COUNT,
+            comparison={"interval": "1d", "value": 100},
+            condition_result=True,
+        )
+        self.workflow_filters = self.create_data_condition_group()
+        self.workflow_dcg = self.create_workflow_data_condition_group(
+            workflow=self.workflow, condition_group=self.workflow_filters
+        )
+        self.create_data_condition(  # filter condition
+            condition_group=self.workflow_filters,
+            type=Condition.EVENT_ATTRIBUTE,
+            comparison={"attribute": "platform", "match": "eq", "value": "python"},
+            condition_result=True,
+        )
+        self.action_group, self.action = self.create_workflow_action(self.workflow)
 
 
 class ProjectRuleListTest(ProjectRuleBaseTestCase):
@@ -79,6 +111,91 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
             status_code=status.HTTP_200_OK,
         )
         assert len(response.data) == Rule.objects.filter(project=self.project).count()
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+        assert (
+            len(response.data)
+            == Workflow.objects.filter(organization=self.project.organization).count()
+        )
+        is_rule_resp = False
+        workflow_resp_1 = response.data[0]
+        workflow_resp_2 = response.data[1]
+
+        if workflow_resp_1["id"] == self.rule.id:
+            is_rule_resp = True
+
+        if not is_rule_resp:
+            assert workflow_resp_1["id"] == str(get_fake_id_from_object_id(self.workflow.id))
+            assert workflow_resp_2["id"] == str(self.rule.id)
+        else:
+            assert workflow_resp_2["id"] == str(get_fake_id_from_object_id(self.workflow.id))
+            assert workflow_resp_1["id"] == str(self.rule.id)
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_unsupported_condition(self) -> None:
+        """Test with an unsupported condition e.g. IssueResolvedTriggerCondition
+        we should return what we can - the supported ones, and skip over the unsupported ones
+        """
+        detector = self.create_detector()
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=detector.project.organization,
+            name="Issue resolved trigger workflow",
+        )
+        self.create_detector_workflow(detector=detector, workflow=workflow)
+        self.create_data_condition(  # trigger condition
+            condition_group=workflow_triggers,
+            type=Condition.ISSUE_RESOLVED_TRIGGER,
+            comparison=True,
+            condition_result=True,
+        )
+        self.create_data_condition(  # trigger condition
+            condition_group=workflow_triggers,
+            type=Condition.EXISTING_HIGH_PRIORITY_ISSUE,
+            comparison=True,
+            condition_result=True,
+        )
+        workflow_filters = self.create_data_condition_group()
+        self.create_workflow_data_condition_group(
+            workflow=workflow, condition_group=workflow_filters
+        )
+        self.create_data_condition(  # filter condition
+            condition_group=workflow_filters,
+            type=Condition.EVENT_ATTRIBUTE,
+            comparison={"attribute": "platform", "match": "eq", "value": "python"},
+            condition_result=True,
+        )
+        self.create_workflow_action(workflow)
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            status_code=status.HTTP_200_OK,
+        )
+        assert (
+            len(response.data)
+            == Workflow.objects.filter(organization=self.project.organization).count()
+        )
+        issue_resolved_trigger_resp = None
+
+        for resp in response.data:
+            if resp["name"] == workflow.name:
+                issue_resolved_trigger_resp = resp
+
+        assert issue_resolved_trigger_resp
+        # assert we skipped over Condition.ISSUE_RESOLVED_TRIGGER and only have Condition.EXISTING_HIGH_PRIORITY_ISSUE
+        assert len(issue_resolved_trigger_resp["conditions"]) == 1
+        assert (
+            issue_resolved_trigger_resp["conditions"][0]["id"]
+            == ExistingHighPriorityIssueCondition.id
+        )
+        assert len(issue_resolved_trigger_resp["filters"]) == 1
 
 
 class GetMaxAlertsTest(ProjectRuleBaseTestCase):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -142,7 +142,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         """Test with an unsupported condition e.g. IssueResolvedTriggerCondition
         we should return what we can - the supported ones, and skip over the unsupported ones
         """
-        detector = self.create_detector()
+        detector = self.create_detector(project=self.project)
         workflow_triggers = self.create_data_condition_group()
         workflow = self.create_workflow(
             when_condition_group=workflow_triggers,

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -75,7 +75,7 @@ class ProjectRuleBaseTestCase(APITestCase, BaseWorkflowTest):
             }
         ]
         # create single written workflow
-        self.detector = self.create_detector()
+        self.detector = self.create_detector(project=self.project)
         self.workflow_triggers = self.create_data_condition_group()
         self.workflow = self.create_workflow(
             when_condition_group=self.workflow_triggers,


### PR DESCRIPTION
Make `ProjectRulesEndpoint` GET method backwards compatible so that it looks up `Workflow`s and serializes them using `WorkflowEngineRuleSerializer`. Since we have some new filters and conditions in ACI that don't exist for `Rule` we simply skip over those and render only those that have a `Rule` equivalent. 