### PR TITLE
feat(uptime-assertions): Improving json path form

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
@@ -140,16 +140,13 @@ describe('AssertionOpJsonPath', () => {
     const comparisonButton = screen.getByTestId('json-path-operators-trigger');
     await userEvent.click(comparisonButton);
 
-    expect(screen.getByRole('option', {name: 'less than'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'greater than'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'less than'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-    expect(screen.getByRole('option', {name: 'greater than'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    const lessThan = screen.getByRole('option', {name: 'less than'});
+    const greaterThan = screen.getByRole('option', {name: 'greater than'});
+
+    expect(lessThan).toBeInTheDocument();
+    expect(greaterThan).toBeInTheDocument();
+    expect(lessThan).toHaveAttribute('aria-disabled', 'true');
+    expect(greaterThan).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('enables < and > comparisons for numeric operand values', async () => {
@@ -182,16 +179,13 @@ describe('AssertionOpJsonPath', () => {
     const comparisonButton = screen.getByTestId('json-path-operators-trigger');
     await userEvent.click(comparisonButton);
 
-    expect(screen.getByRole('option', {name: 'less than'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'greater than'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'less than'})).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-    expect(screen.getByRole('option', {name: 'greater than'})).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    const lessThan = screen.getByRole('option', {name: 'less than'});
+    const greaterThan = screen.getByRole('option', {name: 'greater than'});
+
+    expect(lessThan).toBeInTheDocument();
+    expect(greaterThan).toBeInTheDocument();
+    expect(lessThan).not.toHaveAttribute('aria-disabled', 'true');
+    expect(greaterThan).not.toHaveAttribute('aria-disabled', 'true');
   });
 
   it('shows string operand types as disabled when < or > comparison is selected', async () => {
@@ -205,16 +199,13 @@ describe('AssertionOpJsonPath', () => {
     const comparisonButton = screen.getByTestId('json-path-operators-trigger');
     await userEvent.click(comparisonButton);
 
-    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'Literal'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-    expect(screen.getByRole('option', {name: 'Literal'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    const globPattern = screen.getByRole('option', {name: 'Glob Pattern'});
+    const literal = screen.getByRole('option', {name: 'Literal'});
+
+    expect(globPattern).toBeInTheDocument();
+    expect(literal).toBeInTheDocument();
+    expect(globPattern).toHaveAttribute('aria-disabled', 'true');
+    expect(literal).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('shows string operand types as enabled when = or ≠ comparison is selected', async () => {
@@ -228,16 +219,13 @@ describe('AssertionOpJsonPath', () => {
     const comparisonButton = screen.getByTestId('json-path-operators-trigger');
     await userEvent.click(comparisonButton);
 
-    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'Literal'})).toBeInTheDocument();
-    expect(screen.getByRole('option', {name: 'Glob Pattern'})).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-    expect(screen.getByRole('option', {name: 'Literal'})).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    const globPattern = screen.getByRole('option', {name: 'Glob Pattern'});
+    const literal = screen.getByRole('option', {name: 'Literal'});
+
+    expect(globPattern).toBeInTheDocument();
+    expect(literal).toBeInTheDocument();
+    expect(globPattern).not.toHaveAttribute('aria-disabled', 'true');
+    expect(literal).not.toHaveAttribute('aria-disabled', 'true');
   });
 
   it('resets operator from < or > to equals when the operand is not numeric', async () => {
@@ -257,6 +245,48 @@ describe('AssertionOpJsonPath', () => {
         value: '$.status',
         operator: {cmp: UptimeComparisonType.EQUALS},
         operand: defaultOperand,
+      })
+    );
+  });
+
+  it('resets glob operand to literal when < or > comparison is selected', async () => {
+    function Stateful() {
+      const [state, setState] = useState<UptimeJsonPathOp>(
+        makeJsonPathOp({
+          id: 'test-id-1',
+          value: '$.count',
+          operator: defaultOperator,
+          operand: {jsonpath_op: 'glob', pattern: {value: '123'}},
+        })
+      );
+      return (
+        <AssertionOpJsonPath
+          value={state}
+          onChange={next => {
+            mockOnChange(next);
+            setState(next);
+          }}
+          onRemove={mockOnRemove}
+        />
+      );
+    }
+
+    render(<Stateful />);
+    await screen.findByTestId('json-path-value-input');
+
+    const comparisonButton = screen.getByTestId('json-path-operators-trigger');
+    await userEvent.click(comparisonButton);
+
+    const lessThan = screen.getByRole('option', {name: 'less than'});
+    await userEvent.click(lessThan);
+
+    await waitFor(() =>
+      expect(mockOnChange).toHaveBeenLastCalledWith({
+        id: 'test-id-1',
+        op: UptimeOpType.JSON_PATH,
+        value: '$.count',
+        operator: {cmp: UptimeComparisonType.LESS_THAN},
+        operand: {jsonpath_op: 'literal', value: '123'},
       })
     );
   });

--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.spec.tsx
@@ -130,7 +130,7 @@ describe('AssertionOpJsonPath', () => {
     expect(screen.getByRole('button', {name: 'Reorder assertion'})).toBeInTheDocument();
   });
 
-  it('hides < and > comparisons for non-numeric operand values', async () => {
+  it('shows < and > comparisons as disabled for non-numeric operand values', async () => {
     await renderOp(
       makeJsonPathOp({
         operand: {jsonpath_op: 'literal', value: 'ok'},
@@ -140,11 +140,19 @@ describe('AssertionOpJsonPath', () => {
     const comparisonButton = screen.getByTestId('json-path-operators-trigger');
     await userEvent.click(comparisonButton);
 
-    expect(screen.queryByRole('option', {name: 'less than'})).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', {name: 'greater than'})).not.toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'less than'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'greater than'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'less than'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'greater than'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 
-  it('allows < and > comparisons for numeric operand values and hides string type selector', async () => {
+  it('enables < and > comparisons for numeric operand values', async () => {
     function Stateful() {
       const [state, setState] = useState<UptimeJsonPathOp>({
         ...makeJsonPathOp({
@@ -176,9 +184,60 @@ describe('AssertionOpJsonPath', () => {
 
     expect(screen.getByRole('option', {name: 'less than'})).toBeInTheDocument();
     expect(screen.getByRole('option', {name: 'greater than'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'less than'})).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'greater than'})).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
 
-    expect(screen.queryByRole('option', {name: 'Glob Pattern'})).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', {name: 'Literal'})).not.toBeInTheDocument();
+  it('shows string operand types as disabled when < or > comparison is selected', async () => {
+    await renderOp(
+      makeJsonPathOp({
+        operator: {cmp: UptimeComparisonType.LESS_THAN},
+        operand: {jsonpath_op: 'literal', value: '123'},
+      })
+    );
+
+    const comparisonButton = screen.getByTestId('json-path-operators-trigger');
+    await userEvent.click(comparisonButton);
+
+    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Literal'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'Literal'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('shows string operand types as enabled when = or ≠ comparison is selected', async () => {
+    await renderOp(
+      makeJsonPathOp({
+        operator: defaultOperator,
+        operand: {jsonpath_op: 'literal', value: 'ok'},
+      })
+    );
+
+    const comparisonButton = screen.getByTestId('json-path-operators-trigger');
+    await userEvent.click(comparisonButton);
+
+    expect(screen.getByRole('option', {name: 'Glob Pattern'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Literal'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Glob Pattern'})).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+    expect(screen.getByRole('option', {name: 'Literal'})).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
   });
 
   it('resets operator from < or > to equals when the operand is not numeric', async () => {

--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
@@ -20,6 +20,7 @@ import {COMPARISON_OPTIONS, OpContainer, STRING_OPERAND_OPTIONS} from './opCommo
 import {
   getJsonPathCombinedLabelAndTooltip,
   getJsonPathOperandValue,
+  isNumericComparison,
   normalizeJsonPathOp,
 } from './utils';
 
@@ -44,51 +45,39 @@ export function AssertionOpJsonPath({
   const {combinedLabel, combinedTooltip} =
     getJsonPathCombinedLabelAndTooltip(normalizedOp);
 
-  const isNumeric = isNumericString(operandValue);
+  const isNumericValue = isNumericString(operandValue);
+  const isNumericComparisonSelected = isNumericComparison(normalizedOp.operator.cmp);
 
-  const comparisonOptions = COMPARISON_OPTIONS.filter(opt => {
-    if (
-      opt.value === UptimeComparisonType.ALWAYS ||
-      opt.value === UptimeComparisonType.NEVER
-    ) {
-      return false;
-    }
-    if (
-      !isNumeric &&
-      (opt.value === UptimeComparisonType.LESS_THAN ||
-        opt.value === UptimeComparisonType.GREATER_THAN)
-    ) {
-      return false;
-    }
-    return true;
+  const comparisonOptions = COMPARISON_OPTIONS.filter(
+    opt =>
+      opt.value !== UptimeComparisonType.ALWAYS &&
+      opt.value !== UptimeComparisonType.NEVER
+  ).map(opt => {
+    const isNumericOnly = isNumericComparison(opt.value);
+    return {
+      ...opt,
+      disabled: isNumericOnly && !isNumericValue,
+      tooltip:
+        isNumericOnly && !isNumericValue
+          ? t('Only available for numeric values')
+          : undefined,
+    };
   });
 
+  const stringOperandOptions = STRING_OPERAND_OPTIONS.map(opt => ({
+    ...opt,
+    disabled: isNumericComparisonSelected,
+    tooltip: isNumericComparisonSelected
+      ? t('Only available for string comparisons')
+      : undefined,
+  }));
+
   useEffect(() => {
-    // Normalize the op based on whether the operand is numeric.
-    //
-    // - Non-numeric: disallow < and > comparisons (force equals).
-    // - Numeric: force a literal operand (hide/disable glob).
-    let nextValue: UptimeJsonPathOp | null = null;
-
-    if (
-      !isNumeric &&
-      (normalizedOp.operator.cmp === UptimeComparisonType.LESS_THAN ||
-        normalizedOp.operator.cmp === UptimeComparisonType.GREATER_THAN)
-    ) {
-      nextValue = {...normalizedOp, operator: {cmp: UptimeComparisonType.EQUALS}};
+    // Non-numeric with < or > selected: force back to equals
+    if (!isNumericValue && isNumericComparisonSelected) {
+      onChange({...normalizedOp, operator: {cmp: UptimeComparisonType.EQUALS}});
     }
-
-    if (isNumeric && normalizedOp.operand.jsonpath_op === 'glob') {
-      nextValue = {
-        ...(nextValue ?? normalizedOp),
-        operand: {jsonpath_op: 'literal', value: operandValue},
-      };
-    }
-
-    if (nextValue) {
-      onChange(nextValue);
-    }
-  }, [isNumeric, onChange, operandValue, normalizedOp]);
+  }, [isNumericValue, isNumericComparisonSelected, onChange, normalizedOp]);
 
   const jsonPathInput = (
     <Container flexGrow={2}>
@@ -138,31 +127,27 @@ export function AssertionOpJsonPath({
                 }
                 options={comparisonOptions}
               />
-              {!isNumeric && (
-                <CompositeSelect.Region
-                  label={t('String operand types')}
-                  value={normalizedOp.operand.jsonpath_op}
-                  onChange={option => {
-                    const newOperand: UptimeJsonPathOperand =
-                      option.value === 'literal'
-                        ? {jsonpath_op: 'literal', value: operandValue}
-                        : {jsonpath_op: 'glob', pattern: {value: operandValue}};
-                    onChange({...normalizedOp, operand: newOperand});
-                  }}
-                  options={STRING_OPERAND_OPTIONS}
-                />
-              )}
+              <CompositeSelect.Region
+                label={t('String operand types')}
+                value={normalizedOp.operand.jsonpath_op}
+                onChange={option => {
+                  const newOperand: UptimeJsonPathOperand =
+                    option.value === 'literal'
+                      ? {jsonpath_op: 'literal', value: operandValue}
+                      : {jsonpath_op: 'glob', pattern: {value: operandValue}};
+                  onChange({...normalizedOp, operand: newOperand});
+                }}
+                options={stringOperandOptions}
+              />
             </CompositeSelect>
           </InputGroup.LeadingItems>
           <InputGroup.Input
             value={operandValue}
             onChange={e => {
               const nextValue = e.target.value;
-              const nextIsNumeric = isNumericString(nextValue);
 
-              const newOperand: UptimeJsonPathOperand = nextIsNumeric
-                ? {jsonpath_op: 'literal', value: nextValue}
-                : normalizedOp.operand.jsonpath_op === 'glob'
+              const newOperand: UptimeJsonPathOperand =
+                normalizedOp.operand.jsonpath_op === 'glob'
                   ? {jsonpath_op: 'glob', pattern: {value: nextValue}}
                   : {jsonpath_op: 'literal', value: nextValue};
               onChange({...normalizedOp, operand: newOperand});

--- a/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opJsonPath.tsx
@@ -73,11 +73,25 @@ export function AssertionOpJsonPath({
   }));
 
   useEffect(() => {
+    let nextOp: UptimeJsonPathOp | null = null;
+
     // Non-numeric with < or > selected: force back to equals
     if (!isNumericValue && isNumericComparisonSelected) {
-      onChange({...normalizedOp, operator: {cmp: UptimeComparisonType.EQUALS}});
+      nextOp = {...normalizedOp, operator: {cmp: UptimeComparisonType.EQUALS}};
     }
-  }, [isNumericValue, isNumericComparisonSelected, onChange, normalizedOp]);
+
+    // Glob operand with < or > selected: force to literal (glob is invalid for numeric comparisons)
+    if (isNumericComparisonSelected && normalizedOp.operand.jsonpath_op === 'glob') {
+      nextOp = {
+        ...(nextOp ?? normalizedOp),
+        operand: {jsonpath_op: 'literal', value: operandValue},
+      };
+    }
+
+    if (nextOp) {
+      onChange(nextOp);
+    }
+  }, [isNumericValue, isNumericComparisonSelected, onChange, normalizedOp, operandValue]);
 
   const jsonPathInput = (
     <Container flexGrow={2}>

--- a/static/app/views/alerts/rules/uptime/assertions/utils.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/utils.tsx
@@ -346,11 +346,9 @@ export function getJsonPathCombinedLabelAndTooltip(op: UptimeJsonPathOp): {
       ? ''
       : (STRING_OPERAND_OPTIONS.find(opt => opt.value === operandType)?.symbol ?? '');
 
-  const isNumericComparison =
-    op.operator.cmp === UptimeComparisonType.LESS_THAN ||
-    op.operator.cmp === UptimeComparisonType.GREATER_THAN;
+  const isNumericComparisonSelected = isNumericComparison(op.operator.cmp);
 
-  const combinedLabel = isNumericComparison
+  const combinedLabel = isNumericComparisonSelected
     ? comparisonSymbol
     : operandSymbol
       ? `${comparisonSymbol}${operandSymbol}`
@@ -359,7 +357,7 @@ export function getJsonPathCombinedLabelAndTooltip(op: UptimeJsonPathOp): {
   const combinedTooltip =
     operandType === 'none'
       ? t('JSON path %s', comparisonLabel)
-      : isNumericComparison
+      : isNumericComparisonSelected
         ? t('JSON path value %s', comparisonLabel)
         : t('JSON path value %s to string %s', comparisonLabel, operandLabel);
 
@@ -411,4 +409,10 @@ export function getGroupOpLabel(op: UptimeGroupOp, isNegated: boolean): string {
   // By De Morgan's Laws, NOT (A OR B) is equivalent to (NOT A AND NOT B),
   // i.e. passing when all children fail.
   return isNegated ? t('Assert None') : t('Assert Any');
+}
+
+export function isNumericComparison(cmp: UptimeComparisonType): boolean {
+  return (
+    cmp === UptimeComparisonType.LESS_THAN || cmp === UptimeComparisonType.GREATER_THAN
+  );
 }


### PR DESCRIPTION
- Hiding of options obfuscate functionality.
- Introduced disabling logic based on selection
- Backwards compatible, what was hidden is just now disabled with a message

<img width="299" height="294" alt="Screenshot 2026-03-05 at 2 07 21 PM" src="https://github.com/user-attachments/assets/d1bdbc4f-645b-4b74-a42a-8f030aa42186" />
<img width="264" height="280" alt="Screenshot 2026-03-05 at 2 07 15 PM" src="https://github.com/user-attachments/assets/6629bd37-bed1-4266-a2a3-47c5d0ffba15" />
<img width="332" height="269" alt="Screenshot 2026-03-05 at 1 14 44 PM" src="https://github.com/user-attachments/assets/e13f85da-a169-403e-80b4-66c894eada5b" />
<img width="430" height="293" alt="Screenshot 2026-03-05 at 1 14 36 PM" src="https://github.com/user-attachments/assets/c6e0bb2e-014e-4302-bae7-1ca82bfcf463" />
