### PR TITLE
fix(dashboards): Clamp invalid widget layouts to prevent browser crash

### DIFF
--- a/static/app/views/dashboards/clampWidgetLayout.tsx
+++ b/static/app/views/dashboards/clampWidgetLayout.tsx
@@ -1,0 +1,16 @@
+import {NUM_DESKTOP_COLS} from 'sentry/views/dashboards/constants';
+
+import type {WidgetLayout} from './types';
+
+/**
+ * Clamps a widget layout so that dimensions stay within the dashboard grid bounds.
+ * Widgets with w > NUM_DESKTOP_COLS or x + w > NUM_DESKTOP_COLS can cause an infinite
+ * re-render loop in react-grid-layout when edit mode is enabled (DAIN-1225).
+ */
+export function clampWidgetLayout(layout: WidgetLayout): WidgetLayout {
+  const w = Math.max(1, Math.min(layout.w, NUM_DESKTOP_COLS));
+  const x = Math.max(0, Math.min(layout.x, NUM_DESKTOP_COLS - 1));
+  const clampedW = Math.min(w, NUM_DESKTOP_COLS - x);
+
+  return {...layout, w: clampedW, x};
+}

--- a/static/app/views/dashboards/layoutUtils.spec.tsx
+++ b/static/app/views/dashboards/layoutUtils.spec.tsx
@@ -1,9 +1,16 @@
 import type {Layout} from 'react-grid-layout';
+import * as Sentry from '@sentry/react';
 
+import {clampWidgetLayout} from 'sentry/views/dashboards/clampWidgetLayout';
 import {
+  assignDefaultLayout,
   calculateColumnDepths,
+  getDashboardLayout,
   getNextAvailablePosition,
 } from 'sentry/views/dashboards/layoutUtils';
+import {DisplayType} from 'sentry/views/dashboards/types';
+
+jest.mock('@sentry/react');
 
 describe('Dashboards > Utils', () => {
   describe('calculateColumnDepths', () => {
@@ -113,6 +120,107 @@ describe('Dashboards > Utils', () => {
       getNextAvailablePosition(columnDepths, 4);
 
       expect(columnDepths).toEqual([1, 1, 1, 1, 1, 1]);
+    });
+  });
+
+  describe('clampWidgetLayout', () => {
+    it('returns valid layouts unchanged', () => {
+      const layout = {x: 0, y: 0, w: 2, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual(layout);
+    });
+
+    it('clamps width exceeding grid columns', () => {
+      const layout = {x: 0, y: 0, w: 12, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual({x: 0, y: 0, w: 6, h: 2, minH: 2});
+    });
+
+    it('clamps x + w exceeding grid columns', () => {
+      const layout = {x: 4, y: 0, w: 4, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual({x: 4, y: 0, w: 2, h: 2, minH: 2});
+    });
+
+    it('clamps negative x to 0', () => {
+      const layout = {x: -1, y: 0, w: 2, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual({x: 0, y: 0, w: 2, h: 2, minH: 2});
+    });
+
+    it('clamps width of 0 to 1', () => {
+      const layout = {x: 0, y: 0, w: 0, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual({x: 0, y: 0, w: 1, h: 2, minH: 2});
+    });
+
+    it('clamps x beyond last column', () => {
+      const layout = {x: 10, y: 0, w: 2, h: 2, minH: 2};
+      expect(clampWidgetLayout(layout)).toEqual({x: 5, y: 0, w: 1, h: 2, minH: 2});
+    });
+  });
+
+  describe('getDashboardLayout', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('clamps oversized widget layouts', () => {
+      const widgets = [
+        {
+          displayType: DisplayType.LINE,
+          interval: '5m',
+          title: 'Test',
+          queries: [],
+          id: '1',
+          layout: {x: 0, y: 0, w: 12, h: 2, minH: 2},
+        },
+      ];
+      const layouts = getDashboardLayout(widgets);
+      expect(layouts[0]).toEqual(
+        expect.objectContaining({x: 0, y: 0, w: 6, h: 2, minH: 2})
+      );
+    });
+
+    it('logs to Sentry when layout is clamped', () => {
+      const widgets = [
+        {
+          displayType: DisplayType.LINE,
+          interval: '5m',
+          title: 'Test',
+          queries: [],
+          id: '1',
+          layout: {x: 0, y: 0, w: 12, h: 2, minH: 2},
+        },
+      ];
+      getDashboardLayout(widgets);
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        'Invalid widget layout dimensions detected',
+        expect.objectContaining({extra: expect.any(Object)})
+      );
+    });
+
+    it('does not log to Sentry for valid layouts', () => {
+      const widgets = [
+        {
+          displayType: DisplayType.LINE,
+          interval: '5m',
+          title: 'Test',
+          queries: [],
+          id: '1',
+          layout: {x: 0, y: 0, w: 2, h: 2, minH: 2},
+        },
+      ];
+      getDashboardLayout(widgets);
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('assignDefaultLayout', () => {
+    it('clamps existing oversized layouts', () => {
+      const widgets = [
+        {
+          displayType: DisplayType.LINE,
+          layout: {x: 0, y: 0, w: 12, h: 2, minH: 2},
+        },
+      ];
+      const result = assignDefaultLayout(widgets, [0, 0, 0, 0, 0, 0]);
+      expect(result[0]!.layout).toEqual({x: 0, y: 0, w: 6, h: 2, minH: 2});
     });
   });
 });

--- a/static/app/views/dashboards/layoutUtils.tsx
+++ b/static/app/views/dashboards/layoutUtils.tsx
@@ -1,6 +1,7 @@
 import type {Layout} from 'react-grid-layout';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import {compact} from 'react-grid-layout/build/utils';
+import * as Sentry from '@sentry/react';
 import pickBy from 'lodash/pickBy';
 import sortBy from 'lodash/sortBy';
 import zip from 'lodash/zip';
@@ -9,6 +10,7 @@ import {defined} from 'sentry/utils';
 import {uniqueId} from 'sentry/utils/guid';
 import {NUM_DESKTOP_COLS} from 'sentry/views/dashboards/constants';
 
+import {clampWidgetLayout} from './clampWidgetLayout';
 import type {Widget, WidgetLayout} from './types';
 import {DisplayType} from './types';
 
@@ -65,10 +67,18 @@ export function getDashboardLayout(widgets: Widget[]): Layout[] {
   type WidgetWithDefinedLayout = Omit<Widget, 'layout'> & {layout: WidgetLayout};
   return widgets
     .filter((widget): widget is WidgetWithDefinedLayout => defined(widget.layout))
-    .map(({layout, ...widget}) => ({
-      ...layout,
-      i: constructGridItemKey(widget),
-    }));
+    .map(({layout, ...widget}) => {
+      const clamped = clampWidgetLayout(layout);
+      if (clamped.w !== layout.w || clamped.x !== layout.x) {
+        Sentry.captureMessage('Invalid widget layout dimensions detected', {
+          extra: {
+            original: {x: layout.x, y: layout.y, w: layout.w, h: layout.h},
+            clamped: {x: clamped.x, w: clamped.w},
+          },
+        });
+      }
+      return {...clamped, i: constructGridItemKey(widget)};
+    });
 }
 
 export function pickDefinedStoreKeys(layout: Layout): WidgetLayout {
@@ -161,7 +171,7 @@ export function assignDefaultLayout<T extends Pick<Widget, 'displayType' | 'layo
   let columnDepths = [...initialColumnDepths];
   const newWidgets = widgets.map(widget => {
     if (defined(widget.layout)) {
-      return widget;
+      return {...widget, layout: clampWidgetLayout(widget.layout)};
     }
     const height = getDefaultWidgetHeight(widget.displayType);
     const [nextPosition, nextColumnDepths] = getNextAvailablePosition(


### PR DESCRIPTION
Add frontend clamping for widget layout dimensions that exceed the 6-column grid bounds.

Widgets created via external tools (e.g. LLMs) can have dimensions like `w: 12` where the maximum is `6`. This causes an infinite re-render loop in react-grid-layout when entering edit mode, crashing the browser. The new `clampWidgetLayout()` function normalizes dimensions before they reach the grid library, and logs invalid layouts to Sentry for observability.

Backend validation counterpart: https://github.com/getsentry/sentry/pull/109826

Refs DAIN-1265