### PR TITLE
fix(dashboards): Allow editing global filters on prebuilt dashboards

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -174,7 +174,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         self.check_object_permissions(request, dashboard)
 
         is_prebuilt = isinstance(dashboard, Dashboard) and dashboard.prebuilt_id is not None
-        prebuilt_title = dashboard.title if is_prebuilt else None
+        prebuilt_title = dashboard.title if isinstance(dashboard, Dashboard) else None
 
         tombstone = None
         if isinstance(dashboard, dict):

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -174,7 +174,10 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         self.check_object_permissions(request, dashboard)
 
         if isinstance(dashboard, Dashboard) and dashboard.prebuilt_id is not None:
-            return self.respond({"Cannot edit prebuilt Dashboards."}, status=409)
+            if "widgets" in request.data:
+                return self.respond(
+                    {"detail": "Cannot edit widgets on prebuilt Dashboards."}, status=409
+                )
 
         tombstone = None
         if isinstance(dashboard, dict):

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -173,15 +173,8 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
         self.check_object_permissions(request, dashboard)
 
-        if isinstance(dashboard, Dashboard) and dashboard.prebuilt_id is not None:
-            if "widgets" in request.data:
-                return self.respond(
-                    {"detail": "Cannot edit widgets on prebuilt Dashboards."}, status=409
-                )
-            if "title" in request.data and request.data["title"] != dashboard.title:
-                return self.respond(
-                    {"detail": "Cannot change the title of prebuilt Dashboards."}, status=409
-                )
+        is_prebuilt = isinstance(dashboard, Dashboard) and dashboard.prebuilt_id is not None
+        prebuilt_title = dashboard.title if is_prebuilt else None
 
         tombstone = None
         if isinstance(dashboard, dict):
@@ -201,6 +194,20 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
+
+        if is_prebuilt:
+            if "widgets" in serializer.validated_data:
+                return self.respond(
+                    {"detail": "Cannot edit widgets on prebuilt Dashboards."}, status=409
+                )
+            if (
+                "title" in serializer.validated_data
+                and serializer.validated_data["title"] != prebuilt_title
+            ):
+                return self.respond(
+                    {"detail": "Cannot change the title of prebuilt Dashboards."}, status=409
+                )
+
         try:
             with transaction.atomic(router.db_for_write(DashboardTombstone)):
                 serializer.save()

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -178,6 +178,10 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
                 return self.respond(
                     {"detail": "Cannot edit widgets on prebuilt Dashboards."}, status=409
                 )
+            if "title" in request.data and request.data["title"] != dashboard.title:
+                return self.respond(
+                    {"detail": "Cannot change the title of prebuilt Dashboards."}, status=409
+                )
 
         tombstone = None
         if isinstance(dashboard, dict):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3770,17 +3770,48 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 409
         assert "Cannot delete prebuilt Dashboards." in response.content.decode()
 
-    def test_cannot_edit_prebuilt_insights_dashboard(self) -> None:
+    def test_cannot_edit_prebuilt_insights_dashboard_widgets(self) -> None:
         dashboard = Dashboard.objects.create(
             title="Frontend Session Health",
             organization=self.organization,
             prebuilt_id=PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
         )
         response = self.do_request(
-            "put", self.url(dashboard.id), data={"title": "Frontend Session Health Edited"}
+            "put",
+            self.url(dashboard.id),
+            data={
+                "title": "Frontend Session Health",
+                "widgets": [
+                    {
+                        "title": "New Widget",
+                        "displayType": "line",
+                        "queries": [{"name": "", "conditions": "", "fields": ["count()"]}],
+                    }
+                ],
+            },
         )
         assert response.status_code == 409
-        assert "Cannot edit prebuilt Dashboards." in response.content.decode()
+        assert "Cannot edit widgets on prebuilt Dashboards." in response.content.decode()
+
+    def test_can_edit_prebuilt_insights_dashboard_global_filters(self) -> None:
+        dashboard = Dashboard.objects.create(
+            title="Frontend Session Health",
+            organization=self.organization,
+            prebuilt_id=PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
+        )
+        project = self.create_project(organization=self.organization)
+        response = self.do_request(
+            "put",
+            self.url(dashboard.id),
+            data={
+                "title": "Frontend Session Health",
+                "projects": [project.id],
+                "environment": ["production"],
+                "period": "7d",
+                "filters": {"release": ["v1.0"]},
+            },
+        )
+        assert response.status_code == 200
 
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -3793,6 +3793,20 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 409
         assert "Cannot edit widgets on prebuilt Dashboards." in response.content.decode()
 
+    def test_cannot_edit_prebuilt_insights_dashboard_title(self) -> None:
+        dashboard = Dashboard.objects.create(
+            title="Frontend Session Health",
+            organization=self.organization,
+            prebuilt_id=PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
+        )
+        response = self.do_request(
+            "put",
+            self.url(dashboard.id),
+            data={"title": "Renamed Dashboard"},
+        )
+        assert response.status_code == 409
+        assert "Cannot change the title of prebuilt Dashboards." in response.content.decode()
+
     def test_can_edit_prebuilt_insights_dashboard_global_filters(self) -> None:
         dashboard = Dashboard.objects.create(
             title="Frontend Session Health",


### PR DESCRIPTION
Previously, all PUT requests to prebuilt dashboards (those with a `prebuilt_id`) were rejected with a 409. This was too restrictive — users need to be able to set global filters (projects, environments, period, filters) on prebuilt dashboards.

Now only requests that include `widgets` in the payload are rejected for prebuilt dashboards. All other properties pass through to the serializer normally.