### PR TITLE
ref(grouping): Add git SHA parameterization

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -208,6 +208,17 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (\b(?=[A-F]*[0-9])[0-9A-F]{16,128}\b)
         """,
     ),
+    ParameterizationRegex(
+        name="git_sha",
+        raw_pattern=r"""
+            # This is similar to the hex pattern above, except it has lookaheads for both numbers
+            # and letters, to guarantee we have at least one of each. (This means it will miss git
+            # shas which consist of only letters or only numbers, but fortunately > 96% of 7-digit
+            # hex values are mixed, so that's a tradeoff we're okay with.) Also, it only includes
+            # lowercase letters, since git shas are always expressed that way.
+            (\b(?=[a-f]*[0-9])(?=[0-9]*[a-f])[0-9a-f]{7}\b)
+        """,
+    ),
     ParameterizationRegex(name="float", raw_pattern=r"""-\d+\.\d+\b | \b\d+\.\d+\b"""),
     ParameterizationRegex(name="int", raw_pattern=r"""-\d+\b | \b\d+\b"""),
     ParameterizationRegex(

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -133,6 +133,7 @@ standard_cases = [
     ("hex without prefix - uppercase, no numbers until later", "DEADBEEF 123", "DEADBEEF <int>"),
     ("hex without prefix - no letters, < 8 digits", "1234567", "<int>"),
     ("hex without prefix - no letters, 8+ digits", "12345678", "<hex>"),
+    ("git sha", "commit a93c7d2", "commit <git_sha>"),
     ("git sha - all letters", "commit deadbeef", "commit deadbeef"),
     ("git sha - all numbers", "commit 4150908", "commit <int>"),
     ("float", "0.23", "<float>"),
@@ -212,12 +213,6 @@ def test_experimental_parameterization(
 # parameterization. (Remember to remove the last item in each tuple for the cases you fix.)
 incorrect_cases = [
     # ("name", "input", "desired", "actual")
-    (
-        "git sha",
-        "commit a93c7d2",
-        "commit <git_sha>",
-        "commit a93c7d2",
-    ),
     (
         "int - number in word",
         "Encoding: utf-8",


### PR DESCRIPTION
It is standard git practice to abbreviate commit SHAs to 7 digits where there's no ambiguity. However, for message parameterization our current hex matching only applies to strings 8 characters and up. This therefore adds a new, separate pattern to our collection of parameterizer regexes, specifically to match git SHAs. It's similar to our hex regex, but stricter, in that the string must be exactly 7 characters, must include both a letter and a number (this will miss a few, but both words and ints are more common, so we let them win), and must only use lowercase letters, as git always does.