### PR TITLE
feat(autofix): Pass on_completion_hook to explorer create PR

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -523,10 +523,15 @@ class SeerExplorerClient:
             SeerApiError: If the Seer API request fails
         """
         # Trigger PR creation
+        payload: dict[str, Any] = {"type": "create_pr"}
+        if repo_name:
+            payload["repo_name"] = repo_name
+        if self.on_completion_hook:
+            payload["on_completion_hook"] = extract_hook_definition(self.on_completion_hook).dict()
         update_body = ExplorerUpdateRequest(
             run_id=run_id,
             organization_id=self.organization.id,
-            payload={"type": "create_pr", "repo_name": repo_name},
+            payload=payload,
         )
         response = make_explorer_update_request(update_body)
         if response.status >= 400:


### PR DESCRIPTION
We need to pas the on_completion_hook so upon creating the PR, sentry receives a webhook to post an update to slack.