### PR TITLE
ref(preprod): Remove project query param from artifact URLs

### DIFF
--- a/src/sentry/preprod/url_utils.py
+++ b/src/sentry/preprod/url_utils.py
@@ -13,8 +13,7 @@ def get_preprod_artifact_url(preprod_artifact: PreprodArtifact, view_type: str =
     )
 
     path = f"/organizations/{organization.slug}/preprod/{view_type}/{preprod_artifact.id}"
-    query = f"project={preprod_artifact.project.id}"
-    return organization.absolute_url(path, query=query)
+    return organization.absolute_url(path)
 
 
 def get_preprod_artifact_comparison_url(
@@ -27,5 +26,4 @@ def get_preprod_artifact_comparison_url(
         id=preprod_artifact.project.organization_id
     )
     path = f"/organizations/{organization.slug}/preprod/{comparison_type}/compare/{preprod_artifact.id}/{base_artifact.id}"
-    query = f"project={preprod_artifact.project.id}"
-    return organization.absolute_url(path, query=query)
+    return organization.absolute_url(path)

--- a/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
+++ b/tests/sentry/preprod/api/endpoints/test_organization_preprod_artifact_assemble.py
@@ -549,7 +549,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(
@@ -624,7 +624,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(
@@ -696,7 +696,7 @@ class ProjectPreprodArtifactAssembleTest(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
         assert set(response.data["missingChunks"]) == set()
-        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}?project={self.project.id}"
+        expected_url = f"/organizations/{self.organization.slug}/preprod/size/{artifact_id}"
         assert expected_url in response.data["artifactUrl"]
 
         mock_create_preprod_artifact.assert_called_once_with(

--- a/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_templates.py
@@ -963,8 +963,8 @@ class SuccessStateFormattingTest(StatusCheckTestBase):
             {},
         )
 
-        android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}?project={self.project.id}"
-        ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{ios_artifact.id}?project={self.project.id}"
+        android_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{android_artifact.id}"
+        ios_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{ios_artifact.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
 
         expected = f"""\
@@ -1311,7 +1311,9 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=[triggered_rule],
         )
 
-        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.id}"
+        artifact_url = (
+            f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}"
+        )
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
 
         expected = f"""\
@@ -1458,7 +1460,9 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}?project={self.project.id}"
+        artifact_url = (
+            f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact.id}"
+        )
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-download-absolute&expanded=rule-install-diff&expanded=rule-download-percent"
 
         expected = f"""\
@@ -1566,8 +1570,12 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        artifact1_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact1.id}?project={self.project.id}"
-        artifact2_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact2.id}?project={self.project.id}"
+        artifact1_url = (
+            f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact1.id}"
+        )
+        artifact2_url = (
+            f"http://testserver/organizations/{self.organization.slug}/preprod/size/{artifact2.id}"
+        )
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1&expanded=rule-2"
 
         expected = f"""\
@@ -1670,8 +1678,8 @@ class TriggeredRulesFormattingTest(StatusCheckTestBase):
             triggered_rules=triggered_rules,
         )
 
-        failed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{failed_artifact.id}?project={self.project.id}"
-        passed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{passed_artifact.id}?project={self.project.id}"
+        failed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{failed_artifact.id}"
+        passed_url = f"http://testserver/organizations/{self.organization.slug}/preprod/size/{passed_artifact.id}"
         settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/?expanded=rule-1"
 
         expected = f"""\


### PR DESCRIPTION
Remove the `?project=` query parameter from preprod artifact and comparison URLs.

The project ID is unnecessary in the URL since the artifact ID alone is sufficient to identify the resource. This produces cleaner URLs like `https://sentry.sentry.io/preprod/snapshots/70509` instead of `https://sentry.sentry.io/preprod/snapshots/70509?project=4509968066281472`.