### PR TITLE
fix(preprod): Gate comparison download query on SUCCESS state

### DIFF
--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -109,7 +109,8 @@ export function SizeCompareMainContent() {
         !!mainArtifactComparison?.head_size_metric_id &&
         !!mainArtifactComparison?.base_size_metric_id &&
         !!organization.slug &&
-        !!baseArtifactId,
+        !!baseArtifactId &&
+        mainArtifactComparison?.state === SizeAnalysisComparisonState.SUCCESS,
     }
   );
 


### PR DESCRIPTION
The comparison data download query (`comparisonDataQuery`) fires as soon as metric IDs are available from the status polling query, regardless of whether the async Celery comparison task has actually completed. When the comparison state is still PENDING or PROCESSING, the download endpoint returns 404 because the comparison file hasn't been created yet. React Query exhausts its retries and caches the error. Later, when the status poll detects the transition to SUCCESS, the download query doesn't re-fire because it already has a cached (error) response — resulting in "Comparison not found" being shown to the user.

Adds `mainArtifactComparison?.state === SizeAnalysisComparisonState.SUCCESS` to the `enabled` condition of the download query. This ensures the query only fires after the comparison is confirmed complete, at which point the file is guaranteed to exist. The existing 10-second `refetchInterval` on the status query handles detecting the state transition.

Reported by customer — the issue reproduced ~50% of the time on initial load but always resolved on page reload (because by then the comparison had completed and the SUCCESS state was returned immediately).