### PR TITLE
fix(attachments): Skip rate limiting for attachments already in objectstore

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2455,6 +2455,9 @@ def save_attachment(
 
         logger.exception("Missing chunks for cache_key=%s", cache_key)
         return
+    # Rate limits protect against filestore write abuse. When stored_id is set,
+    # the payload is already in objectstore and putfile will read from there —
+    # no filestore write occurs, so there is nothing to limit.
     if not attachment.stored_id:
         from sentry import ratelimits as ratelimiter
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2455,39 +2455,40 @@ def save_attachment(
 
         logger.exception("Missing chunks for cache_key=%s", cache_key)
         return
-    from sentry import ratelimits as ratelimiter
+    if not attachment.stored_id:
+        from sentry import ratelimits as ratelimiter
 
-    is_limited, _, _ = ratelimiter.backend.is_limited_with_value(
-        key="event_attachment.save_per_sec",
-        limit=options.get("sentry.save-event-attachments.project-per-sec-limit"),
-        project=project,
-        window=1,
-    )
-    rate_limit_tag = "per_sec"
-    if not is_limited:
         is_limited, _, _ = ratelimiter.backend.is_limited_with_value(
-            key="event_attachment.save_5_min",
-            limit=options.get("sentry.save-event-attachments.project-per-5-minute-limit"),
+            key="event_attachment.save_per_sec",
+            limit=options.get("sentry.save-event-attachments.project-per-sec-limit"),
             project=project,
-            window=5 * 60,
+            window=1,
         )
-        rate_limit_tag = "per_five_min"
-    if is_limited:
-        metrics.incr(
-            "event_manager.attachments.rate_limited", tags={"rate_limit_type": rate_limit_tag}
-        )
-        track_outcome(
-            org_id=project.organization_id,
-            project_id=project.id,
-            key_id=key_id,
-            outcome=Outcome.RATE_LIMITED,
-            reason="rate_limited",
-            timestamp=timestamp,
-            event_id=event_id,
-            category=DataCategory.ATTACHMENT,
-            quantity=attachment.size or 1,
-        )
-        return
+        rate_limit_tag = "per_sec"
+        if not is_limited:
+            is_limited, _, _ = ratelimiter.backend.is_limited_with_value(
+                key="event_attachment.save_5_min",
+                limit=options.get("sentry.save-event-attachments.project-per-5-minute-limit"),
+                project=project,
+                window=5 * 60,
+            )
+            rate_limit_tag = "per_five_min"
+        if is_limited:
+            metrics.incr(
+                "event_manager.attachments.rate_limited", tags={"rate_limit_type": rate_limit_tag}
+            )
+            track_outcome(
+                org_id=project.organization_id,
+                project_id=project.id,
+                key_id=key_id,
+                outcome=Outcome.RATE_LIMITED,
+                reason="rate_limited",
+                timestamp=timestamp,
+                event_id=event_id,
+                category=DataCategory.ATTACHMENT,
+                quantity=attachment.size or 1,
+            )
+            return
 
     file = EventAttachment.putfile(project.id, attachment)
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4463,3 +4463,39 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
                 if isinstance(call[0][0], EventProcessingErrorRecorded)
             ]
             assert len(processing_error_calls) == 0
+
+
+class SaveAttachmentTest(TestCase):
+    def test_rate_limit_skipped_when_stored_id_set(self) -> None:
+        from sentry.event_manager import save_attachment
+
+        stored_id = "test-stored-id"
+        attachment = CachedAttachment(
+            name="test.txt",
+            stored_id=stored_id,
+            size=100,
+        )
+
+        mock_putfile = mock.MagicMock()
+        mock_putfile.return_value.content_type = "text/plain"
+        mock_putfile.return_value.size = 100
+        mock_putfile.return_value.sha1 = "abc"
+        mock_putfile.return_value.blob_path = None
+
+        with (
+            mock.patch(
+                "sentry.ratelimits.backend.is_limited_with_value",
+                return_value=(True, 0, 0),
+            ) as mock_rate_limit,
+            mock.patch("sentry.models.eventattachment.EventAttachment.putfile", mock_putfile),
+            mock.patch("sentry.models.eventattachment.EventAttachment.objects.create"),
+        ):
+            save_attachment(
+                cache_key=None,
+                attachment=attachment,
+                project=self.project,
+                event_id="a" * 32,
+            )
+
+        mock_rate_limit.assert_not_called()
+        mock_putfile.assert_called_once()


### PR DESCRIPTION
Attachments with a `stored_id` have already been written to objectstore during ingestion, before `save_attachment` is called. The rate limits exist to protect filestore from write abuse (INC-766, INC-754), but there is no filestore write to protect when `stored_id` is set — `putfile` reads from objectstore rather than writing to it. Rate limiting these attachments only discards already-stored data without any benefit.

Wrap the rate limit checks in `if not attachment.stored_id` so they only run for attachments whose payload still needs to be written.

Refs FS-296