### PR TITLE
meta: update onboarding endpoint owners to value-discovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -544,11 +544,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/helpers/group_index/                        @getsentry/issue-workflow
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issue-workflow
 /src/sentry/api/endpoints/                                  @getsentry/issue-workflow
-## Value Discovery
-/src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
-/src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
-/src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
-## End of Value Discovery
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend
@@ -630,6 +625,13 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/sentry/tasks/test_llm_issue_detection.py             @getsentry/issue-detection-backend
 /tests/snuba/search/                                        @getsentry/issue-workflow
 ## End of Issues
+
+## Value Discovery
+# These must come after /src/sentry/api/endpoints/ catch-all above
+/src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
+/src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
+/src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
+## End of Value Discovery
 
 ## AI Conversations (Telemetry Experience)
 # These must come after /src/sentry/api/endpoints/ catch-all above

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -524,12 +524,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/insights/pages/conversations/                                  @getsentry/telemetry-experience
 ## End of Telemetry Experience
 
-## Value Discovery
-/src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
-/src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
-/src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
-## End of Value Discovery
-
 ## ML & AI
 /static/app/components/events/autofix/                      @getsentry/machine-learning-ai
 /static/app/views/seerExplorer/                             @getsentry/machine-learning-ai
@@ -550,6 +544,11 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/api/helpers/group_index/                        @getsentry/issue-workflow
 /src/sentry/api/helpers/source_map_helper.py                @getsentry/issue-workflow
 /src/sentry/api/endpoints/                                  @getsentry/issue-workflow
+## Value Discovery
+/src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
+/src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
+/src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
+## End of Value Discovery
 /src/sentry/api/helpers/group_index/delete.py               @getsentry/issue-detection-backend
 /src/sentry/deletions/defaults/group.py                     @getsentry/issue-detection-backend
 /src/sentry/deletions/tasks/groups.py                       @getsentry/issue-detection-backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -626,12 +626,12 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /tests/snuba/search/                                        @getsentry/issue-workflow
 ## End of Issues
 
-## Value Discovery
+## Onboarding (Value Discovery)
 # These must come after /src/sentry/api/endpoints/ catch-all above
 /src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
 /src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
 /src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
-## End of Value Discovery
+## End of Onboarding
 
 ## AI Conversations (Telemetry Experience)
 # These must come after /src/sentry/api/endpoints/ catch-all above

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -524,6 +524,12 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/insights/pages/conversations/                                  @getsentry/telemetry-experience
 ## End of Telemetry Experience
 
+## Value Discovery
+/src/sentry/api/endpoints/organization_onboarding_tasks.py                       @getsentry/value-discovery
+/src/sentry/api/endpoints/organization_onboarding_continuation_email.py          @getsentry/value-discovery
+/src/sentry/api/endpoints/project_create_sample.py                               @getsentry/value-discovery
+## End of Value Discovery
+
 ## ML & AI
 /static/app/components/events/autofix/                      @getsentry/machine-learning-ai
 /static/app/views/seerExplorer/                             @getsentry/machine-learning-ai

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -35,4 +35,5 @@ class ApiOwner(Enum):
     SECURITY = "security"
     TELEMETRY_EXPERIENCE = "telemetry-experience"
     UNOWNED = "unowned"
+    VALUE_DISCOVERY = "value-discovery"
     WEB_FRONTEND_SDKS = "team-javascript-sdks"

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -50,7 +50,7 @@ class OrganizationOnboardingContinuationEmail(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.VALUE_DISCOVERY
     permission_classes = (OnboardingContinuationPermission,)
 
     def post(self, request: Request, organization: Organization):

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -23,7 +23,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         "POST": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.VALUE_DISCOVERY
     permission_classes = (OnboardingTaskPermission,)
 
     def post(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/project_create_sample.py
+++ b/src/sentry/api/endpoints/project_create_sample.py
@@ -22,7 +22,7 @@ class ProjectCreateSampleEndpoint(ProjectEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PRIVATE,
     }
-    owner = ApiOwner.TELEMETRY_EXPERIENCE
+    owner = ApiOwner.VALUE_DISCOVERY
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.
     permission_classes = (ProjectEventPermission,)


### PR DESCRIPTION
Add `VALUE_DISCOVERY` to the `ApiOwner` enum and transfer ownership of onboarding-related endpoints from `TELEMETRY_EXPERIENCE` to `VALUE_DISCOVERY`.

Endpoints updated:
- `organization_onboarding_tasks.py`
- `organization_onboarding_continuation_email.py`
- `project_create_sample.py`