### PR TITLE
fix(preprod): Restore full token authentication on retention endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
+++ b/src/sentry/preprod/api/endpoints/organization_preprod_retention.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 from sentry import quotas
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.authentication import UserAuthTokenAuthentication
+from sentry.api.authentication import OrgAuthTokenAuthentication, UserAuthTokenAuthentication
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.constants import DataCategory
@@ -49,8 +49,9 @@ class OrganizationPreprodRetentionEndpoint(OrganizationEndpoint):
     }
     authentication_classes = (
         LaunchpadRpcSignatureAuthentication,
-        SessionAuthentication,
         UserAuthTokenAuthentication,
+        OrgAuthTokenAuthentication,
+        SessionAuthentication,
     )
     permission_classes = (LaunchpadServiceOrOrganizationPermission,)
 


### PR DESCRIPTION
Making sure we can hit the retention endpoint from CLI

https://linear.app/getsentry/issue/EME-855/wire-up-snapshots-retention-in-retention-api

Add `OrgAuthTokenAuthentication` and reorder `authentication_classes` on
`OrganizationPreprodRetentionEndpoint` so token classes come before
`SessionAuthentication`.

Previously, `SessionAuthentication` was listed before `UserAuthTokenAuthentication`.
When a request carried both session cookies and a Bearer token (e.g. from a browser
with an active Sentry session), session auth would win, set `request.auth = None`,
and trigger the SSO check — returning a spurious `401 sso-required` error. Token
auth never got a chance to run.

The fix matches the ordering used by `DEFAULT_AUTHENTICATION` in `src/sentry/api/base.py`:
token classes first, session auth last as a fallback.