### PR TITLE
feat(code-review): Add option to skip code review for excluded PR authors

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -717,7 +717,7 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "coding_workflows.code-review.excluded-pr-author-logins",
+    "seer.code-review.excluded-pr-author-logins",
     type=Sequence,
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -716,6 +716,12 @@ register(
     type=Bool,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "coding_workflows.code-review.excluded-pr-author-logins",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Codecov Integration
 register("codecov.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -145,7 +145,7 @@ class CodeReviewPreflightService:
 
         # Excluded author check applies to all organization types
         if contributor.alias and contributor.alias in options.get(
-            "seer.code-review.excluded-pr-author-logins"
+            "coding-workflows.code-review.excluded-pr-author-logins"
         ):
             return PreflightDenialReason.PR_AUTHOR_EXCLUDED
 

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -145,7 +145,7 @@ class CodeReviewPreflightService:
 
         # Excluded author check applies to all organization types
         if contributor.alias and contributor.alias in options.get(
-            "coding-workflows.code-review.excluded-pr-author-logins"
+            "seer.code-review.excluded-pr-author-logins"
         ):
             return PreflightDenialReason.PR_AUTHOR_EXCLUDED
 

--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from functools import cached_property
 
-from sentry import features, quotas
+from sentry import features, options, quotas
 from sentry.constants import (
     ENABLE_PR_REVIEW_TEST_GENERATION_DEFAULT,
     HIDE_AI_FEATURES_DEFAULT,
@@ -31,6 +31,7 @@ class PreflightDenialReason(StrEnum):
     BILLING_MISSING_CONTRIBUTOR_INFO = "billing_missing_contributor_info"
     BILLING_QUOTA_EXCEEDED = "billing_quota_exceeded"
     ORG_CONTRIBUTOR_NOT_FOUND = "org_contributor_not_found"
+    PR_AUTHOR_EXCLUDED = "pr_author_excluded"
 
 
 @dataclass
@@ -130,13 +131,6 @@ class CodeReviewPreflightService:
         then that means that they've opened a PR before, and either have a seat already OR it's their
         "Free action."
         """
-        # Code review beta and legacy usage-based plan orgs are exempt from quota checks
-        # as long as they haven't purchased the new seat-based plan
-        if not self._is_seat_based_seer_plan_org and (
-            self._is_code_review_beta_org or self._is_legacy_usage_based_seer_plan_org
-        ):
-            return None
-
         if self.integration_id is None or self.pr_author_external_id is None:
             return PreflightDenialReason.BILLING_MISSING_CONTRIBUTOR_INFO
 
@@ -148,6 +142,19 @@ class CodeReviewPreflightService:
             )
         except OrganizationContributors.DoesNotExist:
             return PreflightDenialReason.ORG_CONTRIBUTOR_NOT_FOUND
+
+        # Excluded author check applies to all organization types
+        if contributor.alias and contributor.alias in options.get(
+            "seer.code-review.excluded-pr-author-logins"
+        ):
+            return PreflightDenialReason.PR_AUTHOR_EXCLUDED
+
+        # Code review beta and legacy usage-based plan orgs are exempt from quota checks
+        # as long as they haven't purchased the new seat-based plan
+        if not self._is_seat_based_seer_plan_org and (
+            self._is_code_review_beta_org or self._is_legacy_usage_based_seer_plan_org
+        ):
+            return None
 
         has_quota = quotas.backend.check_seer_quota(
             org_id=self.organization.id,

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -424,6 +424,56 @@ class TestCodeReviewPreflightService(TestCase):
 
         mock_check_quota.assert_called_once()
 
+    @patch("sentry.quotas.backend.check_seer_quota")
+    @with_feature(["organizations:gen-ai-features", "organizations:seat-based-seer-enabled"])
+    def test_denied_when_pr_author_is_excluded(self, mock_check_quota: MagicMock) -> None:
+        mock_check_quota.return_value = True
+
+        self.create_repository_settings(
+            repository=self.repo,
+            enabled_code_review=True,
+        )
+
+        OrganizationContributors.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier=self.external_identifier,
+            alias="dependabot[bot]",
+        )
+
+        with self.options({"seer.code-review.excluded-pr-author-logins": ["dependabot[bot]"]}):
+            service = self._create_service()
+            result = service.check()
+
+        assert result.allowed is False
+        assert result.denial_reason == PreflightDenialReason.PR_AUTHOR_EXCLUDED
+        mock_check_quota.assert_not_called()
+
+    @patch("sentry.quotas.backend.check_seer_quota")
+    @with_feature(
+        [
+            "organizations:gen-ai-features",
+            "organizations:code-review-beta",
+        ]
+    )
+    def test_excluded_author_denied_for_beta_org(self, mock_check_quota: MagicMock) -> None:
+        """Excluded author check applies to all org types, including beta orgs."""
+        self.organization.update_option("sentry:enable_pr_review_test_generation", True)
+
+        OrganizationContributors.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier=self.external_identifier,
+            alias="dependabot[bot]",
+        )
+
+        with self.options({"seer.code-review.excluded-pr-author-logins": ["dependabot[bot]"]}):
+            service = self._create_service()
+            result = service.check()
+
+        assert result.allowed is False
+        assert result.denial_reason == PreflightDenialReason.PR_AUTHOR_EXCLUDED
+
     def test_feature_flag_checks_are_cached(self) -> None:
         service = self._create_service()
 

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -449,31 +449,6 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.denial_reason == PreflightDenialReason.PR_AUTHOR_EXCLUDED
         mock_check_quota.assert_not_called()
 
-    @patch("sentry.quotas.backend.check_seer_quota")
-    @with_feature(
-        [
-            "organizations:gen-ai-features",
-            "organizations:code-review-beta",
-        ]
-    )
-    def test_excluded_author_denied_for_beta_org(self, mock_check_quota: MagicMock) -> None:
-        """Excluded author check applies to all org types, including beta orgs."""
-        self.organization.update_option("sentry:enable_pr_review_test_generation", True)
-
-        OrganizationContributors.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            external_identifier=self.external_identifier,
-            alias="dependabot[bot]",
-        )
-
-        with self.options({"seer.code-review.excluded-pr-author-logins": ["dependabot[bot]"]}):
-            service = self._create_service()
-            result = service.check()
-
-        assert result.allowed is False
-        assert result.denial_reason == PreflightDenialReason.PR_AUTHOR_EXCLUDED
-
     def test_feature_flag_checks_are_cached(self) -> None:
         service = self._create_service()
 


### PR DESCRIPTION
Relates to CW-972

options-automator followup: https://github.com/getsentry/sentry-options-automator/pull/6728

Register `seer.code-review.excluded-pr-author-logins` option to allow configuring a list of PR author logins (e.g., dependabot[bot]) to skip code review for. The check uses contributor.alias and applies to all org types, including beta and legacy orgs.