### PR TITLE
chore(tests): replace store_trace_metrics with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1240,17 +1240,6 @@ class SnubaTestCase(BaseTestCase):
                 events.append(event)
         return events
 
-    def store_trace_metrics(self, trace_metrics):
-        files = {
-            f"trace_metric_{i}": trace_metric.SerializeToString()
-            for i, trace_metric in enumerate(trace_metrics)
-        }
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
     def store_eap_items(self, items: Sequence[TraceItem]) -> None:
         files = {f"eap_items_{i}": item.SerializeToString() for i, item in enumerate(items)}
         response = requests.post(

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -2692,7 +2692,7 @@ class TestMetricsTraceQuery(APITransactionTestCase, SnubaTestCase, TraceMetricsT
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_trace_metrics(self.metrics)
+        self.store_eap_items(self.metrics)
 
     @staticmethod
     def get_id_str(item: TraceItem) -> str:

--- a/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_trace_metrics.py
@@ -28,7 +28,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             for metric_name in ["foo", "bar"]
             for i, metric_value in enumerate(metric_values)
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -56,7 +56,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             for metric_name in ["foo", "bar"]
             for i, metric_value in enumerate(metric_values)
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -85,7 +85,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     "test_metric", 1.0, "counter", timestamp=self.start + timedelta(hours=0)
                 )
             )
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         response = self.do_request(
             {
@@ -144,7 +144,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     attributes={"key": "value2"},
                 )
             )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -186,7 +186,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             for metric_name in ["foo", "bar"]
             for i, metric_value in enumerate(metric_values)
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -47,7 +47,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     )
                 ]
             )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -81,7 +81,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         }
 
     def test_top_events(self) -> None:
-        self.store_trace_metrics(
+        self.store_eap_items(
             [
                 self.create_trace_metric(
                     "foo",
@@ -187,7 +187,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                         timestamp=self.start + timedelta(hours=hour),
                     )
                 )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -226,7 +226,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                         timestamp=self.start + timedelta(hours=hour),
                     )
                 )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -263,7 +263,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     timestamp=self.start + timedelta(hours=hour),
                 )
             )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -300,7 +300,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     timestamp=self.start + timedelta(hours=hour),
                 )
             )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -338,7 +338,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                     timestamp=self.start + timedelta(hours=hour),
                 )
             )
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -371,7 +371,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "request_count", 1, "counter", metric_unit="millisecond", timestamp=self.start
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -403,7 +403,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "request_count", 1, "counter", metric_unit="byte", timestamp=self.start
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={
@@ -435,7 +435,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
                 "request_count", 1, "counter", metric_unit="byte", timestamp=self.start
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self._do_request(
             data={

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -17,7 +17,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -42,7 +42,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -65,7 +65,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -91,7 +91,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -111,7 +111,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         ]
 
     def test_sum(self):
-        self.store_trace_metrics(
+        self.store_eap_items(
             [self.create_trace_metric("test_metric", i + 1, "counter") for i in range(6)]
         )
 
@@ -138,7 +138,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("request_count", 5.0, "counter"),
             self.create_trace_metric("request_count", 3.0, "counter"),
         ]
-        self.store_trace_metrics(counter_metrics)
+        self.store_eap_items(counter_metrics)
 
         response = self.do_request(
             {
@@ -163,7 +163,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("request_duration", 75.0, "distribution"),
             self.create_trace_metric("request_duration", 80.0, "distribution"),
         ]
-        self.store_trace_metrics(gauge_metrics)
+        self.store_eap_items(gauge_metrics)
 
         response = self.do_request(
             {
@@ -185,7 +185,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_per_minute_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
-        self.store_trace_metrics(
+        self.store_eap_items(
             [self.create_trace_metric("test_metric", 1.0, "counter") for _ in range(6)]
         )
 
@@ -210,7 +210,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_per_second_formula(self) -> None:
         # Store 6 trace metrics over a 10 minute period
-        self.store_trace_metrics(
+        self.store_eap_items(
             [self.create_trace_metric("test_metric", 1.0, "counter") for _ in range(6)]
         )
 
@@ -240,7 +240,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("request_count", 5.0, "counter"),
             self.create_trace_metric("request_count", 3.0, "counter"),
         ]
-        self.store_trace_metrics(counter_metrics)
+        self.store_eap_items(counter_metrics)
 
         response = self.do_request(
             {
@@ -263,7 +263,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("cpu_usage", 75.0, "gauge"),
             self.create_trace_metric("cpu_usage", 80.0, "gauge"),
         ]
-        self.store_trace_metrics(gauge_metrics)
+        self.store_eap_items(gauge_metrics)
 
         response = self.do_request(
             {
@@ -288,7 +288,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("cpu_usage", 75.0, "gauge"),
             self.create_trace_metric("cpu_usage", 80.0, "gauge"),
         ]
-        self.store_trace_metrics(gauge_metrics)
+        self.store_eap_items(gauge_metrics)
 
         response = self.do_request(
             {
@@ -314,7 +314,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             *[self.create_trace_metric("baz", 1, "distribution") for _ in range(3)],
             *[self.create_trace_metric("qux", 1, "distribution", "millisecond") for _ in range(4)],
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         # this query does not filter on any metrics, so scan all metrics
         response = self.do_request(
@@ -369,7 +369,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 1, "counter"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -387,7 +387,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             *[self.create_trace_metric("foo", 1, "counter") for _ in range(6)],
             self.create_trace_metric("bar", 594, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -408,7 +408,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("foo", 2, "distribution"),
             self.create_trace_metric("bar", 2, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -434,7 +434,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("bar", 4, "counter"),
             self.create_trace_metric("baz", 8, "gauge"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -513,7 +513,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         trace_metrics = [
             self.create_trace_metric("foo", 1, "counter", project=project1),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -552,7 +552,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "request_duration", 200.0, "distribution", metric_unit="second"
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -587,7 +587,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "request_duration", 200.0, "distribution", metric_unit="second"
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -627,7 +627,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
             self.create_trace_metric("request_count", 5.0, "counter"),
             self.create_trace_metric("request_count", 3.0, "counter"),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -659,7 +659,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "request_duration", 300.0, "distribution", metric_unit="millisecond"
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -685,7 +685,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "request_duration", 300.0, "distribution", metric_unit="second"
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {
@@ -711,7 +711,7 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
                 "request_duration", 300.0, "distribution", metric_unit="second"
             ),
         ]
-        self.store_trace_metrics(trace_metrics)
+        self.store_eap_items(trace_metrics)
 
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -945,7 +945,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
                 },
             ),
         ]
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         response = self.do_request(query={"attributeType": "string"})
 
@@ -986,7 +986,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
                 },
             ),
         ]
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         # Query for http metric attributes
         response = self.do_request(
@@ -1018,7 +1018,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
                 },
             ),
         ]
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         response = self.do_request(query={"attributeType": "number"})
 
@@ -1055,7 +1055,7 @@ class OrganizationTraceItemAttributesEndpointTraceMetricsTest(
                 },
             ),
         ]
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         response = self.do_request(query={"attributeType": "boolean"})
 
@@ -2089,7 +2089,7 @@ class OrganizationTraceItemAttributeValuesEndpointTraceMetricsTest(
                 attributes={"http.method": "POST"},
             ),
         ]
-        self.store_trace_metrics(metrics)
+        self.store_eap_items(metrics)
 
         response = self.do_request(key="http.method")
         assert response.status_code == 200


### PR DESCRIPTION
store_trace_metrics is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "trace_metric_0" vs "eap_items_0"), which Snuba ignores.

Consolidating to a single helper reduces duplication in test utilities.

<!-- Describe your PR here. -->