### PR TITLE
feat(dashboards): Show save button on prebuilt dashboards when filters change

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -170,9 +170,8 @@ export function updateDashboard(
 ): Promise<DashboardDetails> {
   const {title, widgets, projects, environment, period, start, end, filters, utc} =
     dashboard;
-  const data = {
+  const data: Partial<DashboardDetails> = {
     title,
-    widgets: widgets.map(widget => omit(widget, ['tempId'])).map(_enforceWidgetLimit),
     projects,
     environment,
     period,
@@ -181,6 +180,11 @@ export function updateDashboard(
     filters,
     utc,
   };
+  if (widgets) {
+    data.widgets = widgets
+      .map(widget => omit(widget, ['tempId']))
+      .map(_enforceWidgetLimit);
+  }
 
   const promise: Promise<DashboardDetails> = api.requestPromise(
     `/organizations/${orgId}/dashboards/${dashboard.id}/`,

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1171,6 +1171,9 @@ class DashboardDetail extends Component<Props, State> {
                                 filters:
                                   getDashboardFiltersFromURL(location) ??
                                   (modifiedDashboard ?? dashboard).filters,
+                                ...(defined(dashboard.prebuiltId) && {
+                                  widgets: undefined,
+                                }),
                               };
                               this.setState({isSavingDashboardFilters: true});
                               addLoadingMessage(t('Saving dashboard filters'));

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -200,7 +200,7 @@ describe('FiltersBar', () => {
     expect(onDashboardFilterChange).not.toHaveBeenCalled();
   });
 
-  it('should render save button but not cancel on prebuilt dashboard with unsaved changes', async () => {
+  it('should render save and cancel buttons on prebuilt dashboard with unsaved changes', async () => {
     const newLocation = LocationFixture({
       query: {
         [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
@@ -220,7 +220,7 @@ describe('FiltersBar', () => {
       screen.getByRole('button', {name: /browser\.name.*Chrome/i})
     ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
   });
 });
 

--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -200,7 +200,7 @@ describe('FiltersBar', () => {
     expect(onDashboardFilterChange).not.toHaveBeenCalled();
   });
 
-  it('should not render save button on prebuilt dashboard', async () => {
+  it('should render save button but not cancel on prebuilt dashboard with unsaved changes', async () => {
     const newLocation = LocationFixture({
       query: {
         [DashboardFilterKeys.GLOBAL_FILTER]: JSON.stringify({
@@ -212,13 +212,14 @@ describe('FiltersBar', () => {
     });
     renderFilterBar({
       location: newLocation,
+      hasUnsavedChanges: true,
       prebuiltDashboardId: PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
     });
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
     expect(
       screen.getByRole('button', {name: /browser\.name.*Chrome/i})
     ).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Cancel'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -353,12 +353,16 @@ export default function FiltersBar({
               <Button
                 data-test-id="filter-bar-cancel"
                 onClick={() => {
-                  const fallbackFilters = filters.globalFilter?.length
+                  onCancel?.();
+                  // Reset local display state, falling back to prebuilt
+                  // defaults when no saved filters exist
+                  const displayFilters = filters.globalFilter?.length
                     ? filters.globalFilter
                     : prebuiltDashboardFilters;
-                  onCancel?.();
-                  setActiveGlobalFilters(fallbackFilters);
-                  onDashboardFilterChange({...filters, globalFilter: fallbackFilters});
+                  setActiveGlobalFilters(displayFilters);
+                  // Push saved filters (not display fallback) to avoid a
+                  // URL/DB mismatch that re-triggers hasUnsavedFilterChanges
+                  onDashboardFilterChange(filters);
                 }}
               >
                 {t('Cancel')}

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -181,10 +181,12 @@ export default function FiltersBar({
 
   const [activeGlobalFilters, setActiveGlobalFilters] = useState<GlobalFilter[]>(() => {
     const savedFilters = filters?.[DashboardFilterKeys.GLOBAL_FILTER] ?? [];
+    const initialFilters =
+      savedFilters.length > 0 ? savedFilters : prebuiltDashboardFilters;
     const urlFilters = dashboardFiltersFromURL?.[DashboardFilterKeys.GLOBAL_FILTER];
 
     if (!urlFilters) {
-      return savedFilters;
+      return initialFilters;
     }
 
     // Empty array means user explicitly cleared all filters — respect that
@@ -192,11 +194,11 @@ export default function FiltersBar({
       return urlFilters;
     }
 
-    const nonOverlappingSaved = savedFilters.filter(
+    const nonOverlapping = initialFilters.filter(
       saved => !urlFilters.some(url => globalFilterKeysAreEqual(saved, url))
     );
 
-    return [...nonOverlappingSaved, ...urlFilters];
+    return [...nonOverlapping, ...urlFilters];
   });
 
   // Sync merged filters to the URL on mount so widgets see the same filters
@@ -330,8 +332,7 @@ export default function FiltersBar({
         {!hasTemporaryFilters &&
           hasUnsavedChanges &&
           !isEditingDashboard &&
-          !isPreview &&
-          !isPrebuiltDashboard && (
+          !isPreview && (
             <Grid flow="column" align="center" gap="md">
               <Button
                 tooltipProps={{
@@ -349,16 +350,18 @@ export default function FiltersBar({
               >
                 {t('Save')}
               </Button>
-              <Button
-                data-test-id="filter-bar-cancel"
-                onClick={() => {
-                  onCancel?.();
-                  setActiveGlobalFilters(filters.globalFilter ?? []);
-                  onDashboardFilterChange(filters);
-                }}
-              >
-                {t('Cancel')}
-              </Button>
+              {!isPrebuiltDashboard && (
+                <Button
+                  data-test-id="filter-bar-cancel"
+                  onClick={() => {
+                    onCancel?.();
+                    setActiveGlobalFilters(filters.globalFilter ?? []);
+                    onDashboardFilterChange(filters);
+                  }}
+                >
+                  {t('Cancel')}
+                </Button>
+              )}
             </Grid>
           )}
         <ToggleOnDemand />

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -350,18 +350,16 @@ export default function FiltersBar({
               >
                 {t('Save')}
               </Button>
-              {!isPrebuiltDashboard && (
-                <Button
-                  data-test-id="filter-bar-cancel"
-                  onClick={() => {
-                    onCancel?.();
-                    setActiveGlobalFilters(filters.globalFilter ?? []);
-                    onDashboardFilterChange(filters);
-                  }}
-                >
-                  {t('Cancel')}
-                </Button>
-              )}
+              <Button
+                data-test-id="filter-bar-cancel"
+                onClick={() => {
+                  onCancel?.();
+                  setActiveGlobalFilters(filters.globalFilter ?? []);
+                  onDashboardFilterChange(filters);
+                }}
+              >
+                {t('Cancel')}
+              </Button>
             </Grid>
           )}
         <ToggleOnDemand />

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -353,9 +353,12 @@ export default function FiltersBar({
               <Button
                 data-test-id="filter-bar-cancel"
                 onClick={() => {
+                  const fallbackFilters = filters.globalFilter?.length
+                    ? filters.globalFilter
+                    : prebuiltDashboardFilters;
                   onCancel?.();
-                  setActiveGlobalFilters(filters.globalFilter ?? []);
-                  onDashboardFilterChange(filters);
+                  setActiveGlobalFilters(fallbackFilters);
+                  onDashboardFilterChange({...filters, globalFilter: fallbackFilters});
                 }}
               >
                 {t('Cancel')}

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -84,12 +84,14 @@ function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) {
   const {dashboard: prebuiltDashboard, isLoading: isPrebuiltDashboardLoading} =
     useGetPrebuiltDashboard(selectedDashboard?.prebuiltId);
 
-  // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard
+  // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard.
+  // Preserve filters from the DB record so user-saved filter changes persist across refreshes.
   if (selectedDashboard?.prebuiltId) {
     selectedDashboard = {
       ...selectedDashboard,
       ...prebuiltDashboard,
       id: selectedDashboard.id,
+      filters: selectedDashboard.filters,
     };
   }
 

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -85,13 +85,19 @@ function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) {
     useGetPrebuiltDashboard(selectedDashboard?.prebuiltId);
 
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard.
-  // Preserve filters from the DB record so user-saved filter changes persist across refreshes.
+  // Preserve user-saved state (filters and page filters) from the DB record so changes persist.
   if (selectedDashboard?.prebuiltId) {
     selectedDashboard = {
       ...selectedDashboard,
       ...prebuiltDashboard,
       id: selectedDashboard.id,
       filters: selectedDashboard.filters,
+      projects: selectedDashboard.projects,
+      environment: selectedDashboard.environment,
+      period: selectedDashboard.period,
+      start: selectedDashboard.start,
+      end: selectedDashboard.end,
+      utc: selectedDashboard.utc,
     };
   }
 


### PR DESCRIPTION
Allow users to save global filter changes on prebuilt dashboards. Previously,
changing global filters on a prebuilt dashboard showed no save option, so filter
changes were lost on navigation. Now a Save button appears when filters are modified.

- Prebuilt default filters (from the config) remain non-removable, while user-added
  filters can be freely added/removed
- Widgets are omitted from the API payload when saving prebuilt dashboard filters to
  avoid the backend's "Cannot edit widgets on prebuilt Dashboards" validation
- DB-saved filters are preserved during the prebuilt config merge in `orgDashboards`
  so saved filter changes persist across page refreshes
- Falls back to prebuilt default filters when no user-saved filters exist yet

Refs BROWSE-404