### PR TITLE
fix(ui): Move git_pr_number to number tags in explore constants

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -93,11 +93,10 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'build_version',
   'git_base_ref',
   'git_head_ref',
-  'git_pr_number',
   'platform_name',
 ];
 
-export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [];
+export const SENTRY_PREPROD_NUMBER_TAGS: string[] = ['git_pr_number'];
 
 export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = [];
 


### PR DESCRIPTION
`git_pr_number` was listed in `SENTRY_PREPROD_STRING_TAGS` but PR numbers are integers. The backend already treats it as numeric (it's in `numeric_keys` in `artifact_search.py`). This moves it to `SENTRY_PREPROD_NUMBER_TAGS` so the explore view fetches and presents it correctly.

Companion to #110033 which changes the field definition's `valueType` from `STRING` to `INTEGER`.