### PR TITLE
fix(explore): unify header FeedbackButton size as default sm

### DIFF
--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -112,7 +112,6 @@ function LogsHeader() {
       <Layout.HeaderActions>
         <Grid flow="column" align="center" gap="md">
           <FeedbackButton
-            size="xs"
             feedbackOptions={{
               messagePlaceholder: t('How can we make logs work better for you?'),
               tags: {

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -94,7 +94,6 @@ function MetricsHeader() {
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         <FeedbackButton
-          size="xs"
           feedbackOptions={{
             messagePlaceholder: t('How can we make metrics work better for you?'),
             tags: {


### PR DESCRIPTION
Unifies the two `xs`-sized buttons -Logs and Metrics- with the three default `sm`-sized buttons in Traces, Profiles, and Releases.

<table>
<thead>
<tr>
<th>Page</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Traces</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/ee844956-8f74-44c5-92c7-a389cebea221" />
</td>
<td>
<em>(unchanged)</em>
</td>
</tr>
<tr>
<td>Logs</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/9a058923-4577-4460-9ef7-bed9a0afb294" />
</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/bd840268-de5f-41cf-a075-643a0a606d68" />
</td>
</tr>
<tr>
<td>Metrics</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/4eb26e32-2f0f-4c5e-beac-8c46c433cbb1" />
</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/2de5021f-04a1-46c5-a3e7-0488a723d708" />
</td>
</tr>
<tr>
<td>Profiles</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/7aa9254e-97a1-42ab-b80b-55e3e106bbe1" />
</td>
<td>
<em>(unchanged)</em>
</td>
</tr>
<tr>
<td>Releases</td>
<td>
<img width="703" height="247" alt="image" src="https://github.com/user-attachments/assets/edac936b-4dc7-4b2c-ba2e-c476eed2af52" />
</td>
<td>
<em>(unchanged)</em>
</td>
</tr>
<tr
</tbody>
</table>

Fixes https://linear.app/getsentry/issue/EXP-814/unify-give-feedback-header-buttons-in-explore