### PR TITLE
ref(cells): generate_region_url -> generate_locality_url

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -14,7 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import MAX_FILE_SIZE
 from sentry.models.organization import Organization
@@ -140,7 +140,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             else:
                 # We need to generate region specific upload URLs when possible to avoid hitting the API proxy
                 # which tends to cause timeouts and performance issues for uploads.
-                url = absolute_uri(relative_url, generate_region_url())
+                url = absolute_uri(relative_url, generate_locality_url())
         else:
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)

--- a/src/sentry/api/endpoints/organization_auth_tokens.py
+++ b/src/sentry/api/endpoints/organization_auth_tokens.py
@@ -17,7 +17,7 @@ from sentry.api.authentication import SessionNoAuthTokenAuthentication
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.organization import ControlSiloOrganizationEndpoint, OrgAuthTokenPermission
 from sentry.api.serializers import serialize
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
 from sentry.models.orgauthtoken import MAX_NAME_LENGTH, OrgAuthToken
@@ -26,6 +26,7 @@ from sentry.organizations.services.organization.model import (
     RpcUserOrganizationContext,
 )
 from sentry.security.utils import capture_security_activity
+from sentry.types.region import get_locality_name_for_cell
 from sentry.users.models.user import User
 from sentry.utils.security.orgauthtoken_token import (
     SystemUrlPrefixMissingException,
@@ -73,7 +74,8 @@ class OrganizationAuthTokensEndpoint(ControlSiloOrganizationEndpoint):
         try:
             org_mapping = OrganizationMapping.objects.get(organization_id=organization.id)
             token_str = generate_token(
-                organization.slug, generate_region_url(region_name=org_mapping.region_name)
+                organization.slug,
+                generate_locality_url(get_locality_name_for_cell(org_mapping.region_name)),
             )
         except SystemUrlPrefixMissingException:
             return Response(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -25,7 +25,7 @@ from sentry.api.serializers.models.role import (
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.serializers.types import SerializedAvatarFields
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.auth.access import Access
 from sentry.auth.services.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.constants import (
@@ -439,7 +439,7 @@ class OrganizationSerializer(Serializer):
             "allowSuperuserAccess": not obj.flags.prevent_superuser_access,
             "links": {
                 "organizationUrl": generate_organization_url(obj.slug),
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
             },
             "hasAuthProvider": has_auth_provider,
         }

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -43,7 +43,7 @@ from sentry.search.events.constants import (
 from sentry.search.events.types import SnubaParams
 from sentry.search.utils import InvalidQuery, parse_datetime_string
 from sentry.silo.base import SiloMode
-from sentry.types.region import get_local_region
+from sentry.types.region import get_local_locality, get_locality_name_for_cell
 from sentry.utils import json
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.sdk import capture_exception, merge_context_into_scope, set_span_attribute
@@ -304,19 +304,34 @@ def is_member_disabled_from_limit(
         return member.flags.member_limit__restricted
 
 
-def generate_region_url(region_name: str | None = None) -> str:
+def generate_region_url() -> str:
+    # Deprecated. Use generate_locality_url.
+    # This shim exists temporarily for getsentry compatibility.
+    return generate_locality_url()
+
+
+def generate_locality_url(locality_name: str | None = None) -> str:
+    """
+    Return the customer-facing base URL for a locality.
+
+    If locality_name is not provided, it is inferred from the running silo:
+    in REGION mode the local cell's locality is used; in MONOLITH mode with
+    SENTRY_REGION set the corresponding locality is resolved from that cell name.
+    Falls back to system.url-prefix when no template or locality name is available.
+    """
     region_url_template: str | None = options.get("system.region-api-url-template")
-    if region_name is None and SiloMode.get_current_mode() == SiloMode.REGION:
-        region_name = get_local_region().name
+    if locality_name is None and SiloMode.get_current_mode() == SiloMode.REGION:
+        locality_name = get_local_locality().name
+
     if (
-        region_name is None
+        locality_name is None
         and SiloMode.get_current_mode() == SiloMode.MONOLITH
         and settings.SENTRY_REGION
     ):
-        region_name = settings.SENTRY_REGION
-    if not region_url_template or not region_name:
+        locality_name = get_locality_name_for_cell(settings.SENTRY_REGION)
+    if not region_url_template or not locality_name:
         return options.get("system.url-prefix")
-    return region_url_template.replace("{region}", region_name)
+    return region_url_template.replace("{region}", locality_name)
 
 
 def print_and_capture_handler_exception(

--- a/src/sentry/discover/compare_timeseries.py
+++ b/src/sentry/discover/compare_timeseries.py
@@ -43,10 +43,10 @@ def format_api_call(organization_slug, **kwargs):
         kwargs={"organization_id_or_slug": organization_slug},
     )
 
-    from sentry.api.utils import generate_region_url
+    from sentry.api.utils import generate_locality_url
 
     query = urlencode({**kwargs})
-    region_url = generate_region_url()
+    region_url = generate_locality_url()
     api_call = f"{region_url}{path}?{query}"
 
     return api_call

--- a/src/sentry/integrations/coding_agent/integration.py
+++ b/src/sentry/integrations/coding_agent/integration.py
@@ -4,7 +4,7 @@ import abc
 
 from django.utils.translation import gettext_lazy as _
 
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationFeatures,
@@ -60,7 +60,7 @@ class CodingAgentIntegration(IntegrationInstallation, abc.ABC):
         """Generate webhook URL for this integration."""
         return absolute_uri(
             f"/extensions/{self.model.provider}/organizations/{self.organization_id}/webhook/",
-            url_prefix=generate_region_url(),
+            url_prefix=generate_locality_url(),
         )
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -8,7 +8,7 @@ from django import forms
 from django.http import HttpRequest, HttpResponse
 from slack_sdk.errors import SlackApiError
 
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.integrations.messaging.linkage import LinkTeamView
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
@@ -45,7 +45,7 @@ def build_team_linking_url(
         response_url=response_url,
         # The team-linking view is region-specific, so skip the middleware proxy if necessary.
         url_prefix=(
-            generate_region_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
+            generate_locality_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
         ),
     )
 

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,6 +1,6 @@
 import logging
 
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.integrations.messaging.linkage import UnlinkTeamView
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import RpcIntegration
@@ -35,7 +35,7 @@ def build_team_unlinking_url(
         response_url=response_url,
         # The team-linking view is region-specific, so skip the middleware proxy if necessary.
         url_prefix=(
-            generate_region_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
+            generate_locality_url() if SiloMode.get_current_mode() == SiloMode.REGION else None
         ),
     )
 

--- a/src/sentry/models/orgauthtoken.py
+++ b/src/sentry/models/orgauthtoken.py
@@ -88,7 +88,7 @@ class OrgAuthToken(ReplicatedControlModel):
     ) -> int | None:
         # TODO(getsentry/team-ospo#190): Prevents a circular import; could probably split up the
         # source module in such a way that this is no longer an issue.
-        from sentry.api.utils import generate_region_url
+        from sentry.api.utils import generate_locality_url
         from sentry.utils.security.orgauthtoken_token import (
             SystemUrlPrefixMissingException,
             generate_token,
@@ -106,7 +106,7 @@ class OrgAuthToken(ReplicatedControlModel):
                 return None
 
             try:
-                token_str = generate_token(org_slug, generate_region_url())
+                token_str = generate_token(org_slug, generate_locality_url())
             except SystemUrlPrefixMissingException:
                 return None
             self.token_hashed = hash_token(token_str)

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -296,12 +296,12 @@ class ProjectKey(Model):
             )
 
     def get_endpoint(self) -> str:
-        from sentry.api.utils import generate_region_url
+        from sentry.api.utils import generate_locality_url
 
         endpoint = settings.SENTRY_ENDPOINT
         if not endpoint:
             if SiloMode.get_current_mode() == SiloMode.REGION:
-                endpoint = generate_region_url()
+                endpoint = generate_locality_url()
             else:
                 endpoint = options.get("system.url-prefix")
             assert endpoint is not None

--- a/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_upload_options.py
@@ -14,7 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.project import Project
 from sentry.objectstore.types import ObjectstoreUploadOptions
 from sentry.utils.http import absolute_uri
@@ -43,7 +43,7 @@ class ProjectPreprodUploadOptionsEndpoint(ProjectEndpoint):
                 "path": "",
             },
         )
-        url = absolute_uri(path, generate_region_url())
+        url = absolute_uri(path, generate_locality_url())
 
         options = ObjectstoreUploadOptions(
             url=url,

--- a/src/sentry/templates/sentry/toolbar/iframe.html
+++ b/src/sentry/templates/sentry/toolbar/iframe.html
@@ -7,7 +7,7 @@ Required context variables:
 - organization_slug:  string.       The org named in the url params
 - project_id_or_slug: string | int. The project named in the url params
 - organizationUrl:    string.       Result of generate_organization_url()
-- regionUrl:          string.       Result of generate_region_url()
+- regionUrl:          string.       Result of generate_locality_url()
 {% endcomment %}
 {% load sentry_helpers %}
 {% load sentry_assets %}

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -216,7 +216,7 @@ __all__ = (
     "MonitorIngestTestCase",
 )
 
-from ..types.region import get_region_by_name
+from ..types.region import get_cell_by_name
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
 
@@ -464,7 +464,7 @@ class TestCase(BaseTestCase, DjangoTestCase):
                             # TODO: Can we infer the correct region here?  would need to package up the
                             # the request dictionary into a higher level object, which also involves invoking
                             # _base_environ and maybe other logic buried in Client.....
-                            region = get_region_by_name(settings.SENTRY_MONOLITH_REGION)
+                            region = get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
                         with (
                             SingleProcessSiloModeState.exit(),
                             SingleProcessSiloModeState.enter(mode, region),

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -167,7 +167,7 @@ from sentry.tempest.models import TempestCredentials
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
-from sentry.types.region import Region, get_local_region, get_region_by_name
+from sentry.types.region import Region, get_cell_by_name, get_local_region
 from sentry.types.token import AuthTokenType
 from sentry.uptime.models import (
     IntervalSecondsLiteral,
@@ -389,7 +389,7 @@ class Factories:
                 if isinstance(region, Region):
                     region_name = region.name
                 else:
-                    region_obj = get_region_by_name(region)  # Verify it exists
+                    region_obj = get_cell_by_name(region)  # Verify it exists
                     region_name = region_obj.name
 
                 ctx.enter_context(

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -83,14 +83,14 @@ def monkey_patch_single_process_silo_mode_state():
 
 
 def create_test_regions(*names: str, single_tenants: Iterable[str] = ()) -> tuple[Region, ...]:
-    from sentry.api.utils import generate_region_url
+    from sentry.api.utils import generate_locality_url
 
     single_tenants = frozenset(single_tenants)
     return tuple(
         Region(
             name=name,
             snowflake_id=index + 1,
-            address=generate_region_url(name),
+            address=generate_locality_url(name),
             category=(
                 RegionCategory.SINGLE_TENANT
                 if name in single_tenants

--- a/src/sentry/toolbar/views/iframe_view.py
+++ b/src/sentry/toolbar/views/iframe_view.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBase
 
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.organizations.absolute_url import generate_organization_url
@@ -64,7 +64,7 @@ class IframeView(ProjectView):
                 "organization_slug": self.organization_slug,
                 "project_id_or_slug": self.project_id_or_slug,
                 "organization_url": generate_organization_url(self.organization_slug),
-                "region_url": generate_region_url(),
+                "region_url": generate_locality_url(),
             },
         )
 

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -45,12 +45,12 @@ class Locality:
         In monolith mode, there is likely only the historical simulated locality.
         The public URL of the simulated locality is the same as the application base URL.
         """
-        from sentry.api.utils import generate_region_url
+        from sentry.api.utils import generate_locality_url
 
         if SiloMode.get_current_mode() == SiloMode.MONOLITH:
             base_url = options.get("system.url-prefix")
         else:
-            base_url = generate_region_url(self.name)
+            base_url = generate_locality_url(self.name)
         return urljoin(base_url, path)
 
     def api_serialize(self) -> dict[str, Any]:
@@ -378,7 +378,7 @@ def get_region_for_organization(organization_id_or_slug: str) -> Region:
             f"Organization {organization_id_or_slug} has no associated mapping."
         )
 
-    return get_region_by_name(name=mapping.region_name)
+    return get_cell_by_name(name=mapping.region_name)
 
 
 def get_local_locality() -> Locality:
@@ -390,6 +390,12 @@ def get_local_locality() -> Locality:
     return locality
 
 
+def get_locality_name_for_cell(cell_name: str) -> str:
+    """Get the locality name for a cell, falling back to the cell name if unmapped."""
+    locality = get_global_directory().get_locality_for_cell(cell_name)
+    return locality.name if locality is not None else cell_name
+
+
 def get_local_region() -> Region:
     """Get the region in which this server instance is running.
 
@@ -398,7 +404,7 @@ def get_local_region() -> Region:
     """
 
     if SiloMode.get_current_mode() == SiloMode.MONOLITH:
-        return get_region_by_name(settings.SENTRY_MONOLITH_REGION)
+        return get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
 
     if SiloMode.get_current_mode() != SiloMode.REGION:
         raise RegionContextError("Not a region silo")
@@ -413,10 +419,10 @@ def get_local_region() -> Region:
 
     if not settings.SENTRY_REGION:
         if in_test_environment():
-            return get_region_by_name(settings.SENTRY_MONOLITH_REGION)
+            return get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
         else:
             raise Exception("SENTRY_REGION must be set when server is in REGION silo mode")
-    return get_region_by_name(settings.SENTRY_REGION)
+    return get_cell_by_name(settings.SENTRY_REGION)
 
 
 @control_silo_function

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -391,9 +391,14 @@ def get_local_locality() -> Locality:
 
 
 def get_locality_name_for_cell(cell_name: str) -> str:
-    """Get the locality name for a cell, falling back to the cell name if unmapped."""
+    """
+    Get the locality name for a cell
+    """
     locality = get_global_directory().get_locality_for_cell(cell_name)
-    return locality.name if locality is not None else cell_name
+    if locality is None:
+        raise RegionResolutionError(f"No locality found for cell {cell_name!r}")
+
+    return locality.name
 
 
 def get_local_region() -> Region:

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -16,7 +16,7 @@ from rest_framework.request import Request
 
 import sentry
 from sentry import features, options
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.auth import superuser
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.auth.superuser import is_active_superuser
@@ -36,6 +36,7 @@ from sentry.types.region import (
     find_all_multitenant_locality_names,
     get_global_directory,
     get_locality_by_name,
+    get_locality_name_for_cell,
 )
 from sentry.users.models.user import User
 from sentry.users.services.user import UserSerializeType
@@ -293,9 +294,11 @@ class _ClientConfig:
                 organization_mapping = OrganizationMapping.objects.get(
                     organization_id=self.last_org.id
                 )
-                region_url = generate_region_url(organization_mapping.region_name)
+                region_url = generate_locality_url(
+                    get_locality_name_for_cell(organization_mapping.region_name)
+                )
             else:
-                region_url = generate_region_url()
+                region_url = generate_locality_url()
 
         yield "organizationUrl", organization_url
         yield "regionUrl", region_url

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -17,8 +17,7 @@ from sentry.organizations.absolute_url import customer_domain_path, generate_org
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.types.region import (
-    find_all_multitenant_region_names,
-    get_locality_name_for_cell,
+    find_all_multitenant_locality_names,
     subdomain_is_region,
 )
 from sentry.utils.http import is_using_customer_domain, query_string
@@ -77,13 +76,10 @@ class ReactMixin:
         return preconnects
 
     def dns_prefetch(self) -> list[str]:
-        regions = find_all_multitenant_region_names()
-        if len(regions) < 2:
+        localities = find_all_multitenant_locality_names()
+        if len(localities) < 2:
             return []
-        return [
-            generate_locality_url(get_locality_name_for_cell(region_name))
-            for region_name in regions
-        ]
+        return [generate_locality_url(locality_name) for locality_name in localities]
 
     def handle_react(
         self, request: HttpRequest, *, organization: Organization | None = None, **kwargs

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -11,14 +11,14 @@ from django.middleware.csrf import get_token as get_csrf_token
 from django.urls import resolve
 
 from sentry import features, options
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.organization import Organization
 from sentry.organizations.absolute_url import customer_domain_path, generate_organization_url
 from sentry.organizations.services.organization import organization_service
 from sentry.silo.base import SiloMode
 from sentry.types.region import (
     find_all_multitenant_region_names,
-    get_region_by_name,
+    get_locality_name_for_cell,
     subdomain_is_region,
 )
 from sentry.utils.http import is_using_customer_domain, query_string
@@ -81,7 +81,8 @@ class ReactMixin:
         if len(regions) < 2:
             return []
         return [
-            generate_region_url(get_region_by_name(region_name).name) for region_name in regions
+            generate_locality_url(get_locality_name_for_cell(region_name))
+            for region_name in regions
         ]
 
     def handle_react(

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -27,7 +27,7 @@ from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project.service import project_service
 from sentry.projects.services.project_key.model import RpcProjectKey
 from sentry.projects.services.project_key.service import project_key_service
-from sentry.types.region import get_locality_name_for_cell
+from sentry.types.region import RegionResolutionError, get_locality_name_for_cell
 from sentry.types.token import AuthTokenType
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -271,7 +271,7 @@ def get_org_token(mapping: OrganizationMapping, user: User | RpcUser | Anonymous
         token_str = generate_token(
             mapping.slug, generate_locality_url(get_locality_name_for_cell(mapping.region_name))
         )
-    except SystemUrlPrefixMissingException:
+    except (SystemUrlPrefixMissingException, RegionResolutionError):
         return None
 
     token_hashed = hash_token(token_str)

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -15,7 +15,7 @@ from sentry.api.base import allow_cors_options
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY, SETUP_WIZARD_CACHE_TIMEOUT
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import STATUS_LABELS
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.cache import default_cache
 from sentry.demo_mode.utils import is_demo_user
 from sentry.models.apitoken import ApiToken
@@ -27,6 +27,7 @@ from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project.service import project_service
 from sentry.projects.services.project_key.model import RpcProjectKey
 from sentry.projects.services.project_key.service import project_key_service
+from sentry.types.region import get_locality_name_for_cell
 from sentry.types.token import AuthTokenType
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
@@ -268,7 +269,7 @@ def get_token(mappings: list[OrganizationMapping], user: RpcUser):
 def get_org_token(mapping: OrganizationMapping, user: User | RpcUser | AnonymousUser):
     try:
         token_str = generate_token(
-            mapping.slug, generate_region_url(region_name=mapping.region_name)
+            mapping.slug, generate_locality_url(get_locality_name_for_cell(mapping.region_name))
         )
     except SystemUrlPrefixMissingException:
         return None

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -16,7 +16,7 @@ from sentry.api.endpoints.chunk import (
     MAX_CONCURRENCY,
     MAX_REQUEST_SIZE,
 )
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.models.apitoken import ApiToken
 from sentry.models.files.fileblob import FileBlob
 from sentry.models.files.utils import MAX_FILE_SIZE
@@ -57,7 +57,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == MAX_FILE_SIZE
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
         assert response.data["accept"] == CHUNK_UPLOAD_ACCEPT
 
         with override_options({"system.upload-url-prefix": "test"}):
@@ -82,7 +82,7 @@ class ChunkUploadTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["chunkSize"] == settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_chunk_parameters_launchpad_auth_different_org(self) -> None:
@@ -148,7 +148,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/1.70.0",
             format="json",
         )
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
 
         response = self.client.get(
             self.url,
@@ -156,7 +156,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/0.69.3",
             format="json",
         )
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
 
         # user overridden upload url prefix has priority, even when calling from sentry-cli that supports relative urls
         with override_options({"system.upload-url-prefix": "test"}):
@@ -175,7 +175,7 @@ class ChunkUploadTest(APITestCase):
                 HTTP_USER_AGENT="sentry-cli/1.70.1",
                 format="json",
             )
-            assert response.data["url"] == generate_region_url() + self.url
+            assert response.data["url"] == generate_locality_url() + self.url
 
     def test_region_upload_urls(self) -> None:
         response = self.client.get(
@@ -192,7 +192,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/0.69.3",
             format="json",
         )
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
 
         response = self.client.get(
             self.url,
@@ -209,7 +209,7 @@ class ChunkUploadTest(APITestCase):
             format="json",
         )
 
-        assert response.data["url"] == generate_region_url() + self.url
+        assert response.data["url"] == generate_locality_url() + self.url
 
         with override_options({"hybrid_cloud.disable_relative_upload_urls": True}):
             response = self.client.get(
@@ -218,7 +218,7 @@ class ChunkUploadTest(APITestCase):
                 HTTP_USER_AGENT="sentry-cli/2.29.99",
                 format="json",
             )
-            assert response.data["url"] == generate_region_url() + self.url
+            assert response.data["url"] == generate_locality_url() + self.url
 
     def test_wrong_api_token(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -16,7 +16,7 @@ from rest_framework import status
 
 from sentry import audit_log
 from sentry.api.serializers.models.organization import TrustedRelaySerializer
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.auth.authenticators.recovery_code import RecoveryCodeInterface
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.constants import RESERVED_ORGANIZATION_SLUGS, ObjectStatus
@@ -100,7 +100,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase, BaseMetricsLayerTestC
         assert response.data["slug"] == self.organization.slug
         assert response.data["links"] == {
             "organizationUrl": f"http://{self.organization.slug}.testserver",
-            "regionUrl": generate_region_url(),
+            "regionUrl": generate_locality_url(),
         }
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"
@@ -128,7 +128,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase, BaseMetricsLayerTestC
         assert response.data["slug"] == self.organization.slug
         assert response.data["links"] == {
             "organizationUrl": f"http://{self.organization.slug}.testserver",
-            "regionUrl": generate_region_url(),
+            "regionUrl": generate_locality_url(),
         }
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"
@@ -628,7 +628,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase, BaseMetricsLayerTestC
         assert resp.data["avatar"]["avatarUuid"] == "abc123"
         assert (
             resp.data["avatar"]["avatarUrl"]
-            == generate_region_url() + "/organization-avatar/abc123/"
+            == generate_locality_url() + "/organization-avatar/abc123/"
         )
 
     def test_old_orgs_with_options_do_not_get_onboarding_feature_flag(self) -> None:

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -6,7 +6,7 @@ from django.test import override_settings
 from django.urls import reverse
 
 from sentry import options
-from sentry.api.utils import generate_region_url
+from sentry.api.utils import generate_locality_url
 from sentry.auth import superuser
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_deletion
@@ -271,7 +271,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == other_org.slug
             assert data["links"] == {
                 "organizationUrl": f"http://{other_org.slug}.testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
                 "superuserUrl": f"http://{self.organization.slug}.testserver",
             }
@@ -352,7 +352,7 @@ class ClientConfigViewTest(TestCase):
         assert data["lastOrganization"] == self.organization.slug
         assert data["links"] == {
             "organizationUrl": f"http://{self.organization.slug}.testserver",
-            "regionUrl": generate_region_url(),
+            "regionUrl": generate_locality_url(),
             "sentryUrl": "http://testserver",
         }
 
@@ -377,7 +377,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": f"http://{self.organization.slug}.testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 
@@ -402,7 +402,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": "http://testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 
@@ -417,7 +417,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": f"http://{self.organization.slug}.testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 
@@ -442,7 +442,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": "invalid",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 
@@ -457,7 +457,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": "http://testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 
@@ -472,7 +472,7 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
                 "organizationUrl": f"ftp://{self.organization.slug}.testserver",
-                "regionUrl": generate_region_url(),
+                "regionUrl": generate_locality_url(),
                 "sentryUrl": "http://testserver",
             }
 


### PR DESCRIPTION
the url generation function is no explicitly about localities, since cells don't have distinct urls.

the "region" concept is being removed in favor of cells + localities
