### PR TITLE
feat(dashboards): AI Agent prebuilt dashboard improvements

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -387,7 +387,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
     isSortable: true,
     renderFunc: (field, data) => {
       if (typeof data[field] !== 'number') {
-        return <Container>{emptyValue}</Container>;
+        return <NumberContainer>{emptyValue}</NumberContainer>;
       }
       return <CurrencyCell value={data[field]} />;
     },

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -1402,6 +1402,7 @@ const alignedTypes: ColumnValueType[] = [
   'percent_change',
   'rate',
   'size',
+  'currency',
 ];
 
 export function fieldAlignment(

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
@@ -5,6 +5,7 @@ import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltCo
 import {SpanFields} from 'sentry/views/insights/types';
 
 const AI_GENERATIONS_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
+const SUM_ALL_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) + sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) + sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) + sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})`;
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
@@ -66,16 +67,16 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
           name: '',
           conditions: AI_GENERATIONS_FILTER,
           fields: [
-            `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})`,
-            `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})`,
-            `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS})`,
-            `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING}) / (${SUM_ALL_TOKENS})`,
           ],
           aggregates: [
-            `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})`,
-            `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})`,
-            `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS})`,
-            `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING}) / (${SUM_ALL_TOKENS})`,
           ],
           columns: [],
           fieldAliases: [
@@ -109,6 +110,7 @@ const MODELS_TABLE = {
         'count_if(span.status,equals,internal_error)',
         `avg(${SpanFields.SPAN_DURATION})`,
         `p95(${SpanFields.SPAN_DURATION})`,
+        `sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`,
         `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})`,
         `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})`,
         `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS})`,
@@ -119,6 +121,7 @@ const MODELS_TABLE = {
         'count_if(span.status,equals,internal_error)',
         `avg(${SpanFields.SPAN_DURATION})`,
         `p95(${SpanFields.SPAN_DURATION})`,
+        `sum(${SpanFields.GEN_AI_COST_TOTAL_TOKENS})`,
         `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})`,
         `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})`,
         `sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS})`,
@@ -131,6 +134,7 @@ const MODELS_TABLE = {
         t('Errors'),
         t('Avg'),
         t('P95'),
+        t('Cost'),
         t('Input Tokens'),
         t('Cached Tokens'),
         t('Output Tokens'),

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsModels.ts
@@ -5,7 +5,8 @@ import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltCo
 import {SpanFields} from 'sentry/views/insights/types';
 
 const AI_GENERATIONS_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
-const SUM_ALL_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) + sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) + sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) + sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})`;
+// input_tokens includes cached, output_tokens includes reasoning, so total is just the sum of both
+const SUM_ALL_TOKENS = `sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) + sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS})`;
 
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
@@ -67,15 +68,15 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
           name: '',
           conditions: AI_GENERATIONS_FILTER,
           fields: [
-            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|(sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) - sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})) / (${SUM_ALL_TOKENS})`,
             `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) / (${SUM_ALL_TOKENS})`,
-            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|(sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) - sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})) / (${SUM_ALL_TOKENS})`,
             `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING}) / (${SUM_ALL_TOKENS})`,
           ],
           aggregates: [
-            `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|(sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS}) - sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED})) / (${SUM_ALL_TOKENS})`,
             `equation|sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS_CACHED}) / (${SUM_ALL_TOKENS})`,
-            `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) / (${SUM_ALL_TOKENS})`,
+            `equation|(sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS}) - sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING})) / (${SUM_ALL_TOKENS})`,
             `equation|sum(${SpanFields.GEN_AI_USAGE_OUTPUT_TOKENS_REASONING}) / (${SUM_ALL_TOKENS})`,
           ],
           columns: [],
@@ -85,7 +86,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
             t('Output Tokens'),
             t('Reasoning Tokens'),
           ],
-          orderby: `-sum(${SpanFields.GEN_AI_USAGE_INPUT_TOKENS})`,
+          orderby: '',
         },
       ],
     },

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -183,6 +183,7 @@ function VisualizationWidgetContent({
         aggregates.find(aggregate => splitSeriesName.includes(aggregate)) ??
         aggregates[0];
 
+      // This is the query name for the series, aka the legend alias from the UI
       const queryName =
         widget?.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ||
         undefined;

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -201,7 +201,11 @@ function VisualizationWidgetContent({
       }
 
       const fieldIndex = yAxis === undefined ? -1 : fields.indexOf(yAxis);
-      const fieldAlias = fieldIndex >= 0 ? fieldAliases[fieldIndex] : undefined;
+      // Only use field aliases for the yAxis if there are multiple yAxis and no group bys
+      const fieldAlias =
+        aggregates.length > 1 && columns.length === 0 && fieldIndex >= 0
+          ? fieldAliases[fieldIndex]
+          : undefined;
 
       const labelParts = [queryName, fieldAlias ?? formatTimeSeriesLabel(timeSeries)];
       // If there are multiple aggregates and columns, add the yAxis to the label for uniqueness

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -171,6 +171,8 @@ function VisualizationWidgetContent({
   const firstWidgetQuery = widget.queries[0];
   const aggregates = firstWidgetQuery?.aggregates ?? []; // All widget queries have the same aggregates
   const columns = firstWidgetQuery?.columns ?? []; // All widget queries have the same columns
+  const fields = firstWidgetQuery?.fields ?? [...columns, ...aggregates];
+  const fieldAliases = firstWidgetQuery?.fieldAliases ?? [];
 
   const timeSeriesWithPlottable: Array<[TimeSeries, Plottable]> = timeseriesResults
     .map(series => {
@@ -181,7 +183,7 @@ function VisualizationWidgetContent({
         aggregates.find(aggregate => splitSeriesName.includes(aggregate)) ??
         aggregates[0];
 
-      const alias =
+      const queryName =
         widget?.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ||
         undefined;
 
@@ -191,14 +193,17 @@ function VisualizationWidgetContent({
         timeseriesResultsUnits,
         columns,
         yAxis,
-        alias
+        queryName
       );
 
       if (!timeSeries) {
         return null;
       }
 
-      const labelParts = [alias, formatTimeSeriesLabel(timeSeries)];
+      const fieldIndex = yAxis === undefined ? -1 : fields.indexOf(yAxis);
+      const fieldAlias = fieldIndex >= 0 ? fieldAliases[fieldIndex] : undefined;
+
+      const labelParts = [queryName, fieldAlias ?? formatTimeSeriesLabel(timeSeries)];
       // If there are multiple aggregates and columns, add the yAxis to the label for uniqueness
       if (aggregates.length > 1 && columns.length > 1) {
         labelParts.push(timeSeries.yAxis);


### PR DESCRIPTION
This PR involves various improvements to the AI Agents prebuilt dashboards and charting fixes in general:
- Update `currency` type columns to be right aligned and empty value to be right aligned (via `NumberContainer`)
- Update Agent Token Types breakdown chart to use equations to display fraction of total tokens per token series
- Fix chart `visualizationWidget` and legend breakdown to use `fieldAlias` when available for multi y axis widgets without group bys to display series name
- Add cost column to AI Agent Models table