### PR TITLE
[Reference] Simplified DOM contents for LogsInfiniteTable rows

### DIFF
--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -1,7 +1,7 @@
-import {keyframes} from '@emotion/react';
+// import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex, Grid} from '@sentry/scraps/layout';
+// import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
@@ -23,19 +23,23 @@ export function Button({
   busy,
   ...props
 }: ButtonProps) {
-  const {handleClick, hasChildren, accessibleLabel} = useButtonFunctionality({
+  const {
+    handleClick,
+    // hasChildren,
+    accessibleLabel,
+  } = useButtonFunctionality({
     ...props,
     type,
     disabled,
     busy,
   });
 
-  const iconGap =
-    props.icon && hasChildren
-      ? size === 'xs' || size === 'zero'
-        ? 'sm'
-        : 'md'
-      : undefined;
+  // const iconGap =
+  //   props.icon && hasChildren
+  //     ? size === 'xs' || size === 'zero'
+  //       ? 'sm'
+  //       : 'md'
+  //     : undefined;
 
   return (
     <Tooltip
@@ -49,32 +53,22 @@ export function Button({
         aria-disabled={disabled}
         aria-busy={busy}
         disabled={disabled}
+        // style={{ gap: iconGap }}
         size={size}
         type={type}
         busy={busy}
         {...props}
         onClick={handleClick}
         role="button"
+        // visibility={busy ? 'hidden' : undefined}
       >
-        <Grid as="span" align="center" justifyItems="center" minWidth="0" height="100%">
-          <Flex
-            as="span"
-            align="center"
-            area="1 / 1"
-            gap={iconGap}
-            visibility={busy ? 'hidden' : undefined}
-          >
-            {props.icon && (
-              <Flex as="span" align="center" flexShrink={0}>
-                <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
-                  {props.icon}
-                </IconDefaultsProvider>
-              </Flex>
-            )}
-            {props.children}
-          </Flex>
-          {busy ? <BusySpinner role="status" aria-label="Busy" /> : null}
-        </Grid>
+        {props.icon && (
+          <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
+            {props.icon}
+          </IconDefaultsProvider>
+        )}
+        {props.children}
+        {/* {busy ? <BusySpinner role="status" aria-label="Busy" /> : null} */}
       </StyledButton>
     </Tooltip>
   );
@@ -84,23 +78,23 @@ const StyledButton = styled('button')<ButtonProps>`
   ${p => getButtonStyles(p as any)}
 `;
 
-const spin = keyframes`
-  to {
-    transform: rotate(360deg);
-  }
-`;
+// const spin = keyframes`
+//   to {
+//     transform: rotate(360deg);
+//   }
+// `;
 
-const BusySpinner = styled('span')`
-  grid-area: 1 / 1;
+// const BusySpinner = styled('span')`
+//   grid-area: 1 / 1;
 
-  &::after {
-    content: '';
-    display: block;
-    width: 1em;
-    height: 1em;
-    border-radius: 50%;
-    border: 2px solid currentColor;
-    border-top-color: transparent;
-    animation: ${spin} 0.6s linear infinite;
-  }
-`;
+//   &::after {
+//     content: '';
+//     display: block;
+//     width: 1em;
+//     height: 1em;
+//     border-radius: 50%;
+//     border: 2px solid currentColor;
+//     border-top-color: transparent;
+//     animation: ${spin} 0.6s linear infinite;
+//   }
+// `;

--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import {Fragment, memo} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -8,9 +8,10 @@ import {
   TeamAvatar,
   UserAvatar,
 } from '@sentry/scraps/avatar';
-import {Flex} from '@sentry/scraps/layout';
 
-import {space, type ValidSize} from 'sentry/styles/space';
+// import {Flex} from '@sentry/scraps/layout';
+
+// import {space, type ValidSize} from 'sentry/styles/space';
 import type {Actor} from 'sentry/types/core';
 import type {Organization, Team} from 'sentry/types/organization';
 import type {AvatarProject} from 'sentry/types/project';
@@ -44,25 +45,19 @@ export const BaseBadge = memo(
     avatarProps = {},
     avatarSize = 24,
     description,
-    onClick,
+    // onClick,
     team,
     user,
     organization,
     project,
     actor,
-    className,
+    // className,
   }: AllBaseBadgeProps) => {
     // Space items appropriatley depending on avatar size
-    const wrapperGap: ValidSize = avatarSize <= 14 ? 0.5 : avatarSize <= 20 ? 0.75 : 1;
+    // const wrapperGap: ValidSize = avatarSize <= 14 ? 0.5 : avatarSize <= 20 ? 0.75 : 1;
 
     return (
-      <Flex
-        align="center"
-        flexShrink={0}
-        className={className}
-        style={{gap: space(wrapperGap)}}
-        onClick={onClick}
-      >
+      <Fragment>
         {!hideAvatar && (
           <EntityAvatarType
             team={team}
@@ -82,7 +77,7 @@ export const BaseBadge = memo(
             {!!description && <Description>{description}</Description>}
           </DisplayNameAndDescription>
         )}
-      </Flex>
+      </Fragment>
     );
   }
 );

--- a/static/app/components/idBadge/projectBadge.tsx
+++ b/static/app/components/idBadge/projectBadge.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, memo} from 'react';
+import {memo} from 'react';
 import styled from '@emotion/styled';
 
 import type {LinkProps} from '@sentry/scraps/link';
@@ -91,7 +91,7 @@ function ProjectBadge({
     );
   }
 
-  return cloneElement(badge, {className});
+  return badge;
 }
 
 const StyledLink = styled(Link)`

--- a/static/app/components/platformList.tsx
+++ b/static/app/components/platformList.tsx
@@ -27,34 +27,38 @@ export function PlatformList({
   className,
   ref,
 }: Props) {
-  const visiblePlatforms = platforms.slice(0, max);
-
-  function renderContent() {
-    if (!platforms.length) {
+  switch (platforms.length) {
+    case 0:
       return <StyledPlatformIcon size={size} platform="default" />;
+
+    case 1:
+      return (
+        <StyledPlatformIcon
+          data-test-id={`platform-icon-${platforms[0]}`}
+          platform={platforms[0]!}
+          size={size}
+        />
+      );
+
+    default: {
+      const platformIcons = platforms.slice(0, max).reverse();
+
+      return (
+        <Wrapper ref={ref} className={className} size={size}>
+          <PlatformIcons>
+            {platformIcons.map((platform, index) => (
+              <StyledPlatformIcon
+                data-test-id={`platform-icon-${platform}`}
+                key={platform + index}
+                platform={platform}
+                size={size}
+              />
+            ))}
+          </PlatformIcons>
+        </Wrapper>
+      );
     }
-
-    const platformIcons = visiblePlatforms.slice().reverse();
-
-    return (
-      <PlatformIcons>
-        {platformIcons.map((visiblePlatform, index) => (
-          <StyledPlatformIcon
-            data-test-id={`platform-icon-${visiblePlatform}`}
-            key={visiblePlatform + index}
-            platform={visiblePlatform}
-            size={size}
-          />
-        ))}
-      </PlatformIcons>
-    );
   }
-
-  return (
-    <Wrapper ref={ref} className={className} size={size}>
-      {renderContent()}
-    </Wrapper>
-  );
 }
 
 function getOverlapWidth(size: number) {

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -44,7 +44,7 @@ import {
   LogDate,
   LogsFilteredHelperText,
   LogsHighlight,
-  WrappingText,
+  // WrappingText,
   type getLogColors,
 } from 'sentry/views/explore/logs/styles';
 import {OurLogKnownFieldKey, type OurLogFieldKey} from 'sentry/views/explore/logs/types';
@@ -135,14 +135,12 @@ export function SeverityCircleRenderer(props: Omit<LogFieldRendererProps, 'item'
   const level = getLogSeverityLevel(severityNumber, severityText);
   const levelLabel = useFullSeverityText ? severityText : severityLevelToText(level);
   return (
-    <AlignedCellContent align={props.extra.align}>
-      <SeverityCircle
-        level={level}
-        levelLabel={levelLabel}
-        severityText={severityText}
-        logColors={props.extra.logColors}
-      />
-    </AlignedCellContent>
+    <SeverityCircle
+      level={level}
+      levelLabel={levelLabel}
+      severityText={severityText}
+      logColors={props.extra.logColors}
+    />
   );
 }
 
@@ -154,15 +152,13 @@ export function TimestampRenderer(props: LogFieldRendererProps) {
     : props.item.value;
 
   return (
-    <LogDate align={props.extra.align}>
-      <LogsTimestampTooltip
-        timestamp={props.item.value as string | number}
-        attributes={props.extra.attributes}
-        shouldRender={props.extra.shouldRenderHoverElements}
-      >
-        <DateTime seconds milliseconds date={timestampToUse} />
-      </LogsTimestampTooltip>
-    </LogDate>
+    <LogsTimestampTooltip
+      timestamp={props.item.value as string | number}
+      attributes={props.extra.attributes}
+      shouldRender={props.extra.shouldRenderHoverElements}
+    >
+      <DateTime seconds milliseconds date={timestampToUse} />
+    </LogsTimestampTooltip>
   );
 }
 
@@ -450,17 +446,15 @@ export function LogBodyRenderer(props: LogFieldRendererProps) {
       extra={props.extra}
       isAppendingTemplate={!!templateText}
     >
-      <WrappingText wrapText={props.extra.wrapBody}>
-        <LogsHighlight text={highlightTerm}>{stripAnsi(attribute_value)}</LogsHighlight>
-        {isBodyFiltered && templateText && (
-          <FieldReplacementHelper
-            original={attribute_value}
-            replacement={templateText as string}
-            extra={props.extra}
-            item={props.item}
-          />
-        )}
-      </WrappingText>
+      <LogsHighlight text={highlightTerm}>{stripAnsi(attribute_value)}</LogsHighlight>
+      {isBodyFiltered && templateText && (
+        <FieldReplacementHelper
+          original={attribute_value}
+          replacement={templateText as string}
+          extra={props.extra}
+          item={props.item}
+        />
+      )}
     </FilteredTooltip>
   );
 }
@@ -476,7 +470,7 @@ function LogTemplateRenderer(props: LogFieldRendererProps) {
 }
 
 export function LogFieldRenderer(props: LogFieldRendererProps) {
-  const type = props.meta?.fields?.[props.item.fieldKey];
+  // const type = props.meta?.fields?.[props.item.fieldKey];
   const adjustedFieldKey =
     fullFieldToExistingField[props.item.fieldKey] ?? props.item.fieldKey;
 
@@ -493,7 +487,7 @@ export function LogFieldRenderer(props: LogFieldRendererProps) {
 
   const customRenderer = LogAttributesRendererMap[props.item.fieldKey];
 
-  const align = logsFieldAlignment(adjustedFieldKey, type);
+  // const align = logsFieldAlignment(adjustedFieldKey, type);
 
   if (!customRenderer) {
     return (
@@ -505,9 +499,7 @@ export function LogFieldRenderer(props: LogFieldRendererProps) {
 
   return (
     <AnnotatedAttributeWrapper extra={props.extra} fieldKey={props.item.fieldKey}>
-      <AlignedCellContent align={align}>
-        {customRenderer({...props, basicRendered})}
-      </AlignedCellContent>
+      {customRenderer({...props, basicRendered})}
     </AnnotatedAttributeWrapper>
   );
 }

--- a/static/app/views/explore/logs/logsTimeTooltip.tsx
+++ b/static/app/views/explore/logs/logsTimeTooltip.tsx
@@ -142,6 +142,7 @@ export default function LogsTimestampTooltip({
       }
       maxWidth={400}
       isHoverable
+      skipWrapper
     >
       {children}
     </Tooltip>

--- a/static/app/views/explore/logs/styles.tsx
+++ b/static/app/views/explore/logs/styles.tsx
@@ -108,23 +108,23 @@ export const LogAttributeTreeWrapper = styled('div')`
   border-bottom: 0px;
 `;
 
-export const LogTableBodyCell = styled(TableBodyCell)`
-  min-height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
+// export const LogTableBodyCell = styled(TableBodyCell)`
+//   min-height: ${LOGS_GRID_BODY_ROW_HEIGHT}px;
 
-  padding: 2px ${p => p.theme.space.xl};
+//   padding: 2px ${p => p.theme.space.xl};
 
-  font-size: ${p => p.theme.font.size.md};
+//   font-size: ${p => p.theme.font.size.md};
 
-  /* Need to select the 2nd child to select the first cell
-     as the first child is the interaction state layer */
-  &:nth-child(2) {
-    padding: 2px 0 2px ${p => p.theme.space['2xl']};
-  }
+//   /* Need to select the 2nd child to select the first cell
+//      as the first child is the interaction state layer */
+//   &:nth-child(2) {
+//     padding: 2px 0 2px ${p => p.theme.space['2xl']};
+//   }
 
-  &:last-child {
-    padding: 2px ${p => p.theme.space.xl};
-  }
-`;
+//   &:last-child {
+//     padding: 2px ${p => p.theme.space.xl};
+//   }
+// `;
 
 export const LogTableBody = styled(TableBody)<{
   disableBodyPadding?: boolean;
@@ -189,9 +189,9 @@ export const DetailsContent = styled(StyledPanel)`
   padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
 `;
 
-export function LogFirstCellContent(props: FlexProps<'div'>) {
-  return <Flex align="center" {...props} />;
-}
+// export function LogFirstCellContent(props: FlexProps<'div'>) {
+//   return <Flex align="center" {...props} />;
+// }
 
 export const LogBasicRendererContainer = styled('span')<{align?: 'left' | 'right'}>`
   ${NumberContainer} {
@@ -282,10 +282,10 @@ export const FirstTableHeadCell = styled(TableHeadCell)`
   padding-left: ${p => p.theme.space.xl};
 `;
 
-export const LogsTableBodyFirstCell = styled(LogTableBodyCell)`
-  padding-right: 0;
-  padding-left: ${p => p.theme.space.md};
-`;
+// export const LogsTableBodyFirstCell = styled(LogTableBodyCell)`
+//   padding-right: 0;
+//   padding-left: ${p => p.theme.space.md};
+// `;
 
 export function TableActionsContainer(props: FlexProps<'div'>) {
   return <Flex justify="end" align="center" gap="md" {...props} />;
@@ -506,4 +506,12 @@ export const TraceIconStyleWrapper = styled(Flex)`
     height: 12px;
     fill: #ffffff;
   }
+`;
+
+// ...
+
+export const JoshCell = styled('td')`
+  align-items: center;
+  display: flex;
+  height: 28px;
 `;

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -515,7 +515,6 @@ export function LogsInfiniteTable({
                   embeddedOptions={embeddedOptions}
                   sharedHoverTimeoutRef={sharedHoverTimeoutRef}
                   key={virtualRow.key}
-                  canDeferRenderElements
                   onExpand={handleExpand}
                   onCollapse={handleCollapse}
                   logStart={logStart}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -68,13 +68,14 @@ import {
   DetailsContent,
   DetailsWrapper,
   getLogColors,
+  JoshCell,
   LogAttributeTreeWrapper,
   LogDetailTableActionsButtonBar,
   LogDetailTableActionsCell,
   LogDetailTableBodyCell,
-  LogFirstCellContent,
-  LogsTableBodyFirstCell,
-  LogTableBodyCell,
+  // LogFirstCellContent,
+  // LogsTableBodyFirstCell,
+  // LogTableBodyCell,
   LogTableRow,
   StyledChevronButton,
   TraceIconStyleWrapper,
@@ -328,45 +329,43 @@ export const LogRowContent = memo(function LogRowContent({
           }
         }}
       >
-        <LogsTableBodyFirstCell key="first">
-          <LogFirstCellContent>
-            {isPseudoRow ? (
-              <span className="log-table-row-pseudo-row-chevron-replacement" />
-            ) : blockRowExpanding ? null : shouldRenderHoverElements ? (
-              <StyledChevronButton
-                icon={<IconChevron size="xs" direction={expanded ? 'down' : 'right'} />}
-                aria-label={t('Toggle trace details')}
-                aria-expanded={expanded}
-                size="zero"
-                priority="transparent"
-                onClick={() => toggleExpanded()}
-              />
-            ) : (
-              <span className="log-table-row-chevron-button">{chevronIcon}</span>
-            )}
-            {isPseudoRow ? (
-              <Flex align="center" justify="center" gap="sm">
-                <TraceIconStyleWrapper>
-                  <div className="TraceIcon error">
-                    <TraceIcons.Fire />
-                  </div>
-                </TraceIconStyleWrapper>
-              </Flex>
-            ) : (
-              <React.Fragment>
-                <SeverityCircleRenderer extra={rendererExtra} meta={meta} />
-                {project ? (
-                  <ProjectBadge project={project} avatarSize={12} hideName />
-                ) : null}
-              </React.Fragment>
-            )}
-          </LogFirstCellContent>
-        </LogsTableBodyFirstCell>
+        <JoshCell>
+          {isPseudoRow ? (
+            <span className="log-table-row-pseudo-row-chevron-replacement" />
+          ) : blockRowExpanding ? null : shouldRenderHoverElements ? (
+            <StyledChevronButton
+              icon={<IconChevron size="xs" direction={expanded ? 'down' : 'right'} />}
+              aria-label={t('Toggle trace details')}
+              aria-expanded={expanded}
+              size="zero"
+              priority="transparent"
+              onClick={() => toggleExpanded()}
+            />
+          ) : (
+            <span className="log-table-row-chevron-button">{chevronIcon}</span>
+          )}
+          {isPseudoRow ? (
+            <Flex align="center" justify="center" gap="sm">
+              <TraceIconStyleWrapper>
+                <div className="TraceIcon error">
+                  <TraceIcons.Fire />
+                </div>
+              </TraceIconStyleWrapper>
+            </Flex>
+          ) : (
+            <React.Fragment>
+              <SeverityCircleRenderer extra={rendererExtra} meta={meta} />
+              {project ? (
+                <ProjectBadge project={project} avatarSize={12} hideName />
+              ) : null}
+            </React.Fragment>
+          )}
+        </JoshCell>
         {fields?.map(field => {
           const value = (dataRow as OurLogsResponseItem)[field];
 
           if (!defined(value)) {
-            return <LogTableBodyCell key={field} />;
+            return <JoshCell key={field} />;
           }
 
           const renderedField = (
@@ -398,7 +397,7 @@ export const LogRowContent = memo(function LogRowContent({
             shouldRenderHoverElements;
 
           return (
-            <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
+            <JoshCell key={field} data-test-id={'log-table-cell-' + field}>
               {shouldRenderActions ? (
                 <CellAction
                   column={discoverColumn}
@@ -433,7 +432,7 @@ export const LogRowContent = memo(function LogRowContent({
               ) : (
                 renderedField
               )}
-            </LogTableBodyCell>
+            </JoshCell>
           );
         })}
       </LogTableRow>
@@ -531,9 +530,9 @@ function LogRowDetails({
             <DetailsContent>
               <DetailsBody>
                 {isRegularLogResponseItem(dataRow) ? (
-                  LogBodyRenderer({
-                    item: getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta),
-                    extra: {
+                  <LogBodyRenderer
+                    item={getLogRowItem(OurLogKnownFieldKey.MESSAGE, dataRow, meta)}
+                    extra={{
                       highlightTerms,
                       logColors,
                       wrapBody: true,
@@ -545,8 +544,8 @@ function LogRowDetails({
                       meta,
                       theme,
                       traceItemMeta: data?.meta,
-                    },
-                  })
+                    }}
+                  />
                 ) : (
                   <span>{String(dataRow[OurLogKnownFieldKey.MESSAGE] ?? '')}</span>
                 )}

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -109,7 +109,6 @@ type LogsRowProps = {
   meta: EventsMetaType | undefined;
   sharedHoverTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
   blockRowExpanding?: boolean;
-  canDeferRenderElements?: boolean;
   embedded?: boolean;
   embeddedOptions?: {
     openWithExpandedIds?: string[];
@@ -157,7 +156,6 @@ export const LogRowContent = memo(function LogRowContent({
   onCollapse,
   onExpandHeight,
   blockRowExpanding,
-  canDeferRenderElements,
   onEmbeddedRowClick,
   logStart,
   logEnd,
@@ -170,18 +168,7 @@ export const LogRowContent = memo(function LogRowContent({
   const autorefreshEnabled = useLogsAutoRefreshEnabled();
   const setAutorefresh = useSetLogsAutoRefresh();
   const measureRef = useRef<HTMLTableRowElement>(null);
-  const [shouldRenderHoverElements, _setShouldRenderHoverElements] = useState(
-    canDeferRenderElements ? false : true
-  );
-
-  const setShouldRenderHoverElements = useCallback(
-    (value: boolean) => {
-      if (canDeferRenderElements) {
-        _setShouldRenderHoverElements(value);
-      }
-    },
-    [canDeferRenderElements, _setShouldRenderHoverElements]
-  );
+  const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
 
   // This only applies in embedded views where clicking doesn't expand row details.
   function onClick(event: SyntheticEvent) {
@@ -405,9 +392,14 @@ export const LogRowContent = memo(function LogRowContent({
             type: FieldValueType.STRING,
           };
 
+          const shouldRenderActions =
+            !embedded &&
+            field !== OurLogKnownFieldKey.TIMESTAMP &&
+            shouldRenderHoverElements;
+
           return (
             <LogTableBodyCell key={field} data-test-id={'log-table-cell-' + field}>
-              {shouldRenderHoverElements ? (
+              {shouldRenderActions ? (
                 <CellAction
                   column={discoverColumn}
                   dataRow={dataRow as unknown as TableDataRow}
@@ -433,11 +425,7 @@ export const LogRowContent = memo(function LogRowContent({
                         break;
                     }
                   }}
-                  allowActions={
-                    field === OurLogKnownFieldKey.TIMESTAMP || embedded
-                      ? []
-                      : ALLOWED_CELL_ACTIONS
-                  }
+                  allowActions={ALLOWED_CELL_ACTIONS}
                   triggerType={ActionTriggerType.ELLIPSIS}
                 >
                   {renderedField}


### PR DESCRIPTION
This breaks a whole bunch of things in the site and is not a candidate for merge. But it does show a `LogsInfiniteTable` with significantly fewer DOM nodes per row, as a reference for performance investigations.

Part of LOGS-588.