### PR TITLE
chore(tests): replace store_occurrences with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1206,17 +1206,6 @@ class SnubaTestCase(BaseTestCase):
         self.store_eap_items(trace_items)
         return trace_items
 
-    def store_occurrences(self, occurrences: Sequence[TraceItem]):
-        files = {
-            f"occurrence_{i}": occurrence.SerializeToString()
-            for i, occurrence in enumerate(occurrences)
-        }
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
     def store_events_to_snuba_and_eap(
         self,
         fingerprint: str,

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -26,7 +26,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
             },
             project=self.project,
         )
-        self.store_occurrences([occ])
+        self.store_eap_items([occ])
 
         with self.options(
             {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
@@ -56,7 +56,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
             },
             project=self.project,
         )
-        self.store_occurrences([occ])
+        self.store_eap_items([occ])
 
         with self.options(
             {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -64,7 +64,7 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
                     for minute in range(count)
                 ],
             )
-        self.store_occurrences([occurrence for occurrence, group in occurrence_and_groups])
+        self.store_eap_items([occurrence for occurrence, group in occurrence_and_groups])
 
         with self.options(
             {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1514,7 +1514,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         self.load_trace()
         first_group = self.create_group(project=self.project)
         second_group = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(
                     project=self.project,

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -96,7 +96,7 @@ class OrganizationEventsTraceMetaEndpointTest(
         self.load_trace()
         first_group = self.create_group(project=self.project)
         second_group = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(
                     project=self.project,

--- a/tests/snuba/search/test_eap_occurrences.py
+++ b/tests/snuba/search/test_eap_occurrences.py
@@ -61,7 +61,7 @@ class EAPOccurrencesTest(TestCase, SnubaTestCase, OccurrenceTestCase):
             title="test error",
             level="error",
         )
-        self.store_occurrences([trace_item])
+        self.store_eap_items([trace_item])
 
         result = self._query_occurrences(query_string=f"group_id:{group.id}")
         assert len(result["data"]) == 1
@@ -79,7 +79,7 @@ class EAPOccurrencesTest(TestCase, SnubaTestCase, OccurrenceTestCase):
             group_id=group_generic.id,
             occurrence_type="generic",
         )
-        self.store_occurrences([error_occurrence, generic_occurrence])
+        self.store_eap_items([error_occurrence, generic_occurrence])
 
         # OccurrenceCategory.ERROR filters for type != "generic"
         error_result = self._query_occurrences(
@@ -107,7 +107,7 @@ class EAPOccurrencesTest(TestCase, SnubaTestCase, OccurrenceTestCase):
             environment="production",
             transaction="/api/users",
         )
-        self.store_occurrences([trace_item])
+        self.store_eap_items([trace_item])
 
         result = self._query_occurrences(
             query_string=f"group_id:{group.id}",
@@ -129,7 +129,7 @@ class EAPOccurrencesTest(TestCase, SnubaTestCase, OccurrenceTestCase):
             group_id=group.id,
             tags={"browser": "chrome", "os": "linux"},
         )
-        self.store_occurrences([trace_item])
+        self.store_eap_items([trace_item])
 
         matching = self._query_occurrences(query_string="browser:chrome")
         assert len(matching["data"]) == 1
@@ -142,7 +142,7 @@ class EAPOccurrencesTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         group = self.create_group(project=self.project)
 
         occurrences = [self.create_eap_occurrence(group_id=group.id) for _ in range(5)]
-        self.store_occurrences(occurrences)
+        self.store_eap_items(occurrences)
 
         result = self._query_occurrences(query_string=f"group_id:{group.id}")
         assert len(result["data"]) == 1
@@ -179,7 +179,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
     def test_counts_all_occurrences(self) -> None:
         group = self.create_group(project=self.project)
         occurrences = [self.create_eap_occurrence(group_id=group.id) for _ in range(3)]
-        self.store_occurrences(occurrences)
+        self.store_eap_items(occurrences)
 
         result = count_occurrences(
             organization=self.organization,
@@ -193,7 +193,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
     def test_filters_by_group_id(self) -> None:
         group_1 = self.create_group(project=self.project)
         group_2 = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(group_id=group_1.id),
                 self.create_eap_occurrence(group_id=group_2.id),
@@ -223,7 +223,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
 
     def test_filters_by_occurrence_category(self) -> None:
         group = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(group_id=group.id, occurrence_type="error"),
                 self.create_eap_occurrence(group_id=group.id, occurrence_type="error"),
@@ -257,7 +257,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         group = self.create_group(project=self.project)
         trace_id_1 = uuid4().hex
         trace_id_2 = uuid4().hex
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(group_id=group.id, trace_id=trace_id_1),
                 self.create_eap_occurrence(group_id=group.id, trace_id=trace_id_1),
@@ -280,7 +280,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
     def test_counts_grouped_by_trace_ids_with_occurrence_category(self) -> None:
         group = self.create_group(project=self.project)
         trace_id = uuid4().hex
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(
                     group_id=group.id, trace_id=trace_id, occurrence_type="error"
@@ -333,7 +333,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         trace_id = uuid4().hex
         group_1 = self.create_group(project=self.project)
         group_2 = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(group_id=group_1.id, trace_id=trace_id),
                 self.create_eap_occurrence(group_id=group_2.id, trace_id=trace_id),
@@ -359,7 +359,7 @@ class CountOccurrencesQueryTest(TestCase, SnubaTestCase, OccurrenceTestCase):
         trace_id_2 = uuid4().hex
         group_1 = self.create_group(project=self.project)
         group_2 = self.create_group(project=self.project)
-        self.store_occurrences(
+        self.store_eap_items(
             [
                 self.create_eap_occurrence(group_id=group_1.id, trace_id=trace_id_1),
                 self.create_eap_occurrence(group_id=group_1.id, trace_id=trace_id_2),


### PR DESCRIPTION
store_occurrences is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "occurrence_0" vs "eap_items_0"), which Snuba ignores.

Consolidating to a single helper reduces duplication in test utilities.