### PR TITLE
ref(ci): use shared setup-node-pnpm action in acceptance workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -68,12 +68,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         name: Checkout sentry
 
-      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
-        id: setup-node
-        with:
-          node-version-file: '.node-version'
-
-      - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
       - name: Step configurations
         id: config
         run: |
@@ -86,16 +80,7 @@ jobs:
           path: ${{ steps.config.outputs.webpack-path }}
           key: ${{ runner.os }}-v2-webpack-cache-${{ hashFiles('rspack.config.ts', 'pnpm-lock.yaml', 'package.json') }}
 
-      - name: node_modules cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-        id: nodemodulescache
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('pnpm-lock.yaml', 'api-docs/pnpm-lock.yaml', '.node-version') }}
-
-      - name: Install Javascript Dependencies
-        if: steps.nodemodulescache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-node-pnpm
 
       - name: webpack
         env:


### PR DESCRIPTION
## Summary

- The `acceptance.yml` workflow was manually duplicating 4 steps already abstracted into `.github/actions/setup-node-pnpm`: `actions/setup-node`, `pnpm/action-setup`, a `node_modules` cache step, and a conditional install step.
- Replace those 4 steps with a single `uses: ./.github/actions/setup-node-pnpm` call, matching the pattern used in `frontend.yml`, `pre-commit.yml`, and `backend.yml` (api-docs job).
- No behavior change — the shared action performs the exact same operations with the same cache key.

## Test plan

- [x] Verify the `acceptance` CI job passes after this change
- [x] Confirm `node_modules` cache hit/miss behavior is unchanged (same cache key: `pnpm-lock.yaml`, `api-docs/pnpm-lock.yaml`, `.node-version`)