### PR TITLE
feat(tracemetrics): Alerts allow search on field

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -217,7 +217,7 @@ export default function EAPMetricsField({
           options={isFetching ? previousOptions : (metricOptions ?? [])}
           value={traceMetricSelectValue}
           loading={isFetching}
-          onSearch={debouncedSetSearch}
+          onInputChange={debouncedSetSearch}
           placeholder={t('Select a metric')}
           noOptionsMessage={() => t('No metrics found')}
           onChange={(option: MetricSelectOption) => handleMetricChange(option)}


### PR DESCRIPTION
onSearch is silently dropped so searching actually doesn't trigger any re-fetch for metrics.

Apparently `onSearch` it isn't actually a valid field. Something's wrong with the types here because the react select component seems to allow `[key in string]: any` downstream which lets in any props.