### PR TITLE
ref(dashboards): remove `dashboards-categorical-bar-charts` feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -76,8 +76,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:daily-summary", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables read only dashboards
     manager.add("organizations:dashboards-basic", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
-    # Enable categorical bar charts for dashboards
-    manager.add("organizations:dashboards-categorical-bar-charts", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables custom editable dashboards
     manager.add("organizations:dashboards-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enables global filters for dashboards

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -56,18 +56,12 @@ function WidgetBuilderTypeSelector({error, setError}: WidgetBuilderTypeSelectorP
   };
 
   const hasDetailsWidget = organization.features.includes('dashboards-details-widget');
-  const hasCategoricalBar = organization.features.includes(
-    'dashboards-categorical-bar-charts'
-  );
-
   // Use an array to define display type order explicitly.
   // Object key ordering in JS is technically specified but easy to break accidentally.
   const displayTypeOrder: Array<{label: string; type: DisplayType}> = [
     {type: DisplayType.AREA, label: t('Area')},
-    {type: DisplayType.BAR, label: hasCategoricalBar ? t('Bar (Time Series)') : t('Bar')},
-    ...(hasCategoricalBar
-      ? [{type: DisplayType.CATEGORICAL_BAR, label: t('Bar (Categorical)')}]
-      : []),
+    {type: DisplayType.BAR, label: t('Bar (Time Series)')},
+    {type: DisplayType.CATEGORICAL_BAR, label: t('Bar (Categorical)')},
     {type: DisplayType.LINE, label: t('Line')},
     {type: DisplayType.TABLE, label: t('Table')},
     {type: DisplayType.BIG_NUMBER, label: t('Big Number')},

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -755,14 +755,6 @@ function BigNumberComponent({
 function CategoricalSeriesComponent(props: TableComponentProps): React.ReactNode {
   const {widget, tableResults, loading} = props;
 
-  const hasCategoricalBarCharts = useOrganization().features.includes(
-    'dashboards-categorical-bar-charts'
-  );
-
-  if (!hasCategoricalBarCharts) {
-    return null;
-  }
-
   if (loading || !tableResults?.[0]) {
     return <LoadingPlaceholder />;
   }

--- a/static/app/views/dashboards/widgetLibrary/data.tsx
+++ b/static/app/views/dashboards/widgetLibrary/data.tsx
@@ -356,30 +356,26 @@ const getDefaultWidgets = (organization: Organization) => {
         },
       ],
     },
-    ...(organization.features.includes('dashboards-categorical-bar-charts')
-      ? [
-          {
-            id: 'error-count-by-transaction',
-            title: t('Error Count By Transaction'),
-            description: t('Compare error volume across your top transactions.'),
-            displayType: DisplayType.CATEGORICAL_BAR,
-            widgetType: WidgetType.ERRORS,
-            interval: '5m',
-            isCustomizable: true,
-            limit: 20,
-            queries: [
-              {
-                name: '',
-                conditions: '',
-                fields: ['transaction', 'count()'],
-                aggregates: ['count()'],
-                columns: ['transaction'],
-                orderby: '-count()',
-              },
-            ],
-          },
-        ]
-      : []),
+    {
+      id: 'error-count-by-transaction',
+      title: t('Error Count By Transaction'),
+      description: t('Compare error volume across your top transactions.'),
+      displayType: DisplayType.CATEGORICAL_BAR,
+      widgetType: WidgetType.ERRORS,
+      interval: '5m',
+      isCustomizable: true,
+      limit: 20,
+      queries: [
+        {
+          name: '',
+          conditions: '',
+          fields: ['transaction', 'count()'],
+          aggregates: ['count()'],
+          columns: ['transaction'],
+          orderby: '-count()',
+        },
+      ],
+    },
   ];
 
   return isSelfHostedErrorsOnly


### PR DESCRIPTION
Remove the `organizations:dashboards-categorical-bar-charts` feature flag, making categorical bar charts a permanent feature in dashboards.

The feature has been fully rolled out via flagpole. This PR removes all feature checks in frontend code (widget library, widget card chart, and type selector) and removes the flag declaration from `temporary.py`.

Companion PR to remove the flag definition from sentry-options-automator: https://github.com/getsentry/sentry-options-automator/pull/6696

🤖 Generated with [Claude Code](https://claude.com/claude-code)