### PR TITLE
feat(preprod): Add different snapshot diff viewing options

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -236,7 +236,7 @@ function OnionView({
         <Text size="sm" variant="muted">
           {t('Base')}
         </Text>
-        <SliderWrapper>
+        <Flex width="200px">
           <Slider
             min={0}
             max={100}
@@ -244,7 +244,7 @@ function OnionView({
             onChange={onOpacityChange}
             formatLabel={v => `${v}%`}
           />
-        </SliderWrapper>
+        </Flex>
         <Text size="sm" variant="muted">
           {t('Head')}
         </Text>
@@ -288,8 +288,4 @@ const OnionOverlayLayer = styled('div')`
   left: 0;
   width: 100%;
   height: 100%;
-`;
-
-const SliderWrapper = styled('div')`
-  width: 200px;
 `;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Image} from '@sentry/scraps/image';
 import {Flex, Grid} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Slider} from '@sentry/scraps/slider';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
@@ -186,21 +187,21 @@ function WipeView({
   headImageUrl: string;
 }) {
   return (
-    <WipeContainer>
+    <Flex flex="1" minHeight="0">
       <ContentSliderDiff.Body
         before={
-          <WipeImage>
+          <Flex justify="center" align="center" height="100%">
             <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
-          </WipeImage>
+          </Flex>
         }
         after={
-          <WipeImage>
+          <Flex justify="center" align="center" height="100%">
             <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
-          </WipeImage>
+          </Flex>
         }
         minHeight="200px"
       />
-    </WipeContainer>
+    </Flex>
   );
 }
 
@@ -235,13 +236,15 @@ function OnionView({
         <Text size="sm" variant="muted">
           {t('Base')}
         </Text>
-        <OpacitySlider
-          type="range"
-          min={0}
-          max={100}
-          value={opacity}
-          onChange={e => onOpacityChange(Number(e.target.value))}
-        />
+        <SliderWrapper>
+          <Slider
+            min={0}
+            max={100}
+            value={opacity}
+            onChange={onOpacityChange}
+            formatLabel={v => `${v}%`}
+          />
+        </SliderWrapper>
         <Text size="sm" variant="muted">
           {t('Head')}
         </Text>
@@ -274,18 +277,6 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   -webkit-mask-size: 100% 100%;
 `;
 
-const WipeContainer = styled('div')`
-  flex: 1;
-  min-height: 0;
-`;
-
-const WipeImage = styled('div')`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
 const OnionContainer = styled('div')`
   position: relative;
   display: inline-block;
@@ -299,7 +290,6 @@ const OnionOverlayLayer = styled('div')`
   height: 100%;
 `;
 
-const OpacitySlider = styled('input')`
+const SliderWrapper = styled('div')`
   width: 200px;
-  cursor: pointer;
 `;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -3,14 +3,21 @@ import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
 import {Flex, Grid} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
+import {IconInput, IconPause, IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
+export type DiffMode = 'split' | 'wipe' | 'onion';
+
 interface DiffImageDisplayProps {
   diffImageBaseUrl: string;
+  diffMode: DiffMode;
   imageBaseUrl: string;
+  onDiffModeChange: (mode: DiffMode) => void;
   overlayColor: string;
   pair: SnapshotDiffPair;
   showOverlay: boolean;
@@ -22,8 +29,11 @@ export function DiffImageDisplay({
   diffImageBaseUrl,
   showOverlay,
   overlayColor,
+  diffMode,
+  onDiffModeChange,
 }: DiffImageDisplayProps) {
   const [diffMaskUrl, setDiffMaskUrl] = useState<string | null>(null);
+  const [onionOpacity, setOnionOpacity] = useState(50);
   const blobUrlRef = useRef<string | null>(null);
 
   const baseImageUrl = `${imageBaseUrl}${pair.base_image.key}/`;
@@ -76,38 +86,166 @@ export function DiffImageDisplay({
           {t('Diff: %s', diffPercent)}
         </Text>
       )}
-      <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
-        <Flex direction="column" gap="sm">
-          <Heading as="h4">{t('Base')}</Heading>
-          <Flex
-            justify="center"
-            border="primary"
-            radius="md"
-            overflow="hidden"
-            background="secondary"
-          >
-            <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
-          </Flex>
-        </Flex>
 
-        <Flex direction="column" gap="sm">
-          <Heading as="h4">{t('Current Branch')}</Heading>
-          <Flex
-            justify="center"
-            border="primary"
-            radius="md"
-            overflow="hidden"
-            background="secondary"
-          >
-            <ImageWrapper>
-              <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
-              {showOverlay && diffMaskUrl && (
-                <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
-              )}
-            </ImageWrapper>
-          </Flex>
+      {diffMode === 'split' && (
+        <SplitView
+          baseImageUrl={baseImageUrl}
+          headImageUrl={headImageUrl}
+          showOverlay={showOverlay}
+          overlayColor={overlayColor}
+          diffMaskUrl={diffMaskUrl}
+        />
+      )}
+
+      {diffMode === 'wipe' && (
+        <WipeView baseImageUrl={baseImageUrl} headImageUrl={headImageUrl} />
+      )}
+
+      {diffMode === 'onion' && (
+        <OnionView
+          baseImageUrl={baseImageUrl}
+          headImageUrl={headImageUrl}
+          opacity={onionOpacity}
+          onOpacityChange={setOnionOpacity}
+        />
+      )}
+
+      <Flex justify="center">
+        <SegmentedControl value={diffMode} onChange={onDiffModeChange}>
+          <SegmentedControl.Item key="split" icon={<IconPause />}>
+            {t('Split')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="wipe" icon={<IconInput />}>
+            {t('Wipe')}
+          </SegmentedControl.Item>
+          <SegmentedControl.Item key="onion" icon={<IconStack />}>
+            {t('Onion')}
+          </SegmentedControl.Item>
+        </SegmentedControl>
+      </Flex>
+    </Flex>
+  );
+}
+
+interface ViewProps {
+  baseImageUrl: string;
+  diffMaskUrl: string | null;
+  headImageUrl: string;
+  overlayColor: string;
+  showOverlay: boolean;
+}
+
+function SplitView({
+  baseImageUrl,
+  headImageUrl,
+  showOverlay,
+  overlayColor,
+  diffMaskUrl,
+}: ViewProps) {
+  return (
+    <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
+      <Flex direction="column" gap="sm">
+        <Heading as="h4">{t('Base')}</Heading>
+        <Flex
+          justify="center"
+          border="primary"
+          radius="md"
+          overflow="hidden"
+          background="secondary"
+        >
+          <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
         </Flex>
-      </Grid>
+      </Flex>
+
+      <Flex direction="column" gap="sm">
+        <Heading as="h4">{t('Current Branch')}</Heading>
+        <Flex
+          justify="center"
+          border="primary"
+          radius="md"
+          overflow="hidden"
+          background="secondary"
+        >
+          <ImageWrapper>
+            <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
+            {showOverlay && diffMaskUrl && (
+              <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
+            )}
+          </ImageWrapper>
+        </Flex>
+      </Flex>
+    </Grid>
+  );
+}
+
+function WipeView({
+  baseImageUrl,
+  headImageUrl,
+}: {
+  baseImageUrl: string;
+  headImageUrl: string;
+}) {
+  return (
+    <WipeContainer>
+      <ContentSliderDiff.Body
+        before={
+          <WipeImage>
+            <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
+          </WipeImage>
+        }
+        after={
+          <WipeImage>
+            <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
+          </WipeImage>
+        }
+        minHeight="200px"
+      />
+    </WipeContainer>
+  );
+}
+
+function OnionView({
+  baseImageUrl,
+  headImageUrl,
+  opacity,
+  onOpacityChange,
+}: {
+  baseImageUrl: string;
+  headImageUrl: string;
+  onOpacityChange: (value: number) => void;
+  opacity: number;
+}) {
+  return (
+    <Flex direction="column" gap="md" flex="1" minHeight="0" align="center">
+      <Flex
+        justify="center"
+        border="primary"
+        radius="md"
+        overflow="hidden"
+        background="secondary"
+      >
+        <OnionContainer>
+          <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
+          <OnionOverlayLayer style={{opacity: opacity / 100}}>
+            <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
+          </OnionOverlayLayer>
+        </OnionContainer>
+      </Flex>
+      <Flex align="center" gap="sm">
+        <Text size="sm" variant="muted">
+          {t('Base')}
+        </Text>
+        <OpacitySlider
+          type="range"
+          min={0}
+          max={100}
+          value={opacity}
+          onChange={e => onOpacityChange(Number(e.target.value))}
+        />
+        <Text size="sm" variant="muted">
+          {t('Head')}
+        </Text>
+      </Flex>
     </Flex>
   );
 }
@@ -134,4 +272,34 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   mask-mode: luminance;
   -webkit-mask-image: url(${p => p.$maskUrl});
   -webkit-mask-size: 100% 100%;
+`;
+
+const WipeContainer = styled('div')`
+  flex: 1;
+  min-height: 0;
+`;
+
+const WipeImage = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+const OnionContainer = styled('div')`
+  position: relative;
+  display: inline-block;
+`;
+
+const OnionOverlayLayer = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const OpacitySlider = styled('input')`
+  width: 200px;
+  cursor: pointer;
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,3 +1,5 @@
+import styled from '@emotion/styled';
+
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
@@ -8,12 +10,16 @@ import {t} from 'sentry/locale';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {DiffImageDisplay} from './imageDisplay/diffImageDisplay';
+import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
 
 interface SnapshotMainContentProps {
   diffImageBaseUrl: string;
+  diffMode: DiffMode;
   imageBaseUrl: string;
+  onDiffModeChange: (mode: DiffMode) => void;
+  onOverlayColorChange: (color: string) => void;
+  onShowOverlayChange: (show: boolean) => void;
   onVariantChange: (index: number) => void;
   overlayColor: string;
   selectedItem: SidebarItem | null;
@@ -28,7 +34,11 @@ export function SnapshotMainContent({
   imageBaseUrl,
   diffImageBaseUrl,
   showOverlay,
+  onShowOverlayChange,
   overlayColor,
+  onOverlayColorChange,
+  diffMode,
+  onDiffModeChange,
 }: SnapshotMainContentProps) {
   if (!selectedItem) {
     return (
@@ -42,10 +52,26 @@ export function SnapshotMainContent({
     const displayName = getImageName(selectedItem.pair.head_image);
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" gap="md" padding="xl">
+        <Flex align="center" justify="between" gap="md" padding="xl">
           <Text size="lg" bold>
             {displayName}
           </Text>
+          {diffMode === 'split' && (
+            <Flex align="center" gap="sm">
+              <Button
+                size="xs"
+                priority={showOverlay ? 'primary' : 'default'}
+                onClick={() => onShowOverlayChange(!showOverlay)}
+              >
+                {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
+              </Button>
+              <ColorInput
+                type="color"
+                value={overlayColor}
+                onChange={e => onOverlayColorChange(e.target.value)}
+              />
+            </Flex>
+          )}
         </Flex>
         <Separator orientation="horizontal" />
         <DiffImageDisplay
@@ -54,6 +80,8 @@ export function SnapshotMainContent({
           diffImageBaseUrl={diffImageBaseUrl}
           showOverlay={showOverlay}
           overlayColor={overlayColor}
+          diffMode={diffMode}
+          onDiffModeChange={onDiffModeChange}
         />
       </Flex>
     );
@@ -133,3 +161,12 @@ export function SnapshotMainContent({
     </Flex>
   );
 }
+
+const ColorInput = styled('input')`
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.sm};
+  padding: 0;
+`;

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -139,7 +139,7 @@ export function SnapshotSidebarContent({
   return (
     <Flex direction="column" gap="md" height="100%" width="100%">
       <Flex padding="xl" paddingBottom="0">
-        <InputGroup>
+        <InputGroup style={{flex: 1}}>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch size="sm" />
           </InputGroup.LeadingItems>

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -137,7 +137,7 @@ export function SnapshotSidebarContent({
   const isGroupedDiff = isDiffMode && groupedItems !== null;
 
   return (
-    <Flex direction="column" gap="md" height="100%">
+    <Flex direction="column" gap="md" height="100%" width="100%">
       <Flex padding="xl" paddingBottom="0">
         <InputGroup>
           <InputGroup.LeadingItems disablePointerEvents>
@@ -171,7 +171,7 @@ export function SnapshotSidebarContent({
                     <Disclosure.Title
                       trailingItems={
                         <Flex align="center" gap="xs">
-                          <Text size="xs" variant="muted">
+                          <Text size="xs" bold>
                             {sectionItems.length}
                           </Text>
                           {section.icon}
@@ -264,6 +264,16 @@ const SectionWrapper = styled('div')`
   [data-disclosure] > :not(:first-child) {
     padding-left: 0;
     padding-right: 0;
+  }
+
+  [data-disclosure] > div > button {
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  [data-disclosure] > div > button ~ * {
+    flex-shrink: 0;
+    padding-right: ${p => p.theme.space.md};
   }
 `;
 

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,7 +1,6 @@
 import {useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
-import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -25,6 +24,7 @@ import type {
 
 import {SnapshotDevTools} from './header/snapshotDevTools';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
+import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
 import {SnapshotMainContent} from './main/snapshotMainContent';
 import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 
@@ -65,6 +65,7 @@ export default function SnapshotsPage() {
   const [variantIndex, setVariantIndex] = useState(0);
   const [showOverlay, setShowOverlay] = useState(true);
   const [overlayColor, setOverlayColor] = useState('#00cc44');
+  const [diffMode, setDiffMode] = useState<DiffMode>('split');
 
   const {
     size: sidebarWidth,
@@ -198,44 +199,6 @@ export default function SnapshotsPage() {
           </Layout.HeaderActions>
         </Layout.Header>
 
-        {comparisonType === 'diff' && (
-          <Flex
-            align="center"
-            justify="between"
-            gap="lg"
-            padding="lg xl"
-            background="secondary"
-          >
-            <Text size="sm" bold>
-              {t('Comparison')}
-            </Text>
-            <Text size="sm" variant="muted">
-              {t(
-                '%s changed, %s added, %s removed, %s renamed, %s unchanged',
-                firstPageData.changed_count,
-                firstPageData.added_count,
-                firstPageData.removed_count,
-                firstPageData.renamed_count ?? 0,
-                firstPageData.unchanged_count
-              )}
-            </Text>
-            <Flex align="center" gap="sm">
-              <Button
-                size="xs"
-                priority={showOverlay ? 'primary' : 'default'}
-                onClick={() => setShowOverlay(!showOverlay)}
-              >
-                {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
-              </Button>
-              <ColorInput
-                type="color"
-                value={overlayColor}
-                onChange={e => setOverlayColor(e.target.value)}
-              />
-            </Flex>
-          </Flex>
-        )}
-
         <Flex direction="row" height="100%" width="100%" overflow="hidden">
           <Flex flexShrink={0} overflow="hidden" style={{width: sidebarWidth}}>
             <SnapshotSidebarContent
@@ -264,7 +227,11 @@ export default function SnapshotsPage() {
               imageBaseUrl={imageBaseUrl}
               diffImageBaseUrl={diffImageBaseUrl}
               showOverlay={showOverlay}
+              onShowOverlayChange={setShowOverlay}
               overlayColor={overlayColor}
+              onOverlayColorChange={setOverlayColor}
+              diffMode={diffMode}
+              onDiffModeChange={setDiffMode}
             />
           </Flex>
         </Flex>
@@ -290,13 +257,4 @@ const DragHandle = styled('div')`
     user-select: none;
     background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
-`;
-
-const ColorInput = styled('input')`
-  width: 28px;
-  height: 28px;
-  cursor: pointer;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.sm};
-  padding: 0;
 `;


### PR DESCRIPTION
## Summary

Adds three viewing modes for snapshot image diffs: **Split**, **Wipe**, and **Onion Skin**.

- **Split** (existing, now refactored): Side-by-side base vs head with optional diff mask overlay
- **Wipe**: Interactive slider to swipe between base and head images using `ContentSliderDiff`
- **Onion Skin**: Overlays head on base with an adjustable opacity slider to fade between the two

Also includes a few UX improvements:
- Moved overlay controls (toggle + color picker) from the page-level comparison bar into the main content header, scoped to Split mode only
- Removed the top-level comparison count bar — this information is already shown in the sidebar section headers
- Fixed sidebar disclosure sections so count badges and icons remain visible at narrow widths (`min-width: 0` + `flex-shrink: 0`)
- Added `width="100%"` to sidebar root so content properly reflows during resize
- Mode selector uses a `SegmentedControl` anchored below the image display area

## Changes

- `diffImageDisplay.tsx` — Extracted `SplitView`, `WipeView`, `OnionView` sub-components; added `DiffMode` type and mode selector
- `snapshotMainContent.tsx` — Received overlay control props and renders them contextually in the header
- `snapshots.tsx` — Lifted `diffMode` state, removed comparison count bar and its styled components
- `snapshotSidebarContent.tsx` — CSS fixes for disclosure button flex shrinking and count badge visibility

## Test plan
- [ ] Split mode works as before with overlay toggle and color picker
- [ ] Wipe mode renders slider that reveals base/head on drag
- [ ] Onion mode renders opacity slider that blends between images
- [ ] Mode selector persists selection across image navigation
- [ ] Sidebar sections remain readable at narrow widths (counts + icons visible)
- [ ] No regressions on single-image (non-diff) views