### PR TITLE
feat(dashboards): reuse explore confidence footers in dashboard widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -616,7 +616,11 @@ function WidgetViewerModal(props: Props) {
               }}
               noPadding
               widgetLegendState={widgetLegendState}
-              showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+              showConfidenceWarning={
+                widget.widgetType === WidgetType.SPANS ||
+                widget.widgetType === WidgetType.LOGS ||
+                widget.widgetType === WidgetType.TRACEMETRICS
+              }
               widgetInterval={widgetInterval}
             />
           </Container>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -132,7 +132,11 @@ function WidgetPreview({
       onWidgetSplitDecision={() => {}}
       // onWidgetSplitDecision={onWidgetSplitDecision}
       tableItemLimit={widget.limit}
-      showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+      showConfidenceWarning={
+        widget.widgetType === WidgetType.SPANS ||
+        widget.widgetType === WidgetType.LOGS ||
+        widget.widgetType === WidgetType.TRACEMETRICS
+      }
       // ensure table columns are at least a certain width (helps with lack of truncation on large fields)
       minTableColumnWidth={MIN_TABLE_COLUMN_WIDTH_PX}
       disableZoom

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -28,6 +28,8 @@ import type {
   EChartLegendSelectChangeHandler,
   ECharts,
   ReactEchartsRef,
+  Series,
+  SeriesDataUnit,
 } from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -83,6 +85,7 @@ import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/setti
 import type {
   TabularColumn,
   TabularData,
+  TimeSeries,
 } from 'sentry/views/dashboards/widgets/common/types';
 import {DetailsWidgetVisualization} from 'sentry/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
@@ -499,8 +502,9 @@ function WidgetCardChart(props: WidgetCardChartProps) {
 
   const isTopN =
     defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
-  const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopN);
-  const footerConfidence = confidence ?? combineConfidenceForSeries(series);
+  const footerSeries = toFooterTimeSeries(series, dataScanned);
+  const samplingMeta = determineSeriesSampleCountAndIsSampled(footerSeries, isTopN);
+  const footerConfidence = confidence ?? combineConfidenceForSeries(footerSeries);
   const footerSampleCount = defined(sampleCount) ? sampleCount : samplingMeta.sampleCount;
   const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta.isSampled;
   const footerDataScanned = dataScanned ?? samplingMeta.dataScanned;
@@ -512,7 +516,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
       ?.conditions ?? '';
   const footerChartInfo: ChartInfo = {
     chartType: getExploreChartType(widget.displayType),
-    series,
+    series: footerSeries,
     timeseriesResult: {isPending: loading} as ChartInfo['timeseriesResult'],
     yAxis: axisLabel,
     confidence: footerConfidence,
@@ -925,6 +929,50 @@ function WheelComponent(props: TableComponentProps): React.ReactNode {
       selection={props.selection}
     />
   );
+}
+
+function toFooterTimeSeries(
+  series: Array<Series & {fieldName?: string}>,
+  dataScanned?: 'full' | 'partial'
+): TimeSeries[] {
+  return series.map((seriesEntry, seriesIndex) => {
+    const values = seriesEntry.data.map((datum, pointIndex) => {
+      const samplingDatum = datum as SeriesDataUnit & {
+        confidence?: Confidence;
+        sampleCount?: number | null;
+        sampleRate?: number | null;
+      };
+
+      const numericTimestamp =
+        typeof samplingDatum.name === 'number'
+          ? samplingDatum.name
+          : new Date(samplingDatum.name).getTime();
+
+      return {
+        timestamp: Number.isFinite(numericTimestamp)
+          ? numericTimestamp
+          : seriesIndex * 1000 + pointIndex,
+        value: samplingDatum.value,
+        confidence: samplingDatum.confidence,
+        sampleCount: samplingDatum.sampleCount,
+        sampleRate: samplingDatum.sampleRate,
+      };
+    });
+
+    const interval =
+      values.length >= 2 ? Math.max(0, values[1]!.timestamp - values[0]!.timestamp) : 0;
+
+    return {
+      yAxis: seriesEntry.seriesName,
+      values,
+      meta: {
+        interval,
+        valueType: 'number',
+        valueUnit: null,
+        dataScanned,
+      },
+    };
+  });
 }
 
 function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -28,8 +28,6 @@ import type {
   EChartLegendSelectChangeHandler,
   ECharts,
   ReactEchartsRef,
-  Series,
-  SeriesDataUnit,
 } from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -62,7 +60,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {useTrackAnalyticsOnSpanMigrationError} from 'sentry/views/dashboards/hooks/useTrackAnalyticsOnSpanMigrationError';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -85,7 +82,6 @@ import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/setti
 import type {
   TabularColumn,
   TabularData,
-  TimeSeries,
 } from 'sentry/views/dashboards/widgets/common/types';
 import {DetailsWidgetVisualization} from 'sentry/views/dashboards/widgets/detailsWidget/detailsWidgetVisualization';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
@@ -100,15 +96,10 @@ import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
-import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
-import {ConfidenceFooter as LogsConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
-import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
-import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
-import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
-import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
 import {useWidgetRawCounts} from './hooks/useWidgetRawCounts';
+import {WidgetCardConfidenceFooter} from './confidenceFooter';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 const OTHER = 'Other';
@@ -485,86 +476,6 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     }
   };
 
-  // Excluding Other uses a slightly altered regex to match the Other series name
-  // because the series names are formatted with widget IDs to avoid conflicts
-  // when deactivating them across widgets
-  const topEventsCountExcludingOther =
-    timeseriesResults?.length && widget.queries[0]?.columns.length
-      ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
-        (timeseriesResults?.some(
-          ({seriesName}) =>
-            shouldColorOther ||
-            seriesName?.match(new RegExp(`(?:.* : ${OTHER};)|^${OTHER};`))
-        )
-          ? 1
-          : 0)
-      : undefined;
-
-  const isTopN =
-    defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
-  const footerSeries = toFooterTimeSeries(series, dataScanned);
-  const samplingMeta = hasSeriesSamplingMetadata(footerSeries)
-    ? determineSeriesSampleCountAndIsSampled(footerSeries, isTopN)
-    : undefined;
-  const footerConfidence = confidence ?? combineConfidenceForSeries(footerSeries);
-  const footerSampleCount = defined(sampleCount)
-    ? sampleCount
-    : samplingMeta?.sampleCount;
-  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta?.isSampled;
-  const footerDataScanned = dataScanned ?? samplingMeta?.dataScanned;
-  const hasUserQuery = widget.queries.some(
-    query => (query.conditions ?? '').trim().length > 0
-  );
-  const userQuery =
-    widget.queries.find(query => (query.conditions ?? '').trim().length > 0)
-      ?.conditions ?? '';
-  const footerChartInfo: ChartInfo = {
-    chartType: getExploreChartType(widget.displayType),
-    series: footerSeries,
-    timeseriesResult: {isPending: loading} as ChartInfo['timeseriesResult'],
-    yAxis: axisLabel,
-    confidence: footerConfidence,
-    dataScanned: footerDataScanned,
-    isSampled: footerIsSampled,
-    sampleCount: footerSampleCount,
-    topEvents: topEventsCountExcludingOther,
-  };
-
-  let confidenceFooter: React.ReactNode = null;
-  if (showConfidenceWarning) {
-    if (widget.widgetType === WidgetType.SPANS) {
-      confidenceFooter = (
-        <SpansConfidenceFooter
-          confidence={footerChartInfo.confidence}
-          dataScanned={footerChartInfo.dataScanned}
-          isSampled={footerChartInfo.isSampled}
-          isLoading={loading}
-          rawSpanCounts={rawCounts ?? undefined}
-          sampleCount={footerChartInfo.sampleCount}
-          topEvents={footerChartInfo.topEvents}
-          userQuery={userQuery}
-        />
-      );
-    } else if (widget.widgetType === WidgetType.LOGS && rawCounts) {
-      confidenceFooter = (
-        <LogsConfidenceFooter
-          chartInfo={footerChartInfo}
-          hasUserQuery={hasUserQuery}
-          isLoading={loading}
-          rawLogCounts={rawCounts}
-        />
-      );
-    } else if (widget.widgetType === WidgetType.TRACEMETRICS && rawCounts) {
-      confidenceFooter = (
-        <MetricsConfidenceFooter
-          chartInfo={footerChartInfo}
-          hasUserQuery={hasUserQuery}
-          isLoading={loading}
-          rawMetricCounts={rawCounts}
-        />
-      );
-    }
-  }
   return (
     <ChartZoom period={period} start={start} end={end} utc={utc} disabled={disableZoom}>
       {zoomRenderProps => {
@@ -632,7 +543,21 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                       })}
                     </RenderedChartContainer>
 
-                    {confidenceFooter}
+                    <WidgetCardConfidenceFooter
+                      confidence={confidence}
+                      dataScanned={dataScanned}
+                      isSampled={isSampled}
+                      other={OTHER}
+                      loading={loading}
+                      rawCounts={rawCounts}
+                      sampleCount={sampleCount}
+                      series={series}
+                      shouldColorOther={shouldColorOther}
+                      showConfidenceWarning={showConfidenceWarning}
+                      timeseriesResults={timeseriesResults}
+                      widget={widget}
+                      yAxis={axisLabel}
+                    />
                   </ChartWrapper>
                 </TransitionChart>
               );
@@ -935,60 +860,6 @@ function WheelComponent(props: TableComponentProps): React.ReactNode {
   );
 }
 
-function toFooterTimeSeries(
-  series: Array<Series & {fieldName?: string}>,
-  dataScanned?: 'full' | 'partial'
-): TimeSeries[] {
-  return series.map((seriesEntry, seriesIndex) => {
-    const values = seriesEntry.data.map((datum, pointIndex) => {
-      const samplingDatum = datum as SeriesDataUnit & {
-        confidence?: Confidence;
-        sampleCount?: number | null;
-        sampleRate?: number | null;
-      };
-
-      const numericTimestamp =
-        typeof samplingDatum.name === 'number'
-          ? samplingDatum.name
-          : new Date(samplingDatum.name).getTime();
-
-      return {
-        timestamp: Number.isFinite(numericTimestamp)
-          ? numericTimestamp
-          : seriesIndex * 1000 + pointIndex,
-        value: samplingDatum.value,
-        confidence: samplingDatum.confidence,
-        sampleCount: samplingDatum.sampleCount,
-        sampleRate: samplingDatum.sampleRate,
-      };
-    });
-
-    const interval =
-      values.length >= 2 ? Math.max(0, values[1]!.timestamp - values[0]!.timestamp) : 0;
-
-    return {
-      yAxis: seriesEntry.seriesName,
-      values,
-      meta: {
-        interval,
-        valueType: 'number',
-        valueUnit: null,
-        dataScanned,
-      },
-    };
-  });
-}
-
-function hasSeriesSamplingMetadata(series: TimeSeries[]): boolean {
-  return series.some(
-    seriesEntry =>
-      defined(seriesEntry.meta.dataScanned) ||
-      seriesEntry.values.some(
-        value => defined(value.sampleCount) || defined(value.sampleRate)
-      )
-  );
-}
-
 function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {
   const stacked = widget.queries[0]?.columns.length! > 0;
 
@@ -1001,19 +872,6 @@ function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {
     case 'line':
     default:
       return <LineChart {...chartProps} />;
-  }
-}
-
-function getExploreChartType(displayType: DisplayType): ChartType {
-  switch (displayType) {
-    case DisplayType.BAR:
-      return ChartType.BAR;
-    case DisplayType.AREA:
-    case DisplayType.TOP_N:
-      return ChartType.AREA;
-    case DisplayType.LINE:
-    default:
-      return ChartType.LINE;
   }
 }
 

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -60,6 +60,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {getDatasetConfig} from 'sentry/views/dashboards/datasetConfig/base';
 import {useTrackAnalyticsOnSpanMigrationError} from 'sentry/views/dashboards/hooks/useTrackAnalyticsOnSpanMigrationError';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -96,9 +97,15 @@ import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
-import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
+import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ConfidenceFooter as LogsConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
+import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
+import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
+import {useWidgetRawCounts} from './hooks/useWidgetRawCounts';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 const OTHER = 'Other';
@@ -122,6 +129,7 @@ type WidgetCardChartProps = Pick<GenericWidgetQueriesResult, 'timeseriesResults'
     widgetLegendState: WidgetLegendSelectionState;
     chartGroup?: string;
     confidence?: Confidence;
+    dataScanned?: 'full' | 'partial';
     disableZoom?: boolean;
     isMobile?: boolean;
     isSampled?: boolean | null;
@@ -155,6 +163,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     timeseriesResultsTypes,
     shouldResize,
     confidence,
+    dataScanned,
     showConfidenceWarning,
     sampleCount,
     isSampled,
@@ -170,6 +179,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   const chartRef = useRef<ReactEchartsRef>(null);
   const location = useLocation();
   const theme = useTheme();
+  const rawCounts = useWidgetRawCounts({selection, widget});
 
   useTrackAnalyticsOnSpanMigrationError({errorMessage, widget, loading});
 
@@ -486,6 +496,67 @@ function WidgetCardChart(props: WidgetCardChartProps) {
           ? 1
           : 0)
       : undefined;
+
+  const isTopN =
+    defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
+  const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopN);
+  const footerConfidence = confidence ?? combineConfidenceForSeries(series);
+  const footerSampleCount = defined(sampleCount) ? sampleCount : samplingMeta.sampleCount;
+  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta.isSampled;
+  const footerDataScanned = dataScanned ?? samplingMeta.dataScanned;
+  const hasUserQuery = widget.queries.some(
+    query => (query.conditions ?? '').trim().length > 0
+  );
+  const userQuery =
+    widget.queries.find(query => (query.conditions ?? '').trim().length > 0)
+      ?.conditions ?? '';
+  const footerChartInfo: ChartInfo = {
+    chartType: getExploreChartType(widget.displayType),
+    series,
+    timeseriesResult: {isPending: loading} as ChartInfo['timeseriesResult'],
+    yAxis: axisLabel,
+    confidence: footerConfidence,
+    dataScanned: footerDataScanned,
+    isSampled: footerIsSampled,
+    sampleCount: footerSampleCount,
+    topEvents: topEventsCountExcludingOther,
+  };
+
+  let confidenceFooter: React.ReactNode = null;
+  if (showConfidenceWarning) {
+    if (widget.widgetType === WidgetType.SPANS) {
+      confidenceFooter = (
+        <SpansConfidenceFooter
+          confidence={footerChartInfo.confidence}
+          dataScanned={footerChartInfo.dataScanned}
+          isSampled={footerChartInfo.isSampled}
+          isLoading={loading}
+          rawSpanCounts={rawCounts ?? undefined}
+          sampleCount={footerChartInfo.sampleCount}
+          topEvents={footerChartInfo.topEvents}
+          userQuery={userQuery}
+        />
+      );
+    } else if (widget.widgetType === WidgetType.LOGS && rawCounts) {
+      confidenceFooter = (
+        <LogsConfidenceFooter
+          chartInfo={footerChartInfo}
+          hasUserQuery={hasUserQuery}
+          isLoading={loading}
+          rawLogCounts={rawCounts}
+        />
+      );
+    } else if (widget.widgetType === WidgetType.TRACEMETRICS && rawCounts) {
+      confidenceFooter = (
+        <MetricsConfidenceFooter
+          chartInfo={footerChartInfo}
+          hasUserQuery={hasUserQuery}
+          isLoading={loading}
+          rawMetricCounts={rawCounts}
+        />
+      );
+    }
+  }
   return (
     <ChartZoom period={period} start={start} end={end} utc={utc} disabled={disableZoom}>
       {zoomRenderProps => {
@@ -553,14 +624,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                       })}
                     </RenderedChartContainer>
 
-                    {showConfidenceWarning && confidence && (
-                      <ConfidenceFooter
-                        confidence={confidence}
-                        sampleCount={sampleCount}
-                        topEvents={topEventsCountExcludingOther}
-                        isSampled={isSampled}
-                      />
-                    )}
+                    {confidenceFooter}
                   </ChartWrapper>
                 </TransitionChart>
               );
@@ -875,6 +939,19 @@ function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {
     case 'line':
     default:
       return <LineChart {...chartProps} />;
+  }
+}
+
+function getExploreChartType(displayType: DisplayType): ChartType {
+  switch (displayType) {
+    case DisplayType.BAR:
+      return ChartType.BAR;
+    case DisplayType.AREA:
+    case DisplayType.TOP_N:
+      return ChartType.AREA;
+    case DisplayType.LINE:
+    default:
+      return ChartType.LINE;
   }
 }
 

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -548,6 +548,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                       other={OTHER}
                       loading={loading}
                       sampleCount={sampleCount}
+                      selection={selection}
                       series={series}
                       shouldColorOther={shouldColorOther}
                       showConfidenceWarning={showConfidenceWarning}

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -503,11 +503,15 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   const isTopN =
     defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
   const footerSeries = toFooterTimeSeries(series, dataScanned);
-  const samplingMeta = determineSeriesSampleCountAndIsSampled(footerSeries, isTopN);
+  const samplingMeta = hasSeriesSamplingMetadata(footerSeries)
+    ? determineSeriesSampleCountAndIsSampled(footerSeries, isTopN)
+    : undefined;
   const footerConfidence = confidence ?? combineConfidenceForSeries(footerSeries);
-  const footerSampleCount = defined(sampleCount) ? sampleCount : samplingMeta.sampleCount;
-  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta.isSampled;
-  const footerDataScanned = dataScanned ?? samplingMeta.dataScanned;
+  const footerSampleCount = defined(sampleCount)
+    ? sampleCount
+    : samplingMeta?.sampleCount;
+  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta?.isSampled;
+  const footerDataScanned = dataScanned ?? samplingMeta?.dataScanned;
   const hasUserQuery = widget.queries.some(
     query => (query.conditions ?? '').trim().length > 0
   );
@@ -973,6 +977,16 @@ function toFooterTimeSeries(
       },
     };
   });
+}
+
+function hasSeriesSamplingMetadata(series: TimeSeries[]): boolean {
+  return series.some(
+    seriesEntry =>
+      defined(seriesEntry.meta.dataScanned) ||
+      seriesEntry.values.some(
+        value => defined(value.sampleCount) || defined(value.sampleRate)
+      )
+  );
 }
 
 function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -98,7 +98,6 @@ import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
-import {useWidgetRawCounts} from './hooks/useWidgetRawCounts';
 import {WidgetCardConfidenceFooter} from './confidenceFooter';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
@@ -173,7 +172,6 @@ function WidgetCardChart(props: WidgetCardChartProps) {
   const chartRef = useRef<ReactEchartsRef>(null);
   const location = useLocation();
   const theme = useTheme();
-  const rawCounts = useWidgetRawCounts({selection, widget});
 
   useTrackAnalyticsOnSpanMigrationError({errorMessage, widget, loading});
 
@@ -549,7 +547,6 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                       isSampled={isSampled}
                       other={OTHER}
                       loading={loading}
-                      rawCounts={rawCounts}
                       sampleCount={sampleCount}
                       series={series}
                       shouldColorOther={shouldColorOther}

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -1,20 +1,18 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import PageFiltersStore from 'sentry/components/pageFilters/store';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
-import type {RawCounts} from 'sentry/views/explore/useRawCounts';
 
 import {WidgetCardConfidenceFooter} from './confidenceFooter';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 describe('WidgetCardConfidenceFooter', () => {
-  const rawCounts: RawCounts = {
-    normal: {count: 120, isLoading: false},
-    highAccuracy: {count: 500, isLoading: false},
-  };
+  const selection = PageFiltersFixture();
 
   const series: Array<Series & {fieldName?: string}> = [
     {
@@ -48,12 +46,25 @@ describe('WidgetCardConfidenceFooter', () => {
     {seriesName: 'series-b'},
   ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
 
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
   it('does not render when confidence warning is disabled', () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 0}]},
+    });
+
     render(
       <WidgetCardConfidenceFooter
         loading={false}
         other="Other"
-        rawCounts={null}
         series={series}
         showConfidenceWarning={false}
         timeseriesResults={timeseriesResults}
@@ -71,11 +82,21 @@ describe('WidgetCardConfidenceFooter', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders spans footer with user query and top event metadata', () => {
+  it('renders spans footer with user query and top event metadata', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'spans'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 500}]},
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
+    });
+
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        rawCounts={null}
         series={series}
         showConfidenceWarning
         shouldColorOther={false}
@@ -96,26 +117,24 @@ describe('WidgetCardConfidenceFooter', () => {
       />
     );
 
-    const footer = screen.getByText(/Estimated for top 2 groups from/i);
-    expect(footer).toHaveTextContent('18 spans');
+    const footer = await screen.findByText(/Estimated for top 2 groups from/i);
+    expect(footer).toHaveTextContent('18 matches');
+    expect(footer).toHaveTextContent('500 spans');
   });
 
-  it('does not render logs footer when raw counts are missing', () => {
-    const widget = WidgetFixture({
-      displayType: DisplayType.LINE,
-      widgetType: WidgetType.LOGS,
-      queries: [WidgetQueryFixture()],
-    });
-
+  it('does not render footer for unsupported widget types', () => {
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        rawCounts={null}
         other="Other"
         series={series}
         showConfidenceWarning
         timeseriesResults={timeseriesResults}
-        widget={widget}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.ERRORS,
+          queries: [WidgetQueryFixture()],
+        })}
         yAxis="count()"
       />
     );
@@ -123,75 +142,81 @@ describe('WidgetCardConfidenceFooter', () => {
     expect(screen.queryByText(/Estimated from/i)).not.toBeInTheDocument();
   });
 
-  it('renders logs footer when raw counts are present', () => {
-    const widget = WidgetFixture({
-      displayType: DisplayType.LINE,
-      widgetType: WidgetType.LOGS,
-      queries: [WidgetQueryFixture()],
+  it('renders logs footer with raw counts from API', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(message)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'ourlogs'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(message)': 500}]},
+      match: [
+        MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'ourlogs'}),
+      ],
     });
 
     render(
       <WidgetCardConfidenceFooter
         loading={false}
         other="Other"
-        rawCounts={rawCounts}
         series={series}
         showConfidenceWarning
         timeseriesResults={timeseriesResults}
-        widget={widget}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.LOGS,
+          queries: [WidgetQueryFixture()],
+        })}
         yAxis="count()"
       />
     );
 
-    const footer = screen.getByText(/Estimated from/i);
+    const footer = await screen.findByText(/Estimated from/i);
     expect(footer).toHaveTextContent('10 matches');
     expect(footer).toHaveTextContent('500 logs');
   });
 
-  it('does not render metrics footer when raw counts are missing', () => {
-    const widget = WidgetFixture({
-      displayType: DisplayType.LINE,
-      widgetType: WidgetType.TRACEMETRICS,
-      queries: [WidgetQueryFixture()],
+  it('renders metrics footer with raw counts from API', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'tracemetrics'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 500}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'HIGHEST_ACCURACY',
+          dataset: 'tracemetrics',
+        }),
+      ],
     });
 
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        rawCounts={null}
         other="Other"
         series={series}
         showConfidenceWarning
         timeseriesResults={timeseriesResults}
-        widget={widget}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.TRACEMETRICS,
+          queries: [
+            WidgetQueryFixture({
+              aggregates: ['avg(value,duration,d,-)'],
+              fields: ['avg(value,duration,d,-)'],
+              columns: [],
+            }),
+          ],
+        })}
         yAxis="count()"
       />
     );
 
-    expect(screen.queryByText(/Estimated from/i)).not.toBeInTheDocument();
-  });
-
-  it('renders metrics footer when raw counts are present', () => {
-    const widget = WidgetFixture({
-      displayType: DisplayType.LINE,
-      widgetType: WidgetType.TRACEMETRICS,
-      queries: [WidgetQueryFixture()],
-    });
-
-    render(
-      <WidgetCardConfidenceFooter
-        loading={false}
-        rawCounts={rawCounts}
-        other="Other"
-        series={series}
-        showConfidenceWarning
-        timeseriesResults={timeseriesResults}
-        widget={widget}
-        yAxis="count()"
-      />
-    );
-
-    const footer = screen.getByText(/Estimated from/i);
+    const footer = await screen.findByText(/Estimated from/i);
     expect(footer).toHaveTextContent('10 matches');
     expect(footer).toHaveTextContent('500 data points');
   });

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -1,0 +1,198 @@
+import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+import type {RawCounts} from 'sentry/views/explore/useRawCounts';
+
+import {WidgetCardConfidenceFooter} from './confidenceFooter';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+
+describe('WidgetCardConfidenceFooter', () => {
+  const rawCounts: RawCounts = {
+    normal: {count: 120, isLoading: false},
+    highAccuracy: {count: 500, isLoading: false},
+  };
+
+  const series: Array<Series & {fieldName?: string}> = [
+    {
+      seriesName: 'series-a',
+      data: [
+        {
+          name: 1710000000000,
+          value: 10,
+          sampleCount: 10,
+          sampleRate: 0.5,
+          confidence: 'low',
+        } as SeriesDataUnit,
+      ],
+    },
+    {
+      seriesName: 'series-b',
+      data: [
+        {
+          name: 1710000060000,
+          value: 15,
+          sampleCount: 8,
+          sampleRate: 0.5,
+          confidence: 'high',
+        } as SeriesDataUnit,
+      ],
+    },
+  ];
+
+  const timeseriesResults = [
+    {seriesName: 'series-a'},
+    {seriesName: 'series-b'},
+  ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
+
+  it('does not render when confidence warning is disabled', () => {
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        rawCounts={null}
+        series={series}
+        showConfidenceWarning={false}
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.SPANS,
+          queries: [WidgetQueryFixture()],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    expect(
+      screen.queryByText(/Estimated for top 2 groups from/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders spans footer with user query and top event metadata', () => {
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        rawCounts={null}
+        series={series}
+        showConfidenceWarning
+        shouldColorOther={false}
+        other="Other"
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.SPANS,
+          queries: [
+            WidgetQueryFixture({
+              conditions: 'transaction:checkout',
+              columns: ['transaction'],
+              aggregates: ['count()'],
+            }),
+          ],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    const footer = screen.getByText(/Estimated for top 2 groups from/i);
+    expect(footer).toHaveTextContent('18 spans');
+  });
+
+  it('does not render logs footer when raw counts are missing', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.LOGS,
+      queries: [WidgetQueryFixture()],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        rawCounts={null}
+        other="Other"
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={widget}
+        yAxis="count()"
+      />
+    );
+
+    expect(screen.queryByText(/Estimated from/i)).not.toBeInTheDocument();
+  });
+
+  it('renders logs footer when raw counts are present', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.LOGS,
+      queries: [WidgetQueryFixture()],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        rawCounts={rawCounts}
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={widget}
+        yAxis="count()"
+      />
+    );
+
+    const footer = screen.getByText(/Estimated from/i);
+    expect(footer).toHaveTextContent('10 matches');
+    expect(footer).toHaveTextContent('500 logs');
+  });
+
+  it('does not render metrics footer when raw counts are missing', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [WidgetQueryFixture()],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        rawCounts={null}
+        other="Other"
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={widget}
+        yAxis="count()"
+      />
+    );
+
+    expect(screen.queryByText(/Estimated from/i)).not.toBeInTheDocument();
+  });
+
+  it('renders metrics footer when raw counts are present', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [WidgetQueryFixture()],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        rawCounts={rawCounts}
+        other="Other"
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={widget}
+        yAxis="count()"
+      />
+    );
+
+    const footer = screen.getByText(/Estimated from/i);
+    expect(footer).toHaveTextContent('10 matches');
+    expect(footer).toHaveTextContent('500 data points');
+  });
+});

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -1,3 +1,4 @@
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -8,16 +9,15 @@ import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
 import {ConfidenceFooter as LogsConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
 import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
-import type {RawCounts} from 'sentry/views/explore/useRawCounts';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
+import {useWidgetRawCounts} from './hooks/useWidgetRawCounts';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 type Props = {
   loading: boolean;
   other: 'Other';
-  rawCounts: RawCounts | null;
   series: Array<Series & {fieldName?: string}>;
   timeseriesResults: GenericWidgetQueriesResult['timeseriesResults'];
   widget: Widget;
@@ -36,7 +36,6 @@ export function WidgetCardConfidenceFooter({
   isSampled,
   loading,
   other,
-  rawCounts,
   sampleCount,
   series,
   shouldColorOther,
@@ -45,6 +44,9 @@ export function WidgetCardConfidenceFooter({
   widget,
   yAxis,
 }: Props) {
+  const {selection} = usePageFilters();
+  const rawCounts = useWidgetRawCounts({selection, widget});
+
   if (!showConfidenceWarning) {
     return null;
   }

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -1,4 +1,5 @@
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
 import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
 import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
@@ -26,6 +27,7 @@ type Props = {
   dataScanned?: 'full' | 'partial';
   isSampled?: boolean | null;
   sampleCount?: number;
+  selection?: PageFilters;
   shouldColorOther?: boolean;
   showConfidenceWarning?: boolean;
 };
@@ -37,6 +39,7 @@ export function WidgetCardConfidenceFooter({
   loading,
   other,
   sampleCount,
+  selection: selectionProp,
   series,
   shouldColorOther,
   showConfidenceWarning,
@@ -44,7 +47,8 @@ export function WidgetCardConfidenceFooter({
   widget,
   yAxis,
 }: Props) {
-  const {selection} = usePageFilters();
+  const {selection: pageFilterSelection} = usePageFilters();
+  const selection = selectionProp ?? pageFilterSelection;
   const rawCounts = useWidgetRawCounts({selection, widget});
 
   if (!showConfidenceWarning) {

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -1,0 +1,199 @@
+import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ConfidenceFooter as LogsConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
+import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
+import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
+import type {RawCounts} from 'sentry/views/explore/useRawCounts';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+
+type Props = {
+  loading: boolean;
+  other: 'Other';
+  rawCounts: RawCounts | null;
+  series: Array<Series & {fieldName?: string}>;
+  timeseriesResults: GenericWidgetQueriesResult['timeseriesResults'];
+  widget: Widget;
+  yAxis: string;
+  confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
+  isSampled?: boolean | null;
+  sampleCount?: number;
+  shouldColorOther?: boolean;
+  showConfidenceWarning?: boolean;
+};
+
+export function WidgetCardConfidenceFooter({
+  confidence,
+  dataScanned,
+  isSampled,
+  loading,
+  other,
+  rawCounts,
+  sampleCount,
+  series,
+  shouldColorOther,
+  showConfidenceWarning,
+  timeseriesResults,
+  widget,
+  yAxis,
+}: Props) {
+  if (!showConfidenceWarning) {
+    return null;
+  }
+
+  const topEventsCountExcludingOther =
+    timeseriesResults?.length && widget.queries[0]?.columns.length
+      ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
+        (timeseriesResults?.some(
+          ({seriesName}) =>
+            shouldColorOther ||
+            seriesName?.match(new RegExp(`(?:.* : ${other};)|^${other};`))
+        )
+          ? 1
+          : 0)
+      : undefined;
+
+  const isTopN =
+    defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
+  const footerSeries = toFooterTimeSeries(series, dataScanned);
+  const samplingMeta = hasSeriesSamplingMetadata(footerSeries)
+    ? determineSeriesSampleCountAndIsSampled(footerSeries, isTopN)
+    : undefined;
+  const footerConfidence = confidence ?? combineConfidenceForSeries(footerSeries);
+  const footerSampleCount = defined(sampleCount)
+    ? sampleCount
+    : samplingMeta?.sampleCount;
+  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta?.isSampled;
+  const footerDataScanned = dataScanned ?? samplingMeta?.dataScanned;
+  const hasUserQuery = widget.queries.some(
+    query => (query.conditions ?? '').trim().length > 0
+  );
+  const userQuery =
+    widget.queries.find(query => (query.conditions ?? '').trim().length > 0)
+      ?.conditions ?? '';
+  const footerChartInfo: ChartInfo = {
+    chartType: getExploreChartType(widget.displayType),
+    series: footerSeries,
+    timeseriesResult: {isPending: loading} as ChartInfo['timeseriesResult'],
+    yAxis,
+    confidence: footerConfidence,
+    dataScanned: footerDataScanned,
+    isSampled: footerIsSampled,
+    sampleCount: footerSampleCount,
+    topEvents: topEventsCountExcludingOther,
+  };
+
+  if (widget.widgetType === WidgetType.SPANS) {
+    return (
+      <SpansConfidenceFooter
+        confidence={footerChartInfo.confidence}
+        dataScanned={footerChartInfo.dataScanned}
+        isSampled={footerChartInfo.isSampled}
+        isLoading={loading}
+        rawSpanCounts={rawCounts ?? undefined}
+        sampleCount={footerChartInfo.sampleCount}
+        topEvents={footerChartInfo.topEvents}
+        userQuery={userQuery}
+      />
+    );
+  }
+
+  if (widget.widgetType === WidgetType.LOGS && rawCounts) {
+    return (
+      <LogsConfidenceFooter
+        chartInfo={footerChartInfo}
+        hasUserQuery={hasUserQuery}
+        isLoading={loading}
+        rawLogCounts={rawCounts}
+      />
+    );
+  }
+
+  if (widget.widgetType === WidgetType.TRACEMETRICS && rawCounts) {
+    return (
+      <MetricsConfidenceFooter
+        chartInfo={footerChartInfo}
+        hasUserQuery={hasUserQuery}
+        isLoading={loading}
+        rawMetricCounts={rawCounts}
+      />
+    );
+  }
+
+  return null;
+}
+
+function toFooterTimeSeries(
+  series: Array<Series & {fieldName?: string}>,
+  dataScanned?: 'full' | 'partial'
+): TimeSeries[] {
+  return series.map((seriesEntry, seriesIndex) => {
+    const values = seriesEntry.data.map((datum, pointIndex) => {
+      const samplingDatum = datum as SeriesDataUnit & {
+        confidence?: Confidence;
+        sampleCount?: number | null;
+        sampleRate?: number | null;
+      };
+
+      const numericTimestamp =
+        typeof samplingDatum.name === 'number'
+          ? samplingDatum.name
+          : new Date(samplingDatum.name).getTime();
+
+      return {
+        timestamp: Number.isFinite(numericTimestamp)
+          ? numericTimestamp
+          : seriesIndex * 1000 + pointIndex,
+        value: samplingDatum.value,
+        confidence: samplingDatum.confidence,
+        sampleCount: samplingDatum.sampleCount,
+        sampleRate: samplingDatum.sampleRate,
+      };
+    });
+
+    const interval =
+      values.length >= 2 ? Math.max(0, values[1]!.timestamp - values[0]!.timestamp) : 0;
+
+    return {
+      yAxis: seriesEntry.seriesName,
+      values,
+      meta: {
+        interval,
+        valueType: 'number',
+        valueUnit: null,
+        dataScanned,
+      },
+    };
+  });
+}
+
+function hasSeriesSamplingMetadata(series: TimeSeries[]) {
+  return series.some(
+    seriesEntry =>
+      defined(seriesEntry.meta.dataScanned) ||
+      seriesEntry.values.some(
+        value => defined(value.sampleCount) || defined(value.sampleRate)
+      )
+  );
+}
+
+function getExploreChartType(displayType: DisplayType) {
+  switch (displayType) {
+    case DisplayType.BAR:
+      return ChartType.BAR;
+    case DisplayType.AREA:
+    case DisplayType.TOP_N:
+      return ChartType.AREA;
+    case DisplayType.LINE:
+    default:
+      return ChartType.LINE;
+  }
+}

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -42,6 +42,7 @@ export function getReferrer(displayType: DisplayType) {
 
 export type OnDataFetchedProps = {
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -56,6 +57,7 @@ export type OnDataFetchedProps = {
 export type GenericWidgetQueriesResult = {
   loading: boolean;
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -1,0 +1,87 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {WidgetType} from 'sentry/views/dashboards/types';
+
+import {useWidgetRawCounts} from './useWidgetRawCounts';
+
+describe('useWidgetRawCounts', () => {
+  const {organization} = initializeOrg();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  function TestComponent({
+    selection,
+    widget,
+  }: {
+    selection: ReturnType<typeof PageFiltersFixture>;
+    widget: ReturnType<typeof WidgetFixture>;
+  }) {
+    const rawCounts = useWidgetRawCounts({widget, selection});
+
+    return <div>{rawCounts?.normal.count ?? 'missing'}</div>;
+  }
+
+  it('derives the trace metrics count aggregate from the widget metric', async () => {
+    const selection = PageFiltersFixture({
+      projects: [2],
+      environments: ['prod'],
+      datetime: {
+        start: '2025-01-01T00:00:00',
+        end: '2025-01-02T00:00:00',
+        period: null,
+        utc: null,
+      },
+    });
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        {
+          name: '',
+          aggregates: ['avg(value,duration,d,-)'],
+          fields: ['avg(value,duration,d,-)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const normalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 11}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'NORMAL',
+          dataset: 'tracemetrics',
+          field: ['count(value,duration,d,-)'],
+          project: [2],
+          environment: ['prod'],
+        }),
+      ],
+    });
+    const highAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 13}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'HIGHEST_ACCURACY',
+          dataset: 'tracemetrics',
+          field: ['count(value,duration,d,-)'],
+          project: [2],
+          environment: ['prod'],
+        }),
+      ],
+    });
+
+    render(<TestComponent widget={widget} selection={selection} />, {organization});
+
+    await waitFor(() => expect(normalRequest).toHaveBeenCalled());
+    expect(highAccuracyRequest).toHaveBeenCalled();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -4,7 +4,7 @@ import {WidgetFixture} from 'sentry-fixture/widget';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {WidgetType} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 
 import {useWidgetRawCounts} from './useWidgetRawCounts';
 
@@ -83,5 +83,29 @@ describe('useWidgetRawCounts', () => {
 
     await waitFor(() => expect(normalRequest).toHaveBeenCalled());
     expect(highAccuracyRequest).toHaveBeenCalled();
+  });
+
+  it('does not fetch raw counts for non-timeseries display types', () => {
+    const selection = PageFiltersFixture();
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+      displayType: DisplayType.TABLE,
+    });
+
+    const normalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 11}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'spans'})],
+    });
+    const highAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 13}]},
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
+    });
+
+    render(<TestComponent widget={widget} selection={selection} />, {organization});
+
+    expect(normalRequest).not.toHaveBeenCalled();
+    expect(highAccuracyRequest).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -1,31 +1,16 @@
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 
 import {useWidgetRawCounts} from './useWidgetRawCounts';
 
 describe('useWidgetRawCounts', () => {
-  const {organization} = initializeOrg();
-
-  beforeEach(() => {
+  afterEach(() => {
     MockApiClient.clearMockResponses();
   });
-
-  function TestComponent({
-    selection,
-    widget,
-  }: {
-    selection: ReturnType<typeof PageFiltersFixture>;
-    widget: ReturnType<typeof WidgetFixture>;
-  }) {
-    const rawCounts = useWidgetRawCounts({widget, selection});
-
-    return <div>{rawCounts?.normal.count ?? 'missing'}</div>;
-  }
 
   it('derives the trace metrics count aggregate from the widget metric', async () => {
     const selection = PageFiltersFixture({
@@ -65,6 +50,7 @@ describe('useWidgetRawCounts', () => {
         }),
       ],
     });
+
     const highAccuracyRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {data: [{'count(value,duration,d,-)': 13}]},
@@ -79,13 +65,15 @@ describe('useWidgetRawCounts', () => {
       ],
     });
 
-    render(<TestComponent widget={widget} selection={selection} />, {organization});
+    renderHookWithProviders(useWidgetRawCounts, {
+      initialProps: {selection, widget},
+    });
 
     await waitFor(() => expect(normalRequest).toHaveBeenCalled());
-    expect(highAccuracyRequest).toHaveBeenCalled();
+    await waitFor(() => expect(highAccuracyRequest).toHaveBeenCalled());
   });
 
-  it('does not fetch raw counts for non-timeseries display types', () => {
+  it('does not fetch raw counts for non-timeseries display types', async () => {
     const selection = PageFiltersFixture();
     const widget = WidgetFixture({
       widgetType: WidgetType.SPANS,
@@ -103,9 +91,11 @@ describe('useWidgetRawCounts', () => {
       match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
     });
 
-    render(<TestComponent widget={widget} selection={selection} />, {organization});
+    renderHookWithProviders(useWidgetRawCounts, {
+      initialProps: {selection, widget},
+    });
 
-    expect(normalRequest).not.toHaveBeenCalled();
-    expect(highAccuracyRequest).not.toHaveBeenCalled();
+    await waitFor(() => expect(normalRequest).not.toHaveBeenCalled());
+    await waitFor(() => expect(highAccuracyRequest).not.toHaveBeenCalled());
   });
 });

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -18,12 +18,6 @@ type RawCountConfig = {
   aggregate?: string;
 };
 
-const UNSUPPORTED_WIDGET_CONFIG: RawCountConfig = {
-  supported: false,
-  dataset: DiscoverDatasets.SPANS,
-  enabled: false,
-};
-
 export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null {
   const rawCountConfig = useMemo<RawCountConfig>(() => {
     const isSupportedDisplayType =
@@ -64,16 +58,15 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
         };
       }
       default:
-        return UNSUPPORTED_WIDGET_CONFIG;
+        return {
+          supported: false,
+          dataset: DiscoverDatasets.SPANS,
+          enabled: false,
+        };
     }
   }, [widget]);
 
-  const rawCounts = useRawCounts({
-    dataset: rawCountConfig.dataset,
-    aggregate: rawCountConfig.aggregate,
-    enabled: rawCountConfig.enabled,
-    selection,
-  });
+  const rawCounts = useRawCounts({...rawCountConfig, selection});
 
   return rawCountConfig.supported ? rawCounts : null;
 }

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -1,0 +1,67 @@
+import {useMemo} from 'react';
+
+import type {PageFilters} from 'sentry/types/core';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
+import {useRawCounts, type RawCounts} from 'sentry/views/explore/useRawCounts';
+
+type Props = {
+  selection: PageFilters;
+  widget: Widget;
+};
+
+type RawCountConfig = {
+  dataset: DiscoverDatasets;
+  enabled: boolean;
+  supported: boolean;
+  aggregate?: string;
+};
+
+const UNSUPPORTED_WIDGET_CONFIG: RawCountConfig = {
+  supported: false,
+  dataset: DiscoverDatasets.SPANS,
+  enabled: false,
+};
+
+export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null {
+  const rawCountConfig = useMemo<RawCountConfig>(() => {
+    switch (widget.widgetType) {
+      case WidgetType.SPANS:
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.SPANS,
+          enabled: true,
+        };
+      case WidgetType.LOGS:
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.OURLOGS,
+          enabled: true,
+        };
+      case WidgetType.TRACEMETRICS: {
+        const traceMetric = extractTraceMetricFromWidget(widget);
+        const hasMetric = Boolean(traceMetric?.name && traceMetric?.type);
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.TRACEMETRICS,
+          aggregate: hasMetric
+            ? `count(value,${traceMetric.name},${traceMetric.type},${traceMetric.unit ?? '-'})`
+            : 'count(value,,,-)',
+          enabled: hasMetric,
+        };
+      }
+      default:
+        return UNSUPPORTED_WIDGET_CONFIG;
+    }
+  }, [widget]);
+
+  const rawCounts = useRawCounts({
+    dataset: rawCountConfig.dataset,
+    aggregate: rawCountConfig.aggregate,
+    enabled: rawCountConfig.enabled,
+    selection,
+  });
+
+  return rawCountConfig.supported ? rawCounts : null;
+}

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -2,7 +2,7 @@ import {useMemo} from 'react';
 
 import type {PageFilters} from 'sentry/types/core';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
 import {useRawCounts, type RawCounts} from 'sentry/views/explore/useRawCounts';
 
@@ -26,18 +26,24 @@ const UNSUPPORTED_WIDGET_CONFIG: RawCountConfig = {
 
 export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null {
   const rawCountConfig = useMemo<RawCountConfig>(() => {
+    const isSupportedDisplayType =
+      widget.displayType === DisplayType.LINE ||
+      widget.displayType === DisplayType.AREA ||
+      widget.displayType === DisplayType.BAR ||
+      widget.displayType === DisplayType.TOP_N;
+
     switch (widget.widgetType) {
       case WidgetType.SPANS:
         return {
           supported: true,
           dataset: DiscoverDatasets.SPANS,
-          enabled: true,
+          enabled: isSupportedDisplayType,
         };
       case WidgetType.LOGS:
         return {
           supported: true,
           dataset: DiscoverDatasets.OURLOGS,
-          enabled: true,
+          enabled: isSupportedDisplayType,
         };
       case WidgetType.TRACEMETRICS: {
         const traceMetric = extractTraceMetricFromWidget(widget);
@@ -54,7 +60,7 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
           supported: true,
           dataset: DiscoverDatasets.TRACEMETRICS,
           aggregate: `count(value,${traceMetric.name},${traceMetric.type},${traceMetric.unit ?? '-'})`,
-          enabled: true,
+          enabled: isSupportedDisplayType,
         };
       }
       default:

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -41,14 +41,20 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
         };
       case WidgetType.TRACEMETRICS: {
         const traceMetric = extractTraceMetricFromWidget(widget);
-        const hasMetric = Boolean(traceMetric?.name && traceMetric?.type);
+        if (!traceMetric?.name || !traceMetric?.type) {
+          return {
+            supported: true,
+            dataset: DiscoverDatasets.TRACEMETRICS,
+            aggregate: 'count(value,,,-)',
+            enabled: false,
+          };
+        }
+
         return {
           supported: true,
           dataset: DiscoverDatasets.TRACEMETRICS,
-          aggregate: hasMetric
-            ? `count(value,${traceMetric.name},${traceMetric.type},${traceMetric.unit ?? '-'})`
-            : 'count(value,,,-)',
-          enabled: hasMetric,
+          aggregate: `count(value,${traceMetric.name},${traceMetric.type},${traceMetric.unit ?? '-'})`,
+          enabled: true,
         };
       }
       default:

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -126,6 +126,7 @@ type Props = WithRouterProps & {
 
 type Data = {
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   isSampled?: boolean | null;
   pageLinks?: string;
   sampleCount?: number;

--- a/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
@@ -1,0 +1,78 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import LogsWidgetQueries from './logsWidgetQueries';
+
+describe('logsWidgetQueries', () => {
+  const {organization} = initializeOrg();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('calculates confidence and sampling metadata from timeseries', async () => {
+    const selection = PageFiltersFixture();
+    const widget = WidgetFixture({
+      widgetType: WidgetType.LOGS,
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          aggregates: ['count(message)'],
+          fields: ['count(message)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1, [{count: 10}]],
+          [2, [{count: 20}]],
+        ],
+        meta: {
+          dataScanned: 'partial',
+          fields: {'count(message)': 'integer'},
+          units: {'count(message)': null},
+          accuracy: {
+            confidence: [
+              {timestamp: 1, value: 'low'},
+              {timestamp: 2, value: 'low'},
+            ],
+            sampleCount: [
+              {timestamp: 1, value: 10},
+              {timestamp: 2, value: 20},
+            ],
+            samplingRate: [
+              {timestamp: 1, value: 0.5},
+              {timestamp: 2, value: 0.5},
+            ],
+          },
+        },
+      },
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'ourlogs'})],
+    });
+
+    render(
+      <LogsWidgetQueries widget={widget} selection={selection}>
+        {({confidence, sampleCount, isSampled, dataScanned}) => (
+          <div>
+            {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
+          </div>
+        )}
+      </LogsWidgetQueries>,
+      {organization}
+    );
+
+    expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
@@ -1,7 +1,6 @@
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -9,9 +8,7 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import LogsWidgetQueries from './logsWidgetQueries';
 
 describe('logsWidgetQueries', () => {
-  const {organization} = initializeOrg();
-
-  beforeEach(() => {
+  afterEach(() => {
     MockApiClient.clearMockResponses();
   });
 
@@ -69,8 +66,7 @@ describe('logsWidgetQueries', () => {
             {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
           </div>
         )}
-      </LogsWidgetQueries>,
-      {organization}
+      </LogsWidgetQueries>
     );
 
     expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetCard/logsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/logsWidgetQueries.tsx
@@ -1,0 +1,178 @@
+import {useCallback, useState} from 'react';
+
+import type {PageFilters} from 'sentry/types/core';
+import type {
+  Confidence,
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
+import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {LogsConfig} from 'sentry/views/dashboards/datasetConfig/logs';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {isEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {
+  convertEventsStatsToTimeSeriesData,
+  transformToSeriesMap,
+} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+import type {
+  GenericWidgetQueriesResult,
+  OnDataFetchedProps,
+} from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
+
+type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats;
+type TableResult = TableData | EventsTableData;
+
+type LogsWidgetQueriesProps = {
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
+  widget: Widget;
+  cursor?: string;
+  dashboardFilters?: DashboardFilters;
+  limit?: number;
+  onBestEffortDataFetched?: () => void;
+  onDataFetchStart?: () => void;
+  onDataFetched?: (results: OnDataFetchedProps) => void;
+  selection?: PageFilters;
+  widgetInterval?: string;
+};
+
+type LogsWidgetQueriesImplProps = LogsWidgetQueriesProps & {
+  getConfidenceInformation: (result: SeriesResult) => {
+    seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial' | undefined;
+    seriesIsSampled: boolean | null;
+    seriesSampleCount: number | undefined;
+  };
+};
+
+function LogsWidgetQueries(props: LogsWidgetQueriesProps) {
+  const getConfidenceInformation = useCallback(
+    (result: SeriesResult) => {
+      let seriesConfidence: Confidence | null;
+      let seriesSampleCount: number | undefined;
+      let seriesIsSampled: boolean | null;
+      let seriesDataScanned: 'full' | 'partial' | undefined;
+
+      if (isEventsStats(result)) {
+        const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(
+          props.widget.queries[0]?.aggregates[0] ?? '',
+          result
+        );
+
+        seriesConfidence = combineConfidenceForSeries([timeSeries]);
+
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        seriesDataScanned = calculatedDataScanned;
+        seriesSampleCount = calculatedSampleCount;
+        seriesIsSampled = calculatedIsSampled;
+      } else {
+        const dedupedYAxes = dedupeArray(props.widget.queries[0]?.aggregates ?? []);
+        const seriesMap = transformToSeriesMap(result, dedupedYAxes);
+        const series = dedupedYAxes.flatMap(yAxis => seriesMap[yAxis]).filter(defined);
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled(
+          series,
+          Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
+        );
+        seriesDataScanned = calculatedDataScanned;
+        seriesSampleCount = calculatedSampleCount;
+        seriesConfidence = combineConfidenceForSeries(series);
+        seriesIsSampled = calculatedIsSampled;
+      }
+
+      return {
+        seriesDataScanned,
+        seriesConfidence,
+        seriesSampleCount,
+        seriesIsSampled,
+      };
+    },
+    [props.widget.queries]
+  );
+
+  return (
+    <LogsWidgetQueriesSingleRequestImpl
+      {...props}
+      getConfidenceInformation={getConfidenceInformation}
+    />
+  );
+}
+
+function LogsWidgetQueriesSingleRequestImpl({
+  children,
+  widget,
+  cursor,
+  limit,
+  dashboardFilters,
+  onDataFetched,
+  onDataFetchStart,
+  getConfidenceInformation,
+  selection,
+  widgetInterval,
+}: LogsWidgetQueriesImplProps) {
+  const config = LogsConfig;
+  const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
+  const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
+  const [isSampled, setIsSampled] = useState<boolean | null>(null);
+
+  const afterFetchSeriesData = (result: SeriesResult) => {
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
+      getConfidenceInformation(result);
+
+    setDataScanned(seriesDataScanned);
+    setConfidence(seriesConfidence);
+    setSampleCount(seriesSampleCount);
+    setIsSampled(seriesIsSampled);
+    onDataFetched?.({
+      dataScanned: seriesDataScanned,
+      confidence: seriesConfidence,
+      sampleCount: seriesSampleCount,
+      isSampled: seriesIsSampled,
+    });
+  };
+
+  const props = useGenericWidgetQueries<SeriesResult, TableResult>({
+    config,
+    widget,
+    cursor,
+    limit,
+    dashboardFilters,
+    onDataFetched,
+    onDataFetchStart,
+    afterFetchSeriesData,
+    samplingMode: SAMPLING_MODE.NORMAL,
+    selection,
+    widgetInterval,
+  });
+
+  return getDynamicText({
+    value: children({
+      ...props,
+      dataScanned,
+      confidence,
+      sampleCount,
+      isSampled,
+    }),
+    fixed: <div />,
+  });
+}
+
+export default LogsWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -31,6 +31,7 @@ describe('spansWidgetQueries', () => {
           [3, [{count: 3}]],
         ],
         meta: {
+          dataScanned: 'partial',
           accuracy: {
             confidence: [
               {timestamp: 1, value: 'low'},
@@ -44,12 +45,16 @@ describe('spansWidgetQueries', () => {
 
     render(
       <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
-        {({confidence}) => <div>{confidence}</div>}
+        {({confidence, dataScanned}) => (
+          <div>
+            {confidence}:{dataScanned}
+          </div>
+        )}
       </SpansWidgetQueries>,
       {organization}
     );
 
-    expect(await screen.findByText('low')).toBeInTheDocument();
+    expect(await screen.findByText('low:partial')).toBeInTheDocument();
   });
 
   it('calculates the confidence for a multi series', async () => {

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -11,7 +11,6 @@ import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -49,6 +48,7 @@ type SpansWidgetQueriesProps = {
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial';
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };
@@ -60,6 +60,7 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
       let seriesConfidence: Confidence | null;
       let seriesSampleCount: number | undefined;
       let seriesIsSampled: boolean | null;
+      let seriesDataScanned: 'full' | 'partial';
 
       if (isEventsStats(result)) {
         const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(
@@ -67,26 +68,35 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
           result
         );
 
-        seriesConfidence = determineTimeSeriesConfidence(timeSeries);
+        seriesConfidence = combineConfidenceForSeries([timeSeries]);
 
-        const {sampleCount: calculatedSampleCount, isSampled: calculatedIsSampled} =
-          determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        seriesDataScanned = calculatedDataScanned;
         seriesSampleCount = calculatedSampleCount;
         seriesIsSampled = calculatedIsSampled;
       } else {
         const dedupedYAxes = dedupeArray(props.widget.queries[0]?.aggregates ?? []);
         const seriesMap = transformToSeriesMap(result, dedupedYAxes);
         const series = dedupedYAxes.flatMap(yAxis => seriesMap[yAxis]).filter(defined);
-        const {sampleCount: calculatedSampleCount, isSampled: calculatedIsSampled} =
-          determineSeriesSampleCountAndIsSampled(
-            series,
-            Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
-          );
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled(
+          series,
+          Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
+        );
+        seriesDataScanned = calculatedDataScanned;
         seriesSampleCount = calculatedSampleCount;
         seriesConfidence = combineConfidenceForSeries(series);
         seriesIsSampled = calculatedIsSampled;
       }
       return {
+        seriesDataScanned,
         seriesConfidence,
         seriesSampleCount,
         seriesIsSampled,
@@ -117,17 +127,22 @@ function SpansWidgetQueriesSingleRequestImpl({
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
 
   const afterFetchSeriesData = (result: SeriesResult) => {
-    const {seriesConfidence, seriesSampleCount, seriesIsSampled} =
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
       getConfidenceInformation(result);
 
+    setDataScanned(seriesDataScanned);
     setConfidence(seriesConfidence);
     setSampleCount(seriesSampleCount);
     setIsSampled(seriesIsSampled);
     onDataFetched?.({
+      dataScanned: seriesDataScanned,
       confidence: seriesConfidence,
       sampleCount: seriesSampleCount,
       isSampled: seriesIsSampled,
@@ -151,6 +166,7 @@ function SpansWidgetQueriesSingleRequestImpl({
   return getDynamicText({
     value: children({
       ...props,
+      dataScanned,
       confidence,
       sampleCount,
       isSampled,

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -48,7 +48,7 @@ type SpansWidgetQueriesProps = {
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
-    seriesDataScanned: 'full' | 'partial';
+    seriesDataScanned: 'full' | 'partial' | undefined;
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };
@@ -60,7 +60,7 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
       let seriesConfidence: Confidence | null;
       let seriesSampleCount: number | undefined;
       let seriesIsSampled: boolean | null;
-      let seriesDataScanned: 'full' | 'partial';
+      let seriesDataScanned: 'full' | 'partial' | undefined;
 
       if (isEventsStats(result)) {
         const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
@@ -1,0 +1,84 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import TraceMetricsWidgetQueries from './traceMetricsWidgetQueries';
+
+describe('traceMetricsWidgetQueries', () => {
+  const {organization} = initializeOrg();
+  const selection = PageFiltersFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
+  });
+
+  it('calculates confidence and sampling metadata from timeseries', async () => {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          aggregates: ['avg(value,duration,d,-)'],
+          fields: ['avg(value,duration,d,-)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,duration,d,-)',
+            meta: {
+              interval: 3600000,
+              valueType: 'duration',
+              valueUnit: 'millisecond',
+              dataScanned: 'partial',
+            },
+            values: [
+              {
+                timestamp: 1,
+                value: 10,
+                confidence: 'low',
+                sampleCount: 10,
+                sampleRate: 0.5,
+              },
+              {
+                timestamp: 2,
+                value: 20,
+                confidence: 'low',
+                sampleCount: 20,
+                sampleRate: 0.5,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <TraceMetricsWidgetQueries widget={widget} dashboardFilters={{}}>
+        {({confidence, sampleCount, isSampled, dataScanned}) => (
+          <div>
+            {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
+          </div>
+        )}
+      </TraceMetricsWidgetQueries>,
+      {organization}
+    );
+
+    expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
@@ -1,7 +1,6 @@
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import PageFiltersStore from 'sentry/components/pageFilters/store';
@@ -10,13 +9,15 @@ import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import TraceMetricsWidgetQueries from './traceMetricsWidgetQueries';
 
 describe('traceMetricsWidgetQueries', () => {
-  const {organization} = initializeOrg();
   const selection = PageFiltersFixture();
 
   beforeEach(() => {
-    MockApiClient.clearMockResponses();
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState(selection);
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
   });
 
   it('calculates confidence and sampling metadata from timeseries', async () => {
@@ -75,8 +76,7 @@ describe('traceMetricsWidgetQueries', () => {
             {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
           </div>
         )}
-      </TraceMetricsWidgetQueries>,
-      {organization}
+      </TraceMetricsWidgetQueries>
     );
 
     expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -5,12 +5,14 @@ import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {
   EMPTY_METRIC_SELECTION,
   TraceMetricsConfig,
 } from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 
 import type {
   GenericWidgetQueriesResult,
@@ -38,20 +40,28 @@ type TraceMetricsWidgetQueriesProps = {
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial';
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };
 };
 
 function TraceMetricsWidgetQueries(props: TraceMetricsWidgetQueriesProps) {
-  const getConfidenceInformation = useCallback(() => {
-    // TODO(nar): Implement confidence information parsing
-    return {
-      seriesConfidence: null,
-      seriesSampleCount: undefined,
-      seriesIsSampled: null,
-    };
-  }, []);
+  const getConfidenceInformation = useCallback(
+    (result: SeriesResult) => {
+      const series = result.timeSeries ?? [];
+      const isTopN = (props.widget.queries[0]?.columns.length ?? 0) > 0;
+      const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopN);
+
+      return {
+        seriesDataScanned: samplingMeta.dataScanned,
+        seriesConfidence: combineConfidenceForSeries(series),
+        seriesSampleCount: samplingMeta.sampleCount,
+        seriesIsSampled: samplingMeta.isSampled,
+      };
+    },
+    [props.widget.queries]
+  );
 
   return (
     <TraceMetricsWidgetQueriesSingleRequestImpl
@@ -75,17 +85,22 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
 
   const afterFetchSeriesData = (result: SeriesResult) => {
-    const {seriesConfidence, seriesSampleCount, seriesIsSampled} =
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
       getConfidenceInformation(result);
 
+    setDataScanned(seriesDataScanned);
     setConfidence(seriesConfidence);
     setSampleCount(seriesSampleCount);
     setIsSampled(seriesIsSampled);
     onDataFetched?.({
+      dataScanned: seriesDataScanned,
       confidence: seriesConfidence,
       sampleCount: seriesSampleCount,
       isSampled: seriesIsSampled,
@@ -118,6 +133,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   return getDynamicText({
     value: children({
       ...props,
+      dataScanned,
       confidence,
       sampleCount,
       isSampled,

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -40,7 +40,7 @@ type TraceMetricsWidgetQueriesProps = {
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
-    seriesDataScanned: 'full' | 'partial';
+    seriesDataScanned: 'full' | 'partial' | undefined;
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -10,6 +10,7 @@ import type {
   EChartLegendSelectChangeHandler,
   Series,
 } from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -37,7 +38,11 @@ type Props = {
   noPadding?: boolean;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: {
+    confidence?: Confidence;
+    dataScanned?: 'full' | 'partial';
+    isSampled?: boolean | null;
     pageLinks?: string;
+    sampleCount?: number;
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
     timeseriesResultsTypes?: Record<string, AggregationOutputType>;
@@ -130,6 +135,7 @@ export function WidgetCardChartContainer({
         timeseriesResultsTypes,
         timeseriesResultsUnits,
         confidence,
+        dataScanned,
         sampleCount,
         isSampled,
       }) => {
@@ -178,6 +184,7 @@ export function WidgetCardChartContainer({
               widgetLegendState={widgetLegendState}
               showConfidenceWarning={showConfidenceWarning}
               confidence={confidence}
+              dataScanned={dataScanned}
               sampleCount={sampleCount}
               minTableColumnWidth={minTableColumnWidth}
               isSampled={isSampled}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -13,6 +13,7 @@ import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQu
 import TraceMetricsWidgetQueries from 'sentry/views/dashboards/widgetCard/traceMetricsWidgetQueries';
 
 import IssueWidgetQueries from './issueWidgetQueries';
+import LogsWidgetQueries from './logsWidgetQueries';
 import MobileAppSizeWidgetQueries from './mobileAppSizeWidgetQueries';
 import ReleaseWidgetQueries from './releaseWidgetQueries';
 import WidgetQueries from './widgetQueries';
@@ -155,6 +156,22 @@ export function WidgetCardDataLoader({
       >
         {props => <Fragment>{children({...props})}</Fragment>}
       </TraceMetricsWidgetQueries>
+    );
+  }
+
+  if (widget.widgetType === WidgetType.LOGS) {
+    return (
+      <LogsWidgetQueries
+        widget={widget}
+        selection={selection}
+        limit={tableItemLimit}
+        onDataFetchStart={onDataFetchStart}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+        widgetInterval={widgetInterval}
+      >
+        {props => <Fragment>{children({...props})}</Fragment>}
+      </LogsWidgetQueries>
     );
   }
 

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -20,6 +20,7 @@ import WidgetQueries from './widgetQueries';
 type Results = {
   loading: boolean;
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
@@ -48,6 +49,8 @@ type Props = {
       | 'timeseriesResultsUnits'
       | 'totalIssuesCount'
       | 'confidence'
+      | 'dataScanned'
+      | 'isSampled'
       | 'sampleCount'
     >
   ) => void;

--- a/static/app/views/explore/useRawCounts.tsx
+++ b/static/app/views/explore/useRawCounts.tsx
@@ -1,5 +1,6 @@
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
@@ -31,23 +32,26 @@ interface UseRawCountsOptions {
    */
   aggregate?: string;
   enabled?: boolean;
+  selection?: PageFilters;
 }
 
 export function useRawCounts({
   dataset,
   aggregate,
   enabled,
+  selection,
 }: UseRawCountsOptions): RawCounts {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  const {selection: pageFilterSelection} = usePageFilters();
+  const effectiveSelection = selection ?? pageFilterSelection;
 
   const count = aggregate ?? getAggregateForDataset(dataset);
 
   const baseQueryParams = {
     dataset,
-    project: selection.projects,
-    environment: selection.environments,
-    ...normalizeDateTimeParams(selection.datetime),
+    project: effectiveSelection.projects,
+    environment: effectiveSelection.environments,
+    ...normalizeDateTimeParams(effectiveSelection.datetime),
     field: [count],
     disableAggregateExtrapolation: '1',
   };


### PR DESCRIPTION
## Summary
- Reuse Explore confidence footer components in dashboard chart surfaces for spans, logs, and trace metrics (widget builder preview and widget viewer).
- Add dashboard raw-count plumbing with explicit selection override so footer counts stay aligned with widget viewer zoom state.
- Propagate confidence sampling metadata (`dataScanned`, `sampleCount`, `isSampled`) through widget query layers and add focused tests for spans + trace metrics confidence behavior.

Refs LOGS-586

Made with [Cursor](https://cursor.com)