### PR TITLE
docs(search): Note internal wildcard operators

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -168,6 +168,8 @@ numeric_value          = "-"? numeric numeric_unit? &(end_value / comma / closed
 boolean_value          = ~r"(true|1|false|0)"i &end_value
 text_in_list           = open_bracket text_in_value (spaces comma spaces !comma text_in_value?)* closed_bracket &end_value
 numeric_in_list        = open_bracket numeric_value (spaces comma spaces !comma numeric_value?)* closed_bracket &end_value
+# NOTE: These wildcard operators are internal implementation details and
+# should not be included in product docs. Users should use `*` instead.
 wildcard_op            = wildcard_unicode (contains / starts_with / ends_with) wildcard_unicode
 
 # See: https://stackoverflow.com/a/39617181/790169
@@ -206,6 +208,8 @@ closed_bracket       = "]"
 sep                  = ":"
 negation             = "!"
 # Note: wildcard unicode is defined in src/sentry/search/events/constants.py
+# NOTE: These wildcard operators are internal implementation details and
+# should not be included in product docs. Users should use `*` instead.
 wildcard_unicode     = "\uF00D"
 contains             = "Contains"
 starts_with          = "StartsWith"

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -307,7 +307,8 @@ OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exac
 #
 # We use this character as a prefix and suffix with our wildcard operators to avoid
 # introducing breaking changes, and leave the possibility open down to the road to add in
-# new operators.
+# new operators. These operators are internal implementation details and should
+# not be included in product docs. Users should use `*` instead.
 WILDCARD_UNICODE = "\uf00d"
 
 WILDCARD_OPERATOR_MAP = {

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -376,6 +376,8 @@ numeric_in_list
       return tc.tokenValueNumberList(item1, items);
     }
 
+// NOTE: These wildcard operators are internal implementation details and
+// should not be included in product docs. Users should use `*` instead.
 wildcard_op
   = wildcard_unicode
     (contains / starts_with / ends_with )
@@ -454,6 +456,8 @@ open_bracket   = "["
 closed_bracket = "]"
 sep            = ":"
 negation       = "!"
+// NOTE: These wildcard operators are internal implementation details and
+// should not be included in product docs. Users should use `*` instead.
 wildcard_unicode     = [\uF00D]
 contains             = "Contains"
 starts_with          = "StartsWith"

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -76,6 +76,8 @@ export enum TermOperator {
   LESS_THAN = '<',
   EQUAL = '=',
   NOT_EQUAL = '!=',
+  // NOTE: These wildcard operators are internal implementation details and
+  // should not be included in product docs. Users should use `*` instead.
   CONTAINS = '\uf00dContains\uf00d',
   DOES_NOT_CONTAIN = '\uf00dDoesNotContain\uf00d',
   STARTS_WITH = '\uf00dStartsWith\uf00d',


### PR DESCRIPTION
Add comments in the frontend and backend search grammar definitions to mark the internal wildcard operators as non-product syntax.

We support these operators internally, but we do not want product docs to advertise them because users should rely on `*` for wildcard matching instead.

This keeps that guidance next to the relevant grammar and parser definitions so future documentation work stays aligned across both the frontend and backend implementations.

Made with [Cursor](https://cursor.com)