### PR TITLE
ref(replays): Clean up granular-replay-permissions feature flag (backend)

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -570,39 +570,29 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
     ) -> MutableMapping[Organization, MutableMapping[str, Any]]:
         attrs = super().get_attrs(item_list, user)
 
-        replay_permissions = {}
-        has_feature = features.batch_has_for_organizations(
-            "organizations:granular-replay-permissions", item_list
-        )
-        if has_feature and any(has_feature.values()):
-            replay_permissions = {
-                opt.organization_id: opt.value
-                for opt in OrganizationOption.objects.filter(
-                    organization__in=item_list, key="sentry:granular-replay-permissions"
-                )
-            }
+        replay_permissions = {
+            opt.organization_id: opt.value
+            for opt in OrganizationOption.objects.filter(
+                organization__in=item_list, key="sentry:granular-replay-permissions"
+            )
+        }
 
-            # Only process replay access data if replay_permissions is enabled for at least one org
-            enabled_org_ids = [org_id for org_id, enabled in replay_permissions.items() if enabled]
-            replay_access_by_org: dict[int, list[int]] = {}
-            if enabled_org_ids:
-                for org_id, user_id in OrganizationMemberReplayAccess.objects.filter(
-                    organizationmember__organization__in=enabled_org_ids
-                ).values_list("organizationmember__organization_id", "organizationmember__user_id"):
-                    if user_id is not None:
-                        replay_access_by_org.setdefault(org_id, []).append(user_id)
+        enabled_org_ids = [org_id for org_id, enabled in replay_permissions.items() if enabled]
+        replay_access_by_org: dict[int, list[int]] = {}
+        if enabled_org_ids:
+            for org_id, user_id in OrganizationMemberReplayAccess.objects.filter(
+                organizationmember__organization__in=enabled_org_ids
+            ).values_list("organizationmember__organization_id", "organizationmember__user_id"):
+                if user_id is not None:
+                    replay_access_by_org.setdefault(org_id, []).append(user_id)
 
-            for item in item_list:
-                attrs[item]["replay_permissions_enabled"] = replay_permissions.get(item.id, False)
-                attrs[item]["replay_access_members"] = (
-                    replay_access_by_org.get(item.id, [])
-                    if replay_permissions.get(item.id, False)
-                    else []
-                )
-        else:
-            for item in item_list:
-                attrs[item]["replay_permissions_enabled"] = False
-                attrs[item]["replay_access_members"] = []
+        for item in item_list:
+            attrs[item]["replay_permissions_enabled"] = replay_permissions.get(item.id, False)
+            attrs[item]["replay_access_members"] = (
+                replay_access_by_org.get(item.id, [])
+                if replay_permissions.get(item.id, False)
+                else []
+            )
 
         return attrs
 
@@ -774,13 +764,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 team__organization=obj
             ).count(),
             "isDynamicallySampled": is_dynamically_sampled,
-            "hasGranularReplayPermissions": False,
-            "replayAccessMembers": [],
+            "hasGranularReplayPermissions": bool(attrs.get("replay_permissions_enabled")),
+            "replayAccessMembers": attrs.get("replay_access_members", []),
         }
-
-        if features.has("organizations:granular-replay-permissions", obj):
-            context["hasGranularReplayPermissions"] = bool(attrs.get("replay_permissions_enabled"))
-            context["replayAccessMembers"] = attrs.get("replay_access_members", [])
 
         if has_custom_dynamic_sampling(obj, actor=user):
             context["targetSampleRate"] = float(

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django.utils import timezone as django_timezone
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import PermissionDenied
 from sentry_sdk import capture_exception
 
 from bitfield.types import BitHandler
@@ -500,11 +500,7 @@ class OrganizationSerializer(BaseOrganizationSerializer):
         return value
 
     def _validate_granular_replay_permissions(self):
-        organization = self.context["organization"]
         request = self.context["request"]
-
-        if not features.has("organizations:granular-replay-permissions", organization):
-            raise NotFound("This feature is not enabled for your organization.")
 
         if not request.access.has_scope("org:write"):
             raise PermissionDenied(

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -140,6 +140,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-search-agent-translate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable granular permissions for replay features
+    manager.add("organizations:granular-replay-permissions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -140,8 +140,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:gen-ai-search-agent-translate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable GenAI consent
     manager.add("organizations:gen-ai-consent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable granular permissions for replay features
-    manager.add("organizations:granular-replay-permissions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+
     # Enable increased issue_owners rate limit for auto-assignment
     manager.add("organizations:increased-issue-owners-rate-limit", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Starfish: extract metrics from the spans

--- a/src/sentry/replays/permissions.py
+++ b/src/sentry/replays/permissions.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any
 
 from django.http import HttpRequest
 
-from sentry import features
 from sentry.auth.superuser import superuser_has_permission
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationmember import OrganizationMember
@@ -24,14 +23,11 @@ def has_replay_permission(request: HttpRequest, organization: Organization) -> b
     - Superusers always have access.
     - Org auth tokens with event:read scope have access (replays are event data).
     - SentryApp proxy users with event:read scope have access (replays are event data).
-    - If the 'organizations:granular-replay-permissions' feature flag is OFF, all users have access.
     - If the 'sentry:granular-replay-permissions' org option is not set or falsy, all org members have access.
-    - If no allowlist records exist for the organization but the feature flag is on, no one has access.
+    - If no allowlist records exist for the organization, no one has access.
     - If allowlist records exist, only users explicitly present in the OrganizationMemberReplayAccess allowlist have access.
     - Returns True if allowed, False otherwise.
     """
-    if not features.has("organizations:granular-replay-permissions", organization):
-        return True
     if superuser_has_permission(request):
         return True
 

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -162,7 +162,7 @@ class DetailedOrganizationSerializerTest(TestCase):
         assert isinstance(result["teamRoleList"], list)
         assert result["requiresSso"] == acc.requires_sso
 
-    def test_granular_replay_permissions_disabled_without_feature(self) -> None:
+    def test_granular_replay_permissions_without_option(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
@@ -173,28 +173,23 @@ class DetailedOrganizationSerializerTest(TestCase):
         assert result["hasGranularReplayPermissions"] is False
         assert result["replayAccessMembers"] == []
 
-    def test_granular_replay_permissions_flag_with_feature(self) -> None:
+    def test_granular_replay_permissions_with_option(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        with self.feature("organizations:granular-replay-permissions"):
-            serializer = DetailedOrganizationSerializer()
-            result = serialize(organization, user, serializer, access=acc)
-            assert result["hasGranularReplayPermissions"] is False
-            assert result["replayAccessMembers"] == []
+        OrganizationOption.objects.set_value(
+            organization=organization,
+            key="sentry:granular-replay-permissions",
+            value=True,
+        )
 
-            OrganizationOption.objects.set_value(
-                organization=organization,
-                key="sentry:granular-replay-permissions",
-                value=True,
-            )
+        serializer = DetailedOrganizationSerializer()
+        result = serialize(organization, user, serializer, access=acc)
+        assert result["hasGranularReplayPermissions"] is True
+        assert result["replayAccessMembers"] == []
 
-            result = serialize(organization, user, serializer, access=acc)
-            assert result["hasGranularReplayPermissions"] is True
-            assert result["replayAccessMembers"] == []
-
-    def test_replay_access_members_serialized(self) -> None:
+    def test_replay_access_members_not_serialized_without_option(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
         member1 = self.create_member(
@@ -207,10 +202,9 @@ class DetailedOrganizationSerializerTest(TestCase):
         OrganizationMemberReplayAccess.objects.create(organizationmember=member2)
         acc = access.from_user(user, organization)
 
-        with self.feature("organizations:granular-replay-permissions"):
-            serializer = DetailedOrganizationSerializer()
-            result = serialize(organization, user, serializer, access=acc)
-            assert set(result["replayAccessMembers"]) == set()
+        serializer = DetailedOrganizationSerializer()
+        result = serialize(organization, user, serializer, access=acc)
+        assert set(result["replayAccessMembers"]) == set()
 
     def test_replay_access_members_serialized_with_option_enabled(self) -> None:
         user = self.create_user()
@@ -225,29 +219,26 @@ class DetailedOrganizationSerializerTest(TestCase):
         OrganizationMemberReplayAccess.objects.create(organizationmember=member2)
         acc = access.from_user(user, organization)
 
-        with self.feature("organizations:granular-replay-permissions"):
-            # Set the org option to enable granular replay permissions
-            OrganizationOption.objects.set_value(
-                organization=organization,
-                key="sentry:granular-replay-permissions",
-                value=True,
-            )
+        OrganizationOption.objects.set_value(
+            organization=organization,
+            key="sentry:granular-replay-permissions",
+            value=True,
+        )
 
-            serializer = DetailedOrganizationSerializer()
-            result = serialize(organization, user, serializer, access=acc)
-            assert result["hasGranularReplayPermissions"] is True
-            assert set(result["replayAccessMembers"]) == {member1.user_id, member2.user_id}
+        serializer = DetailedOrganizationSerializer()
+        result = serialize(organization, user, serializer, access=acc)
+        assert result["hasGranularReplayPermissions"] is True
+        assert set(result["replayAccessMembers"]) == {member1.user_id, member2.user_id}
 
     def test_replay_access_members_empty_when_none_set(self) -> None:
         user = self.create_user()
         organization = self.create_organization(owner=user)
         acc = access.from_user(user, organization)
 
-        with self.feature("organizations:granular-replay-permissions"):
-            serializer = DetailedOrganizationSerializer()
-            result = serialize(organization, user, serializer, access=acc)
+        serializer = DetailedOrganizationSerializer()
+        result = serialize(organization, user, serializer, access=acc)
 
-            assert result["replayAccessMembers"] == []
+        assert result["replayAccessMembers"] == []
 
 
 class DetailedOrganizationSerializerWithProjectsAndTeamsTest(TestCase):

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1494,7 +1494,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert self.organization.get_option("sentry:enable_seer_coding") is True
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_flag_set(self) -> None:
         with assume_test_silo_mode_of(AuditLogEntry):
             AuditLogEntry.objects.filter(organization_id=self.organization.id).delete()
@@ -1512,7 +1511,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             log = AuditLogEntry.objects.get(organization_id=self.organization.id)
         assert "to True" in log.data["hasGranularReplayPermissions"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_flag_unset(self) -> None:
         self.organization.update_option("sentry:granular-replay-permissions", True)
         with assume_test_silo_mode_of(AuditLogEntry):
@@ -1532,7 +1530,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         assert "to False" in log.data["hasGranularReplayPermissions"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_no_spurious_audit_log(self) -> None:
         self.organization.update_option("sentry:granular-replay-permissions", True)
         with assume_test_silo_mode_of(AuditLogEntry):
@@ -1546,7 +1543,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             audit_logs = AuditLogEntry.objects.filter(organization_id=self.organization.id)
             assert audit_logs.count() == 0
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_change_logs_old_value(self) -> None:
         self.organization.update_option("sentry:granular-replay-permissions", False)
         with assume_test_silo_mode_of(AuditLogEntry):
@@ -1565,11 +1561,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             log = AuditLogEntry.objects.get(organization_id=self.organization.id)
         assert log.data["hasGranularReplayPermissions"] == "from False to True"
 
-    def test_granular_replay_permissions_flag_requires_feature(self) -> None:
-        data = {"hasGranularReplayPermissions": True}
-        self.get_error_response(self.organization.slug, **data, status_code=404)
-
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_flag_requires_admin_scope(self) -> None:
         member_user = self.create_user()
         self.create_member(
@@ -1581,7 +1572,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         response = self.get_error_response(self.organization.slug, **data, status_code=403)
         assert response.status_code == 403
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_add(self) -> None:
         member1 = self.create_member(
             organization=self.organization, user=self.create_user(), role="member"
@@ -1608,7 +1598,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "added 2 user(s)" in log.data["replayAccessMembers"]
         assert "total: 2 user(s)" in log.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_remove(self) -> None:
         member1 = self.create_member(
             organization=self.organization, user=self.create_user(), role="member"
@@ -1637,7 +1626,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "removed 1 user(s)" in log.data["replayAccessMembers"]
         assert "total: 1 user(s)" in log.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_add_and_remove(self) -> None:
         member1 = self.create_member(
             organization=self.organization, user=self.create_user(), role="member"
@@ -1669,7 +1657,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "removed 1 user(s)" in log.data["replayAccessMembers"]
         assert "total: 2 user(s)" in log.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_clear_all(self) -> None:
         member1 = self.create_member(
             organization=self.organization, user=self.create_user(), role="member"
@@ -1692,14 +1679,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "removed 1 user(s)" in log.data["replayAccessMembers"]
         assert "total: 0 user(s)" in log.data["replayAccessMembers"]
 
-    def test_replay_access_members_requires_feature(self) -> None:
-        member1 = self.create_member(
-            organization=self.organization, user=self.create_user(), role="member"
-        )
-        data = {"replayAccessMembers": [member1.user_id]}
-        self.get_error_response(self.organization.slug, **data, status_code=404)
-
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_requires_admin_scope(self) -> None:
         member_user = self.create_user()
         self.create_member(
@@ -1713,7 +1692,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         data = {"replayAccessMembers": [other_member.user_id]}
         self.get_error_response(self.organization.slug, **data, status_code=403)
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_invalid_user_ids(self) -> None:
         nonexistent_id = 999999999
         data = {"replayAccessMembers": [nonexistent_id]}
@@ -1721,7 +1699,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert str(nonexistent_id) in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_from_other_organization(self) -> None:
         other_org = self.create_organization(owner=self.create_user())
         other_org_member = self.create_member(
@@ -1732,7 +1709,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert str(other_org_member.user_id) in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_replay_access_members_mixed_valid_and_invalid(self) -> None:
         valid_member = self.create_member(
             organization=self.organization, user=self.create_user(), role="member"
@@ -1749,7 +1725,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         ).count()
         assert access_count == 0
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_owner_can_edit(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1763,7 +1738,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert response.data["hasGranularReplayPermissions"] is True
         assert member.user_id in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_manager_can_edit(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1779,7 +1753,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert response.data["hasGranularReplayPermissions"] is True
         assert member.user_id in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_admin_cannot_edit(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1792,7 +1765,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             org.slug, hasGranularReplayPermissions=True, replayAccessMembers=[member.user_id]
         )
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_member_cannot_edit_boolean(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1802,7 +1774,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         self.get_error_response(org.slug, hasGranularReplayPermissions=True, status_code=403)
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_member_cannot_edit_list(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1815,7 +1786,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             org.slug, replayAccessMembers=[other_member.user_id], status_code=403
         )
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_retrieve_as_owner(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1831,7 +1801,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert member.user_id in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_retrieve_as_manager(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1849,7 +1818,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert member.user_id in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_retrieve_as_admin(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1867,7 +1835,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert member.user_id in response.data["replayAccessMembers"]
 
-    @with_feature("organizations:granular-replay-permissions")
     def test_granular_replay_permissions_retrieve_as_member(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
@@ -1885,10 +1852,9 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "replayAccessMembers" in response.data
         assert other_member.user_id in response.data["replayAccessMembers"]
 
-    def test_granular_replay_permissions_retrieve_hidden_without_feature(self) -> None:
+    def test_granular_replay_permissions_retrieve_without_option(self) -> None:
         owner = self.create_user()
         org = self.create_organization(owner=owner)
-        org.update_option("sentry:granular-replay-permissions", True)
         self.login_as(owner)
 
         response = self.get_success_response(org.slug, method="get")

--- a/tests/sentry/replays/endpoints/test_project_replay_jobs_delete.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_jobs_delete.py
@@ -345,94 +345,83 @@ class ProjectReplayDeletionJobsIndexTest(APITestCase):
 
     def test_granular_permissions_without_replay_access(self) -> None:
         """Test that users without replay access cannot access endpoints even with project:write"""
-        with self.feature("organizations:granular-replay-permissions"):
-            # Enable granular permissions org option
-            OrganizationOption.objects.set_value(
-                organization=self.organization,
-                key="sentry:granular-replay-permissions",
-                value=True,
-            )
-
-            # Create another user with replay access
-            user_with_access = self.create_user()
-            member_with_access = self.create_member(
-                user=user_with_access, organization=self.organization, role="admin"
-            )
-            OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
-
-            # Login as user without replay access (but has project:write via admin role)
-            user_without_access = self.create_user()
-            self.create_member(
-                user=user_without_access, organization=self.organization, role="admin"
-            )
-            self.login_as(user=user_without_access)
-
-            # GET should return 403
-            self.get_error_response(self.organization.slug, self.project.slug, status_code=403)
-
-            # POST should return 403
-            data = {
-                "data": {
-                    "rangeStart": "2023-01-01T00:00:00Z",
-                    "rangeEnd": "2023-01-02T00:00:00Z",
-                    "environments": ["production"],
-                    "query": "test query",
-                }
-            }
-            self.get_error_response(
-                self.organization.slug, self.project.slug, method="post", **data, status_code=403
-            )
-
-    def test_granular_permissions_with_replay_access(self) -> None:
-        """Test that users with replay access can access endpoints with project:write"""
-        with self.feature("organizations:granular-replay-permissions"):
-            # Enable granular permissions org option
-            OrganizationOption.objects.set_value(
-                organization=self.organization,
-                key="sentry:granular-replay-permissions",
-                value=True,
-            )
-
-            # Create user with replay access (admin role gives project:write)
-            user_with_access = self.create_user()
-            member_with_access = self.create_member(
-                user=user_with_access, organization=self.organization, role="admin"
-            )
-            OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
-            self.login_as(user=user_with_access)
-
-            # GET should succeed
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            assert response.data == {"data": []}
-
-            # POST should succeed
-            data = {
-                "data": {
-                    "rangeStart": "2023-01-01T00:00:00Z",
-                    "rangeEnd": "2023-01-02T00:00:00Z",
-                    "environments": ["production"],
-                    "query": "test query",
-                }
-            }
-            with patch("sentry.replays.tasks.run_bulk_replay_delete_job.delay"):
-                response = self.get_success_response(
-                    self.organization.slug,
-                    self.project.slug,
-                    method="post",
-                    **data,
-                    status_code=201,
-                )
-            assert "data" in response.data
-
-    def test_granular_permissions_feature_disabled_allows_all(self) -> None:
-        """Test that when feature flag is disabled, all users with project:write can access"""
-        # Enable org option but disable feature flag
+        # Enable granular permissions org option
         OrganizationOption.objects.set_value(
             organization=self.organization,
             key="sentry:granular-replay-permissions",
             value=True,
         )
 
+        # Create another user with replay access
+        user_with_access = self.create_user()
+        member_with_access = self.create_member(
+            user=user_with_access, organization=self.organization, role="admin"
+        )
+        OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
+
+        # Login as user without replay access (but has project:write via admin role)
+        user_without_access = self.create_user()
+        self.create_member(user=user_without_access, organization=self.organization, role="admin")
+        self.login_as(user=user_without_access)
+
+        # GET should return 403
+        self.get_error_response(self.organization.slug, self.project.slug, status_code=403)
+
+        # POST should return 403
+        data = {
+            "data": {
+                "rangeStart": "2023-01-01T00:00:00Z",
+                "rangeEnd": "2023-01-02T00:00:00Z",
+                "environments": ["production"],
+                "query": "test query",
+            }
+        }
+        self.get_error_response(
+            self.organization.slug, self.project.slug, method="post", **data, status_code=403
+        )
+
+    def test_granular_permissions_with_replay_access(self) -> None:
+        """Test that users with replay access can access endpoints with project:write"""
+        # Enable granular permissions org option
+        OrganizationOption.objects.set_value(
+            organization=self.organization,
+            key="sentry:granular-replay-permissions",
+            value=True,
+        )
+
+        # Create user with replay access (admin role gives project:write)
+        user_with_access = self.create_user()
+        member_with_access = self.create_member(
+            user=user_with_access, organization=self.organization, role="admin"
+        )
+        OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
+        self.login_as(user=user_with_access)
+
+        # GET should succeed
+        response = self.get_success_response(self.organization.slug, self.project.slug)
+        assert response.data == {"data": []}
+
+        # POST should succeed
+        data = {
+            "data": {
+                "rangeStart": "2023-01-01T00:00:00Z",
+                "rangeEnd": "2023-01-02T00:00:00Z",
+                "environments": ["production"],
+                "query": "test query",
+            }
+        }
+        with patch("sentry.replays.tasks.run_bulk_replay_delete_job.delay"):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                **data,
+                status_code=201,
+            )
+        assert "data" in response.data
+
+    def test_granular_permissions_org_option_disabled_allows_all(self) -> None:
+        """Test that when org option is disabled, all users with project:write can access"""
         # Create user with replay access
         user_with_access = self.create_user()
         member_with_access = self.create_member(
@@ -440,35 +429,14 @@ class ProjectReplayDeletionJobsIndexTest(APITestCase):
         )
         OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
 
-        # Login as user without replay access (admin role gives project:write)
+        # Login as user without replay access (org option is NOT enabled, admin role gives project:write)
         user_without_access = self.create_user()
         self.create_member(user=user_without_access, organization=self.organization, role="admin")
         self.login_as(user=user_without_access)
 
-        # GET should succeed (feature flag is OFF)
+        # GET should succeed (org option is OFF)
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert response.data == {"data": []}
-
-    def test_granular_permissions_org_option_disabled_allows_all(self) -> None:
-        """Test that when org option is disabled, all users with project:write can access"""
-        with self.feature("organizations:granular-replay-permissions"):
-            # Create user with replay access
-            user_with_access = self.create_user()
-            member_with_access = self.create_member(
-                user=user_with_access, organization=self.organization, role="admin"
-            )
-            OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
-
-            # Login as user without replay access (org option is NOT enabled, admin role gives project:write)
-            user_without_access = self.create_user()
-            self.create_member(
-                user=user_without_access, organization=self.organization, role="admin"
-            )
-            self.login_as(user=user_without_access)
-
-            # GET should succeed (org option is OFF)
-            response = self.get_success_response(self.organization.slug, self.project.slug)
-            assert response.data == {"data": []}
 
     @patch("sentry.replays.tasks.run_bulk_replay_delete_job.delay")
     def test_post_has_seer_data(self, mock_task: MagicMock) -> None:
@@ -701,9 +669,7 @@ class ProjectReplayDeletionJobDetailTest(APITestCase):
             status="pending",
         )
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             # Enable granular permissions org option
             OrganizationOption.objects.set_value(
                 organization=self.organization,
@@ -748,9 +714,7 @@ class ProjectReplayDeletionJobDetailTest(APITestCase):
             status="pending",
         )
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             # Enable granular permissions org option
             OrganizationOption.objects.set_value(
                 organization=self.organization,
@@ -773,50 +737,6 @@ class ProjectReplayDeletionJobDetailTest(APITestCase):
             response = self.get_success_response(self.organization.slug, self.project.slug, job.id)
             assert response.data["data"]["id"] == job.id
 
-    def test_granular_permissions_feature_disabled_allows_all(self) -> None:
-        """Test that when feature flag is disabled, all users with project:write can access"""
-        job = ReplayDeletionJobModel.objects.create(
-            project_id=self.project.id,
-            organization_id=self.organization.id,
-            range_start=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
-            range_end=datetime.datetime(2023, 1, 2, tzinfo=datetime.UTC),
-            query="test query",
-            environments=[],
-            status="pending",
-        )
-
-        # Enable session-replay and org option but disable granular-replay-permissions feature flag
-        with self.feature("organizations:session-replay"):
-            OrganizationOption.objects.set_value(
-                organization=self.organization,
-                key="sentry:granular-replay-permissions",
-                value=True,
-            )
-
-            # Create user with replay access
-            user_with_access = self.create_user()
-            member_with_access = self.create_member(
-                user=user_with_access,
-                organization=self.organization,
-                role="admin",
-                teams=[self.team],
-            )
-            OrganizationMemberReplayAccess.objects.create(organizationmember=member_with_access)
-
-            # Login as user without replay access (admin role gives project:write)
-            user_without_access = self.create_user()
-            self.create_member(
-                user=user_without_access,
-                organization=self.organization,
-                role="admin",
-                teams=[self.team],
-            )
-            self.login_as(user=user_without_access)
-
-            # GET should succeed (feature flag is OFF)
-            response = self.get_success_response(self.organization.slug, self.project.slug, job.id)
-            assert response.data["data"]["id"] == job.id
-
     def test_granular_permissions_org_option_disabled_allows_all(self) -> None:
         """Test that when org option is disabled, all users with project:write can access"""
         job = ReplayDeletionJobModel.objects.create(
@@ -829,9 +749,7 @@ class ProjectReplayDeletionJobDetailTest(APITestCase):
             status="pending",
         )
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             # Create user with replay access
             user_with_access = self.create_user()
             member_with_access = self.create_member(

--- a/tests/sentry/replays/endpoints/test_replay_granular_permissions.py
+++ b/tests/sentry/replays/endpoints/test_replay_granular_permissions.py
@@ -35,9 +35,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_organization_replay_index_with_permission(self) -> None:
         """User with replay permission can access org replay index"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -49,9 +47,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_organization_replay_index_without_permission(self) -> None:
         """User without replay permission cannot access org replay index"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -63,9 +59,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_organization_replay_details_with_permission(self) -> None:
         """User with replay permission can access org replay details (gets 404 for non-existent replay, not 403)"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -78,9 +72,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_organization_replay_details_without_permission(self) -> None:
         """User without replay permission cannot access org replay details"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -92,9 +84,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_organization_replay_count_without_permission(self) -> None:
         """User without replay permission cannot access org replay count"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -106,9 +96,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_project_replay_details_without_permission(self) -> None:
         """User without replay permission cannot access project replay details"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -120,9 +108,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_empty_allowlist_denies_all_users(self) -> None:
         """When allowlist is empty and org option is enabled, no org members have access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             self.login_as(self.user_without_access)
             url = f"/api/0/organizations/{self.organization.slug}/replays/"
@@ -131,21 +117,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_org_option_disabled_allows_all_users(self) -> None:
         """When org option is disabled, all org members have access even with allowlist"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
-            OrganizationMemberReplayAccess.objects.create(
-                organizationmember=self.member_with_access
-            )
-            self.login_as(self.user_without_access)
-            url = f"/api/0/organizations/{self.organization.slug}/replays/"
-            response = self.client.get(url)
-            assert response.status_code == 200
-
-    def test_feature_flag_disabled_allows_all_users(self) -> None:
-        """When feature flag is disabled, all org members have access"""
         with self.feature("organizations:session-replay"):
-            self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
             )
@@ -156,9 +128,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_removing_last_user_from_allowlist_keeps_access_denied(self) -> None:
         """When the last user is removed from allowlist, access remains denied (empty allowlist = no access)"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             access_record = OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -180,9 +150,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_disabling_org_option_reopens_access(self) -> None:
         """When org option is disabled, all org members regain access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -207,9 +175,7 @@ class TestReplayGranularPermissions(APITestCase):
         superuser = self.create_user(is_superuser=True)
         self.create_member(organization=self.organization, user=superuser)
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -225,9 +191,7 @@ class TestReplayGranularPermissions(APITestCase):
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user)
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -243,9 +207,7 @@ class TestReplayGranularPermissions(APITestCase):
         superuser = self.create_user(is_superuser=True)
         self.create_member(organization=self.organization, user=superuser)
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -261,9 +223,7 @@ class TestReplayGranularPermissions(APITestCase):
         staff_user = self.create_user(is_staff=True)
         self.create_member(organization=self.organization, user=staff_user)
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
 
             self.login_as(staff_user, staff=True)
@@ -276,9 +236,7 @@ class TestReplayGranularPermissions(APITestCase):
         superuser = self.create_user(is_superuser=True)
         # Note: superuser is NOT added as org member
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -294,9 +252,7 @@ class TestReplayGranularPermissions(APITestCase):
         superuser = self.create_user(is_superuser=True)
         # Note: superuser is NOT added as org member
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             # No allowlist records created
 
@@ -307,9 +263,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_org_auth_token_with_event_read_has_access(self) -> None:
         """Org auth tokens with event:read scope should have access to replays"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -332,9 +286,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_org_auth_token_without_event_read_denied(self) -> None:
         """Org auth tokens without event:read scope should be denied replay access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -357,9 +309,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_org_auth_token_with_event_read_empty_allowlist_has_access(self) -> None:
         """Org auth tokens with event:read scope should have access even when allowlist is empty"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             # No OrganizationMemberReplayAccess records created - empty allowlist
 
@@ -380,9 +330,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_personal_token_with_replay_permission(self) -> None:
         """Personal tokens should have granular permissions applied - user with access can access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -399,9 +347,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_personal_token_without_replay_permission(self) -> None:
         """Personal tokens should have granular permissions applied - user without access cannot access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -418,9 +364,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_sentry_app_with_event_read_scope_has_access(self) -> None:
         """SentryApp with event:read scope should have access to replays"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -448,9 +392,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_sentry_app_without_event_read_scope_denied(self) -> None:
         """SentryApp without event:read scope should be denied replay access"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             OrganizationMemberReplayAccess.objects.create(
                 organizationmember=self.member_with_access
@@ -477,9 +419,7 @@ class TestReplayGranularPermissions(APITestCase):
 
     def test_sentry_app_with_event_read_empty_allowlist_has_access(self) -> None:
         """SentryApp with event:read scope should have access even with empty allowlist"""
-        with self.feature(
-            ["organizations:session-replay", "organizations:granular-replay-permissions"]
-        ):
+        with self.feature("organizations:session-replay"):
             self._enable_granular_permissions()
             # No OrganizationMemberReplayAccess records - empty allowlist
 


### PR DESCRIPTION
Remove the `organizations:granular-replay-permissions` feature flag so granular replay permissions are always available. The org option `sentry:granular-replay-permissions` still controls whether the feature is active per-organization.

Changes:
- Remove the flag from `temporary.py`
- Remove `features.has()` checks in `permissions.py`, `organization.py` serializer, and `organization_details.py` validation
- Always serialize `hasGranularReplayPermissions` and `replayAccessMembers` based on the org option (no longer gated behind the feature flag)
- Remove tests that asserted feature-flag-gating behavior
- Remove `@with_feature` decorators and `self.feature()` context managers for this flag from remaining tests

Refs TET-2017