### PR TITLE
feat(dashboards): Support multiple filters on dashboards list endpoint

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -369,29 +369,20 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             except Exception as err:
                 sentry_sdk.capture_exception(err)
 
-        filter_by = request.query_params.get("filter")
-        if filter_by == "onlyFavorites":
-            dashboards = Dashboard.objects.filter(
-                organization_id=organization.id, dashboardfavoriteuser__user_id=request.user.id
-            )
-        elif filter_by == "excludeFavorites":
-            dashboards = Dashboard.objects.exclude(
-                organization_id=organization.id, dashboardfavoriteuser__user_id=request.user.id
-            )
-        elif filter_by == "owned":
-            dashboards = Dashboard.objects.filter(
-                created_by_id=request.user.id, organization_id=organization.id
-            )
-        elif filter_by == "shared":
-            dashboards = Dashboard.objects.filter(organization_id=organization.id).exclude(
-                created_by_id=request.user.id
-            )
-        elif filter_by == "excludePrebuilt":
-            dashboards = Dashboard.objects.filter(organization_id=organization.id).exclude(
-                prebuilt_id__isnull=False
-            )
-        else:
-            dashboards = Dashboard.objects.filter(organization_id=organization.id)
+        filters = request.query_params.getlist("filter")
+
+        dashboards = Dashboard.objects.filter(organization_id=organization.id)
+        for f in filters:
+            if f == "onlyFavorites":
+                dashboards = dashboards.filter(dashboardfavoriteuser__user_id=request.user.id)
+            elif f == "excludeFavorites":
+                dashboards = dashboards.exclude(dashboardfavoriteuser__user_id=request.user.id)
+            elif f == "owned":
+                dashboards = dashboards.filter(created_by_id=request.user.id)
+            elif f == "shared":
+                dashboards = dashboards.exclude(created_by_id=request.user.id)
+            elif f == "excludePrebuilt":
+                dashboards = dashboards.exclude(prebuilt_id__isnull=False)
 
         query = request.GET.get("query")
         prebuilt_ids = request.GET.getlist("prebuiltId")
@@ -556,12 +547,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             )
             return serialized
 
+        HIDE_PREBUILT_FILTERS = {"onlyFavorites", "owned", "excludePrebuilt"}
         render_pre_built_dashboard = True
-        if (
-            filter_by
-            and filter_by in {"onlyFavorites", "owned", "excludePrebuilt"}
-            or should_filter_by_prebuilt_ids
-        ):
+        if HIDE_PREBUILT_FILTERS.intersection(filters) or should_filter_by_prebuilt_ids:
             render_pre_built_dashboard = False
         elif pin_by and pin_by == "favorites":
             # Only hide prebuilt dashboard when pinning favorites if there are actual dashboards to show

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -680,6 +680,91 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         values = [row["title"] for row in response.data]
         assert values == ["Initial dashboard"]
 
+    def test_get_multiple_filters_owned_and_exclude_prebuilt(self) -> None:
+        user_1 = self.create_user(username="user_1")
+        self.create_member(organization=self.organization, user=user_1)
+        user_2 = self.create_user(username="user_2")
+        self.create_member(organization=self.organization, user=user_2)
+
+        Dashboard.objects.create(
+            title="User 1 Custom",
+            created_by_id=user_1.id,
+            organization=self.organization,
+        )
+        Dashboard.objects.create(
+            title="User 2 Custom",
+            created_by_id=user_2.id,
+            organization=self.organization,
+        )
+        Dashboard.objects.create(
+            title="User 1 Prebuilt",
+            created_by_id=None,
+            organization=self.organization,
+            prebuilt_id=1,
+        )
+
+        self.login_as(user_1)
+        response = self.client.get(self.url, data={"filter": ["owned", "excludePrebuilt"]})
+        assert response.status_code == 200, response.content
+        values = [row["title"] for row in response.data]
+        assert values == ["User 1 Custom"]
+
+    def test_get_multiple_filters_single_filter(self) -> None:
+        user_1 = self.create_user(username="user_1")
+        self.create_member(organization=self.organization, user=user_1)
+        user_2 = self.create_user(username="user_2")
+        self.create_member(organization=self.organization, user=user_2)
+
+        Dashboard.objects.create(
+            title="User 1 Dashboard",
+            created_by_id=user_1.id,
+            organization=self.organization,
+        )
+        Dashboard.objects.create(
+            title="User 2 Dashboard",
+            created_by_id=user_2.id,
+            organization=self.organization,
+        )
+
+        self.login_as(user_1)
+        response = self.client.get(self.url, data={"filter": ["owned"]})
+        assert response.status_code == 200, response.content
+        values = [row["title"] for row in response.data]
+        assert values == ["User 1 Dashboard"]
+
+    def test_get_multiple_filters_favorites_and_owned(self) -> None:
+        user_1 = self.create_user(username="user_1")
+        self.create_member(organization=self.organization, user=user_1)
+
+        owned_fav = Dashboard.objects.create(
+            title="Owned and Favorited",
+            created_by_id=user_1.id,
+            organization=self.organization,
+        )
+        Dashboard.objects.create(
+            title="Owned Not Favorited",
+            created_by_id=user_1.id,
+            organization=self.organization,
+        )
+        other_fav = Dashboard.objects.create(
+            title="Other Favorited",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+
+        DashboardFavoriteUser.objects.insert_favorite_dashboard(
+            organization=self.organization, user_id=user_1.id, dashboard=owned_fav
+        )
+        DashboardFavoriteUser.objects.insert_favorite_dashboard(
+            organization=self.organization, user_id=user_1.id, dashboard=other_fav
+        )
+
+        self.login_as(user_1)
+        response = self.client.get(self.url, data={"filter": ["onlyFavorites", "owned"]})
+        assert response.status_code == 200, response.content
+        values = [row["title"] for row in response.data]
+        assert values == ["Owned and Favorited"]
+
     def test_get_owned_dashboards_can_pin_starred_at_top(self) -> None:
         user_1 = self.create_user(username="user_1")
         self.create_member(organization=self.organization, user=user_1)


### PR DESCRIPTION
Support multiple `filter` query params on the dashboards list endpoint so we can toggle prebuilt dashboards while also filtering by other fields like owned or shared.

Previously `filter` only accepted a single value via an if/elif chain, making combinations like `?filter=owned&filter=excludePrebuilt` impossible. This switches from `query_params.get("filter")` to `query_params.getlist("filter")` and applies each filter sequentially (AND logic). A single `?filter=owned` behaves identically to before, so this is fully backwards compatible.

Refs DAIN-1284