### PR TITLE
feat(perf-detectors): Consider Performance Detectors to be system created

### DIFF
--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -106,6 +106,12 @@ WFE_DETECTOR_TYPE_TO_CONFIG_MAPPING: dict[str, DetectorType] = {
     for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
 }
 
+# WFE detector type slugs for all performance detectors. These are created automatically
+# by Sentry, not by users.
+PERFORMANCE_WFE_DETECTOR_TYPES: frozenset[str] = frozenset(
+    mapping.wfe_detector_type for mapping in PERFORMANCE_DETECTOR_CONFIG_MAPPINGS.values()
+)
+
 
 class EventPerformanceProblem:
     """

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -17,6 +17,7 @@ from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.models.detector_workflow import DetectorWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 # Only those with organization write permissions can edit system-created detectors (e.g. error detectors).
 SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write"}
@@ -25,7 +26,8 @@ USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write", "alerts:write"}
 
 def is_system_created_detector(detector: Detector) -> bool:
     return (
-        detector.type in (ErrorGroupType.slug,) or detector.type in PERFORMANCE_WFE_DETECTOR_TYPES
+        detector.type in (ErrorGroupType.slug, IssueStreamGroupType.slug)
+        or detector.type in PERFORMANCE_WFE_DETECTOR_TYPES
     )
 
 

--- a/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/detector_workflow.py
@@ -10,6 +10,7 @@ from rest_framework.request import Request
 from sentry import audit_log
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.grouping.grouptype import ErrorGroupType
+from sentry.issue_detection.performance_detection import PERFORMANCE_WFE_DETECTOR_TYPES
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.utils.audit import create_audit_entry
@@ -23,7 +24,9 @@ USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write", "alerts:write"}
 
 
 def is_system_created_detector(detector: Detector) -> bool:
-    return detector.type in (ErrorGroupType.slug,)
+    return (
+        detector.type in (ErrorGroupType.slug,) or detector.type in PERFORMANCE_WFE_DETECTOR_TYPES
+    )
 
 
 def can_edit_system_created_detectors(request: Request, project: Project) -> bool:


### PR DESCRIPTION
We're not giving users the ability to create or delete them, so they belong on the list alongside the error detector.

While we're here, add Issue Stream to the list.
