### PR TITLE
chore: Remove graduated emerge-tools backend feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -231,20 +231,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:performance-web-vitals-seer-suggestions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the warning banner to inform users of pending deprecation of the transactions dataset
     manager.add("organizations:performance-transaction-deprecation-banner", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod build distribution
-    manager.add("organizations:preprod-build-distribution", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod frontend routes
     manager.add("organizations:preprod-frontend-routes", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod issue reporting
     manager.add("organizations:preprod-issues", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable writing preprod size metrics to EAP for querying
-    manager.add("organizations:preprod-size-metrics-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable writing preprod build distribution data to EAP for querying
-    manager.add("organizations:preprod-build-distribution-eap-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod PR comments for build distribution
     manager.add("organizations:preprod-build-distribution-pr-comments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable preprod app size dashboard widget
-    manager.add("organizations:preprod-app-size-dashboard", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable enforcement of preprod size quota checks (when disabled, size quota checks always return True)
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)

--- a/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
+++ b/src/sentry/preprod/api/endpoints/project_installable_preprod_artifact_download.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -119,13 +118,12 @@ class ProjectInstallablePreprodArtifactDownloadEndpoint(ProjectEndpoint):
             # Update build distribution data in EAP with new download count
             try:
                 organization = project.organization
-                if features.has("organizations:preprod-build-distribution-eap-write", organization):
-                    produce_preprod_build_distribution_to_eap(
-                        artifact=preprod_artifact,
-                        organization=organization,
-                        organization_id=project.organization_id,
-                        project_id=project.id,
-                    )
+                produce_preprod_build_distribution_to_eap(
+                    artifact=preprod_artifact,
+                    organization=organization,
+                    organization_id=project.organization_id,
+                    project_id=project.id,
+                )
             except Exception:
                 logger.exception(
                     "Failed to write preprod build distribution to EAP after download",

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -10,7 +10,6 @@ import sentry_sdk
 from django.db import router, transaction
 from django.utils import timezone
 
-from sentry import features
 from sentry.constants import DataCategory
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
@@ -514,23 +513,22 @@ def _assemble_preprod_artifact_size_analysis(
 
         try:
             organization = preprod_artifact.project.organization
-            if features.has("organizations:preprod-size-metrics-eap-write", organization):
-                for size_metric in size_metrics_updated:
-                    produce_preprod_size_metric_to_eap(
-                        size_metric=size_metric,
-                        organization=organization,
-                        organization_id=org_id,
-                        project_id=project.id,
-                    )
-                logger.info(
-                    "Successfully wrote preprod size metrics to EAP",
-                    extra={
-                        "preprod_artifact_id": preprod_artifact.id,
-                        "size_metrics_ids": [m.id for m in size_metrics_updated],
-                        "organization_id": org_id,
-                        "project_id": project.id,
-                    },
+            for size_metric in size_metrics_updated:
+                produce_preprod_size_metric_to_eap(
+                    size_metric=size_metric,
+                    organization=organization,
+                    organization_id=org_id,
+                    project_id=project.id,
                 )
+            logger.info(
+                "Successfully wrote preprod size metrics to EAP",
+                extra={
+                    "preprod_artifact_id": preprod_artifact.id,
+                    "size_metrics_ids": [m.id for m in size_metrics_updated],
+                    "organization_id": org_id,
+                    "project_id": project.id,
+                },
+            )
         except Exception as eap_error:
             logger.exception(
                 "Failed to write preprod size metrics to EAP",
@@ -744,21 +742,20 @@ def _assemble_preprod_artifact_installable_app(
 
     try:
         organization = preprod_artifact.project.organization
-        if features.has("organizations:preprod-build-distribution-eap-write", organization):
-            produce_preprod_build_distribution_to_eap(
-                artifact=preprod_artifact,
-                organization=organization,
-                organization_id=org_id,
-                project_id=project.id,
-            )
-            logger.info(
-                "Successfully wrote preprod build distribution to EAP",
-                extra={
-                    "preprod_artifact_id": preprod_artifact.id,
-                    "organization_id": org_id,
-                    "project_id": project.id,
-                },
-            )
+        produce_preprod_build_distribution_to_eap(
+            artifact=preprod_artifact,
+            organization=organization,
+            organization_id=org_id,
+            project_id=project.id,
+        )
+        logger.info(
+            "Successfully wrote preprod build distribution to EAP",
+            extra={
+                "preprod_artifact_id": preprod_artifact.id,
+                "organization_id": org_id,
+                "project_id": project.id,
+            },
+        )
     except Exception:
         logger.exception(
             "Failed to write preprod build distribution to EAP",

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -18,7 +18,6 @@ import type {
 } from 'sentry/utils/discover/fields';
 import {SizeUnit} from 'sentry/utils/discover/fields';
 import {AggregationKey} from 'sentry/utils/fields';
-import useOrganization from 'sentry/utils/useOrganization';
 import type {
   DatasetConfig,
   SearchBarData,
@@ -192,29 +191,16 @@ function MobileAppSizeSearchBar({
 function useMobileAppSizeSearchBarDataProvider(
   props: SearchBarDataProviderProps
 ): SearchBarData {
-  const organization = useOrganization();
   const {
     selection: {projects},
   } = usePageFilters();
 
   const {attributes: stringAttributes, secondaryAliases: stringSecondaryAliases} =
-    usePreprodItemAttributes(
-      {enabled: organization.features.includes('preprod-app-size-dashboard')},
-      'string',
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    usePreprodItemAttributes({enabled: true}, 'string', HIDDEN_PREPROD_ATTRIBUTES);
   const {attributes: numberAttributes, secondaryAliases: numberSecondaryAliases} =
-    usePreprodItemAttributes(
-      {enabled: organization.features.includes('preprod-app-size-dashboard')},
-      'number',
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    usePreprodItemAttributes({enabled: true}, 'number', HIDDEN_PREPROD_ATTRIBUTES);
   const {attributes: booleanAttributes, secondaryAliases: booleanSecondaryAliases} =
-    usePreprodItemAttributes(
-      {enabled: organization.features.includes('preprod-app-size-dashboard')},
-      'boolean',
-      HIDDEN_PREPROD_ATTRIBUTES
-    );
+    usePreprodItemAttributes({enabled: true}, 'boolean', HIDDEN_PREPROD_ATTRIBUTES);
 
   const {filterKeys, filterKeySections, getTagValues} =
     useTraceItemSearchQueryBuilderProps({

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -911,37 +911,6 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         assert watch_metrics.max_download_size == 2000
         assert watch_metrics.max_install_size == 4000
 
-    def test_assemble_preprod_artifact_size_analysis_app_clip_component(self) -> None:
-        status, details = self._run_task_and_verify_status(
-            b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 3, "name": "App Clip", "app_id": "com.example.app.clip", "path": "/AppClips/AppClip.app", "download_size": 2000, "install_size": 4000}]}'
-        )
-
-        assert status == ChunkFileState.OK
-        assert details is None
-
-        all_size_metrics = PreprodArtifactSizeMetrics.objects.filter(
-            preprod_artifact=self.preprod_artifact
-        ).order_by("metrics_artifact_type")
-        assert len(all_size_metrics) == 2
-
-        main_metrics = all_size_metrics[0]
-        assert (
-            main_metrics.metrics_artifact_type
-            == PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT
-        )
-        assert main_metrics.identifier is None
-        assert main_metrics.max_download_size == 3000
-        assert main_metrics.max_install_size == 6000
-
-        app_clip_metrics = all_size_metrics[1]
-        assert (
-            app_clip_metrics.metrics_artifact_type
-            == PreprodArtifactSizeMetrics.MetricsArtifactType.APP_CLIP_ARTIFACT
-        )
-        assert app_clip_metrics.identifier == "com.example.app.clip"
-        assert app_clip_metrics.max_download_size == 2000
-        assert app_clip_metrics.max_install_size == 4000
-
     def test_assemble_preprod_artifact_size_analysis_removes_stale_metrics(self) -> None:
         status, details = self._run_task_and_verify_status(
             b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 1, "name": "Watch App", "app_id": "com.example.app.watchkitapp", "path": "/Watch", "download_size": 2000, "install_size": 4000}]}'
@@ -981,30 +950,8 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
         assert second_analysis_file is not None
         assert main_metrics.analysis_file_id == second_analysis_file.id
 
-    def test_assemble_preprod_artifact_size_analysis_writes_to_eap_when_flag_enabled(self) -> None:
-        """Test that size metrics are written to EAP when feature flag is enabled"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
-                )
-
-                assert status == ChunkFileState.OK
-                assert details is None
-
-                # Verify produce_preprod_size_metric_to_eap was called exactly once
-                # We have other integration tests that verify the EAP write itself works
-                assert mock_eap_write.call_count == 1
-
-                call_args = mock_eap_write.call_args
-                assert call_args is not None
-                size_metric = call_args.kwargs["size_metric"]
-                assert size_metric.preprod_artifact_id == self.preprod_artifact.id
-                assert call_args.kwargs["organization_id"] == self.organization.id
-                assert call_args.kwargs["project_id"] == self.project.id
-
-    def test_assemble_preprod_artifact_size_analysis_skips_eap_when_flag_disabled(self) -> None:
-        """Test that size metrics are NOT written to EAP when feature flag is disabled"""
+    def test_assemble_preprod_artifact_size_analysis_writes_to_eap(self) -> None:
+        """Test that size metrics are written to EAP"""
         with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
             status, details = self._run_task_and_verify_status(
                 b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
@@ -1013,49 +960,53 @@ class AssemblePreprodArtifactSizeAnalysisTest(BaseAssembleTest):
             assert status == ChunkFileState.OK
             assert details is None
 
-            # Verify produce_preprod_size_metric_to_eap was NOT called
-            mock_eap_write.assert_not_called()
+            # Verify produce_preprod_size_metric_to_eap was called exactly once
+            # We have other integration tests that verify the EAP write itself works
+            assert mock_eap_write.call_count == 1
+
+            call_args = mock_eap_write.call_args
+            assert call_args is not None
+            size_metric = call_args.kwargs["size_metric"]
+            assert size_metric.preprod_artifact_id == self.preprod_artifact.id
+            assert call_args.kwargs["organization_id"] == self.organization.id
+            assert call_args.kwargs["project_id"] == self.project.id
 
     def test_assemble_preprod_artifact_size_analysis_eap_write_failure_does_not_fail_task(
         self,
     ) -> None:
         """Test that EAP write failures don't cause the main task to fail"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch(
-                "sentry.preprod.tasks.produce_preprod_size_metric_to_eap",
-                side_effect=Exception("EAP write failed"),
-            ):
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
-                )
+        with patch(
+            "sentry.preprod.tasks.produce_preprod_size_metric_to_eap",
+            side_effect=Exception("EAP write failed"),
+        ):
+            status, details = self._run_task_and_verify_status(
+                b'{"analysis_duration": 1.5, "download_size": 1000, "install_size": 2000, "treemap": null, "analysis_version": null, "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 1000, "install_size": 2000}]}'
+            )
 
-                assert status == ChunkFileState.OK
-                assert details is None
+            assert status == ChunkFileState.OK
+            assert details is None
 
-                size_metrics = PreprodArtifactSizeMetrics.objects.filter(
-                    preprod_artifact=self.preprod_artifact
-                )
-                assert len(size_metrics) == 1
-                assert (
-                    size_metrics[0].state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
-                )
+            size_metrics = PreprodArtifactSizeMetrics.objects.filter(
+                preprod_artifact=self.preprod_artifact
+            )
+            assert len(size_metrics) == 1
+            assert size_metrics[0].state == PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED
 
     def test_assemble_preprod_artifact_size_analysis_writes_multiple_metrics_to_eap(self) -> None:
-        """Test that all size metrics (main + components) are written to EAP when flag is enabled"""
-        with self.feature("organizations:preprod-size-metrics-eap-write"):
-            with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
-                status, details = self._run_task_and_verify_status(
-                    b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 1, "name": "Watch App", "app_id": "com.example.app.watchkitapp", "path": "/Watch", "download_size": 2000, "install_size": 4000}]}'
-                )
+        """Test that all size metrics (main + components) are written to EAP"""
+        with patch("sentry.preprod.tasks.produce_preprod_size_metric_to_eap") as mock_eap_write:
+            status, details = self._run_task_and_verify_status(
+                b'{"analysis_duration": 2.5, "download_size": 5000, "install_size": 10000, "treemap": null, "analysis_version": "1.0", "app_components": [{"component_type": 0, "name": "Main App", "app_id": "com.example.app", "path": "/", "download_size": 3000, "install_size": 6000}, {"component_type": 1, "name": "Watch App", "app_id": "com.example.app.watchkitapp", "path": "/Watch", "download_size": 2000, "install_size": 4000}]}'
+            )
 
-                assert status == ChunkFileState.OK
-                assert details is None
+            assert status == ChunkFileState.OK
+            assert details is None
 
-                assert mock_eap_write.call_count == 2
+            assert mock_eap_write.call_count == 2
 
-                for call in mock_eap_write.call_args_list:
-                    assert call.kwargs["organization_id"] == self.organization.id
-                    assert call.kwargs["project_id"] == self.project.id
+            for call in mock_eap_write.call_args_list:
+                assert call.kwargs["organization_id"] == self.organization.id
+                assert call.kwargs["project_id"] == self.project.id
 
 
 class DetectExpiredPreprodArtifactsTest(TestCase):


### PR DESCRIPTION
Remove 4 graduated feature flags from backend:
- organizations:preprod-build-distribution
- organizations:preprod-build-distribution-eap-write
- organizations:preprod-size-metrics-eap-write
- organizations:preprod-app-size-dashboard

These flags are GA at 100% rollout with no conditions. Keeps organizations:preprod-frontend-routes as it is not yet rolled out to all ST tenants.

<!-- Describe your PR here. -->