### PR TITLE
fix(tracemetrics): Properly handle duration scaling in alerts

### DIFF
--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -10,13 +10,20 @@ import type {
   DataUnit,
   RateUnit,
 } from 'sentry/utils/discover/fields';
-import {ABYTE_UNITS, SizeUnit} from 'sentry/utils/discover/fields';
+import {
+  ABYTE_UNITS,
+  DURATION_UNIT_MULTIPLIERS,
+  SizeUnit,
+} from 'sentry/utils/discover/fields';
 import {axisDuration} from 'sentry/utils/duration/axisDuration';
 import getDuration from 'sentry/utils/duration/getDuration';
 import {formatAbbreviatedNumber, formatRate} from 'sentry/utils/formatters';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
 import {convertSize} from 'sentry/utils/unitConversion/convertSize';
-import {isASizeUnit} from 'sentry/views/dashboards/widgets/common/typePredicates';
+import {
+  isADurationUnit,
+  isASizeUnit,
+} from 'sentry/views/dashboards/widgets/common/typePredicates';
 
 import {categorizeDuration} from './categorizeDuration';
 
@@ -52,8 +59,14 @@ export function tooltipFormatterUsingAggregateOutputType(
       return value.toLocaleString();
     case 'percentage':
       return formatPercentage(value, 2);
-    case 'duration':
-      return getDuration(value / 1000, 2, true);
+    case 'duration': {
+      const durationUnitString = unit ?? undefined;
+      const durationMultiplier = isADurationUnit(durationUnitString)
+        ? DURATION_UNIT_MULTIPLIERS[durationUnitString]
+        : 1; // default to milliseconds
+      const valueInMs = value * durationMultiplier;
+      return getDuration(valueInMs / 1000, 2, true);
+    }
     case 'size': {
       const unitString = unit ?? undefined;
       const resolvedUnit = isASizeUnit(unitString) ? unitString : SizeUnit.BYTE;
@@ -116,8 +129,14 @@ export function axisLabelFormatterUsingAggregateOutputType(
       return abbreviation ? formatAbbreviatedNumber(value) : value.toLocaleString();
     case 'percentage':
       return formatPercentage(value, decimalPlaces);
-    case 'duration':
-      return axisDuration(value, durationUnit);
+    case 'duration': {
+      const durationDataUnit = sizeUnit ?? undefined;
+      const durationMult = isADurationUnit(durationDataUnit)
+        ? DURATION_UNIT_MULTIPLIERS[durationDataUnit]
+        : 1; // default to milliseconds
+      const valueInMs = value * durationMult;
+      return axisDuration(valueInMs, durationUnit);
+    }
     case 'size': {
       const unitString = sizeUnit ?? undefined;
       const resolvedUnit = isASizeUnit(unitString) ? unitString : SizeUnit.BYTE;
@@ -188,13 +207,20 @@ export function findRangeOfMultiSeries(series: Series[], legend?: LegendComponen
  */
 export function getDurationUnit(
   series: Series[],
-  legend?: LegendComponentOption
+  legend?: LegendComponentOption,
+  dataUnit?: DataUnit
 ): number {
   let durationUnit = 0;
   const range = findRangeOfMultiSeries(series, legend);
   if (range) {
-    const avg = (range.max + range.min) / 2;
-    durationUnit = categorizeDuration((range.max - range.min) / 5); // avg of 5 yAxis ticks per chart
+    const unitString = dataUnit ?? undefined;
+    const multiplier = isADurationUnit(unitString)
+      ? DURATION_UNIT_MULTIPLIERS[unitString]
+      : 1; // default to milliseconds
+    const min = range.min * multiplier;
+    const max = range.max * multiplier;
+    const avg = (max + min) / 2;
+    durationUnit = categorizeDuration((max - min) / 5); // avg of 5 yAxis ticks per chart
 
     const numOfDigits = (avg / durationUnit).toFixed(0).length;
     if (numOfDigits > 6) {

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -246,9 +246,10 @@ export default class ThresholdsChart extends PureComponent<Props> {
     // to inferring from the aggregate string when not available.
     const outputType =
       timeseriesResultsTypes?.[aggregate] ?? aggregateOutputType(aggregate);
+    const dataUnit = timeseriesResultsUnits?.[aggregate];
     const isDurationChart = outputType === 'duration';
     const durationUnit = isDurationChart
-      ? getDurationUnit(dataWithoutRecentBucket)
+      ? getDurationUnit(dataWithoutRecentBucket, undefined, dataUnit)
       : undefined;
     const rateUnit = Object.values(RateUnit).includes(
       timeseriesResultsUnits?.[aggregate] as RateUnit
@@ -345,7 +346,9 @@ export default class ThresholdsChart extends PureComponent<Props> {
                 outputType,
                 true,
                 durationUnit,
-                rateUnit
+                rateUnit,
+                0,
+                dataUnit
               );
             }
             return alertAxisFormatter(value, data[0]!.seriesName, aggregate);


### PR DESCRIPTION
These formatters were expecting that the durations provided were always in `ms` since downstream there's a helper that expected seconds. I've just updated the code so we normalize anything (days, weeks, etc) to `ms` which then we can pass properly to the helpers for the tooltip and yAxis formatter functions.

You can test like this:
- Go to https://sentry-test.sentry.io/issues/alerts/new/metric/?aggregate=sum%28value%29&dataset=events_analytics_platform&eventTypes=trace_item_metric&project=nar-node&referrer=alert_stream
- Select `page.load_time` as your metric. I've sent in a number of values as `weeks` but it renders as `ms`
  - e.g. you can check `min(page.load_time)` 
- Doing the same on this branch on the Sentry test org shows the yAxis as `weeks` and the tooltip says years (which is right, I just made a script that sent 95 weeks as the minimum value)