### PR TITLE
fix(ci): Skip selenium plugin import on non-acceptance backend test shards

### DIFF
--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0,30 * * * *'
 
+env:
+  SENTRY_SKIP_SELENIUM_PLUGIN: '1'
+
 jobs:
   # Skip generating coverage if already exists in GCS
   check-existing-coverage:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 3
   SNUBA_NO_WORKERS: 1
+  SENTRY_SKIP_SELENIUM_PLUGIN: '1'
 
 jobs:
   files-changed:

--- a/src/sentry/testutils/pytest/__init__.py
+++ b/src/sentry/testutils/pytest/__init__.py
@@ -1,7 +1,8 @@
+import os
+
 pytest_plugins = [
     "sentry.testutils.skips",
     "sentry.testutils.pytest.sentry",
-    "sentry.testutils.pytest.selenium",
     "sentry.testutils.pytest.fixtures",
     "sentry.testutils.pytest.unittest",
     "sentry.testutils.pytest.kafka",
@@ -12,3 +13,6 @@ pytest_plugins = [
     "sentry.testutils.pytest.show_flaky_failures",
     "sentry.testutils.thread_leaks.pytest",
 ]
+
+if os.environ.get("SENTRY_SKIP_SELENIUM_PLUGIN") != "1":
+    pytest_plugins.append("sentry.testutils.pytest.selenium")


### PR DESCRIPTION
- We don't need to load the rather large selenium plugin for non-acceptance tests.
- Set `SENTRY_SKIP_SELENIUM_PLUGIN=1` at the workflow level in `backend.yml` and `backend-with-coverage.yml`. Acceptance workflows are unaffected.

