### PR TITLE
bug(infra): Fix backend-with-coverage job to have odiff binary

### DIFF
--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -72,6 +72,13 @@ jobs:
           mode: backend-ci
           skip-devservices: true
 
+      - name: Download odiff binary
+        run: |
+          curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
+            | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64
+          sudo install -m 755 odiff-linux-x64 /usr/local/bin/odiff
+          rm odiff-linux-x64
+
       - name: Calculate test shards
         id: calculate-shards
         run: python3 .github/workflows/scripts/calculate-backend-test-shards.py

--- a/.github/workflows/backend-with-coverage.yml
+++ b/.github/workflows/backend-with-coverage.yml
@@ -72,13 +72,6 @@ jobs:
           mode: backend-ci
           skip-devservices: true
 
-      - name: Download odiff binary
-        run: |
-          curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
-            | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64
-          sudo install -m 755 odiff-linux-x64 /usr/local/bin/odiff
-          rm odiff-linux-x64
-
       - name: Calculate test shards
         id: calculate-shards
         run: python3 .github/workflows/scripts/calculate-backend-test-shards.py
@@ -104,6 +97,13 @@ jobs:
         id: setup
         with:
           mode: backend-ci
+
+      - name: Download odiff binary
+        run: |
+          curl -sL https://registry.npmjs.org/odiff-bin/-/odiff-bin-4.3.2.tgz \
+            | tar -xz --strip-components=2 package/raw_binaries/odiff-linux-x64
+          sudo install -m 755 odiff-linux-x64 /usr/local/bin/odiff
+          rm odiff-linux-x64
 
       - name: Run backend test with coverage (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: make test-backend-ci-with-coverage


### PR DESCRIPTION
Last week https://github.com/getsentry/sentry/pull/109381 was merged which added the odiff binary to the backend CI workflow as it was a new required dependency for CI tests.

Unfortunately, we missed adding this to the `backend-with-coverage` job which is used to upload selective testing coverage metrics. This caused all runs of backend with coverage to fail, resulting in no coverage data being uploaded. 

This fixes the `backend-with-coverage` workflow to install the odiff binary which should fix tests.

Manual run to confirm this fixes: https://github.com/getsentry/sentry/actions/runs/22696037548