### PR TITLE
feat(sourcemap-issues): Add sourcemap issue detection to post_process_group pipeline

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -302,6 +302,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enables recording processing errors to analytics for product validation
     manager.add("organizations:processing-error-analytics", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=True)
     manager.add("organizations:processing-errors-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enabled for those orgs who participated in the profiling Beta program

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import logging
+
+from django.utils import timezone
+
+from sentry import features, ratelimits
+from sentry.processing_errors.grouptype import (
+    SourcemapConfigurationType,
+    SourcemapPacketValue,
+    has_js_sourcemap_errors,
+)
+from sentry.processing_errors.provisioning import ensure_sourcemap_detector
+from sentry.tasks.post_process import PostProcessJob
+from sentry.utils import metrics
+from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
+from sentry.workflow_engine.models import DataPacket, DetectorState
+from sentry.workflow_engine.processors.detector import process_detectors
+
+logger = logging.getLogger(__name__)
+
+# How often (seconds) to refresh date_updated when the detector is already triggered.
+# Must be much less than the staleness threshold used for resolution (PR 5).
+REFRESH_INTERVAL_SECONDS = 5 * 60  # 5 minutes
+
+# TTL for the Redis triggered cache. If Redis loses the key, we'll just
+# fall through to the full evaluation path, which is safe.
+TRIGGERED_CACHE_TTL_SECONDS = 60 * 60  # 1 hour
+
+
+def _redis_key_triggered(project_id: int) -> str:
+    return f"sourcemap_detector:triggered:{project_id}"
+
+
+def _is_detector_triggered(project_id: int) -> bool:
+    if get_redis_client().get(_redis_key_triggered(project_id)):
+        return True
+
+    # Cache miss — check the DB and backfill the cache if triggered
+    is_triggered = DetectorState.objects.filter(
+        detector__project_id=project_id,
+        detector__type=SourcemapConfigurationType.slug,
+        is_triggered=True,
+    ).exists()
+
+    if is_triggered:
+        _set_detector_triggered(project_id)
+
+    return is_triggered
+
+
+def _set_detector_triggered(project_id: int) -> None:
+    get_redis_client().set(_redis_key_triggered(project_id), "1", ex=TRIGGERED_CACHE_TTL_SECONDS)
+    # Consume the first rate limit slot so the next refresh is throttled
+    ratelimits.backend.is_limited(
+        f"sourcemap_detector:refresh:{project_id}",
+        limit=1,
+        window=REFRESH_INTERVAL_SECONDS,
+    )
+
+
+def _maybe_refresh_date_updated(project_id: int) -> None:
+    """
+    When the detector is already triggered, periodically refresh
+    DetectorState.date_updated so the resolution task knows the issue
+    is still occurring. Rate-limited to at most once per
+    REFRESH_INTERVAL_SECONDS per project.
+    """
+    if ratelimits.backend.is_limited(
+        f"sourcemap_detector:refresh:{project_id}",
+        limit=1,
+        window=REFRESH_INTERVAL_SECONDS,
+    ):
+        return
+
+    slug = SourcemapConfigurationType.slug
+    rows = DetectorState.objects.filter(
+        detector__project_id=project_id,
+        detector__type=slug,
+        is_triggered=True,
+    ).update(date_updated=timezone.now())
+
+    if rows:
+        metrics.incr("processing_errors.sourcemap_detector.date_updated_refreshed")
+
+
+def detect_sourcemap_issues(job: PostProcessJob) -> None:
+    """
+    Post-process pipeline step that detects sourcemap configuration issues
+    from processing errors on ERROR events.
+    """
+    if job["is_reprocessed"]:
+        return
+
+    event = job["event"]
+
+    if not features.has("organizations:sourcemap-issue-detection", event.project.organization):
+        return
+
+    errors = event.data.get("errors", [])
+    if not has_js_sourcemap_errors(errors):
+        return
+
+    metrics.incr("processing_errors.sourcemap_detector.event_with_js_errors")
+
+    if _is_detector_triggered(event.project.id):
+        _maybe_refresh_date_updated(event.project.id)
+        return
+
+    detector = ensure_sourcemap_detector(event.project)
+
+    packet = DataPacket(
+        source_id=str(event.project.id),
+        packet=SourcemapPacketValue(
+            event_id=event.event_id,
+            event_data=event.data,
+        ),
+    )
+
+    results = process_detectors(packet, [detector])
+
+    for _detector, detector_results in results:
+        for _group_key, result in detector_results.items():
+            if result.is_triggered:
+                _set_detector_triggered(event.project.id)
+                metrics.incr("processing_errors.sourcemap_detector.triggered")

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, override
 
@@ -47,6 +47,11 @@ JS_SOURCEMAP_ERROR_TYPES = frozenset(
 )
 
 
+def has_js_sourcemap_errors(errors: Sequence[Mapping[str, Any]]) -> bool:
+    """Check whether any of the given processing errors are JS sourcemap errors."""
+    return any(e.get("type") in JS_SOURCEMAP_ERROR_TYPES for e in errors)
+
+
 class SourcemapCheckStatus(enum.IntEnum):
     """
     Status values used as the comparison value for detector conditions.
@@ -81,8 +86,11 @@ class SourcemapDetectorHandler(StatefulDetectorHandler[SourcemapPacketValue, Sou
     @override
     def extract_value(self, data_packet: DataPacket[SourcemapPacketValue]) -> SourcemapCheckStatus:
         errors = data_packet.packet.event_data.get("errors", [])
-        has_js_errors = any(e.get("type") in JS_SOURCEMAP_ERROR_TYPES for e in errors)
-        return SourcemapCheckStatus.FAILURE if has_js_errors else SourcemapCheckStatus.SUCCESS
+        return (
+            SourcemapCheckStatus.FAILURE
+            if has_js_sourcemap_errors(errors)
+            else SourcemapCheckStatus.SUCCESS
+        )
 
     @override
     def extract_dedupe_value(self, data_packet: DataPacket[SourcemapPacketValue]) -> int:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1305,6 +1305,12 @@ def process_processing_errors_eap(job: PostProcessJob):
     produce_processing_errors_to_eap(event.project, event.data, processing_errors)
 
 
+def process_sourcemap_issue_detection(job: PostProcessJob):
+    from sentry.processing_errors.detection import detect_sourcemap_issues
+
+    detect_sourcemap_issues(job)
+
+
 def sdk_crash_monitoring(job: PostProcessJob):
     from sentry.utils.sdk_crashes.sdk_crash_detection import sdk_crash_detection
 
@@ -1676,6 +1682,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         detect_base_urls_for_uptime,
         check_if_flags_sent,
         process_processing_errors_eap,
+        process_sourcemap_issue_detection,
     ],
     GroupCategory.FEEDBACK: [
         feedback_filter_decorator(process_snoozes),

--- a/tests/sentry/processing_errors/test_detection.py
+++ b/tests/sentry/processing_errors/test_detection.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from sentry.processing_errors.detection import (
+    _redis_key_triggered,
+    detect_sourcemap_issues,
+)
+from sentry.processing_errors.grouptype import SourcemapConfigurationType
+from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.handlers.detector.stateful import get_redis_client
+from sentry.workflow_engine.models import DetectorState
+
+
+class _FakeEvent:
+    """Minimal event-like object for testing the detection function."""
+
+    def __init__(self, project, errors=None, platform="javascript"):
+        self.project = project
+        self.event_id = "fake-event-id"
+        self.data: dict[str, Any] = {
+            "platform": platform,
+            "sdk": {"name": "sentry.javascript.browser", "version": "7.0.0"},
+        }
+        if errors is not None:
+            self.data["errors"] = errors
+
+
+def _make_job(event, is_reprocessed=False):
+    return {
+        "event": event,
+        "is_reprocessed": is_reprocessed,
+    }
+
+
+class TestDetectSourcemapIssues(TestCase):
+    def setUp(self):
+        super().setUp()
+        get_redis_client().delete(_redis_key_triggered(self.project.id))
+
+    def test_js_errors_trigger_detector(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        )
+        assert state.is_triggered is True
+        assert get_redis_client().get(_redis_key_triggered(self.project.id)) is not None
+
+    def test_no_errors_does_not_trigger(self) -> None:
+        event = _FakeEvent(self.project, errors=[])
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        assert not DetectorState.objects.filter(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_non_js_errors_does_not_trigger(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "native_missing_dsym", "image": "libfoo.so"}],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        assert not DetectorState.objects.filter(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_feature_flag_off_does_not_trigger(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        detect_sourcemap_issues(_make_job(event))
+
+        assert not DetectorState.objects.filter(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_reprocessed_event_skipped(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event, is_reprocessed=True))
+
+        assert not DetectorState.objects.filter(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        ).exists()
+
+    def test_already_triggered_skips_evaluation(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        # First call triggers
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        # Second call should skip evaluation (Redis cache hit)
+        with (
+            self.feature("organizations:sourcemap-issue-detection"),
+            patch("sentry.processing_errors.detection.process_detectors") as mock_process,
+        ):
+            detect_sourcemap_issues(_make_job(event))
+            mock_process.assert_not_called()
+
+    def test_throttled_refresh_updates_date_when_stale(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        )
+        original_date_updated = state.date_updated
+
+        # Allow the rate limiter to pass again by mocking it as not limited
+        with (
+            self.feature("organizations:sourcemap-issue-detection"),
+            patch(
+                "sentry.processing_errors.detection.ratelimits.backend.is_limited",
+                return_value=False,
+            ),
+        ):
+            detect_sourcemap_issues(_make_job(event))
+
+        state.refresh_from_db()
+        assert state.date_updated > original_date_updated
+
+    def test_throttled_refresh_skips_when_recent(self) -> None:
+        event = _FakeEvent(
+            self.project,
+            errors=[{"type": "js_no_source", "url": "https://example.com/app.js"}],
+        )
+
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        state = DetectorState.objects.get(
+            detector__type=SourcemapConfigurationType.slug,
+            detector__project=self.project,
+        )
+        original_date_updated = state.date_updated
+
+        # Second call — rate limiter should block the refresh
+        with self.feature("organizations:sourcemap-issue-detection"):
+            detect_sourcemap_issues(_make_job(event))
+
+        state.refresh_from_db()
+        assert state.date_updated == original_date_updated


### PR DESCRIPTION
Wires the sourcemap configuration detector into post_process group for error events. Checks for JS sourcemap processing errors, provisions an issue via process_detectors.

<!-- Describe your PR here. -->