### PR TITLE
fix(dashboards): Fixes for Agents Traces Table to display properly in widget viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -103,6 +103,7 @@ import ReleaseWidgetQueries from 'sentry/views/dashboards/widgetCard/releaseWidg
 import {WidgetCardChartContainer} from 'sentry/views/dashboards/widgetCard/widgetCardChartContainer';
 import WidgetQueries from 'sentry/views/dashboards/widgetCard/widgetQueries';
 import type WidgetLegendSelectionState from 'sentry/views/dashboards/widgetLegendSelectionState';
+import {AgentsTracesTableWidgetVisualization} from 'sentry/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization';
 import {ALLOWED_CELL_ACTIONS} from 'sentry/views/dashboards/widgets/common/settings';
 import {TableWidgetVisualization} from 'sentry/views/dashboards/widgets/tableWidget/tableWidgetVisualization';
 import {
@@ -519,6 +520,14 @@ function WidgetViewerModal(props: Props) {
   };
 
   function renderWidgetViewerTable() {
+    if (widget.displayType === DisplayType.AGENTS_TRACES_TABLE) {
+      return (
+        <AgentsTracesTableWidgetVisualization
+          limit={FULL_TABLE_ITEM_LIMIT}
+          tableWidths={widget.tableWidths}
+        />
+      );
+    }
     switch (widget.widgetType) {
       case WidgetType.ISSUE:
         return (
@@ -590,11 +599,15 @@ function WidgetViewerModal(props: Props) {
     dashboardCreator
   );
 
+  const shouldRenderChartVisualization =
+    widget.displayType !== DisplayType.TABLE &&
+    widget.displayType !== DisplayType.AGENTS_TRACES_TABLE;
+
   function renderWidgetViewer() {
     return (
       <Fragment>
         {hasSessionDuration && SESSION_DURATION_ALERT}
-        {widget.displayType !== DisplayType.TABLE && (
+        {shouldRenderChartVisualization && (
           <Container
             height={
               widget.displayType === DisplayType.BIG_NUMBER

--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -21,6 +21,8 @@ const DEFAULT_GLOBAL_FILTERS = [
   },
 ];
 
+export const DEFAULT_TRACES_TABLE_WIDTHS = [110, 600, 140, 110, 110, 110, 120, 110, 110];
+
 const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
   [
     {
@@ -161,9 +163,8 @@ const AGENTS_TRACES_TABLE = {
   id: 'ai-agents-traces-table',
   title: t('Traces'),
   displayType: DisplayType.AGENTS_TRACES_TABLE,
-  widgetType: WidgetType.SPANS,
   interval: '1h',
-  tableWidths: [110, 600, -1, -1, -1, -1, -1, -1, -1],
+  tableWidths: DEFAULT_TRACES_TABLE_WIDTHS,
   limit: 20,
   queries: [
     {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -262,6 +262,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
         <AgentsTracesTableWidgetVisualization
           limit={widget.limit}
           tableWidths={widget.tableWidths}
+          frameless
         />
       </TableWrapper>
     );

--- a/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
@@ -1,14 +1,17 @@
+import {DEFAULT_TRACES_TABLE_WIDTHS} from 'sentry/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview';
 import {useTraceViewDrawer} from 'sentry/views/insights/pages/agents/components/drawer';
 import {TracesTable} from 'sentry/views/insights/pages/agents/components/tracesTable';
 
 interface AgentsTracesTableWidgetVisualizationProps {
+  frameless?: boolean;
   limit?: number;
   tableWidths?: number[];
 }
 
 export function AgentsTracesTableWidgetVisualization({
   limit,
-  tableWidths,
+  tableWidths = DEFAULT_TRACES_TABLE_WIDTHS,
+  frameless,
 }: AgentsTracesTableWidgetVisualizationProps) {
   const {openTraceViewDrawer} = useTraceViewDrawer();
 
@@ -17,7 +20,7 @@ export function AgentsTracesTableWidgetVisualization({
       openTraceViewDrawer={openTraceViewDrawer}
       limit={limit}
       tableWidths={tableWidths}
-      frameless
+      frameless={frameless}
     />
   );
 }


### PR DESCRIPTION
Various fixes to get the Agents Traces Table rendering properly in the widget viewer:
- Update to not use `frameless` in the widget viewer to enable pagination
- Fix column widths too small and clipping text
- Disable chart visualization for the Agents Traces Table, since it's not applicable
- Remove `widgetType: WidgetType.SPANS` from widget definition to prevent `Open in Explore` links