### PR TITLE
feat(preprod): Add PR comments toggle to Mobile Builds settings

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -83,7 +83,7 @@ export type Project = {
   options?: Record<string, boolean | string>;
   preprodDistributionEnabledByCustomer?: boolean;
   preprodDistributionEnabledQuery?: string | null;
-  preprodDistributionPrCommentsEnabled?: boolean;
+  preprodDistributionPrCommentsEnabledByCustomer?: boolean;
   preprodSizeEnabledByCustomer?: boolean;
   preprodSizeEnabledQuery?: string | null;
   preprodSizeStatusChecksEnabled?: boolean;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -83,6 +83,7 @@ export type Project = {
   options?: Record<string, boolean | string>;
   preprodDistributionEnabledByCustomer?: boolean;
   preprodDistributionEnabledQuery?: string | null;
+  preprodDistributionPrCommentsEnabled?: boolean;
   preprodSizeEnabledByCustomer?: boolean;
   preprodSizeEnabledQuery?: string | null;
   preprodSizeStatusChecksEnabled?: boolean;

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -12,6 +12,7 @@ import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHea
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import {FeatureFilter} from './featureFilter';
+import {PrCommentsToggle} from './prCommentsToggle';
 import {StatusCheckRules} from './statusCheckRules';
 
 const SIZE_ENABLED_READ_KEY = 'sentry:preprod_size_enabled_by_customer';
@@ -44,7 +45,6 @@ export default function PreprodSettings() {
         </TextBlock>
         <PreprodQuotaAlert />
         <Stack gap="lg">
-          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={SIZE_ENABLED_READ_KEY}
             enabledWriteKey={SIZE_ENABLED_WRITE_KEY}
@@ -54,6 +54,7 @@ export default function PreprodSettings() {
             successMessage={t('Size analysis settings updated')}
             docsUrl="https://docs.sentry.io/product/size-analysis/#configuring-size-analysis-uploads"
           />
+          <StatusCheckRules />
           <FeatureFilter
             enabledReadKey={DISTRIBUTION_ENABLED_READ_KEY}
             enabledWriteKey={DISTRIBUTION_ENABLED_WRITE_KEY}
@@ -64,6 +65,7 @@ export default function PreprodSettings() {
             docsUrl="https://docs.sentry.io/product/build-distribution/"
             display={PreprodBuildsDisplay.DISTRIBUTION}
           />
+          <PrCommentsToggle />
         </Stack>
       </Feature>
     </Fragment>

--- a/static/app/views/settings/project/preprod/index.tsx
+++ b/static/app/views/settings/project/preprod/index.tsx
@@ -65,7 +65,9 @@ export default function PreprodSettings() {
             docsUrl="https://docs.sentry.io/product/build-distribution/"
             display={PreprodBuildsDisplay.DISTRIBUTION}
           />
-          <PrCommentsToggle />
+          <Feature features="organizations:preprod-build-distribution-pr-comments">
+            <PrCommentsToggle />
+          </Feature>
         </Stack>
       </Feature>
     </Fragment>

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -2,6 +2,11 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
 import Panel from 'sentry/components/panels/panel';
 import PanelBody from 'sentry/components/panels/panelBody';
 import PanelHeader from 'sentry/components/panels/panelHeader';
@@ -17,6 +22,21 @@ export function PrCommentsToggle() {
   const {mutate: updateProject} = useUpdateProject(project);
 
   const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+
+  function handleToggle() {
+    addLoadingMessage(t('Saving...'));
+    updateProject(
+      {[WRITE_KEY]: !enabled},
+      {
+        onSuccess: () => {
+          addSuccessMessage(t('PR comment settings updated'));
+        },
+        onError: () => {
+          addErrorMessage(t('Failed to save changes. Please try again.'));
+        },
+      }
+    );
+  }
 
   return (
     <Panel>
@@ -34,7 +54,7 @@ export function PrCommentsToggle() {
           <Switch
             size="lg"
             checked={enabled}
-            onChange={() => updateProject({[WRITE_KEY]: !enabled})}
+            onChange={handleToggle}
             aria-label={t('Toggle build distribution PR comments')}
           />
         </Flex>

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -14,8 +14,8 @@ import {t} from 'sentry/locale';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-const READ_KEY = 'sentry:preprod_distribution_pr_comments_enabled';
-const WRITE_KEY = 'preprodDistributionPrCommentsEnabled';
+const READ_KEY = 'sentry:preprod_distribution_pr_comments_enabled_by_customer';
+const WRITE_KEY = 'preprodDistributionPrCommentsEnabledByCustomer';
 
 export function PrCommentsToggle() {
   const {project} = useProjectSettingsOutlet();

--- a/static/app/views/settings/project/preprod/prCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/prCommentsToggle.tsx
@@ -1,0 +1,44 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Switch} from '@sentry/scraps/switch';
+import {Text} from '@sentry/scraps/text';
+
+import Panel from 'sentry/components/panels/panel';
+import PanelBody from 'sentry/components/panels/panelBody';
+import PanelHeader from 'sentry/components/panels/panelHeader';
+import {t} from 'sentry/locale';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
+import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
+
+const READ_KEY = 'sentry:preprod_distribution_pr_comments_enabled';
+const WRITE_KEY = 'preprodDistributionPrCommentsEnabled';
+
+export function PrCommentsToggle() {
+  const {project} = useProjectSettingsOutlet();
+  const {mutate: updateProject} = useUpdateProject(project);
+
+  const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+
+  return (
+    <Panel>
+      <PanelHeader>{t('Build Distribution - Pull Request Comments')}</PanelHeader>
+      <PanelBody>
+        <Flex align="center" justify="between" padding="xl">
+          <Stack gap="xs">
+            <Text size="lg" bold>
+              {t('Build Distribution Pull Request Comments')}
+            </Text>
+            <Text size="sm" variant="muted">
+              {t('Post build distribution install links as comments on pull requests.')}
+            </Text>
+          </Stack>
+          <Switch
+            size="lg"
+            checked={enabled}
+            onChange={() => updateProject({[WRITE_KEY]: !enabled})}
+            aria-label={t('Toggle build distribution PR comments')}
+          />
+        </Flex>
+      </PanelBody>
+    </Panel>
+  );
+}


### PR DESCRIPTION
Add a toggle in the Build Distribution section of Mobile Builds settings to enable/disable PR comments per project. Uses the `sentry:preprod_distribution_pr_comments_enabled` project option added in the backend PR.

<img width="1222" height="812" alt="Screenshot 2026-03-06 at 17 02 48" src="https://github.com/user-attachments/assets/e66833f7-a6dc-46c9-91cc-d7f7600f405a" />

Also reorders the settings page to place status check rules below the size analysis configuration section as requested by Max.
<img width="1208" height="819" alt="Screenshot 2026-03-06 at 17 10 47" src="https://github.com/user-attachments/assets/20b967b5-b748-49bf-864e-7a199a637e73" />




Depends on #110050

Refs EME-796