### PR TITLE
feat(snapshots): Simplify color picker

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {memo, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
@@ -24,7 +24,7 @@ interface DiffImageDisplayProps {
   showOverlay: boolean;
 }
 
-export function DiffImageDisplay({
+export const DiffImageDisplay = memo(function DiffImageDisplay({
   pair,
   imageBaseUrl,
   diffImageBaseUrl,
@@ -126,7 +126,7 @@ export function DiffImageDisplay({
       </Flex>
     </Flex>
   );
-}
+});
 
 interface ViewProps {
   baseImageUrl: string;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -1,4 +1,4 @@
-import {memo, useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
@@ -24,7 +24,7 @@ interface DiffImageDisplayProps {
   showOverlay: boolean;
 }
 
-export const DiffImageDisplay = memo(function DiffImageDisplay({
+export function DiffImageDisplay({
   pair,
   imageBaseUrl,
   diffImageBaseUrl,
@@ -126,9 +126,9 @@ export const DiffImageDisplay = memo(function DiffImageDisplay({
       </Flex>
     </Flex>
   );
-});
+}
 
-interface ViewProps {
+interface SplitViewProps {
   baseImageUrl: string;
   diffMaskUrl: string | null;
   headImageUrl: string;
@@ -142,7 +142,7 @@ function SplitView({
   showOverlay,
   overlayColor,
   diffMaskUrl,
-}: ViewProps) {
+}: SplitViewProps) {
   return (
     <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
       <Flex direction="column" gap="sm">

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,3 +1,4 @@
+import {useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -7,11 +8,23 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
+
+const OVERLAY_COLORS = [
+  '#ff0000',
+  '#00cc44',
+  '#0088ff',
+  '#00cccc',
+  '#ff00ff',
+  '#ffcc00',
+  '#ff6600',
+  '#ffffff',
+];
 
 interface SnapshotMainContentProps {
   diffImageBaseUrl: string;
@@ -57,20 +70,12 @@ export function SnapshotMainContent({
             {displayName}
           </Text>
           {diffMode === 'split' && (
-            <Flex align="center" gap="sm">
-              <Button
-                size="xs"
-                priority={showOverlay ? 'primary' : 'default'}
-                onClick={() => onShowOverlayChange(!showOverlay)}
-              >
-                {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
-              </Button>
-              <ColorInput
-                type="color"
-                value={overlayColor}
-                onChange={e => onOverlayColorChange(e.target.value)}
-              />
-            </Flex>
+            <OverlayControls
+              showOverlay={showOverlay}
+              onShowOverlayChange={onShowOverlayChange}
+              overlayColor={overlayColor}
+              onOverlayColorChange={onOverlayColorChange}
+            />
           )}
         </Flex>
         <Separator orientation="horizontal" />
@@ -162,11 +167,98 @@ export function SnapshotMainContent({
   );
 }
 
-const ColorInput = styled('input')`
-  width: 28px;
-  height: 28px;
+function OverlayControls({
+  showOverlay,
+  onShowOverlayChange,
+  overlayColor,
+  onOverlayColorChange,
+}: {
+  onOverlayColorChange: (color: string) => void;
+  onShowOverlayChange: (show: boolean) => void;
+  overlayColor: string;
+  showOverlay: boolean;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside(pickerRef, () => setPickerOpen(false));
+
+  return (
+    <Flex align="center" gap="sm">
+      <Button
+        size="xs"
+        priority={showOverlay ? 'primary' : 'default'}
+        onClick={() => onShowOverlayChange(!showOverlay)}
+      >
+        {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
+      </Button>
+      <ColorPickerWrapper ref={pickerRef}>
+        <ColorTrigger
+          $color={overlayColor}
+          onClick={() => setPickerOpen(!pickerOpen)}
+          aria-label={t('Pick overlay color')}
+        />
+        {pickerOpen && (
+          <ColorPickerPopover>
+            {OVERLAY_COLORS.map(color => (
+              <ColorSwatch
+                key={color}
+                $color={color}
+                $selected={overlayColor === color}
+                onClick={() => {
+                  onOverlayColorChange(color);
+                  setPickerOpen(false);
+                }}
+                aria-label={`Overlay color ${color}`}
+              />
+            ))}
+          </ColorPickerPopover>
+        )}
+      </ColorPickerWrapper>
+    </Flex>
+  );
+}
+
+const ColorPickerWrapper = styled('div')`
+  position: relative;
+`;
+
+const ColorTrigger = styled('button')<{$color: string}>`
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
   cursor: pointer;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.sm};
+  border: 2px solid ${p => p.theme.tokens.border.primary};
+  background-color: ${p => p.$color};
   padding: 0;
+
+  &:hover {
+    border-color: ${p => p.theme.tokens.border.accent};
+  }
+`;
+
+const ColorPickerPopover = styled('div')`
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  box-shadow: ${p => p.theme.dropShadowMedium};
+  z-index: ${p => p.theme.zIndex.dropdown};
+`;
+
+const ColorSwatch = styled('button')<{$color: string; $selected: boolean}>`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid
+    ${p => (p.$selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
+  background-color: ${p => p.$color};
+  padding: 0;
+  outline: ${p => (p.$selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
+  outline-offset: 1px;
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,30 +1,19 @@
-import {useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
-
-const OVERLAY_COLORS = [
-  '#ff0000',
-  '#00cc44',
-  '#0088ff',
-  '#00cccc',
-  '#ff00ff',
-  '#ffcc00',
-  '#ff6600',
-  '#ffffff',
-];
 
 interface SnapshotMainContentProps {
   diffImageBaseUrl: string;
@@ -178,9 +167,9 @@ function OverlayControls({
   overlayColor: string;
   showOverlay: boolean;
 }) {
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const pickerRef = useRef<HTMLDivElement>(null);
-  useOnClickOutside(pickerRef, () => setPickerOpen(false));
+  const theme = useTheme();
+
+  const overlayColors = theme.chart.getColorPalette(10);
 
   return (
     <Flex align="center" gap="sm">
@@ -191,36 +180,28 @@ function OverlayControls({
       >
         {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
       </Button>
-      <ColorPickerWrapper ref={pickerRef}>
-        <ColorTrigger
-          $color={overlayColor}
-          onClick={() => setPickerOpen(!pickerOpen)}
-          aria-label={t('Pick overlay color')}
-        />
-        {pickerOpen && (
-          <ColorPickerPopover>
-            {OVERLAY_COLORS.map(color => (
+      <Tooltip
+        isHoverable
+        maxWidth={400}
+        title={
+          <Flex gap="xs">
+            {overlayColors.map(color => (
               <ColorSwatch
                 key={color}
                 $color={color}
                 $selected={overlayColor === color}
-                onClick={() => {
-                  onOverlayColorChange(color);
-                  setPickerOpen(false);
-                }}
-                aria-label={`Overlay color ${color}`}
+                onClick={() => onOverlayColorChange(color)}
+                aria-label={t('Overlay color %s', color)}
               />
             ))}
-          </ColorPickerPopover>
-        )}
-      </ColorPickerWrapper>
+          </Flex>
+        }
+      >
+        <ColorTrigger $color={overlayColor} aria-label={t('Pick overlay color')} />
+      </Tooltip>
     </Flex>
   );
 }
-
-const ColorPickerWrapper = styled('div')`
-  position: relative;
-`;
 
 const ColorTrigger = styled('button')<{$color: string}>`
   width: 24px;
@@ -234,20 +215,6 @@ const ColorTrigger = styled('button')<{$color: string}>`
   &:hover {
     border-color: ${p => p.theme.tokens.border.accent};
   }
-`;
-
-const ColorPickerPopover = styled('div')`
-  position: absolute;
-  top: calc(100% + 4px);
-  right: 0;
-  display: flex;
-  gap: 6px;
-  padding: 8px;
-  background: ${p => p.theme.tokens.background.primary};
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  box-shadow: ${p => p.theme.dropShadowMedium};
-  z-index: ${p => p.theme.zIndex.dropdown};
 `;
 
 const ColorSwatch = styled('button')<{$color: string; $selected: boolean}>`

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -66,9 +66,9 @@ export default function SnapshotsPage() {
   const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
   const [showOverlay, setShowOverlay] = useState(true);
-  const [overlayColor, setOverlayColor] = useState(() => {
+  const [overlayColor, setOverlayColor] = useState<string>(() => {
     const palette = theme.chart.getColorPalette(10);
-    return palette[palette.length - 1];
+    return palette.at(-1) ?? '#67C800';
   });
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
 

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -66,9 +66,10 @@ export default function SnapshotsPage() {
   const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
   const [showOverlay, setShowOverlay] = useState(true);
-  const [overlayColor, setOverlayColor] = useState(
-    () => theme.chart.getColorPalette(10)[0]
-  );
+  const [overlayColor, setOverlayColor] = useState(() => {
+    const palette = theme.chart.getColorPalette(10);
+    return palette[palette.length - 1];
+  });
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
 
   const {

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -30,6 +31,7 @@ import {SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 
 export default function SnapshotsPage() {
   const organization = useOrganization();
+  const theme = useTheme();
   const {snapshotId} = useParams<{
     snapshotId: string;
   }>();
@@ -64,7 +66,9 @@ export default function SnapshotsPage() {
   const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
   const [showOverlay, setShowOverlay] = useState(true);
-  const [overlayColor, setOverlayColor] = useState('#00cc44');
+  const [overlayColor, setOverlayColor] = useState(
+    () => theme.chart.getColorPalette(10)[0]
+  );
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
 
   const {


### PR DESCRIPTION

<img width="254" height="100" alt="image" src="https://github.com/user-attachments/assets/6c759dac-db0c-4e74-9b75-d6f116c20acb" />


Replace the native HTML color input with a popover of 8 predefined
color swatches for choosing the diff overlay tint.

The native color picker was overpowered for this use case — users just
need a few high-contrast options to distinguish the diff overlay from
the underlying image. A set of curated swatches is faster to use and
visually consistent with the rest of the UI.

Also moves the overlay controls (show/hide toggle and color picker)
from the page-level comparison bar into the main content header, only
visible in Split mode where they're relevant.