### PR TITLE
ref(metric-issues): Clarify metric alert types

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
 from sentry import features
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
@@ -11,7 +11,11 @@ from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
 from sentry.incidents.utils.format_duration import format_duration_idiomatic
-from sentry.incidents.utils.types import AnomalyDetectionUpdate, ProcessedSubscriptionUpdate
+from sentry.incidents.utils.types import (
+    AnomalyDetectionUpdate,
+    AnomalyDetectionValues,
+    ProcessedSubscriptionUpdate,
+)
 from sentry.integrations.metric_alerts import TEXT_COMPARISON_DELTA
 from sentry.issues.grouptype import GroupCategory, GroupType
 from sentry.models.organization import Organization
@@ -27,7 +31,12 @@ from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.data_condition import Condition, DataCondition
 from sentry.workflow_engine.models.data_source import DataPacket
 from sentry.workflow_engine.processors.data_condition_group import ProcessedDataConditionGroup
-from sentry.workflow_engine.types import DetectorException, DetectorPriorityLevel, DetectorSettings
+from sentry.workflow_engine.types import (
+    DetectorException,
+    DetectorGroupKey,
+    DetectorPriorityLevel,
+    DetectorSettings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +54,23 @@ QUERY_AGGREGATION_DISPLAY = {
 
 
 MetricUpdate = ProcessedSubscriptionUpdate | AnomalyDetectionUpdate
-MetricResult = float | dict
+
+MetricResult = float | AnomalyDetectionValues
+
+
+# Post-serialization: what's stored in evidence data after JSON round-trip.
+class StoredAnomalyDetectionResult(TypedDict):
+    value: float
+    source_id: str
+    subscription_id: str
+    timestamp: str
+
+
+StoredMetricResult = float | StoredAnomalyDetectionResult
 
 
 @dataclass
-class MetricIssueEvidenceData(EvidenceData[MetricResult]):
+class MetricIssueEvidenceData(EvidenceData[StoredMetricResult]):
     alert_id: int
 
 
@@ -239,12 +260,15 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
     def extract_dedupe_value(self, data_packet: DataPacket[MetricUpdate]) -> int:
         return int(data_packet.packet.timestamp.timestamp())
 
-    def extract_value(self, data_packet: DataPacket[MetricUpdate]) -> MetricResult:
-        # this is a bit of a hack - anomaly detection data packets send extra data we need to pass along
-        values = data_packet.packet.values
+    def extract_value(
+        self, data_packet: DataPacket[MetricUpdate]
+    ) -> MetricResult | dict[DetectorGroupKey, MetricResult]:
         if isinstance(data_packet.packet, AnomalyDetectionUpdate):
-            return {None: values}
-        return values.get("value")
+            # A bare AnomalyDetectionValues dict would be interpreted as a grouped
+            # result dict, so wrap it with an explicit group key.
+            grouped: dict[DetectorGroupKey, MetricResult] = {None: data_packet.packet.values}
+            return grouped
+        return data_packet.packet.values["value"]
 
     def construct_title(
         self,

--- a/src/sentry/incidents/handlers/condition/anomaly_detection_handler.py
+++ b/src/sentry/incidents/handlers/condition/anomaly_detection_handler.py
@@ -1,9 +1,9 @@
 import logging
-from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any
 
 from django.conf import settings
 
+from sentry.incidents.utils.types import AnomalyDetectionValues
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import (
     AnomalyDetectionSeasonality,
@@ -31,15 +31,8 @@ SEER_EVALUATION_TO_DETECTOR_PRIORITY = {
 }
 
 
-class AnomalyDetectionUpdate(TypedDict):
-    value: int
-    source_id: int
-    subscription_id: int
-    timestamp: datetime
-
-
 @condition_handler_registry.register(Condition.ANOMALY_DETECTION)
-class AnomalyDetectionHandler(DataConditionHandler[AnomalyDetectionUpdate]):
+class AnomalyDetectionHandler(DataConditionHandler[AnomalyDetectionValues]):
     group = DataConditionHandler.Group.DETECTOR_TRIGGER
     comparison_json_schema = {
         "type": "object",
@@ -62,7 +55,7 @@ class AnomalyDetectionHandler(DataConditionHandler[AnomalyDetectionUpdate]):
     }
 
     @staticmethod
-    def evaluate_value(update: AnomalyDetectionUpdate, comparison: Any) -> DetectorPriorityLevel:
+    def evaluate_value(update: AnomalyDetectionValues, comparison: Any) -> DetectorPriorityLevel:
         from sentry.seer.anomaly_detection.get_anomaly_data import get_anomaly_data_from_seer
 
         sensitivity = comparison["sensitivity"]

--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -212,7 +212,7 @@ class MetricIssueContext:
     snuba_query: SnubaQuery
     new_status: IncidentStatus
     subscription: QuerySubscription | None
-    metric_value: float | dict | None
+    metric_value: float | None
     group: Group | None
 
     @classmethod
@@ -246,11 +246,10 @@ class MetricIssueContext:
 
         subscription = cls._get_subscription(evidence_data)
         snuba_query = subscription.snuba_query
-        metric_value = (
-            evidence_data.value["value"]
-            if type(evidence_data.value) is dict
-            else evidence_data.value
-        )
+        if isinstance(evidence_data.value, (int, float)):
+            metric_value = float(evidence_data.value)
+        else:
+            metric_value = evidence_data.value["value"]
 
         return cls(
             id=group.id,

--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -36,16 +36,6 @@ class AnomalyDetectionValues(TypedDict):
 
 @dataclass
 class AnomalyDetectionUpdate:
-    """
-    values has format:
-    {
-        "value": float,
-        "source_id": str,
-        "subscription_id": str,
-        "timestamp": datetime,
-    }
-    """
-
     entity: str
     subscription_id: str
     values: AnomalyDetectionValues

--- a/src/sentry/incidents/utils/types.py
+++ b/src/sentry/incidents/utils/types.py
@@ -4,18 +4,33 @@ from enum import Enum
 from typing import Any, TypedDict
 
 
+class QuerySubscriptionUpdateValues(TypedDict):
+    data: list[dict[str, Any]]
+
+
 class QuerySubscriptionUpdate(TypedDict):
     entity: str
     subscription_id: str
-    values: Any
+    values: QuerySubscriptionUpdateValues
     timestamp: datetime
+
+
+class SubscriptionUpdateValues(TypedDict):
+    value: float
 
 
 @dataclass
 class ProcessedSubscriptionUpdate:
     entity: str
     subscription_id: str
-    values: Any
+    values: SubscriptionUpdateValues
+    timestamp: datetime
+
+
+class AnomalyDetectionValues(TypedDict):
+    value: float
+    source_id: str
+    subscription_id: str
     timestamp: datetime
 
 
@@ -33,7 +48,7 @@ class AnomalyDetectionUpdate:
 
     entity: str
     subscription_id: str
-    values: Any
+    values: AnomalyDetectionValues
     timestamp: datetime
 
 

--- a/src/sentry/seer/anomaly_detection/get_anomaly_data.py
+++ b/src/sentry/seer/anomaly_detection/get_anomaly_data.py
@@ -8,7 +8,7 @@ from sentry.conf.server import (
     SEER_ANOMALY_DETECTION_ALERT_DATA_URL,
     SEER_ANOMALY_DETECTION_ENDPOINT_URL,
 )
-from sentry.incidents.handlers.condition.anomaly_detection_handler import AnomalyDetectionUpdate
+from sentry.incidents.utils.types import AnomalyDetectionValues
 from sentry.net.http import connection_from_url
 from sentry.seer.anomaly_detection.types import (
     AlertInSeer,
@@ -97,7 +97,7 @@ def get_anomaly_data_from_seer(
     seasonality: AnomalyDetectionSeasonality,
     threshold_type: AnomalyDetectionThresholdType,
     subscription: QuerySubscription,
-    subscription_update: AnomalyDetectionUpdate,
+    subscription_update: AnomalyDetectionValues,
 ) -> list[TimeSeriesPoint] | None:
     snuba_query: SnubaQuery = subscription.snuba_query
     aggregation_value = subscription_update.get("value")

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -9,7 +9,12 @@ import pytest
 from django.utils import timezone
 
 from sentry.db.models import NodeData
-from sentry.incidents.grouptype import MetricIssue, MetricIssueEvidenceData
+from sentry.incidents.grouptype import (
+    MetricIssue,
+    MetricIssueEvidenceData,
+    StoredAnomalyDetectionResult,
+    StoredMetricResult,
+)
 from sentry.incidents.models.alert_rule import (
     AlertRuleDetectionType,
     AlertRuleSensitivity,
@@ -106,13 +111,14 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
             alert_id=self.alert_rule.id,
         )
 
+        anomaly_detection_result = StoredAnomalyDetectionResult(
+            source_id="12345",
+            subscription_id="some-subscription-id-123",
+            timestamp="2025-06-07",
+            value=6789.0,
+        )
         self.anomaly_detection_evidence_data = MetricIssueEvidenceData(
-            value={
-                "source_id": "12345",
-                "subscription_id": "some-subscription-id-123",
-                "timestamp": "2025-06-07",
-                "value": 6789,
-            },
+            value=anomaly_detection_result,
             detector_id=self.detector.id,
             data_packet_source_id=int(self.data_source.source_id),
             conditions=[
@@ -234,7 +240,7 @@ class MetricAlertHandlerBase(BaseWorkflowTest):
         snuba_query: SnubaQuery,
         new_status: IncidentStatus,
         title: str,
-        metric_value: float | dict | None = None,
+        metric_value: StoredMetricResult | None = None,
         subscription: QuerySubscription | None = None,
         group: Group | None = None,
     ):


### PR DESCRIPTION
Replace some 'Any' uses with accurate type annotations.
Differentiate between pre-serialization (AnomalyDetectionValues withdatetime) and post-serialization (StoredAnomalyDetectionResult with string timestamp) anomaly data, accurately reflecting the current
reality and allowing us to move away from 'dict'.
Used the more commonly used type in the Condition Handler.
