### PR TITLE
fix(tracemetrics): Fix effective sample rate in dual write

### DIFF
--- a/src/sentry/metrics/sentry_sdk.py
+++ b/src/sentry/metrics/sentry_sdk.py
@@ -47,8 +47,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate != 1.0:
-            metric_attributes["sentry.client_sample_rate"] = sample_rate
+        effective_sample_rate = sample_rate * self._experimental_sample_rate
+        if effective_sample_rate != 1.0:
+            metric_attributes["sentry.client_sample_rate"] = effective_sample_rate
 
         metrics.count(
             full_key,
@@ -77,8 +78,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate != 1.0:
-            metric_attributes["sentry.client_sample_rate"] = sample_rate
+        effective_sample_rate = sample_rate * self._experimental_sample_rate
+        if effective_sample_rate != 1.0:
+            metric_attributes["sentry.client_sample_rate"] = effective_sample_rate
 
         metric_attributes["is_timing"] = True
 
@@ -110,8 +112,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate != 1.0:
-            metric_attributes["sentry.client_sample_rate"] = sample_rate
+        effective_sample_rate = sample_rate * self._experimental_sample_rate
+        if effective_sample_rate != 1.0:
+            metric_attributes["sentry.client_sample_rate"] = effective_sample_rate
 
         metrics.gauge(
             full_key,
@@ -141,8 +144,9 @@ class SentrySDKMetricsBackend(MetricsBackend):
         if instance:
             metric_attributes["instance"] = instance
 
-        if sample_rate != 1.0:
-            metric_attributes["sentry.client_sample_rate"] = sample_rate
+        effective_sample_rate = sample_rate * self._experimental_sample_rate
+        if effective_sample_rate != 1.0:
+            metric_attributes["sentry.client_sample_rate"] = effective_sample_rate
 
         metrics.distribution(
             full_key,

--- a/tests/sentry/metrics/test_sentry_sdk.py
+++ b/tests/sentry/metrics/test_sentry_sdk.py
@@ -163,3 +163,19 @@ class TestSentrySDKMetricsBackend:
             unit="millisecond",
             attributes={"x": "y", "sentry.client_sample_rate": 0.75, "is_timing": True},
         )
+
+    @mock.patch("sentry_sdk.metrics.count")
+    def test_incr_effective_sample_rate_includes_experimental(self, mock_count):
+        backend = SentrySDKMetricsBackend(prefix="test.", experimental_sample_rate=0.5)
+        with (
+            mock.patch.object(backend, "_should_sample_experimental", return_value=True),
+            mock.patch.object(backend, "_should_sample", return_value=True),
+        ):
+            backend.incr("foo", tags={"x": "y"}, amount=2, sample_rate=0.5)
+
+        mock_count.assert_called_once_with(
+            "test.foo",
+            2,
+            unit=None,
+            attributes={"x": "y", "sentry.client_sample_rate": 0.25},
+        )


### PR DESCRIPTION
Before we were only attaching the local sample rate per function, but we should be attaching the effective sample rate for extrapolation to work properly.
