### PR TITLE
ref(cells): Migrate hybrid cloud resolvers from region -> cell

### DIFF
--- a/src/sentry/hybridcloud/rpc/caching/service.py
+++ b/src/sentry/hybridcloud/rpc/caching/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 import pydantic
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_method
 from sentry.silo.base import SiloMode
 from sentry.utils import json, metrics
@@ -28,7 +28,7 @@ class RegionCachingService(RpcService):
 
         return LocalRegionCachingService()
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def clear_key(self, *, region_name: str, key: str) -> int:
         pass

--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -37,13 +37,17 @@ class CellResolutionStrategy(ABC):
 
 @dataclass(frozen=True)
 class ByCellName(CellResolutionStrategy):
-    """Resolve from a `str` parameter representing a cell's name."""
+    """Resolve from a `str` parameter representing a cell's name.
 
-    # TODO(cells): change default to "cell_name" once service method parameters are renamed
-    parameter_name: str = "region_name"
+    Accepts either ``cell_name`` or ``region_name`` to ease the migration of
+    service method parameters from the old name to the new one.
+    """
+
+    parameter_name: str = "cell_name"
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
-        cell_name = arguments[self.parameter_name]
+        # TODO(cells): Temporary fall back to "region_name" while service methods are being migrated.
+        cell_name = arguments.get(self.parameter_name) or arguments["region_name"]
         return get_cell_by_name(cell_name)
 
 

--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -47,7 +47,11 @@ class ByCellName(CellResolutionStrategy):
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
         # TODO(cells): Temporary fall back to "region_name" while service methods are being migrated.
-        cell_name = arguments.get(self.parameter_name) or arguments["region_name"]
+        cell_name = (
+            arguments["region_name"]
+            if self.parameter_name not in arguments
+            else arguments[self.parameter_name]
+        )
         return get_cell_by_name(cell_name)
 
 

--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -15,12 +15,12 @@ from sentry.types.region import (
 )
 
 
-class RegionResolutionStrategy(ABC):
-    """Interface for directing a service call to a remote region."""
+class CellResolutionStrategy(ABC):
+    """Interface for directing a service call to a remote cell."""
 
     @abstractmethod
     def resolve(self, arguments: ArgumentDict) -> Cell:
-        """Return the region determined by a service call's arguments."""
+        """Return the cell determined by a service call's arguments."""
         raise NotImplementedError
 
     @staticmethod
@@ -36,18 +36,19 @@ class RegionResolutionStrategy(ABC):
 
 
 @dataclass(frozen=True)
-class ByRegionName(RegionResolutionStrategy):
-    """Resolve from an `str` parameter representing a region's name"""
+class ByCellName(CellResolutionStrategy):
+    """Resolve from a `str` parameter representing a cell's name."""
 
+    # TODO(cells): change default to "cell_name" once service method parameters are renamed
     parameter_name: str = "region_name"
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
-        region_name = arguments[self.parameter_name]
-        return get_cell_by_name(region_name)
+        cell_name = arguments[self.parameter_name]
+        return get_cell_by_name(cell_name)
 
 
 @dataclass(frozen=True)
-class ByOrganizationId(RegionResolutionStrategy):
+class ByOrganizationId(CellResolutionStrategy):
     """Resolve from an `int` parameter representing an organization ID."""
 
     parameter_name: str = "organization_id"
@@ -58,7 +59,7 @@ class ByOrganizationId(RegionResolutionStrategy):
 
 
 @dataclass(frozen=True)
-class ByOrganizationSlug(RegionResolutionStrategy):
+class ByOrganizationSlug(CellResolutionStrategy):
     """Resolve from a `str` parameter representing an organization slug."""
 
     parameter_name: str = "slug"
@@ -69,7 +70,7 @@ class ByOrganizationSlug(RegionResolutionStrategy):
 
 
 @dataclass(frozen=True)
-class ByOrganizationIdAttribute(RegionResolutionStrategy):
+class ByOrganizationIdAttribute(CellResolutionStrategy):
     """Resolve from an object with an organization ID as one of its attributes."""
 
     parameter_name: str
@@ -81,12 +82,12 @@ class ByOrganizationIdAttribute(RegionResolutionStrategy):
         return self._get_from_mapping(organization_id=organization_id)
 
 
-class RequireSingleOrganization(RegionResolutionStrategy):
-    """Resolve to the only region in a single-organization environment.
+class RequireSingleOrganization(CellResolutionStrategy):
+    """Resolve to the only cell in a single-organization environment.
 
     Calling a service method with this resolution strategy will cause an error if the
     environment is not configured with the "single organization" or has more than one
-    region.
+    cell.
     """
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
@@ -95,13 +96,18 @@ class RequireSingleOrganization(RegionResolutionStrategy):
         if not settings.SENTRY_SINGLE_ORGANIZATION:
             raise RegionResolutionError("Method is available only in single-org environment")
 
-        all_region_names = list(
+        all_cell_names = list(
             OrganizationMapping.objects.all().values_list("region_name", flat=True).distinct()[:2]
         )
-        if len(all_region_names) == 0:
+        if len(all_cell_names) == 0:
             return get_cell_by_name(settings.SENTRY_MONOLITH_REGION)
-        if len(all_region_names) != 1:
-            raise RegionResolutionError("Expected single-org environment to have only one region")
+        if len(all_cell_names) != 1:
+            raise RegionResolutionError("Expected single-org environment to have only one cell")
 
-        (single_region_name,) = all_region_names
-        return get_cell_by_name(single_region_name)
+        (single_cell_name,) = all_cell_names
+        return get_cell_by_name(single_cell_name)
+
+
+# TODO(cells): Remove once all callers have been migrated to new names
+RegionResolutionStrategy = CellResolutionStrategy
+ByRegionName = ByCellName

--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -113,5 +113,4 @@ class RequireSingleOrganization(CellResolutionStrategy):
 
 
 # TODO(cells): Remove once all callers have been migrated to new names
-RegionResolutionStrategy = CellResolutionStrategy
 ByRegionName = ByCellName

--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -37,7 +37,7 @@ from sentry.utils import json, metrics
 from sentry.utils.env import in_test_environment
 
 if TYPE_CHECKING:
-    from sentry.hybridcloud.rpc.resolvers import RegionResolutionStrategy
+    from sentry.hybridcloud.rpc.resolvers import CellResolutionStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class RpcMethodSignature(SerializableFunctionSignature):
     def get_name_segments(self) -> Sequence[str]:
         return self.service_name, self.method_name
 
-    def _extract_region_resolution(self) -> RegionResolutionStrategy | None:
+    def _extract_region_resolution(self) -> CellResolutionStrategy | None:
         region_resolution = getattr(self.base_function, _REGION_RESOLUTION_ATTR, None)
 
         is_region_service = self.base_service_cls.local_mode == SiloMode.REGION
@@ -178,7 +178,7 @@ def rpc_method(method: Callable[..., _T]) -> Callable[..., _T]:
 
 
 def regional_rpc_method(
-    resolve: RegionResolutionStrategy,
+    resolve: CellResolutionStrategy,
     return_none_if_mapping_not_found: bool = False,
 ) -> Callable[[Callable[..., _T]], Callable[..., _T]]:
     """Decorate methods to be exposed as part of the RPC interface.

--- a/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
+++ b/src/sentry/hybridcloud/services/region_organization_provisioning/service.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
@@ -20,7 +20,7 @@ class RegionOrganizationProvisioningRpcService(RpcService):
     key = "region_organization_provisioning"
     local_mode = SiloMode.REGION
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def create_organization_in_region(
         self,
@@ -39,7 +39,7 @@ class RegionOrganizationProvisioningRpcService(RpcService):
         :param provision_payload: The provisioning options for the organization.
         """
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def update_organization_slug_from_reservation(
         self,

--- a/src/sentry/hybridcloud/services/replica/service.py
+++ b/src/sentry/hybridcloud/services/replica/service.py
@@ -2,7 +2,7 @@ import abc
 
 from sentry.auth.services.auth import RpcApiKey, RpcApiToken, RpcAuthIdentity, RpcAuthProvider
 from sentry.auth.services.orgauthtoken.model import RpcOrgAuthToken
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_method
 from sentry.hybridcloud.services.control_organization_provisioning import (
     RpcOrganizationSlugReservation,
@@ -49,55 +49,55 @@ class RegionReplicaService(RpcService):
     key = "region_replica"
     local_mode = SiloMode.REGION
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_auth_provider(
         self, *, auth_provider: RpcAuthProvider, region_name: str
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_auth_identity(
         self, *, auth_identity: RpcAuthIdentity, region_name: str
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_api_key(self, *, api_key: RpcApiKey, region_name: str) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_api_token(self, *, api_token: RpcApiToken, region_name: str) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def delete_replicated_api_token(self, *, apitoken_id: int, region_name: str) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_org_auth_token(self, *, token: RpcOrgAuthToken, region_name: str) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def upsert_replicated_org_slug_reservation(
         self, *, slug_reservation: RpcOrganizationSlugReservation, region_name: str
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def delete_replicated_org_slug_reservation(
         self, *, organization_slug_reservation_id: int, region_name: str
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def delete_replicated_auth_provider(self, *, auth_provider_id: int, region_name: str) -> None:
         pass

--- a/src/sentry/hybridcloud/services/tombstone/service.py
+++ b/src/sentry/hybridcloud/services/tombstone/service.py
@@ -4,7 +4,7 @@
 # defined, because we want to reflect on type annotations and avoid forward references.
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_method
 from sentry.hybridcloud.services.tombstone import RpcTombstone
 from sentry.silo.base import SiloMode
@@ -40,7 +40,7 @@ class RegionTombstoneService(RpcService):
 
         return DatabaseBackedRegionTombstoneService()
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def record_remote_tombstone(self, *, region_name: str, tombstone: RpcTombstone) -> None:
         pass

--- a/src/sentry/issues/services/issue/service.py
+++ b/src/sentry/issues/services/issue/service.py
@@ -6,7 +6,7 @@
 
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationSlug, ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationSlug, ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata, RpcGroupShareMetadata
 from sentry.silo.base import SiloMode
@@ -35,7 +35,7 @@ class IssueService(RpcService):
 
         return DatabaseBackedIssueService()
 
-    @regional_rpc_method(resolve=ByRegionName(), return_none_if_mapping_not_found=True)
+    @regional_rpc_method(resolve=ByCellName(), return_none_if_mapping_not_found=True)
     @abstractmethod
     def get_external_issue_groups(
         self, *, region_name: str, external_issue_key: str, integration_id: int
@@ -47,7 +47,7 @@ class IssueService(RpcService):
     def get_shared_for_org(self, *, slug: str, share_id: str) -> RpcGroupShareMetadata | None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName(), return_none_if_mapping_not_found=True)
+    @regional_rpc_method(resolve=ByCellName(), return_none_if_mapping_not_found=True)
     @abstractmethod
     def get_shared_for_region(
         self, *, region_name: str, share_id: str

--- a/src/sentry/issues/services/issue/service.py
+++ b/src/sentry/issues/services/issue/service.py
@@ -6,7 +6,7 @@
 
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByOrganizationSlug, ByCellName
+from sentry.hybridcloud.rpc.resolvers import ByCellName, ByOrganizationId, ByOrganizationSlug
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.issues.services.issue.model import RpcExternalIssueGroupMetadata, RpcGroupShareMetadata
 from sentry.silo.base import SiloMode

--- a/src/sentry/organizations/services/organization/service.py
+++ b/src/sentry/organizations/services/organization/service.py
@@ -14,7 +14,7 @@ from sentry.hybridcloud.rpc.resolvers import (
     ByOrganizationId,
     ByOrganizationIdAttribute,
     ByOrganizationSlug,
-    ByRegionName,
+    ByCellName,
     RequireSingleOrganization,
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
@@ -142,7 +142,7 @@ class OrganizationService(RpcService):
         :param user_id: The user to check membership with
         """
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def get_organizations_by_user_and_scope(
         self, *, region_name: str, user: RpcUser, scope: str | None = None
@@ -479,7 +479,7 @@ class OrganizationService(RpcService):
         """
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def update_region_user(self, *, user: RpcRegionUser, region_name: str) -> None:
         """

--- a/src/sentry/organizations/services/organization/service.py
+++ b/src/sentry/organizations/services/organization/service.py
@@ -11,10 +11,10 @@ from django.dispatch import Signal
 
 from sentry.hybridcloud.rpc import OptionValue, silo_mode_delegation
 from sentry.hybridcloud.rpc.resolvers import (
+    ByCellName,
     ByOrganizationId,
     ByOrganizationIdAttribute,
     ByOrganizationSlug,
-    ByCellName,
     RequireSingleOrganization,
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -11,7 +11,7 @@ from sentry.hybridcloud.rpc.filter_query import OpaqueSerializedResponse
 from sentry.hybridcloud.rpc.resolvers import (
     ByOrganizationId,
     ByOrganizationIdAttribute,
-    ByRegionName,
+    ByCellName,
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project import ProjectFilterArgs, RpcProject, RpcProjectOptionValue
@@ -30,7 +30,7 @@ class ProjectService(RpcService):
 
         return DatabaseBackedProjectService()
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def get_many_by_organizations(
         self,

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -9,9 +9,9 @@ from sentry.auth.services.auth import AuthenticationContext
 from sentry.hybridcloud.rpc import OptionValue
 from sentry.hybridcloud.rpc.filter_query import OpaqueSerializedResponse
 from sentry.hybridcloud.rpc.resolvers import (
+    ByCellName,
     ByOrganizationId,
     ByOrganizationIdAttribute,
-    ByCellName,
 )
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project import ProjectFilterArgs, RpcProject, RpcProjectOptionValue

--- a/src/sentry/projects/services/project_key/service.py
+++ b/src/sentry/projects/services/project_key/service.py
@@ -5,7 +5,7 @@
 
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
+from sentry.hybridcloud.rpc.resolvers import ByCellName, ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project_key import ProjectKeyRole, RpcProjectKey
 from sentry.silo.base import SiloMode

--- a/src/sentry/projects/services/project_key/service.py
+++ b/src/sentry/projects/services/project_key/service.py
@@ -5,7 +5,7 @@
 
 from abc import abstractmethod
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.projects.services.project_key import ProjectKeyRole, RpcProjectKey
 from sentry.silo.base import SiloMode
@@ -35,14 +35,14 @@ class ProjectKeyService(RpcService):
     ) -> RpcProjectKey | None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def get_project_key_by_region(
         self, *, region_name: str, project_id: int, role: ProjectKeyRole
     ) -> RpcProjectKey | None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abstractmethod
     def get_project_keys_by_region(
         self,

--- a/src/sentry/relocation/services/relocation_export/service.py
+++ b/src/sentry/relocation/services/relocation_export/service.py
@@ -6,18 +6,18 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method, rpc_method
 from sentry.silo.base import SiloMode
 
 
 @dataclass(frozen=True)
-class ByRequestingRegionName(ByRegionName):
+class ByRequestingRegionName(ByCellName):
     parameter_name: str = "requesting_region_name"
 
 
 @dataclass(frozen=True)
-class ByReplyingRegionName(ByRegionName):
+class ByReplyingRegionName(ByCellName):
     parameter_name: str = "replying_region_name"
 
 

--- a/src/sentry/seer/services/test_generation/service.py
+++ b/src/sentry/seer/services/test_generation/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.seer.services.test_generation.model import CreateUnitTestResponse
 from sentry.silo.base import SiloMode
@@ -25,7 +25,7 @@ class TestGenerationService(RpcService):
 
         return RegionBackedTestGenerationService()
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def start_unit_test_generation(
         self, *, region_name: str, github_org: str, repo: str, pr_id: int, external_id: str

--- a/src/sentry/sentry_apps/services/app_request/service.py
+++ b/src/sentry/sentry_apps/services/app_request/service.py
@@ -1,6 +1,6 @@
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.app_request.model import (
     RpcSentryAppRequest,
@@ -21,7 +21,7 @@ class SentryAppRequestService(RpcService):
 
         return DatabaseBackedSentryAppRequestService()
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def get_buffer_requests_for_region(
         self,

--- a/src/sentry/sentry_apps/services/hook/service.py
+++ b/src/sentry/sentry_apps/services/hook/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.hook import RpcServiceHook
 from sentry.sentry_apps.services.hook.model import RpcInstallationOrganizationPair
@@ -52,7 +52,7 @@ class HookService(RpcService):
         """
         pass
 
-    @regional_rpc_method(ByRegionName())
+    @regional_rpc_method(ByCellName())
     @abc.abstractmethod
     def update_webhook_and_events_for_app_by_region(
         self,
@@ -83,7 +83,7 @@ class HookService(RpcService):
         """
         pass
 
-    @regional_rpc_method(ByRegionName())
+    @regional_rpc_method(ByCellName())
     @abc.abstractmethod
     def bulk_create_service_hooks_for_app(
         self,

--- a/src/sentry/sentry_apps/services/hook/service.py
+++ b/src/sentry/sentry_apps/services/hook/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
+from sentry.hybridcloud.rpc.resolvers import ByCellName, ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.sentry_apps.services.hook import RpcServiceHook
 from sentry.sentry_apps.services.hook.model import RpcInstallationOrganizationPair

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByRegionName
+from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.silo.base import SiloMode
 
@@ -34,7 +34,7 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def update_action_status_for_sentry_app_installation(
         self,
@@ -46,7 +46,7 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def update_action_status_for_sentry_app_via_sentry_app_id(
         self,
@@ -57,7 +57,7 @@ class ActionService(RpcService):
     ) -> None:
         pass
 
-    @regional_rpc_method(resolve=ByRegionName())
+    @regional_rpc_method(resolve=ByCellName())
     @abc.abstractmethod
     def update_action_status_for_webhook_via_sentry_app_slug(
         self,

--- a/src/sentry/workflow_engine/service/action/service.py
+++ b/src/sentry/workflow_engine/service/action/service.py
@@ -5,7 +5,7 @@
 
 import abc
 
-from sentry.hybridcloud.rpc.resolvers import ByOrganizationId, ByCellName
+from sentry.hybridcloud.rpc.resolvers import ByCellName, ByOrganizationId
 from sentry.hybridcloud.rpc.service import RpcService, regional_rpc_method
 from sentry.silo.base import SiloMode
 


### PR DESCRIPTION
both `region_name` and `cell_name` are now supported in the ByCellName resolver, even though callsites are still passing the original "region_name" parameter