### PR TITLE
perf(attachments): Skip V2 objectstore delete for EventAttachments during cleanup

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import mimetypes
+import os
 from dataclasses import dataclass
 from hashlib import sha1
 from io import BytesIO
@@ -130,10 +131,13 @@ class EventAttachment(Model):
                     storage.delete(self.blob_path)
 
             elif self.blob_path.startswith(V2_PREFIX):
-                organization_id = _get_organization(self.project_id)
-                get_attachments_session(organization_id, self.project_id).delete(
-                    self.blob_path.removeprefix(V2_PREFIX)
-                )
+                # During cleanup, V2 objectstore blobs expire via TTL — skip the
+                # explicit delete to avoid unnecessary load on the objectstore service.
+                if not os.environ.get("_SENTRY_CLEANUP"):
+                    organization_id = _get_organization(self.project_id)
+                    get_attachments_session(organization_id, self.project_id).delete(
+                        self.blob_path.removeprefix(V2_PREFIX)
+                    )
 
             else:
                 raise NotImplementedError()

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+from uuid import uuid4
+
+from sentry.models.eventattachment import EventAttachment
+from sentry.testutils.cases import TestCase
+
+
+class EventAttachmentDeleteTest(TestCase):
+    def _create_v2_attachment(self) -> EventAttachment:
+        return EventAttachment.objects.create(
+            event_id=uuid4().hex,
+            project_id=self.project.id,
+            type="event.attachment",
+            name="test.txt",
+            blob_path="v2/some-key",
+        )
+
+    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
+    def test_v2_delete_calls_objectstore(
+        self,
+        mock_get_org: mock.Mock,
+        mock_get_session: mock.Mock,
+    ) -> None:
+        attachment = self._create_v2_attachment()
+
+        attachment.delete()
+
+        mock_get_session.return_value.delete.assert_called_once_with("some-key")
+
+    @mock.patch("sentry.models.eventattachment.get_attachments_session")
+    @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
+    def test_v2_delete_skips_objectstore_during_cleanup(
+        self,
+        mock_get_org: mock.Mock,
+        mock_get_session: mock.Mock,
+    ) -> None:
+        attachment = self._create_v2_attachment()
+
+        os.environ["_SENTRY_CLEANUP"] = "1"
+        try:
+            attachment.delete()
+        finally:
+            del os.environ["_SENTRY_CLEANUP"]
+
+        mock_get_session.return_value.delete.assert_not_called()
+        assert not EventAttachment.objects.filter(id=attachment.id).exists()


### PR DESCRIPTION
The cleanup job bulk-deletes old `EventAttachment` rows. Each `EventAttachment.delete()` call also deletes the backing blob from storage. For V2 attachments, this hits the objectstore service.

V2 blobs are stored with a 30-day TTL, so they auto-expire. The cleanup job also defaults to 30 days. The explicit objectstore delete during cleanup is unnecessary and adds load to the objectstore service during high-volume cleanup runs.

This modifies `EventAttachment.delete()` to skip the V2 objectstore delete when the `_SENTRY_CLEANUP` environment variable is set. This follows the exact same pattern used by `GroupDeletionTask` — which checks `_SENTRY_CLEANUP` to skip nodestore event deletions — and the Bigtable nodestore backend which uses a `skip_deletes` flag based on `_SENTRY_CLEANUP`.

Normal (non-cleanup) attachment deletes still call objectstore.

Ref FS-248