### PR TITLE
fix(insights): EAP support for status breakdown

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
@@ -14,6 +14,7 @@ import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {getTermHelp, PerformanceTerm} from 'sentry/views/performance/data';
@@ -26,11 +27,13 @@ type Props = {
 
 function StatusBreakdown({eventView, location, organization}: Props) {
   const navigate = useNavigate();
+  const statusAttribute =
+    eventView.dataset === DiscoverDatasets.SPANS ? 'span.status' : 'transaction.status';
 
   const breakdownView = eventView
     .withColumns([
       {kind: 'function', function: ['count', '', '', undefined]},
-      {kind: 'field', field: 'transaction.status'},
+      {kind: 'field', field: statusAttribute},
     ])
     .withSorts([{kind: 'desc', field: 'count'}]);
 
@@ -67,7 +70,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
             );
           }
           const points = tableData.data.map(row => ({
-            label: String(row['transaction.status']),
+            label: String(row[statusAttribute]),
             value: parseInt(String(row['count()']), 10),
             onClick: () => {
               const query = new MutableSearch(eventView.query);
@@ -78,10 +81,8 @@ function StatusBreakdown({eventView, location, organization}: Props) {
               query.removeFilter('event.type').removeFilter('transaction');
 
               query
-                .removeFilter('!transaction.status')
-                .setFilterValues('transaction.status', [
-                  row['transaction.status'] as string,
-                ]);
+                .removeFilter(`!${statusAttribute}`)
+                .setFilterValues(statusAttribute, [row[statusAttribute] as string]);
               navigate({
                 pathname: location.pathname,
                 query: {
@@ -95,7 +96,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
                 'performance_views.transaction_summary.status_breakdown_click',
                 {
                   organization,
-                  status: row['transaction.status'] as string,
+                  status: row[statusAttribute] as string,
                 }
               );
             },


### PR DESCRIPTION
The attribute for the span/transaction's status is different under EAP. Conditionally use the correct attribute name.

Original non-EAP version:
<img width="340" height="142" alt="Screenshot 2026-03-05 at 15 15 10" src="https://github.com/user-attachments/assets/b71be8fd-5b1f-4a03-b774-258038993e16" />

EAP Before:
<img width="354" height="87" alt="Screenshot 2026-03-05 at 15 14 34" src="https://github.com/user-attachments/assets/b8aa1c9e-e24f-411b-b8d3-bacbd0619344" />

EAP After:
<img width="347" height="144" alt="Screenshot 2026-03-05 at 15 15 04" src="https://github.com/user-attachments/assets/70331b7d-aea2-4cba-9d76-bad28258beb9" />


