### PR TITLE
fix(onboarding): Fix CopyDsnField markdown + hide copy button with AI setup

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/contentBlocks/types.tsx
@@ -70,6 +70,13 @@ type ListBlock = BaseBlock<'list'> & {
 type CustomBlock = BaseBlock<'custom'> & {
   content: React.ReactNode;
   bottomMargin?: boolean;
+  /**
+   * Optional markdown representation of this custom block's content.
+   * Because `reactNodeToText` cannot extract rendered output from
+   * component elements, provide this when the custom block renders
+   * a component whose content should appear in the copied markdown.
+   */
+  markdown?: string;
 };
 
 export type ContentBlock =

--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -6,7 +6,7 @@ import TextCopyInput from 'sentry/components/textCopyInput';
 import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
-export function CopyDsnField({params}: {params: DocsParams<any>}) {
+function CopyDsnField({params}: {params: DocsParams<any>}) {
   return (
     <Wrapper>
       <p>
@@ -39,7 +39,13 @@ export function copyDsnFieldBlock(params: DocsParams<any>): ContentBlock {
   return {
     type: 'custom',
     content: <CopyDsnField params={params} />,
-    markdown: `${t("If you already have the configuration for Sentry in your application, and just need this project's (%s) DSN, you can find it below:", params.project.slug)}\n\n\`\`\`\n${params.dsn.public}\n\`\`\``,
+    markdown: [
+      t(
+        "If you already have the configuration for Sentry in your application, and just need this project's (%s) DSN, you can find it below:",
+        params.project.slug
+      ),
+      `\`\`\`\n${params.dsn.public}\n\`\`\``,
+    ].join('\n\n'),
   };
 }
 

--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 
+import type {ContentBlock} from 'sentry/components/onboarding/gettingStartedDoc/contentBlocks/types';
 import type {DocsParams} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import TextCopyInput from 'sentry/components/textCopyInput';
-import {tct} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
 export function CopyDsnField({params}: {params: DocsParams<any>}) {
@@ -28,6 +29,18 @@ export function CopyDsnField({params}: {params: DocsParams<any>}) {
       </TextCopyInput>
     </Wrapper>
   );
+}
+
+/**
+ * Returns a `custom` content block for `CopyDsnField` with a `markdown`
+ * representation so the DSN is included in copied markdown output.
+ */
+export function copyDsnFieldBlock(params: DocsParams<any>): ContentBlock {
+  return {
+    type: 'custom',
+    content: <CopyDsnField params={params} />,
+    markdown: `${t("If you already have the configuration for Sentry in your application, and just need this project's (%s) DSN, you can find it below:", params.project.slug)}\n\n\`\`\`\n${params.dsn.public}\n\`\`\``,
+  };
 }
 
 const Wrapper = styled('div')`

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.spec.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.spec.tsx
@@ -1,0 +1,99 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {OnboardingLayout} from 'sentry/components/onboarding/gettingStartedDoc/onboardingLayout';
+import type {
+  Docs,
+  OnboardingConfig,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+function makeDocsConfig(overrides: Partial<OnboardingConfig> = {}): Docs {
+  const base: OnboardingConfig = {
+    install: () => [
+      {
+        type: StepType.INSTALL,
+        content: [{type: 'text', text: 'Install the SDK'}],
+      },
+    ],
+    configure: () => [],
+    verify: () => [],
+    ...overrides,
+  };
+  return {onboarding: base};
+}
+
+function renderLayout(docsConfig: Docs, features: string[] = []) {
+  const organization = OrganizationFixture({features});
+  const project = ProjectFixture({organization});
+
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/sdks/`,
+    body: {},
+  });
+
+  MockApiClient.addMockResponse({
+    url: `/projects/${organization.slug}/${project.slug}/keys/test-key/`,
+    method: 'PUT',
+    body: [],
+  });
+
+  return render(
+    <OnboardingLayout
+      docsConfig={docsConfig}
+      project={project}
+      dsn={{
+        public: 'test-dsn',
+        secret: 'test-secret',
+        cdn: 'test-cdn',
+        crons: 'test-crons',
+        security: 'test-security',
+        csp: 'test-csp',
+        minidump: 'test-minidump',
+        unreal: 'test-unreal',
+        playstation: 'test-playstation',
+        integration: 'test-integration',
+        otlp_traces: 'test-otlp_traces',
+        otlp_logs: 'test-otlp_logs',
+      }}
+      platformKey="javascript"
+      projectKeyId="test-key"
+    />,
+    {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/projects/${project.slug}/getting-started/`,
+        },
+        route: `/organizations/:orgId/projects/:projectId/getting-started/`,
+      },
+    }
+  );
+}
+
+describe('OnboardingLayout', () => {
+  describe('hideInstructionsCopy', () => {
+    const COPY_FEATURE = 'onboarding-copy-setup-instructions-project-creation';
+
+    it('shows copy instructions button when feature flag is enabled', () => {
+      renderLayout(makeDocsConfig(), [COPY_FEATURE]);
+      expect(screen.getByRole('button', {name: 'Copy instructions'})).toBeInTheDocument();
+    });
+
+    it('hides copy instructions button when hideInstructionsCopy is set', () => {
+      renderLayout(makeDocsConfig({hideInstructionsCopy: true}), [COPY_FEATURE]);
+      expect(
+        screen.queryByRole('button', {name: 'Copy instructions'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides copy instructions button when feature flag is not enabled', () => {
+      renderLayout(makeDocsConfig());
+      expect(
+        screen.queryByRole('button', {name: 'Copy instructions'})
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -184,13 +184,16 @@ export function OnboardingLayout({
           <Divider withBottomMargin />
           <div>
             {steps.map((step, index) => {
-              const copyButton =
-                copyEnabled && index === 0 ? (
-                  <OnboardingCopyMarkdownButton
-                    steps={steps}
-                    source={newOrg ? 'first_time_setup' : 'project_getting_started'}
-                  />
-                ) : null;
+              const showCopy =
+                copyEnabled &&
+                index === 0 &&
+                !(docsConfig[configType] ?? docsConfig.onboarding)?.hideInstructionsCopy;
+              const copyButton = showCopy ? (
+                <OnboardingCopyMarkdownButton
+                  steps={steps}
+                  source={newOrg ? 'first_time_setup' : 'project_getting_started'}
+                />
+              ) : null;
 
               const trailingItems = copyButton ? (
                 step.trailingItems ? (

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -160,6 +160,9 @@ export function OnboardingLayout({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const hideInstructionsCopy = (docsConfig[configType] ?? docsConfig.onboarding)
+    ?.hideInstructionsCopy;
+
   return (
     <AuthTokenGeneratorProvider projectSlug={project.slug}>
       <TabSelectionScope>
@@ -184,10 +187,7 @@ export function OnboardingLayout({
           <Divider withBottomMargin />
           <div>
             {steps.map((step, index) => {
-              const showCopy =
-                copyEnabled &&
-                index === 0 &&
-                !(docsConfig[configType] ?? docsConfig.onboarding)?.hideInstructionsCopy;
+              const showCopy = copyEnabled && index === 0 && !hideInstructionsCopy;
               const copyButton = showCopy ? (
                 <OnboardingCopyMarkdownButton
                   steps={steps}

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -161,7 +161,14 @@ export interface OnboardingConfig<
     onProductSelectionLoad?: (products: ProductSolution[]) => void;
   },
   DocsParams<PlatformOptions>
-> {}
+> {
+  /**
+   * When true, the "Copy instructions" button is hidden for this guide.
+   * Use when the guide includes its own copy mechanism
+   * (e.g. AI-assisted setup prompt).
+   */
+  hideInstructionsCopy?: boolean;
+}
 
 export interface Docs<PlatformOptions extends BasePlatformOptions = BasePlatformOptions> {
   onboarding: OnboardingConfig<PlatformOptions>;

--- a/static/app/components/onboarding/utils/stepsToMarkdown.spec.tsx
+++ b/static/app/components/onboarding/utils/stepsToMarkdown.spec.tsx
@@ -412,6 +412,15 @@ describe('contentBlockToMarkdown', () => {
     const result = contentBlockToMarkdown(block);
     expect(result).toContain('Custom React content');
   });
+
+  it('prefers CustomBlock markdown field over content', () => {
+    const block: ContentBlock = {
+      type: 'custom',
+      content: React.createElement('div', null, 'Rendered UI'),
+      markdown: 'DSN: `https://key@sentry.io/123`',
+    };
+    expect(contentBlockToMarkdown(block)).toBe('DSN: `https://key@sentry.io/123`');
+  });
 });
 
 describe('stepsToMarkdown', () => {

--- a/static/app/components/onboarding/utils/stepsToMarkdown.tsx
+++ b/static/app/components/onboarding/utils/stepsToMarkdown.tsx
@@ -300,7 +300,7 @@ export function contentBlockToMarkdown(
         .join('\n\n');
 
     case 'custom':
-      return reactNodeToText(block.content);
+      return block.markdown ?? reactNodeToText(block.content);
 
     default:
       return '';

--- a/static/app/gettingStartedDocs/android/onboarding.tsx
+++ b/static/app/gettingStartedDocs/android/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
@@ -77,10 +77,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/apple-ios/onboarding.tsx
+++ b/static/app/gettingStartedDocs/apple-ios/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 import {getWizardInstallSnippet} from 'sentry/utils/gettingStartedDocs/mobileWizard';
@@ -78,10 +78,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/flutter/onboarding.tsx
+++ b/static/app/gettingStartedDocs/flutter/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   BasePlatformOptions,
   DocsParams,
@@ -93,10 +93,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   DocsParams,
   OnboardingConfig,
@@ -51,10 +51,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
     getAISetupStep({skillPath: 'sentry-nextjs-sdk'}),

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
@@ -12,6 +12,7 @@ import {t, tct} from 'sentry/locale';
 import {getInstallSnippet} from './utils';
 
 export const onboarding: OnboardingConfig = {
+  hideInstructionsCopy: true,
   install: (params: DocsParams) => [
     {
       title: t('Automatic Configuration (Recommended)'),

--- a/static/app/gettingStartedDocs/javascript-nuxt/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   DocsParams,
   OnboardingConfig,
@@ -33,10 +33,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.tsx
@@ -2,7 +2,7 @@ import {Fragment} from 'react';
 
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   DocsParams,
   OnboardingConfig,
@@ -67,10 +67,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
@@ -43,6 +43,7 @@ function ErrorButton() {
 };
 
 export const onboarding: OnboardingConfig = {
+  hideInstructionsCopy: true,
   introduction: () =>
     tct(
       "In this quick guide you'll use [strong:npm], [strong:yarn], or [strong:pnpm] to set up:",

--- a/static/app/gettingStartedDocs/javascript-remix/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {
   DocsParams,
   OnboardingConfig,
@@ -43,10 +43,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
@@ -30,10 +30,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],

--- a/static/app/gettingStartedDocs/javascript/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript/onboarding.tsx
@@ -8,6 +8,7 @@ import {
 } from './utils';
 
 export const onboarding: OnboardingConfig<PlatformOptions> = {
+  hideInstructionsCopy: true,
   introduction: params =>
     isAutoInstall(params)
       ? loaderScriptOnboarding.introduction?.(params)

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -185,6 +185,7 @@ const getVerifyConfig = (params: Params) => [
 ];
 
 export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
+  hideInstructionsCopy: true,
   introduction: () =>
     tct("In this quick guide you'll use our [strong: Loader Script] to set up:", {
       strong: <strong />,
@@ -382,6 +383,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
 };
 
 export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
+  hideInstructionsCopy: true,
   introduction: () =>
     tct(
       "In this quick guide you'll use [strong:npm], [strong:yarn], or [strong:pnpm] to set up:",

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -185,7 +185,6 @@ const getVerifyConfig = (params: Params) => [
 ];
 
 export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
-  hideInstructionsCopy: true,
   introduction: () =>
     tct("In this quick guide you'll use our [strong: Loader Script] to set up:", {
       strong: <strong />,
@@ -383,7 +382,6 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
 };
 
 export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
-  hideInstructionsCopy: true,
   introduction: () =>
     tct(
       "In this quick guide you'll use [strong:npm], [strong:yarn], or [strong:pnpm] to set up:",

--- a/static/app/gettingStartedDocs/node/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.tsx
@@ -31,6 +31,7 @@ server.listen(3000, "127.0.0.1");
 `;
 
 export const onboarding: OnboardingConfig = {
+  hideInstructionsCopy: true,
   introduction: () =>
     tct("In this quick guide you'll use [strong:npm] or [strong:yarn] to set up:", {
       strong: <strong />,

--- a/static/app/gettingStartedDocs/react-native/onboarding.tsx
+++ b/static/app/gettingStartedDocs/react-native/onboarding.tsx
@@ -1,6 +1,6 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {CopyDsnField} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
+import {copyDsnFieldBlock} from 'sentry/components/onboarding/gettingStartedDoc/copyDsnField';
 import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
@@ -58,10 +58,7 @@ export const onboarding: OnboardingConfig = {
             }
           ),
         },
-        {
-          type: 'custom',
-          content: <CopyDsnField params={params} />,
-        },
+        copyDsnFieldBlock(params),
       ],
     },
   ],


### PR DESCRIPTION
Fixes VDY-16

## Summary

- **CopyDsnField missing from copied markdown**: The `CopyDsnField` component rendered as a `custom` content block was invisible to `reactNodeToText` because the DSN text lives inside the component's render function, not in `props.children`. Added an optional `markdown` field to `CustomBlock` and a `copyDsnFieldBlock(params)` helper that provides both the rendered component and the markdown string. Updated all 9 onboarding configs.
- **Hide "Copy instructions" when AI setup step is present**: Guides with `getAISetupStep` (which has its own "Copy Prompt" button) also showed the "Copy instructions" button. Added `hideInstructionsCopy` to `OnboardingConfig` and set it on the 5 configs that use `getAISetupStep`.

## Test plan

- [ ] Verify copied markdown from onboarding guides now includes the DSN field content
- [ ] Verify "Copy instructions" button is hidden on guides with AI-assisted setup step (javascript-nextjs, node, javascript-react, javascript)
- [ ] Verify "Copy instructions" button still appears on guides without AI setup step