### PR TITLE
fix(workflows): Don't report missing Environment as an error

### DIFF
--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -386,9 +386,9 @@ def get_environment_by_event(event_data: WorkflowEventData) -> Environment | Non
         try:
             environment = event_data.event.get_environment()
         except Environment.DoesNotExist:
-            metrics_incr("process_workflows.error")
-            logger.exception(
-                "Missing environment for event", extra={"event_id": event_data.event.event_id}
+            logger.info(
+                "workflow_engine.process_workflows.environment_not_found",
+                extra={"event_id": event_data.event.event_id},
             )
             raise Environment.DoesNotExist("Environment does not exist for the event")
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -348,9 +348,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
             },
         )
 
-    @patch("sentry.utils.metrics.incr")
     @patch("sentry.workflow_engine.processors.workflow.logger")
-    def test_no_environment(self, mock_logger: MagicMock, mock_incr: MagicMock) -> None:
+    def test_no_environment(self, mock_logger: MagicMock) -> None:
         Environment.objects.all().delete()
         cache.clear()
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
@@ -358,11 +357,8 @@ class TestProcessWorkflows(BaseWorkflowTest):
         assert not result.data.triggered_workflows
         assert result.msg == "Environment for event not found"
 
-        mock_incr.assert_any_call(
-            "workflow_engine.process_workflows.error", 1, tags={"detector_type": "error"}
-        )
-        mock_logger.exception.assert_called_once_with(
-            "Missing environment for event",
+        mock_logger.info.assert_called_once_with(
+            "workflow_engine.process_workflows.environment_not_found",
             extra={"event_id": self.event.event_id},
         )
 


### PR DESCRIPTION
Missing environments are expected on deletion, and should be nearly impossible in other cases.
As such, it can be useful context in a log, but isn't something we should by itself treat as an error.

Additionally, we're re-raising here, and we rarely want to report an exception _and_ let it escape.

Fixes SENTRY-5KW4.
