### PR TITLE
chore: Remove graduated emerge-tools frontend feature flags

### DIFF
--- a/static/app/components/preprod/preprodBuildsDisplay.ts
+++ b/static/app/components/preprod/preprodBuildsDisplay.ts
@@ -4,13 +4,8 @@ export enum PreprodBuildsDisplay {
 }
 
 export function getPreprodBuildsDisplay(
-  display: string | string[] | null | undefined,
-  isDistributionEnabled: boolean
+  display: string | string[] | null | undefined
 ): PreprodBuildsDisplay {
-  if (!isDistributionEnabled) {
-    return PreprodBuildsDisplay.SIZE;
-  }
-
   if (typeof display !== 'string') {
     return PreprodBuildsDisplay.SIZE;
   }

--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -6,7 +6,6 @@ import {MOBILE_BUILDS_ALLOWED_KEYS} from 'sentry/components/preprod/constants';
 import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import {t} from 'sentry/locale';
-import useOrganization from 'sentry/utils/useOrganization';
 
 const displaySelectOptions: Array<SelectOption<PreprodBuildsDisplay>> = [
   {value: PreprodBuildsDisplay.SIZE, label: t('Size')},
@@ -59,11 +58,6 @@ export function PreprodBuildsSearchControls({
   onSearch,
   onDisplayChange,
 }: PreprodBuildsSearchControlsProps) {
-  const organization = useOrganization();
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
-
   return (
     <Flex
       align={{xs: 'stretch', sm: 'center'}}
@@ -80,22 +74,20 @@ export function PreprodBuildsSearchControls({
           projects={projects}
         />
       </Container>
-      {hasDistributionFeature && (
-        <Container maxWidth="200px">
-          <CompactSelect
-            options={displaySelectOptions}
-            value={display}
-            onChange={option => onDisplayChange(option.value)}
-            trigger={triggerProps => (
-              <OverlayTrigger.Button
-                {...triggerProps}
-                prefix={t('Display')}
-                style={{width: '100%', zIndex: 1}}
-              />
-            )}
-          />
-        </Container>
-      )}
+      <Container maxWidth="200px">
+        <CompactSelect
+          options={displaySelectOptions}
+          value={display}
+          onChange={option => onDisplayChange(option.value)}
+          trigger={triggerProps => (
+            <OverlayTrigger.Button
+              {...triggerProps}
+              prefix={t('Display')}
+              style={{width: '100%', zIndex: 1}}
+            />
+          )}
+        />
+      </Container>
     </Flex>
   );
 }

--- a/static/app/components/preprod/preprodBuildsTable.spec.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.spec.tsx
@@ -8,9 +8,7 @@ import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 import {getInstallBuildPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 
-const organization = OrganizationFixture({
-  features: ['preprod-build-distribution'],
-});
+const organization = OrganizationFixture();
 
 const baseBuild = {
   id: 'build-1',

--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -9,7 +9,6 @@ import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import Feature from 'sentry/components/acl/feature';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
@@ -65,34 +64,32 @@ export function PreprodBuildsRowCells({
                   {build.app_info?.name || '--'}
                 </Text>
               </Container>
-              <Feature features="organizations:preprod-build-distribution">
-                {(build.distribution_info?.is_installable ||
-                  showInstallabilityIndicator) && (
-                  <Flex align="center">
-                    {build.distribution_info?.is_installable ? (
-                      <InstallAppButton
-                        projectId={build.project_slug}
-                        artifactId={build.id}
-                        platform={build.app_info.platform ?? null}
-                        source="builds_table"
-                        variant="icon"
-                      />
-                    ) : (
-                      <Tooltip title={t('Not installable')} skipWrapper>
-                        <span>
-                          <Button
-                            aria-label={t('Not installable')}
-                            icon={<IconNot variant="danger" size="xs" />}
-                            priority="transparent"
-                            size="zero"
-                            disabled
-                          />
-                        </span>
-                      </Tooltip>
-                    )}
-                  </Flex>
-                )}
-              </Feature>
+              {(build.distribution_info?.is_installable ||
+                showInstallabilityIndicator) && (
+                <Flex align="center">
+                  {build.distribution_info?.is_installable ? (
+                    <InstallAppButton
+                      projectId={build.project_slug}
+                      artifactId={build.id}
+                      platform={build.app_info.platform ?? null}
+                      source="builds_table"
+                      variant="icon"
+                    />
+                  ) : (
+                    <Tooltip title={t('Not installable')} skipWrapper>
+                      <span>
+                        <Button
+                          aria-label={t('Not installable')}
+                          icon={<IconNot variant="danger" size="xs" />}
+                          priority="transparent"
+                          size="zero"
+                          disabled
+                        />
+                      </span>
+                    </Tooltip>
+                  )}
+                </Flex>
+              )}
             </Flex>
             <Flex align="center" gap="xs">
               <Text size="sm" variant="muted">

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,7 +1,6 @@
 import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
-import useOrganization from 'sentry/utils/useOrganization';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {useTraceItemAttributesWithConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -68,11 +67,9 @@ export function PreprodSearchBar({
   disallowLogicalOperators,
   searchSource = 'preprod',
 }: PreprodSearchBarProps) {
-  const organization = useOrganization();
-
   const traceItemAttributeConfig = {
     traceItemType: TraceItemDataset.PREPROD,
-    enabled: organization.features.includes('preprod-app-size-dashboard'),
+    enabled: true,
   };
 
   // When using allowedKeys, we fetch all attributes then filter to the allowlist.

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -82,13 +82,11 @@ function WidgetBuilderDatasetSelector() {
     details: t('Session data from releases'),
   });
 
-  if (organization.features.includes('preprod-app-size-dashboard')) {
-    datasetOptions.push({
-      value: WidgetType.PREPROD_APP_SIZE,
-      label: t('Mobile Builds'),
-      details: t('Mobile app size metrics'),
-    });
-  }
+  datasetOptions.push({
+    value: WidgetType.PREPROD_APP_SIZE,
+    label: t('Mobile Builds'),
+    details: t('Mobile app size metrics'),
+  });
 
   datasetOptions.push(transactionsOption);
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -92,7 +92,7 @@ function TraceItemAttributeProviderFromDataset({children}: {children: React.Reac
   }
 
   if (state.dataset === WidgetType.PREPROD_APP_SIZE) {
-    enabled = organization.features.includes('preprod-app-size-dashboard');
+    enabled = true;
     traceItemType = TraceItemDataset.PREPROD;
   }
 

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarAppInfo.tsx
@@ -7,7 +7,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import Feature from 'sentry/components/acl/feature';
 import {IconClock, IconFile, IconJson, IconLink, IconMobile} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getFormat, getFormattedDate, getUtcToSystem} from 'sentry/utils/dates';
@@ -103,23 +102,21 @@ export function BuildDetailsSidebarAppInfo(props: BuildDetailsSidebarAppInfoProp
             </Text>
           </Flex>
         </Tooltip>
-        <Feature features="organizations:preprod-build-distribution">
-          <Flex gap="2xs" align="center">
-            <InfoIcon>
-              <IconLink />
-            </InfoIcon>
-            <Text>
-              {props.projectId ? (
-                <InstallAppButton
-                  projectId={props.projectId}
-                  artifactId={props.artifactId}
-                  platform={props.appInfo.platform ?? null}
-                  source="build_details_sidebar"
-                />
-              ) : null}
-            </Text>
-          </Flex>
-        </Feature>
+        <Flex gap="2xs" align="center">
+          <InfoIcon>
+            <IconLink />
+          </InfoIcon>
+          <Text>
+            {props.projectId ? (
+              <InstallAppButton
+                projectId={props.projectId}
+                artifactId={props.artifactId}
+                platform={props.appInfo.platform ?? null}
+                source="build_details_sidebar"
+              />
+            ) : null}
+          </Text>
+        </Flex>
         {props.appInfo.build_configuration && (
           <Tooltip title={labels.buildConfiguration}>
             <Flex gap="2xs" align="center">

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -38,12 +38,9 @@ export default function PreprodBuilds() {
   const projectPlatform = releaseContext.project.platform;
   const params = useParams<{release: string}>();
   const location = useLocation();
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, hasDistributionFeature),
-    [hasDistributionFeature, location.query.display]
+    () => getPreprodBuildsDisplay(location.query.display, true),
+    [location.query.display]
   );
 
   const {query: urlSearchQuery, cursor} = useLocationQuery({

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -39,7 +39,7 @@ export default function PreprodBuilds() {
   const params = useParams<{release: string}>();
   const location = useLocation();
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, true),
+    () => getPreprodBuildsDisplay(location.query.display),
     [location.query.display]
   );
 

--- a/static/app/views/releases/list/index.spec.tsx
+++ b/static/app/views/releases/list/index.spec.tsx
@@ -541,6 +541,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     render(<ReleasesList />, {
       organization,
       initialRouterConfig: {
@@ -564,7 +568,7 @@ describe('ReleasesList', () => {
   it('toggles display mode in the mobile-builds tab', async () => {
     const organizationWithDistribution = OrganizationFixture({
       slug: organization.slug,
-      features: [...organization.features, 'preprod-build-distribution'],
+      features: [...organization.features],
     });
     const mobileProject = ProjectFixture({
       id: '15',
@@ -612,6 +616,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     const {router} = render(<ReleasesList />, {
       organization: organizationWithDistribution,
       initialRouterConfig: {
@@ -681,6 +689,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     render(<ReleasesList />, {
       organization,
       initialRouterConfig: {
@@ -753,6 +765,10 @@ describe('ReleasesList', () => {
       body: [],
     });
 
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
     const {router} = render(<ReleasesList />, {
       organization,
       initialRouterConfig: {

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -37,12 +37,9 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
 
   const [searchQuery] = useQueryState('query', parseAsString);
   const [cursor] = useQueryState('cursor', parseAsString);
-  const hasDistributionFeature = organization.features.includes(
-    'preprod-build-distribution'
-  );
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, hasDistributionFeature),
-    [hasDistributionFeature, location.query.display]
+    () => getPreprodBuildsDisplay(location.query.display, true),
+    [location.query.display]
   );
 
   const buildsQueryParams = useMemo(() => {

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -38,7 +38,7 @@ export default function MobileBuilds({organization, selectedProjectIds}: Props) 
   const [searchQuery] = useQueryState('query', parseAsString);
   const [cursor] = useQueryState('cursor', parseAsString);
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display, true),
+    () => getPreprodBuildsDisplay(location.query.display),
     [location.query.display]
   );
 

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -15,7 +15,6 @@ import type {Permissions} from 'sentry/types/integrations';
 import type {NewInternalAppApiToken} from 'sentry/types/user';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import useOrganization from 'sentry/utils/useOrganization';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -35,16 +34,10 @@ export default function ApiNewToken() {
     Distribution: 'no-access',
   });
   const navigate = useNavigate();
-  const organization = useOrganization({allowNull: true});
   const [hasNewToken, setHasnewToken] = useState(false);
   const [preview, setPreview] = useState<string>('');
 
-  const hasPreprodFeature =
-    organization?.features.includes('organizations:preprod-build-distribution') ?? false;
-
-  const displayedPermissions = SENTRY_APP_PERMISSIONS.filter(
-    o => o.resource !== 'Distribution' || hasPreprodFeature
-  );
+  const displayedPermissions = SENTRY_APP_PERMISSIONS;
 
   const getPreview = () => {
     let previewString = '';

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -54,18 +54,16 @@ export default function PreprodSettings() {
             successMessage={t('Size analysis settings updated')}
             docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
           />
-          <Feature features="organizations:preprod-build-distribution">
-            <FeatureFilter
-              enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
-              enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
-              queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
-              queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
-              title={t('Build Distribution')}
-              successMessage={t('Build distribution settings updated')}
-              docsUrl="https://docs.sentry.io/product/build-distribution/"
-              display={PreprodBuildsDisplay.DISTRIBUTION}
-            />
-          </Feature>
+          <FeatureFilter
+            enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
+            enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
+            queryReadKey={DISTRIBUTION_ENABLED_QUERY_READ_KEY}
+            queryWriteKey={DISTRIBUTION_ENABLED_QUERY_WRITE_KEY}
+            title={t('Build Distribution')}
+            successMessage={t('Build distribution settings updated')}
+            docsUrl="https://docs.sentry.io/product/build-distribution/"
+            display={PreprodBuildsDisplay.DISTRIBUTION}
+          />
         </Stack>
       </Feature>
     </Fragment>


### PR DESCRIPTION
Remove frontend Feature wrappers and checks for graduated flags:
- organizations:preprod-build-distribution
- organizations:preprod-app-size-dashboard

These flags are GA at 100% rollout. Keeps
organizations:preprod-frontend-routes as it is not yet rolled out to all ST tenants.

<!-- Describe your PR here. -->