### PR TITLE
impr(workflow engine): Bump caching TTL for subscription processor to 20 mins

### DIFF
--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -4,7 +4,7 @@ from sentry.utils import metrics
 from sentry.workflow_engine.caches import CacheMapping
 from sentry.workflow_engine.models.detector import Detector
 
-CACHE_TTL = 60 * 3  # 3 minutes
+CACHE_TTL = 60 * 20  # 20 minutes
 
 
 class _DetectorCacheKey(NamedTuple):


### PR DESCRIPTION
Currently our [% Cache hit is approximately 60-70%](https://app.datadoghq.com/dashboard/ccd-cnh-4c7/workflow-engine?fromUser=true&refresh_mode=sliding&from_ts=1772576903887&to_ts=1772578703887&live=true) for bulk_query_detectors going through the subscr processor. We think it's because the cache ttl is only like 3 minutes so we miss out on a p. big chunk of processes that may run less often. So let's bump up the ttl