### PR TITLE
Add snapshot diff status checks

### DIFF
--- a/bin/preprod/test_pr_details
+++ b/bin/preprod/test_pr_details
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 #################
 # Configuration #
 #################
-ORG_SLUG = "sentry-dev-ryan"
+ORG_SLUG = "sentry"
 REPO_NAME = "EmergeTools/hackernews"
-PR_NUMBER = "716"
+PR_NUMBER = "100"
 
 
 def main():

--- a/bin/preprod/test_pr_details
+++ b/bin/preprod/test_pr_details
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 #################
 # Configuration #
 #################
-ORG_SLUG = "sentry"
+ORG_SLUG = "sentry-dev-ryan"
 REPO_NAME = "EmergeTools/hackernews"
-PR_NUMBER = "100"
+PR_NUMBER = "716"
 
 
 def main():

--- a/bin/preprod/trigger_snapshot_status_check
+++ b/bin/preprod/trigger_snapshot_status_check
@@ -1,0 +1,339 @@
+#!/usr/bin/env python
+
+from sentry.runner import configure
+
+configure()
+
+import logging
+import sys
+from datetime import timedelta
+
+logger = logging.getLogger(__name__)
+
+from sentry.models.commitcomparison import CommitComparison
+from sentry.models.project import Project
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactMobileAppInfo,
+    PreprodComparisonApproval,
+)
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    create_preprod_snapshot_status_check_task,
+)
+
+#################
+# Configuration #
+#################
+ORG_SLUG = "sentry"
+PROJECT_SLUG = "internal"
+REPO_NAME = "EmergeTools/hackernews"
+COMMIT_SHA = "db2b4ae626b458b4be651019f1a7c112406c003e"
+
+# Snapshot build configurations
+BUILD_1 = {
+    "app_id": "com.emerge.hackernews.android",
+    "artifact_type": PreprodArtifact.ArtifactType.AAB,
+    "app_name": "HackerNews Android",
+    "build_version": "1.0.3",
+    "build_number": 42,
+    "state": "compared_with_changes",
+    "create_base": True,
+    # Snapshot comparison results
+    "images_changed": 0,
+    "images_added": 0,
+    "images_removed": 0,
+    "images_unchanged": 24,
+    "image_count": 24,
+}
+
+# Set to None to disable BUILD_2
+BUILD_2 = None
+
+# Available states:
+# - "no_metrics":              Artifact has no snapshot metrics yet (processing)
+# - "metrics_no_comparison":   Artifact has metrics but no comparison yet
+# - "comparison_pending":      Comparison created but still pending
+# - "comparison_processing":   Comparison in progress
+# - "comparison_failed":       Comparison failed
+# - "compared_no_changes":     Comparison complete, all images match
+# - "compared_with_changes":   Comparison complete, some images differ
+
+# USAGE EXAMPLES:
+#
+# 1. All images match (SUCCESS):
+#    BUILD_1 = {..., "state": "compared_no_changes"}
+#    BUILD_2 = {..., "state": "compared_no_changes"}
+#
+# 2. Images changed (FAILURE with Approve button):
+#    BUILD_1 = {..., "state": "compared_with_changes", "images_changed": 3}
+#
+# 3. Still comparing (IN_PROGRESS):
+#    BUILD_1 = {..., "state": "comparison_processing"}
+#
+# 4. Mixed states:
+#    BUILD_1 = {..., "state": "compared_with_changes"}
+#    BUILD_2 = {..., "state": "comparison_pending"}
+#
+# 5. Comparison failure:
+#    BUILD_1 = {..., "state": "comparison_failed"}
+
+
+BASE_COMMIT_SHA = "a1b2c3d4e5f6789012345678901234567890abcd"
+
+
+def cleanup_existing_data(project, commit_comparison):
+    """Remove existing test artifacts for idempotent reruns."""
+    logger.info("\n🧹 Cleaning up existing artifacts for commit %s...", COMMIT_SHA[:8])
+
+    base_commit_comparisons = CommitComparison.objects.filter(
+        head_sha=BASE_COMMIT_SHA,
+        organization_id=project.organization_id,
+    )
+
+    all_commit_comparisons = [commit_comparison] + list(base_commit_comparisons)
+    existing_artifacts = PreprodArtifact.objects.filter(
+        commit_comparison__in=all_commit_comparisons,
+        project__organization_id=project.organization_id,
+    )
+
+    if existing_artifacts.exists():
+        artifact_ids = list(existing_artifacts.values_list("id", flat=True))
+        metrics = PreprodSnapshotMetrics.objects.filter(preprod_artifact_id__in=artifact_ids)
+        metrics_ids = list(metrics.values_list("id", flat=True))
+
+        comparison_count = PreprodSnapshotComparison.objects.filter(
+            head_snapshot_metrics_id__in=metrics_ids
+        ).delete()[0]
+        metrics_count = metrics.delete()[0]
+        approval_count = PreprodComparisonApproval.objects.filter(
+            preprod_artifact_id__in=artifact_ids
+        ).delete()[0]
+        artifact_count = existing_artifacts.delete()[0]
+
+        if base_commit_comparisons.exists():
+            base_count = base_commit_comparisons.delete()[0]
+            logger.info(
+                "  ✓ Deleted %s artifacts, %s metrics, %s comparisons, %s approvals, %s base commits",
+                artifact_count,
+                metrics_count,
+                comparison_count,
+                approval_count,
+                base_count,
+            )
+        else:
+            logger.info(
+                "  ✓ Deleted %s artifacts, %s metrics, %s comparisons, %s approvals",
+                artifact_count,
+                metrics_count,
+                comparison_count,
+                approval_count,
+            )
+    else:
+        logger.info("  ✓ No existing artifacts found (clean slate)")
+
+
+def create_artifact_and_metrics(project, build_config, commit_comparison):
+    """Create a preprod artifact with snapshot metrics."""
+    state = build_config["state"]
+
+    artifact = PreprodArtifact.objects.create(
+        project=project,
+        artifact_type=build_config["artifact_type"],
+        app_id=build_config["app_id"],
+        commit_comparison=commit_comparison,
+        state=PreprodArtifact.ArtifactState.PROCESSED,
+    )
+    PreprodArtifactMobileAppInfo.objects.create(
+        preprod_artifact=artifact,
+        app_name=build_config["app_name"],
+        build_version=build_config["build_version"],
+        build_number=build_config["build_number"],
+    )
+
+    # Backdate to simulate processing time
+    artifact.date_added = artifact.date_added - timedelta(minutes=5)
+    artifact.save(update_fields=["date_added"])
+
+    logger.info("  ✓ Created artifact: %s (ID: %s)", build_config["app_id"], artifact.id)
+
+    if state == "no_metrics":
+        logger.info("  ⏳ No metrics created (simulating upload in progress)")
+        return artifact, None
+
+    metrics = PreprodSnapshotMetrics.objects.create(
+        preprod_artifact=artifact,
+        image_count=build_config.get("image_count", 10),
+    )
+    logger.info("  ✓ Created snapshot metrics: %s (%s images)", metrics.id, metrics.image_count)
+
+    return artifact, metrics
+
+
+def create_base_data(project, build_config, head_commit_comparison):
+    """Create base artifact and metrics for comparison."""
+    base_commit_comparison, _ = CommitComparison.objects.get_or_create(
+        head_repo_name=head_commit_comparison.head_repo_name,
+        head_sha=BASE_COMMIT_SHA,
+        provider=head_commit_comparison.provider,
+        organization_id=head_commit_comparison.organization_id,
+    )
+
+    if not head_commit_comparison.base_sha:
+        head_commit_comparison.base_sha = BASE_COMMIT_SHA
+        head_commit_comparison.save(update_fields=["base_sha"])
+
+    base_artifact = PreprodArtifact.objects.create(
+        project=project,
+        artifact_type=build_config["artifact_type"],
+        app_id=build_config["app_id"],
+        commit_comparison=base_commit_comparison,
+        state=PreprodArtifact.ArtifactState.PROCESSED,
+    )
+    PreprodArtifactMobileAppInfo.objects.create(
+        preprod_artifact=base_artifact,
+        app_name=build_config["app_name"],
+        build_version=build_config["build_version"],
+        build_number=build_config["build_number"] - 1,
+    )
+
+    base_metrics = PreprodSnapshotMetrics.objects.create(
+        preprod_artifact=base_artifact,
+        image_count=build_config.get("image_count", 10),
+    )
+
+    logger.info(
+        "  ✓ Created base artifact: %s (ID: %s) with metrics",
+        build_config["app_id"],
+        base_artifact.id,
+    )
+
+    return base_metrics
+
+
+def create_comparison(build_config, head_metrics, base_metrics):
+    """Create a snapshot comparison based on the configured state."""
+    state = build_config["state"]
+
+    state_map = {
+        "comparison_pending": PreprodSnapshotComparison.State.PENDING,
+        "comparison_processing": PreprodSnapshotComparison.State.PROCESSING,
+        "comparison_failed": PreprodSnapshotComparison.State.FAILED,
+        "compared_no_changes": PreprodSnapshotComparison.State.SUCCESS,
+        "compared_with_changes": PreprodSnapshotComparison.State.SUCCESS,
+    }
+
+    comparison_state = state_map.get(state)
+    if comparison_state is None:
+        return None
+
+    comparison = PreprodSnapshotComparison.objects.create(
+        head_snapshot_metrics=head_metrics,
+        base_snapshot_metrics=base_metrics,
+        state=comparison_state,
+        images_changed=build_config.get("images_changed", 0),
+        images_added=build_config.get("images_added", 0),
+        images_removed=build_config.get("images_removed", 0),
+        images_unchanged=build_config.get("images_unchanged", 0),
+    )
+
+    status_label = {
+        PreprodSnapshotComparison.State.PENDING: "⏳ Pending",
+        PreprodSnapshotComparison.State.PROCESSING: "⏳ Processing",
+        PreprodSnapshotComparison.State.FAILED: "❌ Failed",
+        PreprodSnapshotComparison.State.SUCCESS: "✅ Success",
+    }[comparison_state]
+
+    logger.info("  ✓ Created comparison: %s", status_label)
+    if comparison_state == PreprodSnapshotComparison.State.SUCCESS:
+        logger.info(
+            "    Changed: %s, Added: %s, Removed: %s, Unchanged: %s",
+            comparison.images_changed,
+            comparison.images_added,
+            comparison.images_removed,
+            comparison.images_unchanged,
+        )
+
+    return comparison
+
+
+def main():
+    try:
+        project = Project.objects.get(slug=PROJECT_SLUG, organization__slug=ORG_SLUG)
+        logger.info("Found project: %s (ID: %s)", project.name, project.id)
+
+        commit_comparison, created = CommitComparison.objects.get_or_create(
+            head_repo_name=REPO_NAME,
+            head_sha=COMMIT_SHA,
+            provider="github",
+            organization_id=project.organization.id,
+        )
+        logger.info(
+            "%s commit comparison: %s", "Created" if created else "Found", commit_comparison.id
+        )
+
+        cleanup_existing_data(project, commit_comparison)
+
+        build_configs = [BUILD_1]
+        if BUILD_2 is not None:
+            build_configs.append(BUILD_2)
+
+        logger.info("\n🧪 Running snapshot status check test with %s build(s):", len(build_configs))
+        for i, config in enumerate(build_configs, 1):
+            logger.info(
+                "  📱 BUILD_%s: %s (state: %s, base: %s)",
+                i,
+                config["app_id"],
+                config["state"],
+                config.get("create_base", False),
+            )
+
+        created_artifacts = []
+
+        for build_config in build_configs:
+            logger.info("\n📦 Setting up %s...", build_config["app_id"])
+
+            artifact, head_metrics = create_artifact_and_metrics(
+                project, build_config, commit_comparison
+            )
+            created_artifacts.append(artifact)
+
+            if (
+                head_metrics
+                and build_config.get("create_base")
+                and build_config["state"]
+                not in (
+                    "no_metrics",
+                    "metrics_no_comparison",
+                )
+            ):
+                base_metrics = create_base_data(project, build_config, commit_comparison)
+                create_comparison(build_config, head_metrics, base_metrics)
+
+        logger.info(
+            "\n🚀 Calling create_preprod_snapshot_status_check_task with artifact %s...",
+            created_artifacts[0].id,
+        )
+        result = create_preprod_snapshot_status_check_task(
+            preprod_artifact_id=created_artifacts[0].id
+        )
+        logger.info("Task result: %s", result)
+        logger.info("✅ Snapshot status check function called successfully!")
+
+        logger.info("\n🔍 Check your GitHub status check at:")
+        logger.info("   https://github.com/%s/commit/%s", REPO_NAME, COMMIT_SHA)
+
+        logger.info("\n🔧 Debug: Created %s artifacts:", len(created_artifacts))
+        for artifact in created_artifacts:
+            logger.info("  - %s: ID %s", artifact.app_id, artifact.id)
+
+    except Project.DoesNotExist:
+        logger.exception("❌ Project not found: %s/%s", ORG_SLUG, PROJECT_SLUG)
+        sys.exit(1)
+    except Exception:
+        logger.exception("❌ Error running snapshot status check")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,6 +895,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.preprod.tasks",
     "sentry.preprod.vcs.pr_comments.tasks",
     "sentry.preprod.vcs.status_checks.size.tasks",
+    "sentry.preprod.vcs.status_checks.snapshots.tasks",
     "sentry.profiles.task",
     "sentry.release_health.tasks",
     "sentry.relocation.tasks.process",

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_status_checks.py
@@ -14,6 +14,9 @@ from sentry.preprod.analytics import PreprodArtifactApiRerunStatusChecksEvent
 from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    create_preprod_snapshot_status_check_task,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,11 +62,13 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
                 status=400,
             )
 
-        SUPPORTED_CHECK_TYPES = {"size"}
+        SUPPORTED_CHECK_TYPES = {"size", "snapshots"}
         supported_types = list({ct for ct in check_types if ct in SUPPORTED_CHECK_TYPES})
         if not supported_types:
             return Response(
-                {"error": "No supported check types provided. Currently only 'size' is supported."},
+                {
+                    "error": "No supported check types provided. Supported types: 'size', 'snapshots'."
+                },
                 status=400,
             )
 
@@ -89,6 +94,10 @@ class PreprodArtifactRerunStatusChecksEndpoint(PreprodArtifactEndpoint):
                 match check_type:
                     case "size":
                         create_preprod_status_check_task.delay(
+                            preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
+                        )
+                    case "snapshots":
+                        create_preprod_snapshot_status_check_task.delay(
                             preprod_artifact_id=head_artifact.id, caller="rerun_endpoint"
                         )
                     case _:

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -507,6 +507,13 @@ def compare_snapshots(
             ]
         )
 
+        create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_completion",
+            },
+        )
+
         logger.info(
             "Snapshot comparison complete",
             extra={
@@ -519,11 +526,6 @@ def compare_snapshots(
                 "renamed": len(renamed_pairs),
                 "errored": error_count,
             },
-        )
-
-        create_preprod_snapshot_status_check_task.delay(
-            preprod_artifact_id=head_artifact_id,
-            caller="compare_completion",
         )
 
     except BaseException:
@@ -545,15 +547,10 @@ def compare_snapshots(
                     extra={"comparison_id": comparison.id},
                 )
 
-        try:
-            create_preprod_snapshot_status_check_task.delay(
-                preprod_artifact_id=head_artifact_id,
-                caller="compare_failure",
-            )
-        except Exception:
-            logger.exception(
-                "Failed to trigger snapshot status check after comparison failure",
-                extra={"head_artifact_id": head_artifact_id},
-            )
-
+        create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": head_artifact_id,
+                "caller": "compare_failure",
+            },
+        )
         raise

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -18,6 +18,9 @@ from sentry.preprod.snapshots.manifest import (
     SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    create_preprod_snapshot_status_check_task,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
@@ -518,6 +521,11 @@ def compare_snapshots(
             },
         )
 
+        create_preprod_snapshot_status_check_task.delay(
+            preprod_artifact_id=head_artifact_id,
+            caller="compare_completion",
+        )
+
     except BaseException:
         logger.exception(
             "Snapshot comparison failed",
@@ -536,4 +544,16 @@ def compare_snapshots(
                     "Failed to save FAILED state for comparison",
                     extra={"comparison_id": comparison.id},
                 )
+
+        try:
+            create_preprod_snapshot_status_check_task.delay(
+                preprod_artifact_id=head_artifact_id,
+                caller="compare_failure",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to trigger snapshot status check after comparison failure",
+                extra={"head_artifact_id": head_artifact_id},
+            )
+
         raise

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -208,13 +208,13 @@ def create_preprod_status_check_task(
     # Get all artifacts for this commit across all projects in the organization
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
-    client, repository = _get_status_check_client(preprod_artifact.project, commit_comparison)
+    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
     if not client or not repository:
         # logging handled in _get_status_check_client. for now we can be lax about users potentially
         # not having their repos integrated into Sentry
         return
 
-    provider = _get_status_check_provider(
+    provider = get_status_check_provider(
         client,
         commit_comparison.provider,
         preprod_artifact.project.organization_id,
@@ -334,7 +334,7 @@ def create_preprod_status_check_task(
             "preprod.status_checks.create.failed",
             extra=extra,
         )
-        _update_posted_status_check(preprod_artifact, check_type="size", success=False, error=e)
+        update_posted_status_check(preprod_artifact, check_type="size", success=False, error=e)
         raise
 
     if check_id is None:
@@ -347,12 +347,10 @@ def create_preprod_status_check_task(
                 "error_type": "null_check_id",
             },
         )
-        _update_posted_status_check(preprod_artifact, check_type="size", success=False)
+        update_posted_status_check(preprod_artifact, check_type="size", success=False)
         return
 
-    _update_posted_status_check(
-        preprod_artifact, check_type="size", success=True, check_id=check_id
-    )
+    update_posted_status_check(preprod_artifact, check_type="size", success=True, check_id=check_id)
 
     if triggered_rules:
         sentry_analytics.record(
@@ -376,7 +374,7 @@ def create_preprod_status_check_task(
     )
 
 
-def _update_posted_status_check(
+def update_posted_status_check(
     preprod_artifact: PreprodArtifact,
     check_type: str,
     success: bool,
@@ -809,7 +807,7 @@ def _compute_overall_status(
         return StatusCheckStatus.IN_PROGRESS, triggered_rules
 
 
-def _get_status_check_client(
+def get_status_check_client(
     project: Project, commit_comparison: CommitComparison
 ) -> tuple[StatusCheckClient, Repository] | tuple[None, None]:
     """Get status check client for the project's integration.
@@ -875,7 +873,7 @@ def _get_status_check_client(
     return client, repository
 
 
-def _get_status_check_provider(
+def get_status_check_provider(
     client: StatusCheckClient,
     provider: str | None,
     organization_id: int,

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -319,7 +319,7 @@ def create_preprod_status_check_task(
             target_url=target_url,
             started_at=preprod_artifact.date_added,
             completed_at=completed_at,
-            include_approve_action=bool(triggered_rules),
+            approve_action_identifier=APPROVE_SIZE_ACTION_IDENTIFIER if triggered_rules else None,
         )
     except Exception as e:
         extra: dict[str, Any] = {
@@ -932,7 +932,7 @@ class _StatusCheckProvider(ABC):
         started_at: datetime,
         completed_at: datetime | None = None,
         target_url: str | None = None,
-        include_approve_action: bool = False,
+        approve_action_identifier: str | None = None,
     ) -> str | None:
         """Create a status check using provider-specific format."""
         raise NotImplementedError
@@ -952,7 +952,7 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
         started_at: datetime,
         completed_at: datetime | None = None,
         target_url: str | None = None,
-        include_approve_action: bool = False,
+        approve_action_identifier: str | None = None,
     ) -> str | None:
         with self._create_scm_interaction_event().capture() as lifecycle:
             mapped_status = GITHUB_STATUS_CHECK_STATUS_MAPPING.get(status)
@@ -1029,12 +1029,12 @@ class _GitHubStatusCheckProvider(_StatusCheckProvider):
                     "Omit completed_at entirely instead of setting it to None."
                 )
 
-            if include_approve_action:
+            if approve_action_identifier:
                 check_data["actions"] = [
                     {
                         "label": "Approve",
-                        "description": "Approve size changes for this PR",
-                        "identifier": APPROVE_SIZE_ACTION_IDENTIFIER,
+                        "description": "Approve changes for this PR",
+                        "identifier": approve_action_identifier,
                     }
                 ]
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from sentry.integrations.github.status_check import GitHubCheckStatus
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodComparisonApproval,
+)
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.url_utils import get_preprod_artifact_url
+from sentry.preprod.vcs.status_checks.size.tasks import (
+    GITHUB_STATUS_CHECK_STATUS_MAPPING,
+    _get_status_check_client,
+    _get_status_check_provider,
+    _update_posted_status_check,
+)
+from sentry.preprod.vcs.status_checks.snapshots.templates import (
+    format_snapshot_status_check_messages,
+)
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import preprod_tasks
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
+
+# Action identifier for the "Approve" button on snapshot GitHub check runs.
+APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
+
+
+@instrumented_task(
+    name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
+    namespace=preprod_tasks,
+    processing_deadline_duration=30,
+    silo_mode=SiloMode.REGION,
+)
+def create_preprod_snapshot_status_check_task(
+    preprod_artifact_id: int, caller: str | None = None, **kwargs: Any
+) -> None:
+    try:
+        preprod_artifact: PreprodArtifact | None = PreprodArtifact.objects.select_related(
+            "mobile_app_info",
+            "commit_comparison",
+            "project",
+            "project__organization",
+        ).get(id=preprod_artifact_id)
+    except PreprodArtifact.DoesNotExist:
+        logger.exception(
+            "preprod.snapshot_status_checks.create.artifact_not_found",
+            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+        )
+        return
+
+    if not preprod_artifact or not isinstance(preprod_artifact, PreprodArtifact):
+        logger.error(
+            "preprod.snapshot_status_checks.create.artifact_not_found",
+            extra={"artifact_id": preprod_artifact_id, "caller": caller},
+        )
+        return
+
+    logger.info(
+        "preprod.snapshot_status_checks.create.start",
+        extra={"artifact_id": preprod_artifact.id, "caller": caller},
+    )
+
+    if not preprod_artifact.commit_comparison:
+        logger.info(
+            "preprod.snapshot_status_checks.create.no_commit_comparison",
+            extra={"artifact_id": preprod_artifact.id},
+        )
+        return
+
+    commit_comparison: CommitComparison = preprod_artifact.commit_comparison
+    if not commit_comparison.head_sha or not commit_comparison.head_repo_name:
+        logger.error(
+            "preprod.snapshot_status_checks.create.missing_git_info",
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "commit_comparison_id": commit_comparison.id,
+            },
+        )
+        return
+
+    status_checks_enabled = preprod_artifact.project.get_option(
+        SNAPSHOT_ENABLED_OPTION_KEY, default=True
+    )
+    if not status_checks_enabled:
+        logger.info(
+            "preprod.snapshot_status_checks.create.disabled",
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "project_id": preprod_artifact.project.id,
+            },
+        )
+        return
+
+    all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
+
+    client, repository = _get_status_check_client(preprod_artifact.project, commit_comparison)
+    if not client or not repository:
+        return
+
+    provider = _get_status_check_provider(
+        client,
+        commit_comparison.provider,
+        preprod_artifact.project.organization_id,
+        preprod_artifact.project.organization.slug,
+        repository.integration_id,
+    )
+    if not provider:
+        logger.info(
+            "preprod.snapshot_status_checks.create.not_supported_provider",
+            extra={"provider": commit_comparison.provider},
+        )
+        return
+
+    artifact_ids = [a.id for a in all_artifacts]
+    snapshot_metrics_qs = PreprodSnapshotMetrics.objects.filter(
+        preprod_artifact_id__in=artifact_ids,
+    )
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {
+        m.preprod_artifact_id: m for m in snapshot_metrics_qs
+    }
+
+    all_artifacts = [a for a in all_artifacts if a.id in snapshot_metrics_map]
+    if not all_artifacts:
+        logger.info(
+            "preprod.snapshot_status_checks.create.no_snapshot_metrics",
+            extra={"artifact_id": preprod_artifact.id},
+        )
+        return
+
+    metrics_ids = [m.id for m in snapshot_metrics_map.values()]
+    comparisons_qs = PreprodSnapshotComparison.objects.filter(
+        head_snapshot_metrics_id__in=metrics_ids,
+    )
+    comparisons_map: dict[int, PreprodSnapshotComparison] = {
+        c.head_snapshot_metrics_id: c for c in comparisons_qs
+    }
+
+    approvals_map: dict[int, PreprodComparisonApproval] = {}
+    approval_qs = PreprodComparisonApproval.objects.filter(
+        preprod_artifact_id__in=artifact_ids,
+        preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+        approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+    )
+    for approval in approval_qs:
+        approvals_map[approval.preprod_artifact_id] = approval
+
+    base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
+
+    status = _compute_snapshot_status(
+        all_artifacts, snapshot_metrics_map, comparisons_map, approvals_map
+    )
+
+    completed_at: datetime | None = None
+    if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
+        completed_at = preprod_artifact.date_updated
+
+    title, subtitle, summary = format_snapshot_status_check_messages(
+        all_artifacts,
+        snapshot_metrics_map,
+        comparisons_map,
+        status,
+        preprod_artifact.project,
+        base_artifact_map,
+    )
+
+    include_approve_action = status == StatusCheckStatus.FAILURE and _has_snapshot_changes(
+        all_artifacts, snapshot_metrics_map, comparisons_map
+    )
+
+    url_artifact = (
+        preprod_artifact
+        if preprod_artifact.id in {a.id for a in all_artifacts}
+        else all_artifacts[0]
+    )
+    target_url = get_preprod_artifact_url(url_artifact, view_type="snapshots")
+
+    try:
+        check_id = provider.create_status_check(
+            repo=commit_comparison.head_repo_name,
+            sha=commit_comparison.head_sha,
+            status=status,
+            title=title,
+            subtitle=subtitle,
+            text=None,
+            summary=summary,
+            external_id=str(preprod_artifact.id),
+            target_url=target_url,
+            started_at=preprod_artifact.date_added,
+            completed_at=completed_at,
+            include_approve_action=include_approve_action,
+        )
+    except Exception as e:
+        extra: dict[str, Any] = {
+            "artifact_id": preprod_artifact.id,
+            "organization_id": preprod_artifact.project.organization_id,
+            "organization_slug": preprod_artifact.project.organization.slug,
+            "error_type": type(e).__name__,
+        }
+        if isinstance(e, ApiError):
+            extra["status_code"] = e.code
+        logger.exception(
+            "preprod.snapshot_status_checks.create.failed",
+            extra=extra,
+        )
+        _update_posted_status_check(
+            preprod_artifact, check_type="snapshots", success=False, error=e
+        )
+        raise
+
+    if check_id is None:
+        logger.error(
+            "preprod.snapshot_status_checks.create.failed",
+            extra={
+                "artifact_id": preprod_artifact.id,
+                "organization_id": preprod_artifact.project.organization_id,
+                "organization_slug": preprod_artifact.project.organization.slug,
+                "error_type": "null_check_id",
+            },
+        )
+        _update_posted_status_check(preprod_artifact, check_type="snapshots", success=False)
+        return
+
+    _update_posted_status_check(
+        preprod_artifact, check_type="snapshots", success=True, check_id=check_id
+    )
+
+    logger.info(
+        "preprod.snapshot_status_checks.create.success",
+        extra={
+            "artifact_id": preprod_artifact.id,
+            "status": status.value,
+            "check_id": check_id,
+            "organization_id": preprod_artifact.project.organization_id,
+            "organization_slug": preprod_artifact.project.organization.slug,
+        },
+    )
+
+
+def _has_snapshot_changes(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+    comparisons_map: dict[int, PreprodSnapshotComparison],
+) -> bool:
+    """Check if any artifact has snapshot changes (added/removed/changed)."""
+    for artifact in artifacts:
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if not metrics:
+            continue
+        comparison = comparisons_map.get(metrics.id)
+        if not comparison or comparison.state != PreprodSnapshotComparison.State.SUCCESS:
+            continue
+        if (
+            comparison.images_changed > 0
+            or comparison.images_added > 0
+            or comparison.images_removed > 0
+        ):
+            return True
+    return False
+
+
+def _compute_snapshot_status(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+    comparisons_map: dict[int, PreprodSnapshotComparison],
+    approvals_map: dict[int, PreprodComparisonApproval],
+) -> StatusCheckStatus:
+    """Compute the overall snapshot status check status.
+
+    - IN_PROGRESS if any comparison is pending/processing
+    - FAILURE if any comparison failed, or if any has changes and not approved
+    - SUCCESS if all comparisons succeeded with no changes, or all approved
+    """
+    has_in_progress = False
+    has_failure = False
+
+    for artifact in artifacts:
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if not metrics:
+            has_in_progress = True
+            continue
+
+        comparison = comparisons_map.get(metrics.id)
+        if not comparison:
+            has_in_progress = True
+            continue
+
+        if comparison.state in (
+            PreprodSnapshotComparison.State.PENDING,
+            PreprodSnapshotComparison.State.PROCESSING,
+        ):
+            has_in_progress = True
+        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
+            has_failure = True
+        elif comparison.state == PreprodSnapshotComparison.State.SUCCESS:
+            if (
+                comparison.images_changed > 0
+                or comparison.images_added > 0
+                or comparison.images_removed > 0
+            ) and artifact.id not in approvals_map:
+                has_failure = True
+
+    if has_in_progress:
+        return StatusCheckStatus.IN_PROGRESS
+    if has_failure:
+        return StatusCheckStatus.FAILURE
+    return StatusCheckStatus.SUCCESS

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -15,9 +15,9 @@ from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSn
 from sentry.preprod.url_utils import get_preprod_artifact_url
 from sentry.preprod.vcs.status_checks.size.tasks import (
     GITHUB_STATUS_CHECK_STATUS_MAPPING,
-    _get_status_check_client,
-    _get_status_check_provider,
-    _update_posted_status_check,
+    get_status_check_client,
+    get_status_check_provider,
+    update_posted_status_check,
 )
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
     format_snapshot_status_check_messages,
@@ -90,11 +90,11 @@ def create_preprod_snapshot_status_check_task(
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
-    client, repository = _get_status_check_client(preprod_artifact.project, commit_comparison)
+    client, repository = get_status_check_client(preprod_artifact.project, commit_comparison)
     if not client or not repository:
         return
 
-    provider = _get_status_check_provider(
+    provider = get_status_check_provider(
         client,
         commit_comparison.provider,
         preprod_artifact.project.organization_id,
@@ -156,14 +156,11 @@ def create_preprod_snapshot_status_check_task(
         snapshot_metrics_map,
         comparisons_map,
         status,
-        preprod_artifact.project,
         base_artifact_map,
     )
 
     approve_action_identifier: str | None = None
-    if status == StatusCheckStatus.FAILURE and _has_snapshot_changes(
-        all_artifacts, snapshot_metrics_map, comparisons_map
-    ):
+    if _has_snapshot_changes(all_artifacts, snapshot_metrics_map, comparisons_map):
         approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     url_artifact = (
@@ -201,9 +198,7 @@ def create_preprod_snapshot_status_check_task(
             "preprod.snapshot_status_checks.create.failed",
             extra=extra,
         )
-        _update_posted_status_check(
-            preprod_artifact, check_type="snapshots", success=False, error=e
-        )
+        update_posted_status_check(preprod_artifact, check_type="snapshots", success=False, error=e)
         raise
 
     if check_id is None:
@@ -216,10 +211,10 @@ def create_preprod_snapshot_status_check_task(
                 "error_type": "null_check_id",
             },
         )
-        _update_posted_status_check(preprod_artifact, check_type="snapshots", success=False)
+        update_posted_status_check(preprod_artifact, check_type="snapshots", success=False)
         return
 
-    _update_posted_status_check(
+    update_posted_status_check(
         preprod_artifact, check_type="snapshots", success=True, check_id=check_id
     )
 
@@ -270,37 +265,27 @@ def _compute_snapshot_status(
     - FAILURE if any comparison failed, or if any has changes and not approved
     - SUCCESS if all comparisons succeeded with no changes, or all approved
     """
-    has_in_progress = False
-    has_failure = False
-
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
-        if not metrics:
-            has_in_progress = True
-            continue
+        comparison = metrics and comparisons_map.get(metrics.id)
 
-        comparison = comparisons_map.get(metrics.id)
         if not comparison:
-            has_in_progress = True
-            continue
+            return StatusCheckStatus.IN_PROGRESS
 
-        if comparison.state in (
-            PreprodSnapshotComparison.State.PENDING,
-            PreprodSnapshotComparison.State.PROCESSING,
-        ):
-            has_in_progress = True
-        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
-            has_failure = True
-        elif comparison.state == PreprodSnapshotComparison.State.SUCCESS:
-            if (
-                comparison.images_changed > 0
-                or comparison.images_added > 0
-                or comparison.images_removed > 0
-            ) and artifact.id not in approvals_map:
-                has_failure = True
+        match comparison.state:
+            case (
+                PreprodSnapshotComparison.State.PENDING | PreprodSnapshotComparison.State.PROCESSING
+            ):
+                return StatusCheckStatus.IN_PROGRESS
+            case PreprodSnapshotComparison.State.FAILED:
+                return StatusCheckStatus.FAILURE
+            case PreprodSnapshotComparison.State.SUCCESS:
+                if (
+                    comparison.images_changed > 0
+                    or comparison.images_added > 0
+                    or comparison.images_removed > 0
+                    or comparison.images_renamed > 0
+                ) and artifact.id not in approvals_map:
+                    return StatusCheckStatus.FAILURE
 
-    if has_in_progress:
-        return StatusCheckStatus.IN_PROGRESS
-    if has_failure:
-        return StatusCheckStatus.FAILURE
     return StatusCheckStatus.SUCCESS

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -248,6 +248,7 @@ def _has_snapshot_changes(
             comparison.images_changed > 0
             or comparison.images_added > 0
             or comparison.images_removed > 0
+            or comparison.images_renamed > 0
         ):
             return True
     return False

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -29,8 +29,6 @@ from sentry.taskworker.namespaces import preprod_tasks
 
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
-
 # Action identifier for the "Approve" button on snapshot GitHub check runs.
 APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 
@@ -88,18 +86,7 @@ def create_preprod_snapshot_status_check_task(
         )
         return
 
-    status_checks_enabled = preprod_artifact.project.get_option(
-        SNAPSHOT_ENABLED_OPTION_KEY, default=True
-    )
-    if not status_checks_enabled:
-        logger.info(
-            "preprod.snapshot_status_checks.create.disabled",
-            extra={
-                "artifact_id": preprod_artifact.id,
-                "project_id": preprod_artifact.project.id,
-            },
-        )
-        return
+    # TODO(EME-911) Wireup enabled options once gating/billing comes into play
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -173,9 +160,11 @@ def create_preprod_snapshot_status_check_task(
         base_artifact_map,
     )
 
-    include_approve_action = status == StatusCheckStatus.FAILURE and _has_snapshot_changes(
+    approve_action_identifier: str | None = None
+    if status == StatusCheckStatus.FAILURE and _has_snapshot_changes(
         all_artifacts, snapshot_metrics_map, comparisons_map
-    )
+    ):
+        approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     url_artifact = (
         preprod_artifact
@@ -197,7 +186,7 @@ def create_preprod_snapshot_status_check_task(
             target_url=target_url,
             started_at=preprod_artifact.date_added,
             completed_at=completed_at,
-            include_approve_action=include_approve_action,
+            approve_action_identifier=approve_action_identifier,
         )
     except Exception as e:
         extra: dict[str, Any] = {
@@ -259,6 +248,7 @@ def _has_snapshot_changes(
         comparison = comparisons_map.get(metrics.id)
         if not comparison or comparison.state != PreprodSnapshotComparison.State.SUCCESS:
             continue
+
         if (
             comparison.images_changed > 0
             or comparison.images_added > 0

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -266,18 +266,21 @@ def _compute_snapshot_status(
     - FAILURE if any comparison failed, or if any has changes and not approved
     - SUCCESS if all comparisons succeeded with no changes, or all approved
     """
+    has_in_progress = False
+
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
         comparison = metrics and comparisons_map.get(metrics.id)
 
         if not comparison:
-            return StatusCheckStatus.IN_PROGRESS
+            has_in_progress = True
+            continue
 
         match comparison.state:
             case (
                 PreprodSnapshotComparison.State.PENDING | PreprodSnapshotComparison.State.PROCESSING
             ):
-                return StatusCheckStatus.IN_PROGRESS
+                has_in_progress = True
             case PreprodSnapshotComparison.State.FAILED:
                 return StatusCheckStatus.FAILURE
             case PreprodSnapshotComparison.State.SUCCESS:
@@ -288,5 +291,8 @@ def _compute_snapshot_status(
                     or comparison.images_renamed > 0
                 ) and artifact.id not in approvals_map:
                     return StatusCheckStatus.FAILURE
+
+    if has_in_progress:
+        return StatusCheckStatus.IN_PROGRESS
 
     return StatusCheckStatus.SUCCESS

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -143,19 +143,19 @@ def _format_snapshot_summary(
         )
 
         if not metrics:
-            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Processing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Processing |")
             continue
 
         comparison = comparisons_map.get(metrics.id)
         if not comparison:
-            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Processing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Processing |")
             continue
 
         if comparison.state in (
             PreprodSnapshotComparison.State.PENDING,
             PreprodSnapshotComparison.State.PROCESSING,
         ):
-            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Comparing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Comparing |")
         else:
             added = comparison.images_added
             removed = comparison.images_removed

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
+
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.models.project import Project
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_preprod_artifact_url
+
+_SNAPSHOT_TITLE_BASE = _("Snapshot Testing")
+
+
+def format_snapshot_status_check_messages(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+    comparisons_map: dict[int, PreprodSnapshotComparison],
+    overall_status: StatusCheckStatus,
+    project: Project,
+    base_artifact_map: dict[int, PreprodArtifact],
+) -> tuple[str, str, str]:
+    if not artifacts:
+        raise ValueError("Cannot format messages for empty artifact list")
+
+    title = _SNAPSHOT_TITLE_BASE
+
+    total_changed = 0
+    total_added = 0
+    total_removed = 0
+    errored_count = 0
+
+    for artifact in artifacts:
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if not metrics:
+            continue
+
+        comparison = comparisons_map.get(metrics.id)
+        if not comparison:
+            continue
+
+        if comparison.state == PreprodSnapshotComparison.State.FAILED:
+            errored_count += 1
+        elif comparison.state == PreprodSnapshotComparison.State.SUCCESS:
+            total_changed += comparison.images_changed
+            total_added += comparison.images_added
+            total_removed += comparison.images_removed
+
+    if overall_status == StatusCheckStatus.IN_PROGRESS:
+        subtitle = str(_("Comparing..."))
+    elif errored_count > 0 and total_changed == 0 and total_added == 0 and total_removed == 0:
+        subtitle = str(
+            ngettext(
+                "%(count)d comparison failed",
+                "%(count)d comparisons failed",
+                errored_count,
+            )
+            % {"count": errored_count}
+        )
+    elif total_changed == 0 and total_added == 0 and total_removed == 0:
+        subtitle = str(_("All images match"))
+    else:
+        parts = []
+        if total_changed > 0:
+            parts.append(
+                ngettext(
+                    "%(count)d image changed",
+                    "%(count)d images changed",
+                    total_changed,
+                )
+                % {"count": total_changed}
+            )
+        if total_added > 0:
+            parts.append(
+                ngettext(
+                    "%(count)d added",
+                    "%(count)d added",
+                    total_added,
+                )
+                % {"count": total_added}
+            )
+        if total_removed > 0:
+            parts.append(
+                ngettext(
+                    "%(count)d removed",
+                    "%(count)d removed",
+                    total_removed,
+                )
+                % {"count": total_removed}
+            )
+        subtitle = ", ".join(str(p) for p in parts)
+
+    summary = _format_snapshot_summary(
+        artifacts,
+        snapshot_metrics_map,
+        comparisons_map,
+        base_artifact_map,
+        project,
+    )
+
+    return str(title), str(subtitle), str(summary)
+
+
+def _format_snapshot_summary(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+    comparisons_map: dict[int, PreprodSnapshotComparison],
+    base_artifact_map: dict[int, PreprodArtifact],
+    project: Project,
+) -> str:
+    table_rows = []
+
+    for artifact in artifacts:
+        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        app_name = mobile_app_info.app_name if mobile_app_info else None
+        app_display = app_name or artifact.app_id or str(_("Unknown App"))
+
+        metrics = snapshot_metrics_map.get(artifact.id)
+        base_artifact = base_artifact_map.get(artifact.id)
+
+        if base_artifact and metrics:
+            artifact_url = get_preprod_artifact_comparison_url(
+                artifact, base_artifact, comparison_type="snapshots"
+            )
+        else:
+            artifact_url = get_preprod_artifact_url(artifact, view_type="snapshots")
+
+        name_link = f"[{app_display}]({artifact_url})"
+
+        if not metrics:
+            table_rows.append(f"| {name_link} | Processing... | - | - | - |")
+            continue
+
+        comparison = comparisons_map.get(metrics.id)
+        if not comparison:
+            table_rows.append(f"| {name_link} | Processing... | - | - | - |")
+            continue
+
+        if comparison.state in (
+            PreprodSnapshotComparison.State.PENDING,
+            PreprodSnapshotComparison.State.PROCESSING,
+        ):
+            table_rows.append(f"| {name_link} | Comparing... | - | - | - |")
+        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
+            table_rows.append(f"| {name_link} | Failed | - | - | - |")
+        else:
+            changed = comparison.images_changed
+            added = comparison.images_added
+            removed = comparison.images_removed
+            unchanged = comparison.images_unchanged
+            status_emoji = "✅" if (changed == 0 and added == 0 and removed == 0) else "❌"
+            table_rows.append(
+                f"| {name_link} | {status_emoji} {changed} changed | {added} added | {removed} removed | {unchanged} unchanged |"
+            )
+
+    table_header = (
+        "| Name | Changed | Added | Removed | Unchanged |\n"
+        "|------|---------|-------|---------|-----------|\n"
+    )
+
+    settings_url = project.organization.absolute_url(
+        f"/settings/projects/{project.slug}/mobile-builds/"
+    )
+    footer = str(
+        _("[Configure {project_name} snapshot settings]({settings_url})").format(
+            project_name=project.name,
+            settings_url=settings_url,
+        )
+    )
+
+    return table_header + "\n".join(table_rows) + "\n\n" + footer

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -4,7 +4,6 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 
 from sentry.integrations.source_code_management.status_check import StatusCheckStatus
-from sentry.models.project import Project
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_preprod_artifact_url
@@ -17,7 +16,6 @@ def format_snapshot_status_check_messages(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     overall_status: StatusCheckStatus,
-    project: Project,
     base_artifact_map: dict[int, PreprodArtifact],
 ) -> tuple[str, str, str]:
     if not artifacts:
@@ -28,7 +26,8 @@ def format_snapshot_status_check_messages(
     total_changed = 0
     total_added = 0
     total_removed = 0
-    errored_count = 0
+    total_renamed = 0
+    total_unchanged = 0
 
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
@@ -40,32 +39,27 @@ def format_snapshot_status_check_messages(
             continue
 
         if comparison.state == PreprodSnapshotComparison.State.FAILED:
-            errored_count += 1
-        elif comparison.state == PreprodSnapshotComparison.State.SUCCESS:
+            subtitle = str(_("We had trouble comparing snapshots, our team is investigating."))
+            return str(title), str(subtitle), ""
+
+        if comparison.state == PreprodSnapshotComparison.State.SUCCESS:
             total_changed += comparison.images_changed
             total_added += comparison.images_added
             total_removed += comparison.images_removed
+            total_renamed += comparison.images_renamed
+            total_unchanged += comparison.images_unchanged
 
     if overall_status == StatusCheckStatus.IN_PROGRESS:
         subtitle = str(_("Comparing snapshots..."))
-    elif errored_count > 0 and total_changed == 0 and total_added == 0 and total_removed == 0:
-        subtitle = str(
-            ngettext(
-                "%(count)d comparison failed",
-                "%(count)d comparisons failed",
-                errored_count,
-            )
-            % {"count": errored_count}
-        )
-    elif total_changed == 0 and total_added == 0 and total_removed == 0:
+    elif total_changed == 0 and total_added == 0 and total_removed == 0 and total_renamed == 0:
         subtitle = str(_("No changes detected"))
     else:
         parts = []
         if total_changed > 0:
             parts.append(
                 ngettext(
-                    "%(count)d image changed",
-                    "%(count)d images changed",
+                    "%(count)d modified",
+                    "%(count)d modified",
                     total_changed,
                 )
                 % {"count": total_changed}
@@ -88,6 +82,24 @@ def format_snapshot_status_check_messages(
                 )
                 % {"count": total_removed}
             )
+        if total_renamed > 0:
+            parts.append(
+                ngettext(
+                    "%(count)d renamed",
+                    "%(count)d renamed",
+                    total_renamed,
+                )
+                % {"count": total_renamed}
+            )
+        if total_unchanged > 0:
+            parts.append(
+                ngettext(
+                    "%(count)d unchanged",
+                    "%(count)d unchanged",
+                    total_unchanged,
+                )
+                % {"count": total_unchanged}
+            )
         subtitle = ", ".join(str(p) for p in parts)
 
     summary = _format_snapshot_summary(
@@ -95,7 +107,6 @@ def format_snapshot_status_check_messages(
         snapshot_metrics_map,
         comparisons_map,
         base_artifact_map,
-        project,
     )
 
     return str(title), str(subtitle), str(summary)
@@ -106,7 +117,6 @@ def _format_snapshot_summary(
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
     comparisons_map: dict[int, PreprodSnapshotComparison],
     base_artifact_map: dict[int, PreprodArtifact],
-    project: Project,
 ) -> str:
     table_rows = []
 
@@ -114,6 +124,7 @@ def _format_snapshot_summary(
         mobile_app_info = getattr(artifact, "mobile_app_info", None)
         app_name = mobile_app_info.app_name if mobile_app_info else None
         app_display = app_name or artifact.app_id or str(_("Unknown App"))
+        app_id = artifact.app_id or ""
 
         metrics = snapshot_metrics_map.get(artifact.id)
         base_artifact = base_artifact_map.get(artifact.id)
@@ -125,47 +136,41 @@ def _format_snapshot_summary(
         else:
             artifact_url = get_preprod_artifact_url(artifact, view_type="snapshots")
 
-        name_link = f"[{app_display}]({artifact_url})"
+        name_cell = (
+            f"[{app_display}]({artifact_url})<br>`{app_id}`"
+            if app_id
+            else f"[{app_display}]({artifact_url})"
+        )
 
         if not metrics:
-            table_rows.append(f"| {name_link} | Processing... | - | - | - |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Processing |")
             continue
 
         comparison = comparisons_map.get(metrics.id)
         if not comparison:
-            table_rows.append(f"| {name_link} | Processing... | - | - | - |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Processing |")
             continue
 
         if comparison.state in (
             PreprodSnapshotComparison.State.PENDING,
             PreprodSnapshotComparison.State.PROCESSING,
         ):
-            table_rows.append(f"| {name_link} | Comparing... | - | - | - |")
-        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
-            table_rows.append(f"| {name_link} | Failed | - | - | - |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | ⏳ Comparing |")
         else:
-            changed = comparison.images_changed
             added = comparison.images_added
             removed = comparison.images_removed
+            modified = comparison.images_changed
+            renamed = comparison.images_renamed
             unchanged = comparison.images_unchanged
-            status_emoji = "✅" if (changed == 0 and added == 0 and removed == 0) else "❌"
+            has_changes = modified > 0 or added > 0 or removed > 0 or renamed > 0
+            status = "⏳ Needs approval" if has_changes else "✅ Unchanged"
             table_rows.append(
-                f"| {name_link} | {status_emoji} {changed} changed | {added} added | {removed} removed | {unchanged} unchanged |"
+                f"| {name_cell} | {added} | {removed} | {modified} | {renamed} | {unchanged} | {status} |"
             )
 
     table_header = (
-        "| Name | Changed | Added | Removed | Unchanged |\n"
-        "|------|---------|-------|---------|-----------|\n"
+        "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
+        "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
     )
 
-    settings_url = project.organization.absolute_url(
-        f"/settings/projects/{project.slug}/mobile-builds/"
-    )
-    footer = str(
-        _("[Configure {project_name} snapshot settings]({settings_url})").format(
-            project_name=project.name,
-            settings_url=settings_url,
-        )
-    )
-
-    return table_header + "\n".join(table_rows) + "\n\n" + footer
+    return table_header + "\n".join(table_rows)

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -47,7 +47,7 @@ def format_snapshot_status_check_messages(
             total_removed += comparison.images_removed
 
     if overall_status == StatusCheckStatus.IN_PROGRESS:
-        subtitle = str(_("Comparing..."))
+        subtitle = str(_("Comparing snapshots..."))
     elif errored_count > 0 and total_changed == 0 and total_added == 0 and total_removed == 0:
         subtitle = str(
             ngettext(
@@ -58,7 +58,7 @@ def format_snapshot_status_check_messages(
             % {"count": errored_count}
         )
     elif total_changed == 0 and total_added == 0 and total_removed == 0:
-        subtitle = str(_("All images match"))
+        subtitle = str(_("No changes detected"))
     else:
         parts = []
         if total_changed > 0:

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -214,10 +214,12 @@ def handle_preprod_check_run_event(
                 "caller": "github_approve_webhook",
             }
         )
-    else:
+    elif identifier == APPROVE_SNAPSHOT_ACTION_IDENTIFIER:
         create_preprod_snapshot_status_check_task.apply_async(
             kwargs={
                 "preprod_artifact_id": artifact.id,
                 "caller": "github_approve_webhook",
             }
         )
+    else:
+        raise ValueError(f"Unknown identifier: {identifier}")

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -20,6 +20,10 @@ from sentry.preprod.vcs.status_checks.size.tasks import (
     APPROVE_SIZE_ACTION_IDENTIFIER,
     create_preprod_status_check_task,
 )
+from sentry.preprod.vcs.status_checks.snapshots.tasks import (
+    APPROVE_SNAPSHOT_ACTION_IDENTIFIER,
+    create_preprod_snapshot_status_check_task,
+)
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -32,6 +36,7 @@ class Log(StrEnum):
     ARTIFACT_NOT_FOUND = "preprod.webhook.check_run.artifact_not_found"
     APPROVAL_ALREADY_EXISTS = "preprod.webhook.check_run.approval_already_exists"
     APPROVALS_CREATED = "preprod.webhook.check_run.approvals_created"
+    UNKNOWN_IDENTIFIER = "preprod.webhook.check_run.unknown_identifier"
 
 
 class GitHubCheckRunAction(StrEnum):
@@ -68,7 +73,7 @@ def handle_preprod_check_run_event(
     requested_action = event.get("requested_action", {})
     identifier = requested_action.get("identifier")
 
-    if identifier != APPROVE_SIZE_ACTION_IDENTIFIER:
+    if identifier not in (APPROVE_SIZE_ACTION_IDENTIFIER, APPROVE_SNAPSHOT_ACTION_IDENTIFIER):
         return
 
     check_run = event.get("check_run", {})
@@ -119,12 +124,27 @@ def handle_preprod_check_run_event(
     approvals_created = 0
     github_user_info = {"github": {"id": sender.get("id"), "login": sender.get("login")}}
 
+    # Determine feature type based on the action identifier
+    if identifier == APPROVE_SIZE_ACTION_IDENTIFIER:
+        feature_type = PreprodComparisonApproval.FeatureType.SIZE
+        product_name = "size"
+    elif identifier == APPROVE_SNAPSHOT_ACTION_IDENTIFIER:
+        feature_type = PreprodComparisonApproval.FeatureType.SNAPSHOTS
+        product_name = "snapshots"
+    else:
+        logger.warning(
+            Log.UNKNOWN_IDENTIFIER,
+            extra={**extra, "identifier": identifier},
+        )
+        metrics.incr(Log.UNKNOWN_IDENTIFIER)
+        return
+
     # Single query: get latest approval per artifact using window function
     sibling_ids = [s.id for s in sibling_artifacts]
     latest_approvals_qs = (
         PreprodComparisonApproval.objects.filter(
             preprod_artifact_id__in=sibling_ids,
-            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+            preprod_feature_type=feature_type,
         )
         .annotate(
             row_num=Window(
@@ -154,7 +174,7 @@ def handle_preprod_check_run_event(
 
         PreprodComparisonApproval.objects.create(
             preprod_artifact=sibling,
-            preprod_feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+            preprod_feature_type=feature_type,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
             approved_at=datetime.now(timezone.utc),
             approved_by_id=None,
@@ -182,13 +202,21 @@ def handle_preprod_check_run_event(
                 organization_id=organization.id,
                 project_id=artifact.project_id,
                 artifact_id=artifact.id,
-                product="size",
+                product=product_name,
             )
         )
 
-    create_preprod_status_check_task.apply_async(
-        kwargs={
-            "preprod_artifact_id": artifact.id,
-            "caller": "github_approve_webhook",
-        }
-    )
+    if identifier == APPROVE_SIZE_ACTION_IDENTIFIER:
+        create_preprod_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": artifact.id,
+                "caller": "github_approve_webhook",
+            }
+        )
+    else:
+        create_preprod_snapshot_status_check_task.apply_async(
+            kwargs={
+                "preprod_artifact_id": artifact.id,
+                "caller": "github_approve_webhook",
+            }
+        )

--- a/src/sentry/preprod/vcs/webhooks/github_check_run.py
+++ b/src/sentry/preprod/vcs/webhooks/github_check_run.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
@@ -125,6 +125,7 @@ def handle_preprod_check_run_event(
     github_user_info = {"github": {"id": sender.get("id"), "login": sender.get("login")}}
 
     # Determine feature type based on the action identifier
+    product_name: Literal["size", "snapshots"]
     if identifier == APPROVE_SIZE_ACTION_IDENTIFIER:
         feature_type = PreprodComparisonApproval.FeatureType.SIZE
         product_name = "size"

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_checks_tasks.py
@@ -89,11 +89,11 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         mock_provider.create_status_check.return_value = "check_12345"
 
         patcher_client = patch(
-            "sentry.preprod.vcs.status_checks.size.tasks._get_status_check_client",
+            "sentry.preprod.vcs.status_checks.size.tasks.get_status_check_client",
             return_value=(mock_client, repository),
         )
         patcher_provider = patch(
-            "sentry.preprod.vcs.status_checks.size.tasks._get_status_check_provider",
+            "sentry.preprod.vcs.status_checks.size.tasks.get_status_check_provider",
             return_value=mock_provider,
         )
 
@@ -105,11 +105,11 @@ class CreatePreprodStatusCheckTaskTest(TestCase):
         mock_provider = Mock()
 
         patcher_client = patch(
-            "sentry.preprod.vcs.status_checks.size.tasks._get_status_check_client",
+            "sentry.preprod.vcs.status_checks.size.tasks.get_status_check_client",
             return_value=(mock_client, None),
         )
         patcher_provider = patch(
-            "sentry.preprod.vcs.status_checks.size.tasks._get_status_check_provider",
+            "sentry.preprod.vcs.status_checks.size.tasks.get_status_check_provider",
             return_value=mock_provider,
         )
 

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -1,0 +1,698 @@
+from __future__ import annotations
+
+import pytest
+
+from sentry.integrations.source_code_management.status_check import StatusCheckStatus
+from sentry.models.commitcomparison import CommitComparison
+from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.vcs.status_checks.snapshots.templates import (
+    format_snapshot_status_check_messages,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+class SnapshotStatusCheckTestBase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.organization = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.organization)
+        self.project = self.create_project(
+            teams=[self.team], organization=self.organization, name="test_project"
+        )
+
+    def _create_artifact_with_metrics(
+        self,
+        app_id: str = "com.example.app",
+        app_name: str | None = None,
+        build_version: str = "1.0.0",
+        build_number: int = 1,
+        image_count: int = 10,
+        state: int = PreprodArtifact.ArtifactState.PROCESSED,
+        commit_comparison: CommitComparison | None = None,
+    ) -> tuple[PreprodArtifact, PreprodSnapshotMetrics]:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=state,
+            app_id=app_id,
+            app_name=app_name,
+            build_version=build_version,
+            build_number=build_number,
+            commit_comparison=commit_comparison,
+        )
+        metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact,
+            image_count=image_count,
+        )
+        return artifact, metrics
+
+    def _create_comparison(
+        self,
+        head_metrics: PreprodSnapshotMetrics,
+        base_metrics: PreprodSnapshotMetrics,
+        state: int = PreprodSnapshotComparison.State.SUCCESS,
+        images_changed: int = 0,
+        images_added: int = 0,
+        images_removed: int = 0,
+        images_unchanged: int = 10,
+    ) -> PreprodSnapshotComparison:
+        return PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=state,
+            images_changed=images_changed,
+            images_added=images_added,
+            images_removed=images_removed,
+            images_unchanged=images_unchanged,
+        )
+
+
+@region_silo_test
+class SnapshotEmptyArtifactsTest(SnapshotStatusCheckTestBase):
+    def test_empty_artifacts_raises_error(self):
+        with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
+            format_snapshot_status_check_messages(
+                [], {}, {}, StatusCheckStatus.SUCCESS, self.project, {}
+            )
+
+
+@region_silo_test
+class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
+    def test_artifact_without_metrics_shows_processing(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [artifact], {}, {}, StatusCheckStatus.IN_PROGRESS, self.project, {}
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "Comparing..."
+        assert "Processing..." in summary
+        assert "com.example.app" in summary
+
+    def test_artifact_with_metrics_but_no_comparison_shows_processing(self):
+        artifact, metrics = self._create_artifact_with_metrics()
+
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map, {}, StatusCheckStatus.IN_PROGRESS, self.project, {}
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "Comparing..."
+        assert "Processing..." in summary
+
+    def test_comparison_in_pending_state_shows_comparing(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics, base_metrics, state=PreprodSnapshotComparison.State.PENDING
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.IN_PROGRESS,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "Comparing..."
+        assert "Comparing..." in summary
+
+    def test_comparison_in_processing_state_shows_comparing(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics, base_metrics, state=PreprodSnapshotComparison.State.PROCESSING
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.IN_PROGRESS,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "Comparing..."
+
+
+@region_silo_test
+class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
+    def test_all_images_match_shows_success(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App"
+        )
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=0,
+            images_added=0,
+            images_removed=0,
+            images_unchanged=10,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "All images match"
+        assert "✅" in summary
+        assert "0 changed" in summary
+        assert "10 unchanged" in summary
+        assert "My App" in summary
+
+    def test_app_id_used_when_no_app_name(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.noname"
+        )
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(head_metrics, base_metrics)
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, _, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        assert "com.example.noname" in summary
+
+    def test_multiple_artifacts_all_match(self):
+        artifacts = []
+        snapshot_metrics_map = {}
+        comparisons_map = {}
+
+        for i in range(3):
+            head_artifact, head_metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.app{i}", build_number=i + 1
+            )
+            base_artifact, base_metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.base{i}", build_number=i + 10
+            )
+            comparison = self._create_comparison(head_metrics, base_metrics)
+
+            artifacts.append(head_artifact)
+            snapshot_metrics_map[head_artifact.id] = head_metrics
+            comparisons_map[head_metrics.id] = comparison
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "All images match"
+        for i in range(3):
+            assert f"com.example.app{i}" in summary
+
+
+@region_silo_test
+class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
+    def test_images_changed_shows_failure_subtitle(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=3,
+            images_added=0,
+            images_removed=0,
+            images_unchanged=7,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "3 images changed"
+        assert "❌" in summary
+        assert "3 changed" in summary
+        assert "7 unchanged" in summary
+
+    def test_single_image_changed_uses_singular(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=1,
+            images_unchanged=9,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, subtitle, _ = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "1 image changed"
+
+    def test_images_added_and_removed(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=0,
+            images_added=2,
+            images_removed=1,
+            images_unchanged=8,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "2 added, 1 removed"
+        assert "2 added" in summary
+        assert "1 removed" in summary
+
+    def test_all_change_types_combined(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=3,
+            images_added=1,
+            images_removed=2,
+            images_unchanged=5,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "3 images changed, 1 added, 2 removed"
+        assert "❌" in summary
+        assert "3 changed" in summary
+        assert "1 added" in summary
+        assert "2 removed" in summary
+        assert "5 unchanged" in summary
+
+
+@region_silo_test
+class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
+    def test_failed_comparison_shows_failure(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            state=PreprodSnapshotComparison.State.FAILED,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "1 comparison failed"
+        assert "Failed" in summary
+
+    def test_multiple_failed_comparisons(self):
+        artifacts = []
+        snapshot_metrics_map = {}
+        comparisons_map = {}
+
+        for i in range(2):
+            head_artifact, head_metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.app{i}", build_number=i + 1
+            )
+            base_artifact, base_metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.base{i}", build_number=i + 10
+            )
+            comparison = self._create_comparison(
+                head_metrics,
+                base_metrics,
+                state=PreprodSnapshotComparison.State.FAILED,
+            )
+
+            artifacts.append(head_artifact)
+            snapshot_metrics_map[head_artifact.id] = head_metrics
+            comparisons_map[head_metrics.id] = comparison
+
+        _, subtitle, _ = format_snapshot_status_check_messages(
+            artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "2 comparisons failed"
+
+
+@region_silo_test
+class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
+    def test_mixed_success_and_processing(self):
+        head1, head1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.done", build_number=1
+        )
+        base1, base1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base1", build_number=10
+        )
+        comparison1 = self._create_comparison(head1_metrics, base1_metrics, images_unchanged=5)
+
+        # Processing comparison
+        head2, head2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.pending", build_number=2
+        )
+        base2, base2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base2", build_number=11
+        )
+        comparison2 = self._create_comparison(
+            head2_metrics, base2_metrics, state=PreprodSnapshotComparison.State.PROCESSING
+        )
+
+        snapshot_metrics_map = {
+            head1.id: head1_metrics,
+            head2.id: head2_metrics,
+        }
+        comparisons_map = {
+            head1_metrics.id: comparison1,
+            head2_metrics.id: comparison2,
+        }
+
+        _, subtitle, summary = format_snapshot_status_check_messages(
+            [head1, head2],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.IN_PROGRESS,
+            self.project,
+            {},
+        )
+
+        assert subtitle == "Comparing..."
+        assert "✅" in summary
+        assert "Comparing..." in summary
+
+    def test_mixed_changes_and_failures(self):
+        # Comparison with changes
+        head1, head1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.changed", build_number=1
+        )
+        base1, base1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base1", build_number=10
+        )
+        comparison1 = self._create_comparison(
+            head1_metrics, base1_metrics, images_changed=2, images_unchanged=8
+        )
+
+        # Failed comparison
+        head2, head2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.failed", build_number=2
+        )
+        base2, base2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base2", build_number=11
+        )
+        comparison2 = self._create_comparison(
+            head2_metrics, base2_metrics, state=PreprodSnapshotComparison.State.FAILED
+        )
+
+        snapshot_metrics_map = {
+            head1.id: head1_metrics,
+            head2.id: head2_metrics,
+        }
+        comparisons_map = {
+            head1_metrics.id: comparison1,
+            head2_metrics.id: comparison2,
+        }
+
+        _, subtitle, summary = format_snapshot_status_check_messages(
+            [head1, head2],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        # Has changes so subtitle should show changes, not failure count
+        assert subtitle == "2 images changed"
+        assert "❌" in summary
+        assert "Failed" in summary
+
+
+@region_silo_test
+class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
+    def test_summary_table_has_correct_headers(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(head_metrics, base_metrics)
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, _, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        assert "| Name | Changed | Added | Removed | Unchanged |" in summary
+        assert "|------|---------|-------|---------|-----------|\n" in summary
+
+    def test_summary_contains_settings_link(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(head_metrics, base_metrics)
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, _, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
+        assert f"[Configure test_project snapshot settings]({settings_url})" in summary
+
+    def test_summary_uses_comparison_url_when_base_artifact_exists(self):
+        head_commit_comparison = CommitComparison.objects.create(
+            head_repo_name="test/repo",
+            head_sha="head_sha_123",
+            base_sha="base_sha_456",
+            provider="github",
+            organization_id=self.organization.id,
+        )
+
+        head_artifact, head_metrics = self._create_artifact_with_metrics(
+            commit_comparison=head_commit_comparison,
+        )
+        base_artifact, base_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base",
+        )
+        comparison = self._create_comparison(head_metrics, base_metrics)
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+        base_artifact_map = {head_artifact.id: base_artifact}
+
+        _, _, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            base_artifact_map,
+        )
+
+        # Should use comparison URL when base artifact exists
+        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/compare/{head_artifact.id}/{base_artifact.id}"
+        assert expected_url in summary
+
+    def test_summary_uses_artifact_url_when_no_base(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(head_metrics, base_metrics)
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, _, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
+        assert expected_url in summary
+
+    def test_full_success_summary_format(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App"
+        )
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=0,
+            images_added=0,
+            images_removed=0,
+            images_unchanged=15,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.SUCCESS,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "All images match"
+
+        expected = (
+            "| Name | Changed | Added | Removed | Unchanged |\n"
+            "|------|---------|-------|---------|-----------|\n"
+            f"| [My App]({artifact_url}) | ✅ 0 changed | 0 added | 0 removed | 15 unchanged |\n\n"
+            f"[Configure test_project snapshot settings]({settings_url})"
+        )
+        assert summary == expected
+
+    def test_full_failure_summary_format(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App"
+        )
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_changed=3,
+            images_added=1,
+            images_removed=2,
+            images_unchanged=4,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
+        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
+
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            self.project,
+            {},
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "3 images changed, 1 added, 2 removed"
+
+        expected = (
+            "| Name | Changed | Added | Removed | Unchanged |\n"
+            "|------|---------|-------|---------|-----------|\n"
+            f"| [My App]({artifact_url}) | ❌ 3 changed | 1 added | 2 removed | 4 unchanged |\n\n"
+            f"[Configure test_project snapshot settings]({settings_url})"
+        )
+        assert summary == expected

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -55,6 +55,7 @@ class SnapshotStatusCheckTestBase(TestCase):
         images_changed: int = 0,
         images_added: int = 0,
         images_removed: int = 0,
+        images_renamed: int = 0,
         images_unchanged: int = 10,
     ) -> PreprodSnapshotComparison:
         return PreprodSnapshotComparison.objects.create(
@@ -64,6 +65,7 @@ class SnapshotStatusCheckTestBase(TestCase):
             images_changed=images_changed,
             images_added=images_added,
             images_removed=images_removed,
+            images_renamed=images_renamed,
             images_unchanged=images_unchanged,
         )
 
@@ -72,9 +74,7 @@ class SnapshotStatusCheckTestBase(TestCase):
 class SnapshotEmptyArtifactsTest(SnapshotStatusCheckTestBase):
     def test_empty_artifacts_raises_error(self):
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
-            format_snapshot_status_check_messages(
-                [], {}, {}, StatusCheckStatus.SUCCESS, self.project, {}
-            )
+            format_snapshot_status_check_messages([], {}, {}, StatusCheckStatus.SUCCESS, {})
 
 
 @region_silo_test
@@ -89,12 +89,12 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         title, subtitle, summary = format_snapshot_status_check_messages(
-            [artifact], {}, {}, StatusCheckStatus.IN_PROGRESS, self.project, {}
+            [artifact], {}, {}, StatusCheckStatus.IN_PROGRESS, {}
         )
 
         assert title == "Snapshot Testing"
         assert subtitle == "Comparing snapshots..."
-        assert "Processing..." in summary
+        assert "Processing" in summary
         assert "com.example.app" in summary
 
     def test_artifact_with_metrics_but_no_comparison_shows_processing(self):
@@ -103,12 +103,12 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         snapshot_metrics_map = {artifact.id: metrics}
 
         title, subtitle, summary = format_snapshot_status_check_messages(
-            [artifact], snapshot_metrics_map, {}, StatusCheckStatus.IN_PROGRESS, self.project, {}
+            [artifact], snapshot_metrics_map, {}, StatusCheckStatus.IN_PROGRESS, {}
         )
 
         assert title == "Snapshot Testing"
         assert subtitle == "Comparing snapshots..."
-        assert "Processing..." in summary
+        assert "Processing" in summary
 
     def test_comparison_in_pending_state_shows_comparing(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
@@ -126,7 +126,6 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
-            self.project,
             {},
         )
 
@@ -145,12 +144,11 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         snapshot_metrics_map = {head_artifact.id: head_metrics}
         comparisons_map = {head_metrics.id: comparison}
 
-        title, subtitle, summary = format_snapshot_status_check_messages(
+        _, subtitle, _ = format_snapshot_status_check_messages(
             [head_artifact],
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
-            self.project,
             {},
         )
 
@@ -182,18 +180,15 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
         assert title == "Snapshot Testing"
         assert subtitle == "No changes detected"
-        assert "✅" in summary
-        assert "0 changed" in summary
-        assert "10 unchanged" in summary
+        assert "✅ Unchanged" in summary
         assert "My App" in summary
 
-    def test_app_id_used_when_no_app_name(self):
+    def test_app_id_shown_in_name_cell(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics(
             app_id="com.example.noname"
         )
@@ -209,11 +204,10 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
-        assert "com.example.noname" in summary
+        assert "`com.example.noname`" in summary
 
     def test_multiple_artifacts_all_match(self):
         artifacts = []
@@ -238,7 +232,6 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
@@ -271,17 +264,14 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "3 images changed"
-        assert "❌" in summary
-        assert "3 changed" in summary
-        assert "7 unchanged" in summary
+        assert subtitle == "3 modified, 7 unchanged"
+        assert "⏳ Needs approval" in summary
 
-    def test_single_image_changed_uses_singular(self):
+    def test_single_image_changed(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -300,11 +290,10 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
-        assert subtitle == "1 image changed"
+        assert subtitle == "1 modified, 9 unchanged"
 
     def test_images_added_and_removed(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -322,18 +311,39 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
         snapshot_metrics_map = {head_artifact.id: head_metrics}
         comparisons_map = {head_metrics.id: comparison}
 
-        _, subtitle, summary = format_snapshot_status_check_messages(
+        _, subtitle, _ = format_snapshot_status_check_messages(
             [head_artifact],
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
-        assert subtitle == "2 added, 1 removed"
-        assert "2 added" in summary
-        assert "1 removed" in summary
+        assert subtitle == "2 added, 1 removed, 8 unchanged"
+
+    def test_images_renamed(self):
+        head_artifact, head_metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
+
+        comparison = self._create_comparison(
+            head_metrics,
+            base_metrics,
+            images_renamed=4,
+            images_unchanged=6,
+        )
+
+        snapshot_metrics_map = {head_artifact.id: head_metrics}
+        comparisons_map = {head_metrics.id: comparison}
+
+        _, subtitle, _ = format_snapshot_status_check_messages(
+            [head_artifact],
+            snapshot_metrics_map,
+            comparisons_map,
+            StatusCheckStatus.FAILURE,
+            {},
+        )
+
+        assert subtitle == "4 renamed, 6 unchanged"
 
     def test_all_change_types_combined(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -345,6 +355,7 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             images_changed=3,
             images_added=1,
             images_removed=2,
+            images_renamed=1,
             images_unchanged=5,
         )
 
@@ -356,21 +367,16 @@ class SnapshotChangesFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
-        assert subtitle == "3 images changed, 1 added, 2 removed"
-        assert "❌" in summary
-        assert "3 changed" in summary
-        assert "1 added" in summary
-        assert "2 removed" in summary
-        assert "5 unchanged" in summary
+        assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 5 unchanged"
+        assert "⏳ Needs approval" in summary
 
 
 @region_silo_test
 class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
-    def test_failed_comparison_shows_failure(self):
+    def test_failed_comparison_returns_error_message(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
 
@@ -388,46 +394,55 @@ class SnapshotFailureStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "1 comparison failed"
-        assert "Failed" in summary
+        assert subtitle == "We had trouble comparing snapshots, our team is investigating."
+        assert summary == ""
 
-    def test_multiple_failed_comparisons(self):
-        artifacts = []
-        snapshot_metrics_map = {}
-        comparisons_map = {}
+    def test_failed_comparison_early_returns_ignoring_other_artifacts(self):
+        # First artifact has a failed comparison
+        head1, head1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.failed", build_number=1
+        )
+        base1, base1_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base1", build_number=10
+        )
+        comparison1 = self._create_comparison(
+            head1_metrics, base1_metrics, state=PreprodSnapshotComparison.State.FAILED
+        )
 
-        for i in range(2):
-            head_artifact, head_metrics = self._create_artifact_with_metrics(
-                app_id=f"com.example.app{i}", build_number=i + 1
-            )
-            base_artifact, base_metrics = self._create_artifact_with_metrics(
-                app_id=f"com.example.base{i}", build_number=i + 10
-            )
-            comparison = self._create_comparison(
-                head_metrics,
-                base_metrics,
-                state=PreprodSnapshotComparison.State.FAILED,
-            )
+        # Second artifact has changes
+        head2, head2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.changed", build_number=2
+        )
+        base2, base2_metrics = self._create_artifact_with_metrics(
+            app_id="com.example.base2", build_number=11
+        )
+        comparison2 = self._create_comparison(
+            head2_metrics, base2_metrics, images_changed=5, images_unchanged=5
+        )
 
-            artifacts.append(head_artifact)
-            snapshot_metrics_map[head_artifact.id] = head_metrics
-            comparisons_map[head_metrics.id] = comparison
+        snapshot_metrics_map = {
+            head1.id: head1_metrics,
+            head2.id: head2_metrics,
+        }
+        comparisons_map = {
+            head1_metrics.id: comparison1,
+            head2_metrics.id: comparison2,
+        }
 
-        _, subtitle, _ = format_snapshot_status_check_messages(
-            artifacts,
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            [head1, head2],
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
-        assert subtitle == "2 comparisons failed"
+        assert subtitle == "We had trouble comparing snapshots, our team is investigating."
+        assert summary == ""
 
 
 @region_silo_test
@@ -466,59 +481,12 @@ class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.IN_PROGRESS,
-            self.project,
             {},
         )
 
         assert subtitle == "Comparing snapshots..."
-        assert "✅" in summary
+        assert "✅ Unchanged" in summary
         assert "Comparing" in summary
-
-    def test_mixed_changes_and_failures(self):
-        # Comparison with changes
-        head1, head1_metrics = self._create_artifact_with_metrics(
-            app_id="com.example.changed", build_number=1
-        )
-        base1, base1_metrics = self._create_artifact_with_metrics(
-            app_id="com.example.base1", build_number=10
-        )
-        comparison1 = self._create_comparison(
-            head1_metrics, base1_metrics, images_changed=2, images_unchanged=8
-        )
-
-        # Failed comparison
-        head2, head2_metrics = self._create_artifact_with_metrics(
-            app_id="com.example.failed", build_number=2
-        )
-        base2, base2_metrics = self._create_artifact_with_metrics(
-            app_id="com.example.base2", build_number=11
-        )
-        comparison2 = self._create_comparison(
-            head2_metrics, base2_metrics, state=PreprodSnapshotComparison.State.FAILED
-        )
-
-        snapshot_metrics_map = {
-            head1.id: head1_metrics,
-            head2.id: head2_metrics,
-        }
-        comparisons_map = {
-            head1_metrics.id: comparison1,
-            head2_metrics.id: comparison2,
-        }
-
-        _, subtitle, summary = format_snapshot_status_check_messages(
-            [head1, head2],
-            snapshot_metrics_map,
-            comparisons_map,
-            StatusCheckStatus.FAILURE,
-            self.project,
-            {},
-        )
-
-        # Has changes so subtitle should show changes, not failure count
-        assert subtitle == "2 images changed"
-        assert "❌" in summary
-        assert "Failed" in summary
 
 
 @region_silo_test
@@ -536,14 +504,13 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
-        assert "| Name | Changed | Added | Removed | Unchanged |" in summary
-        assert "|------|---------|-------|---------|-----------|\n" in summary
+        assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in summary
+        assert "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |" in summary
 
-    def test_summary_contains_settings_link(self):
+    def test_summary_has_no_settings_link(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(app_id="com.example.base")
         comparison = self._create_comparison(head_metrics, base_metrics)
@@ -556,12 +523,11 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
-        assert f"[Configure test_project snapshot settings]({settings_url})" in summary
+        assert "Configure" not in summary
+        assert "settings" not in summary
 
     def test_summary_uses_comparison_url_when_base_artifact_exists(self):
         head_commit_comparison = CommitComparison.objects.create(
@@ -589,11 +555,9 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             base_artifact_map,
         )
 
-        # Should use comparison URL when base artifact exists
         expected_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/compare/{head_artifact.id}/{base_artifact.id}"
         assert expected_url in summary
 
@@ -610,7 +574,6 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
@@ -628,6 +591,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             images_changed=0,
             images_added=0,
             images_removed=0,
+            images_renamed=0,
             images_unchanged=15,
         )
 
@@ -635,14 +599,12 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         comparisons_map = {head_metrics.id: comparison}
 
         artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
 
         title, subtitle, summary = format_snapshot_status_check_messages(
             [head_artifact],
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.SUCCESS,
-            self.project,
             {},
         )
 
@@ -650,10 +612,9 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "No changes detected"
 
         expected = (
-            "| Name | Changed | Added | Removed | Unchanged |\n"
-            "|------|---------|-------|---------|-----------|\n"
-            f"| [My App]({artifact_url}) | ✅ 0 changed | 0 added | 0 removed | 15 unchanged |\n\n"
-            f"[Configure test_project snapshot settings]({settings_url})"
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
+            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+            f"| [My App]({artifact_url})<br>`com.example.app` | 0 | 0 | 0 | 0 | 15 | ✅ Unchanged |"
         )
         assert summary == expected
 
@@ -668,6 +629,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             images_changed=3,
             images_added=1,
             images_removed=2,
+            images_renamed=1,
             images_unchanged=4,
         )
 
@@ -675,24 +637,21 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         comparisons_map = {head_metrics.id: comparison}
 
         artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{head_artifact.id}"
-        settings_url = f"http://testserver/settings/projects/{self.project.slug}/mobile-builds/"
 
         title, subtitle, summary = format_snapshot_status_check_messages(
             [head_artifact],
             snapshot_metrics_map,
             comparisons_map,
             StatusCheckStatus.FAILURE,
-            self.project,
             {},
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "3 images changed, 1 added, 2 removed"
+        assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         expected = (
-            "| Name | Changed | Added | Removed | Unchanged |\n"
-            "|------|---------|-------|---------|-----------|\n"
-            f"| [My App]({artifact_url}) | ❌ 3 changed | 1 added | 2 removed | 4 unchanged |\n\n"
-            f"[Configure test_project snapshot settings]({settings_url})"
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
+            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+            f"| [My App]({artifact_url})<br>`com.example.app` | 1 | 2 | 3 | 1 | 4 | ⏳ Needs approval |"
         )
         assert summary == expected

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -93,7 +93,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "Comparing..."
+        assert subtitle == "Comparing snapshots..."
         assert "Processing..." in summary
         assert "com.example.app" in summary
 
@@ -107,7 +107,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "Comparing..."
+        assert subtitle == "Comparing snapshots..."
         assert "Processing..." in summary
 
     def test_comparison_in_pending_state_shows_comparing(self):
@@ -131,8 +131,8 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "Comparing..."
-        assert "Comparing..." in summary
+        assert subtitle == "Comparing snapshots..."
+        assert "Comparing" in summary
 
     def test_comparison_in_processing_state_shows_comparing(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
@@ -154,7 +154,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
             {},
         )
 
-        assert subtitle == "Comparing..."
+        assert subtitle == "Comparing snapshots..."
 
 
 @region_silo_test
@@ -187,7 +187,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "All images match"
+        assert subtitle == "No changes detected"
         assert "✅" in summary
         assert "0 changed" in summary
         assert "10 unchanged" in summary
@@ -243,7 +243,7 @@ class SnapshotSuccessStateFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "All images match"
+        assert subtitle == "No changes detected"
         for i in range(3):
             assert f"com.example.app{i}" in summary
 
@@ -470,9 +470,9 @@ class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
             {},
         )
 
-        assert subtitle == "Comparing..."
+        assert subtitle == "Comparing snapshots..."
         assert "✅" in summary
-        assert "Comparing..." in summary
+        assert "Comparing" in summary
 
     def test_mixed_changes_and_failures(self):
         # Comparison with changes
@@ -647,7 +647,7 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         )
 
         assert title == "Snapshot Testing"
-        assert subtitle == "All images match"
+        assert subtitle == "No changes detected"
 
         expected = (
             "| Name | Changed | Added | Removed | Unchanged |\n"


### PR DESCRIPTION
Adds snapshots status checks for diff states. Will add first-time and non-diff states in the future. Some examples:

Single app, no diffs
<img width="1629" height="320" alt="Screenshot 2026-03-05 at 4 47 53 PM" src="https://github.com/user-attachments/assets/f9019ef3-4a62-42fe-8c4d-002feba5101f" />

Single app with diffs
<img width="1665" height="373" alt="Screenshot 2026-03-05 at 4 47 27 PM" src="https://github.com/user-attachments/assets/f532e646-1e22-4616-ba39-21906202b8da" />

Any comparison error (we can add details in future, but for now show a fully errored out display as errors should be on us to start)
<img width="1408" height="230" alt="Screenshot 2026-03-05 at 4 46 52 PM" src="https://github.com/user-attachments/assets/4734c545-fd36-45a2-956c-098616c1fcc6" />

Multi app with diffs/unchanged:
<img width="1653" height="438" alt="Screenshot 2026-03-05 at 4 38 39 PM" src="https://github.com/user-attachments/assets/48a51f68-56e7-4909-9e7c-9ebcf7f344ad" />



Resolves EME-905