### PR TITLE
feat(preprod): Add project-level toggle for build distribution PR comments

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1185,6 +1185,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_distribution_enabled_by_customer": self.get_value_with_default(
                 attrs, "sentry:preprod_distribution_enabled_by_customer"
             ),
+            "sentry:preprod_distribution_pr_comments_enabled": self.get_value_with_default(
+                attrs, "sentry:preprod_distribution_pr_comments_enabled"
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -113,6 +113,7 @@ class ProjectMemberSerializer(serializers.Serializer):
     preprodSizeStatusChecksRules = serializers.JSONField(required=False)
     preprodSizeEnabledByCustomer = serializers.BooleanField(required=False, allow_null=True)
     preprodDistributionEnabledByCustomer = serializers.BooleanField(required=False, allow_null=True)
+    preprodDistributionPrCommentsEnabled = serializers.BooleanField(required=False, allow_null=True)
     preprodSizeEnabledQuery = serializers.CharField(required=False, allow_null=True)
     preprodDistributionEnabledQuery = serializers.CharField(required=False, allow_null=True)
 
@@ -157,6 +158,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodDistributionEnabledQuery",
         "preprodSizeEnabledByCustomer",
         "preprodDistributionEnabledByCustomer",
+        "preprodDistributionPrCommentsEnabled",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -574,7 +576,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         `isBookmarked`, `autofixAutomationTuning`, `seerScannerAutomation`,
         `preprodSizeStatusChecksEnabled`, `preprodSizeStatusChecksRules`,
         `preprodSizeEnabledQuery`, `preprodDistributionEnabledQuery`,
-        `preprodSizeEnabledByCustomer`, and `preprodDistributionEnabledByCustomer`.
+        `preprodSizeEnabledByCustomer`, `preprodDistributionEnabledByCustomer`,
+        and `preprodDistributionPrCommentsEnabled`.
         """
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -825,6 +828,14 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_distribution_enabled_query"] = result[
                     "preprodDistributionEnabledQuery"
+                ]
+        if "preprodDistributionPrCommentsEnabled" in result:
+            if project.update_option(
+                "sentry:preprod_distribution_pr_comments_enabled",
+                result["preprodDistributionPrCommentsEnabled"],
+            ):
+                changed_proj_settings["sentry:preprod_distribution_pr_comments_enabled"] = result[
+                    "preprodDistributionPrCommentsEnabled"
                 ]
         if "debugFilesRole" in result:
             if result["debugFilesRole"] is None:

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -74,6 +74,7 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_distribution_enabled_query",
         "sentry:preprod_size_enabled_by_customer",
         "sentry:preprod_distribution_enabled_by_customer",
+        "sentry:preprod_distribution_pr_comments_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -69,6 +69,13 @@ def create_preprod_pr_comment_task(
         )
         return
 
+    if not artifact.project.get_option("sentry:preprod_distribution_pr_comments_enabled", True):
+        logger.info(
+            "preprod.pr_comments.create.project_disabled",
+            extra={"artifact_id": artifact.id, "project_id": artifact.project.id},
+        )
+        return
+
     organization = artifact.project.organization
     if not features.has("organizations:preprod-build-distribution-pr-comments", organization):
         logger.info(

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -194,3 +194,6 @@ register(key="sentry:preprod_distribution_enabled_by_customer", default=True)
 
 # Structured search filter to determine which preprod builds get build distribution.
 register(key="sentry:preprod_distribution_enabled_query", default="")
+
+# Boolean to enable/disable build distribution PR comments for this project.
+register(key="sentry:preprod_distribution_pr_comments_enabled", default=True)

--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -44,7 +44,6 @@ interface FeatureFilterProps {
   queryWriteKey: string;
   successMessage: string;
   title: string;
-  children?: React.ReactNode;
   display?: PreprodBuildsDisplay;
 }
 
@@ -57,7 +56,6 @@ export function FeatureFilter({
   enabledWriteKey,
   docsUrl,
   display,
-  children,
 }: FeatureFilterProps) {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
@@ -180,7 +178,6 @@ export function FeatureFilter({
             </Text>
           </Container>
         )}
-        {children}
       </PanelBody>
     </Panel>
   );

--- a/static/app/views/settings/project/preprod/featureFilter.tsx
+++ b/static/app/views/settings/project/preprod/featureFilter.tsx
@@ -44,6 +44,7 @@ interface FeatureFilterProps {
   queryWriteKey: string;
   successMessage: string;
   title: string;
+  children?: React.ReactNode;
   display?: PreprodBuildsDisplay;
 }
 
@@ -56,6 +57,7 @@ export function FeatureFilter({
   enabledWriteKey,
   docsUrl,
   display,
+  children,
 }: FeatureFilterProps) {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
@@ -178,6 +180,7 @@ export function FeatureFilter({
             </Text>
           </Container>
         )}
+        {children}
       </PanelBody>
     </Panel>
   );

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -12,6 +12,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import {FeatureFilter} from './featureFilter';
+import {PrCommentsToggle} from './prCommentsToggle';
 import {StatusCheckRules} from './statusCheckRules';
 
 const SIZE_ENABLED_READ_KEY = 'sentry:preprod_size_enabled_by_customer';
@@ -63,7 +64,9 @@ export default function PreprodSettings() {
             successMessage={t('Build distribution settings updated')}
             docsUrl="https://docs.sentry.io/product/build-distribution/"
             display={PreprodBuildsDisplay.DISTRIBUTION}
-          />
+          >
+            <PrCommentsToggle />
+          </FeatureFilter>
         </Stack>
       </Feature>
     </Fragment>

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -45,7 +45,6 @@ export default function PreprodSettings() {
         </TextBlock>
         <PreprodQuotaAlert />
         <Stack gap="lg">
-          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={SIZE_ENABLED_READ_KEY}
             enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
@@ -55,6 +54,7 @@ export default function PreprodSettings() {
             successMessage={t('Size analysis settings updated')}
             docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
           />
+          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
             enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -45,6 +45,7 @@ export default function PreprodSettings() {
         </TextBlock>
         <PreprodQuotaAlert />
         <Stack gap="lg">
+          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={SIZE_ENABLED_READ_KEY}
             enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
@@ -54,7 +55,6 @@ export default function PreprodSettings() {
             successMessage={t('Size analysis settings updated')}
             docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
           />
-          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
             enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -64,9 +64,8 @@ export default function PreprodSettings() {
             successMessage={t('Build distribution settings updated')}
             docsUrl="https://docs.sentry.io/product/build-distribution/"
             display={PreprodBuildsDisplay.DISTRIBUTION}
-          >
-            <PrCommentsToggle />
-          </FeatureFilter>
+          />
+          <PrCommentsToggle />
         </Stack>
       </Feature>
     </Fragment>

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -20,7 +20,7 @@ export function PrCommentsToggle() {
 
   return (
     <Panel>
-      <PanelHeader>{t('Pull Request Comments')}</PanelHeader>
+      <PanelHeader>{t('Build Distribution - Pull Request Comments')}</PanelHeader>
       <PanelBody>
         <Flex align="center" justify="between" padding="xl">
           <Stack gap="xs">

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -1,0 +1,36 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
+
+const READ_KEY = 'sentry:preprod_distribution_pr_comments_enabled';
+const WRITE_KEY = 'preprodDistributionPrCommentsEnabled';
+
+export function PrCommentsToggle() {
+  const {project} = useProjectSettingsOutlet();
+  const {mutate: updateProject} = useUpdateProject(project);
+
+  const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+
+  return (
+    <Flex align="center" justify="between" padding="xl" borderTop="primary">
+      <Stack gap="xs">
+        <Text size="lg" bold>
+          {t('Build Distribution Pull Request Comments')}
+        </Text>
+        <Text size="sm" variant="muted">
+          {t('Post build distribution install links as comments on pull requests.')}
+        </Text>
+      </Stack>
+      <Switch
+        size="lg"
+        checked={enabled}
+        onChange={() => updateProject({[WRITE_KEY]: !enabled})}
+        aria-label={t('Toggle build distribution PR comments')}
+      />
+    </Flex>
+  );
+}

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -2,6 +2,9 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
@@ -16,21 +19,26 @@ export function PrCommentsToggle() {
   const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
 
   return (
-    <Flex align="center" justify="between" padding="xl" borderTop="primary">
-      <Stack gap="xs">
-        <Text size="lg" bold>
-          {t('Build Distribution Pull Request Comments')}
-        </Text>
-        <Text size="sm" variant="muted">
-          {t('Post build distribution install links as comments on pull requests.')}
-        </Text>
-      </Stack>
-      <Switch
-        size="lg"
-        checked={enabled}
-        onChange={() => updateProject({[WRITE_KEY]: !enabled})}
-        aria-label={t('Toggle build distribution PR comments')}
-      />
-    </Flex>
+    <Panel>
+      <PanelHeader>{t('Pull Request Comments')}</PanelHeader>
+      <PanelBody>
+        <Flex align="center" justify="between" padding="xl">
+          <Stack gap="xs">
+            <Text size="lg" bold>
+              {t('Build Distribution Pull Request Comments')}
+            </Text>
+            <Text size="sm" variant="muted">
+              {t('Post build distribution install links as comments on pull requests.')}
+            </Text>
+          </Stack>
+          <Switch
+            size="lg"
+            checked={enabled}
+            onChange={() => updateProject({[WRITE_KEY]: !enabled})}
+            aria-label={t('Toggle build distribution PR comments')}
+          />
+        </Flex>
+      </PanelBody>
+    </Panel>
   );
 }

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -192,6 +192,13 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         with self.feature("organizations:preprod-build-distribution-pr-comments"):
             create_preprod_pr_comment_task(artifact.id)
 
+    def test_skips_when_project_option_disabled(self):
+        self.project.update_option("sentry:preprod_distribution_pr_comments_enabled", False)
+        artifact = self._create_artifact()
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
     def test_skips_when_feature_flag_disabled(self):
         artifact = self._create_artifact()
 


### PR DESCRIPTION
Add a new project option `sentry:preprod_distribution_pr_comments_enabled` so individual projects can disable build distribution PR comments. Previously this was only gated by an org-level feature flag with no per-project control.

**Backend:**
- Register the project option (default `true`)
- Expose it in the project serializer and PUT handler (updatable with `project:read` scope)
- Check it in the PR comment task — returns early before the org feature flag check

**Frontend:**
- Add a toggle row inside the Build Distribution Configuration panel in Mobile Builds settings

Refs EME-796