### PR TITLE
fix(traces): switch 'Edit Table' button to use the Edit icon, not Table

### DIFF
--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -7,7 +7,7 @@ import {TabList, Tabs} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {IconTable} from 'sentry/icons/iconTable';
+import {IconEdit} from 'sentry/icons/iconEdit';
 import {t} from 'sentry/locale';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -125,11 +125,11 @@ export function ExploreTables(props: ExploreTablesProps) {
           </TabList>
         </Tabs>
         {props.tab === Tab.SPAN ? (
-          <Button onClick={openColumnEditor} icon={<IconTable />} size="sm">
+          <Button onClick={openColumnEditor} icon={<IconEdit />} size="sm">
             {t('Edit Table')}
           </Button>
         ) : props.tab === Mode.AGGREGATE ? (
-          <Button onClick={openAggregateColumnEditor} icon={<IconTable />} size="sm">
+          <Button onClick={openAggregateColumnEditor} icon={<IconEdit />} size="sm">
             {t('Edit Table')}
           </Button>
         ) : (
@@ -140,7 +140,7 @@ export function ExploreTables(props: ExploreTablesProps) {
                 : t('Use the Group By and Visualize controls to change table columns')
             }
           >
-            <Button disabled onClick={openColumnEditor} icon={<IconTable />} size="sm">
+            <Button disabled onClick={openColumnEditor} icon={<IconEdit />} size="sm">
               {t('Edit Table')}
             </Button>
           </Tooltip>


### PR DESCRIPTION
Unifies this with Explore > Logs, which uses a pencil icon.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="492" height="189" alt="Screenshot of the Edit Table button above a table with a table icon" src="https://github.com/user-attachments/assets/0d3c8b24-5d96-4b07-afc8-6a2e85a34509" />
</td>
<td>
<img width="492" height="189" alt="Screenshot of the Edit Table button above a table with a pencil (edit) icon" src="https://github.com/user-attachments/assets/4b6da795-85a9-4a56-9ece-98ffedf7c7ff" />
</td>
</tr>
</tbody>
</table>

Note that Logs has nice mobile collapsing of buttons but Traces doesn't. I'll separately ask design if they'd prefer that unified too.

Fixes https://linear.app/getsentry/issue/EXP-815/unify-edit-table-table-button-icons-to-pencils