### PR TITLE
feat(explore): Prioritize known fields in group by dropdown

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -13,6 +13,7 @@ import {IconAdd} from 'sentry/icons/iconAdd';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
+import {getFieldDefinition} from 'sentry/utils/fields';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
@@ -42,6 +43,7 @@ interface ToolbarGroupByDropdownProps {
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
   options: Array<SelectOption<string>>;
+  fieldDefinitionType?: Parameters<typeof getFieldDefinition>[1];
   loading?: boolean;
   onClose?: () => void;
   onSearch?: (search: string) => void;
@@ -56,6 +58,7 @@ export function ToolbarGroupByDropdown({
   onSearch,
   loading,
   onClose,
+  fieldDefinitionType = 'span',
 }: ToolbarGroupByDropdownProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
@@ -93,7 +96,23 @@ export function ToolbarGroupByDropdown({
         options={options}
         value={column.column ?? ''}
         onChange={handleColumnChange}
-        search={{onChange: onSearch}}
+        search={{
+          onChange: onSearch,
+          filter: (option, search) => {
+            const text =
+              option.textValue ?? (typeof option.label === 'string' ? option.label : '');
+            const normalizedText = text.toLowerCase();
+            const normalizedSearch = search.toLowerCase();
+            if (!normalizedText.includes(normalizedSearch)) {
+              return {score: 0};
+            }
+            const isExact = normalizedText === normalizedSearch;
+            const isKnown =
+              getFieldDefinition(String(option.value), fieldDefinitionType) !== null;
+            // exact+known=4, exact+unknown=3, partial+known=2, partial+unknown=1
+            return {score: (isExact ? 2 : 0) + (isKnown ? 2 : 1)};
+          },
+        }}
         trigger={triggerProps => (
           <OverlayTrigger.Button {...triggerProps} style={{width: '100%'}}>
             {label}

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -5,7 +5,7 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import {FieldKind, prettifyTagKey} from 'sentry/utils/fields';
+import {FieldKind, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
 import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
 import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -66,6 +66,13 @@ export function useGroupByFields({
         return true;
       })
       .toSorted((a, b) => {
+        const aKnown =
+          getFieldDefinition(a.value, TRACE_ITEM_FIELD_DEFINITION_TYPE[traceItemType]) !==
+          null;
+        const bKnown =
+          getFieldDefinition(b.value, TRACE_ITEM_FIELD_DEFINITION_TYPE[traceItemType]) !==
+          null;
+        if (aKnown !== bKnown) return aKnown ? -1 : 1;
         const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
         const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
         return aLabel.localeCompare(bLabel);
@@ -86,6 +93,14 @@ export function useGroupByFields({
     ];
   }, [booleanTags, groupBys, hideEmptyOption, numberTags, stringTags, traceItemType]);
 }
+
+const TRACE_ITEM_FIELD_DEFINITION_TYPE: Partial<
+  Record<TraceItemDataset, 'span' | 'log' | 'tracemetric'>
+> = {
+  [TraceItemDataset.SPANS]: 'span',
+  [TraceItemDataset.LOGS]: 'log',
+  [TraceItemDataset.TRACEMETRICS]: 'tracemetric',
+};
 
 // Some fields don't make sense to allow users to group by as they create
 // very high cardinality groupings and is not useful.

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -439,6 +439,7 @@ function ToolbarGroupBy() {
               onSearch={onSearch}
               onClose={onClose}
               loading={numberTagsLoading || stringTagsLoading || booleanTagsLoading}
+              fieldDefinitionType="log"
             />
           ))}
           <ToolbarFooter>

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -24,6 +24,7 @@ import {
 } from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {useLogItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
 import {
   OurLogKnownFieldKey,
   type OurLogsAggregate,
@@ -362,46 +363,13 @@ function ToolbarGroupBy() {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
 
-  const options = useMemo(() => {
-    const seen = new Set<string>();
-    return [
-      {
-        label: '\u2014',
-        value: '',
-        textValue: '\u2014',
-      },
-      ...Object.keys(numberTags ?? {}).map(key => {
-        return optionFromTag(
-          {key, name: prettifyTagKey(key), kind: FieldKind.MEASUREMENT},
-          TraceItemDataset.LOGS
-        );
-      }),
-      ...Object.keys(stringTags ?? {}).map(key => {
-        return optionFromTag(
-          {key, name: prettifyTagKey(key), kind: FieldKind.TAG},
-          TraceItemDataset.LOGS
-        );
-      }),
-      ...Object.keys(booleanTags ?? {}).map(key => {
-        return optionFromTag(
-          {key, name: prettifyTagKey(key), kind: FieldKind.BOOLEAN},
-          TraceItemDataset.LOGS
-        );
-      }),
-    ]
-      .filter(option => {
-        // Filtering by value here, so it's based off of explicit tags i.e. `key`
-        // or `tags[<key>, <boolean | number | string>]
-        if (seen.has(option.value)) return false;
-        seen.add(option.value);
-        return true;
-      })
-      .toSorted((a, b) => {
-        const aLabel = prettifyTagKey(a.value);
-        const bLabel = prettifyTagKey(b.value);
-        return aLabel.localeCompare(bLabel);
-      });
-  }, [booleanTags, numberTags, stringTags]);
+  const options = useGroupByFields({
+    numberTags: numberTags ?? {},
+    stringTags: stringTags ?? {},
+    booleanTags: booleanTags ?? {},
+    groupBys,
+    traceItemType: TraceItemDataset.LOGS,
+  });
 
   const setGroupBysWithOp = useCallback(
     (columns: string[], op: 'insert' | 'update' | 'delete' | 'reorder') => {

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.spec.tsx
@@ -314,14 +314,14 @@ describe('AggregateColumnEditorModal', () => {
 
     const options: string[] = [
       '\u2014',
-      'feature.enabled',
-      'foo',
       'geo.city',
-      'geo.country',
       'project',
       'span.duration',
       'span.op',
       'span.self_time',
+      'feature.enabled',
+      'foo',
+      'geo.country',
     ];
 
     const row = screen.getAllByTestId('editor-row')[0]!;
@@ -334,7 +334,7 @@ describe('AggregateColumnEditorModal', () => {
       expect(option).toHaveTextContent(options[i]!);
     });
 
-    await userEvent.click(groupByOptions[3]!);
+    await userEvent.click(groupByOptions[1]!);
     rows = await screen.findAllByTestId('editor-row');
     expectRows(rows).toHaveAggregateFields([
       {groupBy: 'geo.city'},


### PR DESCRIPTION
Prioritize fields with a known definition (via `getFieldDefinition`) to the top of the group by dropdown in the Explore page.

Previously all fields were sorted purely alphabetically, making it hard to find common fields like `span.op` or `span.description` among potentially hundreds of custom tags. Now known fields sort first (alphabetically within tier), followed by unknown/custom fields.

Also adds a custom search filter so that during search, known fields are boosted above custom tags, and exact matches are boosted above partial matches. Scoring: exact+known > exact+unknown > partial+known > partial+unknown.

The `fieldDefinitionType` prop is threaded through `ToolbarGroupByDropdown` so this works correctly for both spans (`'span'`) and logs (`'log'`).

Refactors the logs toolbar to use the shared `useGroupByFields` hook instead of duplicating inline option-building logic. This consolidates known-fields-first sorting, `DISALLOWED_GROUP_BY_FIELDS` filtering (`id`, `timestamp`), and groupBy injection (ensuring selected values remain visible even when not in the tag collections) — all of which the logs toolbar was previously missing.

Refs BROWSE-409

Made with [Cursor](https://cursor.com)