### PR TITLE
chore(warden): Add gha-security-review skill for workflow files

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -33,3 +33,12 @@ ignorePaths = ["**/tests/**", "**/*_test.py", "**/test_*.py"]
 [[skills.triggers]]
 type = "pull_request"
 actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "gha-security-review"
+remote = "getsentry/skills"
+paths = [".github/workflows/*.yml", ".github/workflows/*.yaml", ".github/actions/**/*.yml", ".github/actions/**/*.yaml"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
Add the `gha-security-review` skill from `getsentry/skills` as a remote
Warden skill. It reviews GitHub Actions workflows for exploitable
vulnerabilities (pwn requests, expression injection, credential theft,
supply chain attacks).

Scoped to only trigger on changes to `.github/workflows/` and
`.github/actions/` files.


Agent transcript: https://claudescope.sentry.dev/share/n-Cxb2Cl0Bqa4d51LfYBqua9PH7lSp-NM9siLc3pxY8