### PR TITLE
fix(grouping): Stop parameterizing message variable in custom titles

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -338,7 +338,12 @@ def expand_title_template(
         # can remove `use_legacy_unknown_variable_handling` and just return the value given by
         # `resolve_fingerprint_variable`
         resolved_value = resolve_fingerprint_variable(
-            variable_key, event, use_legacy_unknown_variable_handling
+            variable_key,
+            event,
+            use_legacy_unknown_variable_handling,
+            # Parameterization is useful for grouping, but we want to show the real error message in
+            # the event/issue title
+            parameterize_message=False,
         )
 
         # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -220,6 +220,7 @@ def resolve_fingerprint_variable(
     variable_key: str,
     event: Event,
     use_legacy_unknown_variable_handling: bool,
+    parameterize_message: bool = True,
 ) -> str | None:
     if variable_key == "transaction":
         return event.data.get("transaction") or "<no-transaction>"
@@ -230,6 +231,11 @@ def resolve_fingerprint_variable(
             or get_path(event.data, "logentry", "message")
             or get_path(event.data, "exception", "values", -1, "value")
         )
+
+        # Fingerprint variables can be used in custom titles, and there we want the original message
+        if not parameterize_message:
+            return message or "<no-message>"
+
         normalized_message = (
             normalize_message_for_grouping(message, event, source="fingerprint", trim_message=False)
             if message

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_no_message_parameterization.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_title_no_message_parameterization.pysnap
@@ -16,7 +16,7 @@ config:
 fingerprint:
 - dogs are great
 - '{{ message }}'
-title: 'Number <int> dog, dog #<int>'
+title: 'Number 1 dog, dog #1'
 variants:
   custom_server_fingerprint:
     contributes: true


### PR DESCRIPTION
Fingerprint rules can be used not only to affect grouping but also to set custom titles for events, using the same variables as are used for fingerprinting. When the `{{ message }}` variable appears in a fingerprint, we parameterize the value, as we do in other places where we use the message for grouping. This parameterization is currently over-applied, though, in that it's also happening when the `{{ message }}` variable is used in custom titles. (We don't parameterize error messages in non-custom titles, so we shouldn't be doing it in custom titles, either.)

This fixes that by adding a new optional `parameterize_message` parameter to our `resolve_fingerprint_variable` helper. It defaults to `True`, so in most places there's no change in behavior, but it allows us to prevent the parameterization when we're calling it from `expand_title_template`. As can be seen in the snapshot, neither the fingerprint nor the hash changes, but the title now uses the original values from the message.

This is the other half of the fix for https://github.com/getsentry/sentry/issues/109301. (The first half was done in https://github.com/getsentry/sentry/pull/109713.)