### PR TITLE
fix(profiling): wrap billing banner inside DescriptionWrapper

### DIFF
--- a/static/app/views/profiling/onboarding.tsx
+++ b/static/app/views/profiling/onboarding.tsx
@@ -313,8 +313,10 @@ export function Onboarding() {
   return (
     <OnboardingPanel project={project}>
       <SetupTitle project={project} />
-      {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
-      <ContinuousProfilingBillingRequirementBanner project={project} />
+      <DescriptionWrapper>
+        {introduction}
+        <ContinuousProfilingBillingRequirementBanner project={project} />
+      </DescriptionWrapper>
       <GuidedSteps>
         {steps.map((step, index) => (
           <StepRenderer
@@ -465,7 +467,7 @@ const DescriptionWrapper = styled('div')`
     color: ${p => p.theme.colors.pink500};
   }
 
-  :not(:last-child) {
+  :not(:last-child):has(*) {
     margin-bottom: ${CONTENT_SPACING};
   }
 


### PR DESCRIPTION
Move \`ContinuousProfilingBillingRequirementBanner\` inside \`DescriptionWrapper\` so it renders alongside the introduction text in the same layout container, instead of being a sibling element outside the wrapper.

Also update the \`:not(:last-child)\` CSS selector to \`:not(:last-child):has(*)\` to avoid adding bottom margin when the wrapper is empty (i.e. when there's no introduction and no banner content).

## Visual changes

| Before | After |
|--------|-------|
|<img width="1188" height="1020" alt="image" src="https://github.com/user-attachments/assets/7dcf2c6f-6ed1-4869-b468-7dbbac4fe0e2" />| <img width="1159" height="1077" alt="image" src="https://github.com/user-attachments/assets/05bc5739-3ee1-447d-b74a-a5b3d774180e" /> |