### PR TITLE
chore(tests): replace store_profile_functions with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1262,17 +1262,6 @@ class SnubaTestCase(BaseTestCase):
         )
         assert response.status_code == 200
 
-    def store_profile_functions(self, profile_functions):
-        files = {
-            f"profile_functions_{i}": profile_function.SerializeToString()
-            for i, profile_function in enumerate(profile_functions)
-        }
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
     def store_eap_items(self, items: Sequence[TraceItem]) -> None:
         files = {f"eap_items_{i}": item.SerializeToString() for i, item in enumerate(items)}
         response = requests.post(

--- a/tests/snuba/api/endpoints/test_organization_events_profile_functions.py
+++ b/tests/snuba/api/endpoints/test_organization_events_profile_functions.py
@@ -11,7 +11,7 @@ class OrganizationEventsProfileFunctionsEndpointTest(OrganizationEventsEndpointT
             self.create_profile_function(attributes={"name": "foo", "self_time_ns": 1}),
             self.create_profile_function(attributes={"name": "bar", "self_time_ns": 2}),
         ]
-        self.store_profile_functions(profile_functions)
+        self.store_eap_items(profile_functions)
 
         response = self.do_request(
             {
@@ -36,7 +36,7 @@ class OrganizationEventsProfileFunctionsEndpointTest(OrganizationEventsEndpointT
             self.create_profile_function(attributes={"name": "foo", "self_time_ns": 1}),
             self.create_profile_function(attributes={"name": "bar", "self_time_ns": 2}),
         ]
-        self.store_profile_functions(profile_functions)
+        self.store_eap_items(profile_functions)
 
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_events_stats_profile_functions.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_profile_functions.py
@@ -28,7 +28,7 @@ class OrganizationEventsStatsProfileFunctionsEndpointTest(OrganizationEventsEndp
             for i, function_value in enumerate(function_values)
         ]
 
-        self.store_profile_functions(profile_functions)
+        self.store_eap_items(profile_functions)
 
         response = self.do_request(
             {


### PR DESCRIPTION
store_profile_functions is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "profile_functions_0" vs "eap_items_0"), which Snuba ignores.

Consolidating to a single helper reduces duplication in test utilities.
