### PR TITLE
ref(insights): replace useRouter with specific hooks in spanSummary sampleList

### DIFF
--- a/src/sentry/api/endpoints/organization_pipeline.py
+++ b/src/sentry/api/endpoints/organization_pipeline.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import control_silo_endpoint
+from sentry.api.bases.organization import (
+    ControlSiloOrganizationEndpoint,
+    OrganizationPermission,
+)
+from sentry.exceptions import NotRegistered
+from sentry.identity.pipeline import IdentityPipeline
+from sentry.integrations.pipeline import (
+    IntegrationPipeline,
+    IntegrationPipelineError,
+    initialize_integration_pipeline,
+)
+from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.pipeline.base import Pipeline
+from sentry.pipeline.types import PipelineStepAction
+
+logger = logging.getLogger(__name__)
+
+# All pipeline classes that can be driven via the API. The endpoint tries each
+# in order and uses whichever one has a valid session for the request.
+PIPELINE_CLASSES = (IntegrationPipeline, IdentityPipeline)
+
+
+class PipelinePermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin", "org:integrations"],
+        "POST": ["org:write", "org:admin", "org:integrations"],
+    }
+
+
+def _get_api_pipeline(
+    request: Request, organization: RpcOrganization, pipeline_name: str
+) -> Response | Pipeline:
+    """Look up an active API-ready pipeline from the session, or return an error Response."""
+    pipelines = {cls.pipeline_name: cls for cls in PIPELINE_CLASSES}
+    if pipeline_name not in pipelines:
+        return Response({"detail": "Invalid pipeline type"}, status=404)
+
+    pipeline = pipelines[pipeline_name].get_for_request(request._request)
+    if not pipeline or not pipeline.organization:
+        return Response({"detail": "No active pipeline session."}, status=404)
+
+    if not pipeline.is_valid() or pipeline.organization.id != organization.id:
+        return Response({"detail": "Invalid pipeline state."}, status=404)
+
+    if not pipeline.is_api_ready():
+        return Response({"detail": "Pipeline does not support API mode."}, status=400)
+
+    return pipeline
+
+
+@control_silo_endpoint
+class OrganizationPipelineEndpoint(ControlSiloOrganizationEndpoint):
+    owner = ApiOwner.ENTERPRISE
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    permission_classes = (PipelinePermission,)
+
+    def get(
+        self, request: Request, organization: RpcOrganization, pipeline_name: str, **kwargs: object
+    ) -> Response:
+        result = _get_api_pipeline(request, organization, pipeline_name)
+        if isinstance(result, Response):
+            return result
+        return Response(result.get_current_step_info())
+
+    def post(
+        self, request: Request, organization: RpcOrganization, pipeline_name: str, **kwargs: object
+    ) -> Response:
+        if request.data.get("action") == "initialize":
+            return self._initialize_pipeline(request, organization, pipeline_name)
+
+        result = _get_api_pipeline(request, organization, pipeline_name)
+        if isinstance(result, Response):
+            return result
+        pipeline = result
+
+        step_result = pipeline.api_advance(request._request, request.data)
+
+        response_data = step_result.serialize()
+        if step_result.action == PipelineStepAction.ADVANCE:
+            response_data.update(pipeline.get_current_step_info())
+
+        if step_result.action == PipelineStepAction.ERROR:
+            return Response(response_data, status=400)
+
+        return Response(response_data)
+
+    def _initialize_pipeline(
+        self, request: Request, organization: RpcOrganization, pipeline_name: str
+    ) -> Response:
+        if pipeline_name != IntegrationPipeline.pipeline_name:
+            return Response(
+                {"detail": "Initialization not supported for this pipeline."}, status=400
+            )
+
+        provider_id = request.data.get("provider")
+        if not provider_id:
+            return Response({"detail": "provider is required."}, status=400)
+
+        try:
+            pipeline = initialize_integration_pipeline(request._request, organization, provider_id)
+        except NotRegistered:
+            return Response({"detail": f"Unknown provider: {provider_id}"}, status=404)
+        except IntegrationPipelineError as e:
+            return Response({"detail": str(e)}, status=404 if e.not_found else 400)
+
+        if not pipeline.is_api_ready():
+            return Response({"detail": "Pipeline does not support API mode."}, status=400)
+
+        pipeline.set_api_mode()
+
+        return Response(pipeline.get_current_step_info())

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -19,6 +19,7 @@ from sentry.api.endpoints.organization_fork import OrganizationForkEndpoint
 from sentry.api.endpoints.organization_insights_tree import OrganizationInsightsTreeEndpoint
 from sentry.api.endpoints.organization_intercom_jwt import OrganizationIntercomJwtEndpoint
 from sentry.api.endpoints.organization_missing_org_members import OrganizationMissingMembersEndpoint
+from sentry.api.endpoints.organization_pipeline import OrganizationPipelineEndpoint
 from sentry.api.endpoints.organization_plugin_deprecation_info import (
     OrganizationPluginDeprecationInfoEndpoint,
 )
@@ -2037,6 +2038,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/external-users/(?P<external_user_id>[^/]+)/$",
         ExternalUserDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-external-user-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/pipeline/(?P<pipeline_name>[^/]+)/$",
+        OrganizationPipelineEndpoint.as_view(),
+        name="sentry-api-0-organization-pipeline",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/integration-requests/$",

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -15,7 +15,9 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from requests import Response
-from requests.exceptions import HTTPError, SSLError
+from requests.exceptions import ConnectionError, HTTPError, SSLError
+from rest_framework.fields import CharField
+from rest_framework.serializers import Serializer
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.exceptions import NotRegistered
@@ -30,6 +32,7 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
 )
+from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import PipelineView
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, ApiUnauthorized
 from sentry.users.models.identity import Identity
@@ -37,11 +40,17 @@ from sentry.utils.http import absolute_uri
 
 from .base import Provider
 
-__all__ = ["OAuth2Provider", "OAuth2CallbackView", "OAuth2LoginView"]
+__all__ = ["OAuth2Provider", "OAuth2CallbackView", "OAuth2LoginView", "OAuth2ApiStep"]
 
 logger = logging.getLogger(__name__)
 ERR_INVALID_STATE = "An error occurred while validating your request."
 ERR_TOKEN_RETRIEVAL = "Failed to retrieve token from the upstream service."
+
+
+class OAuth2ApiStepError(Exception):
+    """Raised when the OAuth2 API step encounters an error during token exchange."""
+
+    pass
 
 
 def _redirect_url(pipeline: IdentityPipeline) -> str:
@@ -137,6 +146,23 @@ class OAuth2Provider(Provider):
             ),
         ]
 
+    def get_pipeline_api_steps(self) -> list[OAuth2ApiStep]:
+        redirect_url = self.config.get(
+            "redirect_url",
+            reverse("sentry-extension-setup", kwargs={"provider_id": "default"}),
+        )
+        return [
+            OAuth2ApiStep(
+                authorize_url=self.get_oauth_authorize_url(),
+                client_id=self.get_oauth_client_id(),
+                client_secret=self.get_oauth_client_secret(),
+                access_token_url=self.get_oauth_access_token_url(),
+                scope=" ".join(self.get_oauth_scopes()),
+                redirect_url=redirect_url,
+                verify_ssl=self.config.get("verify_ssl", True),
+            ),
+        ]
+
     def get_refresh_token_params(
         self, refresh_token: str, identity: Identity | RpcIdentity, **kwargs: Any
     ) -> dict[str, str | None]:
@@ -212,6 +238,124 @@ def record_event(event: IntegrationPipelineViewType, provider: str):
     return IntegrationPipelineViewEvent(
         event, domain=IntegrationDomain.IDENTITY, provider_key=provider
     )
+
+
+class OAuth2ApiSerializer(Serializer):
+    code = CharField(required=True)
+    state = CharField(required=True)
+
+
+class OAuth2ApiStep:
+    """
+    Generic API-mode step for OAuth2 identity authentication.
+
+    Handles the full OAuth2 authorization code flow in a single API step:
+
+    - GET (get_step_data): returns the OAuth authorize URL for the frontend to
+      open in a popup.
+    - POST (handle_post): receives the callback params (code, state) relayed by
+      the trampoline via postMessage, validates state, exchanges the code for an
+      access token, and binds the token data to pipeline state.
+    """
+
+    step_name = "oauth_login"
+
+    def __init__(
+        self,
+        authorize_url: str,
+        client_id: str,
+        client_secret: str,
+        access_token_url: str,
+        scope: str,
+        redirect_url: str,
+        verify_ssl: bool = True,
+        bind_key: str = "data",
+        extra_authorize_params: dict[str, str] | None = None,
+    ) -> None:
+        self.authorize_url = authorize_url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.access_token_url = access_token_url
+        self.scope = scope
+        self.redirect_url = redirect_url
+        self.verify_ssl = verify_ssl
+        self.bind_key = bind_key
+        self.extra_authorize_params = extra_authorize_params or {}
+
+    def get_step_data(self, pipeline: Any, request: HttpRequest) -> dict[str, str]:
+        params = urlencode(
+            {
+                "client_id": self.client_id,
+                "response_type": "code",
+                "scope": self.scope,
+                "state": pipeline.signature,
+                "redirect_uri": absolute_uri(self.redirect_url),
+                **self.extra_authorize_params,
+            }
+        )
+        return {"oauthUrl": f"{self.authorize_url}?{params}"}
+
+    def get_serializer_cls(self) -> type:
+        return OAuth2ApiSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, str],
+        pipeline: Any,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        code = validated_data["code"]
+        state = validated_data["state"]
+
+        if state != pipeline.signature:
+            return PipelineStepResult.error(ERR_INVALID_STATE)
+
+        try:
+            data = self._exchange_token(code)
+        except OAuth2ApiStepError as e:
+            logger.info("identity.token-exchange-error", extra={"error": str(e)})
+            return PipelineStepResult.error(str(e))
+
+        pipeline.bind_state(self.bind_key, data)
+        return PipelineStepResult.advance()
+
+    def _exchange_token(self, code: str) -> dict[str, Any]:
+        """Exchange an authorization code for an access token.
+
+        Raises OAuth2ApiStepError on failure.
+        """
+        token_params = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": absolute_uri(self.redirect_url),
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        try:
+            req = safe_urlopen(self.access_token_url, data=token_params, verify_ssl=self.verify_ssl)
+            req.raise_for_status()
+        except HTTPError as e:
+            error_resp = e.response
+            exc = ApiError.from_response(error_resp, url=self.access_token_url)
+            sentry_sdk.capture_exception(exc)
+            raise OAuth2ApiStepError(
+                f"Could not retrieve access token. Received {exc.code}: {exc.text}"
+            ) from e
+        except SSLError as e:
+            raise OAuth2ApiStepError(
+                f"Could not verify SSL certificate for {self.access_token_url}"
+            ) from e
+        except ConnectionError as e:
+            raise OAuth2ApiStepError(f"Could not connect to {self.access_token_url}") from e
+
+        try:
+            body = safe_urlread(req)
+            content_type = req.headers.get("Content-Type", "").lower()
+            if content_type.startswith("application/x-www-form-urlencoded"):
+                return dict(parse_qsl(body.decode("utf-8")))
+            return orjson.loads(body)
+        except orjson.JSONDecodeError as e:
+            raise OAuth2ApiStepError("Could not decode a JSON response, please try again.") from e
 
 
 class OAuth2LoginView:
@@ -334,7 +478,7 @@ class OAuth2CallbackView:
                 body = safe_urlread(req)
                 content_type = req.headers.get("Content-Type", "").lower()
                 if content_type.startswith("application/x-www-form-urlencoded"):
-                    return dict(parse_qsl(body))
+                    return dict(parse_qsl(body.decode("utf-8")))
                 return orjson.loads(body)
             except orjson.JSONDecodeError:
                 lifecycle.record_failure(

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -312,7 +312,7 @@ class IntegrationProvider(PipelineProvider["IntegrationPipeline"], abc.ABC):
         """
         raise NotImplementedError
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline] | None:
         """
         Return API step objects for this provider's pipeline, or None if API
         mode is not supported. Override to enable the pipeline API for this

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -5,8 +5,11 @@ from typing import Any
 
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
+from django.urls import reverse
 from django.utils.datastructures import OrderedSet
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import CharField
+from rest_framework.serializers import Serializer, ValidationError
 
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
@@ -25,6 +28,7 @@ from sentry.integrations.tasks.migrate_repo import migrate_repo
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import (
     AtlassianConnectValidationError,
+    get_integration_from_jwt,
     get_integration_from_request,
 )
 from sentry.integrations.utils.metrics import (
@@ -34,7 +38,8 @@ from sentry.integrations.utils.metrics import (
 from sentry.models.apitoken import generate_token
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
@@ -191,6 +196,62 @@ class BitbucketIntegration(RepositoryIntegration, BitbucketIssuesSpec):
         return self.model.name
 
 
+class BitbucketVerifySerializer(Serializer):
+    jwt = CharField(required=True)
+
+    def validate_jwt(self, value: str) -> str:
+        callback_path = reverse(
+            "sentry-extension-setup",
+            kwargs={"provider_id": IntegrationProviderSlug.BITBUCKET.value},
+        )
+        try:
+            get_integration_from_jwt(
+                token=value,
+                path=callback_path,
+                provider=IntegrationProviderSlug.BITBUCKET.value,
+                query_params=None,
+            )
+        except AtlassianConnectValidationError as e:
+            raise ValidationError(f"Unable to verify installation: {e}") from e
+        return value
+
+
+class BitbucketAuthorizeApiStep:
+    step_name = "authorize"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        descriptor_uri = absolute_uri("/extensions/bitbucket/descriptor/")
+        authorize_url = (
+            f"https://bitbucket.org/site/addons/authorize?descriptor_uri={descriptor_uri}"
+        )
+        return {"authorizeUrl": authorize_url}
+
+    def get_serializer_cls(self) -> type:
+        return BitbucketVerifySerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        callback_path = reverse(
+            "sentry-extension-setup",
+            kwargs={"provider_id": IntegrationProviderSlug.BITBUCKET.value},
+        )
+        try:
+            integration = get_integration_from_jwt(
+                token=validated_data["jwt"],
+                path=callback_path,
+                provider=IntegrationProviderSlug.BITBUCKET.value,
+                query_params=None,
+            )
+        except AtlassianConnectValidationError:
+            return PipelineStepResult.error("Unable to verify installation.")
+        pipeline.bind_state("external_id", integration.external_id)
+        return PipelineStepResult.advance()
+
+
 class BitbucketIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.BITBUCKET.value
     name = "Bitbucket"
@@ -216,6 +277,9 @@ class BitbucketIntegrationProvider(IntegrationProvider):
             ),
             VerifyInstallation(),
         ]
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [BitbucketAuthorizeApiStep()]
 
     def post_install(
         self,

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 from urllib.parse import parse_qsl
 
 from django.db.models import Count
-from django.http import HttpResponse
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
+from rest_framework.serializers import CharField
 
 from sentry import features, options
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.github.provider import GitHubIdentityProvider
@@ -62,7 +64,12 @@ from sentry.organizations.services.organization.model import (
     RpcOrganization,
     RpcUserOrganizationContext,
 )
-from sentry.pipeline.views.base import PipelineView, render_react_view
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import (
+    ApiPipelineSteps,
+    PipelineView,
+    render_react_view,
+)
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
 from sentry.snuba.referrer import Referrer
@@ -177,6 +184,7 @@ class GithubInstallationInfo(TypedDict):
     installation_id: str
     github_account: str
     avatar_url: str
+    count: NotRequired[int]
 
 
 def build_repository_query(metadata: Mapping[str, Any], name: str, query: str) -> bytes:
@@ -789,6 +797,12 @@ class GitHubIntegrationProvider(IntegrationProvider):
     ]:
         return [OAuthLoginView(), GithubOrganizationSelection(), GitHubInstallation()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            OAuthLoginApiStep(),
+            GithubOrganizationSelectionApiStep(),
+        ]
+
     def get_installation_info(self, installation_id: str) -> Mapping[str, Any]:
         resp: Mapping[str, Any] = self.client.get_installation_info(installation_id=installation_id)
         return resp
@@ -854,32 +868,439 @@ def record_event(event: IntegrationPipelineViewType):
     )
 
 
-class OAuthLoginView:
-    client: GithubSetupApiClient
+class GitHubPipelineError(Exception):
+    """Raised when a GitHub pipeline step fails validation."""
 
+    def __init__(self, error_type: GitHubInstallationError, detail: str | None = None) -> None:
+        self.error_type = error_type
+        self.detail = detail
+        super().__init__(str(error_type))
+
+
+@dataclass
+class GitHubOAuthLoginResult:
+    authenticated_user: str
+    installation_info: list[GithubInstallationInfo]
+
+
+def _get_owner_github_organizations(client: GithubSetupApiClient) -> list[str]:
+    user_org_membership_details = client.get_organization_memberships_for_user()
+    return [
+        gh_org.get("organization", {}).get("login")
+        for gh_org in user_org_membership_details
+        if (
+            gh_org.get("role", "").lower() == "admin"
+            and gh_org.get("state", "").lower() == "active"
+        )
+    ]
+
+
+def _get_eligible_multi_org_installations(
+    client: GithubSetupApiClient, owner_orgs: list[str]
+) -> list[GithubInstallationInfo]:
+    installed_orgs = client.get_user_info_installations()
+    return [
+        {
+            "installation_id": str(installation.get("id")),
+            "github_account": installation.get("account").get("login"),
+            "avatar_url": installation.get("account").get("avatar_url"),
+        }
+        for installation in installed_orgs["installations"]
+        if (
+            installation.get("account").get("login") in owner_orgs
+            or installation.get("target_type") == "User"
+        )
+    ]
+
+
+def exchange_github_oauth(
+    code: str,
+    fetch_installations: bool = True,
+) -> GitHubOAuthLoginResult:
+    """
+    Exchange an OAuth code for a GitHub access token, fetch the authenticated
+    user's info, and optionally determine eligible installations.
+
+    Raises GitHubPipelineError on failure.
+    """
+    ghip = GitHubIdentityProvider()
+    data = {
+        "code": code,
+        "client_id": ghip.get_oauth_client_id(),
+        "client_secret": ghip.get_oauth_client_secret(),
+    }
+
+    req = safe_urlopen(url=ghip.get_oauth_access_token_url(), data=data)
+    try:
+        body = safe_urlread(req).decode("utf-8")
+        payload = dict(parse_qsl(body))
+    except Exception:
+        payload = {}
+
+    if "access_token" not in payload:
+        raise GitHubPipelineError(GitHubInstallationError.MISSING_TOKEN)
+
+    client = GithubSetupApiClient(access_token=payload["access_token"])
+    authenticated_user_info = client.get_user_info()
+
+    installation_info: list[GithubInstallationInfo] = []
+    if fetch_installations:
+        owner_orgs = _get_owner_github_organizations(client)
+        installation_info = _get_eligible_multi_org_installations(client, owner_orgs)
+
+    if "login" not in authenticated_user_info:
+        raise GitHubPipelineError(GitHubInstallationError.MISSING_LOGIN)
+
+    return GitHubOAuthLoginResult(
+        authenticated_user=authenticated_user_info["login"],
+        installation_info=installation_info,
+    )
+
+
+def _build_installation_info_with_counts(
+    installation_info: list[GithubInstallationInfo],
+) -> list[GithubInstallationInfo]:
+    """
+    Enriches an installation info list with Sentry org install counts and appends
+    the 'install on new GitHub org' sentinel option.
+    """
+    installation_ids = [i["installation_id"] for i in installation_info]
+    counts_qs = (
+        OrganizationIntegration.objects.filter(
+            integration__provider=GitHubIntegrationProvider.key,
+            integration__external_id__in=installation_ids,
+        )
+        .values("integration__external_id")
+        .annotate(count=Count("id"))
+    )
+    counts_dict = {item["integration__external_id"]: item["count"] for item in counts_qs}
+
+    result: list[GithubInstallationInfo] = []
+    for installation in installation_info:
+        result.append(
+            {
+                **installation,
+                "count": counts_dict.get(installation["installation_id"], 0),
+            }
+        )
+    result.append(
+        {
+            "installation_id": "-1",
+            "github_account": "Integrate with a new GitHub organization",
+            "avatar_url": "",
+            "count": 0,
+        }
+    )
+    return result
+
+
+def validate_org_installation_choice(
+    chosen_installation_id: str,
+    pipeline: IntegrationPipeline,
+) -> None:
+    """
+    Validates a chosen GitHub installation can be linked to this Sentry org.
+    Checks multi-org feature flag, install count, org consistency, and that the
+    installation belongs to the user. Binds chosen_installation to pipeline state.
+
+    Raises GitHubPipelineError on validation failure.
+    """
+    installation_info: list[GithubInstallationInfo] = (
+        pipeline.fetch_state("existing_installation_info") or []
+    )
+
+    has_scm_multi_org = features.has(
+        "organizations:integrations-scm-multi-org",
+        organization=pipeline.organization,
+    )
+    install_count = OrganizationIntegration.objects.filter(
+        integration__provider=GitHubIntegrationProvider.key,
+        integration__external_id=chosen_installation_id,
+    ).count()
+    if not ((install_count == 0) or has_scm_multi_org):
+        raise GitHubPipelineError(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+
+    installing_org_slug = pipeline.fetch_state("installing_organization_slug")
+    if not (installing_org_slug is not None and installing_org_slug == pipeline.organization.slug):
+        raise GitHubPipelineError(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+
+    valid_ids = [i["installation_id"] for i in installation_info]
+    if chosen_installation_id not in valid_ids:
+        raise GitHubPipelineError(
+            GitHubInstallationError.INVALID_INSTALLATION,
+            detail=str(ERR_INTEGRATION_INVALID_INSTALLATION),
+        )
+
+    pipeline.bind_state("chosen_installation", chosen_installation_id)
+
+
+def validate_github_installation(
+    pipeline: IntegrationPipeline,
+) -> str | None:
+    """
+    Resolves the installation_id from pipeline state (handling chosen_installation),
+    checks for pending deletion and user mismatch against existing integrations.
+
+    Returns the resolved installation_id, or None if the user needs to install the
+    GitHub App first (caller should redirect).
+
+    Raises GitHubPipelineError on validation failure.
+    """
+    chosen_installation_id = pipeline.fetch_state("chosen_installation")
+    if chosen_installation_id is not None:
+        pipeline.bind_state("installation_id", chosen_installation_id)
+
+    installation_id = pipeline.fetch_state("installation_id")
+    if installation_id is None:
+        return None
+
+    pipeline.bind_state("installation_id", installation_id)
+
+    pending_deletion = OrganizationIntegration.objects.filter(
+        integration__provider=GitHubIntegrationProvider.key,
+        organization_id=pipeline.organization.id,
+        status=ObjectStatus.PENDING_DELETION,
+    ).exists()
+    if pending_deletion:
+        raise GitHubPipelineError(GitHubInstallationError.PENDING_DELETION)
+
+    try:
+        integration = Integration.objects.get(
+            external_id=installation_id, status=ObjectStatus.ACTIVE
+        )
+    except Integration.DoesNotExist:
+        return installation_id
+
+    if (
+        chosen_installation_id is None
+        and pipeline.fetch_state("github_authenticated_user")
+        != integration.metadata["sender"]["login"]
+    ):
+        raise GitHubPipelineError(GitHubInstallationError.USER_MISMATCH)
+
+    return installation_id
+
+
+class OAuthLoginStepData(TypedDict):
+    oauthUrl: str
+
+
+class OAuthLoginValidatedData(TypedDict):
+    code: str
+    state: str
+    installation_id: NotRequired[str]
+
+
+class OAuthLoginSerializer(CamelSnakeSerializer):
+    code = CharField(required=True)
+    state = CharField(required=True)
+    # GitHub includes installation_id in the OAuth callback URL when the user
+    # installs the app from GitHub's side rather than from Sentry.
+    installation_id = CharField(required=False)
+
+
+class OAuthLoginApiStep:
+    """
+    Initiates and completes the GitHub OAuth authorization flow.
+
+    On GET (via get_step_data): returns the GitHub OAuth authorize URL. The
+    frontend should open this in a popup/redirect so the user can authorize.
+
+    On POST (via handle_post): receives the OAuth callback params (code, state,
+    and optionally installation_id), exchanges the code for an access token,
+    verifies the authenticated GitHub user, and discovers existing GitHub App
+    installations the user has access to.
+
+    If installation_id is present in the callback, it is bound to pipeline
+    state early. This handles the case where the user started from GitHub's
+    side (installing the app directly on GitHub), which redirects back with
+    installation_id before OAuth has happened. The installation_id persists
+    in pipeline state across the OAuth redirect, so the later installation
+    validation step can find it without requiring a second redirect.
+    """
+
+    step_name = "oauth_login"
+
+    def get_step_data(
+        self, pipeline: IntegrationPipeline, request: HttpRequest
+    ) -> OAuthLoginStepData:
+        ghip = GitHubIdentityProvider()
+        redirect_uri = absolute_uri(
+            reverse(
+                "sentry-extension-setup",
+                kwargs={"provider_id": IntegrationProviderSlug.GITHUB.value},
+            )
+        )
+        oauth_url = (
+            f"{ghip.get_oauth_authorize_url()}"
+            f"?client_id={ghip.get_oauth_client_id()}"
+            f"&state={pipeline.signature}"
+            f"&redirect_uri={redirect_uri}"
+        )
+        return {"oauthUrl": oauth_url}
+
+    def get_serializer_cls(self) -> type:
+        return OAuthLoginSerializer
+
+    def handle_post(
+        self,
+        validated_data: OAuthLoginValidatedData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        with record_event(IntegrationPipelineViewType.OAUTH_LOGIN).capture() as lifecycle:
+            lifecycle.add_extra("organization_id", pipeline.organization.id)
+
+            if installation_id := validated_data.get("installation_id"):
+                pipeline.bind_state("installation_id", installation_id)
+
+            if validated_data["state"] != pipeline.signature:
+                lifecycle.record_failure(GitHubInstallationError.INVALID_STATE)
+                return PipelineStepResult.error(GitHubInstallationError.INVALID_STATE)
+
+            try:
+                result = exchange_github_oauth(code=validated_data["code"])
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.error_type)
+                return PipelineStepResult.error(e.error_type)
+
+            if result.installation_info:
+                pipeline.bind_state("existing_installation_info", result.installation_info)
+            pipeline.bind_state("github_authenticated_user", result.authenticated_user)
+            return PipelineStepResult.advance()
+
+
+class GithubInstallationApiInfo(TypedDict):
+    installationId: str
+    githubAccount: str
+    avatarUrl: str
+    count: NotRequired[int | None]
+
+
+class OrgSelectionStepData(TypedDict):
+    installAppUrl: str
+    installationInfo: list[GithubInstallationApiInfo]
+
+
+class OrgSelectionValidatedData(TypedDict):
+    chosen_installation_id: NotRequired[str]
+    installation_id: NotRequired[str]
+
+
+class OrgSelectionSerializer(CamelSnakeSerializer):
+    chosen_installation_id = CharField(required=False, allow_blank=True)
+    installation_id = CharField(required=False)
+
+
+class GithubOrganizationSelectionApiStep:
+    """
+    Lets the user pick which existing GitHub App installation to connect to
+    their Sentry org.
+
+    On GET: returns the list of GitHub orgs/accounts where the authenticated
+    user has the app installed, enriched with how many Sentry orgs already use
+    each installation. Includes a sentinel option (id "-1") to install on a
+    new GitHub org instead.
+
+    On POST: validates the chosen installation (multi-org feature flag, org
+    consistency, ownership) and binds it to pipeline state. Auto-advances if
+    there are no existing installations to choose from.
+    """
+
+    step_name = "org_selection"
+
+    def get_step_data(
+        self, pipeline: IntegrationPipeline, request: HttpRequest
+    ) -> OrgSelectionStepData:
+        name = options.get("github-app.name")
+        install_app_url = f"https://github.com/apps/{slugify(name)}"
+
+        installation_info: list[GithubInstallationInfo] = list(
+            pipeline.fetch_state("existing_installation_info") or []
+        )
+        if not installation_info:
+            return {"installationInfo": [], "installAppUrl": install_app_url}
+
+        # Bind the installing org slug so we can validate it hasn't changed when
+        # the user submits their choice (same logic as the template flow).
+        pipeline.bind_state("installing_organization_slug", pipeline.organization.slug)
+
+        enriched = _build_installation_info_with_counts(installation_info)
+        return {
+            "installAppUrl": install_app_url,
+            "installationInfo": [
+                {
+                    "installationId": info["installation_id"],
+                    "githubAccount": info["github_account"],
+                    "avatarUrl": info.get("avatar_url", ""),
+                    "count": info.get("count"),
+                }
+                for info in enriched
+            ],
+        }
+
+    def get_serializer_cls(self) -> type | None:
+        return OrgSelectionSerializer
+
+    def handle_post(
+        self,
+        validated_data: OrgSelectionValidatedData,
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        with record_event(
+            IntegrationPipelineViewType.ORGANIZATION_SELECTION
+        ).capture() as lifecycle:
+            lifecycle.add_extra("organization_id", pipeline.organization.id)
+
+            # If the user completed the GitHub App install popup, bind the
+            # installation_id and validate it the same way the old
+            # GitHubInstallationApiStep did.
+            if post_installation_id := validated_data.get("installation_id"):
+                pipeline.bind_state("installation_id", post_installation_id)
+
+            chosen_installation_id = validated_data.get("chosen_installation_id")
+            if chosen_installation_id and chosen_installation_id != "-1":
+                try:
+                    validate_org_installation_choice(chosen_installation_id, pipeline)
+                except GitHubPipelineError as e:
+                    lifecycle.record_failure(e.error_type)
+                    return PipelineStepResult.error(e.error_type)
+                pipeline.bind_state("installation_id", chosen_installation_id)
+                return PipelineStepResult.advance()
+
+            # No existing installation chosen — validate whatever installation_id
+            # is in pipeline state (from the popup callback or OAuth callback).
+            try:
+                installation_id = validate_github_installation(pipeline)
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.error_type)
+                return PipelineStepResult.error(e.error_type)
+
+            if installation_id is None:
+                name = options.get("github-app.name")
+                return PipelineStepResult.stay(
+                    data={"installAppUrl": f"https://github.com/apps/{slugify(name)}"}
+                )
+
+            return PipelineStepResult.advance()
+
+
+class OAuthLoginView:
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
         with record_event(IntegrationPipelineViewType.OAUTH_LOGIN).capture() as lifecycle:
-            self.active_user_organization = determine_active_organization(request)
+            active_user_organization = determine_active_organization(request)
             lifecycle.add_extra(
                 "organization_id",
-                (
-                    self.active_user_organization.organization.id
-                    if self.active_user_organization
-                    else None
-                ),
+                (active_user_organization.organization.id if active_user_organization else None),
             )
-
-            ghip = GitHubIdentityProvider()
-            github_client_id = ghip.get_oauth_client_id()
-            github_client_secret = ghip.get_oauth_client_secret()
 
             installation_id = request.GET.get("installation_id")
             if installation_id:
                 pipeline.bind_state("installation_id", installation_id)
 
             if not request.GET.get("state"):
-                state = pipeline.signature
-
+                ghip = GitHubIdentityProvider()
                 redirect_uri = absolute_uri(
                     reverse(
                         "sentry-extension-setup",
@@ -887,90 +1308,35 @@ class OAuthLoginView:
                     )
                 )
                 return HttpResponseRedirect(
-                    f"{ghip.get_oauth_authorize_url()}?client_id={github_client_id}&state={state}&redirect_uri={redirect_uri}"
+                    f"{ghip.get_oauth_authorize_url()}?client_id={ghip.get_oauth_client_id()}&state={pipeline.signature}&redirect_uri={redirect_uri}"
                 )
 
-            # At this point, we are past the GitHub "authorize" step
             if request.GET.get("state") != pipeline.signature:
                 lifecycle.record_failure(GitHubInstallationError.INVALID_STATE)
                 return error(
                     request,
-                    self.active_user_organization,
+                    active_user_organization,
                     error_short=GitHubInstallationError.INVALID_STATE,
                 )
 
-            # similar to OAuth2CallbackView.get_token_params
-            data = {
-                "code": request.GET.get("code"),
-                "client_id": github_client_id,
-                "client_secret": github_client_secret,
-            }
-
-            # similar to OAuth2CallbackView.exchange_token
-            req = safe_urlopen(url=ghip.get_oauth_access_token_url(), data=data)
             try:
-                body = safe_urlread(req).decode("utf-8")
-                payload = dict(parse_qsl(body))
-            except Exception:
-                payload = {}
-
-            if "access_token" not in payload:
-                lifecycle.record_failure(GitHubInstallationError.MISSING_TOKEN)
+                result = exchange_github_oauth(
+                    code=request.GET.get("code", ""),
+                    fetch_installations=active_user_organization is not None,
+                )
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.error_type)
                 return error(
                     request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.MISSING_TOKEN,
+                    active_user_organization,
+                    error_short=e.error_type,
+                    error_long=e.detail,
                 )
-            self.client = GithubSetupApiClient(access_token=payload["access_token"])
-            authenticated_user_info = self.client.get_user_info()
 
-            if self.active_user_organization is not None:
-                owner_orgs = self._get_owner_github_organizations()
-
-                installation_info = self._get_eligible_multi_org_installations(
-                    owner_orgs=owner_orgs
-                )
-                pipeline.bind_state("existing_installation_info", installation_info)
-
-            if "login" not in authenticated_user_info:
-                lifecycle.record_failure(GitHubInstallationError.MISSING_LOGIN)
-                return error(
-                    request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.MISSING_LOGIN,
-                )
-            pipeline.bind_state("github_authenticated_user", authenticated_user_info["login"])
+            if result.installation_info:
+                pipeline.bind_state("existing_installation_info", result.installation_info)
+            pipeline.bind_state("github_authenticated_user", result.authenticated_user)
             return pipeline.next_step()
-
-    def _get_owner_github_organizations(self) -> list[str]:
-        user_org_membership_details = self.client.get_organization_memberships_for_user()
-
-        return [
-            gh_org.get("organization", {}).get("login")
-            for gh_org in user_org_membership_details
-            if (
-                gh_org.get("role", "").lower() == "admin"
-                and gh_org.get("state", "").lower() == "active"
-            )
-        ]
-
-    def _get_eligible_multi_org_installations(
-        self, owner_orgs: list[str]
-    ) -> list[GithubInstallationInfo]:
-        installed_orgs = self.client.get_user_info_installations()
-
-        return [
-            {
-                "installation_id": str(installation.get("id")),
-                "github_account": installation.get("account").get("login"),
-                "avatar_url": installation.get("account").get("avatar_url"),
-            }
-            for installation in installed_orgs["installations"]
-            if (
-                installation.get("account").get("login") in owner_orgs
-                or installation.get("target_type") == "User"
-            )
-        ]
 
 
 class GithubOrganizationSelection:
@@ -997,79 +1363,23 @@ class GithubOrganizationSelection:
             if len(installation_info) == 0:
                 return pipeline.next_step()
 
-            # add information about number of org integrations per installation
-            installation_ids = [
-                installation["installation_id"] for installation in installation_info
-            ]
-            integration_install_counts = (
-                OrganizationIntegration.objects.filter(
-                    integration__provider=GitHubIntegrationProvider.key,
-                    integration__external_id__in=installation_ids,
-                )
-                .values("integration__external_id")
-                .annotate(count=Count("id"))
-            )
-            integration_install_counts_dict = {
-                item["integration__external_id"]: item["count"]
-                for item in integration_install_counts
-            }
-            for installation in installation_info:
-                installation["count"] = integration_install_counts_dict.get(
-                    installation["installation_id"], 0
-                )
-
-            # add an option for users to install on a new GH organization
-            installation_info.append(
-                {
-                    "installation_id": "-1",
-                    "github_account": "Integrate with a new GitHub organization",
-                    "avatar_url": "",
-                    "count": 0,
-                }
-            )
+            installation_info = _build_installation_info_with_counts(installation_info)
 
             if chosen_installation_id := request.GET.get("chosen_installation_id"):
                 if chosen_installation_id == "-1":
                     return pipeline.next_step()
 
-                # NOTE: there may still be a race condition here where multiple orgs read the same count (0)
-                # the org integration creation logic is in finish_pipeline
-                can_install_chosen_installation = (
-                    integration_install_counts_dict.get(chosen_installation_id, 0) == 0
-                ) or has_scm_multi_org
-
-                # Validate the same org is installing and that they have the multi org feature
-                installing_organization_slug = pipeline.fetch_state("installing_organization_slug")
-                is_same_installing_org = (
-                    (installing_organization_slug is not None)
-                    and installing_organization_slug
-                    == self.active_user_organization.organization.slug
-                )
-
-                if not can_install_chosen_installation or not is_same_installing_org:
-                    lifecycle.record_failure(GitHubInstallationError.FEATURE_NOT_AVAILABLE)
+                try:
+                    validate_org_installation_choice(chosen_installation_id, pipeline)
+                except GitHubPipelineError as e:
+                    lifecycle.record_failure(e.error_type)
                     return error(
                         request,
                         self.active_user_organization,
-                        error_short=GitHubInstallationError.FEATURE_NOT_AVAILABLE,
+                        error_short=e.error_type,
+                        error_long=e.detail,
                     )
 
-                # Verify that the given GH installation belongs to the person installing the pipeline
-                installation_ids = [
-                    installation["installation_id"] for installation in installation_info
-                ]
-                if chosen_installation_id not in installation_ids:
-                    lifecycle.record_failure(
-                        failure_reason=GitHubInstallationError.INVALID_INSTALLATION
-                    )
-                    return error(
-                        request,
-                        self.active_user_organization,
-                        error_short=GitHubInstallationError.INVALID_INSTALLATION,
-                        error_long=ERR_INTEGRATION_INVALID_INSTALLATION,
-                    )
-
-                pipeline.bind_state("chosen_installation", chosen_installation_id)
                 return pipeline.next_step()
             pipeline.bind_state(
                 "installing_organization_slug", self.active_user_organization.organization.slug
@@ -1099,79 +1409,37 @@ class GitHubInstallation:
 
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
         with record_event(IntegrationPipelineViewType.GITHUB_INSTALLATION).capture() as lifecycle:
-            self.active_user_organization = determine_active_organization(request)
-
-            chosen_installation_id = pipeline.fetch_state("chosen_installation")
-            if chosen_installation_id is not None:
-                pipeline.bind_state("installation_id", chosen_installation_id)
-
-            installation_id = pipeline.fetch_state("installation_id") or request.GET.get(
-                "installation_id", None
-            )
-            if installation_id is None:
-                return HttpResponseRedirect(self.get_app_url())
-
-            pipeline.bind_state("installation_id", installation_id)
-
+            active_user_organization = determine_active_organization(request)
             lifecycle.add_extra(
                 "organization_id",
                 (
-                    self.active_user_organization.organization.id
-                    if self.active_user_organization is not None
+                    active_user_organization.organization.id
+                    if active_user_organization is not None
                     else None
                 ),
             )
 
-            error_page = self.check_pending_integration_deletion(request=request)
-            if error_page is not None:
-                lifecycle.record_failure(GitHubInstallationError.PENDING_DELETION)
-                return error_page
-
-            if self.active_user_organization is not None:
-                try:
-                    integration = Integration.objects.get(
-                        external_id=installation_id, status=ObjectStatus.ACTIVE
-                    )
-                except Integration.DoesNotExist:
-                    return pipeline.next_step()
-
-            # Check that the authenticated GitHub user is the same as who installed the app.
-            if (
-                chosen_installation_id is None
-                and pipeline.fetch_state("github_authenticated_user")
-                != integration.metadata["sender"]["login"]
-            ):
-                lifecycle.record_failure(GitHubInstallationError.USER_MISMATCH)
+            if active_user_organization is None:
                 return error(
                     request,
-                    self.active_user_organization,
-                    error_short=GitHubInstallationError.USER_MISMATCH,
+                    None,
+                    error_short=GitHubInstallationError.MISSING_ORGANIZATION,
+                    error_long=ERR_INTEGRATION_MISSING_ORGANIZATION,
                 )
 
+            # The template flow also picks up installation_id from query params
+            if installation_id := request.GET.get("installation_id"):
+                pipeline.bind_state("installation_id", installation_id)
+
+            try:
+                resolved_id = validate_github_installation(pipeline)
+            except GitHubPipelineError as e:
+                lifecycle.record_failure(e.error_type)
+                return error(
+                    request, active_user_organization, error_short=e.error_type, error_long=e.detail
+                )
+
+            if resolved_id is None:
+                return HttpResponseRedirect(self.get_app_url())
+
             return pipeline.next_step()
-
-    def check_pending_integration_deletion(self, request: HttpRequest) -> HttpResponse | None:
-        if self.active_user_organization is None:
-            return error(
-                request,
-                None,
-                error_short=GitHubInstallationError.MISSING_ORGANIZATION,
-                error_long=ERR_INTEGRATION_MISSING_ORGANIZATION,
-            )
-
-        # We want to wait until the scheduled deletions finish or else the
-        # post install to migrate repos do not work.
-        integration_pending_deletion_exists = OrganizationIntegration.objects.filter(
-            integration__provider=GitHubIntegrationProvider.key,
-            organization_id=self.active_user_organization.organization.id,
-            status=ObjectStatus.PENDING_DELETION,
-        ).exists()
-
-        if integration_pending_deletion_exists:
-            return error(
-                request,
-                self.active_user_organization,
-                error_short=GitHubInstallationError.PENDING_DELETION,
-                error_long=ERR_INTEGRATION_PENDING_DELETION,
-            )
-        return None

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -9,8 +9,11 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import BooleanField, CharField, URLField
 
 from sentry import features, http
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -42,7 +45,8 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -499,6 +503,92 @@ class GitHubEnterpriseIntegration(
             self.org_integration = org_integration
 
 
+class GHEInstallationConfigSerializer(CamelSnakeSerializer):
+    url = URLField(required=True)
+    id = CharField(required=True)
+    name = CharField(required=True)
+    public_link = URLField(required=False, allow_blank=True, default="")
+    verify_ssl = BooleanField(required=False, default=True)
+    webhook_secret = CharField(required=True)
+    private_key = CharField(required=True)
+    client_id = CharField(required=True)
+    client_secret = CharField(required=True)
+
+
+class GHEInstallationConfigApiStep:
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "defaults": {
+                "verifySsl": True,
+            },
+        }
+
+    def get_serializer_cls(self) -> type:
+        return GHEInstallationConfigSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        validated_data["url"] = urlparse(validated_data["url"]).netloc
+        if not validated_data["public_link"]:
+            validated_data["public_link"] = None
+
+        pipeline.bind_state("installation_data", validated_data)
+        pipeline.bind_state(
+            "oauth_config_information",
+            {
+                "access_token_url": f"https://{validated_data['url']}/login/oauth/access_token",
+                "authorize_url": f"https://{validated_data['url']}/login/oauth/authorize",
+                "client_id": validated_data["client_id"],
+                "client_secret": validated_data["client_secret"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+        return PipelineStepResult.advance()
+
+
+class GHEAppInstallSerializer(CamelSnakeSerializer):
+    installation_id = CharField(required=False, allow_blank=True, default="")
+
+
+class GHEAppInstallRedirectApiStep:
+    step_name = "app_install_redirect"
+
+    def _get_app_url(self, installation_data: dict[str, Any]) -> str:
+        if installation_data.get("public_link"):
+            return installation_data["public_link"]
+        url = installation_data.get("url")
+        name = installation_data.get("name")
+        return f"https://{url}/github-apps/{name}"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        installation_data = pipeline.fetch_state("installation_data")
+        return {"appInstallUrl": self._get_app_url(installation_data)}
+
+    def get_serializer_cls(self) -> type:
+        return GHEAppInstallSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        installation_id = validated_data.get("installation_id")
+        if not installation_id:
+            installation_data = pipeline.fetch_state("installation_data")
+            return PipelineStepResult.stay(
+                data={"appInstallUrl": self._get_app_url(installation_data)}
+            )
+        pipeline.bind_state("installation_id", installation_id)
+        return PipelineStepResult.advance()
+
+
 class InstallationForm(forms.Form):
     url = forms.CharField(
         label="Installation Url",
@@ -659,11 +749,30 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         return (
             InstallationConfigView(),
             GitHubEnterpriseInstallationRedirect(),
-            # The identity provider pipeline should be constructed at execution
-            # time, this allows for the oauth configuration parameters to be made
-            # available from the installation config view.
             lambda: self._make_identity_pipeline_view(),
         )
+
+    def _make_oauth_api_step(self) -> OAuth2ApiStep:
+        oauth_info = self.pipeline._fetch_state("oauth_config_information")
+        if oauth_info is None:
+            raise AssertionError("pipeline called out of order")
+        return OAuth2ApiStep(
+            authorize_url=oauth_info["authorize_url"],
+            client_id=oauth_info["client_id"],
+            client_secret=oauth_info["client_secret"],
+            access_token_url=oauth_info["access_token_url"],
+            scope="",
+            redirect_url=absolute_uri("/extensions/github-enterprise/setup/"),
+            verify_ssl=oauth_info.get("verify_ssl", True),
+            bind_key="oauth_data",
+        )
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            GHEInstallationConfigApiStep(),
+            GHEAppInstallRedirectApiStep(),
+            lambda: self._make_oauth_api_step(),
+        ]
 
     def post_install(
         self,
@@ -712,7 +821,13 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         return None
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        identity = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            identity = state["oauth_data"]
+        else:
+            identity = state["identity"]["data"]
         installation_data = state["installation_data"]
         user = get_user_info(installation_data["url"], identity["access_token"])
         installation = self._get_ghe_installation_info(

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -9,9 +9,12 @@ from django import forms
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import BooleanField, CharField, URLField
 
 from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.identity.gitlab.provider import GitlabIdentityProvider, get_oauth_data, get_user_info
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -37,7 +40,8 @@ from sentry.models.organization import Organization
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
@@ -369,6 +373,78 @@ class GitlabPRCommentWorkflow(PRCommentWorkflow):
         }
 
 
+class InstallationConfigSerializer(CamelSnakeSerializer):
+    url = URLField(required=False, default="https://gitlab.com")
+    group = CharField(required=False, allow_blank=True, default="")
+    include_subgroups = BooleanField(required=False, default=False)
+    verify_ssl = BooleanField(required=False, default=True)
+    client_id = CharField(required=True)
+    client_secret = CharField(required=True)
+
+
+class InstallationConfigApiStep:
+    """
+    Collects GitLab instance configuration: URL, group path, OAuth
+    credentials, and SSL/subgroup preferences.
+
+    On POST, validates the form data, binds ``installation_data`` and
+    ``oauth_config_information`` to pipeline state, then advances.
+    """
+
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "defaults": {
+                "verifySsl": True,
+                "includeSubgroups": False,
+            },
+            "setupValues": [
+                {"label": "Name", "value": "Sentry"},
+                {
+                    "label": "Redirect URI",
+                    "value": absolute_uri("/extensions/gitlab/setup/"),
+                },
+                {"label": "Scopes", "value": "api"},
+            ],
+        }
+
+    def get_serializer_cls(self) -> type:
+        return InstallationConfigSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        # Strip trailing slash from URL (same as InstallationForm.clean_url)
+        validated_data["url"] = validated_data["url"].rstrip("/")
+
+        pipeline.bind_state("installation_data", validated_data)
+
+        pipeline.bind_state(
+            "oauth_config_information",
+            {
+                "access_token_url": f"{validated_data['url']}/oauth/token",
+                "authorize_url": f"{validated_data['url']}/oauth/authorize",
+                "client_id": validated_data["client_id"],
+                "client_secret": validated_data["client_secret"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+
+        pipeline.get_logger().info(
+            "gitlab.setup.installation-config-api-step.success",
+            extra={
+                "base_url": validated_data["url"],
+                "client_id": validated_data["client_id"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+        return PipelineStepResult.advance()
+
+
 class InstallationForm(forms.Form):
     url = forms.CharField(
         label=_("GitLab URL"),
@@ -580,8 +656,35 @@ class GitlabIntegrationProvider(IntegrationProvider):
             lambda: self._make_identity_pipeline_view(),
         )
 
+    def _make_oauth_api_step(self) -> OAuth2ApiStep:
+        oauth_info = self.pipeline._fetch_state("oauth_config_information")
+        if oauth_info is None:
+            raise AssertionError("pipeline called out of order")
+        return OAuth2ApiStep(
+            authorize_url=oauth_info["authorize_url"],
+            client_id=oauth_info["client_id"],
+            client_secret=oauth_info["client_secret"],
+            access_token_url=oauth_info["access_token_url"],
+            scope=" ".join(sorted(GitlabIdentityProvider.oauth_scopes)),
+            redirect_url=absolute_uri("/extensions/gitlab/setup/"),
+            verify_ssl=oauth_info.get("verify_ssl", True),
+            bind_key="oauth_data",
+        )
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            InstallationConfigApiStep(),
+            lambda: self._make_oauth_api_step(),
+        ]
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            data = state["oauth_data"]
+        else:
+            data = state["identity"]["data"]
 
         # Gitlab requires the client_id and client_secret for refreshing the access tokens
         oauth_config = state.get("oauth_config_information", {})

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -172,7 +172,7 @@ class IntegrationPipeline(Pipeline[Never, PipelineSessionStore]):
     ]:
         return self.provider.get_pipeline_views()
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline] | None:
         return self.provider.get_pipeline_api_steps()
 
     def get_analytics_event(self) -> analytics.Event | None:

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -10,6 +10,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from sentry import options
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -37,7 +38,7 @@ from sentry.notifications.platform.slack.provider import (
 )
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
@@ -338,6 +339,20 @@ class SlackIntegrationProvider(IntegrationProvider):
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
         return [self._identity_pipeline_view()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            OAuth2ApiStep(
+                authorize_url="https://slack.com/oauth/v2/authorize",
+                client_id=options.get("slack.client-id"),
+                client_secret=options.get("slack.client-secret"),
+                access_token_url="https://slack.com/api/oauth.v2.access",
+                scope=" ".join(self._get_oauth_scopes()),
+                redirect_url=absolute_uri("/extensions/slack/setup/"),
+                bind_key="oauth_data",
+                extra_authorize_params={"user_scope": " ".join(self.user_scopes)},
+            ),
+        ]
+
     def _get_team_info(self, access_token: str) -> Any:
         # Manually add authorization since this method is part of slack installation
 
@@ -352,7 +367,13 @@ class SlackIntegrationProvider(IntegrationProvider):
             raise IntegrationError("Could not retrieve Slack team information.")
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            data = state["oauth_data"]
+        else:
+            data = state["identity"]["data"]
         assert data["ok"]
 
         access_token = data["access_token"]

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -260,7 +260,7 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
             return nested_pipeline.fetch_state(key)
         return self._fetch_state(key)
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[Self] | None:
         """
         Return API step objects for this pipeline, or None if API mode is not
         supported. Steps may be callables for late binding (resolved when the

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -275,6 +275,14 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
         """Returns True if this pipeline supports API mode."""
         return self.get_pipeline_api_steps() is not None
 
+    @property
+    def is_api_mode(self) -> bool:
+        """Returns True if this pipeline session was initiated via the API."""
+        return bool(self._fetch_state("api_mode"))
+
+    def set_api_mode(self, enabled: bool = True) -> None:
+        self.bind_state("api_mode", enabled)
+
     def _assert_user_authorization(self) -> None:
         assert not (self.state.uid is not None and self.state.uid != self.request.user.id), (
             ERR_MISMATCHED_USER

--- a/src/sentry/pipeline/provider.py
+++ b/src/sentry/pipeline/provider.py
@@ -36,7 +36,7 @@ class PipelineProvider[P](abc.ABC):
         >>> return [OAuthInitView(), OAuthCallbackView()]
         """
 
-    def get_pipeline_api_steps(self) -> ApiPipelineSteps[P]:
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[P] | None:
         """
         Return API step objects for this provider's pipeline, or None if API
         mode is not supported. Override to enable the pipeline API.

--- a/src/sentry/pipeline/views/base.py
+++ b/src/sentry/pipeline/views/base.py
@@ -58,7 +58,7 @@ class ApiPipelineEndpoint[P, D = Any, V = Any](Protocol):
 
 
 type ApiPipelineStep[P] = ApiPipelineEndpoint[P] | Callable[[], ApiPipelineEndpoint[P]]
-type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]] | None
+type ApiPipelineSteps[P] = Sequence[ApiPipelineStep[P]]
 
 
 def render_react_view(

--- a/src/sentry/uptime/endpoints/validators.py
+++ b/src/sentry/uptime/endpoints/validators.py
@@ -170,6 +170,9 @@ def _validate_check_config(
             "response_capture_enabled", uptime_subscription.response_capture_enabled
         )
 
+    if validated_data.get("assertion") is None:
+        return
+
     region = get_region_config(get_active_regions()[0].slug)
     assert region is not None
     check_config = checker_api.create_preview_check(validated_data, region)

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -1,14 +1,18 @@
+from urllib.parse import parse_qs
+
 from django.contrib import messages
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.http.response import HttpResponseBase
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from sentry import features
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.absolute_url import generate_organization_url
 from sentry.utils.http import absolute_uri, create_redirect_url
+from sentry.utils.json import dumps_htmlsafe
 from sentry.web.frontend.base import BaseView, all_silo_view
 
 # The request doesn't contain the pipeline type (pipeline information is stored
@@ -16,10 +20,70 @@ from sentry.web.frontend.base import BaseView, all_silo_view
 # and use whichever one works.
 PIPELINE_CLASSES = (IntegrationPipeline, IdentityPipeline)
 
+TRAMPOLINE_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body
+    style="margin:0;display:flex;align-items:center;justify-content:center;min-height:100vh;
+    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+    flex-direction:column;padding:2rem">
+<script type="module">
+  const data = {data_json};
+  if (window.opener) {{
+    window.opener.postMessage(data, {origin});
+    window.close();
+  }} else {{
+    document.getElementById("fallback").style.display = "flex";
+  }}
+</script>
+<div id="fallback" style="display:none;flex-direction:column;align-items:center;gap:1.5rem;max-width:600px">
+  <p style="font-size:1.1rem;margin:0">Unable to continue. Please restart the flow.</p>
+</div>
+</body>
+</html>"""
+
+
+def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
+    """Render a minimal page that posts callback params back to the opener."""
+    params: dict[str, str] = {"source": "sentry-pipeline"}
+    for key, values in parse_qs(request.META.get("QUERY_STRING", "")).items():
+        if values:
+            params[key] = values[0]
+
+    data_json = dumps_htmlsafe(params)
+
+    # In multi-region the opener may be on a different origin (e.g.
+    # org-slug.sentry.io) than the trampoline (sentry.io/extensions/...),
+    # so we need the org-specific URL. In single-region document.origin works.
+    if features.has("system:multi-region"):
+        org = getattr(pipeline, "organization", None)
+        origin = dumps_htmlsafe(generate_organization_url(org.slug if org else ""))
+    else:
+        origin = "document.origin"
+
+    return HttpResponse(
+        TRAMPOLINE_HTML.format(data_json=data_json, origin=origin),
+        content_type="text/html",
+    )
+
 
 @all_silo_view
 class PipelineAdvancerView(BaseView):
-    """Gets the current pipeline from the request and executes the current step."""
+    """
+    Gets the current pipeline from the request and executes the current step.
+
+    External services (e.g. GitHub OAuth) redirect back to this view after the
+    user completes an action. For legacy template-driven pipelines this view
+    processes the callback server-side via pipeline.current_step().
+
+    For API-driven pipelines (is_api_mode) this view does NOT process the
+    callback. Instead it renders a lightweight trampoline page that relays the
+    callback URL query params (code, state, installation_id, etc.) back to the
+    opener window via postMessage and closes itself. The frontend is
+    responsible for POSTing those params to the pipeline API endpoint to
+    advance the pipeline.
+    """
 
     auth_required = False
 
@@ -49,6 +113,12 @@ class PipelineAdvancerView(BaseView):
         if pipeline is None or not pipeline.is_valid():
             messages.add_message(request, messages.ERROR, _("Invalid request."))
             return self.redirect("/")
+
+        # If the pipeline was initiated via the API, render a trampoline page
+        # that relays the callback params back to the opener window via
+        # postMessage instead of processing the callback server-side.
+        if pipeline.is_api_mode:
+            return _render_trampoline(request, pipeline)
 
         subdomain = pipeline.fetch_state("subdomain")
         if subdomain is not None and request.subdomain != subdomain:

--- a/static/app/components/onboarding/platformOptionsControl.tsx
+++ b/static/app/components/onboarding/platformOptionsControl.tsx
@@ -8,7 +8,9 @@ import type {
   PlatformOption,
   SelectedPlatformOptions,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {useRouter} from 'sentry/utils/useRouter';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 
 /**
  * Hook that returns the currently selected platform option values from the URL
@@ -17,8 +19,7 @@ import {useRouter} from 'sentry/utils/useRouter';
 export function useUrlPlatformOptions<PlatformOptions extends BasePlatformOptions>(
   platformOptions?: PlatformOptions
 ): SelectedPlatformOptions<PlatformOptions> {
-  const router = useRouter();
-  const {query} = router.location;
+  const {query} = useLocation();
 
   return useMemo(() => {
     if (!platformOptions) {
@@ -28,8 +29,9 @@ export function useUrlPlatformOptions<PlatformOptions extends BasePlatformOption
     return Object.keys(platformOptions).reduce((acc, key) => {
       const defaultValue = platformOptions[key]!.defaultValue;
       const values = platformOptions[key]!.items.map(({value}) => value);
-      acc[key as keyof PlatformOptions] = values.includes(query[key])
-        ? query[key]
+      const queryKey = decodeScalar(query[key]) ?? '';
+      acc[key as keyof PlatformOptions] = values.includes(queryKey)
+        ? queryKey
         : (defaultValue ?? values[0]);
       return acc;
     }, {} as SelectedPlatformOptions<PlatformOptions>);
@@ -80,18 +82,18 @@ export function PlatformOptionsControl({
   platformOptions,
   onChange,
 }: PlatformOptionsControlProps) {
-  const router = useRouter();
+  const navigate = useNavigate();
+  const location = useLocation();
   const urlOptionValues = useUrlPlatformOptions(platformOptions);
 
   const handleChange = (key: string, value: string) => {
     onChange?.({[key]: value});
-    router.replace({
-      ...router.location,
-      query: {
-        ...router.location.query,
-        [key]: value,
-      },
-    });
+    navigate(
+      {...location, query: {...location.query, [key]: value}},
+      {
+        replace: true,
+      }
+    );
   };
 
   return (

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
@@ -1,0 +1,90 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+interface AuthorizeStepData {
+  authorizeUrl?: string;
+}
+
+interface AuthorizeAdvanceData {
+  jwt: string;
+}
+
+function BitbucketAuthorizeStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<AuthorizeStepData, AuthorizeAdvanceData>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      if (data.jwt) {
+        advance({jwt: data.jwt});
+      }
+    },
+    [advance]
+  );
+
+  const {reopenPopup, isWaitingForCallback} = useRedirectPopupStep({
+    redirectUrl: stepData.authorizeUrl,
+    autoOpen: false,
+    onCallback: handleCallback,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Connect your Bitbucket account by authorizing the Sentry add-on for Bitbucket.'
+          )}
+        </Text>
+        {isWaitingForCallback && (
+          <Text variant="muted" size="sm">
+            {t('A popup should have opened to authorize with Bitbucket.')}
+          </Text>
+        )}
+      </Stack>
+      {isAdvancing ? (
+        <Button size="sm" disabled>
+          {t('Authorizing...')}
+        </Button>
+      ) : isWaitingForCallback ? (
+        <Button size="sm" onClick={reopenPopup}>
+          {t('Reopen authorization window')}
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          priority="primary"
+          onClick={reopenPopup}
+          disabled={!stepData.authorizeUrl}
+        >
+          {t('Authorize Bitbucket')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+export const bitbucketIntegrationPipeline = {
+  type: 'integration',
+  provider: 'bitbucket',
+  actionTitle: t('Installing Bitbucket Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'authorize',
+      shortDescription: t('Authorizing Bitbucket'),
+      component: BitbucketAuthorizeStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
@@ -1,0 +1,209 @@
+import {useCallback} from 'react';
+
+import {Avatar} from '@sentry/scraps/avatar';
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {IconAdd} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+interface OrgSelectionStepData {
+  installAppUrl?: string;
+  installationInfo?: Array<{
+    avatarUrl: string;
+    githubAccount: string;
+    installationId: string;
+    count?: number | null;
+  }>;
+}
+
+interface OrgSelectionAdvanceData {
+  chosenInstallationId?: string;
+  installationId?: string;
+}
+
+function GitHubOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<
+  {oauthUrl?: string},
+  {code: string; state: string; installationId?: string}
+>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({
+        code: data.code,
+        state: data.state,
+        installationId: data.rest.installation_id,
+      });
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="GitHub"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+const NEW_INSTALL_KEY = '_new_install';
+
+function OrgSelectionStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<OrgSelectionStepData, OrgSelectionAdvanceData>) {
+  const installations = stepData.installationInfo ?? [];
+
+  const handleInstallCallback = useCallback(
+    (data: Record<string, unknown>) => {
+      advance({
+        installationId: data.installation_id as string,
+      });
+    },
+    [advance]
+  );
+
+  const {reopenPopup, isWaitingForCallback} = useRedirectPopupStep({
+    redirectUrl: stepData.installAppUrl,
+    autoOpen: false,
+    onCallback: handleInstallCallback,
+  });
+
+  // Filter out the "-1" sentinel — we handle "new org" with a dedicated menu item
+  const existingInstallations = installations.filter(
+    inst => inst.installationId !== '-1'
+  );
+
+  if (isAdvancing) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" disabled>
+          {t('Completing...')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  if (isWaitingForCallback) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            'Complete the installation in the popup window. Once finished, this page will update automatically.'
+          )}
+        </Text>
+        <Button size="sm" onClick={reopenPopup}>
+          {t('Reopen installation window')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  // No existing installations — show install button directly
+  if (existingInstallations.length === 0) {
+    return (
+      <Stack gap="lg" align="start">
+        <Text>
+          {t(
+            "Select the GitHub organization you'd like to connect to Sentry, or install the Sentry GitHub App on a new organization."
+          )}
+        </Text>
+        <Button
+          size="sm"
+          priority="primary"
+          onClick={reopenPopup}
+          disabled={!stepData.installAppUrl}
+        >
+          {t('Install GitHub App')}
+        </Button>
+      </Stack>
+    );
+  }
+
+  const menuItems = [
+    ...existingInstallations.map(inst => ({
+      key: inst.installationId,
+      leadingItems: (
+        <Avatar
+          size={16}
+          type="upload"
+          identifier={inst.installationId}
+          uploadUrl={inst.avatarUrl}
+          name={inst.githubAccount}
+        />
+      ),
+      label: inst.githubAccount,
+      details: inst.count
+        ? t('Connected to %s other Sentry organizations', inst.count)
+        : undefined,
+      textValue: inst.githubAccount,
+    })),
+    {
+      key: NEW_INSTALL_KEY,
+      leadingItems: <IconAdd size="sm" />,
+      label: t('Install on a new GitHub organization'),
+      textValue: t('Install on a new GitHub organization'),
+    },
+  ];
+
+  return (
+    <Stack gap="lg" align="start">
+      <Text>
+        {t(
+          "Select the GitHub organization you'd like to connect to Sentry, or install the Sentry GitHub App on a new organization."
+        )}
+      </Text>
+      <DropdownMenu
+        triggerLabel={t('Select GitHub organization')}
+        items={menuItems}
+        isDisabled={isAdvancing}
+        onAction={key => {
+          if (key === NEW_INSTALL_KEY) {
+            reopenPopup();
+          } else {
+            advance({chosenInstallationId: key as string});
+          }
+        }}
+      />
+    </Stack>
+  );
+}
+
+export const githubIntegrationPipeline = {
+  type: 'integration',
+  provider: 'github',
+  actionTitle: t('Installing GitHub Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via GitHub OAuth flow'),
+      component: GitHubOAuthLoginStep,
+    },
+    {
+      stepId: 'org_selection',
+      shortDescription: t('Installing GitHub Application'),
+      component: OrgSelectionStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.tsx
@@ -1,0 +1,353 @@
+import {useCallback} from 'react';
+import {z} from 'zod';
+
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const installationConfigSchema = z.object({
+  url: z.string().min(1, t('Installation URL is required')),
+  id: z.string().min(1, t('GitHub App ID is required')),
+  name: z.string().min(1, t('GitHub App Name is required')),
+  publicLink: z.string(),
+  verifySsl: z.boolean(),
+  webhookSecret: z.string().min(1, t('Webhook Secret is required')),
+  privateKey: z.string().min(1, t('Private Key is required')),
+  clientId: z.string().min(1, t('OAuth Client ID is required')),
+  clientSecret: z.string().min(1, t('OAuth Client Secret is required')),
+});
+
+interface InstallationConfigStepData {
+  defaults?: {
+    verifySsl?: boolean;
+  };
+}
+
+interface InstallationConfigAdvanceData {
+  client_id: string;
+  client_secret: string;
+  id: string;
+  name: string;
+  private_key: string;
+  url: string;
+  webhook_secret: string;
+  public_link?: string;
+  verify_ssl?: boolean;
+}
+
+function InstallationConfigStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
+  const defaults = stepData.defaults ?? {};
+
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      url: '',
+      id: '',
+      name: '',
+      publicLink: '',
+      verifySsl: defaults.verifySsl ?? true,
+      webhookSecret: '',
+      privateKey: '',
+      clientId: '',
+      clientSecret: '',
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      const parsed = installationConfigSchema.parse(value);
+      advance({
+        url: parsed.url.replace(/\/+$/, ''),
+        id: parsed.id,
+        name: parsed.name,
+        public_link: parsed.publicLink || undefined,
+        verify_ssl: parsed.verifySsl,
+        webhook_secret: parsed.webhookSecret,
+        private_key: parsed.privateKey,
+        client_id: parsed.clientId,
+        client_secret: parsed.clientSecret,
+      });
+    },
+  });
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {tct(
+            'Create a GitHub App on your GitHub Enterprise instance and enter the details below. Refer to the [link:documentation] for setup instructions.',
+            {
+              link: (
+                <a
+                  href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github-enterprise/"
+                  target="_blank"
+                  rel="noreferrer"
+                />
+              ),
+            }
+          )}
+        </Text>
+
+        <form.AppField name="url">
+          {field => (
+            <field.Layout.Stack
+              label={t('Installation URL')}
+              hintText={t(
+                'The base URL for your GitHub Enterprise instance, including the protocol.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://github.example.com"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="id">
+          {field => (
+            <field.Layout.Stack
+              label={t('GitHub App ID')}
+              hintText={t("Found on your app's settings page.")}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="1"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="name">
+          {field => (
+            <field.Layout.Stack
+              label={t('GitHub App Name')}
+              hintText={t(
+                "The slug of your GitHub App, found on the app's settings page."
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="our-sentry-app"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="webhookSecret">
+          {field => (
+            <field.Layout.Stack
+              label={t('Webhook Secret')}
+              hintText={t(
+                'The webhook secret configured for your GitHub App. Must match the value in your app settings.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                type="password"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="privateKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Private Key')}
+              hintText={t('The private key generated for your GitHub App.')}
+              required
+            >
+              <field.TextArea
+                value={field.state.value}
+                onChange={field.handleChange}
+                rows={3}
+                placeholder={
+                  '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
+                }
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="clientId">
+          {field => (
+            <field.Layout.Stack label={t('OAuth Client ID')} required>
+              <field.Input value={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="clientSecret">
+          {field => (
+            <field.Layout.Stack label={t('OAuth Client Secret')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                type="password"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="publicLink">
+          {field => (
+            <field.Layout.Stack
+              label={t('Public Link')}
+              hintText={t(
+                'The publicly available link for your GitHub App, if different from the default.'
+              )}
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://github.example.com/github-apps/our-sentry-app"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="verifySsl">
+          {field => (
+            <field.Layout.Stack
+              label={t('Verify SSL')}
+              hintText={t(
+                'Verify SSL certificates when communicating with your GitHub Enterprise instance.'
+              )}
+            >
+              <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing}>
+            {isAdvancing ? t('Submitting...') : t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+interface AppInstallStepData {
+  appInstallUrl?: string;
+}
+
+function AppInstallRedirectStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<AppInstallStepData, {installationId: string}>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      if (data.installation_id) {
+        advance({installationId: data.installation_id});
+      }
+    },
+    [advance]
+  );
+
+  const {reopenPopup, isWaitingForCallback} = useRedirectPopupStep({
+    redirectUrl: stepData.appInstallUrl,
+    autoOpen: false,
+    onCallback: handleCallback,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Install the GitHub App on your GitHub Enterprise instance to grant Sentry access.'
+          )}
+        </Text>
+        {isWaitingForCallback && (
+          <Text variant="muted" size="sm">
+            {t(
+              'Complete the installation in the popup window. This page will update automatically.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isAdvancing ? (
+        <Button size="sm" disabled>
+          {t('Installing...')}
+        </Button>
+      ) : isWaitingForCallback ? (
+        <Button size="sm" onClick={reopenPopup}>
+          {t('Reopen installation window')}
+        </Button>
+      ) : (
+        <Button size="sm" priority="primary" onClick={reopenPopup}>
+          {t('Install GitHub App')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+function GHEOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="GitHub Enterprise"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+export const githubEnterpriseIntegrationPipeline = {
+  type: 'integration',
+  provider: 'github_enterprise',
+  actionTitle: t('Installing GitHub Enterprise Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring GitHub Enterprise connection'),
+      component: InstallationConfigStep,
+    },
+    {
+      stepId: 'app_install_redirect',
+      shortDescription: t('Installing GitHub App'),
+      component: AppInstallRedirectStep,
+    },
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via OAuth'),
+      component: GHEOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -1,0 +1,293 @@
+import {useCallback} from 'react';
+import {z} from 'zod';
+
+import {CodeBlock} from '@sentry/scraps/code';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const installationConfigSchema = z
+  .object({
+    selfHosted: z.boolean(),
+    url: z.string(),
+    group: z.string(),
+    includeSubgroups: z.boolean(),
+    verifySsl: z.boolean(),
+    clientId: z.string().min(1, t('Application ID is required')),
+    clientSecret: z.string().min(1, t('Application Secret is required')),
+  })
+  .refine(data => !data.selfHosted || z.url().safeParse(data.url).success, {
+    path: ['url'],
+    message: t('A valid GitLab URL is required for self-hosted instances'),
+  });
+
+interface InstallationConfigStepData {
+  defaults?: {
+    includeSubgroups?: boolean;
+    verifySsl?: boolean;
+  };
+  setupValues?: Array<{label: string; value: string}>;
+}
+
+interface InstallationConfigAdvanceData {
+  client_id: string;
+  client_secret: string;
+  group: string;
+  include_subgroups: boolean;
+  url?: string;
+  verify_ssl?: boolean;
+}
+
+function InstallationConfigStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
+  const defaults = stepData.defaults ?? {};
+  const setupValues = stepData.setupValues ?? [];
+
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      selfHosted: false,
+      url: '',
+      group: '',
+      includeSubgroups: defaults.includeSubgroups ?? false,
+      verifySsl: defaults.verifySsl ?? true,
+      clientId: '',
+      clientSecret: '',
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      const parsed = installationConfigSchema.parse(value);
+      advance({
+        url: parsed.selfHosted ? parsed.url.replace(/\/+$/, '') : undefined,
+        verify_ssl: parsed.selfHosted ? parsed.verifySsl : undefined,
+        group: parsed.group,
+        include_subgroups: parsed.includeSubgroups,
+        client_id: parsed.clientId,
+        client_secret: parsed.clientSecret,
+      });
+    },
+  });
+
+  const configForm = (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <form.AppField name="clientId">
+          {field => (
+            <field.Layout.Stack label={t('GitLab Application ID')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('Application ID from your GitLab OAuth application')}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="clientSecret">
+          {field => (
+            <field.Layout.Stack label={t('GitLab Application Secret')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('Application Secret from your GitLab OAuth application')}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="group">
+          {field => (
+            <field.Layout.Stack
+              label={t('GitLab Group Path')}
+              hintText={t(
+                'Limit this integration to a specific group. Found in the URL of your group page (e.g. my-group/my-subgroup). Leave empty to integrate all accessible projects.'
+              )}
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="my-group/my-subgroup"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.Subscribe selector={state => state.values.group}>
+          {group =>
+            group ? (
+              <form.AppField name="includeSubgroups">
+                {field => (
+                  <field.Layout.Stack
+                    label={t('Include Subgroups')}
+                    hintText={t('Include projects in subgroups of the GitLab group.')}
+                  >
+                    <field.Switch
+                      checked={field.state.value}
+                      onChange={field.handleChange}
+                    />
+                  </field.Layout.Stack>
+                )}
+              </form.AppField>
+            ) : null
+          }
+        </form.Subscribe>
+        <form.AppField name="selfHosted">
+          {field => (
+            <field.Layout.Stack
+              label={t('Self-Hosted Instance')}
+              hintText={t(
+                'Enable this if you are connecting to a self-hosted GitLab instance instead of gitlab.com.'
+              )}
+            >
+              <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.Subscribe selector={state => state.values.selfHosted}>
+          {isSelfHosted =>
+            isSelfHosted ? (
+              <Stack gap="lg">
+                <form.AppField name="url">
+                  {field => (
+                    <field.Layout.Stack
+                      label={t('GitLab URL')}
+                      hintText={t(
+                        'The base URL for your self-hosted GitLab instance, including the host and protocol.'
+                      )}
+                      required
+                    >
+                      <field.Input
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        placeholder="https://gitlab.example.com"
+                      />
+                    </field.Layout.Stack>
+                  )}
+                </form.AppField>
+                <form.AppField name="verifySsl">
+                  {field => (
+                    <field.Layout.Stack
+                      label={t('Verify SSL')}
+                      hintText={t(
+                        'Verify SSL certificates when communicating with your GitLab instance.'
+                      )}
+                    >
+                      <field.Switch
+                        checked={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    </field.Layout.Stack>
+                  )}
+                </form.AppField>
+              </Stack>
+            ) : null
+          }
+        </form.Subscribe>
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing}>
+            {isAdvancing ? t('Submitting...') : t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+
+  return (
+    <Stack gap="lg">
+      <Text>
+        {t(
+          'To connect Sentry with your GitLab instance, you need to create an OAuth application in GitLab.'
+        )}
+      </Text>
+      <GuidedSteps>
+        <GuidedSteps.Step
+          stepKey="navigate"
+          title={t('Open GitLab application settings')}
+        >
+          <Text density="comfortable">
+            {tct(
+              'Navigate to [bold:User Settings \u203A Access \u203A Applications] in GitLab.',
+              {
+                bold: <strong />,
+              }
+            )}
+            <br />
+            <Text as="div" variant="muted" size="sm">
+              {tct(
+                'For self-managed instances, use [bold:Admin Area \u203A Applications] instead.',
+                {bold: <strong />}
+              )}
+            </Text>
+          </Text>
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="create" title={t('Create a new application')}>
+          <Stack gap="sm">
+            {setupValues.map(({label, value}) => (
+              <Stack key={label} gap="xs">
+                <Text bold size="sm">
+                  {label}
+                </Text>
+                <CodeBlock>{value}</CodeBlock>
+              </Stack>
+            ))}
+          </Stack>
+          <GuidedSteps.StepButtons />
+        </GuidedSteps.Step>
+        <GuidedSteps.Step stepKey="configure" title={t('Configure the integration')}>
+          {configForm}
+        </GuidedSteps.Step>
+      </GuidedSteps>
+    </Stack>
+  );
+}
+
+function GitLabOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="GitLab"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+export const gitlabIntegrationPipeline = {
+  type: 'integration',
+  provider: 'gitlab',
+  actionTitle: t('Installing GitLab Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring GitLab connection'),
+      component: InstallationConfigStep,
+    },
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via GitLab OAuth flow'),
+      component: GitLabOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/pipelineIntegrationSlack.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.tsx
@@ -1,0 +1,46 @@
+import {useCallback} from 'react';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+function SlackOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="Slack"
+      onOAuthCallback={handleOAuthCallback}
+      popup={{height: 900}}
+    />
+  );
+}
+
+export const slackIntegrationPipeline = {
+  type: 'integration',
+  provider: 'slack',
+  actionTitle: t('Installing Slack Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via Slack OAuth'),
+      component: SlackOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,6 +1,7 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
+import {githubEnterpriseIntegrationPipeline} from './pipelineIntegrationGitHubEnterprise';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
 
@@ -11,6 +12,7 @@ export const PIPELINE_REGISTRY = [
   bitbucketIntegrationPipeline,
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
+  githubEnterpriseIntegrationPipeline,
   gitlabIntegrationPipeline,
   slackIntegrationPipeline,
 ] as const;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,6 +1,7 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
+import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
 
 /**
  * All registered pipeline definitions.
@@ -9,6 +10,7 @@ export const PIPELINE_REGISTRY = [
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
   gitlabIntegrationPipeline,
+  slackIntegrationPipeline,
 ] as const;
 
 type AllPipelines = (typeof PIPELINE_REGISTRY)[number];

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,9 +1,13 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
+import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 
 /**
  * All registered pipeline definitions.
  */
-export const PIPELINE_REGISTRY = [dummyIntegrationPipeline] as const;
+export const PIPELINE_REGISTRY = [
+  dummyIntegrationPipeline,
+  githubIntegrationPipeline,
+] as const;
 
 type AllPipelines = (typeof PIPELINE_REGISTRY)[number];
 

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,5 +1,6 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
+import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 
 /**
  * All registered pipeline definitions.
@@ -7,6 +8,7 @@ import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 export const PIPELINE_REGISTRY = [
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
+  gitlabIntegrationPipeline,
 ] as const;
 
 type AllPipelines = (typeof PIPELINE_REGISTRY)[number];

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,4 +1,5 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
+import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
@@ -7,6 +8,7 @@ import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
  * All registered pipeline definitions.
  */
 export const PIPELINE_REGISTRY = [
+  bitbucketIntegrationPipeline,
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
   gitlabIntegrationPipeline,

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -465,6 +465,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/org-auth-tokens/'
   | '/organizations/$organizationIdOrSlug/org-auth-tokens/$tokenId/'
   | '/organizations/$organizationIdOrSlug/pinned-searches/'
+  | '/organizations/$organizationIdOrSlug/pipeline/$pipelineName/'
   | '/organizations/$organizationIdOrSlug/plugins/'
   | '/organizations/$organizationIdOrSlug/plugins/$pluginSlug/deprecation-info/'
   | '/organizations/$organizationIdOrSlug/plugins/configs/'

--- a/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.spec.tsx
@@ -275,7 +275,7 @@ describe('UptimeAssertionsField', () => {
     });
   });
 
-  it('shows empty UI when editing monitor with no assertions', () => {
+  it('shows empty UI when editing monitor with no assertions', async () => {
     // When editing a monitor that has no assertions, pass empty assertion structure
     // (FormField converts null to '' so we can't use null directly)
     const emptyAssertion: UptimeAssertion = {
@@ -298,9 +298,25 @@ describe('UptimeAssertionsField', () => {
     // Should NOT have any assertion inputs (no default 2xx assertions)
     expect(screen.queryAllByRole('textbox')).toHaveLength(0);
 
+    // Should show a warning about no assertions with a button to add the default
+    expect(
+      screen.getByText(
+        'Without any Assertions all uptime checks will be marked as success!',
+        {exact: false}
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Add a 2xx status code assertion.'})
+    ).toBeInTheDocument();
+
     // getValue should return null for empty assertions
-    const transformedData = model.getTransformedData();
-    expect(transformedData.assertion).toBeNull();
+    expect(model.getTransformedData().assertion).toBeNull();
+
+    // Clicking the button should add the default 2xx assertions
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Add a 2xx status code assertion.'})
+    );
+    expect(screen.getAllByRole('textbox')).toHaveLength(2);
   });
 
   it('allows adding assertions when editing monitor with no assertions', async () => {
@@ -368,6 +384,17 @@ describe('UptimeAssertionsField', () => {
     await waitFor(() => {
       expect(screen.queryAllByRole('textbox')).toHaveLength(0);
     });
+
+    // Should now show the no-assertions warning with the add button
+    expect(
+      screen.getByText(
+        'Without any Assertions all uptime checks will be marked as success!',
+        {exact: false}
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Add a 2xx status code assertion.'})
+    ).toBeInTheDocument();
 
     // getValue should return null when all assertions are deleted
     const transformedData = model.getTransformedData();

--- a/static/app/views/alerts/rules/uptime/assertions/field.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/field.tsx
@@ -1,5 +1,10 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
 import type {FormFieldProps} from 'sentry/components/forms/formField';
 import {FormField} from 'sentry/components/forms/formField';
+import {tct} from 'sentry/locale';
 import {uniqueId} from 'sentry/utils/guid';
 import {resolveErroredAssertionOp} from 'sentry/views/alerts/rules/uptime/formErrors';
 import {usePreviewCheckResult} from 'sentry/views/alerts/rules/uptime/previewCheckContext';
@@ -94,16 +99,37 @@ function UptimeAssertionsControl({onChange, onBlur, value}: any) {
   const erroredOp = resolveErroredAssertionOp(previewCheckResult, rootOp) ?? undefined;
 
   return (
-    <AssertionOpGroup
-      root
-      value={rootOp}
-      erroredOp={erroredOp}
-      onChange={op => {
-        previewCheckResult?.resetPreviewCheckResult();
-        onChange({root: op}, {});
-        onBlur({root: op}, {});
-      }}
-    />
+    <Flex direction="column" gap="md">
+      {rootOp.children.length === 0 && (
+        <Alert variant="warning">
+          {tct(
+            'Without any Assertions all uptime checks will be marked as success! [addDefault:Add a 2xx status code assertion.]',
+            {
+              addDefault: (
+                <Button
+                  priority="link"
+                  onClick={() => {
+                    const defaultRoot = createDefaultAssertionRoot();
+                    onChange({root: defaultRoot}, {});
+                    onBlur({root: defaultRoot}, {});
+                  }}
+                />
+              ),
+            }
+          )}
+        </Alert>
+      )}
+      <AssertionOpGroup
+        root
+        value={rootOp}
+        erroredOp={erroredOp}
+        onChange={op => {
+          previewCheckResult?.resetPreviewCheckResult();
+          onChange({root: op}, {});
+          onBlur({root: op}, {});
+        }}
+      />
+    </Flex>
   );
 }
 

--- a/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
+++ b/static/app/views/insights/common/views/spanSummaryPage/sampleList/index.tsx
@@ -13,9 +13,9 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocationQuery} from 'sentry/utils/url/useLocationQuery';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useRouter} from 'sentry/utils/useRouter';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {DATA_TYPE} from 'sentry/views/insights/browser/resources/settings';
 import {decodeSubregions} from 'sentry/views/insights/browser/resources/utils/queryParameterDecoders/subregions';
@@ -82,7 +82,7 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
     },
   });
 
-  const router = useRouter();
+  const navigate = useNavigate();
   const [highlightedSpanId, setHighlightedSpanId] = useState<string | undefined>(
     undefined
   );
@@ -101,13 +101,16 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
   );
 
   const handleSearch = (newSpanSearchQuery: string) => {
-    router.replace({
-      pathname: location.pathname,
-      query: {
-        ...location.query,
-        spanSearchQuery: newSpanSearchQuery,
+    navigate(
+      {
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          spanSearchQuery: newSpanSearchQuery,
+        },
       },
-    });
+      {replace: true}
+    );
   };
 
   // set additional query filters from the span search bar and the `query` param
@@ -146,7 +149,7 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
 
   const handleClickSample = useCallback(
     (span: SpanSample) => {
-      router.push(
+      navigate(
         generateLinkToEventInTraceView({
           targetId: span['transaction.span_id'],
           spanId: span.span_id,
@@ -157,7 +160,7 @@ export function SampleList({groupId, moduleName, transactionRoute, referrer}: Pr
         })
       );
     },
-    [organization, location, router]
+    [organization, location, navigate]
   );
 
   const handleMouseOverSample = useCallback(

--- a/tests/sentry/api/endpoints/test_organization_pipeline.py
+++ b/tests/sentry/api/endpoints/test_organization_pipeline.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import cached_property
+from typing import Any, Never
+from unittest.mock import patch
+
+import responses
+from django.http import HttpResponse
+from django.http.request import HttpRequest
+from django.http.response import HttpResponseBase
+from django.urls import reverse
+
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.organizations.services.organization.serial import serialize_rpc_organization
+from sentry.pipeline.base import Pipeline
+from sentry.pipeline.provider import PipelineProvider
+from sentry.pipeline.store import PipelineSessionStore
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineEndpoint, PipelineView
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+
+
+class DummyStep:
+    def dispatch(self, request: HttpRequest, pipeline: Any) -> HttpResponseBase:
+        return HttpResponse("ok")
+
+
+class DummyApiStep:
+    step_name = "pick_thing"
+
+    def get_step_data(self, pipeline: DummyPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {"options": ["a", "b"]}
+
+    def get_serializer_cls(self) -> type | None:
+        return None
+
+    def handle_post(
+        self, validated_data: Any, pipeline: DummyPipeline, request: HttpRequest
+    ) -> PipelineStepResult:
+        pipeline.bind_state("thing", validated_data.get("thing", "a"))
+        return PipelineStepResult.advance()
+
+
+class DummyProvider(PipelineProvider["DummyPipeline"]):
+    key = "dummy"
+    name = "Dummy"
+
+    def get_pipeline_views(self) -> Sequence[DummyStep]:
+        return [DummyStep()]
+
+    def get_pipeline_api_steps(self) -> Sequence[ApiPipelineEndpoint[DummyPipeline]]:
+        return [DummyApiStep()]
+
+
+class DummyPipeline(Pipeline[Never, PipelineSessionStore]):
+    """A single-step pipeline that supports API mode."""
+
+    pipeline_name = "test_dummy_pipeline"
+
+    @cached_property
+    def provider(self) -> DummyProvider:
+        ret = DummyProvider()
+        ret.set_pipeline(self)
+        ret.update_config(self.config)
+        return ret
+
+    def get_pipeline_views(self) -> Sequence[DummyStep]:
+        return self.provider.get_pipeline_views()
+
+    def get_pipeline_api_steps(self) -> Sequence[ApiPipelineEndpoint[DummyPipeline]] | None:
+        return self.provider.get_pipeline_api_steps()
+
+    def finish_pipeline(self) -> HttpResponseBase:
+        return HttpResponse("done")
+
+    def api_finish_pipeline(self) -> PipelineStepResult:
+        return PipelineStepResult.complete(data={"thing": self.fetch_state("thing")})
+
+
+class NonApiProvider(PipelineProvider["NonApiPipeline"]):
+    key = "non_api"
+    name = "Non-API"
+
+    def get_pipeline_views(self) -> Sequence[PipelineView[NonApiPipeline]]:
+        return [DummyStep()]
+
+
+class NonApiPipeline(Pipeline[Never, PipelineSessionStore]):
+    """A pipeline that does NOT support API mode (no get_pipeline_api_steps)."""
+
+    pipeline_name = "test_non_api_pipeline"
+
+    @cached_property
+    def provider(self) -> NonApiProvider:
+        ret = NonApiProvider()
+        ret.set_pipeline(self)
+        ret.update_config(self.config)
+        return ret
+
+    def get_pipeline_views(self) -> Sequence[PipelineView[NonApiPipeline]]:
+        return self.provider.get_pipeline_views()
+
+    def finish_pipeline(self) -> HttpResponseBase:
+        return HttpResponse("done")
+
+
+@control_silo_test
+class OrganizationPipelineEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def _get_pipeline_url(self, pipeline_name: str | None = None) -> str:
+        return reverse(
+            self.endpoint,
+            args=[
+                self.organization.slug,
+                pipeline_name or IntegrationPipeline.pipeline_name,
+            ],
+        )
+
+    def _init_pipeline_in_session(
+        self, pipeline_cls: type[Pipeline], provider_key: str = "dummy"
+    ) -> Pipeline:
+        """Create and initialize a pipeline, storing it in the test client's session."""
+        with assume_test_silo_mode(SiloMode.CELL):
+            rpc_org = serialize_rpc_organization(self.organization)
+
+        # Use make_request so the request shares the test client's session
+        request = self.make_request(self.user)
+        pipeline = pipeline_cls(request=request, organization=rpc_org, provider_key=provider_key)
+        pipeline.initialize()
+        self.save_session()
+        return pipeline
+
+    @responses.activate
+    def test_initialize_missing_provider(self) -> None:
+        resp = self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "provider is required" in resp.data["detail"]
+
+    @responses.activate
+    def test_initialize_invalid_provider(self) -> None:
+        resp = self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "nonexistent"},
+            format="json",
+        )
+        assert resp.status_code == 404
+        assert "Unknown provider" in resp.data["detail"]
+
+    @responses.activate
+    def test_initialize_wrong_pipeline_name(self) -> None:
+        resp = self.client.post(
+            self._get_pipeline_url("identity_pipeline"),
+            data={"action": "initialize", "provider": "github"},
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "Initialization not supported" in resp.data["detail"]
+
+    @responses.activate
+    def test_get_no_active_session(self) -> None:
+        resp = self.client.get(self._get_pipeline_url())
+        assert resp.status_code == 404
+        assert "No active pipeline session" in resp.data["detail"]
+
+    @responses.activate
+    def test_post_no_active_session(self) -> None:
+        resp = self.client.post(
+            self._get_pipeline_url(),
+            data={"code": "abc", "state": "xyz"},
+            format="json",
+        )
+        assert resp.status_code == 404
+        assert "No active pipeline session" in resp.data["detail"]
+
+    @responses.activate
+    @patch(
+        "sentry.api.endpoints.organization_pipeline.PIPELINE_CLASSES",
+        (DummyPipeline,),
+    )
+    def test_get_step_info(self) -> None:
+        self._init_pipeline_in_session(DummyPipeline)
+        url = self._get_pipeline_url(DummyPipeline.pipeline_name)
+
+        resp = self.client.get(url)
+        assert resp.status_code == 200
+        assert resp.data["step"] == "pick_thing"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "dummy"
+        assert resp.data["data"] == {"options": ["a", "b"]}
+
+    @responses.activate
+    @patch(
+        "sentry.api.endpoints.organization_pipeline.PIPELINE_CLASSES",
+        (DummyPipeline,),
+    )
+    def test_post_advance_completes_single_step_pipeline(self) -> None:
+        self._init_pipeline_in_session(DummyPipeline)
+        url = self._get_pipeline_url(DummyPipeline.pipeline_name)
+
+        resp = self.client.post(url, data={"thing": "b"}, format="json")
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert resp.data["data"] == {"thing": "b"}
+
+    @responses.activate
+    @patch(
+        "sentry.api.endpoints.organization_pipeline.PIPELINE_CLASSES",
+        (NonApiPipeline,),
+    )
+    def test_get_non_api_pipeline_returns_400(self) -> None:
+        self._init_pipeline_in_session(NonApiPipeline, provider_key="non_api")
+        url = self._get_pipeline_url(NonApiPipeline.pipeline_name)
+
+        resp = self.client.get(url)
+        assert resp.status_code == 400
+        assert "Pipeline does not support API mode" in resp.data["detail"]
+
+    @responses.activate
+    @patch(
+        "sentry.api.endpoints.organization_pipeline.PIPELINE_CLASSES",
+        (NonApiPipeline,),
+    )
+    def test_post_non_api_pipeline_returns_400(self) -> None:
+        self._init_pipeline_in_session(NonApiPipeline, provider_key="non_api")
+        url = self._get_pipeline_url(NonApiPipeline.pipeline_name)
+
+        resp = self.client.post(url, data={"thing": "a"}, format="json")
+        assert resp.status_code == 400
+        assert "Pipeline does not support API mode" in resp.data["detail"]
+
+    @responses.activate
+    def test_get_unknown_pipeline_name(self) -> None:
+        resp = self.client.get(self._get_pipeline_url("totally_fake_pipeline"))
+        assert resp.status_code == 404
+        assert "Invalid pipeline type" in resp.data["detail"]
+
+    @responses.activate
+    @patch(
+        "sentry.api.endpoints.organization_pipeline.PIPELINE_CLASSES",
+        (DummyPipeline,),
+    )
+    @patch.object(
+        DummyApiStep,
+        "handle_post",
+        return_value=PipelineStepResult.error("Something went wrong"),
+    )
+    def test_post_step_error_returns_400(self, mock_handle_post: Any) -> None:
+        self._init_pipeline_in_session(DummyPipeline)
+        url = self._get_pipeline_url(DummyPipeline.pipeline_name)
+
+        resp = self.client.post(url, data={"thing": "a"}, format="json")
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert resp.data["data"]["detail"] == "Something went wrong"

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 from collections import namedtuple
 from functools import cached_property
+from typing import Any
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, parse_qsl, urlparse
 
 import responses
 from django.test import Client, RequestFactory
-from requests.exceptions import SSLError
+from requests.exceptions import ConnectionError, SSLError
 
 import sentry.identity
-from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView
+from sentry.identity.oauth2 import OAuth2ApiStep, OAuth2CallbackView, OAuth2LoginView
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.pipeline.types import PipelineStepAction
 from sentry.shared_integrations.exceptions import ApiUnauthorized
 from sentry.testutils.asserts import assert_failure_metric, assert_slo_metric
 from sentry.testutils.silo import control_silo_test
@@ -209,3 +213,171 @@ class OAuth2LoginViewTest(TestCase):
         assert query["response_type"][0] == "code"
         assert query["scope"][0] == "all-the-things"
         assert "state" in query
+
+
+class _FakePipelineContext:
+    """Minimal pipeline-like object for testing OAuth2ApiStep."""
+
+    def __init__(self, signature: str = "test-signature") -> None:
+        self.signature = signature
+        self._state: dict[str, Any] = {}
+
+    def bind_state(self, key: str, value: Any) -> None:
+        self._state[key] = value
+
+    def fetch_state(self, key: str | None = None) -> Any:
+        if key is None:
+            return self._state
+        return self._state.get(key)
+
+
+@control_silo_test
+class OAuth2ApiStepGetStepDataTest(TestCase):
+    @cached_property
+    def step(self) -> OAuth2ApiStep:
+        return OAuth2ApiStep(
+            authorize_url="https://example.org/oauth2/authorize",
+            client_id="123456",
+            client_secret="secret-value",
+            access_token_url="https://example.org/oauth/token",
+            scope="all-the-things",
+            redirect_url="/extensions/default/setup/",
+        )
+
+    def test_returns_oauth_url(self) -> None:
+        ctx = _FakePipelineContext(signature="abc123")
+        request = RequestFactory().get("/")
+        data = self.step.get_step_data(ctx, request)
+
+        assert "oauthUrl" in data
+        url = urlparse(data["oauthUrl"])
+        assert url.scheme == "https"
+        assert url.hostname == "example.org"
+        assert url.path == "/oauth2/authorize"
+
+        query = parse_qs(url.query)
+        assert query["client_id"] == ["123456"]
+        assert query["response_type"] == ["code"]
+        assert query["scope"] == ["all-the-things"]
+        assert query["state"] == ["abc123"]
+        assert "redirect_uri" in query
+
+    def test_serializer_requires_code_and_state(self) -> None:
+        ser_cls = self.step.get_serializer_cls()
+        assert ser_cls is not None
+
+        ser = ser_cls(data={})
+        assert not ser.is_valid()
+        assert "code" in ser.errors
+        assert "state" in ser.errors
+
+        ser = ser_cls(data={"code": "abc", "state": "xyz"})
+        assert ser.is_valid()
+
+
+@control_silo_test
+class OAuth2ApiStepHandlePostTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.request = RequestFactory().get("/")
+
+    @cached_property
+    def step(self) -> OAuth2ApiStep:
+        return OAuth2ApiStep(
+            authorize_url="https://example.org/oauth2/authorize",
+            client_id="123456",
+            client_secret="secret-value",
+            access_token_url="https://example.org/oauth/token",
+            scope="all-the-things",
+            redirect_url="/extensions/default/setup/",
+        )
+
+    @responses.activate
+    def test_exchange_token_success(self) -> None:
+        responses.add(
+            responses.POST,
+            "https://example.org/oauth/token",
+            json={"access_token": "a-fake-token"},
+        )
+        ctx = _FakePipelineContext(signature="valid-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "valid-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ADVANCE
+        assert ctx.fetch_state("data") == {"access_token": "a-fake-token"}
+
+        assert len(responses.calls) == 1
+        data = dict(parse_qsl(responses.calls[0].request.body))
+        assert data["grant_type"] == "authorization_code"
+        assert data["code"] == "auth-code"
+        assert data["client_id"] == "123456"
+        assert data["client_secret"] == "secret-value"
+
+    def test_invalid_state(self) -> None:
+        ctx = _FakePipelineContext(signature="correct-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "wrong-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "detail" in result.data
+
+    @responses.activate
+    def test_ssl_error(self) -> None:
+        def ssl_error(request):
+            raise SSLError("Could not build connection")
+
+        responses.add_callback(
+            responses.POST, "https://example.org/oauth/token", callback=ssl_error
+        )
+        ctx = _FakePipelineContext(signature="valid-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "valid-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "SSL" in result.data["detail"]
+
+    @responses.activate
+    def test_connection_error(self) -> None:
+        def connection_error(request):
+            raise ConnectionError("Name or service not known")
+
+        responses.add_callback(
+            responses.POST, "https://example.org/oauth/token", callback=connection_error
+        )
+        ctx = _FakePipelineContext(signature="valid-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "valid-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "connect" in result.data["detail"].lower()
+
+    @responses.activate
+    def test_empty_response_body(self) -> None:
+        responses.add(responses.POST, "https://example.org/oauth/token", body="")
+        ctx = _FakePipelineContext(signature="valid-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "valid-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "json" in result.data["detail"].lower()
+
+    @responses.activate
+    def test_api_error_401(self) -> None:
+        responses.add(
+            responses.POST,
+            "https://example.org/oauth/token",
+            json={"error": "unauthorized"},
+            status=401,
+        )
+        ctx = _FakePipelineContext(signature="valid-state")
+        result = self.step.handle_post(
+            {"code": "auth-code", "state": "valid-state"}, ctx, self.request
+        )
+
+        assert result.action == PipelineStepAction.ERROR
+        assert "401" in result.data["detail"]

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote, urlencode
 
@@ -7,6 +10,10 @@ from django.urls import reverse
 
 from sentry.integrations.bitbucket.integration import BitbucketIntegrationProvider
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.integrations.utils.atlassian_connect import AtlassianConnectValidationError
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
@@ -268,3 +275,93 @@ class BitbucketIntegrationTest(APITestCase):
             installation.get_repository_choices(None, {})
         assert mock_record_halt.call_count == 0
         assert mock_record_failure.call_count == 1
+
+
+@control_silo_test
+class BitbucketApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.subject = "connect:1234567"
+        self.shared_secret = "234567890"
+        self.integration = self.create_provider_integration(
+            provider="bitbucket",
+            external_id=self.subject,
+            name="sentryuser",
+            metadata={
+                "base_url": "https://api.bitbucket.org",
+                "shared_secret": self.shared_secret,
+            },
+        )
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "bitbucket"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "authorize"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "bitbucket"
+        assert "authorizeUrl" in resp.data["data"]
+        assert "bitbucket.org/site/addons/authorize" in resp.data["data"]["authorizeUrl"]
+
+    @responses.activate
+    def test_missing_jwt(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+
+    @responses.activate
+    @patch(
+        "sentry.integrations.bitbucket.integration.get_integration_from_jwt",
+        side_effect=AtlassianConnectValidationError("Invalid JWT"),
+    )
+    def test_invalid_jwt(self, mock_verify: MagicMock) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({"jwt": "invalid-token"})
+        assert resp.status_code == 400
+        assert "Unable to verify installation" in resp.data["jwt"][0]
+
+    @responses.activate
+    @patch("sentry.integrations.bitbucket.integration.get_integration_from_jwt")
+    def test_full_pipeline_flow(self, mock_verify: MagicMock) -> None:
+        mock_verify.return_value = RpcIntegration(
+            id=self.integration.id,
+            provider=self.integration.provider,
+            external_id=self.subject,
+            name=self.integration.name,
+            metadata=self.integration.metadata,
+            status=self.integration.status,
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "authorize"
+
+        resp = self._advance_step({"jwt": "valid-jwt-token"})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=self.integration,
+        ).exists()

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -28,7 +28,8 @@ from sentry.integrations.github.integration import (
     GitHubInstallationError,
     GitHubIntegration,
     GitHubIntegrationProvider,
-    OAuthLoginView,
+    _get_eligible_multi_org_installations,
+    _get_owner_github_organizations,
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -1658,10 +1659,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_github_installation_gets_owner_orgs(self) -> None:
         self._setup_with_existing_installations()
-        pipeline_view = OAuthLoginView()
-        pipeline_view.client = GithubSetupApiClient(self.access_token)
+        client = GithubSetupApiClient(self.access_token)
 
-        owner_orgs = pipeline_view._get_owner_github_organizations()
+        owner_orgs = _get_owner_github_organizations(client)
 
         assert owner_orgs == ["santry"]
 
@@ -1669,15 +1669,12 @@ class GitHubIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_github_installation_filters_valid_installations(self) -> None:
         self._setup_with_existing_installations()
-        pipeline_view = OAuthLoginView()
-        pipeline_view.client = GithubSetupApiClient(self.access_token)
+        client = GithubSetupApiClient(self.access_token)
 
-        owner_orgs = pipeline_view._get_owner_github_organizations()
+        owner_orgs = _get_owner_github_organizations(client)
         assert owner_orgs == ["santry"]
 
-        installation_info = pipeline_view._get_eligible_multi_org_installations(
-            owner_orgs=owner_orgs
-        )
+        installation_info = _get_eligible_multi_org_installations(client, owner_orgs)
 
         assert installation_info == [
             {

--- a/tests/sentry/integrations/github/test_integration_api_pipeline.py
+++ b/tests/sentry/integrations/github/test_integration_api_pipeline.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
+
+import pytest
+import responses
+from django.urls import reverse
+
+from sentry.integrations.github import client
+from sentry.integrations.github.integration import (
+    GitHubInstallationError,
+)
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers import with_feature
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test
+class GitHubIntegrationApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    base_url = "https://api.github.com"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.installation_id = "install_1"
+        self.user_id = "user_1"
+        self.app_id = "app_1"
+        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.expires_at = "3000-01-01T00:00:00Z"
+        self.login_as(self.user)
+        self._stub_github()
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt(self):
+        with mock.patch.object(client, "get_jwt", return_value="jwt_token_1"):
+            yield
+
+    @pytest.fixture(autouse=True)
+    def stub_get_jwt_function(self):
+        with mock.patch("sentry.integrations.github.utils.get_jwt", return_value="jwt_token_1"):
+            yield
+
+    def _stub_github(self) -> None:
+        """Stubs GitHub API responses needed for the integration pipeline."""
+        self.gh_org = "Test-Organization"
+
+        responses.add(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            body=f"access_token={self.access_token}",
+        )
+        responses.add(responses.GET, self.base_url + "/user", json={"login": "octocat"})
+        responses.add(
+            responses.POST,
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
+            json={
+                "token": self.access_token,
+                "expires_at": self.expires_at,
+                "permissions": {
+                    "administration": "read",
+                    "contents": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "pull_requests": "read",
+                },
+                "repository_selection": "all",
+            },
+        )
+
+        repositories: dict[str, Any] = {
+            "xyz": {
+                "name": "xyz",
+                "full_name": "Test-Organization/xyz",
+                "default_branch": "master",
+            },
+            "foo": {
+                "id": 1296269,
+                "name": "foo",
+                "full_name": "Test-Organization/foo",
+                "default_branch": "master",
+            },
+        }
+
+        responses.add(
+            responses.GET,
+            url=self.base_url + "/installation/repositories",
+            json={
+                "total_count": len(repositories),
+                "repositories": list(repositories.values()),
+            },
+        )
+
+        responses.add(
+            responses.GET,
+            self.base_url + f"/app/installations/{self.installation_id}",
+            json={
+                "id": self.installation_id,
+                "app_id": self.app_id,
+                "account": {
+                    "id": 60591805,
+                    "login": "Test Organization",
+                    "avatar_url": "http://example.com/avatar.png",
+                    "html_url": "https://github.com/Test-Organization",
+                    "type": "Organization",
+                },
+            },
+        )
+
+        responses.add(responses.GET, self.base_url + "/repos/Test-Organization/foo/hooks", json=[])
+
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/user/memberships/orgs",
+            json=[
+                {
+                    "state": "active",
+                    "role": "admin",
+                    "organization": {
+                        "login": "santry",
+                        "id": 1,
+                        "avatar_url": "https://example.com/santry.png",
+                    },
+                },
+            ],
+        )
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        """POST action=initialize to start the pipeline, return the response."""
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "github"},
+            format="json",
+        )
+
+    def _get_step_info(self) -> Any:
+        """GET current step info."""
+        return self.client.get(self._get_pipeline_url())
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        """POST to advance the pipeline with step-specific data."""
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _get_pipeline_signature(self, init_resp: Any) -> str:
+        """Extract the pipeline signature (OAuth state) from an initialize response."""
+        return init_resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    def _stub_user_installations(self, installations: list[dict[str, Any]] | None = None) -> None:
+        """Stub the GitHub /user/installations endpoint."""
+        if installations is None:
+            installations = [
+                {
+                    "id": self.installation_id,
+                    "target_type": "Organization",
+                    "account": {
+                        "login": "santry",
+                        "avatar_url": "https://example.com/santry.png",
+                    },
+                }
+            ]
+        responses.add(
+            responses.GET,
+            f"{self.base_url}/user/installations",
+            json={"installations": installations},
+        )
+
+    def _complete_oauth_step(self, pipeline_signature: str, **extra: Any) -> Any:
+        """Submit the OAuth callback data to advance past the OAuth step."""
+        return self._advance_step(
+            {
+                "code": "12345678901234567890",
+                "state": pipeline_signature,
+                **extra,
+            }
+        )
+
+    def _advance_to_org_selection(self) -> str:
+        """Initialize pipeline and complete OAuth, returning the pipeline signature."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+        return pipeline_signature
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 2
+        assert resp.data["provider"] == "github"
+        assert "oauthUrl" in resp.data["data"]
+
+    @responses.activate
+    def test_get_oauth_step_info(self) -> None:
+        self._initialize_pipeline()
+        resp = self._get_step_info()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "github.com/login/oauth/authorize" in oauth_url
+        assert "client_id=" in oauth_url
+
+    @responses.activate
+    def test_oauth_step_advance(self) -> None:
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+        assert resp.data["stepIndex"] == 1
+
+    @responses.activate
+    def test_oauth_step_invalid_state(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step(
+            {
+                "code": "12345678901234567890",
+                "state": "invalid_state_value",
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "error"
+        assert GitHubInstallationError.INVALID_STATE in resp.data["data"]["detail"]
+
+    @responses.activate
+    def test_oauth_step_missing_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "stay"
+        assert "errors" in resp.data["data"]
+
+    @responses.activate
+    def test_org_selection_get_with_installations(self) -> None:
+        self._advance_to_org_selection()
+        resp = self._get_step_info()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "org_selection"
+        data = resp.data["data"]
+        assert "installAppUrl" in data
+        assert "installationInfo" in data
+        assert len(data["installationInfo"]) > 0
+
+    @responses.activate
+    @with_feature("organizations:integrations-scm-multi-org")
+    def test_org_selection_choose_existing_installation(self) -> None:
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "chosen_installation_id": self.installation_id,
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
+    def test_org_selection_new_installation_from_popup(self) -> None:
+        """When user installs the app via the GitHub popup, installation_id comes in the POST."""
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "installation_id": self.installation_id,
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
+    def test_full_api_pipeline_flow_new_installation(self) -> None:
+        """End-to-end: initialize -> OAuth -> skip org selection -> complete."""
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        self._stub_user_installations(installations=[])
+
+        resp = self._complete_oauth_step(pipeline_signature, installation_id=self.installation_id)
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+
+        resp = self._advance_step({"installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="github")
+        assert integration.external_id == self.installation_id
+        assert integration.name == "Test Organization"
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    @with_feature("organizations:integrations-scm-multi-org")
+    def test_full_api_pipeline_flow_existing_installation(self) -> None:
+        """End-to-end: initialize -> OAuth -> choose existing installation -> complete."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+        self._stub_user_installations()
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "org_selection"
+
+        resp = self._advance_step({"chosen_installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="github")
+        assert integration.external_id == self.installation_id
+
+    @responses.activate
+    def test_oauth_exchange_failure(self) -> None:
+        """OAuth code exchange fails when GitHub returns no access_token."""
+        resp = self._initialize_pipeline()
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        responses.replace(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            body="error=bad_verification_code",
+        )
+
+        resp = self._complete_oauth_step(pipeline_signature)
+        assert resp.status_code == 200
+        assert resp.data["status"] == "error"
+
+    @responses.activate
+    def test_org_selection_invalid_installation(self) -> None:
+        """Choosing an installation not in the user's list fails validation."""
+        self._advance_to_org_selection()
+
+        resp = self._advance_step(
+            {
+                "chosen_installation_id": "99999",
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "error"

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -7,6 +10,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import orjson
 import pytest
 import responses
+from django.urls import reverse
 
 from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClient
 from sentry.integrations.github_enterprise.integration import (
@@ -15,6 +19,7 @@ from sentry.integrations.github_enterprise.integration import (
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
@@ -22,7 +27,7 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1170,3 +1175,185 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
                     "body": "**** wrote:\n\n> hello world\n> This is a comment.\n> \n> \n>     I've changed it"
                 },
             )
+
+
+@control_silo_test
+class GitHubEnterpriseApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    ghe_host = "github.example.com"
+    ghe_url = f"https://{ghe_host}"
+    installation_id = "12345"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "github_enterprise"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _submit_config(self, **overrides: Any) -> Any:
+        data = {
+            "url": self.ghe_url,
+            "id": "1",
+            "name": "sentry-app",
+            "verifySsl": True,
+            "webhookSecret": "webhook-secret-123",
+            "privateKey": "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+            "clientId": "client-id-abc",
+            "clientSecret": "client-secret-xyz",
+        }
+        data.update(overrides)
+        return self._advance_step(data)
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    def _stub_ghe_oauth(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.ghe_url}/login/oauth/access_token",
+            json={
+                "access_token": "test-access-token",
+                "token_type": "bearer",
+            },
+        )
+
+    def _stub_ghe_user(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/user",
+            json={"id": 42, "login": "testuser"},
+        )
+
+    def _stub_ghe_installation(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/app/installations/{self.installation_id}",
+            json={
+                "id": int(self.installation_id),
+                "app_id": 1,
+                "account": {
+                    "login": "Test-Org",
+                    "avatar_url": f"{self.ghe_url}/avatar.png",
+                    "html_url": f"{self.ghe_url}/Test-Org",
+                    "type": "Organization",
+                },
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/user/installations",
+            json={
+                "installations": [
+                    {
+                        "id": int(self.installation_id),
+                        "app_id": 1,
+                        "account": {
+                            "login": "Test-Org",
+                            "avatar_url": f"{self.ghe_url}/avatar.png",
+                            "html_url": f"{self.ghe_url}/Test-Org",
+                            "type": "Organization",
+                        },
+                    }
+                ]
+            },
+        )
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 3
+        assert resp.data["provider"] == "github_enterprise"
+
+    @responses.activate
+    def test_config_step_advance(self) -> None:
+        self._initialize_pipeline()
+        resp = self._submit_config()
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "app_install_redirect"
+        assert resp.data["stepIndex"] == 1
+        assert "appInstallUrl" in resp.data["data"]
+        assert "sentry-app" in resp.data["data"]["appInstallUrl"]
+
+    @responses.activate
+    def test_config_step_validation_missing_required_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({"url": self.ghe_url})
+        assert resp.status_code == 400
+        for field in ("id", "name", "webhookSecret", "privateKey", "clientId", "clientSecret"):
+            assert resp.data[field] == ["This field is required."]
+
+    @responses.activate
+    def test_app_install_step_no_installation_id(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "stay"
+        assert "appInstallUrl" in resp.data["data"]
+
+    @responses.activate
+    def test_app_install_step_with_installation_id(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({"installationId": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "oauth_login"
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert self.ghe_host in oauth_url
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token"
+    )
+    def test_full_pipeline_flow(self, mock_jwt: MagicMock) -> None:
+        self._stub_ghe_oauth()
+        self._stub_ghe_user()
+        self._stub_ghe_installation()
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._submit_config()
+        assert resp.data["step"] == "app_install_redirect"
+
+        resp = self._advance_step({"installationId": self.installation_id})
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="github_enterprise")
+        assert integration.metadata["installation_id"] == int(self.installation_id)
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
@@ -8,6 +11,7 @@ import pytest
 import responses
 from django.core.cache import cache
 from django.test import override_settings
+from django.urls import reverse
 
 from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
@@ -16,6 +20,7 @@ from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_
 from sentry.integrations.gitlab.integration import GitlabIntegration, GitlabIntegrationProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
@@ -27,7 +32,7 @@ from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiForbiddenError, IntegrationConfigurationError
 from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1355,3 +1360,210 @@ class GitlabIssueSyncTest(GitLabTestCase):
         assert org_integration.config["existing_key"] == "existing_value"
         assert org_integration.config["sync_forward_assignment"] is True
         assert org_integration.config["sync_comments"] is True
+
+
+@control_silo_test
+class GitLabIntegrationApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    gitlab_url = "https://gitlab.example.com"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.client_id = "app-id-abc123"
+        self.client_secret = "secret-xyz789"
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "gitlab"},
+            format="json",
+        )
+
+    def _get_step_info(self) -> Any:
+        return self.client.get(self._get_pipeline_url())
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _stub_gitlab_oauth(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.gitlab_url}/oauth/token",
+            json={
+                "access_token": "test-access-token",
+                "token_type": "bearer",
+                "refresh_token": "test-refresh-token",
+                "created_at": 1536798907,
+                "scope": "api",
+            },
+        )
+
+    def _stub_gitlab_user(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.gitlab_url}/api/v4/user",
+            json={
+                "id": 42,
+                "username": "testuser",
+                "email": "test@example.com",
+                "name": "Test User",
+            },
+        )
+
+    def _stub_gitlab_group(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.gitlab_url}/api/v4/groups/my-group",
+            json={
+                "id": 1,
+                "full_name": "My Group",
+                "full_path": "my-group",
+                "avatar_url": "https://gitlab.example.com/avatar.png",
+                "web_url": "https://gitlab.example.com/my-group",
+            },
+        )
+
+    def _submit_config(self, **overrides: Any) -> Any:
+        data = {
+            "url": self.gitlab_url,
+            "group": "my-group",
+            "includeSubgroups": False,
+            "verifySsl": True,
+            "clientId": self.client_id,
+            "clientSecret": self.client_secret,
+        }
+        data.update(overrides)
+        return self._advance_step(data)
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 2
+        assert resp.data["provider"] == "gitlab"
+
+    @responses.activate
+    def test_config_step_data(self) -> None:
+        resp = self._initialize_pipeline()
+        data = resp.data["data"]
+        defaults = data["defaults"]
+        assert defaults["verifySsl"] is True
+        assert defaults["includeSubgroups"] is False
+        setup_values = data["setupValues"]
+        labels = [v["label"] for v in setup_values]
+        assert "Name" in labels
+        assert "Redirect URI" in labels
+        assert "Scopes" in labels
+
+    @responses.activate
+    def test_config_step_validation_missing_required_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({"url": self.gitlab_url})
+        assert resp.status_code == 400
+        assert resp.data["clientId"] == ["This field is required."]
+        assert resp.data["clientSecret"] == ["This field is required."]
+
+    @responses.activate
+    def test_config_step_advance_to_oauth(self) -> None:
+        self._initialize_pipeline()
+        resp = self._submit_config()
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 1
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert self.gitlab_url in oauth_url
+        assert "client_id=" in oauth_url
+
+    @responses.activate
+    def test_oauth_step_invalid_state(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({"code": "abc123", "state": "wrong-state"})
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+
+    @responses.activate
+    def test_oauth_step_missing_code(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+        assert resp.data["code"] == ["This field is required."]
+        assert resp.data["state"] == ["This field is required."]
+
+    @responses.activate
+    def test_full_pipeline_flow(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+        self._stub_gitlab_group()
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._submit_config()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "gitlab-auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="gitlab")
+        assert integration.metadata["base_url"] == self.gitlab_url
+        assert integration.metadata["group_id"] == 1
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    def test_full_pipeline_flow_no_group(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+
+        self._initialize_pipeline()
+        resp = self._submit_config(group="")
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "gitlab-auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="gitlab")
+        assert integration.metadata["group_id"] is None
+        assert integration.metadata["include_subgroups"] is False
+
+    @responses.activate
+    def test_config_strips_trailing_slash(self) -> None:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+        self._stub_gitlab_group()
+
+        self._initialize_pipeline()
+        resp = self._submit_config(url=f"{self.gitlab_url}///")
+        assert resp.data["status"] == "advance"
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "gitlab.example.com/oauth/authorize" in oauth_url
+        assert "///" not in oauth_url

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import orjson
 import pytest
 import responses
+from django.urls import reverse
 from responses.matchers import query_string_matcher
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
@@ -11,6 +15,7 @@ from slack_sdk.web import SlackResponse
 from sentry import audit_log
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.slack import SlackIntegration, SlackIntegrationProvider
 from sentry.integrations.slack.utils.constants import SlackScope
 from sentry.integrations.slack.utils.users import SLACK_GET_USERS_PAGE_SIZE
@@ -653,3 +658,107 @@ class SlackIntegrationNotificationPlatformTest(TestCase):
             channel_id=self.channel_id, thread_ts=self.thread_ts
         )
         assert result == []
+
+
+@control_silo_test
+class SlackApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "slack"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "slack"
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "slack.com/oauth/v2/authorize" in oauth_url
+        assert "user_scope=" in oauth_url
+
+    @responses.activate
+    def test_oauth_step_missing_code(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+
+    @responses.activate
+    @patch("sentry.integrations.slack.integration.WebClient")
+    def test_full_pipeline_flow(self, mock_web_client_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_web_client_cls.return_value = mock_client
+        mock_client.team_info.return_value = SlackResponse(
+            client=mock_client,
+            http_verb="GET",
+            api_url="https://slack.com/api/team.info",
+            req_args={},
+            data={
+                "ok": True,
+                "team": {
+                    "name": "Test Team",
+                    "id": "T1234",
+                    "domain": "test-team",
+                    "icon": {"image_132": "https://example.com/icon.png"},
+                },
+            },
+            headers={},
+            status_code=200,
+        )
+
+        responses.add(
+            responses.POST,
+            "https://slack.com/api/oauth.v2.access",
+            json={
+                "ok": True,
+                "access_token": "xoxb-test-token",
+                "scope": "channels:read,chat:write",
+                "team": {"name": "Test Team", "id": "T1234"},
+                "authed_user": {"id": "U1234"},
+            },
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "slack-auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="slack")
+        assert integration.external_id == "T1234"
+        assert integration.name == "Test Team"
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)