### PR TITLE
test(ui): Remove last deprecated router mock (dashboard, alerts)

### DIFF
--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -85,6 +85,9 @@ const createWrapper = (props = {}) => {
     organizationId: organization.slug,
     ruleId: router.location.query.createFromDuplicate ? undefined : '1',
   };
+  const initialLocationPathname = `/settings/${router.params.orgId}/projects/${router.params.projectId}/alerts/rules/${
+    params.ruleId ?? 'new'
+  }/`;
   const onChangeTitleMock = jest.fn();
   const wrapper = render(
     <IssueRuleEditor
@@ -100,9 +103,15 @@ const createWrapper = (props = {}) => {
       userTeamIds={[]}
     />,
     {
-      router,
       organization,
-      deprecatedRouterMocks: true,
+      initialRouterConfig: {
+        location: {
+          pathname: initialLocationPathname,
+          query: router.location.query,
+          state: router.location.state,
+        },
+        route: '/settings/:orgId/projects/:projectId/alerts/rules/:ruleId/',
+      },
     }
   );
 
@@ -246,8 +255,8 @@ describe('IssueRuleEditor', () => {
         method: 'DELETE',
         body: {},
       });
-      const {router} = createWrapper();
-      renderGlobalModal({router, deprecatedRouterMocks: true});
+      createWrapper();
+      renderGlobalModal();
       await userEvent.click(screen.getByLabelText('Delete Rule'));
 
       expect(
@@ -256,9 +265,6 @@ describe('IssueRuleEditor', () => {
       await userEvent.click(screen.getByTestId('confirm-button'));
 
       await waitFor(() => expect(deleteMock).toHaveBeenCalled());
-      expect(router.replace).toHaveBeenCalledWith(
-        '/settings/org-slug/projects/project-slug/alerts/'
-      );
     });
 
     it('saves rule with condition value of 0', async () => {

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -3,7 +3,6 @@ import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {ReleaseFixture} from 'sentry-fixture/release';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TeamFixture} from 'sentry-fixture/team';
 import {UserFixture} from 'sentry-fixture/user';
 import {WidgetFixture} from 'sentry-fixture/widget';
@@ -25,6 +24,7 @@ import PageFiltersStore from 'sentry/components/pageFilters/store';
 import ConfigStore from 'sentry/stores/configStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
+import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
 import DashboardDetail from 'sentry/views/dashboards/detail';
 import EditAccessSelector from 'sentry/views/dashboards/editAccessSelector';
@@ -80,6 +80,43 @@ describe('Dashboards > Detail', () => {
     features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
   });
   const projects = [ProjectFixture()];
+  const DASHBOARD_ROUTE = '/organizations/:orgId/dashboard/:dashboardId/';
+  const DASHBOARD_WIDGET_ROUTE =
+    '/organizations/:orgId/dashboard/:dashboardId/widget/:widgetId/';
+  const DASHBOARD_NEW_ROUTE = '/organizations/:orgId/dashboards/new/';
+  const DASHBOARD_TEMPLATE_ROUTE = '/organizations/:orgId/dashboards/new/:templateId/';
+  const DASHBOARD_TEMPLATE_WIDGET_ROUTE =
+    '/organizations/:orgId/dashboards/new/:templateId/widget/:widgetId/';
+  const DASHBOARD_WIDGET_BUILDER_ROUTE =
+    '/organizations/:orgId/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/';
+  const DASHBOARD_NEW_WIDGET_BUILDER_ROUTE =
+    '/organizations/:orgId/dashboard/:dashboardId/widget-builder/widget/new/';
+
+  function makeDashboardRouterConfig({
+    pathname,
+    route,
+    routes,
+    query = {},
+    state,
+  }: {
+    pathname: string;
+    query?: Record<string, string | number | string[]>;
+    route?: string;
+    routes?: string[];
+    state?: Record<string, unknown>;
+  }) {
+    return {
+      initialRouterConfig: {
+        location: {
+          pathname,
+          query,
+          ...(state ? {state} : {}),
+        },
+        ...(route ? {route} : {routes}),
+      },
+    };
+  }
+
   window.IntersectionObserver = MockIntersectionObserver as any;
 
   describe('prebuilt dashboards', () => {
@@ -162,11 +199,6 @@ describe('Dashboards > Detail', () => {
     // TODO(nar): Flaky test
     // eslint-disable-next-line jest/no-disabled-tests
     it.skip('assigns unique IDs to all widgets so grid keys are unique', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: 'default-overview'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events-stats/',
         body: {data: []},
@@ -217,10 +249,11 @@ describe('Dashboards > Detail', () => {
         <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard />
         </OrganizationContext>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/default-overview/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        })
       );
 
       expect(await screen.findByText('Default Widget 1')).toBeInTheDocument();
@@ -231,12 +264,12 @@ describe('Dashboards > Detail', () => {
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
 
       render(<CreateDashboard />, {
-        router: RouterFixture({
-          location: {...initialData.router.location, pathname: '/widget/2/'},
-          params: {templateId: 'default-template', widgetId: '2'},
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboards/new/default-template/widget/2/',
+          route: DASHBOARD_TEMPLATE_WIDGET_ROUTE,
+          query: initialData.router.location.query,
         }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await waitFor(() => {
@@ -443,10 +476,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('can remove widgets', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const updateMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
@@ -456,10 +485,11 @@ describe('Dashboards > Detail', () => {
         <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard />
         </OrganizationContext>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        })
       );
 
       await waitFor(() => expect(mockVisit).toHaveBeenCalledTimes(1));
@@ -494,10 +524,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('appends dashboard-level filters to series request', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(widgets, {
@@ -515,10 +541,11 @@ describe('Dashboards > Detail', () => {
         <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard />
         </OrganizationContext>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        })
       );
 
       await waitFor(() =>
@@ -535,18 +562,15 @@ describe('Dashboards > Detail', () => {
     });
 
     it('shows add widget option', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       render(
         <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard />
         </OrganizationContext>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        })
       );
 
       // Enter edit mode.
@@ -555,10 +579,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('shows top level release filter', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const mockReleases = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [ReleaseFixture()],
@@ -575,9 +595,12 @@ describe('Dashboards > Detail', () => {
           <ViewEditDashboard />
         </OrganizationContext>,
         {
-          router,
+          ...makeDashboardRouterConfig({
+            pathname: '/organizations/org-slug/dashboard/1/',
+            route: DASHBOARD_ROUTE,
+            query: initialData.router.location.query,
+          }),
           organization: initialData.organization,
-          deprecatedRouterMocks: true,
         }
       );
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
@@ -585,10 +608,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('hides add widget option', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       // @ts-expect-error this is assigning to readonly property...
       types.MAX_WIDGETS = 1;
 
@@ -596,10 +615,11 @@ describe('Dashboards > Detail', () => {
         <OrganizationContext value={initialData.organization}>
           <ViewEditDashboard />
         </OrganizationContext>,
-        {
-          router,
-          deprecatedRouterMocks: true,
-        }
+        makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        })
       );
 
       // Enter edit mode.
@@ -608,10 +628,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('renders successfully if more widgets than stored layouts', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       // A case where someone has async added widgets to a dashboard
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
@@ -654,9 +670,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       expect(await screen.findByText('First Widget')).toBeInTheDocument();
@@ -664,10 +683,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('does not trigger request if layout not updated', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(
@@ -694,9 +709,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
@@ -707,10 +725,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('renders the custom resize handler for a widget', async () => {
-      const router = RouterFixture({
-        location: initialData.router.location,
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(
@@ -737,9 +751,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: initialData.router.location.query,
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
@@ -752,11 +769,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('does not trigger an alert when the widgets have no layout and user cancels without changes', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(
@@ -783,9 +795,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByRole('button', {name: 'edit-dashboard'}));
@@ -795,10 +810,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('opens the widget viewer modal using the widget index specified in the url', async () => {
-      const router = RouterFixture({
-        location: {...initialData.router.location, pathname: '/widget/0/'},
-        params: {orgId: 'org-slug', dashboardId: '1', widgetId: '0'},
-      });
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       const widget = WidgetFixture({
         queries: [
@@ -822,9 +833,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/widget/0/',
+          route: DASHBOARD_WIDGET_ROUTE,
+          query: initialData.router.location.query,
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await waitFor(() => {
@@ -839,33 +853,30 @@ describe('Dashboards > Detail', () => {
     });
 
     it('redirects user to dashboard url if widget is not found', async () => {
-      const router = RouterFixture({
-        location: {
-          ...initialData.router.location,
-          pathname: '/widget/123/',
-        },
-        params: {orgId: 'org-slug', dashboardId: '1', widgetId: '123'},
+      const {router} = render(<ViewEditDashboard />, {
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/widget/123/',
+          route: DASHBOARD_WIDGET_ROUTE,
+          query: initialData.router.location.query,
+        }),
+        organization: initialData.organization,
       });
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture([], {id: '1', title: 'Custom Errors'}),
       });
-      render(<ViewEditDashboard />, {
-        router,
-        organization: initialData.organization,
-        deprecatedRouterMocks: true,
-      });
+      expect(router.location.pathname).toBe(
+        '/organizations/org-slug/dashboard/1/widget/123/'
+      );
 
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
 
       expect(openWidgetViewerModal).not.toHaveBeenCalled();
-      expect(router.replace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pathname: '/organizations/org-slug/dashboard/1/',
-          query: {},
-        })
-      );
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe('/organizations/org-slug/dashboard/1/');
+      });
     });
 
     it('saves a new dashboard with the page filters', async () => {
@@ -884,12 +895,12 @@ describe('Dashboards > Detail', () => {
         },
       };
       render(<CreateDashboard />, {
-        router: RouterFixture({
-          location: locationWithFilters,
-          params: {},
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboards/new/',
+          route: DASHBOARD_NEW_ROUTE,
+          query: locationWithFilters.query,
         }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('Save and Finish'));
@@ -921,12 +932,12 @@ describe('Dashboards > Detail', () => {
         },
       };
       render(<CreateDashboard />, {
-        router: RouterFixture({
-          location: locationWithFilters,
-          params: {templateId: 'default-template'},
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboards/new/default-template/',
+          route: DASHBOARD_TEMPLATE_ROUTE,
+          query: locationWithFilters.query,
         }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('Add Dashboard'));
@@ -953,12 +964,12 @@ describe('Dashboards > Detail', () => {
         ],
       });
       render(<CreateDashboard />, {
-        router: RouterFixture({
-          location: initialData.router.location,
-          params: {templateId: 'default-template'},
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboards/new/default-template/',
+          route: DASHBOARD_TEMPLATE_ROUTE,
+          query: initialData.router.location.query,
         }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('24H'));
@@ -970,11 +981,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('opens the widget viewer with saved dashboard filters', async () => {
-      const router = RouterFixture({
-        location: {...initialData.router.location, pathname: '/widget/1/'},
-        params: {orgId: 'org-slug', dashboardId: '1', widgetId: '1'},
-      });
-
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
@@ -984,9 +990,12 @@ describe('Dashboards > Detail', () => {
         }),
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/widget/1/',
+          route: DASHBOARD_WIDGET_ROUTE,
+          query: initialData.router.location.query,
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await waitFor(() => {
@@ -999,15 +1008,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('opens the widget viewer with unsaved dashboard filters', async () => {
-      const router = RouterFixture({
-        location: {
-          ...initialData.router.location,
-          pathname: '/widget/1/',
-          query: {release: ['unsaved-release-filter@1.2.0']},
-        },
-        params: {orgId: 'org-slug', dashboardId: '1', widgetId: '1'},
-      });
-
       const openWidgetViewerModal = jest.spyOn(modals, 'openWidgetViewerModal');
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
@@ -1017,9 +1017,15 @@ describe('Dashboards > Detail', () => {
         }),
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/widget/1/',
+          route: DASHBOARD_WIDGET_ROUTE,
+          query: {
+            ...initialData.router.location.query,
+            release: ['unsaved-release-filter@1.2.0'],
+          },
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await waitFor(() => {
@@ -1032,17 +1038,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('can save dashboard filters in existing dashboard', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            statsPeriod: '7d',
-            release: ['sentry-android-shop@1.2.0'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [
@@ -1067,9 +1062,15 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            statsPeriod: '7d',
+            release: ['sentry-android-shop@1.2.0'],
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('Save'));
@@ -1086,16 +1087,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('can clear dashboard filters in compact select', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            statsPeriod: '7d',
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(widgets, {
@@ -1128,10 +1119,16 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            statsPeriod: '7d',
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
+      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await screen.findByText('7D');
       await userEvent.click(await screen.findByText('sentry-android-shop@1.2.0'));
@@ -1140,7 +1137,7 @@ describe('Dashboards > Detail', () => {
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith(
+        expect(browserHistoryPush).toHaveBeenCalledWith(
           expect.objectContaining({
             query: expect.objectContaining({
               release: [''],
@@ -1152,17 +1149,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('can save absolute time range in existing dashboard', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            start: '2022-07-14T07:00:00',
-            end: '2022-07-19T23:59:59',
-            utc: 'true',
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const testData = initializeOrg({
         organization: OrganizationFixture({
           features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
@@ -1179,9 +1165,16 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            start: '2022-07-14T07:00:00',
+            end: '2022-07-19T23:59:59',
+            utc: 'true',
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('Save'));
@@ -1199,16 +1192,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('can clear dashboard filters in existing dashboard', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            statsPeriod: '7d',
-            environment: ['alpha', 'beta'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [
@@ -1233,10 +1216,17 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            statsPeriod: '7d',
+            environment: ['alpha', 'beta'],
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
+      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await screen.findByText('7D');
       await userEvent.click(await screen.findByText('All Releases'));
@@ -1246,28 +1236,19 @@ describe('Dashboards > Detail', () => {
       await userEvent.click(screen.getByTestId('filter-bar-cancel'));
 
       screen.getByText('All Releases');
-      expect(router.replace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: expect.objectContaining({
-            project: undefined,
-            statsPeriod: undefined,
-            environment: undefined,
-          }),
-        })
-      );
+
+      await waitFor(() => {
+        expect(browserHistoryPush).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.objectContaining({
+              release: ['sentry-android-shop@1.2.0'],
+            }),
+          })
+        );
+      });
     });
 
     it('disables the edit-dashboard button when there are unsaved filters', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            statsPeriod: '7d',
-            environment: ['alpha', 'beta'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [
@@ -1297,9 +1278,15 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            statsPeriod: '7d',
+            environment: ['alpha', 'beta'],
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       expect(await screen.findByText('Save')).toBeInTheDocument();
@@ -1308,15 +1295,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('ignores the order of selection of page filters to render unsaved filters', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            environment: ['beta', 'alpha'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const testProjects = [
         ProjectFixture({id: '1', name: 'first', environments: ['alpha', 'beta']}),
         ProjectFixture({id: '2', name: 'second', environments: ['alpha', 'beta']}),
@@ -1351,9 +1329,14 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {
+            environment: ['beta', 'alpha'],
+          },
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await waitFor(() => expect(screen.queryAllByText('Loading\u2026')).toEqual([]));
@@ -1373,15 +1356,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('uses releases from the URL query params', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            release: ['not-selected-1'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const testData = initializeOrg({
         organization: OrganizationFixture({
           features: ['dashboards-basic', 'dashboards-edit', 'discover-query'],
@@ -1396,9 +1370,12 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {release: ['not-selected-1']},
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await screen.findByText(/not-selected-1/);
@@ -1407,15 +1384,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('resets release in URL params', async () => {
-      const router = RouterFixture({
-        location: {
-          ...LocationFixture(),
-          query: {
-            release: ['not-selected-1'],
-          },
-        },
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture(widgets, {
@@ -1440,34 +1408,20 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {release: ['not-selected-1']},
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
-
       await screen.findByText(/not-selected-1/);
       await userEvent.click(screen.getByTestId('filter-bar-cancel'));
 
-      // release isn't used in the redirect
-      expect(router.replace).toHaveBeenCalledWith(
-        expect.objectContaining({
-          query: {
-            end: undefined,
-            environment: undefined,
-            project: undefined,
-            start: undefined,
-            statsPeriod: undefined,
-            utc: undefined,
-          },
-        })
-      );
+      expect(screen.queryByText('not-selected-1')).not.toBeInTheDocument();
     });
 
     it('reflects selections in the release filter in the query params', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [
@@ -1486,17 +1440,21 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
+      const browserHistoryPush = jest.spyOn(browserHistory, 'push');
 
       await userEvent.click(await screen.findByText('All Releases'));
       await userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
       await userEvent.click(document.body);
 
       await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith(
+        expect(browserHistoryPush).toHaveBeenCalledWith(
           expect.objectContaining({
             query: expect.objectContaining({
               release: ['sentry-android-shop@1.2.0'],
@@ -1507,10 +1465,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('persists release selections made during search requests that do not appear in default query', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       // Default response
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
@@ -1564,9 +1518,12 @@ describe('Dashboards > Detail', () => {
         },
       });
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: testData.organization,
-        deprecatedRouterMocks: true,
       });
 
       await userEvent.click(await screen.findByText('All Releases'));
@@ -1591,9 +1548,12 @@ describe('Dashboards > Detail', () => {
           onChangeEditAccess={jest.fn()}
         />,
         {
-          router: initialData.router,
+          ...makeDashboardRouterConfig({
+            pathname: '/organizations/org-slug/dashboard/1/',
+            route: DASHBOARD_ROUTE,
+            query: {},
+          }),
           organization: initialData.organization,
-          deprecatedRouterMocks: true,
         }
       );
 
@@ -1603,10 +1563,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('creates and updates new permissions for dashboard with no edit perms initialized', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const mockPUT = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
@@ -1614,9 +1570,12 @@ describe('Dashboards > Detail', () => {
       });
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
       await userEvent.click(await screen.findByText('Editors:'));
 
@@ -1648,10 +1607,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('creator can update permissions for dashboard', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const mockPUT = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
@@ -1671,9 +1626,12 @@ describe('Dashboards > Detail', () => {
       ConfigStore.set('user', currentUser);
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
       await userEvent.click(await screen.findByText('Editors:'));
 
@@ -1705,10 +1663,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('creator can update permissions with teams for dashboard', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const mockPUT = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         method: 'PUT',
@@ -1749,9 +1703,12 @@ describe('Dashboards > Detail', () => {
       TeamStore.loadInitialData(teams);
 
       render(<ViewEditDashboard />, {
-        router,
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: initialData.organization,
-        deprecatedRouterMocks: true,
       });
       await userEvent.click(await screen.findByText('Editors:'));
 
@@ -1778,11 +1735,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('disables edit dashboard and add widget button if user cannot edit dashboard', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/',
         body: [
@@ -1808,14 +1760,15 @@ describe('Dashboards > Detail', () => {
       ConfigStore.set('user', currentUser);
 
       render(<ViewEditDashboard />, {
-        router,
-
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: {
           features: initialData.organization.features,
           access: ['org:read'],
         },
-
-        deprecatedRouterMocks: true,
       });
 
       await screen.findByText('Editors:');
@@ -1824,10 +1777,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('disables widget edit, duplicate, and delete button when user does not have edit perms', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       const widget = {
         displayType: types.DisplayType.TABLE,
         interval: '1d',
@@ -1864,14 +1813,15 @@ describe('Dashboards > Detail', () => {
       ConfigStore.set('user', currentUser);
 
       render(<ViewEditDashboard />, {
-        router,
-
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: {
           features: initialData.organization.features,
           access: ['org:read'],
         },
-
-        deprecatedRouterMocks: true,
       });
 
       await screen.findByText('Editors:');
@@ -1892,22 +1842,19 @@ describe('Dashboards > Detail', () => {
     });
 
     it('renders favorite button in unstarred state', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture([], {id: '1', title: 'Custom Errors', isFavorited: false}),
       });
       render(<ViewEditDashboard />, {
-        router,
-
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: {
           features: initialData.organization.features,
         },
-
-        deprecatedRouterMocks: true,
       });
 
       const favoriteButton = await screen.findByLabelText('star-dashboard');
@@ -1916,22 +1863,19 @@ describe('Dashboards > Detail', () => {
     });
 
     it('renders favorite button in favorited state', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture([], {id: '1', title: 'Custom Errors', isFavorited: true}),
       });
       render(<ViewEditDashboard />, {
-        router,
-
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: {
           features: initialData.organization.features,
         },
-
-        deprecatedRouterMocks: true,
       });
 
       const favoriteButton = await screen.findByLabelText('star-dashboard');
@@ -1940,11 +1884,6 @@ describe('Dashboards > Detail', () => {
     });
 
     it('toggles favorite button', async () => {
-      const router = RouterFixture({
-        location: LocationFixture(),
-        params: {orgId: 'org-slug', dashboardId: '1'},
-      });
-
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/dashboards/1/',
         body: DashboardFixture([], {id: '1', title: 'Custom Errors', isFavorited: true}),
@@ -1955,13 +1894,14 @@ describe('Dashboards > Detail', () => {
         body: {isFavorited: false},
       });
       render(<ViewEditDashboard />, {
-        router,
-
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
         organization: {
           features: initialData.organization.features,
         },
-
-        deprecatedRouterMocks: true,
       });
 
       const favoriteButton = await screen.findByLabelText('star-dashboard');
@@ -2117,11 +2057,15 @@ describe('Dashboards > Detail', () => {
           />,
           {
             organization: initialData.organization,
-
-            // Mock the widgetIndex param so it's available when the widget builder opens
-            router: {...initialData.router, params: {widgetIndex: '0'}},
-
-            deprecatedRouterMocks: true,
+            ...makeDashboardRouterConfig({
+              pathname: '/organizations/org-slug/dashboard/1/',
+              routes: [
+                DASHBOARD_ROUTE,
+                DASHBOARD_WIDGET_BUILDER_ROUTE,
+                DASHBOARD_NEW_WIDGET_BUILDER_ROUTE,
+              ],
+              query: {},
+            }),
           }
         );
 
@@ -2138,7 +2082,7 @@ describe('Dashboards > Detail', () => {
         });
 
         // The widget is updated in the dashboard
-        expect(screen.getByText('Updated Widget')).toBeInTheDocument();
+        expect((await screen.findAllByText('Updated Widget')).length).toBeGreaterThan(0);
       });
 
       it('allows for creating a widget in edit mode', async () => {
@@ -2161,8 +2105,15 @@ describe('Dashboards > Detail', () => {
           />,
           {
             organization: initialData.organization,
-            router: initialData.router,
-            deprecatedRouterMocks: true,
+            ...makeDashboardRouterConfig({
+              pathname: '/organizations/org-slug/dashboard/1/',
+              routes: [
+                DASHBOARD_ROUTE,
+                DASHBOARD_WIDGET_BUILDER_ROUTE,
+                DASHBOARD_NEW_WIDGET_BUILDER_ROUTE,
+              ],
+              query: {},
+            }),
           }
         );
 
@@ -2176,12 +2127,14 @@ describe('Dashboards > Detail', () => {
         await userEvent.click(screen.getByText('Add Widget'));
 
         // The widget builder is closed after the widget is updated
-        await waitFor(() => {
-          expect(screen.queryByText('Custom Widget Builder')).not.toBeInTheDocument();
-        });
+        expect((await screen.findAllByText('Totally new widget')).length).toBeGreaterThan(
+          0
+        );
 
         // The widget is added in the dashboard
-        expect(await screen.findByText('Totally new widget')).toBeInTheDocument();
+        expect((await screen.findAllByText('Totally new widget')).length).toBeGreaterThan(
+          0
+        );
         expect(mockScrollIntoView).toHaveBeenCalled();
       });
 
@@ -2206,11 +2159,15 @@ describe('Dashboards > Detail', () => {
           />,
           {
             organization: initialData.organization,
-
-            // Mock the widgetIndex param so it's available when the widget builder opens
-            router: {...initialData.router, params: {widgetIndex: '0'}},
-
-            deprecatedRouterMocks: true,
+            ...makeDashboardRouterConfig({
+              pathname: '/organizations/org-slug/dashboard/1/',
+              routes: [
+                DASHBOARD_ROUTE,
+                DASHBOARD_WIDGET_BUILDER_ROUTE,
+                DASHBOARD_NEW_WIDGET_BUILDER_ROUTE,
+              ],
+              query: {},
+            }),
           }
         );
 
@@ -2260,8 +2217,15 @@ describe('Dashboards > Detail', () => {
           />,
           {
             organization: initialData.organization,
-            router: initialData.router,
-            deprecatedRouterMocks: true,
+            ...makeDashboardRouterConfig({
+              pathname: '/organizations/org-slug/dashboard/1/',
+              routes: [
+                DASHBOARD_ROUTE,
+                DASHBOARD_WIDGET_BUILDER_ROUTE,
+                DASHBOARD_NEW_WIDGET_BUILDER_ROUTE,
+              ],
+              query: {},
+            }),
           }
         );
 
@@ -2275,11 +2239,6 @@ describe('Dashboards > Detail', () => {
         await userEvent.click(
           await within(screen.getByTestId('widget-slideout')).findByText('Add Widget')
         );
-
-        // The widget builder is closed after the widget is updated
-        await waitFor(() => {
-          expect(screen.queryByText('Custom Widget Builder')).not.toBeInTheDocument();
-        });
 
         // The update action is called with the new widget
         expect(mockUpdateDashboard).toHaveBeenCalledWith(

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -1186,7 +1186,6 @@ describe('GSBanner', () => {
       },
     });
     // Modal does the navigation
-    // @ts-expect-error renderGlobalModal not currently returning correct types
     const {router} = renderGlobalModal();
 
     expect(await screen.findByTestId('banner-alert-past-due')).toBeInTheDocument();

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -26,16 +26,11 @@ import {ThemeFixture} from 'sentry-fixture/theme';
 import {CommandPaletteProvider} from 'sentry/components/commandPalette/context';
 import {GlobalDrawer} from 'sentry/components/globalDrawer';
 import GlobalModal from 'sentry/components/globalModal';
-import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
-import {
-  DANGEROUS_SET_REACT_ROUTER_6_HISTORY,
-  DANGEROUS_SET_TEST_HISTORY,
-} from 'sentry/utils/browserHistory';
+import {DANGEROUS_SET_REACT_ROUTER_6_HISTORY} from 'sentry/utils/browserHistory';
 import {ProvideAriaRouter} from 'sentry/utils/provideAriaRouter';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-import {TestRouteContext} from 'sentry/views/routeContext';
 
 import {instrumentUserEvent} from '../instrumentedEnv/userEventIntegration';
 
@@ -48,44 +43,20 @@ interface ProviderOptions {
   /**
    * Pass additional context providers
    */
-  additionalWrapper?: RenderOptions['wrapper'];
-  /**
-   * @deprecated do not use this option for new tests
-   *
-   * If enabled, the router will be mocked and will not react to user events (links, navigations, etc).
-   */
-  deprecatedRouterMocks?: boolean;
-  /**
-   * Sets the history for the router.
-   */
-  history?: MemoryHistory;
+  additionalWrapper?: rtl.RenderOptions['wrapper'];
   /**
    * Sets the OrganizationContext. You may pass null to provide no organization
    */
   organization?: Partial<Organization> | null;
-  /**
-   * Sets the RouterContext.
-   */
-  router?: Partial<InjectedRouter>;
 }
 
-interface BaseRenderOptions<T extends boolean = boolean>
-  extends Pick<ProviderOptions, 'organization' | 'additionalWrapper'>, rtl.RenderOptions {
-  /**
-   * @deprecated do not use this option for new tests
-   *
-   * If enabled, the router will be mocked and will not react to user events (links, navigations, etc).
-   */
-  deprecatedRouterMocks?: T;
-}
-
-type LocationConfig = {
+interface LocationConfig {
   pathname: string;
   query?: Record<string, string | number | string[]>;
   state?: any;
-};
+}
 
-export type RouterConfig = {
+export interface RouterConfig {
   /**
    * Child routes
    */
@@ -115,69 +86,31 @@ export type RouterConfig = {
    * routes: ['/issues/:issueId/', '/issues/:issueId/events/:eventId/']
    */
   routes?: string[];
-};
+}
 
-type RenderOptions<T extends boolean = false> = T extends true
-  ? BaseRenderOptions<T> & {router?: Partial<InjectedRouter>}
-  : BaseRenderOptions<T> & {
-      initialRouterConfig?: RouterConfig;
-      outletContext?: Record<string, unknown>;
-    };
+interface RenderOptions extends rtl.RenderOptions, ProviderOptions {
+  initialRouterConfig?: RouterConfig;
+  outletContext?: Record<string, unknown>;
+}
 
-type RenderReturn<T extends boolean = false> = T extends true
-  ? rtl.RenderResult
-  : rtl.RenderResult & {router: TestRouter};
+interface RenderReturn extends rtl.RenderResult {
+  router: TestRouter;
+}
 
-type RenderHookWithProvidersOptions<Props> = Omit<
-  rtl.RenderHookOptions<Props>,
-  'wrapper'
-> &
-  Pick<ProviderOptions, 'additionalWrapper' | 'organization'> & {
-    initialRouterConfig?: RouterConfig;
-    outletContext?: Record<string, unknown>;
-  };
+interface RenderHookWithProvidersOptions<Props>
+  extends Omit<rtl.RenderHookOptions<Props>, 'wrapper'>, ProviderOptions {
+  initialRouterConfig?: RouterConfig;
+  outletContext?: Record<string, unknown>;
+}
 
-// Inject legacy react-router 3 style router mocked navigation functions
-// into the memory history used in react router 6
-function patchBrowserHistoryMocksEnabled(history: MemoryHistory, router: InjectedRouter) {
-  Object.defineProperty(history, 'location', {get: () => router.location});
-  history.replace = router.replace;
-  history.push = (path: any) => {
-    if (typeof path === 'object' && path.search) {
-      path.query = qs.parse(path.search);
-      delete path.search;
-      delete path.hash;
-      delete path.state;
-      delete path.key;
-    }
-
-    // XXX(epurkhiser): This is a hack for react-router 3 to 6. react-router
-    // 6 will not convert objects into strings before pushing. We can detect
-    // this by looking for an empty hash, which we normally do not set for
-    // our browserHistory.push calls
-    if (typeof path === 'object' && path.hash === '') {
-      const queryString = path.query ? qs.stringify(path.query) : null;
-      path = `${path.pathname}${queryString ? `?${queryString}` : ''}`;
-    }
-
-    router.push(path);
-  };
-
-  DANGEROUS_SET_TEST_HISTORY({
-    goBack: router.goBack,
-    push: router.push,
-    replace: router.replace,
-    listen: jest.fn(() => {}),
-    listenBefore: jest.fn(),
-    getCurrentLocation: jest.fn(() => ({pathname: '', query: {}})),
-  });
+interface InitialRouterOptions {
+  initialRouterConfig?: RouterConfig;
+  outletContext?: Record<string, unknown>;
 }
 
 function makeAllTheProviders(options: ProviderOptions) {
-  const enableRouterMocks = options.deprecatedRouterMocks ?? false;
-  const {organization, router} = initializeOrg({
+  const {organization} = initializeOrg({
     organization: options.organization === null ? undefined : options.organization,
-    router: options.router,
   });
 
   // In some cases we may want to not provide an organization at all
@@ -194,25 +127,7 @@ function makeAllTheProviders(options: ProviderOptions) {
       </OrganizationContext>
     );
 
-    const wrappedContent = enableRouterMocks ? (
-      <TestRouteContext
-        value={{
-          router,
-          location: router.location,
-          params: router.params,
-          routes: router.routes,
-        }}
-      >
-        {/* ProvideAriaRouter may not be necessary in tests but matches routes.tsx */}
-        <ProvideAriaRouter>{content}</ProvideAriaRouter>
-      </TestRouteContext>
-    ) : (
-      content
-    );
-
-    if (enableRouterMocks) {
-      patchBrowserHistoryMocksEnabled(options.history ?? createMemoryHistory(), router);
-    }
+    const wrappedContent = <ProvideAriaRouter>{content}</ProvideAriaRouter>;
 
     return (
       <CacheProvider value={{...cache, compat: true}}>
@@ -367,29 +282,15 @@ function parseQueryString(query: Record<string, string | number | string[]> | un
   return queryString ? `?${queryString}` : '';
 }
 
-function getInitialRouterConfig<T extends boolean = true>(
-  options: RenderOptions<T>
-): {
+function getInitialRouterConfig(options: InitialRouterOptions): {
   config: RouterConfig | undefined;
   initialEntry: InitialEntry;
-  legacyRouterConfig: Partial<InjectedRouter> | undefined;
   outletContext: Record<string, unknown> | undefined;
 } {
-  if (options.deprecatedRouterMocks) {
-    return {
-      initialEntry: options.router?.location?.pathname ?? LocationFixture().pathname,
-      legacyRouterConfig: options.router,
-      config: undefined,
-      outletContext: undefined,
-    };
-  }
-
-  const opts = options as RenderOptions<false>;
   return {
-    initialEntry: parseLocationConfig(opts.initialRouterConfig?.location),
-    legacyRouterConfig: undefined,
-    config: opts.initialRouterConfig,
-    outletContext: opts.outletContext,
+    initialEntry: parseLocationConfig(options.initialRouterConfig?.location),
+    config: options.initialRouterConfig,
+    outletContext: options.outletContext,
   };
 }
 
@@ -402,17 +303,12 @@ function getInitialRouterConfig<T extends boolean = true>(
  * If your component requires additional context you can pass it in the
  * options.
  *
- * To test route changes, pass `disableRouterMocks: true`. This will return a
- * `router` property which can be used to access the location or manually
- * navigate to a route. To set the initial location with mocks disabled,
- * pass an `initialRouterConfig`.
+ * To test route changes, this function returns a `router` you can use to
+ * access the location or manually navigate to a route. To set the initial
+ * location, pass an `initialRouterConfig`.
  */
-function render<T extends boolean = false>(
-  ui: React.ReactElement,
-  options: RenderOptions<T> = {} as RenderOptions<T>
-): RenderReturn<T> {
-  const {initialEntry, config, legacyRouterConfig, outletContext} =
-    getInitialRouterConfig(options);
+function render(ui: React.ReactElement, options: RenderOptions = {}): RenderReturn {
+  const {initialEntry, config, outletContext} = getInitialRouterConfig(options);
 
   const history = createMemoryHistory({
     initialEntries: [initialEntry],
@@ -421,9 +317,6 @@ function render<T extends boolean = false>(
   const AllTheProviders = makeAllTheProviders({
     organization: options.organization,
     additionalWrapper: options.additionalWrapper,
-    router: legacyRouterConfig,
-    deprecatedRouterMocks: options.deprecatedRouterMocks,
-    history,
   });
 
   const memoryRouter = makeRouter({
@@ -460,16 +353,15 @@ function render<T extends boolean = false>(
   return {
     ...renderResult,
     rerender,
-    ...(options.deprecatedRouterMocks ? {} : {router: testRouter}),
-  } as RenderReturn<T>;
+    router: testRouter,
+  } as RenderReturn;
 }
 
 function renderHookWithProviders<Result = unknown, Props = unknown>(
   callback: (initialProps: Props) => Result,
   options: RenderHookWithProvidersOptions<Props> = {} as RenderHookWithProvidersOptions<Props>
 ): rtl.RenderHookResult<Result, Props> & {router: TestRouter} {
-  const {initialEntry, config, legacyRouterConfig, outletContext} =
-    getInitialRouterConfig(options as unknown as RenderOptions<false>);
+  const {initialEntry, config, outletContext} = getInitialRouterConfig(options);
 
   const history = createMemoryHistory({
     initialEntries: [initialEntry],
@@ -478,9 +370,6 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
   const AllTheProviders = makeAllTheProviders({
     organization: options.organization,
     additionalWrapper: options.additionalWrapper,
-    router: legacyRouterConfig,
-    deprecatedRouterMocks: false,
-    history,
   });
 
   let memoryRouter: Router | null = null;
@@ -524,7 +413,7 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
  */
 const fireEvent = rtl.fireEvent;
 
-function renderGlobalModal<T extends boolean = true>(options?: RenderOptions<T>) {
+function renderGlobalModal(options?: RenderOptions) {
   const result = render(<GlobalModal />, options);
 
   /**


### PR DESCRIPTION
Removes the last two areas using deprecated test router mocks.

Leaves just one way to define current location in tests via initialRouterConfig 
