### PR TITLE
feat(integrations): Expand `org:ci` token permissions to Bulk Code Mapping API endpoints

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -164,6 +164,15 @@ class OrganizationIntegrationsLoosePermission(OrganizationPermission):
     }
 
 
+class OrganizationCodeMappingsBulkPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
+        "POST": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
+        "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
+        "DELETE": ["org:admin", "org:integrations"],
+    }
+
+
 class OrganizationAdminPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:admin"],

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -168,8 +168,6 @@ class OrganizationCodeMappingsBulkPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
         "POST": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
-        "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
-        "DELETE": ["org:admin", "org:integrations"],
     }
 
 


### PR DESCRIPTION
## Summary
- Add `OrganizationCodeMappingsBulkPermission` permission class that includes `org:ci` in GET and POST scopes
- This allows auth tokens used by sentry-cli in CI to call the upcoming bulk code mappings endpoint
- Follows the precedent of `OrganizationReleasePermission` which already includes `org:ci` for POST

## Test plan
- Permission class is exercised by tests in the follow-up PR
- Verified no existing tests are affected

Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/1073