### PR TITLE
fix(logs): simplify CellAction rendering to only be used if needed

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -515,7 +515,6 @@ export function LogsInfiniteTable({
                   embeddedOptions={embeddedOptions}
                   sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                   key={virtualRow.key}
-                  canDeferRenderElements
                   onExpand={handleExpand}
                   onCollapse={handleCollapse}
                   logStart={logStart}

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -221,7 +221,6 @@ describe('logsTableRow', () => {
           sharedHoverTimeoutRef={
             {current: null} as React.MutableRefObject<NodeJS.Timeout | null>
           }
-          canDeferRenderElements
         />
       </ProviderWrapper>,
       {organization, initialRouterConfig}
@@ -258,7 +257,6 @@ describe('logsTableRow', () => {
               current: null,
             } as React.MutableRefObject<NodeJS.Timeout | null>
           }
-          canDeferRenderElements={false}
         />
       </ProviderWrapper>,
       {organization, initialRouterConfig}
@@ -361,7 +359,6 @@ describe('logsTableRow', () => {
               current: null,
             } as React.MutableRefObject<NodeJS.Timeout | null>
           }
-          canDeferRenderElements={false}
         />
       </ProviderWrapper>,
       {organization, initialRouterConfig: initialRouterConfigWithCodeFilePath}
@@ -370,6 +367,7 @@ describe('logsTableRow', () => {
     // Expand the row to show the attributes
     const logTableRow = await screen.findByTestId('log-table-row');
     expect(logTableRow).toBeInTheDocument();
+    await userEvent.hover(logTableRow);
 
     // At this point, useStacktraceLink should not have been called with enabled: true
     expect(stacktraceLinkMock).not.toHaveBeenCalledWith(
@@ -442,7 +440,6 @@ describe('logsTableRow', () => {
               current: null,
             } as React.MutableRefObject<NodeJS.Timeout | null>
           }
-          canDeferRenderElements={false}
         />
       </ProviderWrapper>,
       {organization, initialRouterConfig}
@@ -544,7 +541,6 @@ describe('logsTableRow', () => {
               current: null,
             } as React.MutableRefObject<NodeJS.Timeout | null>
           }
-          canDeferRenderElements={false}
         />
       </ProviderWrapper>,
       {organization, initialRouterConfig: initialRouterConfigWithScrubbedFields}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -109,7 +109,6 @@ type LogsRowProps = {
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
   blockRowExpanding?: boolean;
-  canDeferRenderElements?: boolean;
   embedded?: boolean;
   embeddedOptions?: {
     openWithExpandedIds?: string[];
@@ -157,7 +156,6 @@ export const LogRowContent = memo(function LogRowContent({
   onCollapse,
   onExpandHeight,
   blockRowExpanding,
-  canDeferRenderElements,
   onEmbeddedRowClick,
   logStart,
   logEnd,
@@ -170,18 +168,7 @@ export const LogRowContent = memo(function LogRowContent({
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
-  const [shouldRenderHoverElements, _setShouldRenderHoverElements] = useState(
-    canDeferRenderElements ? false : true
-  );
-
-  const setShouldRenderHoverElements = useCallback(
-    (value: boolean) => {
-      if (canDeferRenderElements) {
-        _setShouldRenderHoverElements(value);
-      }
-    },
-    [canDeferRenderElements, _setShouldRenderHoverElements]
-  );
+  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
 
   // This only applies in embedded views where clicking doesn't expand row details.
   function onClick(event: SyntheticEvent) {
@@ -405,9 +392,14 @@ export const LogRowContent = memo(function LogRowContent({
             type: FieldValueType.STRING,
           };
 
+          const shouldRenderActions =
+            !embedded &&
+            field !== OurLogKnownFieldKey.TIMESTAMP &&
+            shouldRenderHoverElements;
+
           return (
             <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
-              {shouldRenderHoverElements ? (
+              {shouldRenderActions ? (
                 <CellAction
                   column={discoverColumn}
                   dataRow={dataRow as unknown as TableDataRow}
@@ -433,11 +425,7 @@ export const LogRowContent = memo(function LogRowContent({
                         break;
                     }
                   }}
-                  allowActions={
-                    field === OurLogKnownFieldKey.TIMESTAMP || embedded
-                      ? []
-                      : ALLOWED_CELL_ACTIONS
-                  }
+                  allowActions={ALLOWED_CELL_ACTIONS}
                   triggerType={ActionTriggerType.ELLIPSIS}
                 >
                   {renderedField}


### PR DESCRIPTION
This applies two streamlinings:

1. Removes the `canDeferRenderElements` prop, so deferred rendering again always becomes available...
2. ...but skips using `CellActions` when there won't be any actions anyway, such as in (static?) embedded tables

Part of LOGS-589.