### PR TITLE
fix(preprod): Fix object key in image endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_image.py
@@ -33,11 +33,10 @@ class ProjectPreprodArtifactImageEndpoint(ProjectEndpoint):
         organization_id = project.organization_id
         project_id = project.id
 
-        object_key = f"{organization_id}/{project_id}/{image_id}"
         session = get_preprod_session(organization_id, project_id)
 
         try:
-            result = session.get(object_key)
+            result = session.get(image_id)
             # Read the entire stream at once (necessary for content_type)
             image_data = result.payload.read()
 

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_image.py
@@ -51,7 +51,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.content == png_data
         assert response["Content-Type"] == "image/png"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
-        mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
+        mock_session.get.assert_called_once_with(self.image_id)
 
     @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
     def test_successful_image_retrieval_jpeg(self, mock_get_session):
@@ -68,7 +68,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.content == jpeg_data
         assert response["Content-Type"] == "image/jpeg"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
-        mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
+        mock_session.get.assert_called_once_with(self.image_id)
 
     @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
     def test_successful_image_retrieval_webp(self, mock_get_session):
@@ -85,7 +85,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.content == webp_data
         assert response["Content-Type"] == "image/webp"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
-        mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
+        mock_session.get.assert_called_once_with(self.image_id)
 
     @patch("sentry.preprod.api.endpoints.project_preprod_artifact_image.get_preprod_session")
     def test_unknown_image_format(self, mock_get_session):
@@ -102,7 +102,7 @@ class ProjectPreprodArtifactImageTest(APITestCase):
         assert response.content == unknown_data
         assert response["Content-Type"] == "application/octet-stream"
         mock_get_session.assert_called_once_with(self.org.id, self.project.id)
-        mock_session.get.assert_called_once_with(f"{self.org.id}/{self.project.id}/{self.image_id}")
+        mock_session.get.assert_called_once_with(self.image_id)
 
     def test_endpoint_requires_project_access(self):
         other_user = self.create_user()


### PR DESCRIPTION
Fixes an issue in `ProjectPreprodArtifactImageEndpoint`:

**Object key**: The endpoint was constructing the objectstore key as `{org_id}/{project_id}/{image_id}`, but `get_preprod_session()` already includes usecase, org and project as part of the URL. The previous construction caused all lookups from the frontend to fail with 404 as they resulted in invalid URLs (org and project ID were included both as scopes and part of the object key itself in the resulting objectstore URL)
This makes it consistent with the object key used by sentry-cli on latest master.

Haven't tested this locally, ideally you can confirm this works.