### PR TITLE
ci(warden): Add WARDEN_SENTRY_DSN env var to workflow

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Pass the Sentry DSN to Warden so errors during PR reviews are reported
to Sentry, matching the warden repo's own workflow config.

The `WARDEN_SENTRY_DSN` secret needs to be configured in the repo's
GitHub settings for this to take effect.


Agent transcript: https://claudescope.sentry.dev/share/FqUkwyidXcZDuBZWF8lmHj_uUXjgBMyr_BH3FXbhaH0