### PR TITLE
ref(app): replace useRouter with specific hooks in routeAnalyticsContextProvider

### DIFF
--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -42,7 +42,8 @@ export default function RouteAnalyticsContextProvider({children}: Props) {
     params: useParams(),
     routes: useRoutes(),
     location: useLocation(),
-  };
+    router: undefined,
+  } as Parameters<NonNullable<typeof useRouteActivatedHook>>[0];
 
   const {
     setDisableRouteAnalytics,

--- a/static/app/views/routeAnalyticsContextProvider.tsx
+++ b/static/app/views/routeAnalyticsContextProvider.tsx
@@ -1,11 +1,9 @@
 import {createContext, useMemo} from 'react';
 
 import HookStore from 'sentry/stores/hookStore';
-import type {RouteContextInterface} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
-import useRouter from 'sentry/utils/useRouter';
 import {useRoutes} from 'sentry/utils/useRoutes';
 
 const DEFAULT_CONTEXT = {
@@ -40,10 +38,9 @@ interface Props {
 export default function RouteAnalyticsContextProvider({children}: Props) {
   const useRouteActivatedHook = HookStore.get('react-hook:route-activated')[0];
 
-  const context: RouteContextInterface = {
+  const context = {
     params: useParams(),
     routes: useRoutes(),
-    router: useRouter(),
     location: useLocation(),
   };
 


### PR DESCRIPTION
Part of the React Router 6 cleanup — replaces `useRouter()` with specific hooks (`useNavigate`, `useLocation`, `useParams`, etc.)