### PR TITLE
fix(insights): Remove tag summary from EAP Transaction Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -110,7 +110,6 @@ function EAPSummaryContentInner({
 }: Props) {
   const theme = useTheme();
   const navigate = useNavigate();
-  const domainViewFilters = useDomainViewFilters();
   const spanCategory = decodeScalar(location.query?.[SpanFields.SPAN_CATEGORY]);
 
   const handleSearch = useCallback(
@@ -274,15 +273,6 @@ function EAPSummaryContentInner({
             showViewSampledEventsButton
           />
         </PerformanceAtScaleContextProvider>
-        <TagExplorer
-          eventView={eventView}
-          organization={organization}
-          location={location}
-          projects={projects}
-          transactionName={transactionName}
-          currentFilter={spanOperationBreakdownFilter}
-          domainViewFilters={domainViewFilters}
-        />
         <SuspectFunctionsTable
           eventView={eventView}
           analyticsPageSource="performance_transaction"


### PR DESCRIPTION
We don't support the necessary query for this component in EAP.