### PR TITLE
fix(dashboards): Preserve polarity when clearing threshold values

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -144,6 +144,40 @@ describe('Thresholds', () => {
     );
   });
 
+  it('preserves preferred polarity when thresholds are cleared', async () => {
+    let capturedState: any = null;
+
+    function StateCapture() {
+      const {state} = useWidgetBuilderContext();
+      capturedState = state;
+      return null;
+    }
+
+    render(
+      <WidgetBuilderProvider>
+        <StateCapture />
+        <Thresholds dataType="duration" dataUnit="millisecond" />
+      </WidgetBuilderProvider>,
+      {
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
+            query: {
+              thresholds:
+                '{"max_values":{"max1":100},"unit":"millisecond","preferredPolarity":"+"}',
+            },
+          },
+        },
+      }
+    );
+
+    expect(capturedState.thresholds?.preferredPolarity).toBe('+');
+
+    await userEvent.clear(screen.getByLabelText('First Maximum'));
+
+    expect(capturedState.thresholds?.preferredPolarity).toBe('+');
+  });
+
   it('sets internal state to null (not undefined) when thresholds are fully wiped', async () => {
     let capturedState: any = null;
 

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.tsx
@@ -97,7 +97,10 @@ function ThresholdsSection({
               nextMaxValue => !defined(nextMaxValue)
             )
           ) {
-            newThresholds = null;
+            const {preferredPolarity} = newThresholds;
+            newThresholds = preferredPolarity
+              ? {max_values: {}, unit: null, preferredPolarity}
+              : null;
           }
 
           setError?.({...error, thresholds: {[maxKey]: ''}});


### PR DESCRIPTION
When all threshold max values are cleared in the widget builder, the entire
`thresholds` config was set to `null`, which lost the `preferredPolarity`
setting. When the user re-entered threshold values, the polarity defaulted
back to "lower is better" (`-`), even if they had previously selected
"higher is better" (`+`).

Now when clearing all max values, the `preferredPolarity` is preserved in
the thresholds config so it persists across clearing and re-entering values.

Fixes DAIN-1275