### PR TITLE
ref(dashboards): Standardize table minH across prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/ai/aiAgentsOverview.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
 
@@ -181,7 +182,7 @@ const AGENTS_TRACES_TABLE = {
     y: 6,
     w: 6,
     h: 4,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview.ts
@@ -4,6 +4,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/backendOverview/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SupportedDatabaseSystem} from 'sentry/views/insights/database/utils/constants';
 import {OVERVIEW_PAGE_ALLOWED_OPS} from 'sentry/views/insights/pages/backend/settings';
@@ -273,7 +274,7 @@ const TRANSACTIONS_TABLE: Widget = {
     x: 0,
     w: 6,
     h: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
     y: 7,
   },
 };

--- a/static/app/views/dashboards/utils/prebuiltConfigs/caches/caches.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/caches/caches.ts
@@ -2,6 +2,7 @@ import {t} from 'sentry/locale';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/caches/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -101,7 +102,7 @@ const TRANSACTION_TABLE: Widget = {
     y: 3,
     w: 6,
     h: 6,
-    minH: 6,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssets.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssets.ts
@@ -4,6 +4,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendAssets/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {DEFAULT_RESOURCE_TYPES} from 'sentry/views/insights/browser/resources/settings';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -97,7 +98,7 @@ const ASSETS_TABLE: Widget = {
     y: 2,
     w: 6,
     h: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendOverview/frontendOverview.ts
@@ -7,6 +7,7 @@ import {
   DASHBOARD_TITLE,
   FRONTEND_SDK_NAMES,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/frontendOverview/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SCORE_BREAKDOWN_WHEEL_WIDGET} from 'sentry/views/dashboards/widgetLibrary/webVitalsWidgets';
 import {getResourcesEventViewQuery} from 'sentry/views/insights/browser/common/queries/useResourcesQuery';
@@ -232,7 +233,7 @@ const TRANSACTIONS_TABLE: Widget = {
     y: 7,
     w: 6,
     h: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -15,6 +15,7 @@ import {
   RESPONSE_CODES_TEXT,
   THROUGHPUT_TEXT,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/http/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import type {DefaultDetailWidgetFields} from 'sentry/views/dashboards/widgets/detailsWidget/types';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
@@ -300,7 +301,7 @@ const TRANSACTIONS_TABLE: Widget = {
   layout: {
     x: 0,
     y: 4,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
     h: 5,
     w: 6,
   },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/http.ts
@@ -16,6 +16,7 @@ import {
   RESPONSE_CODES_TEXT,
   THROUGHPUT_TEXT,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/http/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {DataTitles} from 'sentry/views/insights/common/views/spans/types';
 import {SpanFields} from 'sentry/views/insights/types';
@@ -158,7 +159,7 @@ const DOMAIN_TABLE: Widget = {
   layout: {
     x: 0,
     y: 2,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
     h: 4,
     w: 6,
   },

--- a/static/app/views/dashboards/utils/prebuiltConfigs/laravelOverview/laravelOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/laravelOverview/laravelOverview.ts
@@ -7,6 +7,7 @@ import {
   BACKEND_OVERVIEW_SECOND_ROW_WIDGETS,
 } from 'sentry/views/dashboards/utils/prebuiltConfigs/backendOverview/backendOverview';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/laravelOverview/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {SpanFields} from 'sentry/views/insights/types';
 
 const PATHS_TABLE: Widget = {
@@ -56,7 +57,7 @@ const PATHS_TABLE: Widget = {
     y: 7,
     w: 6,
     h: 2,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 
@@ -102,7 +103,7 @@ const COMMANDS_TABLE: Widget = {
     y: 9,
     w: 6,
     h: 2,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 
@@ -150,7 +151,7 @@ const JOBS_TABLE: Widget = {
     y: 11,
     w: 6,
     h: 2,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/mobileVitals.ts
@@ -3,6 +3,7 @@ import {FieldKind} from 'sentry/utils/fields';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
 import type {Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {SpanFields} from 'sentry/views/insights/types';
 
 const TRANSACTION_OP_CONDITION = `${SpanFields.TRANSACTION_OP}:[ui.load,navigation]`;
@@ -328,7 +329,7 @@ const APP_START_TABLE: Widget = {
     x: 0,
     y: 2,
     w: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 
@@ -378,7 +379,7 @@ const SCREEN_RENDERING_TABLE: Widget = {
     x: 0,
     y: 8,
     w: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 
@@ -422,7 +423,7 @@ const SCREEN_LOAD_TABLE: Widget = {
     x: 0,
     y: 5,
     w: 6,
-    minH: 2,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/nextJsOverview/nextJsOverview.ts
@@ -4,6 +4,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/types';
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/nextJsOverview/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {RAGE_AND_DEAD_CLICKS_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/rageAndDeadClicksWidget';
 import {SERVER_TREE_WIDGET_TEMPLATE} from 'sentry/views/dashboards/widgetLibrary/serverTreeWidget';
@@ -176,7 +177,7 @@ const CLIENT_TRANSACTIONS_TABLE: Widget = {
     y: 5,
     w: 6,
     h: 3,
-    minH: 3,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 
@@ -227,7 +228,7 @@ const SERVER_TRANSACTIONS_TABLE: Widget = {
     y: 8,
     w: 6,
     h: 3,
-    minH: 3,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/queues/queues.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/queues/queues.ts
@@ -4,6 +4,7 @@ import {DisplayType, WidgetType, type Widget} from 'sentry/views/dashboards/type
 import type {PrebuiltDashboard} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {QUEUE_CHARTS} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/queueCharts';
 import {DASHBOARD_TITLE} from 'sentry/views/dashboards/utils/prebuiltConfigs/queues/settings';
+import {TABLE_MIN_HEIGHT} from 'sentry/views/dashboards/utils/prebuiltConfigs/settings';
 import {spaceWidgetsEquallyOnRow} from 'sentry/views/dashboards/utils/prebuiltConfigs/utils/spaceWidgetsEquallyOnRow';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -70,7 +71,7 @@ const DESTINATION_TABLE: Widget = {
     y: 3,
     w: 6,
     h: 6,
-    minH: 6,
+    minH: TABLE_MIN_HEIGHT,
   },
 };
 

--- a/static/app/views/dashboards/utils/prebuiltConfigs/settings.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/settings.ts
@@ -1,0 +1,4 @@
+/**
+ * Minimum height (in grid rows) for table widgets in prebuilt dashboards.
+ */
+export const TABLE_MIN_HEIGHT = 2;


### PR DESCRIPTION
Extracts a shared `TABLE_MIN_HEIGHT` constant (set to 2) and applies it to all table widgets across every prebuilt dashboard config.

Some prebuilt tables previously had `minH` values of 3 or 6, which prevented users from shrinking them after duplicating a prebuilt dashboard. With a consistent `minH` of 2, users can adjust table heights to fit their needs when they duplicate and customize prebuilt dashboards.

Affected dashboards: Laravel Overview, Backend Overview, Queues, Caches, Next.js Overview, HTTP, HTTP Domain Summary, Frontend Overview, Frontend Assets, Mobile Vitals, AI Agents Overview.