### PR TITLE
ref(crons): replace useRouter with specific hooks in useDateNavigation

### DIFF
--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -3,7 +3,8 @@ import moment from 'moment-timezone';
 
 import {updateDateTime} from 'sentry/components/pageFilters/actions';
 import getDuration from 'sentry/utils/duration/getDuration';
-import useRouter from 'sentry/utils/useRouter';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {usePageFilterDates} from './useMonitorDates';
 
@@ -29,7 +30,8 @@ export interface DateNavigation {
 }
 
 export function useDateNavigation(): DateNavigation {
-  const router = useRouter();
+  const navigate = useNavigate();
+  const location = useLocation();
   const {since, until, now} = usePageFilterDates();
 
   const windowMs = until.getTime() - since.getTime();
@@ -38,8 +40,12 @@ export function useDateNavigation(): DateNavigation {
     const nextUntil = moment(until).subtract(windowMs, 'milliseconds');
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router);
-  }, [windowMs, router, until]);
+    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
+      location,
+      push: navigate,
+      replace: path => navigate(path, {replace: true}),
+    } as any);
+  }, [windowMs, navigate, location, until]);
 
   const navigateToNextPeriod = useCallback(() => {
     // Do not navigate past the current time
@@ -49,10 +55,14 @@ export function useDateNavigation(): DateNavigation {
     );
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, router, {
+    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
+      location,
+      push: navigate,
+      replace: path => navigate(path, {replace: true}),
+    } as any, {
       keepCursor: true,
     });
-  }, [until, windowMs, now, router]);
+  }, [until, windowMs, now, navigate, location]);
 
   return {
     endIsNow: until.getTime() === now.getTime(),

--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -55,13 +55,18 @@ export function useDateNavigation(): DateNavigation {
     );
     const nextSince = moment(nextUntil).subtract(windowMs, 'milliseconds');
 
-    updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
-      location,
-      push: navigate,
-      replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true}),
-    } as any, {
-      keepCursor: true,
-    });
+    updateDateTime(
+      {start: nextSince.toDate(), end: nextUntil.toDate()},
+      {
+        location,
+        push: navigate,
+        replace: (path: Parameters<typeof navigate>[0]) =>
+          navigate(path, {replace: true}),
+      } as any,
+      {
+        keepCursor: true,
+      }
+    );
   }, [until, windowMs, now, navigate, location]);
 
   return {

--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -43,7 +43,7 @@ export function useDateNavigation(): DateNavigation {
     updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
       location,
       push: navigate,
-      replace: path => navigate(path, {replace: true}),
+      replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true}),
     } as any);
   }, [windowMs, navigate, location, until]);
 
@@ -58,7 +58,7 @@ export function useDateNavigation(): DateNavigation {
     updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
       location,
       push: navigate,
-      replace: path => navigate(path, {replace: true}),
+      replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true}),
     } as any, {
       keepCursor: true,
     });

--- a/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
+++ b/static/app/components/checkInTimeline/hooks/useDateNavigation.tsx
@@ -42,7 +42,7 @@ export function useDateNavigation(): DateNavigation {
 
     updateDateTime({start: nextSince.toDate(), end: nextUntil.toDate()}, {
       location,
-      push: navigate,
+      push: (path: Parameters<typeof navigate>[0]) => navigate(path),
       replace: (path: Parameters<typeof navigate>[0]) => navigate(path, {replace: true}),
     } as any);
   }, [windowMs, navigate, location, until]);
@@ -59,7 +59,7 @@ export function useDateNavigation(): DateNavigation {
       {start: nextSince.toDate(), end: nextUntil.toDate()},
       {
         location,
-        push: navigate,
+        push: (path: Parameters<typeof navigate>[0]) => navigate(path),
         replace: (path: Parameters<typeof navigate>[0]) =>
           navigate(path, {replace: true}),
       } as any,


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)