### PR TITLE
fix(tracemetrics): Metric select field in alerts should use isLoading

### DIFF
--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -216,7 +216,7 @@ export default function EAPMetricsField({
           searchable
           options={isFetching ? previousOptions : (metricOptions ?? [])}
           value={traceMetricSelectValue}
-          loading={isFetching}
+          isLoading={isFetching}
           onInputChange={debouncedSetSearch}
           placeholder={t('Select a metric')}
           noOptionsMessage={() => t('No metrics found')}


### PR DESCRIPTION
Gives the user UI feedback that a search for the metric names is loading. Due to some type stuff, `loading` wasn't rejected when `isLoading` is the true prop we needed to pass. Patching this here for now.