### PR TITLE
ref(crons): replace useRouter with specific hooks in gridLines

### DIFF
--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -260,7 +260,7 @@ export function GridLineOverlay({
           start: dateFromPosition(startX).startOf('minute').toDate(),
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
-        {location, push: navigate, replace: path => navigate(path, {replace: true})} as any,
+        {location, push: navigate, replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true})} as any,
         {keepCursor: !resetPaginationOnZoom}
       ),
     [dateFromPosition, resetPaginationOnZoom, location, navigate]

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -260,7 +260,12 @@ export function GridLineOverlay({
           start: dateFromPosition(startX).startOf('minute').toDate(),
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
-        {location, push: navigate, replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true})} as any,
+        {
+          location,
+          push: navigate,
+          replace: (path: Parameters<typeof navigate>[0]) =>
+            navigate(path, {replace: true}),
+        } as any,
         {keepCursor: !resetPaginationOnZoom}
       ),
     [dateFromPosition, resetPaginationOnZoom, location, navigate]

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -7,7 +7,8 @@ import moment from 'moment-timezone';
 import {DateTime} from 'sentry/components/dateTime';
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import {space} from 'sentry/styles/space';
-import useRouter from 'sentry/utils/useRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {useTimelineCursor, type CursorOffsets} from './timelineCursor';
 import {useTimelineZoom} from './timelineZoom';
@@ -228,7 +229,8 @@ export function GridLineOverlay({
   labelPosition = 'left-top',
   resetPaginationOnZoom,
 }: GridLineOverlayProps) {
-  const router = useRouter();
+  const location = useLocation();
+  const navigate = useNavigate();
   const {periodStart, timelineWidth, dateLabelFormat, rollupConfig, timezone} =
     timeWindowConfig;
   const {timelineUnderscanWidth} = rollupConfig;
@@ -258,10 +260,10 @@ export function GridLineOverlay({
           start: dateFromPosition(startX).startOf('minute').toDate(),
           end: dateFromPosition(endX).add(1, 'minute').startOf('minute').toDate(),
         },
-        router,
+        {location, push: navigate, replace: path => navigate(path, {replace: true})} as any,
         {keepCursor: !resetPaginationOnZoom}
       ),
-    [dateFromPosition, resetPaginationOnZoom, router]
+    [dateFromPosition, resetPaginationOnZoom, location, navigate]
   );
 
   const {

--- a/static/app/components/checkInTimeline/gridLines.tsx
+++ b/static/app/components/checkInTimeline/gridLines.tsx
@@ -262,7 +262,7 @@ export function GridLineOverlay({
         },
         {
           location,
-          push: navigate,
+          push: (path: Parameters<typeof navigate>[0]) => navigate(path),
           replace: (path: Parameters<typeof navigate>[0]) =>
             navigate(path, {replace: true}),
         } as any,


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)