### PR TITLE
fix(traces-explorer): remove chart-specific restrictions on deletion logic

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -35,21 +35,19 @@ export function ToolbarVisualizeHeader() {
 
 interface ToolbarVisualizeDropdownProps {
   aggregateOptions: Array<SelectOption<SelectKey>>;
-  canDelete: boolean;
   fieldOptions: Array<SelectOption<SelectKey>>;
   onChangeAggregate: (option: SelectOption<SelectKey>) => void;
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
-  onDelete: () => void;
   parsedFunction: ParsedFunction | null;
   label?: ReactNode;
   loading?: boolean;
   onClose?: () => void;
+  onDelete?: () => void;
   onSearch?: (search: string) => void;
 }
 
 export function ToolbarVisualizeDropdown({
   aggregateOptions,
-  canDelete,
   fieldOptions,
   onChangeAggregate,
   onChangeArgument,
@@ -99,7 +97,7 @@ export function ToolbarVisualizeDropdown({
           loading={loading}
         />
       )}
-      {canDelete ? (
+      {onDelete ? (
         <Button
           priority="transparent"
           icon={<IconDelete />}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -20,10 +20,10 @@ import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExplor
 import {Visualize} from 'sentry/views/explore/queryParams/visualize';
 
 interface VisualizeEquationProps {
-  onDelete: () => void;
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
   label?: ReactNode;
+  onDelete?: () => void;
 }
 
 export function VisualizeEquation({
@@ -94,13 +94,15 @@ export function VisualizeEquation({
           getSuggestedKey={getSuggestedAttribute}
         />
       </Flex>
-      <Button
-        priority="transparent"
-        icon={<IconDelete />}
-        size="zero"
-        onClick={onDelete}
-        aria-label={t('Remove Overlay')}
-      />
+      {onDelete && (
+        <Button
+          priority="transparent"
+          icon={<IconDelete />}
+          size="zero"
+          onClick={onDelete}
+          aria-label={t('Remove Overlay')}
+        />
+      )}
     </ToolbarRow>
   );
 }

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -165,7 +165,7 @@ function ToolbarVisualize() {
     [setVisualizes, visualizes]
   );
 
-  const onDelete = useCallback(
+  const handleDelete = useCallback(
     (group: number) => {
       const newVisualizes = visualizes.toSpliced(group, 1).map(visualize => {
         return visualize.serialize();
@@ -183,11 +183,11 @@ function ToolbarVisualize() {
       <ToolbarVisualizeHeader />
       {visualizes.map((visualize, group) => {
         if (isVisualizeFunction(visualize)) {
+          const onDelete = canDelete ? () => handleDelete(group) : undefined;
           return (
             <VisualizeDropdown
               key={group}
-              canDelete={canDelete}
-              onDelete={() => onDelete(group)}
+              onDelete={onDelete}
               onReplace={newVisualize => replaceOverlay(group, newVisualize)}
               visualize={visualize}
               sortedBooleanKeys={sortedBooleanKeys}
@@ -212,20 +212,18 @@ function ToolbarVisualize() {
 }
 
 interface VisualizeDropdownProps {
-  canDelete: boolean;
   loading: boolean;
   onClose: () => void;
-  onDelete: () => void;
   onReplace: (visualize: Visualize) => void;
   onSearch: (search: string) => void;
   sortedBooleanKeys: string[];
   sortedNumberKeys: string[];
   sortedStringKeys: string[];
   visualize: VisualizeFunction;
+  onDelete?: () => void;
 }
 
 function VisualizeDropdown({
-  canDelete,
   loading,
   onDelete,
   onReplace,
@@ -324,7 +322,6 @@ function VisualizeDropdown({
     <ToolbarVisualizeDropdown
       aggregateOptions={aggregateOptions}
       fieldOptions={fieldOptions}
-      canDelete={canDelete}
       onChangeAggregate={onChangeAggregate}
       onChangeArgument={onChangeArgument}
       onDelete={onDelete}

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -29,7 +29,6 @@ import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttr
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {
   isVisualizeEquation,
-  isVisualizeFunction,
   MAX_VISUALIZES,
   Visualize,
   VisualizeEquation,
@@ -89,7 +88,7 @@ export function ToolbarVisualize({
     [setVisualizes, visualizes]
   );
 
-  const onDelete = useCallback(
+  const handleOnDelete = useCallback(
     (group: number) => {
       const newVisualizes = visualizes
         .toSpliced(group, 1)
@@ -98,8 +97,6 @@ export function ToolbarVisualize({
     },
     [setVisualizes, visualizes]
   );
-
-  const canDelete = visualizes.filter(isVisualizeFunction).length > 1;
 
   return (
     <ToolbarSection data-test-id="section-visualizes">
@@ -112,12 +109,13 @@ export function ToolbarVisualize({
             onClick={() => toggleVisibility(group)}
           />
         );
+        const onDelete = visualizes.length > 1 ? () => handleOnDelete(group) : undefined;
 
         if (isVisualizeEquation(visualize)) {
           return (
             <VisualizeEquationInput
               key={group}
-              onDelete={() => onDelete(group)}
+              onDelete={onDelete}
               onReplace={newVisualize => replaceOverlay(group, newVisualize)}
               visualize={visualize}
               label={label}
@@ -128,8 +126,7 @@ export function ToolbarVisualize({
         return (
           <ToolbarVisualizeItem
             key={group}
-            canDelete={canDelete}
-            onDelete={() => onDelete(group)}
+            onDelete={onDelete}
             onReplace={newVisualize => replaceOverlay(group, newVisualize)}
             visualize={visualize}
             label={label}
@@ -153,15 +150,13 @@ export function ToolbarVisualize({
 }
 
 interface VisualizeDropdownProps {
-  canDelete: boolean;
   label: ReactNode;
-  onDelete: () => void;
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
+  onDelete?: () => void;
 }
 
 function ToolbarVisualizeItem({
-  canDelete,
   label,
   onDelete,
   onReplace,
@@ -239,7 +234,6 @@ function ToolbarVisualizeItem({
     <ToolbarVisualizeDropdown
       aggregateOptions={aggregateOptions}
       fieldOptions={fieldOptions}
-      canDelete={canDelete}
       onChangeAggregate={onChangeAggregate}
       onChangeArgument={onChangeArgument}
       onDelete={onDelete}


### PR DESCRIPTION
Continues #105982. Builds on #110153 for a more reactive Compare Queries button.

Previously:

* Deletions: the UI required there to be >=1 _chart_ in the visualization toolbar. It would only show deletion icons for charts if there were multiple charts.
  * Though, interestingly, you could manually modify the URL to add just equation(s): [https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&[…]ttribute_count_total%2Cnumber%5D%29%22%5D%7D&statsPeriod=24h](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22equation%7Cavg%28tags%5Battribute_count_total%2Cnumber%5D%29%22%5D%7D&statsPeriod=24h). 😄 
* Query comparison: the button is always enabled, and since at least one first chart is guaranteed to exist, uses it

Now:

* Deletions: the UI _"can we delete this?"_ logic is simplified to just whether there's >=1 of any visualization.
* Query comparison: the button is enabled when there is at least one chart

Fixes EXP-802.