### PR TITLE
fix(search): Respect event-level filters when sorting issues by last seen

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -47,6 +47,11 @@ from sentry.utils.snuba import SnubaQueryParams, aliased_query_params, bulk_raw_
 
 FIRST_RELEASE_FILTERS = ["first_release", "firstRelease"]
 
+# Filter keys that apply to individual events rather than group attributes. When any of these
+# are present, we must use Snuba for sort-by-date so that last_seen is computed over
+# matching events only (e.g. level:fatal → last seen among fatal events).
+EVENT_LEVEL_FILTER_KEYS = frozenset({"level"})
+
 
 class TrendsSortWeights(TypedDict):
     log_level: int
@@ -804,12 +809,15 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         # If the requested sort is `date` (`last_seen`) and there
         # are no other Snuba-based search predicates, we can simply
         # return the results from Postgres.
+        # Do not use Postgres when event-level filters (e.g. level) are present, so that
+        # last_seen ordering reflects the last matching event, not the group's overall last_seen.
         if (
             # XXX: Don't enable this for now, it doesn't properly respect issue platform rules for hiding issue types.
             # We'll need to consolidate where we apply the type filters if we do want this.
             allow_postgres_only_search
             and cursor is None
             and sort_by == "date"
+            and not any(sf.key.name in EVENT_LEVEL_FILTER_KEYS for sf in (search_filters or ()))
             and
             # This handles tags and date parameters for search filters.
             not [

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -959,6 +959,65 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == {self.group1}
 
+    def test_sort_by_last_seen_respects_event_level_filter(self) -> None:
+        """Sort by date with level:fatal must order by last fatal event, not group.last_seen."""
+        # Group A: fatal at T1, then warning at T2 (T2 > T1) -> group A.last_seen = T2
+        # Group B: fatal at T3 (T1 < T3 < T2) -> group B.last_seen = T3
+        # With level:fatal, correct order is B first (last fatal T3), then A (last fatal T1).
+        # Wrong (postgres) order would be A first (group.last_seen T2), then B (T3).
+        proj = self.create_project(organization=self.project.organization)
+        t1 = before_now(days=5)
+        t2 = before_now(days=1)
+        t3 = before_now(days=3)
+
+        event_a_fatal = self.store_event(
+            data={
+                "fingerprint": ["level-sort-group-a"],
+                "message": "group a fatal",
+                "timestamp": t1.isoformat(),
+                "level": "fatal",
+                "stacktrace": {"frames": [{"module": "a"}]},
+            },
+            project_id=proj.id,
+        )
+        group_a = event_a_fatal.group
+        self.store_event(
+            data={
+                "fingerprint": ["level-sort-group-a"],
+                "message": "group a warning",
+                "timestamp": t2.isoformat(),
+                "level": "warning",
+                "stacktrace": {"frames": [{"module": "a"}]},
+            },
+            project_id=proj.id,
+        )
+        group_a.update(last_seen=t2)  # group's last_seen is the warning event
+        self.store_group(group_a)
+
+        event_b_fatal = self.store_event(
+            data={
+                "fingerprint": ["level-sort-group-b"],
+                "message": "group b fatal",
+                "timestamp": t3.isoformat(),
+                "level": "fatal",
+                "stacktrace": {"frames": [{"module": "b"}]},
+            },
+            project_id=proj.id,
+        )
+        group_b = event_b_fatal.group
+        self.store_group(group_b)
+
+        results = self.make_query(
+            projects=[proj],
+            search_filter_query="level:fatal",
+            sort_by="date",
+        )
+        result_list = list(results)
+        assert len(result_list) == 2
+        # B's last fatal is t3, A's last fatal is t1; t3 > t1 so B must be first
+        assert result_list[0].id == group_b.id
+        assert result_list[1].id == group_a.id
+
     def test_date_filter(self) -> None:
         results = self.make_query(
             date_from=self.event2.datetime,


### PR DESCRIPTION
When users filter the issue list by event-level attributes (e.g. `level:fatal`) and sort by date (last seen), the order was not respecting the filter: results were ordered by the group’s overall `last_seen` from Postgres instead of the last event that matched the filter.

**Change:** Skip the postgres-only optimization path when any event-level filter key (e.g. `level`) is present. The search then uses Snuba, which computes `last_seen` as `max(timestamp)` over events that match the query, so sort-by-date reflects "last seen among matching events."

**Testing:** Added `test_sort_by_last_seen_respects_event_level_filter` which creates two groups with different "last fatal" timestamps and asserts that `level:fatal` + sort by date orders by last fatal event, not by `group.last_seen`.

Refs [ISWF-648](https://linear.app/getsentry/issue/ISWF-648/last-seen-issue-sort-not-respecting-event-level-filtering)

Made with [Cursor](https://cursor.com)