### PR TITLE
ref(app): replace useRouter with specific hooks in withDomainRedirect

### DIFF
--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -1,5 +1,4 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {setWindowLocation} from 'sentry-test/utils';
@@ -8,21 +7,9 @@ import ConfigStore from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
 import withDomainRedirect from 'sentry/utils/withDomainRedirect';
 
 jest.unmock('sentry/utils/recreateRoute');
-jest.mock('sentry/utils/useRouter');
-
-// /settings/:orgId/:projectId/(searches/:searchId/)alerts/
-const projectRoutes = [
-  {path: '/', childRoutes: []},
-  {childRoutes: []},
-  {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
-  {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId/', childRoutes: []},
-  {name: 'Alerts', path: 'alerts/'},
-];
 
 describe('withDomainRedirect', () => {
   function MyComponent() {
@@ -127,20 +114,13 @@ describe('withDomainRedirect', () => {
     );
   });
 
-  it('redirect when :orgId is present in the routes', () => {
+  it('redirect when :orgId is present in the routes', async () => {
     ConfigStore.set('features', new Set(['system:multi-region']));
     const organization = OrganizationFixture({
       slug: 'albertos-apples',
     });
-    const replaceFn = jest.fn();
-    jest.mocked(useRouter).mockReturnValue(
-      RouterFixture({
-        routes: projectRoutes,
-        replace: replaceFn,
-      })
-    );
     const WrappedComponent = withDomainRedirect(MyComponent);
-    const {container} = render(<WrappedComponent />, {
+    const {router} = render(<WrappedComponent />, {
       organization,
       initialRouterConfig: {
         location: {
@@ -151,9 +131,7 @@ describe('withDomainRedirect', () => {
       },
     });
 
-    expect(container).toBeEmptyDOMElement();
-    expect(replaceFn).toHaveBeenCalledTimes(1);
-    expect(replaceFn).toHaveBeenCalledWith('/settings/react/alerts/?q=123#hash');
+    expect(router.location.pathname).toBe('/settings/react/alerts/');
   });
 
   it('does not redirect when :orgId is not present in the routes', () => {
@@ -161,8 +139,6 @@ describe('withDomainRedirect', () => {
     const organization = OrganizationFixture({
       slug: 'albertos-apples',
     });
-
-    jest.mocked(useRouter).mockReturnValue(RouterFixture({routes: []}));
 
     const WrappedComponent = withDomainRedirect(MyComponent);
     const {router} = render(<WrappedComponent />, {
@@ -189,16 +165,9 @@ describe('withDomainRedirect', () => {
       sentryUrl: 'https://sentry.io',
       subdomain: '',
     });
-    const replaceFn = jest.fn();
-    jest.mocked(useRouter).mockReturnValue(
-      RouterFixture({
-        routes: projectRoutes,
-        replace: replaceFn,
-      })
-    );
 
     const WrappedComponent = withDomainRedirect(MyComponent);
-    render(<WrappedComponent />, {
+    const {router} = render(<WrappedComponent />, {
       organization,
       initialRouterConfig: {
         location: {
@@ -209,7 +178,6 @@ describe('withDomainRedirect', () => {
       },
     });
 
-    expect(replaceFn).toHaveBeenCalledTimes(1);
-    expect(replaceFn).toHaveBeenCalledWith('/settings/react/alerts/?q=123#hash');
+    expect(router.location.pathname).toBe('/settings/react/alerts/');
   });
 });

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -10,7 +10,7 @@ import recreateRoute from 'sentry/utils/recreateRoute';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
+import {useRoutes} from 'sentry/utils/useRoutes';
 
 import useOrganization from './useOrganization';
 
@@ -39,7 +39,7 @@ function withDomainRedirect<P>(WrappedComponent: RouteComponent) {
     const {sentryUrl} = links;
     const currentOrganization = useOrganization({allowNull: true});
     const params = useParams();
-    const router = useRouter();
+    const routes = useRoutes();
 
     if (customerDomain) {
       // Customer domain is being used on a route that has an :orgId parameter.
@@ -63,7 +63,7 @@ function withDomainRedirect<P>(WrappedComponent: RouteComponent) {
       Object.keys(params).forEach(param => {
         newParams[param] = `:${param}`;
       });
-      const fullRoute = recreateRoute('', {routes: router.routes, params: newParams});
+      const fullRoute = recreateRoute('', {routes, params: newParams});
       const orglessSlugRoute = normalizeUrl(fullRoute, {forceCustomerDomain: true});
 
       if (orglessSlugRoute === fullRoute) {
@@ -77,7 +77,7 @@ function withDomainRedirect<P>(WrappedComponent: RouteComponent) {
       }${window.location.hash}`;
 
       // Redirect to a route path with :orgId omitted.
-      return <Redirect to={redirectOrgURL} router={router} />;
+      return <Redirect to={redirectOrgURL} />;
     }
 
     return <WrappedComponent {...props} />;


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)