### PR TITLE
feat(ACI): Make ProjectRuleDetailsEndpoint DELETE method backwards compatible

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -9,7 +9,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, features
+from sentry import analytics, audit_log
 from sentry.analytics.events.rule_disable_opt_out import (
     RuleDisableOptOutEdit,
     RuleDisableOptOutExplicit,
@@ -137,13 +137,12 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         - Filters - help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
-        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
+        if isinstance(rule, Workflow):
             workflow_engine_rule_serializer = WorkflowEngineRuleSerializer(
                 expand=request.GET.getlist("expand", []),
                 prepare_component_fields=True,
                 project_slug=project.slug,
             )
-            # XXX: Note 'rule' here is actually a workflow object
             serialized_rule = serialize(rule, request.user, workflow_engine_rule_serializer)
         else:
             # Serialize Rule object
@@ -419,28 +418,25 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
          - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         if isinstance(rule, Workflow):
-            return Response(
-                {
-                    "rule": [
-                        "Passing a workflow through this endpoint is not yet supported",
-                    ]
-                },
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        report_used_legacy_models()
-        with transaction.atomic(router.db_for_write(Rule)):
-            rule.update(status=ObjectStatus.PENDING_DELETION)
-            RuleActivity.objects.create(
-                rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
-            )
-            scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
+            audit_id = "WORKFLOW_REMOVE"
+            with transaction.atomic(router.db_for_write(Workflow)):
+                rule.update(status=ObjectStatus.PENDING_DELETION)
+                scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
+        else:
+            audit_id = "RULE_REMOVE"
+            report_used_legacy_models()
+            with transaction.atomic(router.db_for_write(Rule)):
+                rule.update(status=ObjectStatus.PENDING_DELETION)
+                RuleActivity.objects.create(
+                    rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
+                )
+                scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
 
         self.create_audit_entry(
             request=request,
             organization=project.organization,
             target_object=rule.id,
-            event=audit_log.get_event_id("RULE_REMOVE"),
+            event=audit_log.get_event_id(audit_id),
             data=rule.get_audit_log_data(),
             transaction_id=scheduled.id,
         )

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -9,7 +9,6 @@ import responses
 from rest_framework import status
 from slack_sdk.web.slack_response import SlackResponse
 
-from sentry import audit_log
 from sentry.analytics.events.rule_disable_opt_out import (
     RuleDisableOptOutEdit,
     RuleDisableOptOutExplicit,
@@ -19,7 +18,6 @@ from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.utils.channel import strip_channel_name
-from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -32,9 +30,10 @@ from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.actor import Actor
-from sentry.workflow_engine.models import AlertRuleWorkflow
+from sentry.workflow_engine.models import Action, AlertRuleWorkflow
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_condition_group import DataConditionGroup
+from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
@@ -1643,14 +1642,17 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         ).exists()
 
     @with_feature("organizations:workflow-engine-rule-serializers")
-    def test_workflow_passed(self) -> None:
+    def test_single_written_workflow_passed(self) -> None:
         self.get_success_response(
             self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=202
         )
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            assert AuditLogEntry.objects.filter(
-                event=audit_log.get_event_id("WORKFLOW_REMOVE"), target_object=self.workflow.id
-            ).exists()
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Workflow.objects.filter(id=self.workflow.id).exists()
+        assert not DetectorWorkflow.objects.filter(id=self.detector_workflow.id).exists()
+        assert not DataConditionGroup.objects.filter(id=self.workflow_triggers.id).exists()
+        assert not Action.objects.filter(id=self.action.id).exists()
 
     def test_dual_delete_workflow_engine(self) -> None:
         rule = self.create_project_rule(

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -9,6 +9,7 @@ import responses
 from rest_framework import status
 from slack_sdk.web.slack_response import SlackResponse
 
+from sentry import audit_log
 from sentry.analytics.events.rule_disable_opt_out import (
     RuleDisableOptOutEdit,
     RuleDisableOptOutExplicit,
@@ -18,6 +19,7 @@ from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.integrations.slack.utils.channel import strip_channel_name
+from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.environment import Environment
 from sentry.models.rule import NeglectedRule, Rule, RuleActivity, RuleActivityType
 from sentry.models.rulefirehistory import RuleFireHistory
@@ -1642,9 +1644,13 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_passed(self) -> None:
-        self.get_error_response(
-            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=400
+        self.get_success_response(
+            self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=202
         )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            assert AuditLogEntry.objects.filter(
+                event=audit_log.get_event_id("WORKFLOW_REMOVE"), target_object=self.workflow.id
+            ).exists()
 
     def test_dual_delete_workflow_engine(self) -> None:
         rule = self.create_project_rule(


### PR DESCRIPTION
If we are directly passed a `Workflow` we need to delete it rather than expecting a dual written `Rule`.