### PR TITLE
codemod(space): apply changes for @getsentry/design-engineering

### DIFF
--- a/static/app/components/pageFilters/environment/environmentPageFilterTrigger.tsx
+++ b/static/app/components/pageFilters/environment/environmentPageFilterTrigger.tsx
@@ -4,7 +4,6 @@ import {Badge} from '@sentry/scraps/badge';
 import {OverlayTrigger, type TriggerProps} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import {trimSlug} from 'sentry/utils/string/trimSlug';
 
 export interface EnvironmentPageFilterTriggerProps extends Omit<TriggerProps, 'value'> {
@@ -64,8 +63,8 @@ const TriggerLabel = styled('span')`
 `;
 
 const StyledBadge = styled(Badge)`
-  margin-top: -${space(0.5)};
-  margin-bottom: -${space(0.5)};
+  margin-top: -${p => p.theme.space.xs};
+  margin-bottom: -${p => p.theme.space.xs};
   flex-shrink: 0;
   top: auto;
 `;

--- a/static/app/components/pageFilters/project/projectPageFilterTrigger.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilterTrigger.tsx
@@ -5,7 +5,6 @@ import {OverlayTrigger, type TriggerProps} from '@sentry/scraps/overlayTrigger';
 
 import {PlatformList} from 'sentry/components/platformList';
 import {t} from 'sentry/locale';
-import {space} from 'sentry/styles/space';
 import type {Project} from 'sentry/types/project';
 import {trimSlug} from 'sentry/utils/string/trimSlug';
 
@@ -105,8 +104,8 @@ const TriggerLabel = styled('span')`
 `;
 
 const StyledBadge = styled(Badge)`
-  margin-top: -${space(0.5)};
-  margin-bottom: -${space(0.5)};
+  margin-top: -${p => p.theme.space.xs};
+  margin-bottom: -${p => p.theme.space.xs};
   flex-shrink: 0;
   top: auto;
 `;


### PR DESCRIPTION
Applies the [`space` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/space) to files owned by @getsentry/design-engineering.