### PR TITLE
fix(autofix): Handle autofix create PR not started

### DIFF
--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -583,7 +583,7 @@ def get_autofix_explorer_status(
             if stopping_point == AutofixStoppingPoint.OPEN_PR:
                 # If there are no repo_pr_states, it means it's not started
                 if not autofix_state.repo_pr_states:
-                    return False
+                    return None
                 # If there are repo_pr_states, make sure they're not still creating
                 return all(
                     pr_state.pr_creation_status != "creating"

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -579,7 +579,7 @@ class TestGetAutofixExplorerStatus(TestCase):
     def test_open_pr_no_repo_pr_states_returns_false(self):
         block = self._make_block("code_changes")
         state = self._make_state(blocks=[block], repo_pr_states={})
-        assert get_autofix_explorer_status(AutofixStoppingPoint.OPEN_PR, state) is False
+        assert get_autofix_explorer_status(AutofixStoppingPoint.OPEN_PR, state) is None
 
     def test_open_pr_all_prs_completed_returns_true(self):
         block = self._make_block("code_changes")


### PR DESCRIPTION
If create PR was not started, we should return None to indicate as such. Currently, we return False which actually means it started but hasn't finished.