### PR TITLE
feat(insights): Add moving notice banners to Crons and Uptime

### DIFF
--- a/static/app/views/insights/crons/views/overview.tsx
+++ b/static/app/views/insights/crons/views/overview.tsx
@@ -5,6 +5,7 @@ import * as qs from 'query-string';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 
 import {openBulkEditMonitorsModal} from 'sentry/actionCreators/modal';
 import FeedbackButton from 'sentry/components/feedbackButton/feedbackButton';
@@ -16,14 +17,17 @@ import PageFiltersContainer from 'sentry/components/pageFilters/container';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import PageFilterBar from 'sentry/components/pageFilters/pageFilterBar';
-import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {
+  extractSelectionParameters,
+  normalizeDateTimeParams,
+} from 'sentry/components/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Pagination from 'sentry/components/pagination';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd, IconList} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
@@ -31,6 +35,7 @@ import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyti
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
+import {makeMonitorTypePathname} from 'sentry/views/detectors/pathnames';
 import {CronsLandingPanel} from 'sentry/views/insights/crons/components/cronsLandingPanel';
 import {NewMonitorButton} from 'sentry/views/insights/crons/components/newMonitorButton';
 import {OverviewTimeline} from 'sentry/views/insights/crons/components/overviewTimeline';
@@ -141,6 +146,26 @@ function CronsOverview() {
           </Filters>
           <Alert.Container>
             <GlobalMonitorProcessingErrors project={project} />
+            {organization.features.includes('workflow-engine-ui') && (
+              <Alert variant="info" showIcon>
+                {tct(
+                  'Cron Monitors are moving to [link:Monitors]. Head over there for the same functionality in a new home.',
+                  {
+                    link: (
+                      <Link
+                        to={{
+                          pathname: makeMonitorTypePathname(
+                            organization.slug,
+                            'monitor_check_in_failure'
+                          ),
+                          query: extractSelectionParameters(location.query),
+                        }}
+                      />
+                    ),
+                  }
+                )}
+              </Alert>
+            )}
           </Alert.Container>
           {isPending ? (
             <LoadingIndicator />

--- a/static/app/views/insights/uptime/views/overview.tsx
+++ b/static/app/views/insights/uptime/views/overview.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
@@ -14,6 +15,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/pageFilters/container';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import PageFilterBar from 'sentry/components/pageFilters/pageFilterBar';
+import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import Pagination from 'sentry/components/pagination';
@@ -32,6 +34,7 @@ import useProjects from 'sentry/utils/useProjects';
 import {makeAlertsPathname} from 'sentry/views/alerts/pathnames';
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
 import {useDetectorsQuery} from 'sentry/views/detectors/hooks';
+import {makeMonitorTypePathname} from 'sentry/views/detectors/pathnames';
 import {OverviewTimeline} from 'sentry/views/insights/uptime/components/overviewTimeline';
 import {MODULE_DESCRIPTION, MODULE_DOC_LINK} from 'sentry/views/insights/uptime/settings';
 
@@ -115,6 +118,28 @@ export default function UptimeOverview() {
               }}
             />
           </Filters>
+          {organization.features.includes('workflow-engine-ui') && (
+            <Alert.Container>
+              <Alert variant="info" showIcon>
+                {tct(
+                  'Uptime Monitors are moving to [link:Monitors]. Head over there for the same functionality in a new home.',
+                  {
+                    link: (
+                      <Link
+                        to={{
+                          pathname: makeMonitorTypePathname(
+                            organization.slug,
+                            'uptime_domain_failure'
+                          ),
+                          query: extractSelectionParameters(location.query),
+                        }}
+                      />
+                    ),
+                  }
+                )}
+              </Alert>
+            </Alert.Container>
+          )}
           {isPending ? (
             <LoadingIndicator />
           ) : detectors?.length ? (


### PR DESCRIPTION
Add info banners to the Insights Crons and Uptime overview pages notifying users that these pages are moving to the Monitors section.

The banners only appear when the `workflow-engine-ui` feature flag is enabled (i.e., the user has access to the new Monitors section). Each banner links to the corresponding Monitors page, preserving the current page filter selection (project, environment, date range) via `extractSelectionParameters`.

**e.g.,**


<img width="775" height="283" alt="Screenshot 2026-03-04 at 4 23 03 PM" src="https://github.com/user-attachments/assets/039f8f3e-18fe-4459-a703-9c1e5fc8c5c0" />
<img width="438" height="218" alt="Screenshot 2026-03-04 at 4 25 25 PM" src="https://github.com/user-attachments/assets/76217025-f050-4c4b-b738-67f94774bd4c" />

This mirrors the approach used in DAIN-1209 for Insights dashboard pages, and complements the `InsightsRedirectNotice` banners already present on the Monitors side.

Refs DAIN-1212