### PR TITLE
ref(onboarding): replace useRouter with specific hooks in platformDocHeader

### DIFF
--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -14,8 +14,8 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
+import useNavigate from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
-import useRouter from 'sentry/utils/useRouter';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 type Props = {
@@ -27,7 +27,7 @@ type Props = {
 export function PlatformDocHeader({platform, projectSlug, title}: Props) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
-  const router = useRouter();
+  const navigate = useNavigate();
 
   const {project: recentCreatedProject, isProjectActive} = useRecentCreatedProject({
     orgSlug: organization.slug,
@@ -73,13 +73,14 @@ export function PlatformDocHeader({platform, projectSlug, title}: Props) {
       }
     }
 
-    router.replace(
+    navigate(
       makeProjectsPathname({
         path: '/new/',
         organization,
-      }) + `?referrer=getting-started&project=${recentCreatedProject.id}`
+      }) + `?referrer=getting-started&project=${recentCreatedProject.id}`,
+      {replace: true}
     );
-  }, [api, recentCreatedProject, organization, isProjectActive, router]);
+  }, [api, recentCreatedProject, organization, isProjectActive, navigate]);
 
   useBlocker(({historyAction}) => {
     if (historyAction === 'POP') {

--- a/static/app/views/projectInstall/platformDocHeader.tsx
+++ b/static/app/views/projectInstall/platformDocHeader.tsx
@@ -14,7 +14,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
-import useNavigate from 'sentry/utils/useNavigate';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)