### PR TITLE
feat(metric-issues): Add analytics to detector details link

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/detectorSection.tsx
@@ -167,7 +167,14 @@ function DetectorSectionContent({
     <div>
       <SidebarSectionTitle>{title}</SidebarSectionTitle>
       {description && <DetectorDescription>{description}</DetectorDescription>}
-      <LinkButton aria-label={ctaText} to={to} style={{width: '100%'}} size="sm">
+      <LinkButton
+        aria-label={ctaText}
+        to={to}
+        style={{width: '100%'}}
+        size="sm"
+        analyticsEventKey="issue_details.detector_details_link_clicked"
+        analyticsEventName="Issue Details: Detector Details Link Clicked"
+      >
         {ctaText}
       </LinkButton>
     </div>


### PR DESCRIPTION
Track when users click the "View Monitor Details" link in the issue details sidebar. This event fires across all detector types (metric alerts, cron monitors, uptime monitors) and helps measure user engagement with monitoring features.

Event: `issue_details.detector_details_link_clicked` / "Issue Details: Detector Details Link Clicked"