### PR TITLE
ref(replays): Clean up granular-replay-permissions flag (frontend)

### DIFF
--- a/static/app/components/events/eventReplay/index.spec.tsx
+++ b/static/app/components/events/eventReplay/index.spec.tsx
@@ -192,7 +192,7 @@ describe('EventReplay', () => {
 
   it('should not render replay when user does not have granular replay permissions', () => {
     const orgWithGranularPermissions = OrganizationFixture({
-      features: ['session-replay', 'granular-replay-permissions'],
+      features: ['session-replay'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999], // User ID 1 is not in this list
     });

--- a/static/app/components/feedback/feedbackItem/replaySection.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/replaySection.spec.tsx
@@ -37,7 +37,7 @@ describe('ReplaySection', () => {
 
   it('should hide replay section when user does not have granular replay permissions', () => {
     const orgWithGranularPermissions = OrganizationFixture({
-      features: ['session-replay', 'granular-replay-permissions'],
+      features: ['session-replay'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999], // User ID 1 is not in this list
     });

--- a/static/app/components/replays/replayAccess.spec.tsx
+++ b/static/app/components/replays/replayAccess.spec.tsx
@@ -14,25 +14,8 @@ describe('ReplayAccess', () => {
     ConfigStore.set('user', user);
   });
 
-  it('renders children when granular-replay-permissions feature is not enabled', () => {
-    const organization = OrganizationFixture({
-      features: [],
-    });
-
-    render(
-      <ReplayAccess fallback={<div>No access</div>}>
-        <div>Has access</div>
-      </ReplayAccess>,
-      {organization}
-    );
-
-    expect(screen.getByText('Has access')).toBeInTheDocument();
-    expect(screen.queryByText('No access')).not.toBeInTheDocument();
-  });
-
   it('renders children when hasGranularReplayPermissions is false', () => {
     const organization = OrganizationFixture({
-      features: ['granular-replay-permissions'],
       hasGranularReplayPermissions: false,
     });
 
@@ -49,7 +32,6 @@ describe('ReplayAccess', () => {
 
   it('renders children when user is in replayAccessMembers', () => {
     const organization = OrganizationFixture({
-      features: ['granular-replay-permissions'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [1],
     });
@@ -67,7 +49,6 @@ describe('ReplayAccess', () => {
 
   it('renders fallback when user is not in replayAccessMembers', () => {
     const organization = OrganizationFixture({
-      features: ['granular-replay-permissions'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999],
     });
@@ -85,7 +66,6 @@ describe('ReplayAccess', () => {
 
   it('renders null fallback by default when user does not have access', () => {
     const organization = OrganizationFixture({
-      features: ['granular-replay-permissions'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999],
     });

--- a/static/app/utils/replays/hooks/useHasReplayAccess.tsx
+++ b/static/app/utils/replays/hooks/useHasReplayAccess.tsx
@@ -8,9 +8,8 @@ import {useUser} from 'sentry/utils/useUser';
 export function useHasReplayAccess() {
   const organization = useOrganization();
   const user = useUser();
-  const hasFeature = organization.features.includes('granular-replay-permissions');
 
-  if (isActiveSuperuser() || !hasFeature || !organization.hasGranularReplayPermissions) {
+  if (isActiveSuperuser() || !organization.hasGranularReplayPermissions) {
     return true;
   }
 

--- a/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.spec.tsx
@@ -136,7 +136,7 @@ describe('GroupReplays', () => {
     it('should show access denied when user does not have granular replay permissions', async () => {
       const {organization} = init({
         organizationProps: {
-          features: ['session-replay', 'granular-replay-permissions'],
+          features: ['session-replay'],
           hasGranularReplayPermissions: true,
           replayAccessMembers: [999], // User ID 1 is not in this list
         },

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview.spec.tsx
@@ -43,7 +43,7 @@ describe('ReplayPreview', () => {
 
   it('should hide replay preview when user does not have granular replay permissions', () => {
     const orgWithGranularPermissions = OrganizationFixture({
-      features: ['session-replay', 'granular-replay-permissions'],
+      features: ['session-replay'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999], // User ID 1 is not in this list
     });

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -274,7 +274,7 @@ describe('TransactionReplays', () => {
   it('should hide replay content when user does not have granular replay permissions', async () => {
     renderComponent({
       organizationProps: {
-        features: ['performance-view', 'session-replay', 'granular-replay-permissions'],
+        features: ['performance-view', 'session-replay'],
         hasGranularReplayPermissions: true,
         replayAccessMembers: [999], // User ID 1 is not in this list
       },

--- a/static/app/views/replays/details.spec.tsx
+++ b/static/app/views/replays/details.spec.tsx
@@ -78,7 +78,7 @@ describe('ReplayDetails', () => {
 
   it('should show access denied and not fetch data when user does not have granular replay permissions', () => {
     const organization = OrganizationFixture({
-      features: ['session-replay', 'granular-replay-permissions'],
+      features: ['session-replay'],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999], // User ID 1 is not in this list
     });

--- a/static/app/views/replays/list.spec.tsx
+++ b/static/app/views/replays/list.spec.tsx
@@ -196,7 +196,7 @@ describe('ReplayList', () => {
 
   it('should show access denied when user does not have granular replay permissions', async () => {
     const mockOrg = OrganizationFixture({
-      features: [...AM2_FEATURES, 'granular-replay-permissions'],
+      features: [...AM2_FEATURES],
       hasGranularReplayPermissions: true,
       replayAccessMembers: [999], // User ID 1 is not in this list
     });

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.tsx
@@ -608,19 +608,9 @@ describe('OrganizationSettingsForm', () => {
   });
 
   describe('Replay access', () => {
-    it('does not render restrict replay access toggle if org does not have granular-replay-permissions', () => {
+    it('renders restrict replay access toggle', () => {
       render(
         <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />
-      );
-      expect(
-        screen.queryByRole('checkbox', {name: 'Restrict Replay Access'})
-      ).not.toBeInTheDocument();
-    });
-
-    it('renders restrict replay access toggle if org has granular-replay-permissions', () => {
-      render(
-        <OrganizationSettingsForm initialData={OrganizationFixture()} onSave={onSave} />,
-        {organization: {...organization, features: ['granular-replay-permissions']}}
       );
       expect(
         screen.getByRole('checkbox', {name: 'Restrict Replay Access'})
@@ -633,7 +623,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: false,
           },
         }
@@ -652,7 +642,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: true,
           },
         }
@@ -669,7 +659,7 @@ describe('OrganizationSettingsForm', () => {
           organization: {
             ...organization,
             access: [],
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: true,
           },
         }
@@ -688,7 +678,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: false,
           },
         }
@@ -718,7 +708,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: true,
           },
         }
@@ -753,7 +743,7 @@ describe('OrganizationSettingsForm', () => {
         {
           organization: {
             ...organization,
-            features: ['granular-replay-permissions'],
+
             hasGranularReplayPermissions: true,
           },
         }

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -372,45 +372,41 @@ function OrganizationMembershipSettingsBase({
           )}
         </AutoSaveField>
 
-        {features.has('granular-replay-permissions') && (
-          <Fragment>
-            <AutoSaveField
-              name="hasGranularReplayPermissions"
-              schema={membershipSchema}
-              initialValue={organization.hasGranularReplayPermissions ?? false}
-              mutationOptions={mutationOpts}
-              confirm={value =>
-                value
-                  ? undefined
-                  : t(
-                      'This will allow all members of your organization to access replay data. Do you want to continue?'
-                    )
-              }
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Restrict Replay Access')}
-                  hintText={t(
-                    'Allow granular access to replay data by selecting specific members of your organization.'
-                  )}
-                >
-                  <field.Switch
-                    checked={field.state.value}
-                    onChange={field.handleChange}
-                    disabled={!hasOrgWrite}
-                  />
-                </field.Layout.Row>
+        <AutoSaveField
+          name="hasGranularReplayPermissions"
+          schema={membershipSchema}
+          initialValue={organization.hasGranularReplayPermissions ?? false}
+          mutationOptions={mutationOpts}
+          confirm={value =>
+            value
+              ? undefined
+              : t(
+                  'This will allow all members of your organization to access replay data. Do you want to continue?'
+                )
+          }
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('Restrict Replay Access')}
+              hintText={t(
+                'Allow granular access to replay data by selecting specific members of your organization.'
               )}
-            </AutoSaveField>
-
-            {hasGranularReplay && (
-              <ReplayAccessMembersField
-                organization={organization}
-                onSave={onSave}
+            >
+              <field.Switch
+                checked={field.state.value}
+                onChange={field.handleChange}
                 disabled={!hasOrgWrite}
               />
-            )}
-          </Fragment>
+            </field.Layout.Row>
+          )}
+        </AutoSaveField>
+
+        {hasGranularReplay && (
+          <ReplayAccessMembersField
+            organization={organization}
+            onSave={onSave}
+            disabled={!hasOrgWrite}
+          />
         )}
       </FieldGroup>
     </FormSearch>

--- a/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
+++ b/static/gsApp/hooks/organizationMembershipSettingsForm.spec.tsx
@@ -132,20 +132,9 @@ describe('OrganizationMembershipSettings', () => {
     ).toBeDisabled();
   });
 
-  it('does not render restrict replay access if org does not have granular-replay-permissions', () => {
+  it('renders restrict replay access toggle', () => {
     const organization = OrganizationFixture({
       features: ['invite-members'],
-      access: ['org:write'],
-    });
-    renderComponent(organization);
-    expect(
-      screen.queryByRole('checkbox', {name: 'Restrict Replay Access'})
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders restrict replay access if org has granular-replay-permissions', () => {
-    const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
       access: ['org:write'],
       hasGranularReplayPermissions: true,
     });
@@ -157,7 +146,7 @@ describe('OrganizationMembershipSettings', () => {
 
   it('disables restrict replay access if user does not have org:write access', () => {
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: [],
       hasGranularReplayPermissions: true,
     });
@@ -167,7 +156,7 @@ describe('OrganizationMembershipSettings', () => {
 
   it('does not render replay access members field when hasGranularReplayPermissions is false', () => {
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: false,
     });
@@ -182,7 +171,7 @@ describe('OrganizationMembershipSettings', () => {
 
   it('renders replay access members field when hasGranularReplayPermissions is true', () => {
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: true,
     });
@@ -194,7 +183,7 @@ describe('OrganizationMembershipSettings', () => {
 
   it('disables replay access members field if user does not have org:write access', () => {
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: [],
       hasGranularReplayPermissions: true,
     });
@@ -209,7 +198,7 @@ describe('OrganizationMembershipSettings', () => {
       body: OrganizationFixture({hasGranularReplayPermissions: true}),
     });
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: false,
     });
@@ -233,7 +222,7 @@ describe('OrganizationMembershipSettings', () => {
       body: OrganizationFixture({hasGranularReplayPermissions: false}),
     });
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: true,
     });
@@ -257,7 +246,7 @@ describe('OrganizationMembershipSettings', () => {
   it('keeps replay access members field visible when Restrict Replay Access cancel is dismissed', async () => {
     renderGlobalModal();
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: true,
     });
@@ -286,7 +275,7 @@ describe('OrganizationMembershipSettings', () => {
       body: OrganizationFixture({replayAccessMembers: [1]}),
     });
     const organization = OrganizationFixture({
-      features: ['invite-members', 'granular-replay-permissions'],
+      features: ['invite-members'],
       access: ['org:write'],
       hasGranularReplayPermissions: true,
     });

--- a/static/gsApp/hooks/organizationMembershipSettingsForm.tsx
+++ b/static/gsApp/hooks/organizationMembershipSettingsForm.tsx
@@ -275,38 +275,36 @@ function OrganizationMembershipSettingsForm({
           )}
         </AutoSaveField>
 
-        {features.has('granular-replay-permissions') && (
-          <AutoSaveField
-            name="hasGranularReplayPermissions"
-            schema={membershipSchema}
-            initialValue={organization.hasGranularReplayPermissions ?? false}
-            mutationOptions={mutationOpts}
-            confirm={value =>
-              value
-                ? undefined
-                : t(
-                    'This will allow all members of your organization to access replay data. Do you want to continue?'
-                  )
-            }
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Restrict Replay Access')}
-                hintText={t(
-                  'Allow granular access to replay data by selecting specific members of your organization.'
-                )}
-              >
-                <field.Switch
-                  checked={field.state.value}
-                  onChange={field.handleChange}
-                  disabled={baseDisabled}
-                />
-              </field.Layout.Row>
-            )}
-          </AutoSaveField>
-        )}
+        <AutoSaveField
+          name="hasGranularReplayPermissions"
+          schema={membershipSchema}
+          initialValue={organization.hasGranularReplayPermissions ?? false}
+          mutationOptions={mutationOpts}
+          confirm={value =>
+            value
+              ? undefined
+              : t(
+                  'This will allow all members of your organization to access replay data. Do you want to continue?'
+                )
+          }
+        >
+          {field => (
+            <field.Layout.Row
+              label={t('Restrict Replay Access')}
+              hintText={t(
+                'Allow granular access to replay data by selecting specific members of your organization.'
+              )}
+            >
+              <field.Switch
+                checked={field.state.value}
+                onChange={field.handleChange}
+                disabled={baseDisabled}
+              />
+            </field.Layout.Row>
+          )}
+        </AutoSaveField>
 
-        {features.has('granular-replay-permissions') && hasGranularReplay && (
+        {hasGranularReplay && (
           <ReplayAccessMembersField
             organization={organization}
             onSave={onSave}


### PR DESCRIPTION
Remove all frontend references to the `granular-replay-permissions` feature flag. The replay access hook now checks only the org option `hasGranularReplayPermissions` without requiring the feature flag. Settings forms always render the replay access toggle.

Refs TET-2017