### PR TITLE
fix(conversations): Preserve query params on redirect to explore

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2104,7 +2104,9 @@ function buildRoutes(): RouteObject[] {
     // Redirect old conversations links to the new explore location
     {
       path: `${CONVERSATIONS_LANDING_SUB_PATH}/*`,
-      redirectTo: `/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`,
+      component: make(
+        () => import('sentry/views/insights/pages/conversations/conversationsRedirect')
+      ),
     },
     // Redirect old links to the new agents landing page
     {

--- a/static/app/views/insights/pages/conversations/conversationsRedirect.tsx
+++ b/static/app/views/insights/pages/conversations/conversationsRedirect.tsx
@@ -1,0 +1,13 @@
+import {Navigate, useLocation} from 'react-router-dom';
+
+import {CONVERSATIONS_LANDING_SUB_PATH} from 'sentry/views/insights/pages/conversations/settings';
+
+export default function ConversationsRedirect() {
+  const location = useLocation();
+  return (
+    <Navigate
+      to={`/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${location.search}`}
+      replace
+    />
+  );
+}


### PR DESCRIPTION
closes: [TET-2028: Auto-select project in Conversations](https://linear.app/getsentry/issue/TET-2028/auto-select-project-in-conversations)
The redirect from instance conversations to explore conversations was dropping all query parameters (conversation, conversationSpan, query, etc). Replace the static redirectTo with a component that carries over location.search during the redirect.
