### PR TITLE
fix(dashboards): Respect current time series interval in Widget Viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -136,6 +136,7 @@ export interface WidgetViewerModalOptions {
   seriesResultsType?: Record<string, AggregationOutputType>;
   tableData?: TableDataWithTitle[];
   totalIssuesCount?: string;
+  widgetInterval?: string;
 }
 
 interface Props extends ModalRenderProps, WidgetViewerModalOptions {
@@ -210,6 +211,7 @@ function WidgetViewerModal(props: Props) {
     dashboardCreator,
     confidence,
     sampleCount,
+    widgetInterval,
   } = props;
   const theme = useTheme();
   const location = useLocation();
@@ -556,6 +558,7 @@ function WidgetViewerModal(props: Props) {
             }
             cursor={cursor}
             dashboardFilters={dashboardFilters}
+            widgetInterval={widgetInterval}
           >
             {renderIssuesTable}
           </IssueWidgetQueries>
@@ -579,6 +582,7 @@ function WidgetViewerModal(props: Props) {
             }
             cursor={cursor}
             dashboardFilters={dashboardFilters}
+            widgetInterval={widgetInterval}
           >
             {renderTable}
           </ReleaseWidgetQueries>
@@ -603,6 +607,7 @@ function WidgetViewerModal(props: Props) {
             }
             cursor={cursor}
             dashboardFilters={dashboardFilters}
+            widgetInterval={widgetInterval}
           >
             {({tableResults, loading, pageLinks}) => {
               return renderTable({tableResults, loading, pageLinks});
@@ -672,6 +677,7 @@ function WidgetViewerModal(props: Props) {
                 noPadding
                 widgetLegendState={widgetLegendState}
                 showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+                widgetInterval={widgetInterval}
               />
             )}
           </Container>

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -308,6 +308,7 @@ class DashboardDetail extends Component<Props, State> {
           dashboardFilters: getDashboardFiltersFromURL(location) ?? dashboard.filters,
           dashboardPermissions: dashboard.permissions,
           dashboardCreator: dashboard.createdBy,
+          widgetInterval: this.props.widgetInterval,
           onClose: () => {
             // Filter out Widget Viewer Modal query params when exiting the Modal
             const query = omit(location.query, Object.values(WidgetViewerQueryField));

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -57,6 +57,7 @@ type Props = {
   showConfidenceWarning?: boolean;
   showLoadingText?: boolean;
   tableItemLimit?: number;
+  widgetInterval?: string;
   windowWidth?: number;
 };
 
@@ -85,6 +86,7 @@ export function WidgetCardChartContainer({
   onWidgetTableSort,
   onWidgetTableResizeColumn,
   disableTableActions,
+  widgetInterval,
 }: Props) {
   const keepLegendState: EChartLegendSelectChangeHandler = ({selected}) => {
     widgetLegendState.setWidgetSelectionState(selected, widget);
@@ -118,6 +120,7 @@ export function WidgetCardChartContainer({
       onWidgetSplitDecision={onWidgetSplitDecision}
       onDataFetchStart={onDataFetchStart}
       tableItemLimit={tableItemLimit}
+      widgetInterval={widgetInterval}
     >
       {({
         tableResults,


### PR DESCRIPTION
Pass the dashboard's user-selected interval to the Widget Viewer Modal so
that opening a widget in full screen preserves the chosen interval instead
of reverting to the default. This is especially important when we remove
our custom data cache. If the interval changes, TanStack will issue another
network request to fetch the data!

The interval selection feature lets users pick a chart interval (e.g. 1m,
15m) for all time series widgets on a dashboard. This value was already
threaded through the main dashboard widget rendering path, but the Widget
Viewer Modal never received it. When a widget was opened in full screen,
its chart would re-fetch data without the interval override, causing a
jarring change in granularity.

Three changes:
- Add `widgetInterval` to `WidgetViewerModalOptions` and pass it to the
  chart container and all table query components inside the modal
- Add `widgetInterval` to `WidgetCardChartContainer` props so it can
  forward the value to `WidgetCardDataLoader`
- Pass `this.props.widgetInterval` when opening the modal in
  `DashboardDetail.checkIfShouldMountWidgetViewerModal`

Refs DAIN-1257