### PR TITLE
feat(dashboards): add text widget visualization

### DIFF
--- a/static/app/views/dashboards/types.tsx
+++ b/static/app/views/dashboards/types.tsx
@@ -38,6 +38,7 @@ export enum DisplayType {
   WHEEL = 'wheel',
   CATEGORICAL_BAR = 'categorical_bar',
   AGENTS_TRACES_TABLE = 'agents_traces_table',
+  TEXT = 'text',
 }
 
 export enum WidgetType {

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -92,6 +92,7 @@ import {
   convertTableDataToTabularData,
   decodeColumnAliases,
 } from 'sentry/views/dashboards/widgets/tableWidget/utils';
+import {TextWidgetVisualization} from 'sentry/views/dashboards/widgets/textWidget/textWidgetVisualization';
 import {Thresholds as ThresholdsPlottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/thresholds';
 import {WheelWidgetVisualization} from 'sentry/views/dashboards/widgets/wheelWidget/wheelWidgetVisualization';
 import {Actions} from 'sentry/views/discover/table/cellAction';
@@ -267,6 +268,15 @@ function WidgetCardChart(props: WidgetCardChartProps) {
           frameless
         />
       </TableWrapper>
+    );
+  }
+
+  if (widget.displayType === DisplayType.TEXT) {
+    return (
+      <TransitionChart loading={loading} reloading={loading}>
+        <LoadingScreen loading={loading} showLoadingText={showLoadingText} />
+        <TextComponent {...props} />
+      </TransitionChart>
     );
   }
 
@@ -849,6 +859,16 @@ function WheelComponent(props: TableComponentProps): React.ReactNode {
       selection={props.selection}
     />
   );
+}
+
+function TextComponent(props: TableComponentProps): React.ReactNode {
+  const hasTextWidgets = useOrganization().features.includes('dashboards-text-widgets');
+
+  if (!hasTextWidgets) {
+    return null;
+  }
+
+  return <TextWidgetVisualization text={props.widget.description} />;
 }
 
 function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.spec.tsx
@@ -1,0 +1,91 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {TextWidgetVisualization} from './textWidgetVisualization';
+
+describe('TextWidgetVisualization', () => {
+  it('renders empty state with em dash when no description provided', () => {
+    render(<TextWidgetVisualization />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders empty state with em dash when description is empty string', () => {
+    render(<TextWidgetVisualization text="" />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders plain text without markdown', () => {
+    render(<TextWidgetVisualization text="This is plain text" />);
+    expect(screen.getByText('This is plain text')).toBeInTheDocument();
+  });
+
+  it('renders markdown bold text', () => {
+    render(<TextWidgetVisualization text="This is **bold text**" />);
+    const container = screen.getByText((content, element) => {
+      return element?.tagName === 'STRONG' && content === 'bold text';
+    });
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders markdown italic text', () => {
+    render(<TextWidgetVisualization text="This is *italic text*" />);
+    const container = screen.getByText((content, element) => {
+      return element?.tagName === 'EM' && content === 'italic text';
+    });
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders markdown links', () => {
+    render(<TextWidgetVisualization text="[Click here](https://example.com)" />);
+    const link = screen.getByRole('link', {name: 'Click here'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('renders markdown headings', () => {
+    render(<TextWidgetVisualization text="# Heading 1" />);
+    expect(
+      screen.getByRole('heading', {level: 1, name: 'Heading 1'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders markdown code blocks', async () => {
+    const code = '```javascript\nconst foo = "bar";\n```';
+    render(<TextWidgetVisualization text={code} />);
+    expect(await screen.findByText(/const foo/)).toBeInTheDocument();
+  });
+
+  it('renders markdown lists', () => {
+    const list = '- Item 1\n- Item 2\n- Item 3';
+    render(<TextWidgetVisualization text={list} />);
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+
+  it('renders multiline text with line breaks', () => {
+    const multiline = 'Line 1\n\nLine 2\n\nLine 3';
+    render(<TextWidgetVisualization text={multiline} />);
+    expect(screen.getByText('Line 1')).toBeInTheDocument();
+    expect(screen.getByText('Line 2')).toBeInTheDocument();
+    expect(screen.getByText('Line 3')).toBeInTheDocument();
+  });
+
+  it('renders complex markdown with mixed formatting', () => {
+    const markdown =
+      '# Title\n\nThis is **bold** and *italic* text with a [link](https://example.com)';
+    render(<TextWidgetVisualization text={markdown} />);
+    expect(screen.getByRole('heading', {level: 1, name: 'Title'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'link'})).toBeInTheDocument();
+  });
+
+  it('sanitizes dangerous markdown and does not execute scripts', () => {
+    const dangerousMarkdown = '[XSS](javascript:alert("XSS"))';
+    render(<TextWidgetVisualization text={dangerousMarkdown} />);
+    // Should render as plain text, not as a clickable link with javascript: protocol
+    const links = screen.queryAllByRole('link');
+    links.forEach(link => {
+      // eslint-disable-next-line no-script-url
+      expect(link.getAttribute('href')).not.toContain('javascript:');
+    });
+  });
+});

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.stories.tsx
@@ -38,7 +38,7 @@ export default Storybook.story('TextWidgetVisualization', story => {
     return (
       <Fragment>
         <p>
-          When the <code>text</code> prop is notprovided (or an empty string is passed),{' '}
+          When the <code>text</code> prop is not provided (or an empty string is passed),{' '}
           <Storybook.JSXNode name="TextWidgetVisualization" /> renders a centered em dash
           placeholder.
         </p>

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.stories.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.stories.tsx
@@ -1,0 +1,150 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {TextArea} from '@sentry/scraps/textarea';
+
+import * as Storybook from 'sentry/stories';
+
+import {TextWidgetVisualization} from './textWidgetVisualization';
+
+export default Storybook.story('TextWidgetVisualization', story => {
+  story('Getting Started', () => {
+    return (
+      <Fragment>
+        <p>
+          <Storybook.JSXNode name="TextWidgetVisualization" /> is a visualization used for
+          Text widgets in Dashboards. It renders freeform text with full Markdown support,
+          making it useful for adding notes, documentation, or context alongside your data
+          widgets.
+        </p>
+        <p>
+          It has features like:
+          <ul>
+            <li>
+              Markdown rendering (headings, bold, italic, links, lists, code blocks)
+            </li>
+            <li>Empty state with an em dash placeholder when no text is provided</li>
+            <li>Scrollable content area that fills its parent container</li>
+          </ul>
+          NOTE: The borders in this storybook are only for visual purposes and are not
+          part the TextWidgetVisualization component. The visualization's constraints are
+          imposed by its parent component.
+        </p>
+      </Fragment>
+    );
+  });
+
+  story('Empty State', () => {
+    return (
+      <Fragment>
+        <p>
+          When the <code>text</code> prop is notprovided (or an empty string is passed),{' '}
+          <Storybook.JSXNode name="TextWidgetVisualization" /> renders a centered em dash
+          placeholder.
+        </p>
+        <InvisibleWidgetFrame>
+          <TextWidgetVisualization />
+        </InvisibleWidgetFrame>
+      </Fragment>
+    );
+  });
+
+  story('Plain Text', () => {
+    return (
+      <Fragment>
+        <p>Plain text is rendered as-is inside a scrollable container with padding.</p>
+        <InvisibleWidgetFrame>
+          <TextWidgetVisualization text="This is a plain text widget. Use it to add notes or context to your dashboard." />
+        </InvisibleWidgetFrame>
+      </Fragment>
+    );
+  });
+
+  story('Markdown', () => {
+    return (
+      <Fragment>
+        <p>
+          <Storybook.JSXNode name="TextWidgetVisualization" /> supports full Markdown
+          syntax including headings, emphasis, links, lists, and code blocks.
+        </p>
+        <Storybook.SideBySide>
+          <div>
+            <p>Headings &amp; emphasis</p>
+            <InvisibleWidgetFrame>
+              <TextWidgetVisualization
+                text={`# Dashboard Notes\n\nThis widget shows **critical** metrics for the *payments* service.`}
+              />
+            </InvisibleWidgetFrame>
+          </div>
+          <div>
+            <p>Links &amp; lists</p>
+            <InvisibleWidgetFrame>
+              <TextWidgetVisualization
+                text={`## Runbook\n\n- Check the [error dashboard](https://sentry.io)\n- Review recent deploys\n- Page on-call if p99 > 500ms`}
+              />
+            </InvisibleWidgetFrame>
+          </div>
+          <div>
+            <p>Code blocks</p>
+            <InvisibleWidgetFrame>
+              <TextWidgetVisualization
+                text={"Query used:\n\n```sql\nSELECT *\nFROM foo\nWHERE bar = 'baz'\n```"}
+              />
+            </InvisibleWidgetFrame>
+          </div>
+        </Storybook.SideBySide>
+      </Fragment>
+    );
+  });
+
+  story('Long Content', () => {
+    return (
+      <Fragment>
+        <p>
+          When the text content exceeds the parent container's height, the visualization
+          container scrolls vertically.
+        </p>
+        <InvisibleWidgetFrame>
+          <TextWidgetVisualization
+            text={`# Section 1\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n# Section 2\n\nPellentesque habitant morbi tristique senectus et netus.\n\n# Section 3\n\nVivamus lacinia odio vitae vestibulum vestibulum.\n\n# Section 4\n\nDonec in efficitur leo, in commodo orci.`}
+          />
+        </InvisibleWidgetFrame>
+      </Fragment>
+    );
+  });
+
+  story('User Demo', () => {
+    const [text, setText] = useState('');
+    return (
+      <Fragment>
+        <p>
+          Now try it out for yourself! Try adding some text/markdown into the text field
+          and see how it renders in real-time.
+        </p>
+        <Storybook.SideBySide justify="between">
+          <div>
+            <p style={{fontWeight: 'bold'}}>Text</p>
+            <TextArea
+              value={text}
+              onChange={e => setText(e.target.value)}
+              style={{width: '300px', height: 300}}
+            />
+          </div>
+          <div>
+            <p style={{fontWeight: 'bold'}}>Markdown</p>
+            <InvisibleWidgetFrame>
+              <TextWidgetVisualization text={text} />
+            </InvisibleWidgetFrame>
+          </div>
+        </Storybook.SideBySide>
+      </Fragment>
+    );
+  });
+});
+
+const InvisibleWidgetFrame = styled('div')`
+  width: 400px;
+  height: 300px;
+  border: ${p => p.theme.border.md} dashed ${p => p.theme.colors.gray300};
+  border-radius: ${p => p.theme.radius.md};
+`;

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
@@ -1,7 +1,7 @@
-import {Fragment} from 'react';
+import {Fragment, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -15,11 +15,11 @@ interface TextWidgetProps {
 export function TextWidgetVisualization({text}: TextWidgetProps) {
   if (!text) {
     return (
-      <Flex align="center" justify="center" height="100%" minHeight="100px">
+      <EmptyStateContainer>
         <Text variant="muted" size="2xl">
           {EMPTY_PLACEHOLDER}
         </Text>
-      </Flex>
+      </EmptyStateContainer>
     );
   }
 
@@ -32,11 +32,23 @@ export function TextWidgetVisualization({text}: TextWidgetProps) {
   );
 }
 
-const TextContainer = styled('div')`
-  padding: ${p => p.theme.space.xl};
-  height: 100%;
-  overflow-y: auto;
-  white-space: pre-wrap;
+function EmptyStateContainer({children}: {children: ReactNode}) {
+  return (
+    <Flex align="center" justify="center" height="100%" minHeight="100px">
+      {children}
+    </Flex>
+  );
+}
+
+function TextContainer({children}: {children: ReactNode}) {
+  return (
+    <StyledContainer padding="xl" overflowY="auto" height="100%" whiteSpace="pre-wrap">
+      {children}
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled(Container)`
   word-wrap: break-word;
   overflow-wrap: break-word;
 `;

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
@@ -1,0 +1,42 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {MarkedText} from 'sentry/utils/marked/markedText';
+
+const EMPTY_PLACEHOLDER = '\u2014'; // em dash
+
+interface TextWidgetProps {
+  text?: string;
+}
+
+export function TextWidgetVisualization({text}: TextWidgetProps) {
+  if (!text) {
+    return (
+      <Flex align="center" justify="center" height="100%" minHeight="100px">
+        <Text variant="muted" size="2xl">
+          {EMPTY_PLACEHOLDER}
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Fragment>
+      <TextContainer>
+        <MarkedText text={text} />
+      </TextContainer>
+    </Fragment>
+  );
+}
+
+const TextContainer = styled('div')`
+  padding: ${p => p.theme.space.xl};
+  height: 100%;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+`;

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -24,11 +24,9 @@ export function TextWidgetVisualization({text}: TextWidgetProps) {
   }
 
   return (
-    <Fragment>
-      <TextContainer>
-        <MarkedText text={text} />
-      </TextContainer>
-    </Fragment>
+    <TextContainer>
+      <MarkedText text={text} />
+    </TextContainer>
   );
 }
 

--- a/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/textWidget/textWidgetVisualization.tsx
@@ -1,6 +1,3 @@
-import {type ReactNode} from 'react';
-import styled from '@emotion/styled';
-
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -15,38 +12,19 @@ interface TextWidgetProps {
 export function TextWidgetVisualization({text}: TextWidgetProps) {
   if (!text) {
     return (
-      <EmptyStateContainer>
+      <Flex align="start" justify="start" height="100%" minHeight="100px" padding="xl">
         <Text variant="muted" size="2xl">
           {EMPTY_PLACEHOLDER}
         </Text>
-      </EmptyStateContainer>
+      </Flex>
     );
   }
 
   return (
-    <TextContainer>
-      <MarkedText text={text} />
-    </TextContainer>
+    <Container padding="xl" overflowY="auto" height="100%" whiteSpace="normal">
+      <Text wordBreak="break-word">
+        <MarkedText text={text} />
+      </Text>
+    </Container>
   );
 }
-
-function EmptyStateContainer({children}: {children: ReactNode}) {
-  return (
-    <Flex align="center" justify="center" height="100%" minHeight="100px">
-      {children}
-    </Flex>
-  );
-}
-
-function TextContainer({children}: {children: ReactNode}) {
-  return (
-    <StyledContainer padding="xl" overflowY="auto" height="100%" whiteSpace="pre-wrap">
-      {children}
-    </StyledContainer>
-  );
-}
-
-const StyledContainer = styled(Container)`
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-`;


### PR DESCRIPTION
created the text widget visualization and added a story for it so it can be seen! It supports markdown (the component is approved by security on behalf of Geoff), is scrollable and has an empty state, all of which is documented in the storybook. I'll integrate this into widget builder and widget viewer modal in upcoming PRs.

an example:
<img width="521" height="338" alt="image" src="https://github.com/user-attachments/assets/ad7176dd-adb6-4442-82c3-cea3e2dc2bd1" />
