### PR TITLE
feat(perf-detectors): Create Performance Detectors by default

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -73,7 +73,17 @@ class PerformanceDetectorConfigMapping:
     option_keys: dict[str, str]  # detector setting name -> ProjectOption key
 
 
-# Mapping from DetectorType to WFE Detector configuration
+# Mapping from DetectorType to WFE Detector configuration.
+#
+# Membership in this mapping means the detector is:
+#   - Sentry-managed: created automatically on project creation
+#   - Backed by the (soon to be removed) per-project performance detector config UI (ProjectOption-based)
+#   - GroupCategory.PERFORMANCE (for category, not category_v2)
+#
+# All but web_vitals, performance_p95_endpoint_regression and profile_function_regression
+# have corresponding DetectorTypes and are span-based.
+#
+# TODO: Complete this mapping.
 PERFORMANCE_DETECTOR_CONFIG_MAPPINGS: dict[DetectorType, PerformanceDetectorConfigMapping] = {
     DetectorType.SLOW_DB_QUERY: PerformanceDetectorConfigMapping(
         settings_key=DetectorType.SLOW_DB_QUERY,

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -15,6 +15,7 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
+from sentry.issue_detection.performance_detection import PERFORMANCE_DETECTOR_CONFIG_MAPPINGS
 from sentry.issues import grouptype
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
@@ -51,7 +52,11 @@ from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 logger = logging.getLogger(__name__)
 
-VALID_DEFAULT_DETECTOR_TYPES = [ErrorGroupType.slug, IssueStreamGroupType.slug]
+VALID_DEFAULT_DETECTOR_TYPES = [
+    ErrorGroupType.slug,
+    IssueStreamGroupType.slug,
+    *[m.wfe_detector_type for m in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()],
+]
 
 
 class UnableToAcquireLockApiError(SentryAPIException):
@@ -104,6 +109,8 @@ def _ensure_detector(project: Project, type: str) -> Detector:
                         ERROR_DETECTOR_NAME
                         if slug == ErrorGroupType.slug
                         else ISSUE_STREAM_DETECTOR_NAME
+                        if slug == IssueStreamGroupType.slug
+                        else group_type.description
                     ),
                 },
             )
@@ -228,10 +235,24 @@ def ensure_default_anomaly_detector(
         raise UnableToAcquireLockApiError
 
 
-def ensure_default_detectors(project: Project) -> tuple[Detector, Detector]:
-    return _ensure_detector(project, ErrorGroupType.slug), _ensure_detector(
-        project, IssueStreamGroupType.slug
-    )
+def ensure_performance_detectors(project: Project) -> dict[str, Detector]:
+    if not features.has("projects:workflow-engine-performance-detectors", project):
+        return {}
+
+    detectors = {}
+    for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+        wfe_type = mapping.wfe_detector_type
+        detectors[wfe_type] = _ensure_detector(project, wfe_type)
+
+    return detectors
+
+
+def ensure_default_detectors(project: Project) -> dict[str, Detector]:
+    detectors: dict[str, Detector] = {}
+    detectors.update(ensure_performance_detectors(project))
+    detectors[ErrorGroupType.slug] = _ensure_detector(project, ErrorGroupType.slug)
+    detectors[IssueStreamGroupType.slug] = _ensure_detector(project, IssueStreamGroupType.slug)
+    return detectors
 
 
 @dataclass(frozen=True)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -249,9 +249,9 @@ def ensure_performance_detectors(project: Project) -> dict[str, Detector]:
 
 def ensure_default_detectors(project: Project) -> dict[str, Detector]:
     detectors: dict[str, Detector] = {}
-    detectors.update(ensure_performance_detectors(project))
     detectors[ErrorGroupType.slug] = _ensure_detector(project, ErrorGroupType.slug)
     detectors[IssueStreamGroupType.slug] = _ensure_detector(project, IssueStreamGroupType.slug)
+    detectors.update(ensure_performance_detectors(project))
     return detectors
 
 

--- a/tests/sentry/receivers/test_default_detector.py
+++ b/tests/sentry/receivers/test_default_detector.py
@@ -6,6 +6,7 @@ from django.db.models.signals import post_save
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
+from sentry.issue_detection.performance_detection import PERFORMANCE_DETECTOR_CONFIG_MAPPINGS
 from sentry.models.project import Project
 from sentry.receivers.project_detectors import (
     create_default_anomaly_detector,
@@ -17,7 +18,10 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models import DataSource, Detector
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
-from sentry.workflow_engine.processors.detector import ensure_default_anomaly_detector
+from sentry.workflow_engine.processors.detector import (
+    ensure_default_anomaly_detector,
+    ensure_performance_detectors,
+)
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
@@ -200,3 +204,44 @@ class TestDisableDefaultDetectorCreation(TestCase):
 
         # Metric detector should not be created because the signal handler was disconnected
         assert not Detector.objects.filter(project=project, type=MetricIssue.slug).exists()
+
+
+class TestCreatePerformanceDetectors(TestCase):
+    @with_feature("projects:workflow-engine-performance-detectors")
+    def test_creates_detectors_on_project_creation(self):
+        project = self.create_project()
+
+        for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+            assert Detector.objects.filter(project=project, type=mapping.wfe_detector_type).exists()
+
+    def test_does_not_create_detectors_when_flag_disabled(self):
+        project = self.create_project()
+
+        for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+            assert not Detector.objects.filter(
+                project=project, type=mapping.wfe_detector_type
+            ).exists()
+
+    @with_feature("projects:workflow-engine-performance-detectors")
+    def test_idempotent_no_duplicates(self):
+        with disable_default_detector_creation():
+            project = self.create_project()
+
+        ensure_performance_detectors(project)
+        ensure_performance_detectors(project)
+
+        for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+            assert (
+                Detector.objects.filter(project=project, type=mapping.wfe_detector_type).count()
+                == 1
+            )
+
+    @with_feature("projects:workflow-engine-performance-detectors")
+    def test_disable_default_detector_creation_prevents_performance_detectors(self):
+        with disable_default_detector_creation():
+            project = self.create_project()
+
+        for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values():
+            assert not Detector.objects.filter(
+                project=project, type=mapping.wfe_detector_type
+            ).exists()

--- a/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_issue_alert_migration.py
@@ -635,23 +635,24 @@ class TestEnsureDefaultDetectors(TestCase):
 
     def test_ensure_default_detector(self) -> None:
         project = self.create_project()
-        error_detector, issue_stream_detector = ensure_default_detectors(project)
+        detectors = ensure_default_detectors(project)
 
+        error_detector = detectors[ErrorGroupType.slug]
         assert error_detector.name == ERROR_DETECTOR_NAME
         assert error_detector.project_id == project.id
         assert error_detector.type == ErrorGroupType.slug
+
+        issue_stream_detector = detectors[IssueStreamGroupType.slug]
         assert issue_stream_detector.name == ISSUE_STREAM_DETECTOR_NAME
         assert issue_stream_detector.project_id == project.id
         assert issue_stream_detector.type == IssueStreamGroupType.slug
 
     def test_ensure_default_detector__already_exists(self) -> None:
         project = self.create_project()
-        detectors = Detector.objects.filter(project=project)
+        existing = Detector.objects.filter(project=project)
         with patch("sentry.workflow_engine.processors.detector.locks.get") as mock_lock:
             default_detectors = ensure_default_detectors(project)
-            assert {default_detectors[0].id, default_detectors[1].id} == {
-                detectors.id for detectors in detectors
-            }
+            assert {d.id for d in default_detectors.values()} == {d.id for d in existing}
             # No lock if it already exists.
             mock_lock.assert_not_called()
 


### PR DESCRIPTION
When enabled, we want Performance Detectors to be created by default when we create a new project.

Fixes ISWF-2061, for now.