### PR TITLE
fix(objectstore): Use OrganizationReleasePermission for Objectstore endpoint

### DIFF
--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -25,6 +25,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationReleasePermission
 from sentry.models.organization import Organization
 from sentry.objectstore import parse_accept_encoding
 
@@ -38,6 +39,7 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.FOUNDATIONAL_STORAGE
+    permission_classes = (OrganizationReleasePermission,)
     parser_classes = ()  # don't attempt to parse request data, so we can access the raw body in wsgi.input
 
     def _check_flag(self, request: Request, organization: Organization) -> Response | None:

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -40,7 +40,7 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         self.organization = self.create_organization(owner=self.user)
         self.api_key = self.create_api_key(
             organization=self.organization,
-            scope_list=["org:admin"],
+            scope_list=["project:releases"],
         )
 
     def get_endpoint_url(self) -> str:
@@ -177,7 +177,7 @@ class OrganizationObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
         self.organization = self.create_organization(owner=self.user)
         self.api_key = self.create_api_key(
             organization=self.organization,
-            scope_list=["org:admin"],
+            scope_list=["project:releases"],
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Use `OrganizationReleasePermission` instead of the default `OrganizationPermission` for the objectstore proxy endpoint.

The default `OrganizationPermission` requires `org:write`/`org:admin` scopes, which is too restrictive for a file upload/download endpoint. CI tools and sentry-cli typically authenticate with `project:releases` or `org:ci` tokens, which would be rejected. All other comparable endpoints (ChunkUpload, ArtifactBundles, ArtifactLookup, debug files) use `OrganizationReleasePermission`, which accepts these scopes.