### PR TITLE
feat(ACI): Dual delete Workflow/Rule if flag enabled

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -422,14 +422,14 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
             with transaction.atomic(router.db_for_write(Workflow)):
                 rule.update(status=ObjectStatus.PENDING_DELETION)
                 scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
-                self.create_audit_entry(
-                    request=request,
-                    organization=project.organization,
-                    target_object=rule.id,
-                    event=audit_log.get_event_id("WORKFLOW_REMOVE"),
-                    data=rule.get_audit_log_data(),
-                    transaction_id=scheduled.id,
-                )
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=rule.id,
+                event=audit_log.get_event_id("WORKFLOW_REMOVE"),
+                data=rule.get_audit_log_data(),
+                transaction_id=scheduled.id,
+            )
             try:
                 ard = AlertRuleWorkflow.objects.get(workflow_id=rule.id)
                 rule = Rule.objects.get(id=ard.rule_id, project=project)

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -45,6 +45,7 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
+from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
@@ -418,12 +419,40 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
          - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
         if isinstance(rule, Workflow):
-            audit_id = "WORKFLOW_REMOVE"
             with transaction.atomic(router.db_for_write(Workflow)):
                 rule.update(status=ObjectStatus.PENDING_DELETION)
                 scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
+                self.create_audit_entry(
+                    request=request,
+                    organization=project.organization,
+                    target_object=rule.id,
+                    event=audit_log.get_event_id("WORKFLOW_REMOVE"),
+                    data=rule.get_audit_log_data(),
+                    transaction_id=scheduled.id,
+                )
+            try:
+                ard = AlertRuleWorkflow.objects.get(workflow_id=rule.id)
+                rule = Rule.objects.get(id=ard.rule_id, project=project)
+
+                report_used_legacy_models()
+                with transaction.atomic(router.db_for_write(Rule)):
+                    rule.update(status=ObjectStatus.PENDING_DELETION)
+                    RuleActivity.objects.create(
+                        rule=rule, user_id=request.user.id, type=RuleActivityType.DELETED.value
+                    )
+                    scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
+                self.create_audit_entry(
+                    request=request,
+                    organization=project.organization,
+                    target_object=rule.id,
+                    event=audit_log.get_event_id("RULE_REMOVE"),
+                    data=rule.get_audit_log_data(),
+                    transaction_id=scheduled.id,
+                )
+            except (AlertRuleWorkflow.DoesNotExist, Rule.DoesNotExist):
+                return Response(status=202)
+
         else:
-            audit_id = "RULE_REMOVE"
             report_used_legacy_models()
             with transaction.atomic(router.db_for_write(Rule)):
                 rule.update(status=ObjectStatus.PENDING_DELETION)
@@ -432,12 +461,12 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                 )
                 scheduled = RegionScheduledDeletion.schedule(rule, days=0, actor=request.user)
 
-        self.create_audit_entry(
-            request=request,
-            organization=project.organization,
-            target_object=rule.id,
-            event=audit_log.get_event_id(audit_id),
-            data=rule.get_audit_log_data(),
-            transaction_id=scheduled.id,
-        )
+            self.create_audit_entry(
+                request=request,
+                organization=project.organization,
+                target_object=rule.id,
+                event=audit_log.get_event_id("RULE_REMOVE"),
+                data=rule.get_audit_log_data(),
+                transaction_id=scheduled.id,
+            )
         return Response(status=202)

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1654,6 +1654,43 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         assert not DataConditionGroup.objects.filter(id=self.workflow_triggers.id).exists()
         assert not Action.objects.filter(id=self.action.id).exists()
 
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_dual_delete_workflow_engine_flag_enabled(self) -> None:
+        rule = self.create_project_rule(
+            self.project,
+            condition_data=[
+                {
+                    "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+                    "name": "A new issue is created",
+                },
+                {
+                    "id": "sentry.rules.filters.latest_release.LatestReleaseFilter",
+                    "name": "The event occurs",
+                },
+            ],
+        )
+
+        alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+        workflow = alert_rule_workflow.workflow
+        when_dcg = workflow.when_condition_group
+        assert when_dcg
+        if_dcg = WorkflowDataConditionGroup.objects.get(workflow=workflow).condition_group
+
+        self.get_success_response(
+            self.organization.slug, rule.project.slug, rule.id, status_code=202
+        )
+
+        with self.tasks():
+            run_scheduled_deletions()
+
+        assert not AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists()
+        assert not Workflow.objects.filter(id=workflow.id).exists()
+        assert not DataConditionGroup.objects.filter(id=when_dcg.id).exists()
+        assert not DataConditionGroup.objects.filter(id=if_dcg.id).exists()
+        assert not DataCondition.objects.filter(condition_group=when_dcg).exists()
+        assert not DataCondition.objects.filter(condition_group=if_dcg).exists()
+        assert not Rule.objects.filter(id=rule.id).exists()
+
     def test_dual_delete_workflow_engine(self) -> None:
         rule = self.create_project_rule(
             self.project,


### PR DESCRIPTION
Try to look up the related `Rule` object and delete that as well if we are passed a workflow to the issue alert rule delete method. In https://github.com/getsentry/sentry/pull/109752 I assumed we'd always be getting a single written workflow but that may not always be the case. 