### PR TITLE
ref(spans): Make HDEL redirect map batch size configurable via option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3298,6 +3298,14 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Batch size for HDEL calls when removing spans from the redirect map during flush.
+register(
+    "spans.buffer.hdel-redirect-map-batch-size",
+    type=Int,
+    default=100,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Segments consumer
 register(
     "spans.process-segments.consumer.enable",

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -744,6 +744,7 @@ class SpansBuffer:
         return payloads
 
     def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
+        hdel_batch_size = options.get("spans.buffer.hdel-redirect-map-batch-size")
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
         with metrics.timer("spans.buffer.done_flush_segments"):
             with self.client.pipeline(transaction=False) as p:
@@ -757,7 +758,7 @@ class SpansBuffer:
                     project_id, trace_id, _ = parse_segment_key(segment_key)
                     redirect_map_key = b"span-buf:ssr:{%s:%s}" % (project_id, trace_id)
 
-                    for span_batch in itertools.batched(flushed_segment.spans, 100):
+                    for span_batch in itertools.batched(flushed_segment.spans, hdel_batch_size):
                         span_ids = [output_span.payload["span_id"] for output_span in span_batch]
                         p.hdel(redirect_map_key, *span_ids)
 

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -744,7 +744,7 @@ class SpansBuffer:
         return payloads
 
     def done_flush_segments(self, segment_keys: dict[SegmentKey, FlushedSegment]):
-        hdel_batch_size = options.get("spans.buffer.hdel-redirect-map-batch-size")
+        hdel_batch_size = max(1, options.get("spans.buffer.hdel-redirect-map-batch-size"))
         metrics.timing("spans.buffer.done_flush_segments.num_segments", len(segment_keys))
         with metrics.timer("spans.buffer.done_flush_segments"):
             with self.client.pipeline(transaction=False) as p:

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -31,6 +31,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.debug-traces": [],
     "spans.buffer.evalsha-cumulative-logger-enabled": True,
     "spans.buffer.zero-copy-dest-threshold-bytes": 0,
+    "spans.buffer.hdel-redirect-map-batch-size": 100,
 }
 
 
@@ -1250,4 +1251,59 @@ def test_partition_routing_stable_across_rebalance() -> None:
         assert rv[seg_key].queue_key == b"span-buf:q:1"
 
         buf.done_flush_segments(rv)
+        assert_clean(buf.client)
+
+
+@pytest.mark.parametrize("batch_size,expected_batches", [(2, 3), (3, 2), (5, 1)])
+def test_hdel_redirect_map_batch_size(batch_size: int, expected_batches: int) -> None:
+    """
+    Test that done_flush_segments correctly batches HDEL calls
+    """
+    with override_options(
+        {
+            **DEFAULT_OPTIONS,
+            "spans.buffer.hdel-redirect-map-batch-size": batch_size,
+        }
+    ):
+        buf = SpansBuffer(assigned_shards=list(range(32)))
+        buf.client.flushdb()
+
+        spans = [
+            Span(
+                payload=_payload(f"{c}" * 16),
+                trace_id="a" * 32,
+                span_id=f"{c}" * 16,
+                parent_span_id="a" * 16 if c != "a" else None,
+                segment_id=None,
+                is_segment_span=(c == "a"),
+                project_id=1,
+                end_timestamp=1700000000.0,
+            )
+            for c in "abcde"
+        ]
+
+        process_spans(spans, buf, now=0)
+
+        rv = buf.flush_segments(now=11)
+        _normalize_output(rv)
+
+        seg_key = _segment_id(1, "a" * 32, "a" * 16)
+        assert seg_key in rv
+        assert len(rv[seg_key].spans) == 5
+
+        batch_sizes_seen: list[int] = []
+        real_batched = itertools.batched
+
+        def tracking_batched(iterable, n):
+            for batch in real_batched(iterable, n):
+                batch_sizes_seen.append(n)
+                yield batch
+
+        with mock.patch("sentry.spans.buffer.itertools.batched", tracking_batched):
+            buf.done_flush_segments(rv)
+
+        assert len(batch_sizes_seen) == expected_batches
+        assert all(n == batch_size for n in batch_sizes_seen)
+
+        assert buf.flush_segments(now=30) == {}
         assert_clean(buf.client)


### PR DESCRIPTION
Make the HDEL batch size for redirect map cleanup in done_flush_segments configurable with the `spans.buffer.hdel-redirect-map-batch-size` option (default 100).