### PR TITLE
feat(dashboards): Add logs confidence footer to dashboard widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -631,7 +631,8 @@ function WidgetViewerModal(props: Props) {
               widgetLegendState={widgetLegendState}
               showConfidenceWarning={
                 widget.widgetType === WidgetType.SPANS ||
-                widget.widgetType === WidgetType.TRACEMETRICS
+                widget.widgetType === WidgetType.TRACEMETRICS ||
+                widget.widgetType === WidgetType.LOGS
               }
               widgetInterval={widgetInterval}
             />

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -134,7 +134,8 @@ function WidgetPreview({
       tableItemLimit={widget.limit}
       showConfidenceWarning={
         widget.widgetType === WidgetType.SPANS ||
-        widget.widgetType === WidgetType.TRACEMETRICS
+        widget.widgetType === WidgetType.TRACEMETRICS ||
+        widget.widgetType === WidgetType.LOGS
       }
       // ensure table columns are at least a certain width (helps with lack of truncation on large fields)
       minTableColumnWidth={MIN_TABLE_COLUMN_WIDTH_PX}

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -546,12 +546,10 @@ function WidgetCardChart(props: WidgetCardChartProps) {
                         confidence={confidence}
                         dataScanned={dataScanned}
                         isSampled={isSampled}
-                        other={OTHER}
                         loading={loading}
                         sampleCount={sampleCount}
                         selection={selection}
                         series={series}
-                        shouldColorOther={shouldColorOther}
                         timeseriesResults={timeseriesResults}
                         widget={widget}
                         yAxis={axisLabel}

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -45,6 +45,9 @@ describe('WidgetCardConfidenceFooter', () => {
     {seriesName: 'series-a'},
     {seriesName: 'series-b'},
   ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
+  const singleTimeseriesResults = [
+    {seriesName: 'series-a'},
+  ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
 
   beforeEach(() => {
     PageFiltersStore.init();
@@ -115,13 +118,14 @@ describe('WidgetCardConfidenceFooter', () => {
       <WidgetCardConfidenceFooter
         loading={false}
         other="Other"
-        series={series}
-        timeseriesResults={timeseriesResults}
+        series={[series[0]!]}
+        timeseriesResults={singleTimeseriesResults}
         widget={WidgetFixture({
           displayType: DisplayType.LINE,
           widgetType: WidgetType.TRACEMETRICS,
           queries: [
             WidgetQueryFixture({
+              conditions: 'transaction:checkout',
               aggregates: ['avg(value,duration,d,-)'],
               fields: ['avg(value,duration,d,-)'],
               columns: [],
@@ -135,6 +139,47 @@ describe('WidgetCardConfidenceFooter', () => {
     const footer = await screen.findByText(/Estimated from/i);
     expect(footer).toHaveTextContent('10 matches');
     expect(footer).toHaveTextContent('500 data points');
+  });
+
+  it('renders logs footer with raw counts from API', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(message)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'ourlogs'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(message)': 500}]},
+      match: [
+        MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'ourlogs'}),
+      ],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        series={[series[0]!]}
+        timeseriesResults={singleTimeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.LOGS,
+          queries: [
+            WidgetQueryFixture({
+              conditions: 'level:error',
+              aggregates: ['count(message)'],
+              fields: ['count(message)'],
+              columns: [],
+            }),
+          ],
+        })}
+        yAxis="count(message)"
+      />
+    );
+
+    const footer = await screen.findByText(/Estimated from/i);
+    expect(footer).toHaveTextContent('10 matches');
+    expect(footer).toHaveTextContent('500 logs');
   });
 
   it('does not render footer for unsupported widget types', () => {

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -45,6 +45,26 @@ describe('WidgetCardConfidenceFooter', () => {
     {seriesName: 'series-a'},
     {seriesName: 'series-b'},
   ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
+  const seriesWithOther: Array<Series & {fieldName?: string}> = [
+    ...series,
+    {
+      seriesName: 'Other',
+      data: [
+        {
+          name: 1710000120000,
+          value: 5,
+          sampleCount: 4,
+          sampleRate: 0.5,
+          confidence: 'high',
+        } as SeriesDataUnit,
+      ],
+    },
+  ];
+  const timeseriesResultsWithOther = [
+    {seriesName: 'series-a'},
+    {seriesName: 'series-b'},
+    {seriesName: 'Other'},
+  ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
   const singleTimeseriesResults = [
     {seriesName: 'series-a'},
   ] as unknown as GenericWidgetQueriesResult['timeseriesResults'];
@@ -74,8 +94,6 @@ describe('WidgetCardConfidenceFooter', () => {
       <WidgetCardConfidenceFooter
         loading={false}
         series={series}
-        shouldColorOther={false}
-        other="Other"
         timeseriesResults={timeseriesResults}
         widget={WidgetFixture({
           displayType: DisplayType.LINE,
@@ -95,6 +113,43 @@ describe('WidgetCardConfidenceFooter', () => {
     const footer = await screen.findByText(/Estimated for top 2 groups from/i);
     expect(footer).toHaveTextContent('18 matches');
     expect(footer).toHaveTextContent('500 spans');
+  });
+
+  it('excludes Other from spans top event metadata', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'spans'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(span.duration)': 500}]},
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY', dataset: 'spans'})],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        series={seriesWithOther}
+        timeseriesResults={timeseriesResultsWithOther}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.SPANS,
+          queries: [
+            WidgetQueryFixture({
+              conditions: 'transaction:checkout',
+              columns: ['transaction'],
+              aggregates: ['count()'],
+            }),
+          ],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    const footer = await screen.findByText(/Estimated for top 2 groups from/i);
+    expect(footer).toHaveTextContent('18 matches');
+    expect(footer).not.toHaveTextContent('top 3 groups');
   });
 
   it('renders metrics footer with raw counts from API', async () => {
@@ -117,7 +172,6 @@ describe('WidgetCardConfidenceFooter', () => {
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        other="Other"
         series={[series[0]!]}
         timeseriesResults={singleTimeseriesResults}
         widget={WidgetFixture({
@@ -158,7 +212,6 @@ describe('WidgetCardConfidenceFooter', () => {
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        other="Other"
         series={[series[0]!]}
         timeseriesResults={singleTimeseriesResults}
         widget={WidgetFixture({
@@ -186,7 +239,6 @@ describe('WidgetCardConfidenceFooter', () => {
     render(
       <WidgetCardConfidenceFooter
         loading={false}
-        other="Other"
         series={series}
         timeseriesResults={timeseriesResults}
         widget={WidgetFixture({

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -55,7 +55,7 @@ export function WidgetCardConfidenceFooter({
         (timeseriesResults?.some(
           ({seriesName}) =>
             shouldColorOther ||
-            seriesName?.match(new RegExp(`(?:.* : ${other};)|^${other};`))
+            seriesName?.match(new RegExp(`(?:.* : ${other})|^${other}`))
         )
           ? 1
           : 0)

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -18,7 +18,6 @@ import type {GenericWidgetQueriesResult} from './genericWidgetQueries';
 
 type Props = {
   loading: boolean;
-  other: 'Other';
   series: Array<Series & {fieldName?: string}>;
   timeseriesResults: GenericWidgetQueriesResult['timeseriesResults'];
   widget: Widget;
@@ -28,7 +27,6 @@ type Props = {
   isSampled?: boolean | null;
   sampleCount?: number;
   selection?: PageFilters;
-  shouldColorOther?: boolean;
 };
 
 export function WidgetCardConfidenceFooter({
@@ -36,11 +34,9 @@ export function WidgetCardConfidenceFooter({
   dataScanned,
   isSampled,
   loading,
-  other,
   sampleCount,
   selection: selectionProp,
   series,
-  shouldColorOther,
   timeseriesResults,
   widget,
   yAxis,
@@ -48,17 +44,14 @@ export function WidgetCardConfidenceFooter({
   const {selection: pageFilterSelection} = usePageFilters();
   const selection = selectionProp ?? pageFilterSelection;
   const rawCounts = useWidgetRawCounts({selection, widget});
+  const hasOtherSeries = timeseriesResults?.some(({seriesName}) =>
+    seriesName?.match(/(?:.* : Other)$|^Other$/)
+  );
 
   const topEventsCountExcludingOther =
     timeseriesResults?.length && widget.queries[0]?.columns.length
       ? Math.floor(timeseriesResults.length / widget.queries[0]?.aggregates.length) -
-        (timeseriesResults?.some(
-          ({seriesName}) =>
-            shouldColorOther ||
-            seriesName?.match(new RegExp(`(?:.* : ${other})|^${other}`))
-        )
-          ? 1
-          : 0)
+        (hasOtherSeries ? 1 : 0)
       : undefined;
 
   const isTopN =

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -7,6 +7,7 @@ import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ConfidenceFooter as LogsConfidenceFooter} from 'sentry/views/explore/logs/confidenceFooter';
 import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
@@ -112,6 +113,17 @@ export function WidgetCardConfidenceFooter({
         hasUserQuery={hasUserQuery}
         isLoading={loading}
         rawMetricCounts={rawCounts}
+      />
+    );
+  }
+
+  if (widget.widgetType === WidgetType.LOGS && rawCounts) {
+    return (
+      <LogsConfidenceFooter
+        chartInfo={footerChartInfo}
+        hasUserQuery={hasUserQuery}
+        isLoading={loading}
+        rawLogCounts={rawCounts}
       />
     );
   }

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -51,6 +51,12 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
           enabled: isSupportedDisplayType,
         };
       }
+      case WidgetType.LOGS:
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.OURLOGS,
+          enabled: isSupportedDisplayType,
+        };
       default:
         return {
           supported: false,

--- a/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/logsWidgetQueries.spec.tsx
@@ -1,0 +1,74 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import LogsWidgetQueries from './logsWidgetQueries';
+
+describe('logsWidgetQueries', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('calculates confidence and sampling metadata from timeseries', async () => {
+    const selection = PageFiltersFixture();
+    const widget = WidgetFixture({
+      widgetType: WidgetType.LOGS,
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          aggregates: ['count(message)'],
+          fields: ['count(message)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        data: [
+          [1, [{count: 10}]],
+          [2, [{count: 20}]],
+        ],
+        meta: {
+          dataScanned: 'partial',
+          fields: {'count(message)': 'integer'},
+          units: {'count(message)': null},
+          accuracy: {
+            confidence: [
+              {timestamp: 1, value: 'low'},
+              {timestamp: 2, value: 'low'},
+            ],
+            sampleCount: [
+              {timestamp: 1, value: 10},
+              {timestamp: 2, value: 20},
+            ],
+            samplingRate: [
+              {timestamp: 1, value: 0.5},
+              {timestamp: 2, value: 0.5},
+            ],
+          },
+        },
+      },
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'ourlogs'})],
+    });
+
+    render(
+      <LogsWidgetQueries widget={widget} selection={selection}>
+        {({confidence, sampleCount, isSampled, dataScanned}) => (
+          <div>
+            {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
+          </div>
+        )}
+      </LogsWidgetQueries>
+    );
+
+    expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/logsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/logsWidgetQueries.tsx
@@ -1,0 +1,178 @@
+import {useCallback, useState} from 'react';
+
+import type {PageFilters} from 'sentry/types/core';
+import type {
+  Confidence,
+  EventsStats,
+  GroupedMultiSeriesEventsStats,
+  MultiSeriesEventsStats,
+} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {dedupeArray} from 'sentry/utils/dedupeArray';
+import type {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import getDynamicText from 'sentry/utils/getDynamicText';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
+import {LogsConfig} from 'sentry/views/dashboards/datasetConfig/logs';
+import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {isEventsStats} from 'sentry/views/dashboards/utils/isEventsStats';
+import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
+import {
+  convertEventsStatsToTimeSeriesData,
+  transformToSeriesMap,
+} from 'sentry/views/insights/common/queries/useSortedTimeSeries';
+
+import type {
+  GenericWidgetQueriesResult,
+  OnDataFetchedProps,
+} from './genericWidgetQueries';
+import {useGenericWidgetQueries} from './genericWidgetQueries';
+
+type SeriesResult = EventsStats | MultiSeriesEventsStats | GroupedMultiSeriesEventsStats;
+type TableResult = TableData | EventsTableData;
+
+type LogsWidgetQueriesProps = {
+  children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
+  widget: Widget;
+  cursor?: string;
+  dashboardFilters?: DashboardFilters;
+  limit?: number;
+  onBestEffortDataFetched?: () => void;
+  onDataFetchStart?: () => void;
+  onDataFetched?: (results: OnDataFetchedProps) => void;
+  selection?: PageFilters;
+  widgetInterval?: string;
+};
+
+type LogsWidgetQueriesImplProps = LogsWidgetQueriesProps & {
+  getConfidenceInformation: (result: SeriesResult) => {
+    seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial' | undefined;
+    seriesIsSampled: boolean | null;
+    seriesSampleCount: number | undefined;
+  };
+};
+
+function LogsWidgetQueries(props: LogsWidgetQueriesProps) {
+  const getConfidenceInformation = useCallback(
+    (result: SeriesResult) => {
+      let seriesConfidence: Confidence | null;
+      let seriesSampleCount: number | undefined;
+      let seriesIsSampled: boolean | null;
+      let seriesDataScanned: 'full' | 'partial' | undefined;
+
+      if (isEventsStats(result)) {
+        const [_order, timeSeries] = convertEventsStatsToTimeSeriesData(
+          props.widget.queries[0]?.aggregates[0] ?? '',
+          result
+        );
+
+        seriesConfidence = combineConfidenceForSeries([timeSeries]);
+
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled([timeSeries], false);
+        seriesDataScanned = calculatedDataScanned;
+        seriesSampleCount = calculatedSampleCount;
+        seriesIsSampled = calculatedIsSampled;
+      } else {
+        const dedupedYAxes = dedupeArray(props.widget.queries[0]?.aggregates ?? []);
+        const seriesMap = transformToSeriesMap(result, dedupedYAxes);
+        const series = dedupedYAxes.flatMap(yAxis => seriesMap[yAxis]).filter(defined);
+        const {
+          dataScanned: calculatedDataScanned,
+          sampleCount: calculatedSampleCount,
+          isSampled: calculatedIsSampled,
+        } = determineSeriesSampleCountAndIsSampled(
+          series,
+          Object.keys(result).some(seriesName => seriesName.toLowerCase() !== 'other')
+        );
+        seriesDataScanned = calculatedDataScanned;
+        seriesSampleCount = calculatedSampleCount;
+        seriesConfidence = combineConfidenceForSeries(series);
+        seriesIsSampled = calculatedIsSampled;
+      }
+
+      return {
+        seriesDataScanned,
+        seriesConfidence,
+        seriesSampleCount,
+        seriesIsSampled,
+      };
+    },
+    [props.widget.queries]
+  );
+
+  return (
+    <LogsWidgetQueriesSingleRequestImpl
+      {...props}
+      getConfidenceInformation={getConfidenceInformation}
+    />
+  );
+}
+
+function LogsWidgetQueriesSingleRequestImpl({
+  children,
+  widget,
+  cursor,
+  limit,
+  dashboardFilters,
+  onDataFetched,
+  onDataFetchStart,
+  getConfidenceInformation,
+  selection,
+  widgetInterval,
+}: LogsWidgetQueriesImplProps) {
+  const config = LogsConfig;
+  const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
+  const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
+  const [isSampled, setIsSampled] = useState<boolean | null>(null);
+
+  const afterFetchSeriesData = (result: SeriesResult) => {
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
+      getConfidenceInformation(result);
+
+    setDataScanned(seriesDataScanned);
+    setConfidence(seriesConfidence);
+    setSampleCount(seriesSampleCount);
+    setIsSampled(seriesIsSampled);
+    onDataFetched?.({
+      dataScanned: seriesDataScanned,
+      confidence: seriesConfidence,
+      sampleCount: seriesSampleCount,
+      isSampled: seriesIsSampled,
+    });
+  };
+
+  const props = useGenericWidgetQueries<SeriesResult, TableResult>({
+    config,
+    widget,
+    cursor,
+    limit,
+    dashboardFilters,
+    onDataFetched,
+    onDataFetchStart,
+    afterFetchSeriesData,
+    samplingMode: SAMPLING_MODE.NORMAL,
+    selection,
+    widgetInterval,
+  });
+
+  return getDynamicText({
+    value: children({
+      ...props,
+      dataScanned,
+      confidence,
+      sampleCount,
+      isSampled,
+    }),
+    fixed: <div />,
+  });
+}
+
+export default LogsWidgetQueries;

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -432,7 +432,6 @@ function VisualizationWidgetContent({
       confidence={confidence}
       dataScanned={dataScanned}
       isSampled={isSampled}
-      other="Other"
       loading={loading}
       sampleCount={sampleCount}
       series={timeseriesResults}

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -460,7 +460,6 @@ function VisualizationWidgetContent({
             {footerTable}
           </Container>
         </Flex>
-        {confidenceFooter}
       </Flex>
     );
   }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -460,6 +460,7 @@ function VisualizationWidgetContent({
             {footerTable}
           </Container>
         </Flex>
+        {confidenceFooter}
       </Flex>
     );
   }

--- a/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardDataLoader.tsx
@@ -13,6 +13,7 @@ import SpansWidgetQueries from 'sentry/views/dashboards/widgetCard/spansWidgetQu
 import TraceMetricsWidgetQueries from 'sentry/views/dashboards/widgetCard/traceMetricsWidgetQueries';
 
 import IssueWidgetQueries from './issueWidgetQueries';
+import LogsWidgetQueries from './logsWidgetQueries';
 import MobileAppSizeWidgetQueries from './mobileAppSizeWidgetQueries';
 import ReleaseWidgetQueries from './releaseWidgetQueries';
 import WidgetQueries from './widgetQueries';
@@ -155,6 +156,22 @@ export function WidgetCardDataLoader({
       >
         {props => <Fragment>{children({...props})}</Fragment>}
       </TraceMetricsWidgetQueries>
+    );
+  }
+
+  if (widget.widgetType === WidgetType.LOGS) {
+    return (
+      <LogsWidgetQueries
+        widget={widget}
+        selection={selection}
+        limit={tableItemLimit}
+        onDataFetchStart={onDataFetchStart}
+        onDataFetched={onDataFetched}
+        dashboardFilters={dashboardFilters}
+        widgetInterval={widgetInterval}
+      >
+        {props => <Fragment>{children({...props})}</Fragment>}
+      </LogsWidgetQueries>
     );
   }
 


### PR DESCRIPTION
Wire up `LogsWidgetQueries` for sampling-aware log widget queries and add logs confidence footer rendering to the dashboard widget card system.

Key changes:
- New `LogsWidgetQueries` component (mirrors `SpansWidgetQueries` pattern) that extracts confidence and sampling metadata from timeseries results
- Logs routing added to `WidgetCardDataLoader`
- `WidgetCardConfidenceFooter` extended with `WidgetType.LOGS` branch using the explore `LogsConfidenceFooter`
- `useWidgetRawCounts` extended to fetch raw counts for the `ourlogs` dataset
- `showConfidenceWarning` extended to include `WidgetType.LOGS` in widget viewer modal and widget preview

**Stack:**
- PR 1: Spans confidence refactor (base: master) #109939
- **This PR** (base: PR 1)

Made with [Cursor](https://cursor.com)

Examples:
<img width="1136" height="303" alt="Screenshot 2026-03-05 at 11 32 44" src="https://github.com/user-attachments/assets/3b1ca830-c8d7-4e45-ab20-42c50dc2a52b" />
<img width="787" height="417" alt="Screenshot 2026-03-05 at 11 32 54" src="https://github.com/user-attachments/assets/907666b6-1eea-461e-a25f-1881a4d1764e" />
