### PR TITLE
feat(dashboards): Add trace metrics confidence footer to dashboard widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -629,7 +629,10 @@ function WidgetViewerModal(props: Props) {
               }}
               noPadding
               widgetLegendState={widgetLegendState}
-              showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+              showConfidenceWarning={
+                widget.widgetType === WidgetType.SPANS ||
+                widget.widgetType === WidgetType.TRACEMETRICS
+              }
               widgetInterval={widgetInterval}
             />
           </Container>

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -132,7 +132,10 @@ function WidgetPreview({
       onWidgetSplitDecision={() => {}}
       // onWidgetSplitDecision={onWidgetSplitDecision}
       tableItemLimit={widget.limit}
-      showConfidenceWarning={widget.widgetType === WidgetType.SPANS}
+      showConfidenceWarning={
+        widget.widgetType === WidgetType.SPANS ||
+        widget.widgetType === WidgetType.TRACEMETRICS
+      }
       // ensure table columns are at least a certain width (helps with lack of truncation on large fields)
       minTableColumnWidth={MIN_TABLE_COLUMN_WIDTH_PX}
       disableZoom

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -94,6 +94,50 @@ describe('WidgetCardConfidenceFooter', () => {
     expect(footer).toHaveTextContent('500 spans');
   });
 
+  it('renders metrics footer with raw counts from API', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 120}]},
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL', dataset: 'tracemetrics'})],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 500}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'HIGHEST_ACCURACY',
+          dataset: 'tracemetrics',
+        }),
+      ],
+    });
+
+    render(
+      <WidgetCardConfidenceFooter
+        loading={false}
+        other="Other"
+        series={series}
+        showConfidenceWarning
+        timeseriesResults={timeseriesResults}
+        widget={WidgetFixture({
+          displayType: DisplayType.LINE,
+          widgetType: WidgetType.TRACEMETRICS,
+          queries: [
+            WidgetQueryFixture({
+              aggregates: ['avg(value,duration,d,-)'],
+              fields: ['avg(value,duration,d,-)'],
+              columns: [],
+            }),
+          ],
+        })}
+        yAxis="count()"
+      />
+    );
+
+    const footer = await screen.findByText(/Estimated from/i);
+    expect(footer).toHaveTextContent('10 matches');
+    expect(footer).toHaveTextContent('500 data points');
+  });
+
   it('does not render footer for unsupported widget types', () => {
     render(
       <WidgetCardConfidenceFooter

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.spec.tsx
@@ -116,7 +116,6 @@ describe('WidgetCardConfidenceFooter', () => {
         loading={false}
         other="Other"
         series={series}
-        showConfidenceWarning
         timeseriesResults={timeseriesResults}
         widget={WidgetFixture({
           displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -7,6 +7,7 @@ import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import type {ChartInfo} from 'sentry/views/explore/components/chart/types';
+import {ConfidenceFooter as MetricsConfidenceFooter} from 'sentry/views/explore/metrics/confidenceFooter';
 import {ConfidenceFooter as SpansConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
@@ -71,6 +72,9 @@ export function WidgetCardConfidenceFooter({
     : samplingMeta?.sampleCount;
   const footerIsSampled = defined(isSampled) ? isSampled : samplingMeta?.isSampled;
   const footerDataScanned = dataScanned ?? samplingMeta?.dataScanned;
+  const hasUserQuery = widget.queries.some(
+    query => (query.conditions ?? '').trim().length > 0
+  );
   const userQuery =
     widget.queries.find(query => (query.conditions ?? '').trim().length > 0)
       ?.conditions ?? '';
@@ -97,6 +101,17 @@ export function WidgetCardConfidenceFooter({
         sampleCount={footerChartInfo.sampleCount}
         topEvents={footerChartInfo.topEvents}
         userQuery={userQuery}
+      />
+    );
+  }
+
+  if (widget.widgetType === WidgetType.TRACEMETRICS && rawCounts) {
+    return (
+      <MetricsConfidenceFooter
+        chartInfo={footerChartInfo}
+        hasUserQuery={hasUserQuery}
+        isLoading={loading}
+        rawMetricCounts={rawCounts}
       />
     );
   }

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.spec.tsx
@@ -12,6 +12,67 @@ describe('useWidgetRawCounts', () => {
     MockApiClient.clearMockResponses();
   });
 
+  it('derives the trace metrics count aggregate from the widget metric', async () => {
+    const selection = PageFiltersFixture({
+      projects: [2],
+      environments: ['prod'],
+      datetime: {
+        start: '2025-01-01T00:00:00',
+        end: '2025-01-02T00:00:00',
+        period: null,
+        utc: null,
+      },
+    });
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      queries: [
+        {
+          name: '',
+          aggregates: ['avg(value,duration,d,-)'],
+          fields: ['avg(value,duration,d,-)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    const normalRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 11}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'NORMAL',
+          dataset: 'tracemetrics',
+          field: ['count(value,duration,d,-)'],
+          project: [2],
+          environment: ['prod'],
+        }),
+      ],
+    });
+
+    const highAccuracyRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{'count(value,duration,d,-)': 13}]},
+      match: [
+        MockApiClient.matchQuery({
+          sampling: 'HIGHEST_ACCURACY',
+          dataset: 'tracemetrics',
+          field: ['count(value,duration,d,-)'],
+          project: [2],
+          environment: ['prod'],
+        }),
+      ],
+    });
+
+    renderHookWithProviders(useWidgetRawCounts, {
+      initialProps: {selection, widget},
+    });
+
+    await waitFor(() => expect(normalRequest).toHaveBeenCalled());
+    await waitFor(() => expect(highAccuracyRequest).toHaveBeenCalled());
+  });
+
   it('does not fetch raw counts for non-timeseries display types', async () => {
     const selection = PageFiltersFixture();
     const widget = WidgetFixture({

--- a/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useWidgetRawCounts.tsx
@@ -3,6 +3,7 @@ import {useMemo} from 'react';
 import type {PageFilters} from 'sentry/types/core';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
+import {extractTraceMetricFromWidget} from 'sentry/views/dashboards/utils/extractTraceMetricFromWidget';
 import {useRawCounts, type RawCounts} from 'sentry/views/explore/useRawCounts';
 
 type Props = {
@@ -32,6 +33,24 @@ export function useWidgetRawCounts({selection, widget}: Props): RawCounts | null
           dataset: DiscoverDatasets.SPANS,
           enabled: isSupportedDisplayType,
         };
+      case WidgetType.TRACEMETRICS: {
+        const traceMetric = extractTraceMetricFromWidget(widget);
+        if (!traceMetric?.name || !traceMetric?.type) {
+          return {
+            supported: true,
+            dataset: DiscoverDatasets.TRACEMETRICS,
+            aggregate: 'count(value,,,-)',
+            enabled: false,
+          };
+        }
+
+        return {
+          supported: true,
+          dataset: DiscoverDatasets.TRACEMETRICS,
+          aggregate: `count(value,${traceMetric.name},${traceMetric.type},${traceMetric.unit ?? '-'})`,
+          enabled: isSupportedDisplayType,
+        };
+      }
       default:
         return {
           supported: false,

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
@@ -1,0 +1,84 @@
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+import {WidgetFixture} from 'sentry-fixture/widget';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import PageFiltersStore from 'sentry/components/pageFilters/store';
+import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
+
+import TraceMetricsWidgetQueries from './traceMetricsWidgetQueries';
+
+describe('traceMetricsWidgetQueries', () => {
+  const selection = PageFiltersFixture();
+
+  beforeEach(() => {
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState(selection);
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('calculates confidence and sampling metadata from timeseries', async () => {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          aggregates: ['avg(value,duration,d,-)'],
+          fields: ['avg(value,duration,d,-)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {
+        timeSeries: [
+          {
+            yAxis: 'avg(value,duration,d,-)',
+            meta: {
+              interval: 3600000,
+              valueType: 'duration',
+              valueUnit: 'millisecond',
+              dataScanned: 'partial',
+            },
+            values: [
+              {
+                timestamp: 1,
+                value: 10,
+                confidence: 'low',
+                sampleCount: 10,
+                sampleRate: 0.5,
+              },
+              {
+                timestamp: 2,
+                value: 20,
+                confidence: 'low',
+                sampleCount: 20,
+                sampleRate: 0.5,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <TraceMetricsWidgetQueries widget={widget} dashboardFilters={{}}>
+        {({confidence, sampleCount, isSampled, dataScanned}) => (
+          <div>
+            {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
+          </div>
+        )}
+      </TraceMetricsWidgetQueries>
+    );
+
+    expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -5,12 +5,14 @@ import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {determineSeriesSampleCountAndIsSampled} from 'sentry/views/alerts/rules/metric/utils/determineSeriesSampleCount';
 import {
   EMPTY_METRIC_SELECTION,
   TraceMetricsConfig,
 } from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 
 import type {
   GenericWidgetQueriesResult,
@@ -38,20 +40,28 @@ type TraceMetricsWidgetQueriesProps = {
 type TraceMetricsWidgetQueriesImplProps = TraceMetricsWidgetQueriesProps & {
   getConfidenceInformation: (result: SeriesResult) => {
     seriesConfidence: Confidence | null;
+    seriesDataScanned: 'full' | 'partial' | undefined;
     seriesIsSampled: boolean | null;
     seriesSampleCount: number | undefined;
   };
 };
 
 function TraceMetricsWidgetQueries(props: TraceMetricsWidgetQueriesProps) {
-  const getConfidenceInformation = useCallback(() => {
-    // TODO(nar): Implement confidence information parsing
-    return {
-      seriesConfidence: null,
-      seriesSampleCount: undefined,
-      seriesIsSampled: null,
-    };
-  }, []);
+  const getConfidenceInformation = useCallback(
+    (result: SeriesResult) => {
+      const series = result.timeSeries ?? [];
+      const isTopN = (props.widget.queries[0]?.columns.length ?? 0) > 0;
+      const samplingMeta = determineSeriesSampleCountAndIsSampled(series, isTopN);
+
+      return {
+        seriesDataScanned: samplingMeta.dataScanned,
+        seriesConfidence: combineConfidenceForSeries(series),
+        seriesSampleCount: samplingMeta.sampleCount,
+        seriesIsSampled: samplingMeta.isSampled,
+      };
+    },
+    [props.widget.queries]
+  );
 
   return (
     <TraceMetricsWidgetQueriesSingleRequestImpl
@@ -75,17 +85,22 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
 }: TraceMetricsWidgetQueriesImplProps) {
   const config = TraceMetricsConfig;
   const [confidence, setConfidence] = useState<Confidence | null>(null);
+  const [dataScanned, setDataScanned] = useState<'full' | 'partial' | undefined>(
+    undefined
+  );
   const [sampleCount, setSampleCount] = useState<number | undefined>(undefined);
   const [isSampled, setIsSampled] = useState<boolean | null>(null);
 
   const afterFetchSeriesData = (result: SeriesResult) => {
-    const {seriesConfidence, seriesSampleCount, seriesIsSampled} =
+    const {seriesDataScanned, seriesConfidence, seriesSampleCount, seriesIsSampled} =
       getConfidenceInformation(result);
 
+    setDataScanned(seriesDataScanned);
     setConfidence(seriesConfidence);
     setSampleCount(seriesSampleCount);
     setIsSampled(seriesIsSampled);
     onDataFetched?.({
+      dataScanned: seriesDataScanned,
       confidence: seriesConfidence,
       sampleCount: seriesSampleCount,
       isSampled: seriesIsSampled,
@@ -118,6 +133,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
   return getDynamicText({
     value: children({
       ...props,
+      dataScanned,
       confidence,
       sampleCount,
       isSampled,

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -460,7 +460,6 @@ function VisualizationWidgetContent({
             {footerTable}
           </Container>
         </Flex>
-        {confidenceFooter}
       </Flex>
     );
   }

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -460,6 +460,7 @@ function VisualizationWidgetContent({
             {footerTable}
           </Container>
         </Flex>
+        {confidenceFooter}
       </Flex>
     );
   }


### PR DESCRIPTION
Implement real confidence extraction for trace metrics widgets (replacing the previous TODO stub) and wire it into the dashboard widget card system.

Key changes:
- `traceMetricsWidgetQueries.tsx` now extracts confidence, dataScanned, sampleCount, and isSampled from timeseries results using `determineSeriesSampleCountAndIsSampled` and `combineConfidenceForSeries`
- `WidgetCardConfidenceFooter` extended with `WidgetType.TRACEMETRICS` branch using the explore `MetricsConfidenceFooter`
- `useWidgetRawCounts` extended to derive the correct `count(value,...)` aggregate from the widget's trace metric definition
- `showConfidenceWarning` extended to include `WidgetType.TRACEMETRICS` in widget viewer modal and widget preview

**Stack:**
- PR 1: Spans confidence refactor (base: master) #109939
- **This PR** (base: PR 1)

Made with [Cursor](https://cursor.com)

Examples:
<img width="1140" height="274" alt="Screenshot 2026-03-05 at 11 33 35" src="https://github.com/user-attachments/assets/22d7d108-7aeb-4573-9748-2500bcf38d9f" />
<img width="750" height="336" alt="Screenshot 2026-03-05 at 11 33 44" src="https://github.com/user-attachments/assets/9415cb68-084b-4f43-9dd7-ef95db228ba8" />
