### PR TITLE
fix(dashboards): Show full aggregate name in widget legends for measurements

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.spec.tsx
@@ -46,8 +46,8 @@ describe('formatSeriesName', () => {
 
   describe('aggregates of measurements', () => {
     it.each([
-      ['p75(measurements.lcp)', 'LCP'],
-      ['p50(measurements.lcp)', 'LCP'],
+      ['p75(measurements.lcp)', 'p75(measurements.lcp)'],
+      ['p50(measurements.lcp)', 'p50(measurements.lcp)'],
     ])('Formats %s as %s', (name, result) => {
       const timeSeries = TimeSeriesFixture({
         yAxis: name,

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
@@ -1,10 +1,5 @@
 import {t} from 'sentry/locale';
-import {
-  getAggregateArg,
-  getMeasurementSlug,
-  maybeEquationAlias,
-  stripEquationPrefix,
-} from 'sentry/utils/discover/fields';
+import {maybeEquationAlias, stripEquationPrefix} from 'sentry/utils/discover/fields';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import WidgetLegendNameEncoderDecoder from 'sentry/views/dashboards/widgetLegendNameEncoderDecoder';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
@@ -54,16 +49,6 @@ export function formatTimeSeriesLabel(timeSeries: TimeSeries): string {
   // correctly specify `yAxis` and `groupBy`, and/or to use the time
   // `/events-timeseries` endpoint which does this automatically.
   seriesName = formatVersion(seriesName);
-
-  // Check for special-case measurement formatting
-  const arg = getAggregateArg(seriesName);
-  if (arg) {
-    const slug = getMeasurementSlug(arg);
-
-    if (slug) {
-      seriesName = slug.toUpperCase();
-    }
-  }
 
   // Strip equation prefix
   if (maybeEquationAlias(seriesName)) {


### PR DESCRIPTION
Remove special-case measurement formatting that replaced full aggregate expressions like `p75(measurements.lcp)` with just `LCP` in chart legends.

Previously, if multiple aggregates of a Web Vitals like `p75(measurements.lcp)` and `p50(measurements.lcp)` were on the same chart, they would display as `LCP` in the legend, making it impossible to distinguish which percentile was being shown. Now the full expression is preserved.

**Before:**
<img width="469" height="272" alt="Screenshot 2026-03-04 at 3 13 07 PM" src="https://github.com/user-attachments/assets/8633cc43-7e6a-452f-bf1e-da424c78efa2" />

**After:**
<img width="463" height="272" alt="Screenshot 2026-03-04 at 3 14 47 PM" src="https://github.com/user-attachments/assets/90e481ca-aa2b-408d-95bf-d9f6dc1a8f37" />

Fixes DAIN-1237