### PR TITLE
fix(dashboards): Use correct table item limit for categorical bar charts in widget viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -526,7 +526,8 @@ function WidgetViewerModal(props: Props) {
             widget={tableWidget}
             selection={modalSelection}
             limit={
-              widget.displayType === DisplayType.TABLE
+              widget.displayType === DisplayType.TABLE ||
+              widget.displayType === DisplayType.CATEGORICAL_BAR
                 ? FULL_TABLE_ITEM_LIMIT
                 : HALF_TABLE_ITEM_LIMIT
             }
@@ -543,7 +544,8 @@ function WidgetViewerModal(props: Props) {
             widget={tableWidget}
             selection={modalSelection}
             limit={
-              widget.displayType === DisplayType.TABLE
+              widget.displayType === DisplayType.TABLE ||
+              widget.displayType === DisplayType.CATEGORICAL_BAR
                 ? FULL_TABLE_ITEM_LIMIT
                 : HALF_TABLE_ITEM_LIMIT
             }
@@ -561,7 +563,8 @@ function WidgetViewerModal(props: Props) {
             widget={tableWidget}
             selection={modalSelection}
             limit={
-              widget.displayType === DisplayType.TABLE
+              widget.displayType === DisplayType.TABLE ||
+              widget.displayType === DisplayType.CATEGORICAL_BAR
                 ? FULL_TABLE_ITEM_LIMIT
                 : HALF_TABLE_ITEM_LIMIT
             }
@@ -605,6 +608,7 @@ function WidgetViewerModal(props: Props) {
               dashboardFilters={dashboardFilters}
               // Top N charts rely on the orderby of the table
               widget={primaryWidget}
+              tableItemLimit={widget.limit}
               onZoom={onZoom}
               onLegendSelectChanged={onLegendSelectChanged}
               legendOptions={{


### PR DESCRIPTION
Categorical bar chart widgets in the Widget Viewer modal were showing fewer bars than configured and a smaller table.

The Widget Viewer was treating CATEGORICAL_BAR like time series charts (LINE, AREA, BAR), giving them `HALF_TABLE_ITEM_LIMIT` (10 rows) for the table and falling back to `DEFAULT_TABLE_LIMIT` (5) for the chart's data fetch. Instead, CATEGORICAL_BAR should behave like TABLE widgets for the table limit and use the widget's configured `limit` for the chart.

- Add `CATEGORICAL_BAR` to the `FULL_TABLE_ITEM_LIMIT` condition in all three query branches (Issue, Release, Discover)
- Pass `widget.limit` as `tableItemLimit` to the chart container so it fetches the correct number of bars

Closes DAIN-1256