### PR TITLE
Make user account and organization deletion grace periods consistent

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -38,6 +38,8 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(MODULE_ROOT))
 DATA_ROOT = os.path.join(MODULE_ROOT, "data")
 STATIC_ROOT = os.path.join(PROJECT_ROOT, "static")
 
+DELETION_GRACE_PERIOD_DAYS = 14
+
 BAD_RELEASE_CHARS = "\r\n\f\x0c\t/\\"
 MAX_VERSION_LENGTH = 200
 MAX_COMMIT_LENGTH = 64

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -18,7 +18,7 @@ from bitfield.types import BitHandler
 from sentry import analytics, audit_log, features, options, roles
 from sentry.analytics.events.organization_removed import OrganizationRemoved
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import ONE_DAY, region_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.fields import AvatarField
@@ -50,6 +50,7 @@ from sentry.constants import (
     DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
     DEFAULT_CODE_REVIEW_TRIGGERS,
     DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
+    DELETION_GRACE_PERIOD_DAYS,
     ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT,
     ENABLE_SEER_CODING_DEFAULT,
     ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
@@ -803,7 +804,9 @@ def post_org_pending_deletion(
                     slug=updated_organization.slug,
                     user_id=request.user.id if request.user.is_authenticated else None,
                     deletion_request_datetime=entry.datetime.isoformat(),
-                    deletion_datetime=(entry.datetime + timedelta(seconds=ONE_DAY)).isoformat(),
+                    deletion_datetime=(
+                        entry.datetime + timedelta(days=DELETION_GRACE_PERIOD_DAYS)
+                    ).isoformat(),
                 )
             )
         except Exception as e:
@@ -813,7 +816,7 @@ def post_org_pending_deletion(
             "username": request.user.get_username(),
             "ip_address": entry.ip_address,
             "deletion_datetime": entry.datetime,
-            "countdown": ONE_DAY,
+            "countdown": int(timedelta(days=DELETION_GRACE_PERIOD_DAYS).total_seconds()),
             "organization": updated_organization,
         }
         send_delete_confirmation(delete_confirmation_args)

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -11,6 +11,7 @@ from django.dispatch import Signal
 from sentry import roles
 from sentry.api.serializers import serialize
 from sentry.backup.dependencies import merge_users_for_model_in_org
+from sentry.constants import DELETION_GRACE_PERIOD_DAYS
 from sentry.db.postgres.transactions import enforce_constraints
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.hybridcloud.models.outbox import ControlOutbox, outbox_context
@@ -723,7 +724,9 @@ class DatabaseBackedOrganizationService(OrganizationService):
             )
 
             if updated_organization is not None:
-                schedule = RegionScheduledDeletion.schedule(orm_organization, days=1, actor=user)
+                schedule = RegionScheduledDeletion.schedule(
+                    orm_organization, days=DELETION_GRACE_PERIOD_DAYS, actor=user
+                )
 
                 Organization.objects.uncache_object(updated_organization.id)
                 return RpcOrganizationDeleteResponse(

--- a/src/sentry/users/api/endpoints/user_details.py
+++ b/src/sentry/users/api/endpoints/user_details.py
@@ -23,7 +23,7 @@ from sentry.api.serializers.rest_framework import CamelSnakeModelSerializer
 from sentry.audit_log.services.log import AuditLogEvent, log_service
 from sentry.auth.elevated_mode import has_elevated_mode
 from sentry.conf.types.sentry_config import SentryMode
-from sentry.constants import LANGUAGES
+from sentry.constants import DELETION_GRACE_PERIOD_DAYS, LANGUAGES
 from sentry.core.endpoints.organization_details import post_org_pending_deletion
 from sentry.models.authidentity import AuthIdentity
 from sentry.models.organization import OrganizationStatus
@@ -65,7 +65,7 @@ def user_can_elevate(target_user: User) -> bool:
 
 def record_user_deactivation(*, user: User, actor: Any, ip_address: str) -> None:
     deactivation_datetime = django_timezone.now()
-    scheduled_deletion_datetime = deactivation_datetime + timedelta(days=30)
+    scheduled_deletion_datetime = deactivation_datetime + timedelta(days=DELETION_GRACE_PERIOD_DAYS)
 
     try:
         analytics.record(

--- a/static/gsAdmin/components/closeAccountInfo.tsx
+++ b/static/gsAdmin/components/closeAccountInfo.tsx
@@ -5,7 +5,7 @@ function CloseAccountInfo() {
     <Fragment>
       <p>
         Closing this account will schedule the organization for deletion per the standard
-        delay (e.g. 24 hours). When the delete operation begins, the subscription will
+        delay (e.g. 14 days). When the delete operation begins, the subscription will
         automatically be cancelled.
       </p>
       <p>

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -19,7 +19,11 @@ from sentry.api.serializers.models.organization import TrustedRelaySerializer
 from sentry.api.utils import generate_locality_url
 from sentry.auth.authenticators.recovery_code import RecoveryCodeInterface
 from sentry.auth.authenticators.totp import TotpInterface
-from sentry.constants import RESERVED_ORGANIZATION_SLUGS, ObjectStatus
+from sentry.constants import (
+    DELETION_GRACE_PERIOD_DAYS,
+    RESERVED_ORGANIZATION_SLUGS,
+    ObjectStatus,
+)
 from sentry.core.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
 from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.dynamic_sampling.types import DynamicSamplingMode
@@ -1153,7 +1157,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
     def test_cancel_delete(self) -> None:
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
-        RegionScheduledDeletion.schedule(org, days=1)
+        RegionScheduledDeletion.schedule(org, days=DELETION_GRACE_PERIOD_DAYS)
 
         self.get_success_response(org.slug, **{"cancelDeletion": True})
 
@@ -1973,9 +1977,8 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
             self.get_error_response(org.slug, status_code=400)
 
     def test_redo_deletion(self) -> None:
-        # Orgs can delete, undelete, delete within a day
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
-        RegionScheduledDeletion.schedule(org, days=1)
+        RegionScheduledDeletion.schedule(org, days=DELETION_GRACE_PERIOD_DAYS)
 
         self.get_success_response(org.slug, status_code=status.HTTP_202_ACCEPTED)
 


### PR DESCRIPTION
User account and organization grace periods vary by 29 days. One day grace periods for org deletion have been challenging for support and investigation needs and a 30 days user activation is exceptionally long.

Currently reviewing all documentation locations that need to be updated in tandem. 