### PR TITLE
fix(jira): Update error handling to handle more form errors

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -126,7 +126,15 @@ metadata = IntegrationMetadata(
 # Some Jira errors for invalid field values don't actually provide the field
 # ID in an easily mappable way, so we have to manually map known error types
 # here to make it explicit to the user what failed.
-CUSTOM_ERROR_MESSAGE_MATCHERS = [(re.compile("Team with id '.*' not found.$"), "Team Field")]
+CUSTOM_ERROR_MESSAGE_MATCHERS = [
+    (re.compile("Team with id '.*' not found.$"), "Team Field"),
+    (
+        re.compile(
+            r"Issue does not exist or you do not have permission to see it\.?$", re.IGNORECASE
+        ),
+        "Issue",
+    ),
+]
 
 # Hide linked issues fields because we don't have the necessary UI for fully specifying
 # a valid link (e.g. "is blocked by ISSUE-1").
@@ -529,7 +537,11 @@ class JiraIntegration(IssueSyncIntegration):
         Jira installation's implementation of IssueSyncIntegration's `get_issue`.
         """
         client = self.get_client()
-        issue = client.get_issue(issue_id)
+        try:
+            issue = client.get_issue(issue_id)
+        except ApiError as e:
+            self.raise_error(e)
+
         fields = issue.get("fields", {})
         return {
             "key": issue_id,
@@ -1011,11 +1023,16 @@ class JiraIntegration(IssueSyncIntegration):
             "request_body": str(exc.json) if isinstance(exc, ApiError) else None,
         }
 
-        if isinstance(exc, ApiError) and not exc.json:
-            logger.warning("sentry.jira.raise_error.non_json_error_response", extra=logging_context)
-            raise IntegrationConfigurationError(
-                "Something went wrong while communicating with Jira"
-            ) from exc
+        if isinstance(exc, ApiError):
+            if not exc.json:
+                logger.warning(
+                    "sentry.jira.raise_error.non_json_error_response", extra=logging_context
+                )
+                raise IntegrationConfigurationError(
+                    "Something went wrong while communicating with Jira"
+                ) from exc
+            else:
+                return self.error_fields_from_json(exc.json)
 
         if isinstance(exc, ApiInvalidRequestError):
             error_fields = self.error_fields_from_json(exc.json)

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -1031,18 +1031,16 @@ class JiraIntegration(IssueSyncIntegration):
                 raise IntegrationConfigurationError(
                     "Something went wrong while communicating with Jira"
                 ) from exc
-            else:
-                return self.error_fields_from_json(exc.json)
 
-        if isinstance(exc, ApiInvalidRequestError):
             error_fields = self.error_fields_from_json(exc.json)
             if error_fields is not None:
                 raise IntegrationFormError(error_fields).with_traceback(sys.exc_info()[2])
 
-            logger.warning(
-                "sentry.jira.raise_error.generic_api_invalid_error", extra=logging_context
-            )
-            raise IntegrationConfigurationError(exc.text) from exc
+            if isinstance(exc, ApiInvalidRequestError):
+                logger.warning(
+                    "sentry.jira.raise_error.generic_api_invalid_error", extra=logging_context
+                )
+                raise IntegrationConfigurationError(exc.text) from exc
 
         super().raise_error(exc, identity=identity)
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1297,6 +1297,32 @@ class JiraIntegrationTest(APITestCase):
             == "hello world, goodnight, moon"
         )
 
+    def test_error_fields_from_json_issue_not_found(self) -> None:
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+        installation = integration.get_installation(self.organization.id)
+
+        # Matches the exact Jira error message with trailing period
+        msg_with_period = "Issue does not exist or you do not have permission to see it."
+        result = installation.error_fields_from_json(
+            {"errorMessages": [msg_with_period], "errors": {}}
+        )
+        assert result == {"Issue": [msg_with_period]}
+
+        # Also matches without trailing period
+        msg_no_period = "Issue does not exist or you do not have permission to see it"
+        result = installation.error_fields_from_json(
+            {"errorMessages": [msg_no_period], "errors": {}}
+        )
+        assert result == {"Issue": [msg_no_period]}
+
+        # Also matches with different casing
+        msg_lowercase = "issue does not exist or you do not have permission to see it."
+        result = installation.error_fields_from_json(
+            {"errorMessages": [msg_lowercase], "errors": {}}
+        )
+        assert result == {"Issue": [msg_lowercase]}
+
 
 class JiraMigrationIntegrationTest(APITestCase):
     @cached_property

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1323,6 +1323,21 @@ class JiraIntegrationTest(APITestCase):
         )
         assert result == {"Issue": [msg_lowercase]}
 
+    def test_raise_error_with_issue_not_found_json(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiError
+
+        integration = self.create_provider_integration(provider="jira", name="Example Jira")
+        integration.add_organization(self.organization, self.user)
+        installation = integration.get_installation(self.organization.id)
+
+        msg = "Issue does not exist or you do not have permission to see it."
+        exc = ApiError(json.dumps({"errorMessages": [msg], "errors": {}}), code=404)
+
+        with pytest.raises(IntegrationFormError) as exc_info:
+            installation.raise_error(exc)
+
+        assert exc_info.value.field_errors == {"Issue": [msg]}
+
 
 class JiraMigrationIntegrationTest(APITestCase):
     @cached_property


### PR DESCRIPTION
When Jira returns with {"errorMessages": ["Issue does not exist or you do not have                                                 
  permission to see it."], "errors": {}}, surface it as a field-level IntegrationFormError                
                                                                                              
Currently we're not processing the response to an `ApiInvalidRequestError` and it's remaining as an ApiError.
  The fix consolidates the error handling for  into a single ApiError block. Also adds the raise_error() call
  in get_issue() so the mapped exception actually reaches the caller.

  Fixes SENTRY-5H66
  Co-Authored-By: Claude <noreply@anthropic.com>