### PR TITLE
ref(button) handle busy state

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -18,6 +18,7 @@ type AssigneeBadgeProps = {
   assignedTo?: Actor | undefined;
   assignmentReason?: SuggestedOwnerReason;
   chevronDirection?: 'up' | 'down';
+  className?: string;
   isTooltipDisabled?: boolean;
   loading?: boolean;
   showLabel?: boolean;
@@ -32,6 +33,7 @@ export function AssigneeBadge({
   chevronDirection = 'down',
   loading = false,
   isTooltipDisabled,
+  className,
 }: AssigneeBadgeProps) {
   const theme = useTheme();
   const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
@@ -90,7 +92,7 @@ export function AssigneeBadge({
   );
 
   return loading ? (
-    <StyledTag icon={loadingIcon} variant="muted" />
+    <StyledTag className={className} icon={loadingIcon} variant="muted" />
   ) : assignedTo ? (
     <Tooltip
       isHoverable
@@ -106,7 +108,11 @@ export function AssigneeBadge({
       }
       skipWrapper
     >
-      <StyledTag icon={makeAssignedIcon(assignedTo)} variant="muted" />
+      <StyledTag
+        className={className}
+        icon={makeAssignedIcon(assignedTo)}
+        variant="muted"
+      />
     </Tooltip>
   ) : (
     <Tooltip
@@ -129,7 +135,7 @@ export function AssigneeBadge({
       }
       skipWrapper
     >
-      <UnassignedTag icon={unassignedIcon} variant="muted" />
+      <UnassignedTag className={className} icon={unassignedIcon} variant="muted" />
     </Tooltip>
   );
 }

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -247,24 +247,20 @@ export function GroupPriorityDropdown({
   );
 }
 
-const DropdownButton = styled(Button)`
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  border: none;
-  padding: 0;
-  height: unset;
-  border-radius: 20px;
-  box-shadow: none;
-
-  > span > div {
-    border-radius: 20px;
-  }
-`;
-
 const StyledTag = styled(Tag)`
   gap: ${p => p.theme.space['2xs']};
   position: relative;
   height: 24px;
   overflow: hidden;
+`;
+
+const DropdownButton = styled(Button)`
+  padding: 0;
+  border-radius: ${p => p.theme.radius.full};
+
+  ${StyledTag} {
+    border-radius: ${p => p.theme.radius.full};
+  }
 `;
 
 const InlinePlaceholder = styled(Placeholder)`

--- a/static/app/components/core/button/button.spec.tsx
+++ b/static/app/components/core/button/button.spec.tsx
@@ -26,6 +26,34 @@ describe('Button', () => {
 
     expect(spy).not.toHaveBeenCalled();
   });
+
+  it('does not call `onClick` on busy buttons', async () => {
+    const spy = jest.fn();
+    render(
+      <Button onClick={spy} busy>
+        Click me
+      </Button>
+    );
+    await userEvent.click(screen.getByText('Click me'));
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('shows spinner when busy', () => {
+    render(<Button busy>Busy Button</Button>);
+
+    const button = screen.getByRole('button', {name: 'Busy Button'});
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', {name: 'Busy'})).not.toHaveStyle({
+      visibility: 'hidden',
+    });
+  });
+
+  it('hides spinner when not busy', () => {
+    render(<Button>Normal Button</Button>);
+
+    expect(screen.queryByRole('status', {name: 'Busy'})).not.toBeInTheDocument();
+  });
 });
 
 describe('LinkButton', () => {

--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -61,6 +61,8 @@ export function Button({
             as="span"
             align="center"
             area="1 / 1"
+            width="100%"
+            justify="center"
             gap={iconGap}
             visibility={busy ? 'hidden' : undefined}
           >

--- a/static/app/components/core/button/button.tsx
+++ b/static/app/components/core/button/button.tsx
@@ -1,6 +1,7 @@
+import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconDefaultsProvider} from 'sentry/icons/useIconDefaults';
@@ -29,6 +30,13 @@ export function Button({
     busy,
   });
 
+  const iconGap =
+    props.icon && hasChildren
+      ? size === 'xs' || size === 'zero'
+        ? 'sm'
+        : 'md'
+      : undefined;
+
   return (
     <Tooltip
       skipWrapper
@@ -48,30 +56,25 @@ export function Button({
         onClick={handleClick}
         role="button"
       >
-        <Flex
-          as="span"
-          align="center"
-          justify="center"
-          minWidth="0"
-          height="100%"
-          whiteSpace="nowrap"
-        >
-          {props.icon && (
-            <Flex
-              as="span"
-              align="center"
-              flexShrink={0}
-              marginRight={
-                hasChildren ? (size === 'xs' || size === 'zero' ? 'sm' : 'md') : undefined
-              }
-            >
-              <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
-                {props.icon}
-              </IconDefaultsProvider>
-            </Flex>
-          )}
-          {props.children}
-        </Flex>
+        <Grid as="span" align="center" justifyItems="center" minWidth="0" height="100%">
+          <Flex
+            as="span"
+            align="center"
+            area="1 / 1"
+            gap={iconGap}
+            visibility={busy ? 'hidden' : undefined}
+          >
+            {props.icon && (
+              <Flex as="span" align="center" flexShrink={0}>
+                <IconDefaultsProvider size={BUTTON_ICON_SIZES[size]}>
+                  {props.icon}
+                </IconDefaultsProvider>
+              </Flex>
+            )}
+            {props.children}
+          </Flex>
+          {busy ? <BusySpinner role="status" aria-label="Busy" /> : null}
+        </Grid>
       </StyledButton>
     </Tooltip>
   );
@@ -79,4 +82,25 @@ export function Button({
 
 const StyledButton = styled('button')<ButtonProps>`
   ${p => getButtonStyles(p as any)}
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+const BusySpinner = styled('span')`
+  grid-area: 1 / 1;
+
+  &::after {
+    content: '';
+    display: block;
+    width: 1em;
+    height: 1em;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    animation: ${spin} 0.6s linear infinite;
+  }
 `;

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -132,11 +132,7 @@ export function DO_NOT_USE_getButtonStyles(
       zIndex: 1,
       position: 'relative',
 
-      display: 'inherit',
-      alignItems: 'inherit',
-      justifyContent: 'inherit',
       flex: '1',
-      gap: 'inherit',
       overflow: 'hidden',
 
       whiteSpace: 'nowrap',

--- a/static/app/components/core/form/scrapsForm.spec.tsx
+++ b/static/app/components/core/form/scrapsForm.spec.tsx
@@ -1,0 +1,65 @@
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+
+function TestForm({onSubmit}: {onSubmit?: () => Promise<void>}) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      name: 'default',
+    },
+    onSubmit: onSubmit ? async () => onSubmit() : undefined,
+  });
+
+  return (
+    <form.AppForm form={form}>
+      <form.AppField name="name">
+        {field => (
+          <input
+            value={field.state.value}
+            onChange={e => field.handleChange(e.target.value)}
+          />
+        )}
+      </form.AppField>
+      <form.SubmitButton>Save</form.SubmitButton>
+    </form.AppForm>
+  );
+}
+
+describe('SubmitButton', () => {
+  it('is not disabled when form has default values', () => {
+    render(<TestForm />);
+
+    expect(screen.getByRole('button', {name: 'Save'})).toBeEnabled();
+  });
+
+  it('is disabled and shows busy state while submitting', async () => {
+    let resolveSubmit!: () => void;
+    const submitPromise = () =>
+      new Promise<void>(resolve => {
+        resolveSubmit = resolve;
+      });
+
+    render(<TestForm onSubmit={submitPromise} />);
+
+    const button = screen.getByRole('button', {name: 'Save'});
+    await userEvent.click(button);
+
+    // Button should be busy and disabled while submitting
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-busy', 'true');
+    });
+    expect(button).toBeDisabled();
+
+    // Resolve the submit
+    act(() => {
+      resolveSubmit();
+    });
+
+    // Button should no longer be busy
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute('aria-busy', 'true');
+    });
+    expect(button).toBeEnabled();
+  });
+});

--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -69,14 +69,15 @@ const {useAppForm} = createFormHook({
 function SubmitButton(props: ButtonProps) {
   const form = useFormContext();
   return (
-    <form.Subscribe selector={state => state.isSubmitting || state.isDefaultValue}>
-      {isDisabled => (
+    <form.Subscribe selector={state => state.isSubmitting}>
+      {isSubmitting => (
         <Button
           {...props}
           priority="primary"
           type="submit"
           form={form.formId}
-          disabled={isDisabled || props.disabled}
+          busy={isSubmitting}
+          disabled={isSubmitting || props.disabled}
         />
       )}
     </form.Subscribe>

--- a/static/app/components/core/layout/container.tsx
+++ b/static/app/components/core/layout/container.tsx
@@ -84,6 +84,8 @@ interface ContainerLayoutProps {
   alignSelf?: Responsive<React.CSSProperties['alignSelf']>;
   justifySelf?: Responsive<React.CSSProperties['justifySelf']>;
 
+  visibility?: Responsive<'visible' | 'hidden' | 'collapse'>;
+
   // Text Wrapping
   whiteSpace?: Responsive<
     'break-spaces' | 'normal' | 'nowrap' | 'pre' | 'pre-line' | 'pre-wrap'
@@ -222,6 +224,7 @@ const omitContainerProps = new Set<keyof ContainerLayoutProps | 'as'>([
   'right',
   'row',
   'top',
+  'visibility',
   'width',
   'whiteSpace',
 ]);
@@ -309,6 +312,7 @@ export const Container = styled(
   ${p => rc('border-left', p.borderLeft, p.theme, getBorder)};
   ${p => rc('border-right', p.borderRight, p.theme, getBorder)};
 
+  ${p => rc('visibility', p.visibility, p.theme)};
   ${p => rc('white-space', p.whiteSpace, p.theme)};
 
   /**

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -116,7 +116,7 @@ export function AssigneeSelector({
           aria-label={t('Modify issue assignee')}
           size="zero"
         >
-          <AssigneeBadge
+          <StyledAssigneeBadge
             assignedTo={group.assignedTo ?? undefined}
             assignmentReason={
               group.owners?.find(owner => {
@@ -135,15 +135,11 @@ export function AssigneeSelector({
   );
 }
 
-const StyledTrigger = styled(OverlayTrigger.Button)`
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  border: none;
-  padding: 0;
-  height: unset;
-  border-radius: 20px;
-  box-shadow: none;
+const StyledAssigneeBadge = styled(AssigneeBadge)`
+  border-radius: ${p => p.theme.radius.full};
+`;
 
-  > span > div {
-    border-radius: 20px;
-  }
+const StyledTrigger = styled(OverlayTrigger.Button)`
+  padding: 0;
+  border-radius: ${p => p.theme.radius.full};
 `;

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -395,7 +395,7 @@ const StyledSummary = styled('summary')`
 
 const StyledButton = styled(Button)`
   width: 100%;
-  > span {
+  > span > span {
     display: block;
   }
 `;


### PR DESCRIPTION
Reverts 72228d7b413 and applies a change to the internal label that cause the contents of the button to stretch the full width - this was previously an implicit dependency as the flex container occupied the full width of the label