### PR TITLE
chore(autofix): Remove seer-slack-workflows-explorer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -353,8 +353,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:autofix-on-explorer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Workflows in Slack
     manager.add("organizations:seer-slack-workflows", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Additionally allow users with `autofix-on-explorer` flags to use this feature.
-    manager.add("organizations:seer-slack-workflows-explorer", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new compact issue alert UI in Slack
     manager.add("organizations:slack-compact-alerts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Explorer in Slack via @mentions

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -77,15 +77,6 @@ class SeerOperator[CachePayloadT]:
         if not has_seer_access(organization):
             return False
 
-        # Currently, this feature is built around legacy autofix
-        # The explorer autofix pipeline and history is entirely separate, so the runs we trigger
-        # at the moment, won't be visible in-app to users with this flag.
-        # This check can only be removed once this feature migrates to explorer-based autofix.
-        if features.has("organizations:autofix-on-explorer", organization) and not features.has(
-            "organizations:seer-slack-workflows-explorer", organization
-        ):
-            return False
-
         if entrypoint_key:
             if entrypoint_key not in entrypoint_registry.registrations:
                 logger.error(

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -422,11 +422,6 @@ class SeerOperatorTest(TestCase):
         assert payload["type"] == "select_root_cause"
         assert payload["cause_id"] == AUTOFIX_FALLBACK_CAUSE_ID
 
-    @patch("sentry.seer.entrypoints.operator.has_seer_access", return_value=True)
-    def test_has_access_returns_false_with_autofix_on_explorer(self, _mock_has_seer_access):
-        with self.feature({"organizations:autofix-on-explorer": True}):
-            assert not SeerOperator.has_access(organization=self.group.project.organization)
-
     @patch("sentry.seer.entrypoints.operator.update_autofix")
     @patch("sentry.seer.entrypoints.operator.get_autofix_state")
     def test_solution_stopping_point_uses_cause_id_from_state(


### PR DESCRIPTION
The slack workflows should now work with with explorer autofix so remove this additional feature flag.