### PR TITLE
fix(auth): Show warning when authenticated user isn't an org member

### DIFF
--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -81,6 +81,19 @@ class AuthOrganizationLoginView(AuthLoginView):
         except AuthProvider.DoesNotExist:
             auth_provider = None
 
+        if request.user.is_authenticated:
+            membership = organization_service.check_membership_by_id(
+                organization_id=organization.id, user_id=request.user.id
+            )
+            if membership is None:
+                messages.add_message(
+                    request,
+                    messages.WARNING,
+                    f"Your account ({request.user.email}) is not a member of the "
+                    f"{organization.name} organization. Ask an organization admin to "
+                    f"invite you, or sign in with a different account.",
+                )
+
         session_expired = "session_expired" in request.COOKIES
         if session_expired:
             messages.add_message(request, messages.WARNING, WARN_SESSION_EXPIRED)

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -81,7 +81,7 @@ class AuthOrganizationLoginView(AuthLoginView):
         except AuthProvider.DoesNotExist:
             auth_provider = None
 
-        if request.user.is_authenticated:
+        if request.method == "GET" and request.user.is_authenticated:
             membership = organization_service.check_membership_by_id(
                 organization_id=organization.id, user_id=request.user.id
             )

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -71,6 +71,15 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert len(messages) == 1
         assert "is not a member of the" in str(messages[0])
 
+    def test_no_non_member_warning_on_post(self) -> None:
+        non_member = self.create_user("nonmember@example.com")
+        self.login_as(non_member)
+        AuthProvider.objects.create(organization_id=self.organization.id, provider="dummy")
+        resp = self.client.post(self.path, {"init": True})
+
+        assert resp.status_code == 200
+        assert "is not a member of the" not in resp.content.decode("utf-8")
+
     def test_renders_session_expire_message(self) -> None:
         self.client.cookies["session_expired"] = "1"
         resp = self.client.get(self.path)

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -61,6 +61,16 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
         assert resp.context["join_request_link"] is None
 
+    def test_renders_non_member_warning(self) -> None:
+        non_member = self.create_user("nonmember@example.com")
+        self.login_as(non_member)
+        resp = self.client.get(self.path)
+
+        assert resp.status_code == 200
+        messages = list(resp.context["messages"])
+        assert len(messages) == 1
+        assert "is not a member of the" in str(messages[0])
+
     def test_renders_session_expire_message(self) -> None:
         self.client.cookies["session_expired"] = "1"
         resp = self.client.get(self.path)


### PR DESCRIPTION
## Summary

- When an authenticated user lands on an org login page but isn't a member of that org, they now see a warning message explaining the situation and suggesting next steps (ask for an invite or sign in with a different account).
- Previously, completing OAuth for a non-member org silently redirected back to the login page with no feedback, causing a confusing loop.

## Test plan

- Added `test_renders_non_member_warning` to verify the warning message appears for authenticated non-members.
- Verified existing tests (`test_renders_basic`, `test_renders_session_expire_message`) still pass.