### PR TITLE
feat(ACI): Add error for unsupported condition

### DIFF
--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -36,6 +36,19 @@ from sentry.workflow_engine.processors.workflow_fire_history import get_last_fir
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
+# Check for unsupported conditions which exist in Workflows, but are unsupported in Rules
+# if we're trying to return these in legacy APIs, it's best to skip over them and warn the user
+UNSUPPORTED_CONDITIONS = [
+    Condition.EVENT_CREATED_BY_DETECTOR.value,
+    Condition.EVENT_SEEN_COUNT.value,
+    Condition.ISSUE_OPEN_DURATION.value,
+    Condition.ISSUE_PRIORITY_EQUALS.value,
+    Condition.ISSUE_PRIORITY_DEESCALATING.value,
+    Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL.value,
+    Condition.ISSUE_RESOLUTION_CHANGE.value,
+    Condition.ISSUE_RESOLVED_TRIGGER.value,
+]
+
 
 def generate_rule_label(project, rule, data):
     from sentry.rules import rules
@@ -631,17 +644,6 @@ class WorkflowEngineRuleSerializer(Serializer):
             result[workflow]["conditions"] = conditions
             result[workflow]["filters"] = filters
 
-            # Check for unsupported conditions
-            UNSUPPORTED_CONDITIONS = [
-                Condition.EVENT_CREATED_BY_DETECTOR.value,
-                Condition.EVENT_SEEN_COUNT.value,
-                Condition.ISSUE_OPEN_DURATION.value,
-                Condition.ISSUE_PRIORITY_EQUALS.value,
-                Condition.ISSUE_PRIORITY_DEESCALATING.value,
-                Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL.value,
-                Condition.ISSUE_RESOLUTION_CHANGE.value,
-                Condition.ISSUE_RESOLVED_TRIGGER.value,
-            ]
             trigger_conditions = (
                 list(workflow.when_condition_group.conditions.all())
                 if workflow.when_condition_group

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -24,6 +24,7 @@ from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.models import (
     Action,
     AlertRuleWorkflow,
+    Condition,
     DataCondition,
     DataConditionGroup,
     Workflow,
@@ -623,14 +624,41 @@ class WorkflowEngineRuleSerializer(Serializer):
 
                 serialized_actions.append(action_data)
 
-            if len(errors):
-                result[workflow]["errors"] = errors
             # Generate conditions and filters
             conditions, filters = self._generate_rule_conditions_filters(
                 workflow, result[workflow]["projects"][0], workflow_dcg
             )
             result[workflow]["conditions"] = conditions
             result[workflow]["filters"] = filters
+
+            # Check for unsupported conditions
+            UNSUPPORTED_CONDITIONS = [
+                Condition.EVENT_CREATED_BY_DETECTOR.value,
+                Condition.EVENT_SEEN_COUNT.value,
+                Condition.ISSUE_OPEN_DURATION.value,
+                Condition.ISSUE_PRIORITY_EQUALS.value,
+                Condition.ISSUE_PRIORITY_DEESCALATING.value,
+                Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL.value,
+                Condition.ISSUE_RESOLUTION_CHANGE.value,
+                Condition.ISSUE_RESOLVED_TRIGGER.value,
+            ]
+            trigger_conditions = (
+                list(workflow.when_condition_group.conditions.all())
+                if workflow.when_condition_group
+                else []
+            )
+            filter_conditions = list(workflow_dcg.condition_group.conditions.all())
+
+            for condition in trigger_conditions:
+                if condition.type in UNSUPPORTED_CONDITIONS:
+                    errors.append(f"Condition not supported: {condition.type}")
+
+            for f in filter_conditions:
+                if condition.type in UNSUPPORTED_CONDITIONS:
+                    errors.append(f"Filter not supported: {f.type}")
+
+            if len(errors):
+                result[workflow]["errors"] = errors
 
             if workflow.id in last_triggered_lookup:
                 result[workflow]["last_triggered"] = last_triggered_lookup[workflow.id]

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -651,11 +651,11 @@ class WorkflowEngineRuleSerializer(Serializer):
 
             for condition in trigger_conditions:
                 if condition.type in UNSUPPORTED_CONDITIONS:
-                    errors.append(f"Condition not supported: {condition.type}")
+                    errors.append({"detail": f"Condition not supported: {condition.type}"})
 
             for f in filter_conditions:
                 if f.type in UNSUPPORTED_CONDITIONS:
-                    errors.append(f"Filter not supported: {f.type}")
+                    errors.append({"detail": f"Filter not supported: {f.type}"})
 
             if len(errors):
                 result[workflow]["errors"] = errors

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -654,7 +654,7 @@ class WorkflowEngineRuleSerializer(Serializer):
                     errors.append(f"Condition not supported: {condition.type}")
 
             for f in filter_conditions:
-                if condition.type in UNSUPPORTED_CONDITIONS:
+                if f.type in UNSUPPORTED_CONDITIONS:
                     errors.append(f"Filter not supported: {f.type}")
 
             if len(errors):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -197,7 +197,7 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
         )
         assert len(issue_resolved_trigger_resp["filters"]) == 1
         assert (
-            issue_resolved_trigger_resp["errors"][0]
+            issue_resolved_trigger_resp["errors"][0]["detail"]
             == f"Condition not supported: {Condition.ISSUE_RESOLVED_TRIGGER}"
         )
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -196,6 +196,10 @@ class ProjectRuleListTest(ProjectRuleBaseTestCase):
             == ExistingHighPriorityIssueCondition.id
         )
         assert len(issue_resolved_trigger_resp["filters"]) == 1
+        assert (
+            issue_resolved_trigger_resp["errors"][0]
+            == f"Condition not supported: {Condition.ISSUE_RESOLVED_TRIGGER}"
+        )
 
     @with_feature("organizations:workflow-engine-rule-serializers")
     def test_workflow_engine_only_fetch_workflows_in_project(self) -> None:


### PR DESCRIPTION
We have some conditions that exist in ACI that don't exist in the old world - if a `Workflow` has one / more of these we can't render it in the old UI, but we should at least let the user know they're seeing incomplete data. This PR adds the unsupported condition type to the errors in the payload which can be picked up by the front end and used to render a warning in a follow up.