### PR TITLE
feat(ACI): Make OrganizationAlertRuleDetails DELETE method backwards compatible

### DIFF
--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -116,6 +116,12 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         organization = kwargs["organization"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
 
+        # Allow orgs that have downgraded plans to delete metric alerts
+        if request.method != "DELETE" and not features.has(
+            "organizations:incidents", organization, actor=request.user
+        ):
+            raise ResourceDoesNotExist
+
         if features.has("organizations:workflow-engine-rule-serializers", organization):
             try:
                 ard = AlertRuleDetector.objects.get(
@@ -135,12 +141,6 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
                     raise ResourceDoesNotExist
 
             return args, kwargs
-
-        # Allow orgs that have downgraded plans to delete metric alerts
-        if request.method != "DELETE" and not features.has(
-            "organizations:incidents", organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
 
         try:
             kwargs["alert_rule"] = AlertRule.objects.get(

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -8,9 +8,12 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
+from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
+from sentry.workflow_engine.models.detector import Detector
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -86,6 +89,52 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
         args, kwargs = super().convert_args(request, *args, **kwargs)
         organization = kwargs["organization"]
         validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
+
+        # Allow orgs that have downgraded plans to delete metric alerts
+        if request.method != "DELETE" and not features.has(
+            "organizations:incidents", organization, actor=request.user
+        ):
+            raise ResourceDoesNotExist
+
+        try:
+            kwargs["alert_rule"] = AlertRule.objects.get(
+                organization=organization, id=validated_alert_rule_id
+            )
+        except AlertRule.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return args, kwargs
+
+
+class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint):
+    def convert_args(
+        self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        args, kwargs = super(OrganizationAlertRuleEndpoint, self).convert_args(
+            request, *args, **kwargs
+        )
+        organization = kwargs["organization"]
+        validated_alert_rule_id = to_valid_int_id("alert_rule_id", alert_rule_id, raise_404=True)
+
+        if features.has("organizations:workflow-engine-rule-serializers", organization):
+            try:
+                ard = AlertRuleDetector.objects.get(
+                    alert_rule_id=validated_alert_rule_id,
+                    detector__project__organization=organization,
+                )
+                kwargs["alert_rule"] = ard.detector
+            except AlertRuleDetector.DoesNotExist:
+                # XXX: this means the detector was single written and has no ARD or related AlertRule object
+                try:
+                    detector_id = get_object_id_from_fake_id(validated_alert_rule_id)
+                    kwargs["alert_rule"] = Detector.objects.get(
+                        id=detector_id,
+                        project__organization=organization,
+                    )
+                except Detector.DoesNotExist:
+                    raise ResourceDoesNotExist
+
+            return args, kwargs
 
         # Allow orgs that have downgraded plans to delete metric alerts
         if request.method != "DELETE" and not features.has(

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -136,7 +136,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
                     kwargs["alert_rule"] = Detector.objects.get(
                         id=detector_id,
                         project__organization=organization,
-                    )
+                    ).select_related("project")
                 except Detector.DoesNotExist:
                     raise ResourceDoesNotExist
 

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -136,7 +136,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
                     kwargs["alert_rule"] = Detector.objects.get(
                         id=detector_id,
                         project__organization=organization,
-                    ).select_related("project")
+                    )
                 except Detector.DoesNotExist:
                     raise ResourceDoesNotExist
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -146,15 +146,14 @@ def remove_alert_rule(
     request: Request, organization: Organization, target: AlertRule | Detector
 ) -> Response:
     if isinstance(target, Detector):
-        detector = target
         try:
             with transaction.atomic(router.db_for_write(Detector)):
-                remove_detector(request, organization, detector)
+                remove_detector(request, organization, target)
                 try:
-                    ard = AlertRuleDetector.objects.get(detector_id=detector.id)
-                    detector = AlertRule.objects.get(id=ard.alert_rule_id)
+                    ard = AlertRuleDetector.objects.get(detector_id=target.id)
+                    target = AlertRule.objects.get(id=ard.alert_rule_id)
                     delete_alert_rule(
-                        detector,
+                        target,
                         user=_anon_to_None(request.user),
                         ip_address=request.META.get("REMOTE_ADDR"),
                     )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -143,17 +143,18 @@ def update_alert_rule(
 
 
 def remove_alert_rule(
-    request: Request, organization: Organization, alert_rule: AlertRule | Detector
+    request: Request, organization: Organization, target: AlertRule | Detector
 ) -> Response:
-    if isinstance(alert_rule, Detector):
+    if isinstance(target, Detector):
+        detector = target
         try:
             with transaction.atomic(router.db_for_write(Detector)):
-                remove_detector(request, organization, alert_rule)
+                remove_detector(request, organization, detector)
                 try:
-                    ard = AlertRuleDetector.objects.get(detector_id=alert_rule.id)
-                    alert_rule = AlertRule.objects.get(id=ard.alert_rule_id)
+                    ard = AlertRuleDetector.objects.get(detector_id=detector.id)
+                    detector = AlertRule.objects.get(id=ard.alert_rule_id)
                     delete_alert_rule(
-                        alert_rule,
+                        detector,
                         user=_anon_to_None(request.user),
                         ip_address=request.META.get("REMOTE_ADDR"),
                     )
@@ -172,7 +173,7 @@ def remove_alert_rule(
         # that the extra table data is deleted. If the rows don't exist, we'll exit early.
         with transaction.atomic(router.db_for_write(AlertRule)):
             try:
-                dual_delete_migrated_alert_rule(alert_rule=alert_rule)
+                dual_delete_migrated_alert_rule(alert_rule=target)
             except Exception as e:
                 logger.exception(
                     "Error when dual deleting alert rule",
@@ -183,7 +184,7 @@ def remove_alert_rule(
                     status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
             delete_alert_rule(
-                alert_rule,
+                target,
                 user=_anon_to_None(request.user),
                 ip_address=request.META.get("REMOTE_ADDR"),
             )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -146,22 +146,28 @@ def remove_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
     if isinstance(alert_rule, Detector):
-        remove_detector(request, organization, alert_rule)
         try:
-            ard = AlertRuleDetector.objects.get(detector_id=alert_rule.id)
-            alert_rule = AlertRule.objects.get(id=ard.alert_rule_id)
-            delete_alert_rule(
-                alert_rule,
-                user=_anon_to_None(request.user),
-                ip_address=request.META.get("REMOTE_ADDR"),
-            )
-        except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
-            return Response(
-                "This detector was single written, no alert rule to delete",
-                status=status.HTTP_204_NO_CONTENT,
-            )
+            with transaction.atomic(router.db_for_write(Detector)):
+                remove_detector(request, organization, alert_rule)
+                try:
+                    ard = AlertRuleDetector.objects.get(detector_id=alert_rule.id)
+                    alert_rule = AlertRule.objects.get(id=ard.alert_rule_id)
+                    delete_alert_rule(
+                        alert_rule,
+                        user=_anon_to_None(request.user),
+                        ip_address=request.META.get("REMOTE_ADDR"),
+                    )
+                except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
+                    return Response(
+                        "This detector was single written, no alert rule to delete",
+                        status=status.HTTP_204_NO_CONTENT,
+                    )
 
-        return Response(status=status.HTTP_204_NO_CONTENT)
+                return Response(status=status.HTTP_204_NO_CONTENT)
+        except AlreadyDeletedError:
+            return Response(
+                "This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST
+            )
 
     try:
         # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -24,8 +24,6 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
-from sentry.constants import ObjectStatus
-from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
 from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers.alert_rule import (
     AlertRuleSerializer,
@@ -48,6 +46,7 @@ from sentry.models.rulesnooze import RuleSnooze
 from sentry.sentry_apps.services.app import app_service
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.users.services.user.service import user_service
+from sentry.workflow_engine.endpoints.organization_detector_details import remove_detector
 from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
@@ -147,10 +146,7 @@ def remove_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
     if isinstance(alert_rule, Detector):
-        with transaction.atomic(router.db_for_write(Detector)):
-            alert_rule.update(status=ObjectStatus.PENDING_DELETION)
-            RegionScheduledDeletion.schedule(alert_rule, days=0, actor=request.user)
-        return Response(status=status.HTTP_202_ACCEPTED)
+        return remove_detector(request, organization, alert_rule)
 
     try:
         # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -48,7 +48,7 @@ from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.users.services.user.service import user_service
 from sentry.workflow_engine.endpoints.organization_detector_details import remove_detector
 from sentry.workflow_engine.migration_helpers.alert_rule import dual_delete_migrated_alert_rule
-from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models import AlertRuleDetector, Detector
 from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 logger = logging.getLogger(__name__)
@@ -146,7 +146,22 @@ def remove_alert_rule(
     request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
     if isinstance(alert_rule, Detector):
-        return remove_detector(request, organization, alert_rule)
+        remove_detector(request, organization, alert_rule)
+        try:
+            ard = AlertRuleDetector.objects.get(detector_id=alert_rule.id)
+            alert_rule = AlertRule.objects.get(id=ard.alert_rule_id)
+            delete_alert_rule(
+                alert_rule,
+                user=_anon_to_None(request.user),
+                ip_address=request.META.get("REMOTE_ADDR"),
+            )
+        except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
+            return Response(
+                "This detector was single written, no alert rule to delete",
+                status=status.HTTP_204_NO_CONTENT,
+            )
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     try:
         # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -158,10 +158,7 @@ def remove_alert_rule(
                         ip_address=request.META.get("REMOTE_ADDR"),
                     )
                 except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
-                    return Response(
-                        "This detector was single written, no alert rule to delete",
-                        status=status.HTTP_204_NO_CONTENT,
-                    )
+                    return Response(status=status.HTTP_204_NO_CONTENT)
 
                 return Response(status=status.HTTP_204_NO_CONTENT)
         except AlreadyDeletedError:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -147,20 +147,19 @@ def remove_alert_rule(
 ) -> Response:
     if isinstance(target, Detector):
         try:
-            with transaction.atomic(router.db_for_write(Detector)):
-                remove_detector(request, organization, target)
-                try:
-                    ard = AlertRuleDetector.objects.get(detector_id=target.id)
-                    target = AlertRule.objects.get(id=ard.alert_rule_id)
-                    delete_alert_rule(
-                        target,
-                        user=_anon_to_None(request.user),
-                        ip_address=request.META.get("REMOTE_ADDR"),
-                    )
-                except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
-                    return Response(status=status.HTTP_204_NO_CONTENT)
-
+            remove_detector(request, organization, target)
+            try:
+                ard = AlertRuleDetector.objects.get(detector_id=target.id)
+                target = AlertRule.objects.get(id=ard.alert_rule_id)
+                delete_alert_rule(
+                    target,
+                    user=_anon_to_None(request.user),
+                    ip_address=request.META.get("REMOTE_ADDR"),
+                )
+            except (AlertRuleDetector.DoesNotExist, AlertRule.DoesNotExist):
                 return Response(status=status.HTTP_204_NO_CONTENT)
+
+            return Response(status=status.HTTP_204_NO_CONTENT)
         except AlreadyDeletedError:
             return Response(
                 "This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -10,7 +10,6 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
@@ -25,13 +24,12 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
-from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
+from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import RegionScheduledDeletion
+from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers.alert_rule import (
     AlertRuleSerializer,
     DetailedAlertRuleSerializer,
-)
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
-    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.logic import (
     AlreadyDeletedError,
@@ -62,25 +60,15 @@ def _anon_to_None[T](u: T | AnonymousUser) -> T | None:
 
 
 def fetch_alert_rule(
-    request: Request, organization: Organization, alert_rule: AlertRule
+    request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
+    if isinstance(alert_rule, Detector):
+        return Response(
+            {"alert_rule": ["Passing a detector through this endpoint is not yet supported"]},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     # Serialize Alert Rule
     expand = request.GET.getlist("expand", [])
-
-    if features.has("organizations:workflow-engine-rule-serializers", organization):
-        try:
-            detector = Detector.objects.with_type_filters().get(
-                alertruledetector__alert_rule_id=alert_rule.id
-            )
-            return Response(
-                serialize(
-                    detector,
-                    request.user,
-                    WorkflowEngineDetectorSerializer(expand=expand, prepare_component_fields=True),
-                )
-            )
-        except Detector.DoesNotExist:
-            return Response(status=status.HTTP_404_NOT_FOUND)
 
     serialized_rule = serialize(
         alert_rule,
@@ -106,8 +94,13 @@ def fetch_alert_rule(
 
 
 def update_alert_rule(
-    request: Request, organization: Organization, alert_rule: AlertRule
+    request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
+    if isinstance(alert_rule, Detector):
+        return Response(
+            {"alert_rule": ["Passing a detector through this endpoint is not yet supported"]},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     data = request.data
     current_owner = alert_rule.owner
     validator = DrfAlertRuleSerializer(
@@ -145,30 +138,20 @@ def update_alert_rule(
             # The user has requested a new Slack channel and we tell the client to check again in a bit
             return Response({"uuid": client.uuid}, status=202)
         else:
-            if features.has("organizations:workflow-engine-rule-serializers", organization):
-                validator.save()
-                try:
-                    detector = Detector.objects.with_type_filters().get(
-                        alertruledetector__alert_rule_id=alert_rule.id
-                    )
-                    return Response(
-                        serialize(
-                            detector,
-                            request.user,
-                            WorkflowEngineDetectorSerializer(),
-                        ),
-                        status=status.HTTP_200_OK,
-                    )
-                except Detector.DoesNotExist:
-                    return Response(status=status.HTTP_404_NOT_FOUND)
             return Response(serialize(validator.save(), request.user), status=status.HTTP_200_OK)
 
     return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 def remove_alert_rule(
-    request: Request, organization: Organization, alert_rule: AlertRule
+    request: Request, organization: Organization, alert_rule: AlertRule | Detector
 ) -> Response:
+    if isinstance(alert_rule, Detector):
+        with transaction.atomic(router.db_for_write(Detector)):
+            alert_rule.update(status=ObjectStatus.PENDING_DELETION)
+            RegionScheduledDeletion.schedule(alert_rule, days=0, actor=request.user)
+        return Response(status=status.HTTP_202_ACCEPTED)
+
     try:
         # NOTE: we want to run the dual delete regardless of whether the user is flagged into dual writes:
         # the user could be removed from the dual write flag for whatever reason, and we need to make sure
@@ -300,17 +283,20 @@ Metric alert rule trigger actions follow the following structure:
 
 
 def _check_project_access[T](
-    func: Callable[[T, Request, Organization, AlertRule], Response],
-) -> Callable[[T, Request, Organization, AlertRule], Response]:
+    func: Callable[[T, Request, Organization, AlertRule | Detector], Response],
+) -> Callable[[T, Request, Organization, AlertRule | Detector], Response]:
     @functools.wraps(func)
     def wrapper(
-        self, request: Request, organization: Organization, alert_rule: AlertRule
+        self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
         project = None
 
         try:
-            # check to see if there's a project associated with the alert rule
-            project = alert_rule.projects.get()
+            if isinstance(alert_rule, Detector):
+                project = alert_rule.project
+            else:
+                # check to see if there's a project associated with the alert rule
+                project = alert_rule.projects.get()
         except Exception:
             pass
 
@@ -327,7 +313,7 @@ def _check_project_access[T](
 
 @extend_schema(tags=["Alerts"])
 @region_silo_endpoint
-class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
+class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEndpoint):
     owner = ApiOwner.ISSUES
     publish_status = {
         "DELETE": ApiPublishStatus.PUBLIC,
@@ -348,7 +334,9 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
-    def get(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
+    def get(
+        self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
+    ) -> Response:
         """
         ## Deprecated
         🚧 Use [Fetch a Monitor](/api/monitors/fetch-a-monitor) and [Fetch an Alert](/api/monitors/fetch-an-alert) instead.
@@ -379,7 +367,9 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     )
     @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
-    def put(self, request: Request, organization: Organization, alert_rule: AlertRule) -> Response:
+    def put(
+        self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
+    ) -> Response:
         """
         ## Deprecated
         🚧 Use [Update a Monitor by ID](/api/monitors/update-a-monitor-by-id) and [Update an Alert by ID](/api/monitors/update-an-alert-by-id) instead.
@@ -414,7 +404,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def delete(
-        self, request: Request, organization: Organization, alert_rule: AlertRule
+        self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
         """
         ## Deprecated

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -150,7 +150,7 @@ def remove_alert_rule(
             remove_detector(request, organization, target)
             try:
                 ard = AlertRuleDetector.objects.get(detector_id=target.id)
-                target = AlertRule.objects.get(id=ard.alert_rule_id)
+                target = AlertRule.objects.get(id=ard.alert_rule_id, organization=organization)
                 delete_alert_rule(
                     target,
                     user=_anon_to_None(request.user),

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -42,6 +42,30 @@ from sentry.workflow_engine.endpoints.validators.utils import get_unknown_detect
 from sentry.workflow_engine.models import Detector
 
 
+def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:
+    """
+    Delete a given detector. This method is used by the OrganizationAlertRuleDetailsEndpoint DELETE method
+    for backwards compatibility and can be moved back under DELETE after API deprecation.
+    """
+    if not can_delete_detector(detector, request):
+        raise PermissionDenied
+
+    validator = get_detector_validator(request, detector.project, detector.type, instance=detector)
+    validator.delete()
+
+    if detector.type == MetricIssue.slug:
+        schedule_update_project_config(detector)
+
+    create_audit_entry(
+        request=request,
+        organization=detector.project.organization,
+        target_object=detector.id,
+        event=audit_log.get_event_id("DETECTOR_REMOVE"),
+        data=detector.get_audit_log_data(),
+    )
+    return Response(status=204)
+
+
 def get_detector_validator(
     request: Request,
     project: Project,
@@ -208,22 +232,4 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
 
         Delete a monitor
         """
-        if not can_delete_detector(detector, request):
-            raise PermissionDenied
-
-        validator = get_detector_validator(
-            request, detector.project, detector.type, instance=detector
-        )
-        validator.delete()
-
-        if detector.type == MetricIssue.slug:
-            schedule_update_project_config(detector)
-
-        create_audit_entry(
-            request=request,
-            organization=detector.project.organization,
-            target_object=detector.id,
-            event=audit_log.get_event_id("DETECTOR_REMOVE"),
-            data=detector.get_audit_log_data(),
-        )
-        return Response(status=204)
+        remove_detector(request, organization, detector)

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -232,4 +232,4 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
 
         Delete a monitor
         """
-        remove_detector(request, organization, detector)
+        return remove_detector(request, organization, detector)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -2436,3 +2436,23 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             run_scheduled_deletions()
 
         assert not Detector.objects.filter(id=detector.id).exists()
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_dual_delete_detector_id_passed(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
+        fake_detector_id = get_fake_id_from_object_id(ard.detector_id)
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not AlertRule.objects_with_snapshots.filter(name=self.alert_rule.name).exists()
+        assert not AlertRule.objects_with_snapshots.filter(id=self.alert_rule.id).exists()
+        assert not Detector.objects.filter(id=ard.detector_id).exists()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -25,6 +25,7 @@ from sentry.auth.access import OrganizationGlobalAccess
 from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
+from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
@@ -2414,3 +2415,23 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
 
         with self.feature("organizations:incidents"):
             self.get_success_response(self.organization.slug, other_alert_rule.id, status_code=204)
+
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_workflow_engine_detector_deleted(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        detector = self.create_detector(project=self.project)
+        fake_detector_id = get_fake_id_from_object_id(detector.id)
+        self.get_success_response(self.organization.slug, fake_detector_id, status_code=202)
+
+        # Detector.objects excludes PENDING_DELETION, so the detector not appearing here confirms
+        # it was scheduled for deletion.
+        assert not Detector.objects.filter(id=detector.id).exists()
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not Detector.objects.filter(id=detector.id).exists()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -58,7 +58,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
-from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.models import DataSource, DataSourceDetector, Detector
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 from tests.sentry.workflow_engine.migration_helpers.test_migrate_alert_rule import (
@@ -2404,6 +2404,8 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         self.login_as(self.user)
 
         detector = self.create_detector(project=self.project, type=MetricIssue.slug)
+        data_source = self.create_data_source()
+        data_source_detector = self.create_data_source_detector(data_source, detector)
         fake_detector_id = get_fake_id_from_object_id(detector.id)
         self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
 
@@ -2415,6 +2417,8 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             run_scheduled_deletions()
 
         assert not Detector.objects.filter(id=detector.id).exists()
+        assert not DataSource.objects.filter(id=data_source.id).exists()
+        assert not DataSourceDetector.objects.filter(id=data_source_detector.id).exists()
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_dual_delete_detector_id_passed(self) -> None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -26,9 +26,6 @@ from sentry.conf.server import SEER_ANOMALY_DETECTION_STORE_DATA_URL
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
-    WorkflowEngineDetectorSerializer,
-)
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
@@ -224,20 +221,17 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 
         assert resp.data == serialize(self.alert_rule, serializer=DetailedAlertRuleSerializer())
 
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:incidents")
     def test_workflow_engine_serializer(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
 
         ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
         self.detector = Detector.objects.get(id=ard.detector_id)
+        fake_detector_id = get_fake_id_from_object_id(self.detector.id)
 
-        with (
-            self.feature("organizations:incidents"),
-            self.feature("organizations:workflow-engine-rule-serializers"),
-        ):
-            resp = self.get_success_response(self.organization.slug, self.alert_rule.id)
-
-        assert resp.data == serialize(self.detector, serializer=WorkflowEngineDetectorSerializer())
+        self.get_error_response(self.organization.slug, fake_detector_id, status_code=400)
 
     def test_aggregate_translation(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
@@ -788,33 +782,18 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         alert_rule.refresh_from_db()
         assert alert_rule.snuba_query.aggregate == original_aggregate  # Still upsampled_count()
 
+    @with_feature("organizations:incidents")
+    @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_serializer(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
 
         ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
         self.detector = Detector.objects.get(id=ard.detector_id)
+        fake_detector_id = get_fake_id_from_object_id(self.detector.id)
 
-        alert_rule = self.alert_rule
-        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
-        serialized_alert_rule = self.get_serialized_alert_rule()
-        serialized_alert_rule["name"] = "what"
-
-        with (
-            self.feature("organizations:incidents"),
-            self.feature("organizations:workflow-engine-rule-serializers"),
-            outbox_runner(),
-        ):
-            resp = self.get_success_response(
-                self.organization.slug, alert_rule.id, **serialized_alert_rule
-            )
-
-        alert_rule.name = "what"
-        alert_rule.date_modified = resp.data["dateModified"]
-        detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-        assert resp.data == serialize(detector, serializer=WorkflowEngineDetectorSerializer())
-        assert resp.data["name"] == "what"
-        assert resp.data["dateModified"] > serialized_alert_rule["dateModified"]
+        with outbox_runner():
+            self.get_error_response(self.organization.slug, fake_detector_id, status_code=400)
 
     def test_not_updated_fields(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -29,6 +29,7 @@ from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     WorkflowEngineDetectorSerializer,
 )
+from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
     AlertRule,
@@ -2423,9 +2424,9 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
         )
         self.login_as(self.user)
 
-        detector = self.create_detector(project=self.project)
+        detector = self.create_detector(project=self.project, type=MetricIssue.slug)
         fake_detector_id = get_fake_id_from_object_id(detector.id)
-        self.get_success_response(self.organization.slug, fake_detector_id, status_code=202)
+        self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
 
         # Detector.objects excludes PENDING_DELETION, so the detector not appearing here confirms
         # it was scheduled for deletion.


### PR DESCRIPTION
Make the delete an alert rule method backwards compatible by accepting a detector ID and using the `OrganizationDetectorDetailsEndpoint` delete strategy. This also implements a new base class and `convert_args` to look up either a detector or an alert rule, and removes some old code using the feature flag from before we needed this to work in the UI. For now, this just makes the other methods fail if a detector is passed in. 