### PR TITLE
feat(explorer): add max_iterations support to SeerExplorerClient

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -178,6 +178,7 @@ class SeerExplorerClient:
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
             is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI.
             enable_coding: Include code editing tools. When False, the agent cannot make code changes. Default is False. If enable_coding is True and the organization does not have the enable_seer_coding option, a SeerPermissionError will be raised.
+            max_iterations: Optional maximum number of agent iterations. Useful for lightweight/fast runs that don't need full exploration depth.
     """
 
     def __init__(
@@ -192,6 +193,7 @@ class SeerExplorerClient:
         intelligence_level: Literal["low", "medium", "high"] = "medium",
         is_interactive: bool = False,
         enable_coding: bool = False,
+        max_iterations: int | None = None,
     ):
         self.organization = organization
         self.user = user
@@ -202,6 +204,7 @@ class SeerExplorerClient:
         self.category_key = category_key
         self.category_value = category_value
         self.is_interactive = is_interactive
+        self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
             raise SeerPermissionError("Seer coding is not enabled for this organization")
@@ -271,6 +274,9 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
         )
+
+        if self.max_iterations is not None:
+            chat_body["max_iterations"] = self.max_iterations
 
         if self.project:
             chat_body["project_id"] = self.project.id

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -65,6 +65,7 @@ class ExplorerChatRequest(TypedDict):
     category_value: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
+    max_iterations: NotRequired[int]
 
 
 class ExplorerRunsRequest(TypedDict):

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -204,6 +204,62 @@ class TestSeerExplorerClient(TestCase):
         assert body["intelligence_level"] == "low"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    def test_client_init_with_max_iterations(self, mock_access):
+        """Test that max_iterations is stored"""
+        mock_access.return_value = (True, None)
+
+        client = SeerExplorerClient(self.organization, self.user, max_iterations=3)
+        assert client.max_iterations == 3
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    def test_client_init_default_max_iterations(self, mock_access):
+        """Test that max_iterations defaults to None"""
+        mock_access.return_value = (True, None)
+
+        client = SeerExplorerClient(self.organization, self.user)
+        assert client.max_iterations is None
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_run_includes_max_iterations(self, mock_collect_context, mock_post, mock_access):
+        """Test that max_iterations is included in the payload when set"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 444}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerExplorerClient(self.organization, self.user, max_iterations=3)
+        run_id = client.start_run("Test query")
+
+        assert run_id == 444
+        body = mock_post.call_args[0][0]
+        assert body["max_iterations"] == 3
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_run_excludes_max_iterations_when_none(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """Test that max_iterations is not included in the payload when None"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 445}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.start_run("Test query")
+
+        assert run_id == 445
+        body = mock_post.call_args[0][0]
+        assert "max_iterations" not in body
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_basic(self, mock_post, mock_access):
         """Test continuing an existing run"""


### PR DESCRIPTION
Add max_iterations field to ExplorerChatRequest TypedDict and SeerExplorerClient. Follow up of https://github.com/getsentry/seer/pull/5138. 