### PR TITLE
ref(crons): replace useRouter with specific hooks in gridLines

### DIFF
--- a/static/app/components/modals/importDashboardFromFileModal.tsx
+++ b/static/app/components/modals/importDashboardFromFileModal.tsx
@@ -12,8 +12,8 @@ import type {Client} from 'sentry/api';
 import {IconUpload} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {
   assignDefaultLayout,
   getInitialColumnDepths,
@@ -35,6 +35,7 @@ function ImportDashboardFromFileModal({
   api,
   location,
 }: ModalRenderProps & ImportDashboardFromFileModalProps) {
+  const navigate = useNavigate();
   const [dashboardData, setDashboardData] = useState('');
   const [validated, setValidated] = useState(false);
 
@@ -83,7 +84,7 @@ function ImportDashboardFromFileModal({
   };
 
   const loadDashboard = (dashboardId: string) => {
-    browserHistory.push(
+    navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboards/${dashboardId}/`,
         query: location.query,

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -3,9 +3,9 @@ import {useCallback, useReducer} from 'react';
 import type {Location} from 'history';
 
 import type {Organization} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {MEPDataProvider} from 'sentry/utils/performance/contexts/metricsEnhancedPerformanceDataContext';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {createDefinedContext} from './utils';
@@ -83,6 +83,7 @@ export function MEPSettingProvider({
   location?: Location;
 }) {
   const organization = useOrganization();
+  const navigate = useNavigate();
 
   const canUseMEP = canUseMetricsData(organization);
 
@@ -111,16 +112,19 @@ export function MEPSettingProvider({
       if (!location) {
         return;
       }
-      browserHistory.replace({
-        ...location,
-        query: {
-          ...location.query,
-          [METRIC_SETTING_PARAM]: settingState,
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            [METRIC_SETTING_PARAM]: settingState,
+          },
         },
-      });
+        {replace: true}
+      );
       _setMetricSettingState(settingState);
     },
-    [location, _setMetricSettingState]
+    [location, navigate, _setMetricSettingState]
   );
 
   const [autoSampleState, setAutoSampleState] = useReducer(

--- a/static/app/views/auth/loginForm.tsx
+++ b/static/app/views/auth/loginForm.tsx
@@ -12,7 +12,7 @@ import {IconGithub, IconGoogle, IconVsts} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {AuthConfig} from 'sentry/types/auth';
-import {browserHistory} from 'sentry/utils/browserHistory';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type LoginProvidersProps = Partial<
   Pick<AuthConfig, 'vstsLoginLink' | 'githubLoginLink' | 'googleLoginLink'>
@@ -52,6 +52,7 @@ type Props = {
 };
 
 function LoginForm({authConfig}: Props) {
+  const navigate = useNavigate();
   const [error, setError] = useState('');
 
   const {githubLoginLink, vstsLoginLink} = authConfig;
@@ -71,7 +72,7 @@ function LoginForm({authConfig}: Props) {
 
           // TODO(epurkhiser): Reconfigure sentry SDK identity
 
-          browserHistory.push({pathname: response.nextUri});
+          navigate({pathname: response.nextUri});
         }}
         onSubmitError={response => {
           // TODO(epurkhiser): Need much better error handling here

--- a/static/app/views/auth/registerForm.tsx
+++ b/static/app/views/auth/registerForm.tsx
@@ -11,7 +11,7 @@ import Form from 'sentry/components/forms/form';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import type {AuthConfig} from 'sentry/types/auth';
-import {browserHistory} from 'sentry/utils/browserHistory';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type Props = {
   authConfig: AuthConfig;
@@ -19,6 +19,7 @@ type Props = {
 
 function RegisterForm({authConfig}: Props) {
   const {hasNewsletter} = authConfig;
+  const navigate = useNavigate();
 
   const [error, setError] = useState('');
 
@@ -30,7 +31,7 @@ function RegisterForm({authConfig}: Props) {
       submitLabel={t('Continue')}
       onSubmitSuccess={response => {
         ConfigStore.set('user', response.user);
-        browserHistory.push({pathname: response.nextUri});
+        navigate({pathname: response.nextUri});
       }}
       onSubmitError={response => {
         setError(response.responseJSON.detail);

--- a/static/app/views/auth/ssoForm.tsx
+++ b/static/app/views/auth/ssoForm.tsx
@@ -6,13 +6,14 @@ import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
 import {t, tct} from 'sentry/locale';
 import type {AuthConfig} from 'sentry/types/auth';
-import {browserHistory} from 'sentry/utils/browserHistory';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 type Props = {
   authConfig: AuthConfig;
 };
 
 function SsoForm({authConfig}: Props) {
+  const navigate = useNavigate();
   const [error, setError] = useState('');
 
   const {serverHostname} = authConfig;
@@ -22,7 +23,7 @@ function SsoForm({authConfig}: Props) {
       apiMethod="POST"
       apiEndpoint="/auth/sso-locate/"
       onSubmitSuccess={response => {
-        browserHistory.push({pathname: response.nextUri});
+        navigate({pathname: response.nextUri});
       }}
       onSubmitError={response => {
         setError(response.responseJSON.detail);

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -19,13 +19,13 @@ import type {SelectValue} from 'sentry/types/core';
 import type {NewQuery, SavedQuery} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import EventView from 'sentry/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'sentry/utils/discover/urls';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeDiscoverPathname} from 'sentry/views/discover/pathnames';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
@@ -131,6 +131,7 @@ const useDiscoverLandingQuery = (renderPrebuilt: boolean) => {
 const RENDER_PREBUILT_KEY = 'discover-render-prebuilt';
 
 function DiscoverLanding() {
+  const navigate = useNavigate();
   const organization = useOrganization();
   const location = useLocation();
   const activeSort = useActiveSort();
@@ -158,7 +159,7 @@ function DiscoverLanding() {
 
   const handleSortChange = (value: string) => {
     trackAnalytics('discover_v2.change_sort', {organization, sort: value});
-    browserHistory.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...location.query,
@@ -169,7 +170,7 @@ function DiscoverLanding() {
   };
 
   const handleSearchQuery = (searchQuery: string) => {
-    browserHistory.push({
+    navigate({
       pathname: location.pathname,
       query: {
         ...location.query,

--- a/static/app/views/insights/crons/components/monitorCreateForm.tsx
+++ b/static/app/views/insights/crons/components/monitorCreateForm.tsx
@@ -18,9 +18,9 @@ import PanelBody from 'sentry/components/panels/panelBody';
 import {timezoneOptions} from 'sentry/data/timezones';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import type {Monitor} from 'sentry/views/insights/crons/types';
@@ -45,6 +45,7 @@ const DEFAULT_SCHEDULE_CONFIG = {
 
 export default function MonitorCreateForm() {
   const theme = useTheme();
+  const navigate = useNavigate();
   const organization = useOrganization();
   const {projects} = useProjects();
   const {selection} = usePageFilters();
@@ -72,7 +73,7 @@ export default function MonitorCreateForm() {
         environment: selection.environments,
       },
     };
-    browserHistory.push(
+    navigate(
       normalizeUrl({
         pathname: `/organizations/${organization.slug}/alerts/rules/crons/${data.project.slug}/${data.slug}/details/`,
         query: endpointOptions.query,

--- a/static/app/views/organizationRestore/index.tsx
+++ b/static/app/views/organizationRestore/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {Navigate} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -13,7 +14,6 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
@@ -55,8 +55,7 @@ function OrganizationRestoreBody({orgSlug}: BodyProps) {
     );
   }
   if (data.status.id === 'active') {
-    browserHistory.replace(normalizeUrl(`/organizations/${orgSlug}/issues/`));
-    return null;
+    return <Navigate replace to={normalizeUrl(`/organizations/${orgSlug}/issues/`)} />;
   }
   if (data.status.id === 'pending_deletion') {
     return <RestoreForm organization={data} endpoint={endpoint} />;

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -21,7 +21,6 @@ import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import toArray from 'sentry/utils/array/toArray';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import type EventView from 'sentry/utils/discover/eventView';
@@ -39,6 +38,7 @@ import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import type {DomainViewFilters} from 'sentry/views/insights/pages/useFilters';
@@ -134,6 +134,7 @@ export default function EventsTable({
   referrer,
   renderTableHeader,
 }: Props) {
+  const navigate = useNavigate();
   const api = useApi({persistInFlight: true});
   const [lastFetchedCursor, setLastFetchedCursor] = useState('');
   const [attachments, setAttachments] = useState<IssueAttachment[]>([]);
@@ -170,7 +171,7 @@ export default function EventsTable({
             newEnvs = newEnvs.filter(env => env !== value);
           }
 
-          browserHistory.push({
+          navigate({
             pathname: location.pathname,
             query: {
               ...location.query,
@@ -181,7 +182,7 @@ export default function EventsTable({
           return;
         }
 
-        browserHistory.push({
+        navigate({
           pathname: location.pathname,
           query: {
             ...location.query,
@@ -191,7 +192,7 @@ export default function EventsTable({
         });
       };
     },
-    [organization, eventView, excludedTags, applyEnvironmentFilter, location]
+    [organization, eventView, excludedTags, applyEnvironmentFilter, location, navigate]
   );
 
   const renderBodyCell = useCallback(

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -18,7 +18,6 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import {isFieldSortable} from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
@@ -29,6 +28,7 @@ import type {
 } from 'sentry/utils/performance/segmentExplorer/segmentExplorerQuery';
 import SegmentExplorerQuery from 'sentry/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import CellAction, {Actions, updateQuery} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {
@@ -195,6 +195,7 @@ export function TagExplorer(props: Props) {
     domainViewFilters,
   } = props;
 
+  const navigate = useNavigate();
   const [widths, setWidths] = useState<number[]>([]);
 
   const handleResizeColumn = useCallback(
@@ -290,7 +291,7 @@ export function TagExplorer(props: Props) {
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 
-      browserHistory.push({
+      navigate({
         pathname: location.pathname,
         query: {
           ...location.query,
@@ -458,13 +459,14 @@ type HeaderProps = {
 
 function TagsHeader(props: HeaderProps) {
   const domainViewFilters = useDomainViewFilters();
+  const navigate = useNavigate();
   const {pageLinks, organization, location, transactionName} = props;
 
   const handleCursor: CursorHandler = (cursor, pathname, query) => {
     trackAnalytics('performance_views.summary.tag_explorer.change_page', {
       organization,
     });
-    browserHistory.push({
+    navigate({
       pathname,
       query: {...query, [TAGS_CURSOR_NAME]: cursor},
     });

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -16,7 +16,6 @@ import {space} from 'sentry/styles/space';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import type EventView from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
@@ -142,7 +141,7 @@ export function TagValueTable({
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 
-      browserHistory.push({
+      navigate({
         pathname: location.pathname,
         query: {
           ...location.query,

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -9,7 +9,6 @@ import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingM
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {
   axisLabelFormatter,
@@ -20,6 +19,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeList} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import generateTrendFunctionAsString from 'sentry/views/performance/trends/utils/generateTrendFunctionAsString';
 import transformEventStats from 'sentry/views/performance/trends/utils/transformEventStats';
 import type {ViewProps} from 'sentry/views/performance/types';
@@ -98,6 +98,7 @@ export function Chart({
   applyRegressionFormatToInterval = false,
 }: Props) {
   const location = useLocation();
+  const navigate = useNavigate();
   const theme = useTheme();
 
   const handleLegendSelectChanged = (legendChange: any) => {
@@ -115,7 +116,7 @@ export function Chart({
       ...location,
       query,
     };
-    browserHistory.push(to);
+    navigate(to);
   };
 
   const derivedTrendChangeType = organization.features.includes('performance-new-trends')

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -31,13 +31,13 @@ import {DataCategory} from 'sentry/types/core';
 import type {PageFilters} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {formatError, formatSort} from 'sentry/utils/profiling/hooks/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {LandingAggregateFlamegraph} from 'sentry/views/profiling/landingAggregateFlamegraph';
@@ -66,6 +66,7 @@ export default function ProfilingContent() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const dispatchDataState = useLandingAnalytics();
   const updateWidget1DataState = useCallback(
@@ -123,7 +124,7 @@ export default function ProfilingContent() {
         organization,
         tab: newTab,
       });
-      browserHistory.push({
+      navigate({
         ...location,
         query: {
           ...location.query,
@@ -131,7 +132,7 @@ export default function ProfilingContent() {
         },
       });
     },
-    [dispatchDataState, location, organization]
+    [dispatchDataState, location, navigate, organization]
   );
 
   const maxPickableDays = useMaxPickableDays({
@@ -258,10 +259,11 @@ interface TabbedContentProps extends ProfilingTabProps {
 }
 
 function TransactionsTab({onDataState, location, selection}: TabbedContentProps) {
+  const navigate = useNavigate();
   const query = decodeScalar(location.query.query, '');
   const handleSearch = useCallback(
     (searchQuery: string) => {
-      browserHistory.push({
+      navigate({
         ...location,
         query: {
           ...location.query,
@@ -270,7 +272,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
         },
       });
     },
-    [location]
+    [location, navigate]
   );
 
   const fields = ALL_FIELDS;

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -33,7 +33,6 @@ import type {Series} from 'sentry/types/echarts';
 import type {EventsStatsSeries} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {getShortEventId} from 'sentry/utils/events';
 import {Frame} from 'sentry/utils/profiling/frame';
@@ -45,6 +44,7 @@ import type {UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import useRouter from 'sentry/utils/useRouter';
@@ -87,6 +87,7 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
   widgetHeight,
   onDataState,
 }: SlowestFunctionsWidgetProps<F>) {
+  const navigate = useNavigate();
   const router = useRouter();
   const location = useLocation();
   const organization = useOrganization();
@@ -116,12 +117,12 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
 
   const handleCursor = useCallback(
     (cursor: any, pathname: any, query: any) => {
-      browserHistory.push({
+      navigate({
         pathname,
         query: {...query, [cursorName]: cursor},
       });
     },
-    [cursorName]
+    [cursorName, navigate]
   );
 
   const paginationAnalyticsEvent = useCallback(

--- a/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/preprodBuilds.tsx
@@ -14,13 +14,13 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useApiQuery, type UseApiQueryResult} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useLocationQuery from 'sentry/utils/url/useLocationQuery';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
@@ -37,6 +37,7 @@ export default function PreprodBuilds() {
   const projectSlug = releaseContext.project.slug;
   const projectPlatform = releaseContext.project.platform;
   const params = useParams<{release: string}>();
+  const navigate = useNavigate();
   const location = useLocation();
   const activeDisplay = useMemo(
     () => getPreprodBuildsDisplay(location.query.display),
@@ -59,7 +60,7 @@ export default function PreprodBuilds() {
 
   useEffect(() => {
     if (debouncedLocalSearchQuery !== (urlSearchQuery || '')) {
-      browserHistory.push({
+      navigate({
         ...location,
         query: {
           ...location.query,
@@ -68,7 +69,7 @@ export default function PreprodBuilds() {
         },
       });
     }
-  }, [debouncedLocalSearchQuery, urlSearchQuery, location]);
+  }, [debouncedLocalSearchQuery, urlSearchQuery, location, navigate]);
 
   const queryParams: Record<string, any> = {
     per_page: 25,
@@ -132,7 +133,7 @@ export default function PreprodBuilds() {
 
   const handleDisplayChange = useCallback(
     (display: PreprodBuildsDisplay) => {
-      browserHistory.push({
+      navigate({
         ...location,
         query: {
           ...location.query,
@@ -141,7 +142,7 @@ export default function PreprodBuilds() {
         },
       });
     },
-    [location]
+    [location, navigate]
   );
 
   const builds = buildsData ?? [];

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -25,7 +25,6 @@ import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
 import type {NewQuery, Organization} from 'sentry/types/organization';
 import {SessionFieldWithOperation} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
@@ -33,6 +32,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import useRouter from 'sentry/utils/useRouter';
@@ -93,6 +93,7 @@ function ReleaseOverview() {
   const {selection} = usePageFilters();
   const location = useLocation();
   const router = useRouter();
+  const navigate = useNavigate();
   const api = useApi();
 
   const {commitCount, version} = release;
@@ -237,7 +238,7 @@ function ReleaseOverview() {
       pathname: location.pathname,
       query: {...location.query, showTransactions: value, transactionCursor: undefined},
     };
-    browserHistory.push(target);
+    navigate(target);
   };
 
   const handleDateChange = (datetime: ChangeData) => {

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -7,12 +7,12 @@ import type {CursorHandler} from 'sentry/components/pagination';
 import type {ChangeData} from 'sentry/components/timeRangeSelector';
 import type {DateString} from 'sentry/types/core';
 import type {AuditLog} from 'sentry/types/organization';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {getDateWithTimezoneInUtc, getUserTimezone} from 'sentry/utils/dates';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
@@ -33,6 +33,7 @@ type State = {
 
 function OrganizationAuditLog() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [state, setState] = useState<State>({
     entryList: [],
     entryListPageLinks: null,
@@ -151,7 +152,7 @@ function OrganizationAuditLog() {
       ...prevState,
       eventType: value,
     }));
-    browserHistory.push({
+    navigate({
       pathname: location.pathname,
       query: {...location.query, event: value},
     });
@@ -196,7 +197,7 @@ function OrganizationAuditLog() {
       newQuery.utc = data.utc ? 'true' : 'false';
     }
 
-    browserHistory.push({
+    navigate({
       pathname: location.pathname,
       query: newQuery,
     });

--- a/static/app/views/settings/project/preprod/statusCheckRules.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRules.tsx
@@ -14,8 +14,8 @@ import PanelHeader from 'sentry/components/panels/panelHeader';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useRepositories} from 'sentry/utils/useRepositories';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
@@ -28,6 +28,7 @@ export function StatusCheckRules() {
   const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
   const location = useLocation();
+  const navigate = useNavigate();
   const {data: repositories, isPending: isLoadingRepos} = useRepositories({
     orgSlug: organization.slug,
   });
@@ -57,15 +58,18 @@ export function StatusCheckRules() {
 
   const updateExpandedInUrl = useCallback(
     (expandedIds: string[]) => {
-      browserHistory.replace({
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          expanded: expandedIds,
+      navigate(
+        {
+          pathname: location.pathname,
+          query: {
+            ...location.query,
+            expanded: expandedIds,
+          },
         },
-      });
+        {replace: true}
+      );
     },
-    [location.pathname, location.query]
+    [location.pathname, location.query, navigate]
   );
 
   const handleToggleExpanded = useCallback(

--- a/static/app/views/settings/project/projectKeys/details/index.tsx
+++ b/static/app/views/settings/project/projectKeys/details/index.tsx
@@ -5,10 +5,10 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import type {ProjectKey} from 'sentry/types/project';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {browserHistory} from 'sentry/utils/browserHistory';
 import {setApiQueryData, useApiQuery, useQueryClient} from 'sentry/utils/queryClient';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import useApi from 'sentry/utils/useApi';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import RouteError from 'sentry/views/routeError';
@@ -24,6 +24,7 @@ export default function ProjectKeyDetails() {
   const params = useParams<{keyId: string; projectId: string}>();
   const {keyId, projectId} = params;
   const api = useApi();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const theme = useTheme();
 
@@ -61,9 +62,7 @@ export default function ProjectKeyDetails() {
   }
 
   const handleRemove = () => {
-    browserHistory.push(
-      normalizeUrl(`/settings/${organization.slug}/projects/${projectId}/keys/`)
-    );
+    navigate(normalizeUrl(`/settings/${organization.slug}/projects/${projectId}/keys/`));
   };
 
   if (isError) {


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)

See REACT_ROUTER_6_CLEANUP.md for full context.