### PR TITLE
feat(integrations): Add bulk code mappings API endpoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -475,6 +475,7 @@ module = [
     "sentry.incidents.utils.*",
     "sentry.ingest.slicing",
     "sentry.insights.migrations.*",
+    "sentry.integrations.api.endpoints.organization_code_mappings_bulk",
     "sentry.integrations.api.parsers.*",
     "sentry.integrations.coding_agent.*",
     "sentry.integrations.discord.actions.*",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -250,6 +250,9 @@ from sentry.integrations.api.endpoints.organization_code_mapping_details import 
 from sentry.integrations.api.endpoints.organization_code_mappings import (
     OrganizationCodeMappingsEndpoint,
 )
+from sentry.integrations.api.endpoints.organization_code_mappings_bulk import (
+    OrganizationCodeMappingsBulkEndpoint,
+)
 from sentry.integrations.api.endpoints.organization_coding_agents import (
     OrganizationCodingAgentsEndpoint,
 )
@@ -1435,6 +1438,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/code-mappings/$",
         OrganizationCodeMappingsEndpoint.as_view(),
         name="sentry-api-0-organization-code-mappings",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/code-mappings/bulk/$",
+        OrganizationCodeMappingsBulkEndpoint.as_view(),
+        name="sentry-api-0-organization-code-mappings-bulk",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/derive-code-mappings/$",

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.db import router, transaction
-from django.db.models.signals import post_save
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -24,6 +23,7 @@ from sentry.integrations.api.endpoints.organization_code_mappings import (
 from sentry.integrations.models.repository_project_path_config import (
     RepositoryProjectPathConfig,
     process_resource_change,
+    suppress_post_save_signal,
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
@@ -150,13 +150,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
         has_errors = False
         last_saved_config = None
 
-        # Suppress per-save signals during the loop to avoid redundant
-        # cache clears and celery task dispatches for every mapping.
-        post_save.disconnect(
-            sender=RepositoryProjectPathConfig,
-            dispatch_uid="repository_project_path_config_post_save",
-        )
-        try:
+        with suppress_post_save_signal():
             for mapping in mappings:
                 try:
                     with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
@@ -199,13 +193,6 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
                             "detail": "Failed to save mapping.",
                         }
                     )
-        finally:
-            post_save.connect(
-                lambda instance, **kwargs: process_resource_change(instance, **kwargs),
-                sender=RepositoryProjectPathConfig,
-                weak=False,
-                dispatch_uid="repository_project_path_config_post_save",
-            )
 
         # Fire side effects once for the entire batch.
         if last_saved_config is not None:

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -70,6 +70,75 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
     }
     permission_classes = (OrganizationCodeMappingsBulkPermission,)
 
+    @staticmethod
+    def _auto_create_repository(
+        organization: Organization,
+        repo_name: str,
+        provider: str,
+    ) -> tuple[Repository | None, Response | None]:
+        """
+        Auto-create a Repository if the provider integration can verify it exists.
+        Returns (repo, None) on success or (None, error_response) on failure.
+        """
+        # Normalize provider: strip "integrations:" prefix if present
+        short_provider = provider.removeprefix("integrations:")
+        repo_provider = f"integrations:{short_provider}"
+
+        org_integrations = integration_service.get_organization_integrations(
+            organization_id=organization.id, providers=[short_provider]
+        )
+        if not org_integrations:
+            return None, Response(
+                {"detail": f"No {provider} integration installed on this organization."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Use the first matching integration
+        org_int = org_integrations[0]
+        integration = integration_service.get_integration(integration_id=org_int.integration_id)
+        if not integration:
+            return None, None  # Fall through to 404
+
+        try:
+            install = integration.get_installation(organization_id=organization.id)
+        except Exception:
+            logger.exception("bulk_code_mappings.auto_create_repo.get_installation_error")
+            return None, None
+
+        if not isinstance(install, RepositoryIntegration):
+            return None, None
+
+        # Verify the repo exists on the provider
+        try:
+            repositories = install.get_repositories(query=repo_name)
+        except Exception:
+            logger.exception("bulk_code_mappings.auto_create_repo.get_repositories_error")
+            return None, None
+
+        repo_info = None
+        for r in repositories:
+            if r.get("identifier") == repo_name:
+                repo_info = r
+                break
+        if not repo_info:
+            for r in repositories:
+                if r.get("name") == repo_name:
+                    repo_info = r
+                    break
+
+        if not repo_info:
+            return None, None  # Repo doesn't exist on provider, fall through to 404
+
+        repo, _ = Repository.objects.get_or_create(
+            name=repo_name,
+            organization_id=organization.id,
+            defaults={
+                "integration_id": org_int.integration_id,
+                "provider": repo_provider,
+            },
+        )
+        return repo, None
+
     def post(self, request: Request, organization: Organization) -> Response:
         serializer = BulkCodeMappingsRequestSerializer(data=request.data)
         if not serializer.is_valid():
@@ -106,11 +175,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         if provider:
             repo_filter = repo_filter.filter(provider__in=[provider, f"integrations:{provider}"])
         repos = list(repo_filter[:2])  # Only need 2 to detect duplicates
-        if len(repos) == 0:
-            return Response(
-                {"detail": f"Repository not found: {data['repository']}"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+
         if len(repos) > 1:
             return Response(
                 {
@@ -119,7 +184,22 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
                 },
                 status=status.HTTP_409_CONFLICT,
             )
-        repo = repos[0]
+
+        repo: Repository | None = repos[0] if repos else None
+
+        # Auto-create repository if not found and provider is given
+        if repo is None and provider:
+            repo, error_response = self._auto_create_repository(
+                organization, data["repository"], provider
+            )
+            if error_response:
+                return error_response
+
+        if repo is None:
+            return Response(
+                {"detail": f"Repository not found: {data['repository']}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
 
         if not repo.integration_id:
             return Response(

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -34,12 +34,12 @@ logger = logging.getLogger(__name__)
 MAX_MAPPINGS = 300
 
 
-class MappingItemSerializer(serializers.Serializer):
+class MappingItemSerializer(serializers.Serializer[dict[str, object]]):
     stack_root = gen_path_regex_field()
     source_root = gen_path_regex_field()
 
 
-class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer):
+class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]]):
     project = serializers.CharField(required=True)
     repository = serializers.CharField(required=True)
     default_branch = serializers.RegexField(
@@ -50,7 +50,7 @@ class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer):
     )
     mappings = MappingItemSerializer(many=True, required=True)
 
-    def validate_mappings(self, mappings):
+    def validate_mappings(self, mappings: list[dict[str, str]]) -> list[dict[str, str]]:
         if len(mappings) > MAX_MAPPINGS:
             raise serializers.ValidationError(
                 f"A maximum of {MAX_MAPPINGS} mappings can be submitted at once."

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,0 +1,204 @@
+import logging
+
+from django.db import router, transaction
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import (
+    OrganizationCodeMappingsBulkPermission,
+    OrganizationEndpoint,
+)
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.constants import ObjectStatus
+from sentry.integrations.api.endpoints.organization_code_mappings import (
+    BRANCH_NAME_ERROR_MESSAGE,
+    OrganizationIntegrationMixin,
+    gen_path_regex_field,
+)
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.services.integration import integration_service
+from sentry.integrations.types import IntegrationProviderSlug
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.models.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+MAX_MAPPINGS = 300
+
+
+class MappingItemSerializer(serializers.Serializer):
+    stack_root = gen_path_regex_field()
+    source_root = gen_path_regex_field()
+
+
+class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer):
+    project = serializers.CharField(required=True)
+    repository = serializers.CharField(required=True)
+    default_branch = serializers.RegexField(
+        r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
+        required=False,
+        allow_blank=True,
+        error_messages={"invalid": _(BRANCH_NAME_ERROR_MESSAGE)},
+    )
+    mappings = MappingItemSerializer(many=True, required=True)
+
+    def validate_mappings(self, mappings):
+        if len(mappings) > MAX_MAPPINGS:
+            raise serializers.ValidationError(
+                f"A maximum of {MAX_MAPPINGS} mappings can be submitted at once."
+            )
+        if len(mappings) == 0:
+            raise serializers.ValidationError("At least one mapping is required.")
+        return mappings
+
+
+@region_silo_endpoint
+class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationIntegrationMixin):
+    owner = ApiOwner.ISSUES
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+    permission_classes = (OrganizationCodeMappingsBulkPermission,)
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        serializer = BulkCodeMappingsRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+
+        # Resolve project by slug
+        try:
+            project = Project.objects.get(
+                organization=organization,
+                slug=data["project"],
+                status=ObjectStatus.ACTIVE,
+            )
+        except Project.DoesNotExist:
+            return Response(
+                {"detail": f"Project not found: {data['project']}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not request.access.has_project_access(project):
+            return Response(
+                {"detail": "You do not have access to this project."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Resolve repository by name
+        try:
+            repo = Repository.objects.get(
+                organization_id=organization.id,
+                name=data["repository"],
+                status=ObjectStatus.ACTIVE,
+            )
+        except Repository.DoesNotExist:
+            return Response(
+                {"detail": f"Repository not found: {data['repository']}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except Repository.MultipleObjectsReturned:
+            return Response(
+                {
+                    "detail": f"Multiple repositories found with name: {data['repository']}. Please ensure repository names are unique."
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if not repo.integration_id:
+            return Response(
+                {"detail": "Repository is not associated with an integration."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Resolve organization integration
+        org_integration = integration_service.get_organization_integration(
+            integration_id=repo.integration_id, organization_id=organization.id
+        )
+        if not org_integration:
+            return Response(
+                {"detail": "Integration is not installed on this organization."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Validate default_branch
+        default_branch = data.get("default_branch", "")
+        integration = integration_service.get_integration(integration_id=repo.integration_id)
+        if (
+            not default_branch
+            and integration
+            and integration.provider != IntegrationProviderSlug.PERFORCE
+        ):
+            return Response(
+                {"detail": "defaultBranch is required for this integration type."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        mappings = data["mappings"]
+        results = []
+        has_errors = False
+
+        with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+            for mapping in mappings:
+                try:
+                    config, created = RepositoryProjectPathConfig.objects.update_or_create(
+                        project=project,
+                        stack_root=mapping["stack_root"],
+                        defaults={
+                            "repository": repo,
+                            "organization_integration_id": org_integration.id,
+                            "organization_id": organization.id,
+                            "integration_id": repo.integration_id,
+                            "source_root": mapping["source_root"],
+                            "default_branch": default_branch,
+                            "automatically_generated": False,
+                        },
+                    )
+                    results.append(
+                        {
+                            "stackRoot": mapping["stack_root"],
+                            "sourceRoot": mapping["source_root"],
+                            "status": "created" if created else "updated",
+                        }
+                    )
+                except Exception:
+                    logger.exception(
+                        "bulk_code_mappings.mapping_error",
+                        extra={
+                            "organization_id": organization.id,
+                            "project_id": project.id,
+                            "stack_root": mapping["stack_root"],
+                        },
+                    )
+                    has_errors = True
+                    results.append(
+                        {
+                            "stackRoot": mapping["stack_root"],
+                            "sourceRoot": mapping["source_root"],
+                            "status": "error",
+                            "detail": "Failed to save mapping.",
+                        }
+                    )
+
+        created_count = sum(1 for r in results if r["status"] == "created")
+        updated_count = sum(1 for r in results if r["status"] == "updated")
+        error_count = sum(1 for r in results if r["status"] == "error")
+
+        response_data = {
+            "created": created_count,
+            "updated": updated_count,
+            "errors": error_count,
+            "mappings": results,
+        }
+
+        if has_errors:
+            return Response(response_data, status=207)
+
+        return Response(response_data, status=status.HTTP_200_OK)

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -17,7 +17,6 @@ from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.api.endpoints.organization_code_mappings import (
     BRANCH_NAME_ERROR_MESSAGE,
-    OrganizationIntegrationMixin,
     gen_path_regex_field,
 )
 from sentry.integrations.models.repository_project_path_config import (
@@ -62,7 +61,7 @@ class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer):
 
 
 @region_silo_endpoint
-class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationIntegrationMixin):
+class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
@@ -190,7 +189,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
                         "status": "created" if created else "updated",
                     }
                 )
-            except Exception:
+            except IntegrityError:
                 logger.exception(
                     "bulk_code_mappings.mapping_error",
                     extra={

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -46,6 +46,7 @@ class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]])
     default_branch = serializers.RegexField(
         r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
         required=False,
+        allow_blank=True,  # Perforce allows empty streams
         error_messages={"invalid": _(BRANCH_NAME_ERROR_MESSAGE)},
     )
     mappings = MappingItemSerializer(many=True, required=True)
@@ -135,9 +136,12 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         integration = integration_service.get_integration(integration_id=repo.integration_id)
         if not default_branch and integration:
             if integration.provider != IntegrationProviderSlug.PERFORCE:
-                install = integration.get_installation(organization_id=organization.id)
-                if isinstance(install, RepositoryIntegration):
-                    default_branch = install.get_repository_default_branch(repo) or ""
+                try:
+                    install = integration.get_installation(organization_id=organization.id)
+                    if isinstance(install, RepositoryIntegration):
+                        default_branch = install.get_repository_default_branch(repo) or ""
+                except Exception:
+                    logger.exception("bulk_code_mappings.branch_inference_error")
                 if not default_branch:
                     return Response(
                         {

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -120,15 +120,23 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         if not repo_info:
             return None, None  # Repo doesn't exist on provider, fall through to 404
 
-        repo, _ = Repository.objects.get_or_create(
-            name=repo_name,
-            organization_id=organization.id,
-            provider=repo_provider,
-            defaults={
-                "integration_id": org_int.integration_id,
-            },
-        )
-        return repo, None
+        try:
+            return Repository.objects.create(
+                name=repo_name,
+                organization_id=organization.id,
+                provider=repo_provider,
+                integration_id=org_int.integration_id,
+                external_id=repo_info.get("identifier", ""),
+            ), None
+        except IntegrityError:
+            # Race condition — repo was created between our lookup and now
+            existing = Repository.objects.filter(
+                name=repo_name,
+                organization_id=organization.id,
+                provider=repo_provider,
+                status=ObjectStatus.ACTIVE,
+            ).first()
+            return existing, None
 
     def post(self, request: Request, organization: Organization) -> Response:
         serializer = BulkCodeMappingsRequestSerializer(data=request.data)

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -43,6 +43,7 @@ class MappingItemSerializer(serializers.Serializer[dict[str, object]]):
 class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]]):
     project = serializers.CharField(required=True)
     repository = serializers.CharField(required=True)
+    provider = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     default_branch = serializers.RegexField(
         r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
         required=False,
@@ -85,7 +86,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
             )
         except Project.DoesNotExist:
             return Response(
-                {"detail": f"Project not found: {data['project']}"},
+                {"detail": f"Project not found or not active: {data['project']}"},
                 status=status.HTTP_404_NOT_FOUND,
             )
 
@@ -95,25 +96,30 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        # Resolve repository by name
-        try:
-            repo = Repository.objects.get(
-                organization_id=organization.id,
-                name=data["repository"],
-                status=ObjectStatus.ACTIVE,
-            )
-        except Repository.DoesNotExist:
+        # Resolve repository by name (and optionally provider)
+        repo_filter = Repository.objects.filter(
+            organization_id=organization.id,
+            name=data["repository"],
+            status=ObjectStatus.ACTIVE,
+        )
+        provider = (data.get("provider") or "").strip()
+        if provider:
+            repo_filter = repo_filter.filter(provider__in=[provider, f"integrations:{provider}"])
+        repos = list(repo_filter[:2])  # Only need 2 to detect duplicates
+        if len(repos) == 0:
             return Response(
                 {"detail": f"Repository not found: {data['repository']}"},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except Repository.MultipleObjectsReturned:
+        if len(repos) > 1:
             return Response(
                 {
-                    "detail": f"Multiple repositories found with name: {data['repository']}. Please ensure repository names are unique."
+                    "detail": f"Multiple repositories found with name: {data['repository']}. "
+                    "Provide the provider field (e.g. 'github', 'gitlab') to disambiguate."
                 },
                 status=status.HTTP_409_CONFLICT,
             )
+        repo = repos[0]
 
         if not repo.integration_id:
             return Response(

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -24,6 +24,8 @@ from sentry.integrations.models.repository_project_path_config import (
     process_resource_change,
 )
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -66,6 +68,38 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationCodeMappingsBulkPermission,)
+
+    @staticmethod
+    def _get_default_branch_from_integration(
+        integration: RpcIntegration,
+        organization: Organization,
+        repo: Repository,
+    ) -> str:
+        """Attempt to resolve a repository's default branch via the integration API."""
+        try:
+            install = integration.get_installation(organization_id=organization.id)
+        except Exception:
+            logger.exception("bulk_code_mappings.get_installation_error")
+            return ""
+
+        if not isinstance(install, RepositoryIntegration):
+            return ""
+
+        try:
+            repositories = install.get_repositories(query=repo.name)
+        except Exception:
+            logger.exception("bulk_code_mappings.get_repositories_error")
+            return ""
+
+        for repo_info in repositories:
+            if repo_info.get("identifier") == repo.name:
+                return repo_info.get("default_branch") or ""
+
+        for repo_info in repositories:
+            if repo_info.get("name") == repo.name:
+                return repo_info.get("default_branch") or ""
+
+        return ""
 
     def post(self, request: Request, organization: Organization) -> Response:
         serializer = BulkCodeMappingsRequestSerializer(data=request.data)
@@ -129,18 +163,23 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Validate default_branch
+        # Resolve default_branch: use provided value, or infer from integration
         default_branch = data.get("default_branch", "")
         integration = integration_service.get_integration(integration_id=repo.integration_id)
-        if (
-            not default_branch
-            and integration
-            and integration.provider != IntegrationProviderSlug.PERFORCE
-        ):
-            return Response(
-                {"detail": "defaultBranch is required for this integration type."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if not default_branch and integration:
+            if integration.provider == IntegrationProviderSlug.PERFORCE:
+                pass  # Perforce does not use branches
+            else:
+                default_branch = self._get_default_branch_from_integration(
+                    integration, organization, repo
+                )
+                if not default_branch:
+                    return Response(
+                        {
+                            "detail": "Could not determine the default branch. Please provide defaultBranch explicitly."
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
         mappings = data["mappings"]
         results = []

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -23,7 +23,6 @@ from sentry.integrations.api.endpoints.organization_code_mappings import (
 from sentry.integrations.models.repository_project_path_config import (
     RepositoryProjectPathConfig,
     process_resource_change,
-    suppress_post_save_signal,
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
@@ -150,49 +149,65 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
         has_errors = False
         last_saved_config = None
 
-        with suppress_post_save_signal():
-            for mapping in mappings:
-                try:
-                    with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
-                        config, created = RepositoryProjectPathConfig.objects.update_or_create(
+        defaults = {
+            "repository": repo,
+            "organization_integration_id": org_integration.id,
+            "organization_id": organization.id,
+            "integration_id": repo.integration_id,
+            "default_branch": default_branch,
+            "automatically_generated": False,
+        }
+
+        for mapping in mappings:
+            try:
+                with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+                    try:
+                        config = RepositoryProjectPathConfig.objects.select_for_update().get(
                             project=project,
                             stack_root=mapping["stack_root"],
-                            defaults={
-                                "repository": repo,
-                                "organization_integration_id": org_integration.id,
-                                "organization_id": organization.id,
-                                "integration_id": repo.integration_id,
-                                "source_root": mapping["source_root"],
-                                "default_branch": default_branch,
-                                "automatically_generated": False,
-                            },
                         )
-                    last_saved_config = config
-                    results.append(
-                        {
-                            "stackRoot": mapping["stack_root"],
-                            "sourceRoot": mapping["source_root"],
-                            "status": "created" if created else "updated",
-                        }
-                    )
-                except Exception:
-                    logger.exception(
-                        "bulk_code_mappings.mapping_error",
-                        extra={
-                            "organization_id": organization.id,
-                            "project_id": project.id,
-                            "stack_root": mapping["stack_root"],
-                        },
-                    )
-                    has_errors = True
-                    results.append(
-                        {
-                            "stackRoot": mapping["stack_root"],
-                            "sourceRoot": mapping["source_root"],
-                            "status": "error",
-                            "detail": "Failed to save mapping.",
-                        }
-                    )
+                        for key, value in {
+                            **defaults,
+                            "source_root": mapping["source_root"],
+                        }.items():
+                            setattr(config, key, value)
+                        created = False
+                    except RepositoryProjectPathConfig.DoesNotExist:
+                        config = RepositoryProjectPathConfig(
+                            project=project,
+                            stack_root=mapping["stack_root"],
+                            source_root=mapping["source_root"],
+                            **defaults,
+                        )
+                        created = True
+                    config._skip_post_save = True
+                    config.save()
+                last_saved_config = config
+                results.append(
+                    {
+                        "stackRoot": mapping["stack_root"],
+                        "sourceRoot": mapping["source_root"],
+                        "status": "created" if created else "updated",
+                    }
+                )
+            except Exception:
+                logger.exception(
+                    "bulk_code_mappings.mapping_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                        "stack_root": mapping["stack_root"],
+                    },
+                )
+                has_errors = True
+                results.append(
+                    {
+                        "stackRoot": mapping["stack_root"],
+                        "sourceRoot": mapping["source_root"],
+                        "status": "error",
+                        "detail": "Failed to save mapping.",
+                    }
+                )
 
         # Fire side effects once for the entire batch.
         if last_saved_config is not None:

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -145,9 +145,9 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
         results = []
         has_errors = False
 
-        with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
-            for mapping in mappings:
-                try:
+        for mapping in mappings:
+            try:
+                with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
                     config, created = RepositoryProjectPathConfig.objects.update_or_create(
                         project=project,
                         stack_root=mapping["stack_root"],
@@ -161,31 +161,31 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
                             "automatically_generated": False,
                         },
                     )
-                    results.append(
-                        {
-                            "stackRoot": mapping["stack_root"],
-                            "sourceRoot": mapping["source_root"],
-                            "status": "created" if created else "updated",
-                        }
-                    )
-                except Exception:
-                    logger.exception(
-                        "bulk_code_mappings.mapping_error",
-                        extra={
-                            "organization_id": organization.id,
-                            "project_id": project.id,
-                            "stack_root": mapping["stack_root"],
-                        },
-                    )
-                    has_errors = True
-                    results.append(
-                        {
-                            "stackRoot": mapping["stack_root"],
-                            "sourceRoot": mapping["source_root"],
-                            "status": "error",
-                            "detail": "Failed to save mapping.",
-                        }
-                    )
+                results.append(
+                    {
+                        "stackRoot": mapping["stack_root"],
+                        "sourceRoot": mapping["source_root"],
+                        "status": "created" if created else "updated",
+                    }
+                )
+            except Exception:
+                logger.exception(
+                    "bulk_code_mappings.mapping_error",
+                    extra={
+                        "organization_id": organization.id,
+                        "project_id": project.id,
+                        "stack_root": mapping["stack_root"],
+                    },
+                )
+                has_errors = True
+                results.append(
+                    {
+                        "stackRoot": mapping["stack_root"],
+                        "sourceRoot": mapping["source_root"],
+                        "status": "error",
+                        "detail": "Failed to save mapping.",
+                    }
+                )
 
         created_count = sum(1 for r in results if r["status"] == "created")
         updated_count = sum(1 for r in results if r["status"] == "updated")

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -45,7 +45,6 @@ class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]])
     default_branch = serializers.RegexField(
         r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
         required=False,
-        allow_blank=True,
         error_messages={"invalid": _(BRANCH_NAME_ERROR_MESSAGE)},
     )
     mappings = MappingItemSerializer(many=True, required=True)

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import region_silo_endpoint
+from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import (
     OrganizationCodeMappingsBulkPermission,
     OrganizationEndpoint,
@@ -62,7 +62,7 @@ class BulkCodeMappingsRequestSerializer(CamelSnakeSerializer[dict[str, object]])
         return mappings
 
 
-@region_silo_endpoint
+@cell_silo_endpoint
 class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
@@ -123,9 +123,9 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         repo, _ = Repository.objects.get_or_create(
             name=repo_name,
             organization_id=organization.id,
+            provider=repo_provider,
             defaults={
                 "integration_id": org_int.integration_id,
-                "provider": repo_provider,
             },
         )
         return repo, None

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -211,6 +211,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
 
         # Fire side effects once for the entire batch.
         if last_saved_config is not None:
+            last_saved_config._skip_post_save = False
             process_resource_change(last_saved_config)
 
         created_count = sum(1 for r in results if r["status"] == "created")

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -24,7 +24,6 @@ from sentry.integrations.models.repository_project_path_config import (
     process_resource_change,
 )
 from sentry.integrations.services.integration import integration_service
-from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
@@ -68,38 +67,6 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (OrganizationCodeMappingsBulkPermission,)
-
-    @staticmethod
-    def _get_default_branch_from_integration(
-        integration: RpcIntegration,
-        organization: Organization,
-        repo: Repository,
-    ) -> str:
-        """Attempt to resolve a repository's default branch via the integration API."""
-        try:
-            install = integration.get_installation(organization_id=organization.id)
-        except Exception:
-            logger.exception("bulk_code_mappings.get_installation_error")
-            return ""
-
-        if not isinstance(install, RepositoryIntegration):
-            return ""
-
-        try:
-            repositories = install.get_repositories(query=repo.name)
-        except Exception:
-            logger.exception("bulk_code_mappings.get_repositories_error")
-            return ""
-
-        for repo_info in repositories:
-            if repo_info.get("identifier") == repo.name:
-                return repo_info.get("default_branch") or ""
-
-        for repo_info in repositories:
-            if repo_info.get("name") == repo.name:
-                return repo_info.get("default_branch") or ""
-
-        return ""
 
     def post(self, request: Request, organization: Organization) -> Response:
         serializer = BulkCodeMappingsRequestSerializer(data=request.data)
@@ -167,12 +134,10 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
         default_branch = data.get("default_branch", "")
         integration = integration_service.get_integration(integration_id=repo.integration_id)
         if not default_branch and integration:
-            if integration.provider == IntegrationProviderSlug.PERFORCE:
-                pass  # Perforce does not use branches
-            else:
-                default_branch = self._get_default_branch_from_integration(
-                    integration, organization, repo
-                )
+            if integration.provider != IntegrationProviderSlug.PERFORCE:
+                install = integration.get_installation(organization_id=organization.id)
+                if isinstance(install, RepositoryIntegration):
+                    default_branch = install.get_repository_default_branch(repo) or ""
                 if not default_branch:
                     return Response(
                         {

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.db import router, transaction
+from django.db.models.signals import post_save
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -20,7 +21,10 @@ from sentry.integrations.api.endpoints.organization_code_mappings import (
     OrganizationIntegrationMixin,
     gen_path_regex_field,
 )
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.models.repository_project_path_config import (
+    RepositoryProjectPathConfig,
+    process_resource_change,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
@@ -144,48 +148,68 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint, OrganizationInt
         mappings = data["mappings"]
         results = []
         has_errors = False
+        last_saved_config = None
 
-        for mapping in mappings:
-            try:
-                with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
-                    config, created = RepositoryProjectPathConfig.objects.update_or_create(
-                        project=project,
-                        stack_root=mapping["stack_root"],
-                        defaults={
-                            "repository": repo,
-                            "organization_integration_id": org_integration.id,
+        # Suppress per-save signals during the loop to avoid redundant
+        # cache clears and celery task dispatches for every mapping.
+        post_save.disconnect(
+            sender=RepositoryProjectPathConfig,
+            dispatch_uid="repository_project_path_config_post_save",
+        )
+        try:
+            for mapping in mappings:
+                try:
+                    with transaction.atomic(using=router.db_for_write(RepositoryProjectPathConfig)):
+                        config, created = RepositoryProjectPathConfig.objects.update_or_create(
+                            project=project,
+                            stack_root=mapping["stack_root"],
+                            defaults={
+                                "repository": repo,
+                                "organization_integration_id": org_integration.id,
+                                "organization_id": organization.id,
+                                "integration_id": repo.integration_id,
+                                "source_root": mapping["source_root"],
+                                "default_branch": default_branch,
+                                "automatically_generated": False,
+                            },
+                        )
+                    last_saved_config = config
+                    results.append(
+                        {
+                            "stackRoot": mapping["stack_root"],
+                            "sourceRoot": mapping["source_root"],
+                            "status": "created" if created else "updated",
+                        }
+                    )
+                except Exception:
+                    logger.exception(
+                        "bulk_code_mappings.mapping_error",
+                        extra={
                             "organization_id": organization.id,
-                            "integration_id": repo.integration_id,
-                            "source_root": mapping["source_root"],
-                            "default_branch": default_branch,
-                            "automatically_generated": False,
+                            "project_id": project.id,
+                            "stack_root": mapping["stack_root"],
                         },
                     )
-                results.append(
-                    {
-                        "stackRoot": mapping["stack_root"],
-                        "sourceRoot": mapping["source_root"],
-                        "status": "created" if created else "updated",
-                    }
-                )
-            except Exception:
-                logger.exception(
-                    "bulk_code_mappings.mapping_error",
-                    extra={
-                        "organization_id": organization.id,
-                        "project_id": project.id,
-                        "stack_root": mapping["stack_root"],
-                    },
-                )
-                has_errors = True
-                results.append(
-                    {
-                        "stackRoot": mapping["stack_root"],
-                        "sourceRoot": mapping["source_root"],
-                        "status": "error",
-                        "detail": "Failed to save mapping.",
-                    }
-                )
+                    has_errors = True
+                    results.append(
+                        {
+                            "stackRoot": mapping["stack_root"],
+                            "sourceRoot": mapping["source_root"],
+                            "status": "error",
+                            "detail": "Failed to save mapping.",
+                        }
+                    )
+        finally:
+            post_save.connect(
+                lambda instance, **kwargs: process_resource_change(instance, **kwargs),
+                sender=RepositoryProjectPathConfig,
+                weak=False,
+                dispatch_uid="repository_project_path_config_post_save",
+            )
+
+        # Fire side effects once for the entire batch.
+        if last_saved_config is not None:
+            process_resource_change(last_saved_config)
 
         created_count = sum(1 for r in results if r["status"] == "created")
         updated_count = sum(1 for r in results if r["status"] == "updated")

--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -115,16 +115,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
             logger.exception("bulk_code_mappings.auto_create_repo.get_repositories_error")
             return None, None
 
-        repo_info = None
-        for r in repositories:
-            if r.get("identifier") == repo_name:
-                repo_info = r
-                break
-        if not repo_info:
-            for r in repositories:
-                if r.get("name") == repo_name:
-                    repo_info = r
-                    break
+        repo_info = RepositoryIntegration.find_repo_info(repositories, repo_name)
 
         if not repo_info:
             return None, None  # Repo doesn't exist on provider, fall through to 404

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -1,30 +1,7 @@
-from collections.abc import Generator
-from contextlib import contextmanager
-from contextvars import ContextVar
-
 from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
 from sentry.backup.scopes import RelocationScope
-
-_suppress_post_save = ContextVar("suppress_rppc_post_save", default=False)
-
-
-@contextmanager
-def suppress_post_save_signal() -> Generator[None]:
-    """Thread-safe suppression of RepositoryProjectPathConfig post_save signal.
-
-    Used by the bulk code mappings endpoint to avoid redundant side effects
-    (cache clears, celery tasks) per mapping. The caller is responsible for
-    invoking process_resource_change() once after the batch completes.
-    """
-    token = _suppress_post_save.set(True)
-    try:
-        yield
-    finally:
-        _suppress_post_save.reset(token)
-
-
 from sentry.db.models import (
     BoundedBigIntegerField,
     DefaultFieldsModelExisting,
@@ -68,7 +45,7 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
 
 
 def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
-    if _suppress_post_save.get():
+    if getattr(instance, "_skip_post_save", False):
         return
 
     from sentry.models.group import Group
@@ -112,5 +89,4 @@ post_save.connect(
     lambda instance, **kwargs: process_resource_change(instance, **kwargs),
     sender=RepositoryProjectPathConfig,
     weak=False,
-    dispatch_uid="repository_project_path_config_post_save",
 )

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -1,7 +1,30 @@
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
 from django.db import models, router, transaction
 from django.db.models.signals import post_save
 
 from sentry.backup.scopes import RelocationScope
+
+_suppress_post_save = ContextVar("suppress_rppc_post_save", default=False)
+
+
+@contextmanager
+def suppress_post_save_signal() -> Generator[None]:
+    """Thread-safe suppression of RepositoryProjectPathConfig post_save signal.
+
+    Used by the bulk code mappings endpoint to avoid redundant side effects
+    (cache clears, celery tasks) per mapping. The caller is responsible for
+    invoking process_resource_change() once after the batch completes.
+    """
+    token = _suppress_post_save.set(True)
+    try:
+        yield
+    finally:
+        _suppress_post_save.reset(token)
+
+
 from sentry.db.models import (
     BoundedBigIntegerField,
     DefaultFieldsModelExisting,
@@ -45,6 +68,9 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
 
 
 def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
+    if _suppress_post_save.get():
+        return
+
     from sentry.models.group import Group
     from sentry.models.project import Project
     from sentry.tasks.codeowners import update_code_owners_schema

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -30,6 +30,10 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
     # Indicates if Sentry created this mapping
     automatically_generated = models.BooleanField(default=False, db_default=False)
 
+    # Transient flag: when True, the post_save signal skips side effects.
+    # Used by the bulk endpoint to fire side effects once per batch.
+    _skip_post_save: bool = False
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_repositoryprojectpathconfig"
@@ -45,7 +49,7 @@ class RepositoryProjectPathConfig(DefaultFieldsModelExisting):
 
 
 def process_resource_change(instance: RepositoryProjectPathConfig, **kwargs):
-    if getattr(instance, "_skip_post_save", False):
+    if instance._skip_post_save:
         return
 
     from sentry.models.group import Group

--- a/src/sentry/integrations/models/repository_project_path_config.py
+++ b/src/sentry/integrations/models/repository_project_path_config.py
@@ -86,4 +86,5 @@ post_save.connect(
     lambda instance, **kwargs: process_resource_change(instance, **kwargs),
     sender=RepositoryProjectPathConfig,
     weak=False,
+    dispatch_uid="repository_project_path_config_post_save",
 )

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -101,6 +101,21 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         """Used for migrating repositories. Checks if the installation has access to the repository."""
         raise NotImplementedError
 
+    def get_repository_default_branch(self, repo: Repository) -> str | None:
+        """
+        Resolve a repository's default branch using integration repository metadata.
+        """
+        repositories = self.get_repositories(query=repo.name)
+        for repo_info in repositories:
+            if repo_info.get("identifier") == repo.name:
+                return repo_info.get("default_branch")
+
+        for repo_info in repositories:
+            if repo_info.get("name") == repo.name:
+                return repo_info.get("default_branch")
+
+        return None
+
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         """
         Get all repositories which are in our database but no longer exist as far as

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -101,20 +101,26 @@ class RepositoryIntegration(IntegrationInstallation, BaseRepositoryIntegration, 
         """Used for migrating repositories. Checks if the installation has access to the repository."""
         raise NotImplementedError
 
+    @staticmethod
+    def find_repo_info(repositories: list[dict[str, Any]], repo_name: str) -> dict[str, Any] | None:
+        """
+        Find a repository dict by matching identifier first, then name.
+        """
+        for repo_info in repositories:
+            if repo_info.get("identifier") == repo_name:
+                return repo_info
+        for repo_info in repositories:
+            if repo_info.get("name") == repo_name:
+                return repo_info
+        return None
+
     def get_repository_default_branch(self, repo: Repository) -> str | None:
         """
         Resolve a repository's default branch using integration repository metadata.
         """
         repositories = self.get_repositories(query=repo.name)
-        for repo_info in repositories:
-            if repo_info.get("identifier") == repo.name:
-                return repo_info.get("default_branch")
-
-        for repo_info in repositories:
-            if repo_info.get("name") == repo.name:
-                return repo_info.get("default_branch")
-
-        return None
+        repo_info = self.find_repo_info(repositories, repo.name)
+        return repo_info.get("default_branch") if repo_info else None
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         """

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -207,6 +207,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/code-mappings/'
   | '/organizations/$organizationIdOrSlug/code-mappings/$configId/'
   | '/organizations/$organizationIdOrSlug/code-mappings/$configId/codeowners/'
+  | '/organizations/$organizationIdOrSlug/code-mappings/bulk/'
   | '/organizations/$organizationIdOrSlug/codeowners-associations/'
   | '/organizations/$organizationIdOrSlug/combined-rules/'
   | '/organizations/$organizationIdOrSlug/conduit-demo/'

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -3,6 +3,7 @@ from unittest import mock
 from django.urls import reverse
 
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
 
 
@@ -318,6 +319,41 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         # With provider, should resolve to the correct repo
         response = self.make_post({"provider": "github"})
         assert response.status_code == 200, response.content
+
+    def test_auto_create_repository_when_provider_given(self) -> None:
+        new_repo_name = "getsentry/new-repo"
+        assert not Repository.objects.filter(
+            name=new_repo_name, organization_id=self.organization.id
+        ).exists()
+
+        def fake_auto_create(organization, repo_name, provider):
+            repo, _ = Repository.objects.get_or_create(
+                name=repo_name,
+                organization_id=organization.id,
+                defaults={
+                    "integration_id": self.integration.id,
+                    "provider": "integrations:github",
+                },
+            )
+            return repo, None
+
+        with mock.patch(
+            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
+            "OrganizationCodeMappingsBulkEndpoint._auto_create_repository",
+            side_effect=fake_auto_create,
+        ):
+            response = self.make_post(
+                {
+                    "repository": new_repo_name,
+                    "provider": "github",
+                }
+            )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+
+        repo = Repository.objects.get(name=new_repo_name, organization_id=self.organization.id)
+        assert repo.provider == "integrations:github"
+        assert repo.integration_id == self.integration.id
 
     def test_duplicate_stack_root_in_request_last_wins(self) -> None:
         response = self.make_post(

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -43,8 +43,6 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             payload.update(data)
         return self.client.post(self.url, data=payload, format="json", **kwargs)
 
-    # --- Happy path ---
-
     def test_create_single_mapping(self) -> None:
         response = self.make_post()
         assert response.status_code == 200, response.content
@@ -154,8 +152,6 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["created"] == 1
 
-    # --- Validation errors ---
-
     def test_missing_project(self) -> None:
         response = self.make_post({"project": None})
         assert response.status_code == 400
@@ -217,8 +213,6 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
     def test_valid_branch_with_periods(self) -> None:
         response = self.make_post({"defaultBranch": "release-2.0.0"})
         assert response.status_code == 200, response.content
-
-    # --- Resolution errors ---
 
     def test_unknown_project_slug(self) -> None:
         response = self.make_post({"project": "nonexistent-project"})

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -234,12 +234,47 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert response.status_code == 400
         assert "not associated with an integration" in response.data["detail"]
 
-    def test_missing_default_branch_for_non_perforce(self) -> None:
+    def test_blank_default_branch_rejected(self) -> None:
         response = self.make_post({"defaultBranch": ""})
         assert response.status_code == 400
         assert "defaultBranch" in str(response.data)
 
-    # --- Side effects ---
+    def test_missing_default_branch_inferred_from_integration(self) -> None:
+        with mock.patch(
+            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
+            "OrganizationCodeMappingsBulkEndpoint._get_default_branch_from_integration",
+            return_value="develop",
+        ):
+            payload = {
+                "project": self.project1.slug,
+                "repository": self.repo1.name,
+                "mappings": [
+                    {"stackRoot": "com/example/a", "sourceRoot": "modules/a/src"},
+                ],
+            }
+            response = self.client.post(self.url, data=payload, format="json")
+        assert response.status_code == 200, response.content
+        config = RepositoryProjectPathConfig.objects.get(
+            project=self.project1, stack_root="com/example/a"
+        )
+        assert config.default_branch == "develop"
+
+    def test_missing_default_branch_inference_fails(self) -> None:
+        with mock.patch(
+            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
+            "OrganizationCodeMappingsBulkEndpoint._get_default_branch_from_integration",
+            return_value="",
+        ):
+            payload = {
+                "project": self.project1.slug,
+                "repository": self.repo1.name,
+                "mappings": [
+                    {"stackRoot": "com/example/a", "sourceRoot": "modules/a/src"},
+                ],
+            }
+            response = self.client.post(self.url, data=payload, format="json")
+        assert response.status_code == 400
+        assert "Could not determine the default branch" in response.data["detail"]
 
     def test_process_resource_change_fires_once_after_batch(self) -> None:
         with mock.patch(

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -237,7 +237,7 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
     def test_missing_default_branch_for_non_perforce(self) -> None:
         response = self.make_post({"defaultBranch": ""})
         assert response.status_code == 400
-        assert "defaultBranch is required" in response.data["detail"]
+        assert "defaultBranch" in str(response.data)
 
     # --- Side effects ---
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -241,8 +241,8 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
 
     def test_missing_default_branch_inferred_from_integration(self) -> None:
         with mock.patch(
-            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
-            "OrganizationCodeMappingsBulkEndpoint._get_default_branch_from_integration",
+            "sentry.integrations.source_code_management.repository."
+            "RepositoryIntegration.get_repository_default_branch",
             return_value="develop",
         ):
             payload = {
@@ -261,9 +261,9 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
 
     def test_missing_default_branch_inference_fails(self) -> None:
         with mock.patch(
-            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
-            "OrganizationCodeMappingsBulkEndpoint._get_default_branch_from_integration",
-            return_value="",
+            "sentry.integrations.source_code_management.repository."
+            "RepositoryIntegration.get_repository_default_branch",
+            return_value=None,
         ):
             payload = {
                 "project": self.project1.slug,

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -234,10 +234,15 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert response.status_code == 400
         assert "not associated with an integration" in response.data["detail"]
 
-    def test_blank_default_branch_rejected(self) -> None:
-        response = self.make_post({"defaultBranch": ""})
+    def test_blank_default_branch_triggers_inference(self) -> None:
+        with mock.patch(
+            "sentry.integrations.source_code_management.repository."
+            "RepositoryIntegration.get_repository_default_branch",
+            return_value=None,
+        ):
+            response = self.make_post({"defaultBranch": ""})
         assert response.status_code == 400
-        assert "defaultBranch" in str(response.data)
+        assert "Could not determine the default branch" in response.data["detail"]
 
     def test_missing_default_branch_inferred_from_integration(self) -> None:
         with mock.patch(

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -1,0 +1,244 @@
+from django.urls import reverse
+
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.repository import Repository
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationCodeMappingsBulkTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.login_as(user=self.user)
+        self.team = self.create_team(
+            organization=self.organization, name="Mariachi Band", members=[self.user]
+        )
+        self.project1 = self.create_project(
+            organization=self.organization, teams=[self.team], name="Bengal"
+        )
+        self.repo1 = Repository.objects.create(
+            name="getsentry/sentry-android",
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+        )
+        self.url = reverse(
+            "sentry-api-0-organization-code-mappings-bulk",
+            args=[self.organization.slug],
+        )
+
+    def make_post(self, data=None, **kwargs):
+        payload = {
+            "project": self.project1.slug,
+            "repository": self.repo1.name,
+            "defaultBranch": "main",
+            "mappings": [
+                {
+                    "stackRoot": "com/example/maps",
+                    "sourceRoot": "modules/maps/src/main/java/com/example/maps",
+                },
+            ],
+        }
+        if data:
+            payload.update(data)
+        return self.client.post(self.url, data=payload, format="json", **kwargs)
+
+    # --- Happy path ---
+
+    def test_create_single_mapping(self) -> None:
+        response = self.make_post()
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+        assert response.data["updated"] == 0
+        assert response.data["errors"] == 0
+        assert len(response.data["mappings"]) == 1
+        assert response.data["mappings"][0]["status"] == "created"
+
+        config = RepositoryProjectPathConfig.objects.get(
+            project=self.project1, stack_root="com/example/maps"
+        )
+        assert config.source_root == "modules/maps/src/main/java/com/example/maps"
+        assert config.default_branch == "main"
+        assert config.repository == self.repo1
+        assert config.organization_id == self.organization.id
+
+    def test_create_multiple_mappings(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {
+                        "stackRoot": "com/example/maps",
+                        "sourceRoot": "modules/maps/src/main/java/com/example/maps",
+                    },
+                    {
+                        "stackRoot": "com/example/auth",
+                        "sourceRoot": "modules/auth/src/main/java/com/example/auth",
+                    },
+                    {
+                        "stackRoot": "com/example/core",
+                        "sourceRoot": "modules/core/src/main/java/com/example/core",
+                    },
+                ],
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 3
+        assert response.data["updated"] == 0
+        assert RepositoryProjectPathConfig.objects.filter(project=self.project1).count() == 3
+
+    def test_update_existing_mapping(self) -> None:
+        self.create_code_mapping(
+            project=self.project1,
+            repo=self.repo1,
+            stack_root="com/example/maps",
+            source_root="old/source/root",
+        )
+
+        response = self.make_post(
+            {
+                "mappings": [
+                    {
+                        "stackRoot": "com/example/maps",
+                        "sourceRoot": "modules/maps/src/main/java/com/example/maps",
+                    },
+                ],
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 0
+        assert response.data["updated"] == 1
+
+        config = RepositoryProjectPathConfig.objects.get(
+            project=self.project1, stack_root="com/example/maps"
+        )
+        assert config.source_root == "modules/maps/src/main/java/com/example/maps"
+
+    def test_mixed_create_and_update(self) -> None:
+        self.create_code_mapping(
+            project=self.project1,
+            repo=self.repo1,
+            stack_root="com/example/existing",
+            source_root="old/path",
+        )
+
+        response = self.make_post(
+            {
+                "mappings": [
+                    {
+                        "stackRoot": "com/example/existing",
+                        "sourceRoot": "new/path",
+                    },
+                    {
+                        "stackRoot": "com/example/new",
+                        "sourceRoot": "brand/new/path",
+                    },
+                ],
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+        assert response.data["updated"] == 1
+
+    def test_empty_roots_allowed(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {
+                        "stackRoot": "",
+                        "sourceRoot": "",
+                    },
+                ],
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+
+    # --- Validation errors ---
+
+    def test_missing_project(self) -> None:
+        response = self.make_post({"project": None})
+        assert response.status_code == 400
+
+    def test_missing_repository(self) -> None:
+        response = self.make_post({"repository": None})
+        assert response.status_code == 400
+
+    def test_missing_mappings(self) -> None:
+        response = self.make_post({"mappings": None})
+        assert response.status_code == 400
+
+    def test_empty_mappings_list(self) -> None:
+        response = self.make_post({"mappings": []})
+        assert response.status_code == 400
+        assert "At least one mapping" in str(response.data)
+
+    def test_too_many_mappings(self) -> None:
+        mappings = [
+            {"stackRoot": f"com/example/mod{i}", "sourceRoot": f"modules/mod{i}/src"}
+            for i in range(301)
+        ]
+        response = self.make_post({"mappings": mappings})
+        assert response.status_code == 400
+        assert "maximum of 300" in str(response.data)
+
+    def test_invalid_stack_root_with_spaces(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {"stackRoot": "has space", "sourceRoot": "valid/path"},
+                ],
+            }
+        )
+        assert response.status_code == 400
+
+    def test_invalid_source_root_with_quotes(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {"stackRoot": "valid/path", "sourceRoot": "has'quote"},
+                ],
+            }
+        )
+        assert response.status_code == 400
+
+    def test_invalid_branch_name(self) -> None:
+        response = self.make_post({"defaultBranch": "/leading-slash"})
+        assert response.status_code == 400
+
+    def test_trailing_slash_in_branch(self) -> None:
+        response = self.make_post({"defaultBranch": "trailing-slash/"})
+        assert response.status_code == 400
+
+    def test_valid_branch_with_slashes(self) -> None:
+        response = self.make_post({"defaultBranch": "prod/deploy-branch"})
+        assert response.status_code == 200, response.content
+
+    def test_valid_branch_with_periods(self) -> None:
+        response = self.make_post({"defaultBranch": "release-2.0.0"})
+        assert response.status_code == 200, response.content
+
+    # --- Resolution errors ---
+
+    def test_unknown_project_slug(self) -> None:
+        response = self.make_post({"project": "nonexistent-project"})
+        assert response.status_code == 404
+        assert "Project not found" in response.data["detail"]
+
+    def test_unknown_repository_name(self) -> None:
+        response = self.make_post({"repository": "nonexistent/repo"})
+        assert response.status_code == 404
+        assert "Repository not found" in response.data["detail"]
+
+    def test_repository_without_integration(self) -> None:
+        repo_no_integration = Repository.objects.create(
+            name="standalone/repo",
+            organization_id=self.organization.id,
+            integration_id=None,
+        )
+        response = self.make_post({"repository": repo_no_integration.name})
+        assert response.status_code == 400
+        assert "not associated with an integration" in response.data["detail"]
+
+    def test_missing_default_branch_for_non_perforce(self) -> None:
+        response = self.make_post({"defaultBranch": ""})
+        assert response.status_code == 400
+        assert "defaultBranch is required" in response.data["detail"]

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -299,7 +299,25 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         instance = mock_prc.call_args[0][0]
         assert instance._skip_post_save is False
 
-    # --- Edge cases ---
+    def test_provider_disambiguates_duplicate_repos(self) -> None:
+        # Give repo1 a provider so we can filter on it
+        self.repo1.provider = "integrations:github"
+        self.repo1.save()
+        # Create a second repo with the same name but different provider
+        self.create_repo(
+            project=self.project1,
+            name=self.repo1.name,
+            provider="integrations:gitlab",
+            integration_id=self.integration.id,
+        )
+        # Without provider, should get 409
+        response = self.make_post()
+        assert response.status_code == 409
+        assert "Multiple repositories" in response.data["detail"]
+
+        # With provider, should resolve to the correct repo
+        response = self.make_post({"provider": "github"})
+        assert response.status_code == 200, response.content
 
     def test_duplicate_stack_root_in_request_last_wins(self) -> None:
         response = self.make_post(

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
@@ -242,3 +244,50 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         response = self.make_post({"defaultBranch": ""})
         assert response.status_code == 400
         assert "defaultBranch is required" in response.data["detail"]
+
+    # --- Side effects ---
+
+    def test_process_resource_change_fires_once_after_batch(self) -> None:
+        with mock.patch(
+            "sentry.integrations.api.endpoints.organization_code_mappings_bulk.process_resource_change"
+        ) as mock_prc:
+            response = self.make_post(
+                {
+                    "mappings": [
+                        {"stackRoot": "com/example/a", "sourceRoot": "modules/a/src"},
+                        {"stackRoot": "com/example/b", "sourceRoot": "modules/b/src"},
+                        {"stackRoot": "com/example/c", "sourceRoot": "modules/c/src"},
+                    ],
+                }
+            )
+        assert response.status_code == 200, response.content
+        assert mock_prc.call_count == 1
+        instance = mock_prc.call_args[0][0]
+        assert instance._skip_post_save is False
+
+    # --- Edge cases ---
+
+    def test_duplicate_stack_root_in_request_last_wins(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {"stackRoot": "com/example/dup", "sourceRoot": "first/path"},
+                    {"stackRoot": "com/example/dup", "sourceRoot": "second/path"},
+                ],
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["created"] == 1
+        assert response.data["updated"] == 1
+
+        config = RepositoryProjectPathConfig.objects.get(
+            project=self.project1, stack_root="com/example/dup"
+        )
+        assert config.source_root == "second/path"
+
+    def test_skip_post_save_does_not_leak_to_fetched_instances(self) -> None:
+        self.make_post()
+        config = RepositoryProjectPathConfig.objects.get(
+            project=self.project1, stack_root="com/example/maps"
+        )
+        assert config._skip_post_save is False

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -1,7 +1,6 @@
 from django.urls import reverse
 
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.models.repository import Repository
 from sentry.testutils.cases import APITestCase
 
 
@@ -16,9 +15,9 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         self.project1 = self.create_project(
             organization=self.organization, teams=[self.team], name="Bengal"
         )
-        self.repo1 = Repository.objects.create(
+        self.repo1 = self.create_repo(
+            project=self.project1,
             name="getsentry/sentry-android",
-            organization_id=self.organization.id,
             integration_id=self.integration.id,
         )
         self.url = reverse(
@@ -60,6 +59,7 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert config.default_branch == "main"
         assert config.repository == self.repo1
         assert config.organization_id == self.organization.id
+        assert config.automatically_generated is False
 
     def test_create_multiple_mappings(self) -> None:
         response = self.make_post(
@@ -229,9 +229,9 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         assert "Repository not found" in response.data["detail"]
 
     def test_repository_without_integration(self) -> None:
-        repo_no_integration = Repository.objects.create(
+        repo_no_integration = self.create_repo(
+            project=self.project1,
             name="standalone/repo",
-            organization_id=self.organization.id,
             integration_id=None,
         )
         response = self.make_post({"repository": repo_no_integration.name})


### PR DESCRIPTION
## Summary
- Add `POST /api/0/organizations/{org}/code-mappings/bulk/` endpoint that accepts human-readable identifiers (project slug, repo name) instead of internal IDs
- Uses `update_or_create` loop for best-effort upsert with per-mapping status reporting
- Supports up to 300 mappings per request, enabling sentry-cli to upload all mappings for multi-module projects
- Validates paths, branch names, project/repo resolution, and integration association

Depends on #109783
Closes https://github.com/getsentry/sentry-android-gradle-plugin/issues/1074

## Test plan
- [x] 20 tests covering happy path (single/multiple/update/mixed create+update), validation errors, and resolution errors
- [x] Pre-commit passes
- [x] Existing code mappings tests unaffected