### PR TITLE
feat(ai-conversations): move to explore

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2101,20 +2101,10 @@ function buildRoutes(): RouteObject[] {
         },
       ],
     },
+    // Redirect old conversations links to the new explore location
     {
-      path: `${CONVERSATIONS_LANDING_SUB_PATH}/`,
-      component: make(() => import('sentry/views/insights/pages/conversations/layout')),
-      children: [
-        {
-          index: true,
-          handle: {module: undefined},
-          component: make(
-            () => import('sentry/views/insights/pages/conversations/overview')
-          ),
-        },
-        transactionSummaryRoute,
-        traceView,
-      ],
+      path: `${CONVERSATIONS_LANDING_SUB_PATH}/*`,
+      redirectTo: `/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`,
     },
     // Redirect old links to the new agents landing page
     {
@@ -2346,6 +2336,21 @@ function buildRoutes(): RouteObject[] {
       path: 'metrics/',
       component: make(() => import('sentry/views/explore/metrics')),
       children: metricsChildren,
+    },
+    {
+      path: `${CONVERSATIONS_LANDING_SUB_PATH}/`,
+      component: make(() => import('sentry/views/insights/pages/conversations/layout')),
+      children: [
+        {
+          index: true,
+          handle: {module: undefined},
+          component: make(
+            () => import('sentry/views/insights/pages/conversations/overview')
+          ),
+        },
+        transactionSummaryRoute,
+        traceView,
+      ],
     },
     {
       path: 'saved-queries/',

--- a/static/app/views/insights/pages/conversations/settings.ts
+++ b/static/app/views/insights/pages/conversations/settings.ts
@@ -1,8 +1,8 @@
 import {t} from 'sentry/locale';
 
 export const CONVERSATIONS_LANDING_SUB_PATH = 'conversations';
-export const CONVERSATIONS_LANDING_TITLE = t('Conversations');
-export const CONVERSATIONS_SIDEBAR_LABEL = t('Conversations');
+export const CONVERSATIONS_LANDING_TITLE = t('LLM Conversations');
+export const CONVERSATIONS_SIDEBAR_LABEL = t('LLM Conversations');
 
 export const MAX_PICKABLE_DAYS = 30;
 

--- a/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/explore/exploreSecondaryNav.tsx
@@ -12,6 +12,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {useGetSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {canUseMetricsUI} from 'sentry/views/explore/metrics/metricsFlags';
+import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/conversations/settings';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {ExploreSavedQueryNavItems} from 'sentry/views/nav/secondary/sections/explore/exploreSavedQueryNavItems';
@@ -144,6 +145,15 @@ export function ExploreSecondaryNav() {
           >
             {t('Releases')}
           </SecondaryNav.Item>
+          <Feature features="gen-ai-conversations">
+            <SecondaryNav.Item
+              to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
+              analyticsItemName="explore_conversations"
+              trailingItems={<FeatureBadge type="alpha" />}
+            >
+              {t('LLM Conversations')}
+            </SecondaryNav.Item>
+          </Feature>
         </SecondaryNav.Section>
         <Feature features={['visibility-explore-view', 'performance-view']}>
           <SecondaryNav.Section id="explore-all-queries">

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -16,10 +16,6 @@ import {
   BACKEND_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/backend/settings';
 import {
-  CONVERSATIONS_LANDING_SUB_PATH,
-  CONVERSATIONS_SIDEBAR_LABEL,
-} from 'sentry/views/insights/pages/conversations/settings';
-import {
   FRONTEND_LANDING_SUB_PATH,
   FRONTEND_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/frontend/settings';
@@ -83,14 +79,6 @@ export function InsightsSecondaryNav() {
           </SecondaryNav.Item>
         </SecondaryNav.Section>
         <SecondaryNav.Section id="insights-ai" title={t('AI')}>
-          <Feature features="gen-ai-conversations">
-            <SecondaryNav.Item
-              to={`${baseUrl}/${CONVERSATIONS_LANDING_SUB_PATH}/`}
-              analyticsItemName="insights_conversations"
-            >
-              {CONVERSATIONS_SIDEBAR_LABEL}
-            </SecondaryNav.Item>
-          </Feature>
           <SecondaryNav.Item
             to={`${baseUrl}/${AGENTS_LANDING_SUB_PATH}/`}
             analyticsItemName="insights_agents"


### PR DESCRIPTION
closes [TET-2050: Move Conversations from Insights to Explore](https://linear.app/getsentry/issue/TET-2050/move-conversations-from-insights-to-explore)


<img width="1681" height="1313" alt="CleanShot 2026-03-04 at 17 12 47" src="https://github.com/user-attachments/assets/030dd417-11f5-452b-8904-b46bf00613bc" />

