### PR TITLE
feat: Disable webhook forwarding to codecov

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -570,6 +570,8 @@ def perform_request(payload: WebhookPayload) -> None:
             region = get_cell_by_name(name=payload.region_name)
             perform_region_request(region, payload)
         case DestinationType.CODECOV:
+            if options.get("codecov.forward-webhooks.disabled"):
+                return
             perform_codecov_request(payload)
 
 
@@ -690,6 +692,10 @@ def _should_skip_codecov_forward_for_github_owner(payload: WebhookPayload) -> bo
     Return True if this payload should be skipped (not forwarded to Codecov).
     The payload is still deleted by the caller when skipped.
     """
+
+    if options.get("codecov.forward-webhooks.disabled"):
+        return True
+
     skip_github_owners = options.get("codecov.forward-webhooks.skip-github-owners") or ()
     skip_set = (
         frozenset(str(x) for x in skip_github_owners if x) if skip_github_owners else frozenset()
@@ -719,6 +725,9 @@ def perform_codecov_request(payload: WebhookPayload) -> None:
     """
     We don't retry forwarding Codecov requests for now. We want to prove out that it would work.
     """
+    if options.get("codecov.forward-webhooks.disabled"):
+        return
+
     with metrics.timer(
         "hybridcloud.deliver_webhooks.send_request_to_codecov",
     ):

--- a/src/sentry/integrations/middleware/hybrid_cloud/parser.py
+++ b/src/sentry/integrations/middleware/hybrid_cloud/parser.py
@@ -386,6 +386,9 @@ class BaseRequestParser(ABC):
         self,
         external_id: str | None = None,
     ):
+        if options.get("codecov.forward-webhooks.disabled"):
+            return
+
         rollout_rate = options.get("codecov.forward-webhooks.rollout")
 
         # we don't want to emit metrics unless we've started to roll this out

--- a/src/sentry/middleware/integrations/parsers/github.py
+++ b/src/sentry/middleware/integrations/parsers/github.py
@@ -89,6 +89,8 @@ class GithubRequestParser(BaseRequestParser):
         return Integration.objects.filter(external_id=external_id, provider=self.provider).first()
 
     def try_forward_to_codecov(self, event: Mapping[str, Any]) -> None:
+        if options.get("codecov.forward-webhooks.disabled"):
+            return
         try:
             self.forward_to_codecov(external_id=self._get_external_id(event=event))
         except Exception:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -731,6 +731,7 @@ register(
     default=["getsentry"],
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register("codecov.forward-webhooks.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
 
 # GitHub Integration

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -351,7 +351,9 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL="https://api.codecov.io")
-    @override_options({"codecov.api-bridge-signing-secret": "test"})
+    @override_options(
+        {"codecov.api-bridge-signing-secret": "test", "codecov.forward-webhooks.disabled": False}
+    )
     @override_regions(region_config)
     def test_drain_success_codecov(self) -> None:
         responses.add(
@@ -371,6 +373,7 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL=None)
+    @override_options({"codecov.forward-webhooks.disabled": False})
     @override_regions(region_config)
     def test_drain_codecov_configuration_error(self) -> None:
         responses.add(
@@ -392,7 +395,9 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL="https://api.codecov.io")
-    @override_options({"codecov.api-bridge-signing-secret": "test"})
+    @override_options(
+        {"codecov.api-bridge-signing-secret": "test", "codecov.forward-webhooks.disabled": False}
+    )
     @override_regions(region_config)
     def test_drain_codecov_request_error(self) -> None:
         responses.add(
@@ -413,6 +418,7 @@ class DrainMailboxTest(TestCase):
         assert len(responses.calls) == 3
 
     @responses.activate
+    @override_options({"codecov.forward-webhooks.disabled": False})
     def test_drain_codecov_filtered_getsentry_owner(self) -> None:
         """Skip list uses default option (getsentry); no client or request needed."""
         records = create_payloads_with_destination_type(
@@ -427,7 +433,9 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL="https://api.codecov.io")
-    @override_options({"codecov.api-bridge-signing-secret": "test"})
+    @override_options(
+        {"codecov.api-bridge-signing-secret": "test", "codecov.forward-webhooks.disabled": False}
+    )
     @override_regions(region_config)
     def test_drain_codecov_not_filtered_other_owner(self) -> None:
         responses.add(
@@ -449,7 +457,9 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL="https://api.codecov.io")
-    @override_options({"codecov.api-bridge-signing-secret": "test"})
+    @override_options(
+        {"codecov.api-bridge-signing-secret": "test", "codecov.forward-webhooks.disabled": False}
+    )
     @override_regions(region_config)
     def test_drain_codecov_not_filtered_malformed_body(self) -> None:
         responses.add(
@@ -467,6 +477,19 @@ class DrainMailboxTest(TestCase):
         drain_mailbox(records[0].id)
 
         assert len(responses.calls) == 3
+        assert not WebhookPayload.objects.filter().exists()
+
+    @responses.activate
+    @override_options({"codecov.forward-webhooks.disabled": True})
+    @override_regions(region_config)
+    def test_drain_codecov_skipped_when_forwarding_disabled(self) -> None:
+        """When codecov.forward-webhooks.disabled is True, payloads are drained but not sent."""
+        records = create_payloads_with_destination_type(
+            2, "github:codecov:123", DestinationType.CODECOV
+        )
+        drain_mailbox(records[0].id)
+
+        assert len(responses.calls) == 0
         assert not WebhookPayload.objects.filter().exists()
 
     @responses.activate
@@ -1006,7 +1029,9 @@ class DeliveryTimeMetricsTest(TestCase):
 
     @responses.activate
     @override_settings(CODECOV_API_BASE_URL="https://api.codecov.io")
-    @override_options({"codecov.api-bridge-signing-secret": "test"})
+    @override_options(
+        {"codecov.api-bridge-signing-secret": "test", "codecov.forward-webhooks.disabled": False}
+    )
     @override_regions(region_config)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     def test_delivery_time_metrics_codecov_region_sent_to(self, mock_metrics: MagicMock) -> None:

--- a/tests/sentry/middleware/integrations/parsers/test_github.py
+++ b/tests/sentry/middleware/integrations/parsers/test_github.py
@@ -163,7 +163,11 @@ class GithubRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL, CODECOV_API_BASE_URL="https://api.codecov.io")
     @override_options(
-        {"codecov.forward-webhooks.rollout": 1.0, "codecov.forward-webhooks.regions": ["us"]}
+        {
+            "codecov.forward-webhooks.rollout": 1.0,
+            "codecov.forward-webhooks.regions": ["us"],
+            "codecov.forward-webhooks.disabled": False,
+        }
     )
     @override_regions(region_config)
     def test_webhook_for_codecov(self):
@@ -195,10 +199,55 @@ class GithubRequestParserTest(TestCase):
 
     @override_settings(SILO_MODE=SiloMode.CONTROL, CODECOV_API_BASE_URL="https://api.codecov.io")
     @override_options(
-        {"codecov.forward-webhooks.rollout": 1.0, "codecov.forward-webhooks.regions": []}
+        {
+            "codecov.forward-webhooks.rollout": 1.0,
+            "codecov.forward-webhooks.regions": [],
+            "codecov.forward-webhooks.disabled": False,
+        }
     )
     @override_regions(region_config)
     def test_webhook_for_codecov_no_regions(self):
+        integration = self.get_integration()
+        request = self.factory.post(
+            self.path,
+            data={"installation": {"id": "1"}},
+            content_type="application/json",
+            headers={"X-GITHUB-EVENT": GithubWebhookType.PUSH.value},
+        )
+        parser = GithubRequestParser(request=request, response_handler=self.get_response)
+
+        response = parser.get_response()
+        assert isinstance(response, HttpResponse)
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.content == b""
+        assert_webhook_payloads_for_mailbox(
+            request=request,
+            mailbox_name=f"github:{integration.id}",
+            region_names=[region.name],
+            destination_types={DestinationType.SENTRY_REGION: 1},
+        )
+        with pytest.raises(
+            Exception,
+            match="Missing 1 WebhookPayloads for codecov",
+        ):
+            assert_webhook_payloads_for_mailbox(
+                request=request,
+                mailbox_name="github:codecov:1",
+                region_names=[],
+                destination_types={DestinationType.CODECOV: 1},
+            )
+
+    @override_settings(SILO_MODE=SiloMode.CONTROL, CODECOV_API_BASE_URL="https://api.codecov.io")
+    @override_options(
+        {
+            "codecov.forward-webhooks.rollout": 1.0,
+            "codecov.forward-webhooks.regions": ["us"],
+            "codecov.forward-webhooks.disabled": True,
+        }
+    )
+    @override_regions(region_config)
+    def test_webhook_no_codecov_payload_when_forwarding_disabled(self):
+        """When codecov.forward-webhooks.disabled is True, only region payload is created."""
         integration = self.get_integration()
         request = self.factory.post(
             self.path,


### PR DESCRIPTION
Disable webhook forwarding behind a flag for monitoring behavior before complete removal of the feature. Paired with https://github.com/getsentry/sentry-options-automator/pull/6742