### PR TITLE
fix(api): Fix user serializers to return emails for superusers

### DIFF
--- a/src/sentry/users/api/serializers/user.py
+++ b/src/sentry/users/api/serializers/user.py
@@ -183,11 +183,13 @@ class UserSerializer(Serializer):
             "experiments": {},
         }
 
-        if self._user_is_requester(obj, user):
+        if self._user_is_requester(obj, user) or user.is_superuser:
             d["emails"] = [
                 {"id": str(e.id), "email": e.email, "is_verified": e.is_verified}
                 for e in attrs["emails"]
             ]
+
+        if self._user_is_requester(obj, user):
             d = cast(UserSerializerResponseSelf, d)
             options = {
                 o.key: o.value

--- a/tests/sentry/users/api/serializers/test_user.py
+++ b/tests/sentry/users/api/serializers/test_user.py
@@ -49,6 +49,30 @@ class UserSerializerTest(TestCase):
         result = serialize(user)
         assert result["isSuperuser"] is True
 
+    def test_superuser_can_see_other_user_emails(self) -> None:
+        superuser = self.create_user(is_superuser=True)
+        other_user = self.create_user()
+
+        result = serialize(other_user, superuser)
+        assert len(result["emails"]) == 1
+        assert result["emails"][0]["email"] == other_user.email
+        assert result["emails"][0]["is_verified"]
+
+    def test_non_requester_cannot_see_emails(self) -> None:
+        viewer = self.create_user()
+        other_user = self.create_user()
+
+        result = serialize(other_user, viewer)
+        assert result["emails"] == []
+
+    def test_superuser_does_not_get_self_fields_for_other_user(self) -> None:
+        superuser = self.create_user(is_superuser=True)
+        other_user = self.create_user()
+
+        result = serialize(other_user, superuser)
+        assert "options" not in result
+        assert "flags" not in result
+
 
 @control_silo_test
 class DetailedUserSerializerTest(TestCase):


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/108287 caused superusers to not be able to see user's emails, this fixes the problem.

<!-- Describe your PR here. -->