### PR TITLE
fix(metric-issues): Handle 10k data point limit for the metric chart

### DIFF
--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -98,7 +98,7 @@ describe('limitDateTimeParamsToMaxPoints', () => {
 
     expect(result).toEqual({
       dateTimeParams: {
-        start: getUtcDateString(endMs - 10_100 * 300 * 1000),
+        start: getUtcDateString(endMs - (10_100 - 1) * 300 * 1000),
         end: getUtcDateString(endMs),
       },
       isRangeLimited: true,

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -82,7 +82,7 @@ describe('limitDateTimeParamsToMaxPoints', () => {
 
     expect(result).toEqual({
       dateTimeParams: {
-        statsPeriod: '7d',
+        statsPeriod: '168h',
       },
       isRangeLimited: true,
     });

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -52,7 +52,7 @@ describe('buildDetectorZoomQuery', () => {
     });
   });
 
-  it('uses day units when the duration resolves to whole days', () => {
+  it('uses hours for multi-day durations', () => {
     setMockDate(Date.parse('2026-02-05T00:00:00Z'));
     const zoomRange = computeZoomRangeMs({
       startMs: Date.parse('2026-02-02T00:10:00Z'),
@@ -98,7 +98,7 @@ describe('limitDateTimeParamsToMaxPoints', () => {
 
     expect(result).toEqual({
       dateTimeParams: {
-        start: getUtcDateString(endMs - 10_000 * 300 * 1000),
+        start: getUtcDateString(endMs - 10_100 * 300 * 1000),
         end: getUtcDateString(endMs),
       },
       isRangeLimited: true,

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.spec.ts
@@ -2,7 +2,11 @@ import {setMockDate} from 'sentry-test/utils';
 
 import {getUtcDateString} from 'sentry/utils/dates';
 
-import {buildDetectorZoomQuery, computeZoomRangeMs} from './buildDetectorZoomQuery';
+import {
+  buildDetectorZoomQuery,
+  computeZoomRangeMs,
+  limitDateTimeParamsToMaxPoints,
+} from './buildDetectorZoomQuery';
 
 describe('buildDetectorZoomQuery', () => {
   it('uses absolute start/end for historical ranges', () => {
@@ -65,6 +69,57 @@ describe('buildDetectorZoomQuery', () => {
       start: undefined,
       end: undefined,
       statsPeriod: '3d',
+    });
+  });
+});
+
+describe('limitDateTimeParamsToMaxPoints', () => {
+  it('limits long statsPeriod ranges to max points', () => {
+    const result = limitDateTimeParamsToMaxPoints({
+      statsPeriod: '30d',
+      intervalSeconds: 60,
+    });
+
+    expect(result).toEqual({
+      dateTimeParams: {
+        statsPeriod: '7d',
+      },
+      isRangeLimited: true,
+    });
+  });
+
+  it('limits long absolute ranges to max points', () => {
+    const endMs = Date.parse('2026-02-01T00:00:00Z');
+    const result = limitDateTimeParamsToMaxPoints({
+      start: getUtcDateString(Date.parse('2025-01-01T00:00:00Z')),
+      end: getUtcDateString(endMs),
+      intervalSeconds: 300,
+    });
+
+    expect(result).toEqual({
+      dateTimeParams: {
+        start: getUtcDateString(endMs - 10_000 * 300 * 1000),
+        end: getUtcDateString(endMs),
+      },
+      isRangeLimited: true,
+    });
+  });
+
+  it('does not modify ranges within max points', () => {
+    const start = getUtcDateString(Date.parse('2026-02-01T00:00:00Z'));
+    const end = getUtcDateString(Date.parse('2026-02-02T00:00:00Z'));
+    const result = limitDateTimeParamsToMaxPoints({
+      start,
+      end,
+      intervalSeconds: 60,
+    });
+
+    expect(result).toEqual({
+      dateTimeParams: {
+        start,
+        end,
+      },
+      isRangeLimited: false,
     });
   });
 });

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -46,7 +46,7 @@ interface LimitDateTimeParamsToMaxPointsResult {
 
 function getMaxSpanMs(intervalSeconds?: number): number {
   const intervalMs = Math.max((intervalSeconds ?? 60) * 1000, MIN_INTERVAL_MS);
-  const pointsSpanMs = MAX_DETECTOR_CHART_POINTS * intervalMs;
+  const pointsSpanMs = (MAX_DETECTOR_CHART_POINTS - 1) * intervalMs;
   return Math.min(pointsSpanMs, NINETY_DAYS_MS);
 }
 

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -1,7 +1,13 @@
+import moment from 'moment-timezone';
+
+import {parseStatsPeriod} from 'sentry/components/pageFilters/parse';
 import {getUtcDateString} from 'sentry/utils/dates';
 
 // If the end time is within 10 minutes of now, we use a relative time range instead of an absolute one
 const NEAR_NOW_THRESHOLD_MS = 10 * 60 * 1000;
+const MIN_INTERVAL_MS = 60_000;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+export const MAX_DETECTOR_CHART_POINTS = 10_000;
 
 interface ComputeZoomRangeOptions {
   endMs: number;
@@ -19,6 +25,63 @@ interface RelativeZoomRangeMs {
 }
 
 type ZoomRangeMs = AbsoluteZoomRangeMs | RelativeZoomRangeMs;
+
+interface LimitDateTimeParamsToMaxPointsOptions {
+  end?: string | null;
+  intervalSeconds?: number;
+  start?: string | null;
+  statsPeriod?: string | null;
+}
+
+interface LimitDateTimeParamsToMaxPointsResult {
+  dateTimeParams: {
+    end?: string;
+    start?: string;
+    statsPeriod?: string;
+  };
+  isRangeLimited: boolean;
+}
+
+function getMaxSpanMs(intervalSeconds?: number): number {
+  const intervalMs = Math.max((intervalSeconds ?? 60) * 1000, MIN_INTERVAL_MS);
+  const pointsSpanMs = MAX_DETECTOR_CHART_POINTS * intervalMs;
+  return Math.min(pointsSpanMs, NINETY_DAYS_MS);
+}
+
+function parseStatsPeriodDurationMs(statsPeriod: string): number | null {
+  const parsed = parseStatsPeriod(statsPeriod);
+  if (!parsed) {
+    return null;
+  }
+
+  const period = Number(parsed.period);
+  if (!Number.isFinite(period)) {
+    return null;
+  }
+
+  const periodLengthMs = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+    w: 7 * 24 * 60 * 60 * 1000,
+  }[parsed.periodLength];
+
+  return period * periodLengthMs;
+}
+
+function parseDateTimeMs(dateTime?: string | null): number | null {
+  if (!dateTime) {
+    return null;
+  }
+
+  const parsedDateTime = moment.utc(dateTime);
+  if (!parsedDateTime.isValid()) {
+    return null;
+  }
+
+  return parsedDateTime.valueOf();
+}
 
 function toStatsPeriod(durationMs: number): string {
   const hourMs = 60 * 60 * 1000;
@@ -51,16 +114,13 @@ export function computeZoomRangeMs({
   endMs,
   intervalSeconds,
 }: ComputeZoomRangeOptions): ZoomRangeMs {
-  const intervalMs = Math.max((intervalSeconds ?? 60) * 1000, 60_000);
+  const intervalMs = Math.max((intervalSeconds ?? 60) * 1000, MIN_INTERVAL_MS);
   const bufferMs = 10 * intervalMs;
 
   const desiredStart = startMs - bufferMs;
   const desiredEnd = truncateEndTime(endMs + bufferMs);
 
-  const MAX_POINTS = 10_000;
-  const pointsSpanMs = MAX_POINTS * intervalMs;
-  const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
-  const maxSpanMs = Math.min(pointsSpanMs, ninetyDaysMs);
+  const maxSpanMs = getMaxSpanMs(intervalSeconds);
 
   const endIsNearNow = desiredEnd >= Date.now() - NEAR_NOW_THRESHOLD_MS;
   let zoomStartMs = desiredStart;
@@ -77,6 +137,64 @@ export function computeZoomRangeMs({
   const end = Math.ceil(zoomEndMs / 60_000) * 60_000;
 
   return {start, end};
+}
+
+/**
+ * Ensure detector chart date params request no more than 10k points. The
+ * event stats endpoint will respond with a 400 if we request more than that.
+ */
+export function limitDateTimeParamsToMaxPoints({
+  start,
+  end,
+  statsPeriod,
+  intervalSeconds,
+}: LimitDateTimeParamsToMaxPointsOptions): LimitDateTimeParamsToMaxPointsResult {
+  const maxSpanMs = getMaxSpanMs(intervalSeconds);
+
+  if (statsPeriod) {
+    const statsPeriodDurationMs = parseStatsPeriodDurationMs(statsPeriod);
+    if (!statsPeriodDurationMs || statsPeriodDurationMs <= maxSpanMs) {
+      return {
+        dateTimeParams: {statsPeriod},
+        isRangeLimited: false,
+      };
+    }
+
+    return {
+      dateTimeParams: {statsPeriod: toStatsPeriod(maxSpanMs)},
+      isRangeLimited: true,
+    };
+  }
+
+  const startMs = parseDateTimeMs(start);
+  const endMs = parseDateTimeMs(end);
+  if (startMs === null || endMs === null || endMs <= startMs) {
+    return {
+      dateTimeParams: {
+        start: start ?? undefined,
+        end: end ?? undefined,
+      },
+      isRangeLimited: false,
+    };
+  }
+
+  if (endMs - startMs <= maxSpanMs) {
+    return {
+      dateTimeParams: {
+        start: start ?? undefined,
+        end: end ?? undefined,
+      },
+      isRangeLimited: false,
+    };
+  }
+
+  return {
+    dateTimeParams: {
+      start: getUtcDateString(endMs - maxSpanMs),
+      end: getUtcDateString(endMs),
+    },
+    isRangeLimited: true,
+  };
 }
 
 /**

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -7,7 +7,9 @@ import {getUtcDateString} from 'sentry/utils/dates';
 const NEAR_NOW_THRESHOLD_MS = 10 * 60 * 1000;
 const MIN_INTERVAL_MS = 60_000;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
-export const MAX_DETECTOR_CHART_POINTS = 10_000;
+
+// See MAX_ROLLUP_POINTS in sentry/constants.py
+const MAX_DETECTOR_CHART_POINTS = 10_100;
 
 interface ComputeZoomRangeOptions {
   endMs: number;
@@ -85,10 +87,10 @@ function parseDateTimeMs(dateTime?: string | null): number | null {
 
 function toStatsPeriod(durationMs: number): string {
   const hourMs = 60 * 60 * 1000;
-  const durationHours = Math.max(Math.ceil(durationMs / hourMs), 4);
+  const durationHours = Math.max(Math.floor(durationMs / hourMs), 4);
 
-  if (durationHours > 24) {
-    return `${Math.ceil(durationHours / 24)}d`;
+  if (durationHours > 24 && durationHours % 24 <= 12) {
+    return `${Math.floor(durationHours / 24)}d`;
   }
 
   return `${durationHours}h`;

--- a/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
+++ b/static/app/views/detectors/components/details/common/buildDetectorZoomQuery.ts
@@ -85,12 +85,14 @@ function parseDateTimeMs(dateTime?: string | null): number | null {
   return parsedDateTime.valueOf();
 }
 
-function toStatsPeriod(durationMs: number): string {
+// Converts the duration of a zoom range to a statsPeriod string.
+// Rounds up to the nearest hour or day (if it's more than 24 hours).
+function zoomDurationToStatsPeriod(durationMs: number): string {
   const hourMs = 60 * 60 * 1000;
-  const durationHours = Math.max(Math.floor(durationMs / hourMs), 4);
+  const durationHours = Math.max(Math.ceil(durationMs / hourMs), 4);
 
-  if (durationHours > 24 && durationHours % 24 <= 12) {
-    return `${Math.floor(durationHours / 24)}d`;
+  if (durationHours >= 24) {
+    return `${Math.ceil(durationHours / 24)}d`;
   }
 
   return `${durationHours}h`;
@@ -132,7 +134,7 @@ export function computeZoomRangeMs({
   }
 
   if (endIsNearNow) {
-    return {statsPeriod: toStatsPeriod(Date.now() - zoomStartMs)};
+    return {statsPeriod: zoomDurationToStatsPeriod(zoomEndMs - zoomStartMs)};
   }
 
   const start = Math.floor(zoomStartMs / 60_000) * 60_000;
@@ -162,8 +164,12 @@ export function limitDateTimeParamsToMaxPoints({
       };
     }
 
+    const hourMs = 60 * 60 * 1000;
+    // Query to the nearest hour, rounded down
+    const durationHours = Math.floor(maxSpanMs / hourMs);
+
     return {
-      dateTimeParams: {statsPeriod: toStatsPeriod(maxSpanMs)},
+      dateTimeParams: {statsPeriod: `${durationHours}h`},
       isRangeLimited: true,
     };
   }

--- a/static/app/views/detectors/datasetConfig/errors.spec.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.spec.tsx
@@ -1,5 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
 import type {SnubaQuery} from 'sentry/types/workflowEngine/detectors';
 import {Dataset, EventTypes} from 'sentry/views/alerts/rules/metric/types';
 import {DetectorErrorsConfig} from 'sentry/views/detectors/datasetConfig/errors';
@@ -33,26 +31,5 @@ describe('DetectorErrorsConfig.toSnubaQueryString', () => {
 
     const result = DetectorErrorsConfig.toSnubaQueryString(snubaQuery);
     expect(result).toBe('event.type:error is:unresolved');
-  });
-});
-
-describe('DetectorErrorsConfig.getSeriesQueryOptions', () => {
-  it('adjusts statsPeriod from 7d to 9998m when interval is 60 seconds', () => {
-    const options = {
-      aggregate: 'count()',
-      organization: OrganizationFixture(),
-      projectId: '1',
-      query: 'is:unresolved',
-      environment: '',
-      comparisonDelta: undefined,
-      dataset: Dataset.ERRORS,
-      eventTypes: [EventTypes.ERROR],
-      interval: 60,
-      statsPeriod: '7d',
-    };
-
-    const result = DetectorErrorsConfig.getSeriesQueryOptions(options);
-
-    expect(result[1]!.query!.statsPeriod).toBe('9998m');
   });
 });

--- a/static/app/views/detectors/datasetConfig/errors.tsx
+++ b/static/app/views/detectors/datasetConfig/errors.tsx
@@ -81,12 +81,6 @@ export const DetectorErrorsConfig: DetectorDatasetConfig<ErrorsSeriesResponse> =
   defaultField: DEFAULT_FIELD,
   getAggregateOptions: () => AGGREGATE_OPTIONS,
   getSeriesQueryOptions: options => {
-    // If interval is 1 minute and statsPeriod is 7 days, apply a 9998m statsPeriod to avoid the 10k results limit.
-    // Applied specifically to errors dataset because it has 1m intervals, spans/logs have a minimum of 5m intervals.
-    if (options.interval === 60 && options.statsPeriod === '7d') {
-      options.statsPeriod = '9998m';
-    }
-
     return getDiscoverSeriesQueryOptions({
       ...options,
       dataset: DetectorErrorsConfig.getDiscoverDataset(),

--- a/static/app/views/detectors/datasetConfig/transactions.spec.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.spec.tsx
@@ -31,24 +31,6 @@ describe('DetectorTransactionsConfig', () => {
       expect(params.project).toEqual(['1']);
     });
 
-    it('expands 7d statsPeriod to 9998m for 1m intervals', () => {
-      const key = DetectorTransactionsConfig.getSeriesQueryOptions({
-        organization,
-        aggregate: 'count()',
-        interval: 60,
-        query: '',
-        environment: '',
-        projectId: '1',
-        dataset: Dataset.TRANSACTIONS,
-        eventTypes: [EventTypes.TRANSACTION],
-        statsPeriod: '7d',
-        comparisonDelta: undefined,
-      });
-
-      const params = key[1]!.query!;
-      expect(params.statsPeriod).toBe('9998m');
-    });
-
     it('on-demand success (apdex) returns METRICS_ENHANCED and prefixed query', () => {
       const orgWithFeature = OrganizationFixture({
         features: ['on-demand-metrics-extraction', 'on-demand-metrics-ui'],

--- a/static/app/views/detectors/datasetConfig/transactions.tsx
+++ b/static/app/views/detectors/datasetConfig/transactions.tsx
@@ -18,7 +18,6 @@ import {
   BASE_DYNAMIC_INTERVALS,
   BASE_INTERVALS,
   getStandardTimePeriodsForInterval,
-  MetricDetectorTimePeriod,
 } from 'sentry/views/detectors/datasetConfig/utils/timePeriods';
 import {
   translateAggregateTag,
@@ -77,14 +76,6 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
     defaultField: TransactionsConfig.defaultField,
     getAggregateOptions,
     getSeriesQueryOptions: options => {
-      // Force statsPeriod to be 9998m to avoid the 10k results limit.
-      // This is specific to the transactions dataset, since it has 1m intervals and does not support 10k+ results.
-      const isOneMinuteInterval = options.interval === 60;
-      const timePeriod =
-        options.statsPeriod === MetricDetectorTimePeriod.SEVEN_DAYS && isOneMinuteInterval
-          ? '9998m'
-          : options.statsPeriod;
-
       const hasMetricDataset =
         hasOnDemandMetricAlertFeature(options.organization) ||
         options.organization.features.includes('dashboards-metrics-transition');
@@ -102,7 +93,7 @@ export const DetectorTransactionsConfig: DetectorDatasetConfig<TransactionsSerie
       return getDiscoverSeriesQueryOptions({
         ...options,
         query,
-        statsPeriod: timePeriod,
+        statsPeriod: options.statsPeriod,
         dataset: DetectorTransactionsConfig.getDiscoverDataset(),
         aggregate: translateAggregateTag(options.aggregate),
         ...(isOnDemand && {extra: {useOnDemandMetrics: 'true'}}),

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
@@ -7,6 +7,7 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {parseStatsPeriod} from 'sentry/components/pageFilters/parse';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {MetricIssueChart} from 'sentry/views/issueDetails/metricIssues/metricIssueChart';
 import {IssueDetailsContext} from 'sentry/views/issueDetails/streamline/context';
@@ -73,6 +74,64 @@ describe('MetricIssueChart', () => {
     expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
     expect(mockDetector).toHaveBeenCalled();
     expect(mockStats).toHaveBeenCalled();
+  });
+
+  it('limits metric issue chart range to 10k points and shows a warning', async () => {
+    const detectorDetails = getDetectorDetails({event, organization, project});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/${detector.id}/`,
+      body: detector,
+    });
+    const mockStats = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: EventsStatsFixture(),
+    });
+
+    render(
+      <IssueDetailsContext value={{...baseIssueDetailsContext, detectorDetails}}>
+        <MetricIssueChart group={group} event={event} />
+      </IssueDetailsContext>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/issues/group-id/',
+            query: {statsPeriod: '30d'},
+          },
+        },
+      }
+    );
+
+    expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Showing only the most recent 10,000 data points\. Narrow the time range to view older data\./
+      )
+    ).toBeInTheDocument();
+    expect(mockStats).toHaveBeenCalled();
+    const [, statsRequest] = mockStats.mock.calls[0] ?? [];
+    const clampedStatsPeriod = statsRequest?.query?.statsPeriod;
+
+    expect(clampedStatsPeriod).not.toBe('30d');
+    const parsedStatsPeriod = parseStatsPeriod(clampedStatsPeriod);
+    expect(parsedStatsPeriod).toBeDefined();
+    if (!parsedStatsPeriod) {
+      throw new Error('Expected a clamped stats period');
+    }
+
+    const durationMinutesByPeriodLength = {
+      s: 1 / 60,
+      m: 1,
+      h: 60,
+      d: 24 * 60,
+      w: 7 * 24 * 60,
+    };
+    const durationMinutes =
+      Number(parsedStatsPeriod.period) *
+      durationMinutesByPeriodLength[parsedStatsPeriod.periodLength];
+
+    expect(durationMinutes).toBeLessThanOrEqual(10_000);
   });
 
   it('shows detector load error message when detector request fails', async () => {

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
@@ -7,7 +7,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {parseStatsPeriod} from 'sentry/components/pageFilters/parse';
 import {IssueCategory, IssueType} from 'sentry/types/group';
 import {MetricIssueChart} from 'sentry/views/issueDetails/metricIssues/metricIssueChart';
 import {IssueDetailsContext} from 'sentry/views/issueDetails/streamline/context';
@@ -106,32 +105,19 @@ describe('MetricIssueChart', () => {
     expect(await screen.findByTestId('area-chart')).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Showing only the most recent 10,000 data points\. Narrow the time range to view older data\./
+        'The selected time range contains too many data points. Narrow the range to view all data.'
       )
     ).toBeInTheDocument();
-    expect(mockStats).toHaveBeenCalled();
-    const [, statsRequest] = mockStats.mock.calls[0] ?? [];
-    const clampedStatsPeriod = statsRequest?.query?.statsPeriod;
 
-    expect(clampedStatsPeriod).not.toBe('30d');
-    const parsedStatsPeriod = parseStatsPeriod(clampedStatsPeriod);
-    expect(parsedStatsPeriod).toBeDefined();
-    if (!parsedStatsPeriod) {
-      throw new Error('Expected a clamped stats period');
-    }
-
-    const durationMinutesByPeriodLength = {
-      s: 1 / 60,
-      m: 1,
-      h: 60,
-      d: 24 * 60,
-      w: 7 * 24 * 60,
-    };
-    const durationMinutes =
-      Number(parsedStatsPeriod.period) *
-      durationMinutesByPeriodLength[parsedStatsPeriod.periodLength];
-
-    expect(durationMinutes).toBeLessThanOrEqual(10_000);
+    // Expect it to be called with 7d instead of 30d
+    expect(mockStats).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          statsPeriod: '7d',
+        }),
+      })
+    );
   });
 
   it('shows detector load error message when detector request fails', async () => {

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.spec.tsx
@@ -114,7 +114,7 @@ describe('MetricIssueChart', () => {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          statsPeriod: '7d',
+          statsPeriod: '168h',
         }),
       })
     );

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
@@ -1,3 +1,4 @@
+import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex} from '@sentry/scraps/layout';
 
 import {AreaChart} from 'sentry/components/charts/areaChart';
@@ -9,6 +10,10 @@ import type {Event} from 'sentry/types/event';
 import type {Group, GroupOpenPeriod} from 'sentry/types/group';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import type RequestError from 'sentry/utils/requestError/requestError';
+import {
+  limitDateTimeParamsToMaxPoints,
+  MAX_DETECTOR_CHART_POINTS,
+} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
 import {useMetricDetectorChart} from 'sentry/views/detectors/components/details/metric/chart';
 import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {
@@ -91,6 +96,13 @@ function MetricIssueChartContent({
     groupId: group.id,
     eventId: event?.id,
   });
+  const dateTimeParams = normalizeDateTimeParams(selection.datetime);
+  const intervalSeconds = detector.dataSources[0]?.queryObj?.snubaQuery?.timeWindow;
+  const {dateTimeParams: cappedDateTimeParams, isRangeLimited} =
+    limitDateTimeParamsToMaxPoints({
+      ...dateTimeParams,
+      intervalSeconds,
+    });
 
   const {
     chartProps,
@@ -102,7 +114,7 @@ function MetricIssueChartContent({
     highlightedOpenPeriodId: openPeriod?.id,
     height: CHART_HEIGHT,
     enabled: !isOpenPeriodPending,
-    ...normalizeDateTimeParams(selection.datetime),
+    ...cappedDateTimeParams,
   });
 
   if (isOpenPeriodPending || isLoading) {
@@ -121,7 +133,17 @@ function MetricIssueChartContent({
 
   return (
     <MetricChartSection>
-      <AreaChart {...chartProps} />
+      <Flex direction="column" paddingTop="md">
+        {isRangeLimited ? (
+          <Alert variant="warning">
+            {t(
+              'Showing only the most recent %s data points. Narrow the time range to view older data.',
+              MAX_DETECTOR_CHART_POINTS.toLocaleString()
+            )}
+          </Alert>
+        ) : null}
+        <AreaChart {...chartProps} />
+      </Flex>
     </MetricChartSection>
   );
 }

--- a/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
+++ b/static/app/views/issueDetails/metricIssues/metricIssueChart.tsx
@@ -10,10 +10,7 @@ import type {Event} from 'sentry/types/event';
 import type {Group, GroupOpenPeriod} from 'sentry/types/group';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import type RequestError from 'sentry/utils/requestError/requestError';
-import {
-  limitDateTimeParamsToMaxPoints,
-  MAX_DETECTOR_CHART_POINTS,
-} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
+import {limitDateTimeParamsToMaxPoints} from 'sentry/views/detectors/components/details/common/buildDetectorZoomQuery';
 import {useMetricDetectorChart} from 'sentry/views/detectors/components/details/metric/chart';
 import {useDetectorQuery} from 'sentry/views/detectors/hooks';
 import {
@@ -137,8 +134,7 @@ function MetricIssueChartContent({
         {isRangeLimited ? (
           <Alert variant="warning">
             {t(
-              'Showing only the most recent %s data points. Narrow the time range to view older data.',
-              MAX_DETECTOR_CHART_POINTS.toLocaleString()
+              'The selected time range contains too many data points. Narrow the range to view all data.'
             )}
           </Alert>
         ) : null}


### PR DESCRIPTION
Closes ISWF-2151

For metric detectors with a small time window (like 1 minute), some of the time ranges will fetch too much data for the chart and cause the request to respond with a 400. 

This PR prevents us from fetching too much data, and displays a message to the user to explain that they will need to narrow the time range.

See here for an example: https://demo.sentry.io/issues/6755986934/

Before:
 
<img width="1762" height="314" alt="CleanShot 2026-03-04 at 09 01 00@2x" src="https://github.com/user-attachments/assets/9ec48e7c-34f6-4c38-8f7c-c023ffb51398" />

After:

<img width="1522" height="610" alt="CleanShot 2026-03-04 at 10 46 45@2x" src="https://github.com/user-attachments/assets/40532d41-9d94-477e-af20-20b2211fa630" />
