### PR TITLE
feat(dashboards): Add moving notice banner to insight pages

### DIFF
--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -1,4 +1,9 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Container} from '@sentry/scraps/layout';
+
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
+import {tct} from 'sentry/locale';
+import useOrganization from 'sentry/utils/useOrganization';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import {
   DashboardState,
@@ -21,6 +26,7 @@ export function PrebuiltDashboardRenderer({
   additionalGlobalFilters,
   storageNamespace,
 }: PrebuiltDashboardRendererProps) {
+  const organization = useOrganization();
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
     useGetPrebuiltDashboard(prebuiltId);
@@ -66,8 +72,26 @@ export function PrebuiltDashboardRenderer({
     projects: undefined,
   };
 
+  const dashboardId = populatedPrebuiltDashboard?.id;
+
   return (
     <LoadingContainer isLoading={isLoading} showChildrenWhileLoading={false}>
+      {dashboardId && (
+        <Container padding="xl 3xl 0">
+          <Alert variant="info" showIcon>
+            {tct(
+              'Insights pages are moving to Dashboards. Same functionality you love with more customization (and a less cheesy name). [link:View this page on Dashboards]',
+              {
+                link: (
+                  <a
+                    href={`/organizations/${organization.slug}/dashboards/${dashboardId}/`}
+                  />
+                ),
+              }
+            )}
+          </Alert>
+        </Container>
+      )}
       <DashboardDetail
         dashboard={dashboard}
         dashboards={[]}

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -1,5 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
 import {Container} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 
 import LoadingContainer from 'sentry/components/loading/loadingContainer';
 import {tct} from 'sentry/locale';
@@ -83,8 +84,8 @@ export function PrebuiltDashboardRenderer({
               'Insights pages are moving to Dashboards. Same functionality you love with more customization (and a less cheesy name). [link:View this page on Dashboards]',
               {
                 link: (
-                  <a
-                    href={`/organizations/${organization.slug}/dashboards/${dashboardId}/`}
+                  <Link
+                    to={`/organizations/${organization.slug}/dashboards/${dashboardId}/`}
                   />
                 ),
               }


### PR DESCRIPTION
Add an info banner to prebuilt dashboard (Insights) pages notifying users that Insights pages are moving to Dashboards. The banner includes a direct link to the equivalent dashboard page.

The banner only renders when the prebuilt dashboard has a resolved `dashboardId`, ensuring it doesn't show during loading or for dashboards that haven't been populated yet.

<img width="1434" height="234" alt="image" src="https://github.com/user-attachments/assets/6f1f68de-5f56-4c17-84e7-5d476f2fd5d9" />
