### PR TITLE
feat(metric-issues): Track notification UUID on issue details

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -69,7 +69,12 @@ export type TeamInsightsEventParameters = {
   'alert_builder.noisy_warning_agreed': Record<string, unknown>;
   'alert_builder.noisy_warning_viewed': Record<string, unknown>;
   'alert_details.viewed': {alert_id: number};
-  'alert_rule_details.viewed': {alert: string; has_chartcuterie: string; rule_id: number};
+  'alert_rule_details.viewed': {
+    alert: string;
+    has_chartcuterie: string;
+    notification_uuid: string;
+    rule_id: number;
+  };
   'alert_rules.viewed': {sort: string};
   'alert_stream.viewed': Record<string, unknown>;
   'alert_wizard.option_selected': {alert_type: string};

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -101,6 +101,7 @@ class MetricAlertDetails extends Component<Props, State> {
       organization,
       rule_id: parseInt(ruleId, 10),
       alert: (location.query.alert as string) ?? '',
+      notification_uuid: (location.query.notification_uuid as string) ?? '',
       has_chartcuterie: organization.features
         .includes('metric-alert-chartcuterie')
         .toString(),

--- a/static/app/views/alerts/workflowEngineRedirects.spec.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.spec.tsx
@@ -161,6 +161,10 @@ describe('workflowEngineRedirects', () => {
           `/organizations/${organization.slug}/issues/group-1/`
         );
       });
+      expect(router.location.query).toMatchObject({
+        alert: 'alert-1',
+        notification_uuid: 'notification-uuid',
+      });
     });
 
     it('does not redirect without workflow-engine-metric-issue-ui flag', async () => {
@@ -251,6 +255,10 @@ describe('workflowEngineRedirects', () => {
           `/organizations/${organization.slug}/issues/group-1/`
         );
       });
+      expect(router.location.query).toMatchObject({
+        alert: 'alert-1',
+        notification_uuid: 'notification-uuid',
+      });
     });
 
     it('does not redirect without workflow-engine-ui flag', async () => {
@@ -330,6 +338,10 @@ describe('workflowEngineRedirects', () => {
           `/organizations/${organization.slug}/issues/group-1/`
         );
       });
+      expect(router.location.query).toMatchObject({
+        alert: 'alert-1',
+        notification_uuid: 'notification-uuid',
+      });
     });
   });
 
@@ -381,6 +393,7 @@ describe('workflowEngineRedirects', () => {
         route: '/organizations/:orgId/alerts/open-periods/:alertId/',
         location: {
           pathname: `/organizations/${organization.slug}/alerts/open-periods/alert-2/`,
+          query: {notification_uuid: 'notification-uuid'},
         },
       };
 
@@ -390,6 +403,9 @@ describe('workflowEngineRedirects', () => {
         expect(router.location.pathname).toBe(
           `/organizations/${organization.slug}/issues/group-2/`
         );
+      });
+      expect(router.location.query).toMatchObject({
+        notification_uuid: 'notification-uuid',
       });
     });
   });

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -5,6 +5,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -40,14 +41,16 @@ interface IncidentGroupOpenPeriod {
 function getIssueDetailsPath({
   orgSlug,
   groupId,
+  openPeriodId,
   query,
 }: {
   groupId: string;
+  openPeriodId: string | undefined;
   orgSlug: string;
   query: Query;
 }) {
-  const search = qs.stringify(query);
-  const pathname = `/organizations/${orgSlug}/issues/${groupId}/`;
+  const search = qs.stringify({...query, openPeriod: openPeriodId});
+  const pathname = normalizeUrl(`/organizations/${orgSlug}/issues/${groupId}/`);
 
   return search ? `${pathname}?${search}` : pathname;
 }
@@ -278,6 +281,7 @@ function RedirectToIssue({
         to={getIssueDetailsPath({
           orgSlug: organization.slug,
           groupId: incidentGroupOpenPeriod.groupId,
+          openPeriodId: incidentGroupOpenPeriod.openPeriodId,
           query: location.query,
         })}
       />
@@ -405,6 +409,7 @@ export function withOpenPeriodRedirect<P extends Record<string, any>>(
             to={getIssueDetailsPath({
               orgSlug: organization.slug,
               groupId: incidentGroupOpenPeriod.groupId,
+              openPeriodId: incidentGroupOpenPeriod.openPeriodId,
               query: location.query,
             })}
           />

--- a/static/app/views/alerts/workflowEngineRedirects.tsx
+++ b/static/app/views/alerts/workflowEngineRedirects.tsx
@@ -1,3 +1,6 @@
+import type {Query} from 'history';
+import * as qs from 'query-string';
+
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Redirect from 'sentry/components/redirect';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
@@ -32,6 +35,21 @@ interface IncidentGroupOpenPeriod {
   incidentId: string | null;
   incidentIdentifier: string;
   openPeriodId: string;
+}
+
+function getIssueDetailsPath({
+  orgSlug,
+  groupId,
+  query,
+}: {
+  groupId: string;
+  orgSlug: string;
+  query: Query;
+}) {
+  const search = qs.stringify(query);
+  const pathname = `/organizations/${orgSlug}/issues/${groupId}/`;
+
+  return search ? `${pathname}?${search}` : pathname;
 }
 
 /**
@@ -233,6 +251,7 @@ function RedirectToIssue({
   children: React.ReactNode;
 }) {
   const organization = useOrganization();
+  const location = useLocation();
 
   const {data: incidentGroupOpenPeriod, isPending: isOpenPeriodPending} =
     useApiQuery<IncidentGroupOpenPeriod>(
@@ -256,7 +275,11 @@ function RedirectToIssue({
   if (incidentGroupOpenPeriod) {
     return (
       <Redirect
-        to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}/`}
+        to={getIssueDetailsPath({
+          orgSlug: organization.slug,
+          groupId: incidentGroupOpenPeriod.groupId,
+          query: location.query,
+        })}
       />
     );
   }
@@ -348,6 +371,7 @@ export function withOpenPeriodRedirect<P extends Record<string, any>>(
 ) {
   return function OpenPeriodRedirectWrapper(props: P) {
     const organization = useOrganization();
+    const location = useLocation();
     const {alertId} = useParams();
 
     const hasRedirectOptOut = organization.features.includes(
@@ -378,7 +402,11 @@ export function withOpenPeriodRedirect<P extends Record<string, any>>(
       if (incidentGroupOpenPeriod) {
         return (
           <Redirect
-            to={`/organizations/${organization.slug}/issues/${incidentGroupOpenPeriod.groupId}/`}
+            to={getIssueDetailsPath({
+              orgSlug: organization.slug,
+              groupId: incidentGroupOpenPeriod.groupId,
+              query: location.query,
+            })}
           />
         );
       }

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -521,7 +521,8 @@ function useTrackView({
   project?: Project;
 }) {
   const location = useLocation();
-  const {alert_date, alert_rule_id, alert_type, ref_fallback, query} = location.query;
+  const {alert_date, alert_rule_id, alert_type, ref_fallback, query, notification_uuid} =
+    location.query;
   const groupEventType = useLoadedEventType();
   const user = useUser();
   const hasStreamlinedUI = useHasStreamlinedUI();
@@ -545,6 +546,8 @@ function useTrackView({
     org_streamline_only: organization.streamlineOnly ?? undefined,
     has_streamlined_ui: hasStreamlinedUI,
     has_seer_access: hasAutofixQuota,
+    notification_uuid:
+      typeof notification_uuid === 'string' ? notification_uuid : undefined,
   });
   // Set default values for properties that may be updated in subcomponents.
   // Must be separate from the above values, otherwise the actual values filled in


### PR DESCRIPTION
This enables better CTR tracking for all issue types, though I had to add some extra logic for metric issues:

- Tracks notification_uuid on the issue details viewed event
- When redirection on a notification metric alert link, passes on all query params (like notification_uuid)
- Also adds notification_uuid to the metric alert page view so we can compare the two