### PR TITLE
feat(dashboards): Add spans table field renderer for internal error count

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -200,5 +200,6 @@ describe('SpansConfig', () => {
     const href = link.getAttribute('href')!;
     expect(href).toContain('gen_ai.tool.name%3A%22Web%20Search%22');
     expect(href).toContain('gen_ai.operation.type%3Atool');
+    expect(href).toContain('span.status%3Ainternal_error');
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.spec.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.spec.tsx
@@ -1,4 +1,10 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ThemeFixture} from 'sentry-fixture/theme';
+import {UserFixture} from 'sentry-fixture/user';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import type {
   EventsStats,
@@ -6,9 +12,13 @@ import type {
   MultiSeriesEventsStats,
   Organization,
 } from 'sentry/types/organization';
+import type {EventViewOptions} from 'sentry/utils/discover/eventView';
+import EventView from 'sentry/utils/discover/eventView';
 import {ALLOWED_EXPLORE_VISUALIZE_AGGREGATES} from 'sentry/utils/fields';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
-import {type WidgetQuery} from 'sentry/views/dashboards/types';
+import {DisplayType, type WidgetQuery} from 'sentry/views/dashboards/types';
+
+const theme = ThemeFixture();
 
 describe('SpansConfig', () => {
   let organization: Organization;
@@ -122,5 +132,73 @@ describe('SpansConfig', () => {
     const resultUnits = SpansConfig.getSeriesResultUnit!(multiSeriesData, widgetQuery);
     expect(resultUnits['count(span.duration)']).toBeNull();
     expect(resultUnits['p50(span.duration)']).toBe('millisecond');
+  });
+
+  it('renders internal error count as a link to explore with error filter', () => {
+    const field = 'count_if(span.status,equals,internal_error)';
+    const location = LocationFixture();
+
+    const baseEventViewOptions: EventViewOptions = {
+      start: undefined,
+      end: undefined,
+      createdBy: UserFixture(),
+      display: undefined,
+      fields: [],
+      sorts: [],
+      query: '',
+      project: [1],
+      environment: [],
+      yAxis: 'count()',
+      id: undefined,
+      name: undefined,
+      statsPeriod: '14d',
+      team: [],
+      topEvents: undefined,
+    };
+
+    const widget = WidgetFixture({
+      displayType: DisplayType.TABLE,
+      queries: [
+        {
+          name: '',
+          fields: ['gen_ai.tool.name', field],
+          columns: ['gen_ai.tool.name'],
+          fieldAliases: [],
+          aggregates: [field],
+          conditions: 'gen_ai.operation.type:tool',
+          orderby: `-${field}`,
+        },
+      ],
+    });
+
+    const org = OrganizationFixture({features: ['performance-view']});
+    const renderer = SpansConfig.getCustomFieldRenderer!(
+      field,
+      {},
+      widget,
+      org,
+      undefined
+    );
+    render(
+      renderer(
+        {[field]: 5, 'gen_ai.tool.name': 'Web Search'},
+        {
+          organization: org,
+          location,
+          theme,
+          eventView: new EventView({
+            ...baseEventViewOptions,
+            fields: [{field}],
+          }),
+        }
+      ) as React.ReactElement<any, any>
+    );
+
+    const link = screen.getByRole('link', {name: '5'});
+    expect(link).toBeInTheDocument();
+
+    const href = link.getAttribute('href')!;
+    expect(href).toContain('gen_ai.tool.name%3A%22Web%20Search%22');
+    expect(href).toContain('gen_ai.operation.type%3Atool');
   });
 });

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -491,6 +491,8 @@ function renderTransactionAsLinkable(data: EventData, baggage: RenderFunctionBag
 // Returns a link to the explore page with the internal error filter applied.
 function renderInternalErrorCount(widget?: Widget, dashboardFilters?: DashboardFilters) {
   return function (data: EventData, baggage: RenderFunctionBaggage) {
+    const {organization, eventView} = baggage;
+    const selection = eventView?.getPageFilters();
     const value = data[INTERNAL_ERROR_COUNT_FIELD];
     const count = typeof value === 'number' ? value : 0;
 
@@ -498,12 +500,9 @@ function renderInternalErrorCount(widget?: Widget, dashboardFilters?: DashboardF
       return <NumberContainer>0</NumberContainer>;
     }
 
-    if (!widget) {
+    if (!widget || !selection) {
       return <NumberContainer>{count}</NumberContainer>;
     }
-
-    const {organization, eventView} = baggage;
-    const selection = eventView?.getPageFilters();
 
     const baseConditions = widget.queries[0]?.conditions ?? '';
     const errorQuery = new MutableSearch(baseConditions);
@@ -517,7 +516,7 @@ function renderInternalErrorCount(widget?: Widget, dashboardFilters?: DashboardF
     };
 
     const getRowExploreUrl = getWidgetTableRowExploreUrlFunction(
-      selection!,
+      selection,
       widgetWithErrorFilter,
       organization,
       dashboardFilters

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -20,7 +20,7 @@ import {
   type DataUnit,
   type QueryFieldValue,
 } from 'sentry/utils/discover/fields';
-import {Container} from 'sentry/utils/discover/styles';
+import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getShortEventId} from 'sentry/utils/events';
 import {
@@ -43,7 +43,13 @@ import {
   transformEventsResponseToTable,
 } from 'sentry/views/dashboards/datasetConfig/errorsAndTransactions';
 import {combineBaseFieldsWithTags} from 'sentry/views/dashboards/datasetConfig/utils/combineBaseFieldsWithEapTags';
-import {DisplayType, type WidgetQuery} from 'sentry/views/dashboards/types';
+import {
+  DisplayType,
+  type DashboardFilters,
+  type Widget,
+  type WidgetQuery,
+} from 'sentry/views/dashboards/types';
+import {getWidgetTableRowExploreUrlFunction} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {
   isEventsStats,
   isGroupedMultiSeriesEventsStats,
@@ -133,6 +139,8 @@ const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce(
   },
   {} as Record<AggregationKey, Aggregation>
 );
+
+const INTERNAL_ERROR_COUNT_FIELD = 'count_if(span.status,equals,internal_error)';
 
 function useSpansSearchBarDataProvider(props: SearchBarDataProviderProps): SearchBarData {
   const {pageFilters, widgetQuery} = props;
@@ -301,6 +309,9 @@ export const SpansConfig: DatasetConfig<
       )
     ) {
       return renderTransactionAsLinkable;
+    }
+    if (field === INTERNAL_ERROR_COUNT_FIELD) {
+      return renderInternalErrorCount(widget, dashboardFilters);
     }
     return getFieldRenderer(field, meta, false, widget, dashboardFilters);
   },
@@ -473,6 +484,52 @@ function renderTransactionAsLinkable(data: EventData, baggage: RenderFunctionBag
       <Container>{transaction}</Container>
     </Link>
   );
+}
+
+// Renders the count of internal errors for a given widget and dashboard filters.
+// Displays 0 if a row receives null count.
+// Returns a link to the explore page with the internal error filter applied.
+function renderInternalErrorCount(widget?: Widget, dashboardFilters?: DashboardFilters) {
+  return function (data: EventData, baggage: RenderFunctionBaggage) {
+    const value = data[INTERNAL_ERROR_COUNT_FIELD];
+    const count = typeof value === 'number' ? value : 0;
+
+    if (count === 0) {
+      return <NumberContainer>0</NumberContainer>;
+    }
+
+    if (!widget) {
+      return <NumberContainer>{count}</NumberContainer>;
+    }
+
+    const {organization, eventView} = baggage;
+    const selection = eventView?.getPageFilters();
+
+    const baseConditions = widget.queries[0]?.conditions ?? '';
+    const errorQuery = new MutableSearch(baseConditions);
+    errorQuery.addStringFilter('span.status:internal_error');
+    const widgetWithErrorFilter: Widget = {
+      ...widget,
+      queries: widget.queries.map(q => ({
+        ...q,
+        conditions: errorQuery.formatString(),
+      })),
+    };
+
+    const getRowExploreUrl = getWidgetTableRowExploreUrlFunction(
+      selection!,
+      widgetWithErrorFilter,
+      organization,
+      dashboardFilters
+    );
+    const target = getRowExploreUrl(data);
+
+    return (
+      <NumberContainer>
+        <Link to={target}>{count}</Link>
+      </NumberContainer>
+    );
+  };
 }
 
 function transformSeries(


### PR DESCRIPTION
Adds a field renderer specifically for the `count_if(span.status,equals,internal_error)` field used by AI dashboards to mirror AI modules behaviour
- Displays 0 when receiving `null` for error count
- Adds a link to explore when error count is > 0 by reusing `getWidgetTableRowExploreUrlFunction` and appending `span.status:internal.error` to the query filter