### PR TITLE
fix(dashboards): Treat TOP_N display type as AREA

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState.tsx
@@ -1232,6 +1232,9 @@ function useWidgetBuilderState(): {
  * Returns the default display type if the value is not a valid display type
  */
 function deserializeDisplayType(value: string): DisplayType {
+  if (value === DisplayType.TOP_N) {
+    return DisplayType.AREA;
+  }
   if (Object.values(DisplayType).includes(value as DisplayType)) {
     return value as DisplayType;
   }

--- a/static/app/views/dashboards/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/index.spec.tsx
@@ -295,9 +295,10 @@ describe('Dashboards > WidgetCard', () => {
     );
 
     await userEvent.click(await screen.findByLabelText('Widget actions'));
+    // TOP_N is converted to AREA, so the discover URL no longer has display=top5
     expect(screen.getByRole('menuitemradio', {name: 'Open in Discover'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/discover/results/?display=top5&environment=prod&field=transaction&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror&queryDataset=error-events&statsPeriod=14d&yAxis=count%28%29'
+      '/organizations/org-slug/explore/discover/results/?environment=prod&field=transaction&field=count%28%29&name=Errors&project=1&query=event.type%3Aerror&queryDataset=error-events&statsPeriod=14d&yAxis=count%28%29'
     );
   });
 

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -43,7 +43,6 @@ import {
   WidgetType,
 } from 'sentry/views/dashboards/types';
 import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
-import {DEFAULT_RESULTS_LIMIT} from 'sentry/views/dashboards/widgetBuilder/utils';
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
 import type {TabularColumn} from 'sentry/views/dashboards/widgets/common/types';
@@ -191,15 +190,7 @@ function WidgetCard(props: Props) {
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
-    const queries = widget.queries.map(query => ({
-      ...query,
-      // Use the last aggregate because that's where the y-axis is stored
-      aggregates: query.aggregates.length
-        ? [query.aggregates[query.aggregates.length - 1]!]
-        : [],
-    }));
-    widget.queries = queries;
-    widget.limit = DEFAULT_RESULTS_LIMIT;
+    widget.displayType = DisplayType.AREA;
   }
 
   const hasSessionDuration = widget.queries.some(query =>


### PR DESCRIPTION
`TOP_N` is an outdated display type that some users still have saved in their
dashboards (e.g. from the General Template). It uses a legacy rendering path
that doesn't abbreviate y-axis values, causing large numbers like `150000000`
to display unformatted.

Tested with https://sentry.sentry.io/dashboard/128570/
Before
<img width="572" height="279" alt="image" src="https://github.com/user-attachments/assets/192ff600-435e-418b-9004-73333681cbeb" />

After
<img width="419" height="292" alt="image" src="https://github.com/user-attachments/assets/b7318394-a9f1-4910-ba75-965b06002f86" />


This PR maps `TOP_N` → `AREA` in two places:

- **Widget builder**: `deserializeDisplayType` now converts `TOP_N` to `AREA`,
  so when users open an old TOP_N widget, the type selector shows "Area". When
  they re-save, the widget is persisted as AREA — gradually migrating users off
  the deprecated type.

- **Widget card**: Instead of the old TOP_N-specific query manipulation (trimming
  aggregates, setting a results limit), it simply converts the display type to
  AREA so the widget renders through the standard area chart path with proper
  formatting.

Fixes DAIN-1267