### PR TITLE
ref: Graduate ourlogs-replay-ui and ourlogs-export feature flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -435,10 +435,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ourlogs-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs stats to be displayed in the UI.
     manager.add("organizations:ourlogs-stats", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable replay logs UI.
-    manager.add("organizations:ourlogs-replay-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable UI for logs export
-    manager.add("organizations:ourlogs-export", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable overlaying charts in logs
     manager.add("organizations:ourlogs-overlay-charts-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable alerting on trace metrics

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -608,9 +608,7 @@ function BasicDiscoverRenderer(props: LogFieldRendererProps) {
 function ReplayIDRenderer(props: LogFieldRendererProps) {
   const replayId = props.item.value;
 
-  const hasFeature = props.extra.organization.features.includes('ourlogs-replay-ui');
-
-  if (typeof replayId !== 'string' || !replayId || !hasFeature) {
+  if (typeof replayId !== 'string' || !replayId) {
     return props.basicRendered;
   }
 

--- a/static/app/views/explore/logs/hasLogsOnReplays.tsx
+++ b/static/app/views/explore/logs/hasLogsOnReplays.tsx
@@ -9,10 +9,7 @@ export function hasLogsOnReplays(
   project?: Project | null,
   replay?: ReplayRecord | null
 ): boolean {
-  const hasFeatureFlag =
-    isLogsEnabled(organization) && organization.features.includes('ourlogs-replay-ui');
-
-  if (!hasFeatureFlag) {
+  if (!isLogsEnabled(organization)) {
     return false;
   }
 

--- a/static/app/views/explore/logs/isLogsEnabled.tsx
+++ b/static/app/views/explore/logs/isLogsEnabled.tsx
@@ -3,7 +3,3 @@ import type {Organization} from 'sentry/types/organization';
 export function isLogsEnabled(organization: Organization): boolean {
   return organization.features.includes('ourlogs-enabled');
 }
-
-export function isLogsExportEnabled(organization: Organization): boolean {
-  return organization.features.includes('ourlogs-export');
-}

--- a/static/app/views/explore/logs/logsExport.spec.tsx
+++ b/static/app/views/explore/logs/logsExport.spec.tsx
@@ -14,7 +14,7 @@ jest.mock('sentry/views/explore/logs/logsExportCsv');
 
 describe('LogsExportButton', () => {
   const {organization, setupPageFilters} = initializeLogsTest({
-    organization: {features: ['ourlogs-enabled', 'ourlogs-export', 'discover-query']},
+    organization: {features: ['ourlogs-enabled', 'discover-query']},
   });
   const initialRouterConfig = {
     location: {

--- a/static/app/views/explore/logs/logsExport.tsx
+++ b/static/app/views/explore/logs/logsExport.tsx
@@ -1,8 +1,6 @@
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreExport} from 'sentry/views/explore/components/exploreExport';
 import {QUERY_PAGE_LIMIT} from 'sentry/views/explore/logs/constants';
-import {isLogsExportEnabled} from 'sentry/views/explore/logs/isLogsEnabled';
 import {downloadLogsAsCsv} from 'sentry/views/explore/logs/logsExportCsv';
 import type {OurLogFieldKey, OurLogsResponseItem} from 'sentry/views/explore/logs/types';
 import {
@@ -31,17 +29,10 @@ interface LogsQueryInfo {
 }
 
 export function LogsExportButton(props: LogsExportButtonProps) {
-  const organization = useOrganization();
   const {selection} = usePageFilters();
   const logsSearch = useQueryParamsSearch();
   const fields = useQueryParamsFields();
   const sortBys = useQueryParamsSortBys();
-  const isEnabled = isLogsExportEnabled(organization);
-
-  if (!isEnabled) {
-    return <span />;
-  }
-
   const {start, end, period: statsPeriod} = selection.datetime;
   const {environments, projects} = selection;
 

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -78,7 +78,7 @@ jest.mock('@tanstack/react-virtual', () => {
 
 describe('LogsInfiniteTable', () => {
   const organization = OrganizationFixture({
-    features: ['ourlogs-enabled', 'ourlogs-replay-ui'],
+    features: ['ourlogs-enabled'],
   });
   const project = ProjectFixture();
 


### PR DESCRIPTION
These flags are fully rolled out and no longer needed. Removes the flag registrations from temporary.py and all conditional checks in the logs UI.
