### PR TITLE
fix(issue-timeseries): Allow higher granularities

### DIFF
--- a/src/sentry/issues/endpoints/organization_issue_timeseries.py
+++ b/src/sentry/issues/endpoints/organization_issue_timeseries.py
@@ -57,16 +57,14 @@ class OrganizationIssueTimeSeriesEndpoint(OrganizationEndpoint):
         )
 
         # This step validates our maximum granularity. Without this we could see unbounded
-        # cardinality in our queries. Our maximum granularity is 200 which is more than enough to
-        # accommodate common aggregation intervals.
-        #
-        # Max granularity estimates for a given range (rounded to understandable intervals):
-        #   - One week range -> one hour interval.
-        #   - One day range -> ten minute interval.
-        #   - One hour range -> twenty second interval.
+        # cardinality in our queries. Our maximum granularity is 10_000 to match our other endpoints
         interval = timedelta(
             seconds=get_rollup_from_request(
-                request, end - start, "1h", ParseError("Invalid Interval"), max_rollup_override=200
+                request,
+                end - start,
+                "1h",
+                ParseError("Invalid Interval"),
+                max_rollup_override=10_000,
             )
         )
 
@@ -115,7 +113,11 @@ class OrganizationIssueTimeSeriesEndpoint(OrganizationEndpoint):
                 groupby_key_to_dict[key] = groupby_dict
                 grouped_counter[key] += row["value"]
                 grouped_series[key].append(
-                    Row(timestamp=row["timestamp"] * 1000, value=row["value"], incomplete=False)
+                    Row(
+                        timestamp=row["timestamp"] * 1000,
+                        value=row["value"],
+                        incomplete=False,
+                    )
                 )
 
             # Group the smallest series into the "other" bucket.
@@ -205,7 +207,7 @@ def make_timeseries_query(
     environments: list[int],
     type_filter: Q,
     group_by: list[str],
-    stride: timedelta,
+    interval: timedelta,
     source: str,
     start: datetime,
     end: datetime,
@@ -227,7 +229,7 @@ def make_timeseries_query(
 
     annotations["timestamp"] = Extract(
         Func(
-            stride,
+            interval,
             source,
             start,
             function="date_bin",

--- a/tests/sentry/issues/endpoints/test_organization_issue_timeseries.py
+++ b/tests/sentry/issues/endpoints/test_organization_issue_timeseries.py
@@ -88,7 +88,10 @@ class OrganizationIssueMetricsTestCase(APITestCase):
         )
         self.create_group(project=self.project2, status=2, first_seen=self.start, type=4)
         self.create_group(
-            project=self.project2, status=2, first_seen=self.start, type=FeedbackGroup.type_id
+            project=self.project2,
+            status=2,
+            first_seen=self.start,
+            type=FeedbackGroup.type_id,
         )
 
     def do_request(self, data: dict[str, Any], url: str | None = None) -> Any:
@@ -112,7 +115,7 @@ class OrganizationIssueMetricsTestCase(APITestCase):
         response = self.do_request(
             {
                 "statsPeriod": "14d",
-                "interval": "1001",
+                "interval": "2",
                 "category": "issue",
                 "yAxis": "count(new_issues)",
                 "groupBy": ["release"],
@@ -387,7 +390,11 @@ class OrganizationIssueMetricsTestCase(APITestCase):
         # Release issues.
         for release in self.releases:
             self.create_group(
-                project=self.project1, status=0, first_seen=self.end, first_release=release, type=1
+                project=self.project1,
+                status=0,
+                first_seen=self.end,
+                first_release=release,
+                type=1,
             )
 
         response = self.do_request(


### PR DESCRIPTION
- Will need to keep an eye on this, but from some experimenting this didn't significantly change the query speed since we still select the same amount of data, just change the grouping
- Going with 10k to match our other endpoints for now
- Closes DAIN-1231