### PR TITLE
ref(search): replace useRouter with specific hooks in search

### DIFF
--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -9,8 +9,9 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
 
 import ApiSource from './sources/apiSource';
 import CommandSource from './sources/commandSource';
@@ -93,8 +94,8 @@ function Search({
   searchOptions,
   sources,
 }: SearchProps): React.ReactElement {
-  const router = useRouter();
-
+  const navigate = useNavigate();
+  const location = useLocation();
   const params = useParams<{orgId: string}>();
   useEffect(() => {
     trackAnalytics(`${entryPoint}.open`, {
@@ -153,12 +154,12 @@ function Search({
             };
       if (item.configUrl) {
         // @ts-expect-error TODO(ryan953): Invalid useApiQuery path (comes from api response)
-        navigateTo(nextTo, router, [item.configUrl]);
+        navigateTo(nextTo, {push: navigate, location} as any, [item.configUrl]);
       } else {
-        navigateTo(nextTo, router);
+        navigateTo(nextTo, {push: navigate, location} as any);
       }
     },
-    [entryPoint, router, params, onAction]
+    [entryPoint, navigate, location, params, onAction]
   );
 
   const saveQueryMetrics = useCallback(


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)