### PR TITLE
feat(spans): Propagate segment duration to non-segment spans

### DIFF
--- a/src/sentry/spans/consumers/process_segments/enrichment.py
+++ b/src/sentry/spans/consumers/process_segments/enrichment.py
@@ -139,6 +139,15 @@ class TreeEnricher:
                         "value": agent_name,
                     }
 
+            if not span.get("is_segment"):
+                segment_duration_ms = (
+                    self._segment_span["end_timestamp"] - self._segment_span["start_timestamp"]
+                ) * 1_000
+                attributes["sentry.transaction.duration"] = {
+                    "type": "double",
+                    "value": segment_duration_ms,
+                }
+
         attributes["sentry.exclusive_time_ms"] = {
             "type": "double",
             "value": self._exclusive_time(span),

--- a/tests/sentry/spans/consumers/process_segments/test_enrichment.py
+++ b/tests/sentry/spans/consumers/process_segments/test_enrichment.py
@@ -477,6 +477,53 @@ def _mock_performance_issue_span(is_segment, attributes, **fields) -> SpanEvent:
     )
 
 
+def test_transaction_duration_propagated_to_non_segment_spans() -> None:
+    """Test that sentry.transaction.duration is set on non-segment spans."""
+    segment_span = build_mock_span(
+        project_id=1,
+        is_segment=True,
+        start_timestamp=1609455600.0,
+        end_timestamp=1609455605.0,
+        span_id="aaaaaaaaaaaaaaaa",
+    )
+
+    child_span = build_mock_span(
+        project_id=1,
+        span_id="bbbbbbbbbbbbbbbb",
+        parent_span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+    )
+
+    grandchild_span = build_mock_span(
+        project_id=1,
+        span_id="cccccccccccccccc",
+        parent_span_id="bbbbbbbbbbbbbbbb",
+        start_timestamp=1609455601.2,
+        end_timestamp=1609455601.8,
+    )
+
+    spans = [segment_span, child_span, grandchild_span]
+    _, enriched_spans = TreeEnricher.enrich_spans(spans)
+
+    assert attribute_value(enriched_spans[0], "sentry.transaction.duration") is None
+    assert attribute_value(enriched_spans[1], "sentry.transaction.duration") == 5000.0
+    assert attribute_value(enriched_spans[2], "sentry.transaction.duration") == 5000.0
+
+
+def test_transaction_duration_not_set_without_segment() -> None:
+    """Test that sentry.transaction.duration is not set when there is no segment span."""
+    span = build_mock_span(
+        project_id=1,
+        span_id="aaaaaaaaaaaaaaaa",
+        start_timestamp=1609455601.0,
+        end_timestamp=1609455602.0,
+    )
+
+    _, enriched_spans = TreeEnricher.enrich_spans([span])
+    assert attribute_value(enriched_spans[0], "sentry.transaction.duration") is None
+
+
 def test_enrich_gen_ai_agent_name_from_immediate_parent() -> None:
     """Test that gen_ai.agent.name is inherited from the immediate parent with gen_ai.invoke_agent operation."""
     parent_span = build_mock_span(


### PR DESCRIPTION
Adds a `sentry.transaction.duration` attribute to all non-segment spans during segment enrichment. The value is the segment (transaction) span's duration in milliseconds.

This enables querying and filtering span data by the duration of their parent transaction without needing to join back to the segment span.

The attribute is only set when a segment span exists in the span list, and is intentionally omitted from the segment span itself since it already carries its own duration.

The product use case here is for the insights cache module, where we want to see the cost of a cache hit or cache miss, we landed on transaction duration being a decent indicator of the cost, if a hit results in a much lower duration then you could consider caching to be working as intended.