### PR TITLE
feat(supergroups): add API endpoints for supergroups

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -538,6 +538,12 @@ from sentry.seer.endpoints.organization_seer_explorer_update import (
 from sentry.seer.endpoints.organization_seer_onboarding_check import OrganizationSeerOnboardingCheck
 from sentry.seer.endpoints.organization_seer_rpc import OrganizationSeerRpcEndpoint
 from sentry.seer.endpoints.organization_seer_setup_check import OrganizationSeerSetupCheckEndpoint
+from sentry.seer.endpoints.organization_supergroup_details import (
+    OrganizationSupergroupDetailsEndpoint,
+)
+from sentry.seer.endpoints.organization_supergroups import (
+    OrganizationSupergroupsEndpoint,
+)
 from sentry.seer.endpoints.organization_trace_summary import OrganizationTraceSummaryEndpoint
 from sentry.seer.endpoints.project_seer_preferences import ProjectSeerPreferencesEndpoint
 from sentry.seer.endpoints.search_agent_start import SearchAgentStartEndpoint
@@ -2390,6 +2396,16 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/seer/explorer-update/(?P<run_id>[^/]+)/$",
         OrganizationSeerExplorerUpdateEndpoint.as_view(),
         name="sentry-api-0-organization-seer-explorer-update",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/supergroups/$",
+        OrganizationSupergroupsEndpoint.as_view(),
+        name="sentry-api-0-organization-supergroups",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/seer/supergroups/(?P<supergroup_id>[^/]+)/$",
+        OrganizationSupergroupDetailsEndpoint.as_view(),
+        name="sentry-api-0-organization-supergroup-details",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/seer/setup-check/$",

--- a/src/sentry/seer/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/endpoints/organization_supergroup_details.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.organization import Organization
+from sentry.seer.signed_seer_api import make_supergroups_get_request
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationSupergroupDetailsPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUE_DETECTION_BACKEND
+    permission_classes = (OrganizationSupergroupDetailsPermission,)
+
+    def get(self, request: Request, organization: Organization, supergroup_id: int) -> Response:
+        if not features.has("organizations:top-issues-ui", organization, actor=request.user):
+            return Response({"detail": "Feature not available"}, status=403)
+
+        response = make_supergroups_get_request(
+            body={
+                "organization_id": organization.id,
+                "supergroup_id": supergroup_id,
+            },
+            timeout=10,
+        )
+
+        if response.status >= 400:
+            return Response(
+                {"detail": "Supergroup not found"},
+                status=response.status,
+            )
+
+        return Response(orjson.loads(response.data))

--- a/src/sentry/seer/endpoints/organization_supergroups.py
+++ b/src/sentry/seer/endpoints/organization_supergroups.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+
+import orjson
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.models.organization import Organization
+from sentry.seer.signed_seer_api import make_supergroups_list_request
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationSupergroupsPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationSupergroupsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUE_DETECTION_BACKEND
+    permission_classes = (OrganizationSupergroupsPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:top-issues-ui", organization, actor=request.user):
+            return Response({"detail": "Feature not available"}, status=403)
+
+        response = make_supergroups_list_request(
+            body={
+                "organization_id": organization.id,
+            },
+            timeout=10,
+        )
+
+        if response.status >= 400:
+            return Response(
+                {"detail": "Failed to fetch supergroups"},
+                status=response.status,
+            )
+
+        return Response(orjson.loads(response.data))

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -229,6 +229,17 @@ class SupergroupsEmbeddingRequest(TypedDict):
     artifact_data: dict[str, Any]
 
 
+class SupergroupsListRequest(TypedDict):
+    organization_id: int
+    offset: NotRequired[int | None]
+    limit: NotRequired[int | None]
+
+
+class SupergroupsGetRequest(TypedDict):
+    organization_id: int
+    supergroup_id: int
+
+
 class ServiceMapUpdateRequest(TypedDict):
     organization_id: int
     nodes: list[dict[str, Any]]
@@ -325,6 +336,30 @@ def make_supergroups_embedding_request(
         body=orjson.dumps(body),
         timeout=timeout,
         viewer_context=viewer_context,
+    )
+
+
+def make_supergroups_list_request(
+    body: SupergroupsListRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v0/issues/supergroups/list",
+        body=orjson.dumps(body),
+        timeout=timeout,
+    )
+
+
+def make_supergroups_get_request(
+    body: SupergroupsGetRequest,
+    timeout: int | float | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v0/issues/supergroups/get",
+        body=orjson.dumps(body),
+        timeout=timeout,
     )
 
 

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -558,6 +558,8 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/seer/explorer-update/$runId/'
   | '/organizations/$organizationIdOrSlug/seer/onboarding-check/'
   | '/organizations/$organizationIdOrSlug/seer/setup-check/'
+  | '/organizations/$organizationIdOrSlug/seer/supergroups/'
+  | '/organizations/$organizationIdOrSlug/seer/supergroups/$supergroupId/'
   | '/organizations/$organizationIdOrSlug/sent-first-event/'
   | '/organizations/$organizationIdOrSlug/sentry-app-components/'
   | '/organizations/$organizationIdOrSlug/sentry-app-installations/'


### PR DESCRIPTION
Some seer endpoints were added in https://github.com/getsentry/seer/pull/4788 to retrieve supergroup data — this sets up the sentry equivalent so we can start using them in the frontend. Gated by `organizations:top-issues-ui`, which is only enabled internally right now