### PR TITLE
ref(grouping): Add fingerprinting test input for title parameterization

### DIFF
--- a/tests/sentry/grouping/fingerprint_inputs/fingerprint-title-no-message-parameterization.json
+++ b/tests/sentry/grouping/fingerprint_inputs/fingerprint-title-no-message-parameterization.json
@@ -1,0 +1,12 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [["message", "*dog*"]],
+      "fingerprint": ["dogs are great", "{{ message }}"],
+      "attributes": {"title": "{{ message }}"}
+    }
+  ],
+  "logentry": {
+    "formatted": "Number 1 dog, dog #1"
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_no_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_no_message_parameterization.pysnap
@@ -1,0 +1,38 @@
+---
+source: tests/sentry/grouping/test_fingerprinting.py::test_event_hash_variant
+---
+config:
+  rules:
+  - attributes:
+      title: '{{ message }}'
+    fingerprint:
+    - dogs are great
+    - '{{ message }}'
+    matchers:
+    - - message
+      - '*dog*'
+    text: message:"*dog*" -> "dogs are great{{ message }}" title="{{ message }}"
+  version: 1
+fingerprint:
+- dogs are great
+- '{{ message }}'
+title: 'Number <int> dog, dog #<int>'
+variants:
+  custom_server_fingerprint:
+    contributes: true
+    hint: null
+    key: custom_server_fingerprint
+    matched_rule: message:"*dog*" -> "dogs are great{{ message }}" title="{{ message
+      }}"
+    type: custom_fingerprint
+    values:
+    - dogs are great
+    - 'Number <int> dog, dog #<int>'
+  default:
+    component:
+      contributes: false
+      hint: ignored because custom server fingerprint takes precedence
+    contributes: false
+    hint: ignored because custom server fingerprint takes precedence
+    key: message
+    type: component


### PR DESCRIPTION
This adds a new fingerprinting snapshot test input, to illustrate the fact that we currently parameterize the `{{ message }}` parameter in both fingerprints (this is good) and custom titles (this is bad). This is being added separately from the fix so it will be easier to see in isolation what changes when the fix is made.