### PR TITLE
ref(grouping): Small normalization and parameterization refactors

### DIFF
--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -237,7 +237,7 @@ def resolve_fingerprint_variable(
             return message or "<no-message>"
 
         normalized_message = (
-            normalize_message_for_grouping(message, event, source="fingerprint", trim_message=False)
+            normalize_message_for_grouping(message, event, reason="fingerprint", trim_message=False)
             if message
             else None
         )

--- a/src/sentry/grouping/fingerprinting/utils.py
+++ b/src/sentry/grouping/fingerprinting/utils.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from sentry.grouping.fingerprinting.types import FingerprintInfo
-from sentry.grouping.utils import normalize_message_for_grouping
+from sentry.grouping.utils import get_canonical_message_from_event, normalize_message_for_grouping
 from sentry.stacktraces.functions import get_function_name_for_frame
 from sentry.stacktraces.platform import get_behavior_family_for_platform
 from sentry.stacktraces.processing import get_crash_frame_from_event_data
@@ -226,11 +226,7 @@ def resolve_fingerprint_variable(
         return event.data.get("transaction") or "<no-transaction>"
 
     elif variable_key == "message":
-        message = (
-            get_path(event.data, "logentry", "formatted")
-            or get_path(event.data, "logentry", "message")
-            or get_path(event.data, "exception", "values", -1, "value")
-        )
+        message = get_canonical_message_from_event(event)
 
         # Fingerprint variables can be used in custom titles, and there we want the original message
         if not parameterize_message:

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 
 
 @dataclasses.dataclass
@@ -251,20 +251,6 @@ EXPERIMENTAL_PARAMETERIZATION_REGEXES_MAP = {
     r.name: r.experimental_pattern if r.experimental_pattern else r.pattern
     for r in DEFAULT_PARAMETERIZATION_REGEXES
 }
-
-
-@dataclasses.dataclass
-class ParameterizationCallable:
-    """
-    Represents a callable that can be used to modify a string, which can give us more flexibility
-    than just using regex.
-
-    Note: Future-proofing. Not currently in use.
-    """
-
-    name: str  # name of the pattern (also used as group name in combined regex)
-    apply: Callable[[str], tuple[str, int]]  # function for modifying the input string
-    counter: int = 0
 
 
 class Parameterizer:

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -276,9 +276,9 @@ class Parameterizer:
         regex_pattern_keys: Sequence[str] | None = None,
         # Whether to use experimental patterns, if available. (Pattern types without an experimental
         # pattern will fall back to the standard pattern.)
-        experimental: bool = False,
+        use_experimental_regexes: bool = False,
     ):
-        self._experimental = experimental
+        self._experimental = use_experimental_regexes
         self._parameterization_regex = self._make_regex_from_patterns(
             regex_pattern_keys or DEFAULT_PARAMETERIZATION_REGEXES_MAP.keys()
         )

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -304,7 +304,7 @@ class Parameterizer:
 
         return re.compile(rf"(?x){'|'.join(regexes_map[k] for k in pattern_keys)}")
 
-    def parametrize_w_regex(self, input_str: str, parameterization_regex: re.Pattern[str]) -> str:
+    def parameterize(self, input_str: str) -> str:
         """
         Replace all matches of the given regex in the input string with a placeholder.
 
@@ -324,7 +324,4 @@ class Parameterizer:
                     return f"<{key}>"
             return ""
 
-        return parameterization_regex.sub(_handle_regex_match, input_str)
-
-    def parameterize(self, input_str: str) -> str:
-        return self.parametrize_w_regex(input_str, self._parameterization_regex)
+        return self._parameterization_regex.sub(_handle_regex_match, input_str)

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -306,12 +306,10 @@ class Parameterizer:
 
     def parameterize(self, input_str: str) -> str:
         """
-        Replace all matches of the given regex in the input string with a placeholder.
+        Replace all regex matches in the input string with placeholder strings, using the regexes
+        with which the parameterizer was initialized.
 
-        @param input_str: The string to replace matches in.
-        @param parameterization_regex: The compiled regex pattern to match.
-
-        @returns: The input string with all matches replaced with placeholders.
+        For example, turn "Error with order #1231" into "Error with order #<int>".
         """
 
         def _handle_regex_match(match: re.Match[str]) -> str:

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -11,7 +11,6 @@ class ParameterizationRegex:
     raw_pattern_experimental: str | None = None
     lookbehind: str | None = None  # positive lookbehind prefix if needed
     lookahead: str | None = None  # positive lookahead postfix if needed
-    counter: int = 0
 
     # These need to be used with `(?x)`, to tell the regex compiler to ignore comments
     # and unescaped whitespace, so we can use newlines and indentation for better legibility.

--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -326,5 +326,5 @@ class Parameterizer:
 
         return parameterization_regex.sub(_handle_regex_match, input_str)
 
-    def parameterize_all(self, input_str: str) -> str:
+    def parameterize(self, input_str: str) -> str:
         return self.parametrize_w_regex(input_str, self._parameterization_regex)

--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -27,7 +27,7 @@ def message_v1(
     if context["normalize_message"]:
         raw_message = interface.message or interface.formatted or ""
         normalized = normalize_message_for_grouping(
-            raw_message, event, source="message_component", trim_message=True
+            raw_message, event, reason="message_component", trim_message=True
         )
         hint = "stripped event-specific values" if raw_message != normalized else None
         return {variant_name: MessageGroupingComponent(values=[normalized], hint=hint)}

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -597,7 +597,7 @@ def single_exception(
         raw = exception.value
         if raw is not None:
             normalized = normalize_message_for_grouping(
-                raw, event, source="value_component", trim_message=True
+                raw, event, reason="value_component", trim_message=True
             )
             hint = "stripped event-specific values" if raw != normalized else None
             if normalized:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -62,7 +62,9 @@ def normalize_message_for_grouping(
     `trim_message` is True, trim the message to at most 2 lines.
     """
     parameterizer = Parameterizer(
-        experimental=in_rollout_group("grouping.experimental_parameterization", event.project_id),
+        use_experimental_regexes=in_rollout_group(
+            "grouping.experimental_parameterization", event.project_id
+        ),
     )
 
     if trim_message:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -11,6 +11,7 @@ from django.utils.encoding import force_bytes
 from sentry.grouping.parameterization import Parameterizer
 from sentry.options.rollout import in_rollout_group
 from sentry.utils import metrics
+from sentry.utils.safe import get_path
 
 if TYPE_CHECKING:
     from sentry.grouping.component import ExceptionGroupingComponent
@@ -101,3 +102,16 @@ def _trim_extra_lines(input_str: str) -> str:
     if trimmed != input_str:
         trimmed += "..."
     return trimmed
+
+
+def get_canonical_message_from_event(event: Event) -> str:
+    """
+    Get the event's message for purposes of grouping, i.e., what would be used as the value for
+    the `{{ message }}` variable. Returns an empty string if no message can be found.
+    """
+    return (
+        get_path(event.data, "logentry", "formatted")
+        or get_path(event.data, "logentry", "message")
+        or get_path(event.data, "exception", "values", -1, "value")
+        or ""
+    )

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -69,15 +69,7 @@ def normalize_message_for_grouping(
 
     if trim_message:
         # If there are multiple lines, grab the first two non-empty ones
-        trimmed = "\n".join(
-            islice(
-                (x for x in message.splitlines() if x.strip()),
-                2,
-            )
-        )
-        if trimmed != message:
-            trimmed += "..."
-
+        trimmed = _trim_extra_lines(message)
         normalized = parameterizer.parameterize(trimmed)
     else:
         normalized = parameterizer.parameterize(message)
@@ -92,3 +84,20 @@ def normalize_message_for_grouping(
             metrics.incr("grouping.value_trimmed_from_message", amount=value, tags={"key": key})
 
     return normalized
+
+
+def _trim_extra_lines(input_str: str) -> str:
+    """
+    Trim the given string by removing blank lines and then trimming the result to 2 lines.
+
+    This is a no-op for single-line strings and strings containing two non-empty lines.
+    """
+    trimmed = "\n".join(
+        islice(
+            (x for x in input_str.splitlines() if x.strip()),
+            2,
+        )
+    )
+    if trimmed != input_str:
+        trimmed += "..."
+    return trimmed

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -78,9 +78,9 @@ def normalize_message_for_grouping(
         if trimmed != message:
             trimmed += "..."
 
-        normalized = parameterizer.parameterize_all(trimmed)
+        normalized = parameterizer.parameterize(trimmed)
     else:
-        normalized = parameterizer.parameterize_all(message)
+        normalized = parameterizer.parameterize(message)
 
     parameterization_counts = parameterizer.matches_counter.items()
     if parameterization_counts:

--- a/src/sentry/grouping/utils.py
+++ b/src/sentry/grouping/utils.py
@@ -55,7 +55,7 @@ def bool_from_string(value: str) -> bool | None:
 # lines.
 @metrics.wraps("grouping.normalize_message_for_grouping")
 def normalize_message_for_grouping(
-    message: str, event: Event, *, source: str, trim_message: bool
+    message: str, event: Event, *, reason: str, trim_message: bool
 ) -> str:
     """
     Replace values from a event's message with placeholders (in order to improve grouping). If
@@ -84,7 +84,7 @@ def normalize_message_for_grouping(
 
     parameterization_counts = parameterizer.matches_counter.items()
     if parameterization_counts:
-        metrics.incr("grouping.message_parameterized", tags={"source": source})
+        metrics.incr("grouping.message_parameterized", tags={"source": reason})
 
         for key, value in parameterization_counts:
             # `key` can only be one of the keys from `_parameterization_regex`, thus, not a large

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -9,12 +9,12 @@ from sentry.grouping.parameterization import (
 
 @pytest.fixture
 def parameterizer() -> Parameterizer:
-    return Parameterizer(experimental=False)
+    return Parameterizer(use_experimental_regexes=False)
 
 
 @pytest.fixture
 def experimental_parameterizer() -> Parameterizer:
-    return Parameterizer(experimental=True)
+    return Parameterizer(use_experimental_regexes=True)
 
 
 standard_cases = [

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -172,20 +172,20 @@ experimental_cases: list[tuple[str, str, str]] = [
 def test_default_parameterization(
     name: str, input: str, expected: str, parameterizer: Parameterizer
 ) -> None:
-    assert parameterizer.parameterize_all(input) == expected
-    assert parameterizer.parameterize_all(f"prefix {input}") == f"prefix {expected}"
-    assert parameterizer.parameterize_all(f"{input} suffix") == f"{expected} suffix"
-    assert parameterizer.parameterize_all(f"prefix {input} suffix") == f"prefix {expected} suffix"
+    assert parameterizer.parameterize(input) == expected
+    assert parameterizer.parameterize(f"prefix {input}") == f"prefix {expected}"
+    assert parameterizer.parameterize(f"{input} suffix") == f"{expected} suffix"
+    assert parameterizer.parameterize(f"prefix {input} suffix") == f"prefix {expected} suffix"
 
 
 @pytest.mark.parametrize(("name", "input", "expected"), experimental_cases)
 def test_default_parameterizer_misses_experimental_cases(
     name: str, input: str, expected: str, parameterizer: Parameterizer
 ) -> None:
-    assert parameterizer.parameterize_all(input) != expected
-    assert parameterizer.parameterize_all(f"prefix {input}") != f"prefix {expected}"
-    assert parameterizer.parameterize_all(f"{input} suffix") != f"{expected} suffix"
-    assert parameterizer.parameterize_all(f"prefix {input} suffix") != f"prefix {expected} suffix"
+    assert parameterizer.parameterize(input) != expected
+    assert parameterizer.parameterize(f"prefix {input}") != f"prefix {expected}"
+    assert parameterizer.parameterize(f"{input} suffix") != f"{expected} suffix"
+    assert parameterizer.parameterize(f"prefix {input} suffix") != f"prefix {expected} suffix"
 
 
 @pytest.mark.skipif(
@@ -196,11 +196,11 @@ def test_default_parameterizer_misses_experimental_cases(
 def test_experimental_parameterization(
     name: str, input: str, expected: str, experimental_parameterizer: Parameterizer
 ) -> None:
-    assert experimental_parameterizer.parameterize_all(input) == expected
-    assert experimental_parameterizer.parameterize_all(f"prefix {input}") == f"prefix {expected}"
-    assert experimental_parameterizer.parameterize_all(f"{input} suffix") == f"{expected} suffix"
+    assert experimental_parameterizer.parameterize(input) == expected
+    assert experimental_parameterizer.parameterize(f"prefix {input}") == f"prefix {expected}"
+    assert experimental_parameterizer.parameterize(f"{input} suffix") == f"{expected} suffix"
     assert (
-        experimental_parameterizer.parameterize_all(f"prefix {input} suffix")
+        experimental_parameterizer.parameterize(f"prefix {input} suffix")
         == f"prefix {expected} suffix"
     )
 
@@ -258,5 +258,5 @@ incorrect_cases = [
 def test_incorrect_parameterization(
     name: str, input: str, desired: str, actual: str, parameterizer: Parameterizer
 ) -> None:
-    assert parameterizer.parameterize_all(input) != desired
-    assert parameterizer.parameterize_all(input) == actual
+    assert parameterizer.parameterize(input) != desired
+    assert parameterizer.parameterize(input) == actual


### PR DESCRIPTION
This includes a number of small refactors to our message normalization and parameterization code, extracted from a number of upcoming PRs to make them easier to review. No behavior changes.

- Rename a handful of variables/functions.

- Remove pass-through wrapper method in `Parameterizer` class (combine it and the method it called).

- Remove unused `ParameterizationRegex.counter` attribute and unused `ParameterizationCallable` dataclass.

- Pull message trimming and getting message from event into helper functions.