### PR TITLE
feat(debug-files): Show console symbol sources for orgs with console access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -709,7 +709,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/test_auto_remove_inbox.py               @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_resolve_issues.py             @getsentry/issue-detection-backend
 /tests/sentry/tasks/seer/test_delete_seer_grouping_records.py @getsentry/issue-detection-backend
-/tests/sentry/tasks/test_console_platform_cleanup.py        @getsentry/ingest
+/tests/sentry/tasks/test_console_platform_cleanup.py        @getsentry/gdx
 /tests/sentry/tasks/test_check_new_issue_threshold_met.py   @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_resolutions.py       @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_rulesnoozes.py       @getsentry/issue-detection-backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -709,6 +709,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/test_auto_remove_inbox.py               @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_auto_resolve_issues.py             @getsentry/issue-detection-backend
 /tests/sentry/tasks/seer/test_delete_seer_grouping_records.py @getsentry/issue-detection-backend
+/tests/sentry/tasks/test_console_platform_cleanup.py        @getsentry/ingest
 /tests/sentry/tasks/test_check_new_issue_threshold_met.py   @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_resolutions.py       @getsentry/issue-detection-backend
 /tests/sentry/tasks/test_clear_expired_rulesnoozes.py       @getsentry/issue-detection-backend

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -11,6 +11,11 @@ from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
 from sentry.utils.console_platforms import organization_has_console_platform_access
 
+# Game engine platforms that can target console hardware and may need
+# console-specific symbol sources (e.g., Nintendo symbols for a Unity
+# project shipping on Switch).
+GAME_ENGINE_PLATFORMS = frozenset({"native", "unity", "unreal", "godot"})
+
 
 def normalize_symbol_source(key, source):
     return {
@@ -48,15 +53,26 @@ class BuiltinSymbolSourcesEndpoint(Endpoint):
         for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
             source_platforms: list[str] | None = cast("list[str] | None", source.get("platforms"))
 
-            # If source has platform restrictions, check if current platform matches
+            # If source has platform restrictions, only show it when:
+            # 1. The project platform directly matches (e.g., nintendo-switch)
+            #    or is a game engine (native, unity, unreal, godot), AND
+            # 2. The organization has access to at least one of the source's
+            #    required console platforms.
+            # This allows e.g. Unity projects to see the Nintendo source
+            # if the org has nintendo-switch console access, without showing
+            # it to unrelated platforms like PlayStation or Python.
             if source_platforms is not None:
-                if not platform or platform not in source_platforms:
-                    continue
-
-                # Platform matches - now check if organization has access to this console platform
-                if not organization or not organization_has_console_platform_access(
-                    organization, platform
+                if not platform or (
+                    platform not in source_platforms and platform not in GAME_ENGINE_PLATFORMS
                 ):
+                    continue
+                if not organization:
+                    continue
+                has_access = any(
+                    organization_has_console_platform_access(organization, p)
+                    for p in source_platforms
+                )
+                if not has_access:
                     continue
 
             sources.append(normalize_symbol_source(key, source))

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -12,11 +12,6 @@ from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
 from sentry.utils.console_platforms import organization_has_console_platform_access
 
-# Game engine platforms that can target console hardware and may need
-# console-specific symbol sources (e.g., Nintendo symbols for a Unity
-# project shipping on Switch).
-GAME_ENGINE_PLATFORMS = frozenset({"native", "unity", "unreal", "godot"})
-
 
 def normalize_symbol_source(key, source):
     return {
@@ -41,18 +36,15 @@ class BuiltinSymbolSourcesEndpoint(OrganizationEndpoint):
         for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
             source_platforms: list[str] | None = cast("list[str] | None", source.get("platforms"))
 
-            # If source has platform restrictions, only show it when:
-            # 1. The project platform directly matches (e.g., nintendo-switch)
-            #    or is a game engine (native, unity, unreal, godot), AND
+            # If source has platform restrictions, only show it if:
+            # 1. A platform is specified (required to view platform-restricted sources), AND
             # 2. The organization has access to at least one of the source's
             #    required console platforms.
-            # This allows e.g. Unity projects to see the Nintendo source
-            # if the org has nintendo-switch console access, without showing
-            # it to unrelated platforms like PlayStation or Python.
+            #
+            # Any project type can see console sources if the org has the necessary
+            # access. Auto-enable still only applies to recognized project platforms.
             if source_platforms is not None:
-                if not platform or (
-                    platform not in source_platforms and platform not in GAME_ENGINE_PLATFORMS
-                ):
+                if not platform:
                     continue
                 has_access = any(
                     organization_has_console_platform_access(organization, p)

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -54,8 +54,6 @@ class BuiltinSymbolSourcesEndpoint(OrganizationEndpoint):
                     platform not in source_platforms and platform not in GAME_ENGINE_PLATFORMS
                 ):
                     continue
-                if not organization:
-                    continue
                 has_access = any(
                     organization_has_console_platform_access(organization, p)
                     for p in source_platforms

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -6,7 +6,8 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import Endpoint, cell_silo_endpoint
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
 from sentry.utils.console_platforms import organization_has_console_platform_access
@@ -26,28 +27,15 @@ def normalize_symbol_source(key, source):
     }
 
 
-@cell_silo_endpoint
-class BuiltinSymbolSourcesEndpoint(Endpoint):
+@region_silo_endpoint
+class BuiltinSymbolSourcesEndpoint(OrganizationEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {
         "GET": ApiPublishStatus.PRIVATE,
     }
-    permission_classes = ()
 
-    def get(self, request: Request, **kwargs) -> Response:
+    def get(self, request: Request, organization: Organization, **kwargs) -> Response:
         platform = request.GET.get("platform")
-
-        # Get organization if organization context is available
-        organization = None
-        organization_id_or_slug = kwargs.get("organization_id_or_slug")
-        if organization_id_or_slug:
-            try:
-                if str(organization_id_or_slug).isdecimal():
-                    organization = Organization.objects.get_from_cache(id=organization_id_or_slug)
-                else:
-                    organization = Organization.objects.get_from_cache(slug=organization_id_or_slug)
-            except Organization.DoesNotExist:
-                pass
 
         sources = []
         for key, source in settings.SENTRY_BUILTIN_SOURCES.items():

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models.organization import Organization
@@ -22,7 +22,7 @@ def normalize_symbol_source(key, source):
     }
 
 
-@region_silo_endpoint
+@cell_silo_endpoint
 class BuiltinSymbolSourcesEndpoint(OrganizationEndpoint):
     owner = ApiOwner.OWNERS_INGEST
     publish_status = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -942,6 +942,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.tasks.collect_project_platforms",
     "sentry.tasks.commit_context",
     "sentry.tasks.commits",
+    "sentry.tasks.console_platform_cleanup",
     "sentry.tasks.delete_pending_groups",
     "sentry.tasks.seer.delete_seer_grouping_records",
     "sentry.tasks.digests",

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1299,11 +1299,11 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                     )
                     if revoked_platforms:
                         from sentry.tasks.console_platform_cleanup import (
-                            remove_revoked_console_platform_sources,
+                            remove_inaccessible_console_platform_sources,
                         )
 
-                        remove_revoked_console_platform_sources.delay(
-                            organization.id, list(revoked_platforms)
+                        remove_inaccessible_console_platform_sources.delay(
+                            organization.id, current_console_platforms
                         )
 
                     del changed_data["enabledConsolePlatforms"]

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -110,6 +110,7 @@ from sentry.relay.datascrubbing import validate_pii_config_update, validate_pii_
 from sentry.replays.models import OrganizationMemberReplayAccess
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.services.organization.provisioning import organization_provisioning_service
+from sentry.tasks.console_platform_cleanup import remove_inaccessible_console_platform_sources
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.audit import create_audit_entry
 
@@ -1298,10 +1299,6 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                         current_console_platforms
                     )
                     if revoked_platforms:
-                        from sentry.tasks.console_platform_cleanup import (
-                            remove_inaccessible_console_platform_sources,
-                        )
-
                         remove_inaccessible_console_platform_sources.delay(
                             organization.id, current_console_platforms
                         )

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1282,12 +1282,29 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 CellScheduledDeletion.cancel(organization)
             elif changed_data:
                 if "enabledConsolePlatforms" in changed_data:
+                    current_console_platforms = serializer.validated_data.get(
+                        "enabledConsolePlatforms", []
+                    )
                     create_console_platform_audit_log(
                         request,
                         organization,
                         previous_console_platforms,
-                        serializer.validated_data.get("enabledConsolePlatforms", []),
+                        current_console_platforms,
                     )
+
+                    # If any console platforms were revoked, clean up their
+                    # symbol sources from all projects in the org.
+                    revoked_platforms = set(previous_console_platforms or []) - set(
+                        current_console_platforms
+                    )
+                    if revoked_platforms:
+                        from sentry.tasks.console_platform_cleanup import (
+                            remove_revoked_console_platform_sources,
+                        )
+
+                        remove_revoked_console_platform_sources.delay(
+                            organization.id, list(revoked_platforms)
+                        )
 
                     del changed_data["enabledConsolePlatforms"]
 

--- a/src/sentry/tasks/console_platform_cleanup.py
+++ b/src/sentry/tasks/console_platform_cleanup.py
@@ -1,0 +1,61 @@
+import logging
+
+from django.conf import settings
+
+from sentry.models.options.project_option import ProjectOption
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import symbolication_tasks
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.console_platform_cleanup.remove_revoked_console_platform_sources",
+    namespace=symbolication_tasks,
+    silo_mode=SiloMode.REGION,
+)
+def remove_revoked_console_platform_sources(
+    organization_id: int, revoked_platforms: list[str], **kwargs
+) -> None:
+    """
+    Remove symbol sources associated with revoked console platforms from all
+    projects in an organization.
+
+    When an organization loses access to a console platform (e.g., nintendo-switch),
+    this task removes any builtin symbol sources that are restricted to that platform
+    from all projects in the organization.
+    """
+    # Find which source keys are restricted to the revoked platforms
+    source_keys_to_remove: set[str] = set()
+    for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
+        source_platforms: list[str] | None = source.get("platforms")
+        if source_platforms is None:
+            continue
+        # If all of a source's required platforms have been revoked, remove it
+        if all(p in revoked_platforms for p in source_platforms):
+            source_keys_to_remove.add(key)
+
+    if not source_keys_to_remove:
+        return
+
+    # Find all projects in this org that have explicit builtin symbol sources
+    project_options = ProjectOption.objects.filter(
+        project__organization_id=organization_id,
+        key="sentry:builtin_symbol_sources",
+    )
+
+    for option in project_options:
+        current_sources: list[str] = option.value or []
+        updated_sources = [s for s in current_sources if s not in source_keys_to_remove]
+
+        if updated_sources != current_sources:
+            ProjectOption.objects.set_value(option.project_id, option.key, updated_sources)
+            logger.info(
+                "console_platform_cleanup.removed_sources",
+                extra={
+                    "organization_id": organization_id,
+                    "project_id": option.project_id,
+                    "removed_sources": list(source_keys_to_remove & set(current_sources)),
+                },
+            )

--- a/src/sentry/tasks/console_platform_cleanup.py
+++ b/src/sentry/tasks/console_platform_cleanup.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 from django.conf import settings
 
@@ -29,7 +30,7 @@ def remove_revoked_console_platform_sources(
     # Find which source keys are restricted to the revoked platforms
     source_keys_to_remove: set[str] = set()
     for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
-        source_platforms: list[str] | None = source.get("platforms")
+        source_platforms: list[str] | None = cast("list[str] | None", source.get("platforms"))
         if source_platforms is None:
             continue
         # If all of a source's required platforms have been revoked, remove it

--- a/src/sentry/tasks/console_platform_cleanup.py
+++ b/src/sentry/tasks/console_platform_cleanup.py
@@ -4,9 +4,11 @@ from typing import cast
 from django.conf import settings
 
 from sentry.models.options.project_option import ProjectOption
+from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import symbolication_tasks
+from sentry.utils.console_platforms import organization_has_console_platform_access
 
 logger = logging.getLogger(__name__)
 
@@ -24,17 +26,27 @@ def remove_revoked_console_platform_sources(
     projects in an organization.
 
     When an organization loses access to a console platform (e.g., nintendo-switch),
-    this task removes any builtin symbol sources that are restricted to that platform
-    from all projects in the organization.
+    this task removes any builtin symbol sources that the organization no longer
+    has access to from all projects in the organization.
     """
-    # Find which source keys are restricted to the revoked platforms
+    try:
+        organization = Organization.objects.get_from_cache(id=organization_id)
+    except Organization.DoesNotExist:
+        return
+
+    # Find source keys the org no longer has access to.  This mirrors
+    # the endpoint logic: a source is accessible when the org has access
+    # to *any* of its platforms, so it must be removed when the org has
+    # access to *none* of them.
     source_keys_to_remove: set[str] = set()
     for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
         source_platforms: list[str] | None = cast("list[str] | None", source.get("platforms"))
         if source_platforms is None:
             continue
-        # If all of a source's required platforms have been revoked, remove it
-        if all(p in revoked_platforms for p in source_platforms):
+        has_access = any(
+            organization_has_console_platform_access(organization, p) for p in source_platforms
+        )
+        if not has_access:
             source_keys_to_remove.add(key)
 
     if not source_keys_to_remove:

--- a/src/sentry/tasks/console_platform_cleanup.py
+++ b/src/sentry/tasks/console_platform_cleanup.py
@@ -4,55 +4,45 @@ from typing import cast
 from django.conf import settings
 
 from sentry.models.options.project_option import ProjectOption
-from sentry.models.organization import Organization
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import symbolication_tasks
-from sentry.utils.console_platforms import organization_has_console_platform_access
 
 logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
-    name="sentry.tasks.console_platform_cleanup.remove_revoked_console_platform_sources",
+    name="sentry.tasks.console_platform_cleanup.remove_inaccessible_console_platform_sources",
     namespace=symbolication_tasks,
     silo_mode=SiloMode.REGION,
 )
-def remove_revoked_console_platform_sources(
-    organization_id: int, revoked_platforms: list[str], **kwargs
+def remove_inaccessible_console_platform_sources(
+    organization_id: int, current_platforms: list[str], **kwargs
 ) -> None:
     """
-    Remove symbol sources associated with revoked console platforms from all
-    projects in an organization.
+    Remove symbol sources that the organization can no longer access from all
+    projects in the organization.
 
-    When an organization loses access to a console platform (e.g., nintendo-switch),
-    this task removes any builtin symbol sources that the organization no longer
-    has access to from all projects in the organization.
+    Called when console platform access is revoked.  ``current_platforms`` is the
+    set of console platforms the organization still has access to *after* the
+    revocation.  Any builtin source whose required platforms are all absent from
+    this list is removed from every project's ``sentry:builtin_symbol_sources``.
     """
-    try:
-        organization = Organization.objects.get_from_cache(id=organization_id)
-    except Organization.DoesNotExist:
-        return
-
-    # Find source keys the org no longer has access to.  This mirrors
-    # the endpoint logic: a source is accessible when the org has access
-    # to *any* of its platforms, so it must be removed when the org has
+    # A source is accessible when the org has access to *any* of its platforms
+    # (mirroring BuiltinSymbolSourcesEndpoint), so remove it when the org has
     # access to *none* of them.
+    current_platform_set = set(current_platforms)
     source_keys_to_remove: set[str] = set()
     for key, source in settings.SENTRY_BUILTIN_SOURCES.items():
         source_platforms: list[str] | None = cast("list[str] | None", source.get("platforms"))
         if source_platforms is None:
             continue
-        has_access = any(
-            organization_has_console_platform_access(organization, p) for p in source_platforms
-        )
-        if not has_access:
+        if not current_platform_set.intersection(source_platforms):
             source_keys_to_remove.add(key)
 
     if not source_keys_to_remove:
         return
 
-    # Find all projects in this org that have explicit builtin symbol sources
     project_options = ProjectOption.objects.filter(
         project__organization_id=organization_id,
         key="sentry:builtin_symbol_sources",

--- a/src/sentry/tasks/console_platform_cleanup.py
+++ b/src/sentry/tasks/console_platform_cleanup.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.tasks.console_platform_cleanup.remove_inaccessible_console_platform_sources",
     namespace=symbolication_tasks,
-    silo_mode=SiloMode.REGION,
+    silo_mode=SiloMode.CELL,
 )
 def remove_inaccessible_console_platform_sources(
     organization_id: int, current_platforms: list[str], **kwargs

--- a/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
+++ b/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
@@ -49,6 +49,26 @@ class BuiltinSymbolSourcesWithSlugTest(APITestCase):
         assert "hidden" in body[0]
 
 
+class BuiltinSymbolSourcesAuthTest(APITestCase):
+    endpoint = "sentry-api-0-organization-builtin-symbol-sources"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+
+    def test_unauthenticated(self) -> None:
+        """Unauthenticated requests should be rejected"""
+        resp = self.get_response(self.organization.slug)
+        assert resp.status_code == 401
+
+    def test_other_org(self) -> None:
+        """Authenticated user should not access another org's sources"""
+        other_org = self.create_organization()
+        self.login_as(self.user)
+        resp = self.get_response(other_org.slug)
+        assert resp.status_code == 403
+
+
 class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
     endpoint = "sentry-api-0-organization-builtin-symbol-sources"
 

--- a/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
+++ b/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
@@ -93,8 +93,8 @@ class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
         assert "public-source-2" in source_keys
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
-    def test_platform_filtering_unity(self) -> None:
-        """Unity platform should NOT see nintendo source"""
+    def test_platform_filtering_unity_without_console_access(self) -> None:
+        """Unity platform should NOT see nintendo source without console access"""
         resp = self.get_response(self.organization.slug, qs_params={"platform": "unity"})
         assert resp.status_code == 200
 
@@ -104,12 +104,29 @@ class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
         # Unity should see public sources (no platform restriction)
         assert "public-source-1" in source_keys
         assert "public-source-2" in source_keys
-        # Unity should NOT see nintendo (restricted to nintendo-switch)
+        # Unity should NOT see nintendo without org console access
         assert "nintendo" not in source_keys
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
+    def test_platform_filtering_unity_with_console_access(self) -> None:
+        """Unity platform SHOULD see nintendo source if org has console access"""
+        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
+
+        resp = self.get_response(self.organization.slug, qs_params={"platform": "unity"})
+        assert resp.status_code == 200
+
+        body = resp.data
+        source_keys = [source["sentry_key"] for source in body]
+
+        # Unity should see public sources
+        assert "public-source-1" in source_keys
+        assert "public-source-2" in source_keys
+        # Unity SHOULD see nintendo because org has console access
+        assert "nintendo" in source_keys
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
     def test_no_platform_parameter(self) -> None:
-        """Without platform parameter, should see public sources but not platform-restricted ones"""
+        """Without platform parameter and no console access, should not see platform-restricted sources"""
         resp = self.get_response(self.organization.slug)
         assert resp.status_code == 200
 
@@ -119,5 +136,58 @@ class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
         # Should see public sources (no platform restriction)
         assert "public-source-1" in source_keys
         assert "public-source-2" in source_keys
-        # Should NOT see platform-restricted source when no platform is provided
+        # Should NOT see platform-restricted source without console access
+        assert "nintendo" not in source_keys
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
+    def test_no_platform_with_console_access(self) -> None:
+        """Without platform parameter, should NOT see platform-restricted sources even with access"""
+        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
+
+        resp = self.get_response(self.organization.slug)
+        assert resp.status_code == 200
+
+        body = resp.data
+        source_keys = [source["sentry_key"] for source in body]
+
+        # Should see public sources
+        assert "public-source-1" in source_keys
+        assert "public-source-2" in source_keys
+        # Should NOT see nintendo without a gaming platform specified
+        assert "nintendo" not in source_keys
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
+    def test_non_gaming_platform_with_console_access(self) -> None:
+        """Non-gaming platform should NOT see nintendo source even with console access"""
+        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
+
+        resp = self.get_response(self.organization.slug, qs_params={"platform": "python"})
+        assert resp.status_code == 200
+
+        body = resp.data
+        source_keys = [source["sentry_key"] for source in body]
+
+        # Should see public sources
+        assert "public-source-1" in source_keys
+        assert "public-source-2" in source_keys
+        # Python is NOT a game engine platform, so should NOT see nintendo
+        assert "nintendo" not in source_keys
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
+    def test_other_console_platform_does_not_see_nintendo(self) -> None:
+        """PlayStation platform should NOT see nintendo source"""
+        self.organization.update_option(
+            "sentry:enabled_console_platforms", ["nintendo-switch", "playstation"]
+        )
+
+        resp = self.get_response(self.organization.slug, qs_params={"platform": "playstation"})
+        assert resp.status_code == 200
+
+        body = resp.data
+        source_keys = [source["sentry_key"] for source in body]
+
+        # Should see public sources
+        assert "public-source-1" in source_keys
+        assert "public-source-2" in source_keys
+        # PlayStation should NOT see nintendo (not a matching console or game engine)
         assert "nintendo" not in source_keys

--- a/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
+++ b/tests/sentry/api/endpoints/test_builtin_symbol_sources.py
@@ -113,38 +113,6 @@ class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
         assert "public-source-2" in source_keys
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
-    def test_platform_filtering_unity_without_console_access(self) -> None:
-        """Unity platform should NOT see nintendo source without console access"""
-        resp = self.get_response(self.organization.slug, qs_params={"platform": "unity"})
-        assert resp.status_code == 200
-
-        body = resp.data
-        source_keys = [source["sentry_key"] for source in body]
-
-        # Unity should see public sources (no platform restriction)
-        assert "public-source-1" in source_keys
-        assert "public-source-2" in source_keys
-        # Unity should NOT see nintendo without org console access
-        assert "nintendo" not in source_keys
-
-    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
-    def test_platform_filtering_unity_with_console_access(self) -> None:
-        """Unity platform SHOULD see nintendo source if org has console access"""
-        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
-
-        resp = self.get_response(self.organization.slug, qs_params={"platform": "unity"})
-        assert resp.status_code == 200
-
-        body = resp.data
-        source_keys = [source["sentry_key"] for source in body]
-
-        # Unity should see public sources
-        assert "public-source-1" in source_keys
-        assert "public-source-2" in source_keys
-        # Unity SHOULD see nintendo because org has console access
-        assert "nintendo" in source_keys
-
-    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
     def test_no_platform_parameter(self) -> None:
         """Without platform parameter and no console access, should not see platform-restricted sources"""
         resp = self.get_response(self.organization.slug)
@@ -174,40 +142,4 @@ class BuiltinSymbolSourcesPlatformFilteringTest(APITestCase):
         assert "public-source-1" in source_keys
         assert "public-source-2" in source_keys
         # Should NOT see nintendo without a gaming platform specified
-        assert "nintendo" not in source_keys
-
-    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
-    def test_non_gaming_platform_with_console_access(self) -> None:
-        """Non-gaming platform should NOT see nintendo source even with console access"""
-        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
-
-        resp = self.get_response(self.organization.slug, qs_params={"platform": "python"})
-        assert resp.status_code == 200
-
-        body = resp.data
-        source_keys = [source["sentry_key"] for source in body]
-
-        # Should see public sources
-        assert "public-source-1" in source_keys
-        assert "public-source-2" in source_keys
-        # Python is NOT a game engine platform, so should NOT see nintendo
-        assert "nintendo" not in source_keys
-
-    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_PLATFORM_TEST)
-    def test_other_console_platform_does_not_see_nintendo(self) -> None:
-        """PlayStation platform should NOT see nintendo source"""
-        self.organization.update_option(
-            "sentry:enabled_console_platforms", ["nintendo-switch", "playstation"]
-        )
-
-        resp = self.get_response(self.organization.slug, qs_params={"platform": "playstation"})
-        assert resp.status_code == 200
-
-        body = resp.data
-        source_keys = [source["sentry_key"] for source in body]
-
-        # Should see public sources
-        assert "public-source-1" in source_keys
-        assert "public-source-2" in source_keys
-        # PlayStation should NOT see nintendo (not a matching console or game engine)
         assert "nintendo" not in source_keys

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1497,25 +1497,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         mock_cleanup_task.assert_called_once_with(self.organization.id, [])
 
-    def test_enable_pr_review_test_generation_default_false(self) -> None:
-        response = self.get_success_response(self.organization.slug)
-        assert response.data["enablePrReviewTestGeneration"] is False
-
-    def test_enable_pr_review_test_generation_can_be_disabled(self) -> None:
-        data = {"enablePrReviewTestGeneration": False}
-        self.get_success_response(self.organization.slug, **data)
-
-        assert self.organization.get_option("sentry:enable_pr_review_test_generation") is False
-
-    def test_enable_pr_review_test_generation_can_be_enabled(self) -> None:
-        # First disable it
-        self.organization.update_option("sentry:enable_pr_review_test_generation", False)
-
-        data = {"enablePrReviewTestGeneration": True}
-        self.get_success_response(self.organization.slug, **data)
-
-        assert self.organization.get_option("sentry:enable_pr_review_test_generation") is True
-
     def test_enable_seer_enhanced_alerts_default_true(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["enableSeerEnhancedAlerts"] is True

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1441,6 +1441,81 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
                 == "Enabled platforms: PlayStation, Xbox; Disabled platforms: Nintendo Switch"
             )
 
+    @patch(
+        "sentry.tasks.console_platform_cleanup.remove_inaccessible_console_platform_sources.delay"
+    )
+    def test_console_platform_revocation_dispatches_cleanup_task(
+        self, mock_cleanup_task: MagicMock
+    ) -> None:
+        """Revoking console platforms dispatches the cleanup task with remaining platforms"""
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(organization=self.organization, user=staff_user, role="owner")
+        self.login_as(user=staff_user, staff=True)
+
+        self.organization.update_option(
+            "sentry:enabled_console_platforms", ["playstation", "nintendo-switch"]
+        )
+
+        data = {"enabledConsolePlatforms": ["playstation"]}
+        self.get_success_response(self.organization.slug, **data)
+
+        mock_cleanup_task.assert_called_once_with(self.organization.id, ["playstation"])
+
+    @patch(
+        "sentry.tasks.console_platform_cleanup.remove_inaccessible_console_platform_sources.delay"
+    )
+    def test_console_platform_addition_does_not_dispatch_cleanup_task(
+        self, mock_cleanup_task: MagicMock
+    ) -> None:
+        """Adding console platforms without revoking any does not dispatch the cleanup task"""
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(organization=self.organization, user=staff_user, role="owner")
+        self.login_as(user=staff_user, staff=True)
+
+        data = {"enabledConsolePlatforms": ["playstation", "xbox"]}
+        self.get_success_response(self.organization.slug, **data)
+
+        mock_cleanup_task.assert_not_called()
+
+    @patch(
+        "sentry.tasks.console_platform_cleanup.remove_inaccessible_console_platform_sources.delay"
+    )
+    def test_console_platform_revoke_all_dispatches_cleanup_task(
+        self, mock_cleanup_task: MagicMock
+    ) -> None:
+        """Revoking all console platforms dispatches the cleanup task with empty list"""
+        staff_user = self.create_user(is_staff=True)
+        self.create_member(organization=self.organization, user=staff_user, role="owner")
+        self.login_as(user=staff_user, staff=True)
+
+        self.organization.update_option(
+            "sentry:enabled_console_platforms", ["playstation", "nintendo-switch"]
+        )
+
+        data: dict[str, list[str]] = {"enabledConsolePlatforms": []}
+        self.get_success_response(self.organization.slug, **data)
+
+        mock_cleanup_task.assert_called_once_with(self.organization.id, [])
+
+    def test_enable_pr_review_test_generation_default_false(self) -> None:
+        response = self.get_success_response(self.organization.slug)
+        assert response.data["enablePrReviewTestGeneration"] is False
+
+    def test_enable_pr_review_test_generation_can_be_disabled(self) -> None:
+        data = {"enablePrReviewTestGeneration": False}
+        self.get_success_response(self.organization.slug, **data)
+
+        assert self.organization.get_option("sentry:enable_pr_review_test_generation") is False
+
+    def test_enable_pr_review_test_generation_can_be_enabled(self) -> None:
+        # First disable it
+        self.organization.update_option("sentry:enable_pr_review_test_generation", False)
+
+        data = {"enablePrReviewTestGeneration": True}
+        self.get_success_response(self.organization.slug, **data)
+
+        assert self.organization.get_option("sentry:enable_pr_review_test_generation") is True
+
     def test_enable_seer_enhanced_alerts_default_true(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["enableSeerEnhancedAlerts"] is True

--- a/tests/sentry/tasks/test_console_platform_cleanup.py
+++ b/tests/sentry/tasks/test_console_platform_cleanup.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 
 from sentry.models.options.project_option import ProjectOption
-from sentry.tasks.console_platform_cleanup import remove_revoked_console_platform_sources
+from sentry.tasks.console_platform_cleanup import remove_inaccessible_console_platform_sources
 from sentry.testutils.cases import TestCase
 
 SENTRY_BUILTIN_SOURCES_TEST = {
@@ -47,31 +47,29 @@ SENTRY_BUILTIN_SOURCES_TEST = {
 }
 
 
-class RemoveRevokedConsolePlatformSourcesTest(TestCase):
+class RemoveInaccessibleConsolePlatformSourcesTest(TestCase):
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_removes_revoked_sources(self) -> None:
+    def test_removes_sources_for_revoked_platform(self) -> None:
         """Revoking nintendo-switch access removes 'nintendo' from projects"""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        # current_platforms after revocation: no console access left
+        remove_inaccessible_console_platform_sources(self.organization.id, [])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft"]
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_preserves_non_revoked_sources(self) -> None:
-        """Only sources for revoked platforms are removed, others are preserved"""
-        # Org still has playstation access
-        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-
+    def test_preserves_sources_for_remaining_platforms(self) -> None:
+        """Only sources for inaccessible platforms are removed"""
         project = self.create_project(organization=self.organization)
         project.update_option(
             "sentry:builtin_symbol_sources", ["microsoft", "nintendo", "playstation"]
         )
 
-        # Only revoke nintendo-switch, not playstation
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        # Org still has playstation, lost nintendo-switch
+        remove_inaccessible_console_platform_sources(self.organization.id, ["playstation"])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert "microsoft" in sources
@@ -80,11 +78,11 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
     def test_no_change_when_project_lacks_source(self) -> None:
-        """Projects without the revoked source are not modified"""
+        """Projects without the inaccessible source are not modified"""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        remove_inaccessible_console_platform_sources(self.organization.id, [])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft"]
@@ -96,7 +94,7 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
         other_project = self.create_project(organization=other_org)
         other_project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        remove_inaccessible_console_platform_sources(self.organization.id, [])
 
         sources = ProjectOption.objects.get_value(other_project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft", "nintendo"]
@@ -109,7 +107,7 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
         project1.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
         project2.update_option("sentry:builtin_symbol_sources", ["nintendo"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        remove_inaccessible_console_platform_sources(self.organization.id, [])
 
         sources1 = ProjectOption.objects.get_value(project1, "sentry:builtin_symbol_sources")
         sources2 = ProjectOption.objects.get_value(project2, "sentry:builtin_symbol_sources")
@@ -117,56 +115,47 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
         assert sources2 == []
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_noop_when_no_matching_sources(self) -> None:
-        """Revoking a platform with no configured sources is a no-op"""
+    def test_noop_when_all_platforms_still_accessible(self) -> None:
+        """No changes when org still has access to all platforms"""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
-        # Org still has nintendo access, only xbox (no sources) is revoked
-        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["xbox"])
+        remove_inaccessible_console_platform_sources(
+            self.organization.id, ["nintendo-switch", "playstation"]
+        )
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft", "nintendo"]
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_multi_platform_source_removed_when_only_partial_access_revoked(self) -> None:
-        """A multi-platform source is removed when the org's only matching
-        platform is revoked, even if the source lists other platforms the org
-        never had access to. This is the any() vs all() bug scenario."""
-        # Org only ever had nintendo-switch, never playstation
-        # multi-console source has platforms: ["nintendo-switch", "playstation"]
+    def test_multi_platform_source_removed_when_no_platforms_accessible(self) -> None:
+        """A multi-platform source is removed when the org has access to none
+        of its platforms."""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft", "multi-console"])
 
-        # Revoke nintendo-switch — org now has no console access at all
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        # Org has no console access at all
+        remove_inaccessible_console_platform_sources(self.organization.id, [])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft"]
-        # multi-console must be removed because the org has access to *none*
-        # of its platforms (the old `all()` logic would have kept it)
-        assert "multi-console" not in sources
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
-    def test_multi_platform_source_kept_when_other_platform_still_accessible(self) -> None:
+    def test_multi_platform_source_kept_when_one_platform_still_accessible(self) -> None:
         """A multi-platform source is preserved when the org still has access
         to at least one of its platforms."""
-        # Org has both platforms, revoke only nintendo-switch
-        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
-
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft", "multi-console"])
 
-        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+        # Org lost nintendo-switch but still has playstation
+        remove_inaccessible_console_platform_sources(self.organization.id, ["playstation"])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert "microsoft" in sources
-        # multi-console should be kept — org still has playstation access
         assert "multi-console" in sources
 
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
     def test_nonexistent_organization(self) -> None:
-        """Task gracefully handles a deleted organization"""
-        remove_revoked_console_platform_sources(999999999, ["nintendo-switch"])
+        """Task gracefully handles a nonexistent organization"""
+        remove_inaccessible_console_platform_sources(999999999, [])
         # Should not raise

--- a/tests/sentry/tasks/test_console_platform_cleanup.py
+++ b/tests/sentry/tasks/test_console_platform_cleanup.py
@@ -33,6 +33,17 @@ SENTRY_BUILTIN_SOURCES_TEST = {
         "layout": {"type": "native"},
         "platforms": ["playstation"],
     },
+    "multi-console": {
+        "id": "sentry:multi-console",
+        "name": "Multi Console SDK",
+        "type": "s3",
+        "bucket": "multi-console-symbols",
+        "region": "us-east-1",
+        "access_key": "test-key",
+        "secret_key": "test-secret",
+        "layout": {"type": "native"},
+        "platforms": ["nintendo-switch", "playstation"],
+    },
 }
 
 
@@ -51,6 +62,9 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
     @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
     def test_preserves_non_revoked_sources(self) -> None:
         """Only sources for revoked platforms are removed, others are preserved"""
+        # Org still has playstation access
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+
         project = self.create_project(organization=self.organization)
         project.update_option(
             "sentry:builtin_symbol_sources", ["microsoft", "nintendo", "playstation"]
@@ -107,9 +121,52 @@ class RemoveRevokedConsolePlatformSourcesTest(TestCase):
         """Revoking a platform with no configured sources is a no-op"""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
+        # Org still has nintendo access, only xbox (no sources) is revoked
+        self.organization.update_option("sentry:enabled_console_platforms", ["nintendo-switch"])
 
-        # Revoke a platform that has no sources in SENTRY_BUILTIN_SOURCES
         remove_revoked_console_platform_sources(self.organization.id, ["xbox"])
 
         sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
         assert sources == ["microsoft", "nintendo"]
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_multi_platform_source_removed_when_only_partial_access_revoked(self) -> None:
+        """A multi-platform source is removed when the org's only matching
+        platform is revoked, even if the source lists other platforms the org
+        never had access to. This is the any() vs all() bug scenario."""
+        # Org only ever had nintendo-switch, never playstation
+        # multi-console source has platforms: ["nintendo-switch", "playstation"]
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:builtin_symbol_sources", ["microsoft", "multi-console"])
+
+        # Revoke nintendo-switch — org now has no console access at all
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert sources == ["microsoft"]
+        # multi-console must be removed because the org has access to *none*
+        # of its platforms (the old `all()` logic would have kept it)
+        assert "multi-console" not in sources
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_multi_platform_source_kept_when_other_platform_still_accessible(self) -> None:
+        """A multi-platform source is preserved when the org still has access
+        to at least one of its platforms."""
+        # Org has both platforms, revoke only nintendo-switch
+        self.organization.update_option("sentry:enabled_console_platforms", ["playstation"])
+
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:builtin_symbol_sources", ["microsoft", "multi-console"])
+
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert "microsoft" in sources
+        # multi-console should be kept — org still has playstation access
+        assert "multi-console" in sources
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_nonexistent_organization(self) -> None:
+        """Task gracefully handles a deleted organization"""
+        remove_revoked_console_platform_sources(999999999, ["nintendo-switch"])
+        # Should not raise

--- a/tests/sentry/tasks/test_console_platform_cleanup.py
+++ b/tests/sentry/tasks/test_console_platform_cleanup.py
@@ -1,0 +1,115 @@
+from django.test import override_settings
+
+from sentry.models.options.project_option import ProjectOption
+from sentry.tasks.console_platform_cleanup import remove_revoked_console_platform_sources
+from sentry.testutils.cases import TestCase
+
+SENTRY_BUILTIN_SOURCES_TEST = {
+    "microsoft": {
+        "id": "sentry:microsoft",
+        "name": "Microsoft",
+        "type": "http",
+        "url": "https://msdl.microsoft.com/download/symbols/",
+    },
+    "nintendo": {
+        "id": "sentry:nintendo",
+        "name": "Nintendo SDK",
+        "type": "s3",
+        "bucket": "nintendo-symbols",
+        "region": "us-east-1",
+        "access_key": "test-key",
+        "secret_key": "test-secret",
+        "layout": {"type": "native"},
+        "platforms": ["nintendo-switch"],
+    },
+    "playstation": {
+        "id": "sentry:playstation",
+        "name": "PlayStation SDK",
+        "type": "s3",
+        "bucket": "playstation-symbols",
+        "region": "us-east-1",
+        "access_key": "test-key",
+        "secret_key": "test-secret",
+        "layout": {"type": "native"},
+        "platforms": ["playstation"],
+    },
+}
+
+
+class RemoveRevokedConsolePlatformSourcesTest(TestCase):
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_removes_revoked_sources(self) -> None:
+        """Revoking nintendo-switch access removes 'nintendo' from projects"""
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
+
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert sources == ["microsoft"]
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_preserves_non_revoked_sources(self) -> None:
+        """Only sources for revoked platforms are removed, others are preserved"""
+        project = self.create_project(organization=self.organization)
+        project.update_option(
+            "sentry:builtin_symbol_sources", ["microsoft", "nintendo", "playstation"]
+        )
+
+        # Only revoke nintendo-switch, not playstation
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert "microsoft" in sources
+        assert "playstation" in sources
+        assert "nintendo" not in sources
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_no_change_when_project_lacks_source(self) -> None:
+        """Projects without the revoked source are not modified"""
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
+
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert sources == ["microsoft"]
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_other_org_projects_unaffected(self) -> None:
+        """Projects in other orgs are not modified"""
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
+
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources = ProjectOption.objects.get_value(other_project, "sentry:builtin_symbol_sources")
+        assert sources == ["microsoft", "nintendo"]
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_multiple_projects_cleaned_up(self) -> None:
+        """All projects in the org are cleaned up"""
+        project1 = self.create_project(organization=self.organization)
+        project2 = self.create_project(organization=self.organization)
+        project1.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
+        project2.update_option("sentry:builtin_symbol_sources", ["nintendo"])
+
+        remove_revoked_console_platform_sources(self.organization.id, ["nintendo-switch"])
+
+        sources1 = ProjectOption.objects.get_value(project1, "sentry:builtin_symbol_sources")
+        sources2 = ProjectOption.objects.get_value(project2, "sentry:builtin_symbol_sources")
+        assert sources1 == ["microsoft"]
+        assert sources2 == []
+
+    @override_settings(SENTRY_BUILTIN_SOURCES=SENTRY_BUILTIN_SOURCES_TEST)
+    def test_noop_when_no_matching_sources(self) -> None:
+        """Revoking a platform with no configured sources is a no-op"""
+        project = self.create_project(organization=self.organization)
+        project.update_option("sentry:builtin_symbol_sources", ["microsoft", "nintendo"])
+
+        # Revoke a platform that has no sources in SENTRY_BUILTIN_SOURCES
+        remove_revoked_console_platform_sources(self.organization.id, ["xbox"])
+
+        sources = ProjectOption.objects.get_value(project, "sentry:builtin_symbol_sources")
+        assert sources == ["microsoft", "nintendo"]


### PR DESCRIPTION
Allow projects to see console-restricted symbol sources in Built-in Repositories when the organization has console platform access. This lets e.g. a Unity project add the Nintendo symbol source if the org has nintendo-switch access.

When console access is revoked, a Celery task removes the corresponding symbol sources from all projects in the organization.

---

Also updates `BuiltinSymbolSourcesEndpoint` to no longer be accessible as an endpoint without having Organization auth by changing the class it inherits from to `OrganizationEndpoint`.

