### PR TITLE
ref(dashboards): Extract spans confidence footer into reusable component

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -540,22 +540,22 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                         fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                       })}
                     </RenderedChartContainer>
-
-                    <WidgetCardConfidenceFooter
-                      confidence={confidence}
-                      dataScanned={dataScanned}
-                      isSampled={isSampled}
-                      other={OTHER}
-                      loading={loading}
-                      sampleCount={sampleCount}
-                      selection={selection}
-                      series={series}
-                      shouldColorOther={shouldColorOther}
-                      showConfidenceWarning={showConfidenceWarning}
-                      timeseriesResults={timeseriesResults}
-                      widget={widget}
-                      yAxis={axisLabel}
-                    />
+                    {showConfidenceWarning ? (
+                      <WidgetCardConfidenceFooter
+                        confidence={confidence}
+                        dataScanned={dataScanned}
+                        isSampled={isSampled}
+                        other={OTHER}
+                        loading={loading}
+                        sampleCount={sampleCount}
+                        selection={selection}
+                        series={series}
+                        shouldColorOther={shouldColorOther}
+                        timeseriesResults={timeseriesResults}
+                        widget={widget}
+                        yAxis={axisLabel}
+                      />
+                    ) : null}
                   </ChartWrapper>
                 </TransitionChart>
               );

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -96,9 +96,9 @@ import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
-import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import type {SpanResponse} from 'sentry/views/insights/types';
 
+import {WidgetCardConfidenceFooter} from './confidenceFooter';
 import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 const OTHER = 'Other';
@@ -122,6 +122,7 @@ type WidgetCardChartProps = Pick<GenericWidgetQueriesResult, 'timeseriesResults'
     widgetLegendState: WidgetLegendSelectionState;
     chartGroup?: string;
     confidence?: Confidence;
+    dataScanned?: 'full' | 'partial';
     disableZoom?: boolean;
     isMobile?: boolean;
     isSampled?: boolean | null;
@@ -155,6 +156,7 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     timeseriesResultsTypes,
     shouldResize,
     confidence,
+    dataScanned,
     showConfidenceWarning,
     sampleCount,
     isSampled,
@@ -472,20 +474,6 @@ function WidgetCardChart(props: WidgetCardChartProps) {
     }
   };
 
-  // Excluding Other uses a slightly altered regex to match the Other series name
-  // because the series names are formatted with widget IDs to avoid conflicts
-  // when deactivating them across widgets
-  const topEventsCountExcludingOther =
-    timeseriesResults?.length && widget.queries[0]?.columns.length
-      ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
-        (timeseriesResults?.some(
-          ({seriesName}) =>
-            shouldColorOther ||
-            seriesName?.match(new RegExp(`(?:.* : ${OTHER};)|^${OTHER};`))
-        )
-          ? 1
-          : 0)
-      : undefined;
   return (
     <ChartZoom period={period} start={start} end={end} utc={utc} disabled={disableZoom}>
       {zoomRenderProps => {
@@ -553,14 +541,21 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                       })}
                     </RenderedChartContainer>
 
-                    {showConfidenceWarning && confidence && (
-                      <ConfidenceFooter
-                        confidence={confidence}
-                        sampleCount={sampleCount}
-                        topEvents={topEventsCountExcludingOther}
-                        isSampled={isSampled}
-                      />
-                    )}
+                    <WidgetCardConfidenceFooter
+                      confidence={confidence}
+                      dataScanned={dataScanned}
+                      isSampled={isSampled}
+                      other={OTHER}
+                      loading={loading}
+                      sampleCount={sampleCount}
+                      selection={selection}
+                      series={series}
+                      shouldColorOther={shouldColorOther}
+                      showConfidenceWarning={showConfidenceWarning}
+                      timeseriesResults={timeseriesResults}
+                      widget={widget}
+                      yAxis={axisLabel}
+                    />
                   </ChartWrapper>
                 </TransitionChart>
               );

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -55,33 +55,6 @@ describe('WidgetCardConfidenceFooter', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('does not render when confidence warning is disabled', () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
-      body: {data: [{'count(span.duration)': 0}]},
-    });
-
-    render(
-      <WidgetCardConfidenceFooter
-        loading={false}
-        other="Other"
-        series={series}
-        showConfidenceWarning={false}
-        timeseriesResults={timeseriesResults}
-        widget={WidgetFixture({
-          displayType: DisplayType.LINE,
-          widgetType: WidgetType.SPANS,
-          queries: [WidgetQueryFixture()],
-        })}
-        yAxis="count()"
-      />
-    );
-
-    expect(
-      screen.queryByText(/Estimated for top 2 groups from/i)
-    ).not.toBeInTheDocument();
-  });
-
   it('renders spans footer with user query and top event metadata', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
@@ -98,7 +71,6 @@ describe('WidgetCardConfidenceFooter', () => {
       <WidgetCardConfidenceFooter
         loading={false}
         series={series}
-        showConfidenceWarning
         shouldColorOther={false}
         other="Other"
         timeseriesResults={timeseriesResults}
@@ -128,7 +100,6 @@ describe('WidgetCardConfidenceFooter', () => {
         loading={false}
         other="Other"
         series={series}
-        showConfidenceWarning
         timeseriesResults={timeseriesResults}
         widget={WidgetFixture({
           displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -1,0 +1,144 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import {WidgetCardConfidenceFooter} from './confidenceFooter';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+
+describe('WidgetCardConfidenceFooter', () => {
+  const selection = PageFiltersFixture();
+
+  const series: Array<Series & {fieldName?: string}> = [
+    {
+      seriesName: 'series-a',
+      data: [
+        {
+          name: 1710000000000,
+          value: 10,
+          sampleCount: 10,
+          sampleRate: 0.5,
+          confidence: 'low',
+        } as SeriesDataUnit,
+      ],
+    },
+    {
+      seriesName: 'series-b',
+      data: [
+        {
+          name: 1710000060000,
+          value: 15,
+          sampleCount: 8,
+          sampleRate: 0.5,
+          confidence: 'high',
+        } as SeriesDataUnit,
+      ],
+    },
+  ];
+
+  const timeseriesResults = [
+    {seriesName: 'series-a'},
+    {seriesName: 'series-b'},
+  ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
+
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not render when confidence warning is disabled', () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 0}]},
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        series={series}
+        showConfidenceWarning={false}
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.SPANS,
+          queries: [WidgetQueryFixture()],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    expect(
+      screen.queryByText(/Estimated for top 2 groups from/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders spans footer with user query and top event metadata', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'spans'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 500}]},
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        series={series}
+        showConfidenceWarning
+        shouldColorOther={false}
+        other="Other"
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.SPANS,
+          queries: [
+            WidgetQueryFixture({
+              conditions: 'transaction:checkout',
+              columns: ['transaction'],
+              aggregates: ['count()'],
+            }),
+          ],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    const footer = await screen.findByText(/Estimated for top 2 groups from/i);
+    expect(footer).toHaveTextContent('18 matches');
+    expect(footer).toHaveTextContent('500 spans');
+  });
+
+  it('does not render footer for unsupported widget types', () => {
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.ERRORS,
+          queries: [WidgetQueryFixture()],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    expect(screen.queryByText(/Estimated from/i)).not.toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -27,7 +27,6 @@ type Props = {
   sampleCount?: number;
   selection?: PageFilters;
   shouldColorOther?: boolean;
-  showConfidenceWarning?: boolean;
 };
 
 export function WidgetCardConfidenceFooter({
@@ -40,7 +39,6 @@ export function WidgetCardConfidenceFooter({
   selection: selectionProp,
   series,
   shouldColorOther,
-  showConfidenceWarning,
   timeseriesResults,
   widget,
   yAxis,
@@ -48,10 +46,6 @@ export function WidgetCardConfidenceFooter({
   const {selection: pageFilterSelection} = usePageFilters();
   const selection = selectionProp ?? pageFilterSelection;
   const rawCounts = useWidgetRawCounts({selection, widget});
-
-  if (!showConfidenceWarning) {
-    return null;
-  }
 
   const topEventsCountExcludingOther =
     timeseriesResults?.length && widget.queries[0]?.columns.length

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -1,0 +1,178 @@
+import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
+import type {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {ChartType} from 'sentry/views/insights/common/components/chart';
+
+import {useWidgetRawCounts} from './hooks/useWidgetRawCounts';
+import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
+
+type Props = {
+  loading: boolean;
+  other: 'Other';
+  series: Array<Series & {fieldName?: string}>;
+  timeseriesResults: GenericWidgetQueriesResult['timeseriesResults'];
+  widget: Widget;
+  yAxis: string;
+  confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
+  isSampled?: boolean | null;
+  sampleCount?: number;
+  selection?: PageFilters;
+  shouldColorOther?: boolean;
+  showConfidenceWarning?: boolean;
+};
+
+export function WidgetCardConfidenceFooter({
+  confidence,
+  dataScanned,
+  isSampled,
+  loading,
+  other,
+  sampleCount,
+  selection: selectionProp,
+  series,
+  shouldColorOther,
+  showConfidenceWarning,
+  timeseriesResults,
+  widget,
+  yAxis,
+}: Props) {
+  const {selection: pageFilterSelection} = usePageFilters();
+  const selection = selectionProp ?? pageFilterSelection;
+  const rawCounts = useWidgetRawCounts({selection, widget});
+
+  if (!showConfidenceWarning) {
+    return null;
+  }
+
+  const topEventsCountExcludingOther =
+    timeseriesResults?.length && widget.queries[0]?.columns.length
+      ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
+        (timeseriesResults?.some(
+          ({seriesName}) =>
+            shouldColorOther ||
+            seriesName?.match(new RegExp(`(?:.* : ${other};)|^${other};`))
+        )
+          ? 1
+          : 0)
+      : undefined;
+
+  const isTopN =
+    defined(topEventsCountExcludingOther) && topEventsCountExcludingOther > 1;
+  const footerSeries = toFooterTimeSeries(series, dataScanned);
+  const samplingMeta = hasSeriesSamplingMetadata(footerSeries)
+    ? determineSeriesSampleCountAndIsSampled(footerSeries, isTopN)
+    : undefined;
+  const footerConfidence = confidence ?? combineConfidenceForSeries(footerSeries);
+  const footerSampleCount = defined(sampleCount)
+    ? sampleCount
+    : samplingMeta?.sampleCount;
+  const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta?.isSampled;
+  const footerDataScanned = dataScanned ?? samplingMeta?.dataScanned;
+  const userQuery =
+    widget.queries.find(query => (query.conditions ?? '').trim().length > 0)
+      ?.conditions ?? '';
+  const footerChartInfo: ChartInfo = {
+    chartType: getExploreChartType(widget.displayType),
+    series: footerSeries,
+    timeseriesResult: {isPending: loading} as ChartInfo['timeseriesResult'],
+    yAxis,
+    confidence: footerConfidence,
+    dataScanned: footerDataScanned,
+    isSampled: footerIsSampled,
+    sampleCount: footerSampleCount,
+    topEvents: topEventsCountExcludingOther,
+  };
+
+  if (widget.widgetType === WidgetType.SPANS) {
+    return (
+      <SpansConfidenceFooter
+        confidence={footerChartInfo.confidence}
+        dataScanned={footerChartInfo.dataScanned}
+        isSampled={footerChartInfo.isSampled}
+        isLoading={loading}
+        rawSpanCounts={rawCounts ?? undefined}
+        sampleCount={footerChartInfo.sampleCount}
+        topEvents={footerChartInfo.topEvents}
+        userQuery={userQuery}
+      />
+    );
+  }
+
+  return null;
+}
+
+function toFooterTimeSeries(
+  series: Array<Series & {fieldName?: string}>,
+  dataScanned?: 'full' | 'partial'
+): TimeSeries[] {
+  return series.map((seriesEntry, seriesIndex) => {
+    const values = seriesEntry.data.map((datum, pointIndex) => {
+      const samplingDatum = datum as SeriesDataUnit & {
+        confidence?: Confidence;
+        sampleCount?: number | null;
+        sampleRate?: number | null;
+      };
+
+      const numericTimestamp =
+        typeof samplingDatum.name === 'number'
+          ? samplingDatum.name
+          : new Date(samplingDatum.name).getTime();
+
+      return {
+        timestamp: Number.isFinite(numericTimestamp)
+          ? numericTimestamp
+          : seriesIndex * 1000 + pointIndex,
+        value: samplingDatum.value,
+        confidence: samplingDatum.confidence,
+        sampleCount: samplingDatum.sampleCount,
+        sampleRate: samplingDatum.sampleRate,
+      };
+    });
+
+    const interval =
+      values.length >= 2 ? Math.max(0, values[1]!.timestamp - values[0]!.timestamp) : 0;
+
+    return {
+      yAxis: seriesEntry.seriesName,
+      values,
+      meta: {
+        interval,
+        valueType: 'number',
+        valueUnit: null,
+        dataScanned,
+      },
+    };
+  });
+}
+
+function hasSeriesSamplingMetadata(series: TimeSeries[]) {
+  return series.some(
+    seriesEntry =>
+      defined(seriesEntry.meta.dataScanned) ||
+      seriesEntry.values.some(
+        value => defined(value.sampleCount) || defined(value.sampleRate)
+      )
+  );
+}
+
+function getExploreChartType(displayType: DisplayType) {
+  switch (displayType) {
+    case DisplayType.BAR:
+      return ChartType.BAR;
+    case DisplayType.AREA:
+    case DisplayType.TOP_N:
+      return ChartType.AREA;
+    case DisplayType.LINE:
+    default:
+      return ChartType.LINE;
+  }
+}

--- a/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/genericWidgetQueries.tsx
@@ -42,6 +42,7 @@ export function getReferrer(displayType: DisplayType) {
 
 export type OnDataFetchedProps = {
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
   pageLinks?: string;
@@ -56,6 +57,7 @@ export type OnDataFetchedProps = {
 export type GenericWidgetQueriesResult = {
   loading: boolean;
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -1,0 +1,40 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import {useWidgetRawCounts} from './useWidgetRawCounts';
+
+describe('useWidgetRawCounts', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not fetch raw counts for non-timeseries display types', async () => {
+    const selection = PageFiltersFixture();
+    const widget = WidgetFixture({
+      widgetType: WidgetType.SPANS,
+      displayType: DisplayType.TABLE,
+    });
+
+    const normalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 11}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'spans'})],
+    });
+    const highAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 13}]},
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
+    });
+
+    renderHookWithProviders(useWidgetRawCounts, {
+      initialProps: {selection, widget},
+    });
+
+    await waitFor(() => expect(normalRequest).not.toHaveBeenCalled());
+    await waitFor(() => expect(highAccuracyRequest).not.toHaveBeenCalled());
+  });
+});

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -1,0 +1,47 @@
+import {useMemo} from 'react';
+
+import type {PageFilters} from 'sentry/types/core';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {useRawCounts, type RawCounts} from 'sentry/views/explore/useRawCounts';
+
+type Props = {
+  selection: PageFilters;
+  widget: Widget;
+};
+
+type RawCountConfig = {
+  dataset: DiscoverDatasets;
+  enabled: boolean;
+  supported: boolean;
+  aggregate?: string;
+};
+
+export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null {
+  const rawCountConfig = useMemo<RawCountConfig>(() => {
+    const isSupportedDisplayType =
+      widget.displayType === DisplayType.LINE ||
+      widget.displayType === DisplayType.AREA ||
+      widget.displayType === DisplayType.BAR ||
+      widget.displayType === DisplayType.TOP_N;
+
+    switch (widget.widgetType) {
+      case WidgetType.SPANS:
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.SPANS,
+          enabled: isSupportedDisplayType,
+        };
+      default:
+        return {
+          supported: false,
+          dataset: DiscoverDatasets.SPANS,
+          enabled: false,
+        };
+    }
+  }, [widget]);
+
+  const rawCounts = useRawCounts({...rawCountConfig, selection});
+
+  return rawCountConfig.supported ? rawCounts : null;
+}

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -126,6 +126,7 @@ type Props = WithRouterProps & {
 
 type Data = {
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   isSampled?: boolean | null;
   pageLinks?: string;
   sampleCount?: number;

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -351,6 +351,7 @@ function WidgetCard(props: Props) {
               onDataFetchStart={onDataFetchStart}
               tableItemLimit={tableItemLimit}
               widgetInterval={widgetInterval}
+              showConfidenceWarning={showConfidenceWarning}
             />
           </WidgetFrame>
         </VisuallyCompleteWithData>

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.spec.tsx
@@ -31,6 +31,7 @@ describe('spansWidgetQueries', () => {
           [3, [{count: 3}]],
         ],
         meta: {
+          dataScanned: 'partial',
           accuracy: {
             confidence: [
               {timestamp: 1, value: 'low'},
@@ -44,12 +45,16 @@ describe('spansWidgetQueries', () => {
 
     render(
       <SpansWidgetQueries widget={widget} dashboardFilters={{}}>
-        {({confidence}) => <div>{confidence}</div>}
+        {({confidence, dataScanned}) => (
+          <div>
+            {confidence}:{dataScanned}
+          </div>
+        )}
       </SpansWidgetQueries>,
       {organization}
     );
 
-    expect(await screen.findByText('low')).toBeInTheDocument();
+    expect(await screen.findByText('low:partial')).toBeInTheDocument();
   });
 
   it('calculates the confidence for a multi series', async () => {

--- a/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/spansWidgetQueries.tsx
@@ -11,7 +11,6 @@ import {defined} from 'sentry/utils';
 import {dedupeArray} from 'sentry/utils/dedupeArray';
 import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
-import {determineTimeSeriesConfidence} from 'sentry/views/alerts/rules/metric/utils/determineSeriesConfidence';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {SpansConfig} from 'sentry/views/dashboards/datasetConfig/spans';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -49,6 +48,7 @@ type SpansWidgetQueriesProps = {
 type SpansWidgetQueriesImplProps = SpansWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial' | undefined;
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };
@@ -60,6 +60,7 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
       let seriesConfidence: Confidence | null;
       let seriesSampleCount: number | undefined;
       let seriesIsSampled: boolean | null;
+      let seriesDataScanned: 'full' | 'partial' | undefined;
 
       if (isEventsStats(result)) {
         const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(
@@ -67,26 +68,35 @@ function SpansWidgetQueries(props: SpansWidgetQueriesProps) {
           result
         );
 
-        seriesConfidence = determineTimeSeriesConfidence(timeSeries);
+        seriesConfidence = combineConfidenceForSeries([timeSeries]);
 
-        const {sampleCount: calculatedSampleCount, isSampled: calculatedIsSampled} =
-          determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        seriesDataScanned = calculatedDataScanned;
         seriesSampleCount = calculatedSampleCount;
         seriesIsSampled = calculatedIsSampled;
       } else {
         const dedupedYAxes = dedupeArray(props.widget.queries[0]?.aggregates ?? []);
         const seriesMap = transformToSeriesMap(result, dedupedYAxes);
         const series = dedupedYAxes.flatMap(yAxis => seriesMap[yAxis]).filter(defined);
-        const {sampleCount: calculatedSampleCount, isSampled: calculatedIsSampled} =
-          determineSeriesSampleCountAndIsSampled(
-            series,
-            Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
-          );
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled(
+          series,
+          Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
+        );
+        seriesDataScanned = calculatedDataScanned;
         seriesSampleCount = calculatedSampleCount;
         seriesConfidence = combineConfidenceForSeries(series);
         seriesIsSampled = calculatedIsSampled;
       }
       return {
+        seriesDataScanned,
         seriesConfidence,
         seriesSampleCount,
         seriesIsSampled,
@@ -117,17 +127,22 @@ function SpansWidgetQueriesSingleRequestImpl({
 }: SpansWidgetQueriesImplProps) {
   const config = SpansConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
 
   const afterFetchSeriesData = (result: SeriesResult) => {
-    const {seriesConfidence, seriesSampleCount, seriesIsSampled} =
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
       getConfidenceInformation(result);
 
+    setDataScanned(seriesDataScanned);
     setConfidence(seriesConfidence);
     setSampleCount(seriesSampleCount);
     setIsSampled(seriesIsSampled);
     onDataFetched?.({
+      dataScanned: seriesDataScanned,
       confidence: seriesConfidence,
       sampleCount: seriesSampleCount,
       isSampled: seriesIsSampled,
@@ -151,6 +166,7 @@ function SpansWidgetQueriesSingleRequestImpl({
   return getDynamicText({
     value: children({
       ...props,
+      dataScanned,
       confidence,
       sampleCount,
       isSampled,

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -454,25 +454,19 @@ function VisualizationWidgetContent({
             axisRange={widget.axisRange}
           />
         </Container>
+        <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>
         <Flex flex={1} direction="column" borderTop="primary" overflowY="auto">
           <Container flex={1} width="100%">
             {footerTable}
           </Container>
         </Flex>
-        {confidenceFooter}
       </Flex>
     );
   }
 
   return (
-    <Flex
-      direction="column"
-      height="100%"
-      paddingLeft={timeseriesContainerPadding.paddingLeft}
-      paddingRight={timeseriesContainerPadding.paddingRight}
-      paddingBottom={timeseriesContainerPadding.paddingBottom}
-    >
-      <Container flex={1}>
+    <Flex direction="column" height="100%">
+      <Container flex={1} {...timeseriesContainerPadding}>
         <TimeSeriesWidgetVisualization
           plottables={plottables}
           releases={releases}
@@ -480,7 +474,7 @@ function VisualizationWidgetContent({
           axisRange={widget.axisRange}
         />
       </Container>
-      {confidenceFooter}
+      <Container {...timeseriesContainerPadding}>{confidenceFooter}</Container>
     </Flex>
   );
 }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -10,6 +10,7 @@ import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
 import {IconWarning} from 'sentry/icons';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
@@ -54,6 +55,7 @@ import {
 } from 'sentry/views/insights/pages/platform/shared/styles';
 import {SpanFields} from 'sentry/views/insights/types';
 
+import {WidgetCardConfidenceFooter} from './confidenceFooter';
 import {WidgetCardDataLoader} from './widgetCardDataLoader';
 
 interface VisualizationWidgetProps {
@@ -72,6 +74,7 @@ interface VisualizationWidgetProps {
   onWidgetTableResizeColumn?: (columns: TabularColumn[]) => void;
   onWidgetTableSort?: (sort: Sort) => void;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
+  showConfidenceWarning?: boolean;
   showReleaseAs?: LoadableChartWidgetProps['showReleaseAs'];
   tableItemLimit?: number;
   widgetInterval?: string;
@@ -87,6 +90,7 @@ export function VisualizationWidget({
   widgetInterval,
   renderErrorMessage,
   showReleaseAs = 'bubble',
+  showConfidenceWarning,
 }: VisualizationWidgetProps) {
   const {releases: releasesWithDate} = useReleaseStats(selection, {
     enabled: showReleaseAs !== 'none',
@@ -115,6 +119,10 @@ export function VisualizationWidget({
         tableResults,
         errorMessage,
         loading,
+        confidence,
+        dataScanned,
+        isSampled,
+        sampleCount,
       }) => {
         return (
           <VisualizationWidgetContent
@@ -129,6 +137,11 @@ export function VisualizationWidget({
             showReleaseAs={showReleaseAs}
             renderErrorMessage={renderErrorMessage}
             dashboardFilters={dashboardFilters}
+            showConfidenceWarning={showConfidenceWarning}
+            confidence={confidence}
+            dataScanned={dataScanned}
+            isSampled={isSampled}
+            sampleCount={sampleCount}
           />
         );
       }}
@@ -142,9 +155,14 @@ interface VisualizationWidgetContentProps {
   showReleaseAs: LoadableChartWidgetProps['showReleaseAs'];
   timeseriesResults: Series[];
   widget: Widget;
+  confidence?: Confidence;
   dashboardFilters?: DashboardFilters;
+  dataScanned?: 'full' | 'partial';
   errorMessage?: string;
+  isSampled?: boolean | null;
   renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
+  sampleCount?: number;
+  showConfidenceWarning?: boolean;
   tableResults?: TableDataWithTitle[];
   timeseriesResultsTypes?: Record<string, AggregationOutputType>;
   timeseriesResultsUnits?: Record<string, DataUnit>;
@@ -162,6 +180,11 @@ function VisualizationWidgetContent({
   showReleaseAs,
   renderErrorMessage,
   dashboardFilters,
+  showConfidenceWarning,
+  confidence,
+  dataScanned,
+  isSampled,
+  sampleCount,
 }: VisualizationWidgetContentProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -404,6 +427,21 @@ function VisualizationWidgetContent({
     );
   }
 
+  const confidenceFooter = showConfidenceWarning ? (
+    <WidgetCardConfidenceFooter
+      confidence={confidence}
+      dataScanned={dataScanned}
+      isSampled={isSampled}
+      other="Other"
+      loading={loading}
+      sampleCount={sampleCount}
+      series={timeseriesResults}
+      timeseriesResults={timeseriesResults}
+      widget={widget}
+      yAxis={widget.queries[0]?.aggregates[0] ?? ''}
+    />
+  ) : null;
+
   if (showBreakdownData) {
     return (
       <Flex direction="column" height="100%">
@@ -421,19 +459,29 @@ function VisualizationWidgetContent({
             {footerTable}
           </Container>
         </Flex>
+        {confidenceFooter}
       </Flex>
     );
   }
 
   return (
-    <Container flex={1} {...timeseriesContainerPadding}>
-      <TimeSeriesWidgetVisualization
-        plottables={plottables}
-        releases={releases}
-        showReleaseAs={showReleaseAs}
-        axisRange={widget.axisRange}
-      />
-    </Container>
+    <Flex
+      direction="column"
+      height="100%"
+      paddingLeft={timeseriesContainerPadding.paddingLeft}
+      paddingRight={timeseriesContainerPadding.paddingRight}
+      paddingBottom={timeseriesContainerPadding.paddingBottom}
+    >
+      <Container flex={1}>
+        <TimeSeriesWidgetVisualization
+          plottables={plottables}
+          releases={releases}
+          showReleaseAs={showReleaseAs}
+          axisRange={widget.axisRange}
+        />
+      </Container>
+      {confidenceFooter}
+    </Flex>
   );
 }
 

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -10,6 +10,7 @@ import type {
   EChartLegendSelectChangeHandler,
   Series,
 } from 'sentry/types/echarts';
+import type {Confidence} from 'sentry/types/organization';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, Sort} from 'sentry/utils/discover/fields';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
@@ -37,7 +38,11 @@ type Props = {
   noPadding?: boolean;
   onDataFetchStart?: () => void;
   onDataFetched?: (results: {
+    confidence?: Confidence;
+    dataScanned?: 'full' | 'partial';
+    isSampled?: boolean | null;
     pageLinks?: string;
+    sampleCount?: number;
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
     timeseriesResultsTypes?: Record<string, AggregationOutputType>;
@@ -130,6 +135,7 @@ export function WidgetCardChartContainer({
         timeseriesResultsTypes,
         timeseriesResultsUnits,
         confidence,
+        dataScanned,
         sampleCount,
         isSampled,
       }) => {
@@ -178,6 +184,7 @@ export function WidgetCardChartContainer({
               widgetLegendState={widgetLegendState}
               showConfidenceWarning={showConfidenceWarning}
               confidence={confidence}
+              dataScanned={dataScanned}
               sampleCount={sampleCount}
               minTableColumnWidth={minTableColumnWidth}
               isSampled={isSampled}

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -20,6 +20,7 @@ import WidgetQueries from './widgetQueries';
 type Results = {
   loading: boolean;
   confidence?: Confidence;
+  dataScanned?: 'full' | 'partial';
   errorMessage?: string;
   isProgressivelyLoading?: boolean;
   isSampled?: boolean | null;
@@ -48,6 +49,8 @@ type Props = {
       | 'timeseriesResultsUnits'
       | 'totalIssuesCount'
       | 'confidence'
+      | 'dataScanned'
+      | 'isSampled'
       | 'sampleCount'
     >
   ) => void;

--- a/static/app/views/explore/useRawCounts.tsx
+++ b/static/app/views/explore/useRawCounts.tsx
@@ -1,5 +1,6 @@
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import usePageFilters from 'sentry/components/pageFilters/usePageFilters';
+import type {PageFilters} from 'sentry/types/core';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
@@ -31,23 +32,26 @@ interface UseRawCountsOptions {
    */
   aggregate?: string;
   enabled?: boolean;
+  selection?: PageFilters;
 }
 
 export function useRawCounts({
   dataset,
   aggregate,
   enabled,
+  selection,
 }: UseRawCountsOptions): RawCounts {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
+  const {selection: pageFilterSelection} = usePageFilters();
+  const effectiveSelection = selection ?? pageFilterSelection;
 
   const count = aggregate ?? getAggregateForDataset(dataset);
 
   const baseQueryParams = {
     dataset,
-    project: selection.projects,
-    environment: selection.environments,
-    ...normalizeDateTimeParams(selection.datetime),
+    project: effectiveSelection.projects,
+    environment: effectiveSelection.environments,
+    ...normalizeDateTimeParams(effectiveSelection.datetime),
     field: [count],
     disableAggregateExtrapolation: '1',
   };


### PR DESCRIPTION
Extract the inline `ConfidenceFooter` from `chart.tsx` into a dedicated `WidgetCardConfidenceFooter` component and thread `dataScanned` through the widget query data pipeline alongside existing confidence/sampleCount props.

This is a refactor that prepares the confidence footer infrastructure for reuse across multiple widget types (logs and trace metrics will follow in stacked PRs). Currently scoped to spans widgets only -- no behavior change for other widget types.

Key changes:
- New `WidgetCardConfidenceFooter` component that encapsulates the top-N calculation, series conversion, and sampling metadata logic previously inline in `chart.tsx`
- New `useWidgetRawCounts` hook for fetching raw span counts
- `dataScanned` prop threaded through `genericWidgetQueries` -> `widgetCardChartContainer` -> `chart`
- `useRawCounts` updated to accept an optional `selection` prop for dashboard widget contexts

**Stack:**
- **This PR** (base: master)
- PR 2: Logs confidence (base: this branch)
- PR 3: Trace metrics confidence (base: this branch)

Made with [Cursor](https://cursor.com)

Example:
<img width="790" height="412" alt="Screenshot 2026-03-05 at 11 17 35" src="https://github.com/user-attachments/assets/87cbb7fd-f2cd-49ab-a32c-b654a8dced98" />
