### PR TITLE
chore(dep): Bump sentry-relay to 0.9.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "sentry-ophio>=1.1.3",
     "sentry-protos>=0.8.2",
     "sentry-redis-tools>=0.5.0",
-    "sentry-relay>=0.9.23",
+    "sentry-relay>=0.9.24",
     "sentry-sdk[http2]>=2.47.0",
     "sentry-usage-accountant>=0.0.10",
     # remove once there are no unmarked transitive dependencies on setuptools

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -56,6 +56,8 @@ def call_endpoint(client, relay, private_key):
             "spans": "base64",
             "transactions": "base64",
         },
+        "relay.eap-outcomes.rollout-rate": 1.0,
+        "relay.eap-span-outcomes.rollout-rate": 1.0,
     }
 )
 def test_global_config() -> None:
@@ -66,16 +68,6 @@ def test_global_config() -> None:
     # It is not allowed to specify `None` as default for an option.
     if not config["options"]["relay.span-normalization.allowed_hosts"]:
         del config["options"]["relay.span-normalization.allowed_hosts"]
-
-    # This option has `skip_serializing_if = "is_default"`
-    # So if it's 0.0, then it is removed in the normalized configs
-    if config["options"]["relay.eap-outcomes.rollout-rate"] == 0.0:
-        del config["options"]["relay.eap-outcomes.rollout-rate"]
-
-    # This option has `skip_serializing_if = "is_default"`
-    # So if it's 0.0, then it is removed in the normalized configs
-    if config["options"]["relay.eap-span-outcomes.rollout-rate"] == 0.0:
-        del config["options"]["relay.eap-span-outcomes.rollout-rate"]
 
     assert normalized == config
 

--- a/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
+++ b/tests/sentry/api/endpoints/test_relay_globalconfig_v3.py
@@ -67,6 +67,16 @@ def test_global_config() -> None:
     if not config["options"]["relay.span-normalization.allowed_hosts"]:
         del config["options"]["relay.span-normalization.allowed_hosts"]
 
+    # This option has `skip_serializing_if = "is_default"`
+    # So if it's 0.0, then it is removed in the normalized configs
+    if config["options"]["relay.eap-outcomes.rollout-rate"] == 0.0:
+        del config["options"]["relay.eap-outcomes.rollout-rate"]
+
+    # This option has `skip_serializing_if = "is_default"`
+    # So if it's 0.0, then it is removed in the normalized configs
+    if config["options"]["relay.eap-span-outcomes.rollout-rate"] == 0.0:
+        del config["options"]["relay.eap-span-outcomes.rollout-rate"]
+
     assert normalized == config
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2348,7 +2348,7 @@ requires-dist = [
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-protos", specifier = ">=0.8.2" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
-    { name = "sentry-relay", specifier = ">=0.9.23" },
+    { name = "sentry-relay", specifier = ">=0.9.24" },
     { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.47.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -2544,15 +2544,15 @@ wheels = [
 
 [[package]]
 name = "sentry-relay"
-version = "0.9.23"
+version = "0.9.24"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "milksnake", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.23-py2.py3-none-macosx_14_0_arm64.whl", hash = "sha256:f4ae642fa433bd0e211edad0c09567be41ee7a32e98f5d4bff953c1d90898552" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.23-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:abbd239ef3ac4651898bfa889b5815133ad3af995a05ba8fcaf070ce5eea410e" },
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.23-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ecd10614d334223d115310e93e42848daf8a4d1302ae4a59b18393ca0995ec50" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.24-py2.py3-none-macosx_14_0_arm64.whl", hash = "sha256:55f39d594e9fee5b67e3ca9ce84386af4855fbac5b9f34c27c3c4703d6cf75e8" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.24-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4d79279834683d1d59dfbfe2e6233446e84807e8768ffec1752615a51406aa4b" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_relay-0.9.24-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:69d0124c2fa1c067af420f7245308d129d5f6ad767341f46e1269dc2d31712ca" },
 ]
 
 [[package]]


### PR DESCRIPTION
This release contains DataCategory.PROFILE_BACKEND and DataCategory.PROFILE_UI