### PR TITLE
meta: update frontend onboarding/platform codeowners to value-discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -512,11 +512,11 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/ai_agent_monitoring.py                                         @getsentry/telemetry-experience
 /tests/sentry/tasks/test_ai_agent_monitoring.py                                  @getsentry/telemetry-experience
 /static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
-/static/app/data/platformCategories.tsx                                          @getsentry/telemetry-experience
-/static/app/data/platformPickerCategories.tsx                                    @getsentry/telemetry-experience
-/static/app/data/platforms.tsx                                                   @getsentry/telemetry-experience
-/static/app/gettingStartedDocs/                                                  @getsentry/telemetry-experience
-/static/app/types/project.tsx                                                    @getsentry/telemetry-experience
+/static/app/data/platformCategories.tsx                                          @getsentry/value-discovery
+/static/app/data/platformPickerCategories.tsx                                    @getsentry/value-discovery
+/static/app/data/platforms.tsx                                                   @getsentry/value-discovery
+/static/app/gettingStartedDocs/                                                  @getsentry/value-discovery
+/static/app/types/project.tsx                                                    @getsentry/value-discovery
 /static/app/views/settings/dynamicSampling/                                      @getsentry/telemetry-experience
 /static/app/views/insights/pages/agents/                                         @getsentry/telemetry-experience
 /static/app/views/insights/pages/mcp/                                            @getsentry/telemetry-experience

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -512,17 +512,20 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/ai_agent_monitoring.py                                         @getsentry/telemetry-experience
 /tests/sentry/tasks/test_ai_agent_monitoring.py                                  @getsentry/telemetry-experience
 /static/app/actionCreators/metrics.tsx                                           @getsentry/telemetry-experience
-/static/app/data/platformCategories.tsx                                          @getsentry/value-discovery
-/static/app/data/platformPickerCategories.tsx                                    @getsentry/value-discovery
-/static/app/data/platforms.tsx                                                   @getsentry/value-discovery
-/static/app/gettingStartedDocs/                                                  @getsentry/value-discovery
-/static/app/types/project.tsx                                                    @getsentry/value-discovery
 /static/app/views/settings/dynamicSampling/                                      @getsentry/telemetry-experience
 /static/app/views/insights/pages/agents/                                         @getsentry/telemetry-experience
 /static/app/views/insights/pages/mcp/                                            @getsentry/telemetry-experience
 /static/app/views/insights/pages/platform/                                       @getsentry/telemetry-experience
 /static/app/views/insights/pages/conversations/                                  @getsentry/telemetry-experience
 ## End of Telemetry Experience
+
+## Value Discovery
+/static/app/data/platformCategories.tsx                                          @getsentry/value-discovery
+/static/app/data/platformPickerCategories.tsx                                    @getsentry/value-discovery
+/static/app/data/platforms.tsx                                                   @getsentry/value-discovery
+/static/app/gettingStartedDocs/                                                  @getsentry/value-discovery
+/static/app/types/project.tsx                                                    @getsentry/value-discovery
+## End of Value Discovery
 
 ## ML & AI
 /static/app/components/events/autofix/                      @getsentry/machine-learning-ai


### PR DESCRIPTION
Transfer ownership of frontend onboarding and platform-related files from `telemetry-experience` to `value-discovery` team.

Paths updated in CODEOWNERS:
- `static/app/gettingStartedDocs/`
- `static/app/data/platforms.tsx`
- `static/app/data/platformCategories.tsx`
- `static/app/data/platformPickerCategories.tsx`
- `static/app/types/project.tsx`