### PR TITLE
fix(ui): Change git_pr_number field type from STRING to INTEGER

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -2566,7 +2566,7 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
   git_pr_number: {
     desc: t('The pull request number associated with a build'),
     kind: FieldKind.FIELD,
-    valueType: FieldValueType.STRING,
+    valueType: FieldValueType.INTEGER,
   },
 };
 


### PR DESCRIPTION
The `git_pr_number` field was defined as `FieldValueType.STRING`, which allowed wildcard patterns like `*2209*` to be entered in the UI. The backend correctly rejects these as invalid numbers since PR numbers are always integers.

Changes the field type to `FieldValueType.INTEGER` so the frontend validates input correctly before sending requests.

<img width="320" height="213" alt="image" src="https://github.com/user-attachments/assets/2f39317a-ca9b-41b6-8c4f-556e8c1d32b8" />
