### PR TITLE
chore(tests): replace store_ourlogs with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1167,14 +1167,6 @@ class SnubaTestCase(BaseTestCase):
             == 200
         )
 
-    def store_ourlogs(self, ourlogs):
-        files = {f"log_{i}": log.SerializeToString() for i, log in enumerate(ourlogs)}
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
     def produce_and_store_eap_items(
         self, producer_mock_path: str, produce_fn: Callable[..., Any], *args: Any, **kwargs: Any
     ) -> list[TraceItem]:

--- a/tests/acceptance/test_explore_logs.py
+++ b/tests/acceptance/test_explore_logs.py
@@ -75,7 +75,7 @@ class ExploreLogsTest(AcceptanceTestCase, SnubaTestCase, OurLogTestCase):
                     timestamp=self.start_minus_two_minutes,
                 ),
             ]
-            self.store_ourlogs(logs)
+            self.store_eap_items(logs)
 
             self.page.visit_explore_logs(self.organization.slug)
             row = self.page.toggle_log_row_with_message("check these attributes")

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -755,7 +755,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                 attributes={"custom.field": "test_value"},
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         de = ExportedData.objects.create(
             user_id=self.user.id,
@@ -809,7 +809,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                 organization=self.org,
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         # Test spans dataset export
         de_spans = ExportedData.objects.create(
@@ -953,7 +953,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                 project=self.project,
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         de = ExportedData.objects.create(
             user_id=self.user.id,
@@ -1106,7 +1106,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
             )
             for i in range(5)
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         de = ExportedData.objects.create(
             user_id=self.user.id,

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -2972,7 +2972,7 @@ class TestLogsQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         result = execute_table_query(
             org_id=self.organization.id,
@@ -3044,7 +3044,7 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(self.logs)
+        self.store_eap_items(self.logs)
 
     @staticmethod
     def get_id_str(item: TraceItem) -> str:

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -3048,7 +3048,7 @@ class TestLogsTraceQuery(APITransactionTestCase, SnubaTestCase, OurLogTestCase):
 
     @staticmethod
     def get_id_str(item: TraceItem) -> str:
-        return item.item_id[::-1].hex()
+        return item.item_id.hex()
 
     def test_get_log_attributes_for_trace_basic(self) -> None:
         result = get_log_attributes_for_trace(

--- a/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_cross_trace.py
@@ -17,7 +17,7 @@ class OrganizationEventsCrossTraceEndpointTest(OrganizationEventsEndpointTestBas
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id
@@ -122,7 +122,7 @@ class OrganizationEventsCrossTraceEndpointTest(OrganizationEventsEndpointTestBas
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id
@@ -251,7 +251,7 @@ class OrganizationEventsCrossTraceEndpointTest(OrganizationEventsEndpointTestBas
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -62,7 +62,7 @@ class OrganizationEventsMetaEndpoint(
         assert response.data["count"] == 1
 
     def test_logs_dataset(self) -> None:
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo"},

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 from unittest.mock import ANY, patch
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from django.test import override_settings
@@ -54,11 +54,11 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert len(data) == 2
         assert data == [
             {
-                "id": UUID(bytes=bytes(reversed(logs[0].item_id))).hex,
+                "id": logs[0].item_id.hex(),
                 "log.body": "foo",
             },
             {
-                "id": UUID(bytes=bytes(reversed(logs[1].item_id))).hex,
+                "id": logs[1].item_id.hex(),
                 "log.body": "bar",
             },
         ]
@@ -417,7 +417,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert len(data) == 2
         for result, source in zip(data, reversed(logs)):
             assert result == {
-                "sentry.item_id": UUID(bytes=bytes(reversed(source.item_id))).hex,
+                "sentry.item_id": source.item_id.hex(),
                 "project.id": self.project.id,
                 "trace": source.trace_id,
                 "severity_number": source.attributes["sentry.severity_number"].int_value,

--- a/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_ourlogs.py
@@ -38,7 +38,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["id", "log.body"],
@@ -80,7 +80,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.ten_mins_ago + timedelta(microseconds=2),
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["log.body", "timestamp"],
@@ -121,7 +121,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["log.body"],
@@ -155,7 +155,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["log.body", "timestamp"],
@@ -182,7 +182,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.ten_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["project"],
@@ -212,7 +212,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.ten_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["message", "trace"],
@@ -245,7 +245,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             {"body": "bar"},
             timestamp=three_days_ago,
         )
-        self.store_ourlogs([log1, log2])
+        self.store_eap_items([log1, log2])
 
         request = {
             "field": ["message"],
@@ -290,7 +290,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             {"body": "foo"},
             timestamp=one_day_ago,
         )
-        self.store_ourlogs([log1])
+        self.store_eap_items([log1])
 
         request = {
             "field": ["message", "count()"],
@@ -316,7 +316,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             attributes={"sentry.payload_size_bytes": 1234567},
             timestamp=one_day_ago,
         )
-        self.store_ourlogs([log1])
+        self.store_eap_items([log1])
 
         request = {
             "field": ["message", "payload_size"],
@@ -340,7 +340,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             {"body": "test"},
             timestamp=self.ten_mins_ago,
         )
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
 
         response = self.do_request(
             {
@@ -388,7 +388,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "cursor": "",
@@ -468,7 +468,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             ),
         ]
 
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(
             {
@@ -556,7 +556,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.ten_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["id", "timestamp", "message"],
@@ -594,7 +594,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 log_id="0" + uuid4().hex[1:],  # qux's id sorts after bar's id
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         response = self.do_request(
             {
                 "field": ["id", "timestamp", "message"],
@@ -637,7 +637,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=self.nine_mins_ago,
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(
             {
@@ -669,7 +669,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             )
             for i in range(n)
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(
             {
@@ -703,7 +703,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
             )
             for i in range(n)
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         request = {
             "field": ["timestamp", "message"],
@@ -760,7 +760,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=hour_3 - timedelta(minutes=30),
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         for hour in [hour_4, hour_3]:
             self.store_outcomes(
                 {
@@ -837,7 +837,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
                 timestamp=hour_3 - timedelta(minutes=30),
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_outcomes(
             {
                 "org_id": self.organization.id,
@@ -902,7 +902,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert links["next"]["results"] == "true"
 
     def test_bytes_scanned(self):
-        self.store_ourlogs([self.create_ourlog({"body": "log"}, timestamp=self.ten_mins_ago)])
+        self.store_eap_items([self.create_ourlog({"body": "log"}, timestamp=self.ten_mins_ago)])
 
         request = {
             "field": ["timestamp", "message"],
@@ -916,7 +916,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         assert response.data["meta"]["bytesScanned"] > 0
 
     def test_count_message(self):
-        self.store_ourlogs([self.create_ourlog({"body": "log"}, timestamp=self.ten_mins_ago)])
+        self.store_eap_items([self.create_ourlog({"body": "log"}, timestamp=self.ten_mins_ago)])
         request = {
             "field": ["count(message)"],
             "project": self.project.id,
@@ -951,7 +951,7 @@ class OrganizationEventsOurLogsEndpointTest(OrganizationEventsEndpointTestBase, 
         project1 = self.create_project()
         project2 = self.create_project()
 
-        self.store_ourlogs(
+        self.store_eap_items(
             [self.create_ourlog({"body": "log"}, project=project1, timestamp=self.ten_mins_ago)]
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3097,7 +3097,7 @@ class OrganizationEventsStatsTopNEventsLogs(APITestCase, SnubaTestCase, OurLogTe
                 for i in range(60)
             ]
         )
-        self.store_ourlogs(self.logs)
+        self.store_eap_items(self.logs)
 
         self.enabled_features = {
             "organizations:discover-basic": True,

--- a/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_ourlogs.py
@@ -44,7 +44,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
                     for minute in range(count)
                 ],
             )
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self._do_request(
             data={
@@ -128,7 +128,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
                     for minute in range(count)
                 ],
             )
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self._do_request(
             data={
@@ -184,7 +184,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
                     for minute in range(count)
                 ],
             )
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self._do_request(
             data={
@@ -213,7 +213,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
             assert response.data[key]["meta"]["dataset"] == "logs"
 
     def test_top_events_multi_y_axis(self) -> None:
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": message},
@@ -254,7 +254,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_top_events_with_project(self) -> None:
         projects = [self.create_project(), self.create_project()]
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo"},
@@ -291,7 +291,7 @@ class OrganizationEventsStatsOurlogsEndpointTest(OrganizationEventsEndpointTestB
 
     def test_top_events_with_project_and_project_id(self) -> None:
         projects = [self.create_project(), self.create_project()]
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo"},

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_cross_trace.py
@@ -36,7 +36,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id
@@ -158,7 +158,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id
@@ -299,7 +299,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 # only this event should show up since we'll filtered to trace_id
@@ -362,7 +362,7 @@ class OrganizationEventsTimeseriesCrossTraceEndpointTest(OrganizationEventsEndpo
                 timestamp=self.nine_mins_ago,
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
         self.store_spans(
             [
                 self.create_span(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -50,7 +50,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
                     for minute in range(count)
                 ],
             )
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self._do_request(
             data={
@@ -88,7 +88,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
         }
 
     def test_top_events(self) -> None:
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo"},

--- a/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_item_attributes.py
@@ -96,7 +96,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 },
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         # Test with empty prefix (should return all attributes)
         response = self.do_request(query={"substringMatch": ""})
@@ -133,7 +133,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 },
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request()
 
@@ -154,7 +154,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 },
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request()
 
@@ -174,7 +174,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             ),
         ]
 
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request()
 
@@ -206,7 +206,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             ),
         ]
 
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(query={"attributeType": "string"})
 
@@ -339,7 +339,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
             ),
         ]
 
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request()
 
@@ -373,7 +373,7 @@ class OrganizationTraceItemAttributesEndpointLogsTest(
                 },
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(query={"attributeType": "boolean"})
 
@@ -1144,7 +1144,7 @@ class OrganizationTraceItemAttributeValuesEndpointLogsTest(
                 },
             ),
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         response = self.do_request(key="test1")
 

--- a/tests/snuba/api/endpoints/test_organization_trace_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_logs.py
@@ -36,7 +36,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_invalid_trace_id(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -59,7 +59,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_simple(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -88,7 +88,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_multiple_traces(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -121,7 +121,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_sort(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -154,7 +154,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_orderby_validation(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -179,7 +179,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
         project2 = self.create_project(organization=self.organization)
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -213,7 +213,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_query_field(self) -> None:
         trace_id_1 = "1" * 32
         trace_id_2 = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": trace_id_1},
@@ -245,7 +245,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
             {"body": "test", "trace_id": trace_id},
             timestamp=self.ten_mins_ago,
         )
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
 
         response = self.client.get(
             self.url,
@@ -278,7 +278,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
                 timestamp=self.ten_mins_ago,
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         with patch("sentry.snuba.rpc_dataset_common.RPCBase._run_table_query") as mock_run_query:
             mock_run_query.return_value = {
@@ -318,7 +318,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
                 timestamp=self.ten_mins_ago,
             )
         ]
-        self.store_ourlogs(logs)
+        self.store_eap_items(logs)
 
         with patch("sentry.snuba.rpc_dataset_common.RPCBase._run_table_query") as mock_run_query:
             mock_run_query.return_value = {
@@ -352,7 +352,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
 
     def test_replay_id_simple(self) -> None:
         replay_id = "1" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "replay_id": replay_id},
@@ -378,7 +378,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert log_data["message"] == "foo"
 
     def test_replay_id_invalid(self) -> None:
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "replay_id": "1" * 32},
@@ -397,7 +397,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
     def test_trace_and_replay_id_combined(self) -> None:
         trace_id = "1" * 32
         replay_id = "2" * 32
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "trace_log", "trace_id": trace_id},
@@ -426,7 +426,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsEndpointTestBase):
         assert messages == {"trace_log", "replay_log"}
 
     def test_no_trace_or_replay_id(self) -> None:
-        self.store_ourlogs(
+        self.store_eap_items(
             [
                 self.create_ourlog(
                     {"body": "foo", "trace_id": "1" * 32},

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -66,7 +66,7 @@ class ProjectTraceItemDetailsEndpointTest(
             },
             timestamp=self.one_min_ago,
         )
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
         item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
 
         trace_details_response = self.do_request("logs", item_id)
@@ -121,7 +121,7 @@ class ProjectTraceItemDetailsEndpointTest(
             },
             timestamp=self.one_min_ago,
         )
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
         item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
 
         trace_details_response = self.do_request("logs", item_id)
@@ -321,7 +321,7 @@ class ProjectTraceItemDetailsEndpointTest(
             },
             timestamp=self.one_min_ago,
         )
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
         item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
 
         trace_details_response = self.do_request("logs", item_id)
@@ -374,7 +374,7 @@ class ProjectTraceItemDetailsEndpointTest(
             timestamp=self.one_min_ago,
         )
 
-        self.store_ourlogs([log])
+        self.store_eap_items([log])
         item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
 
         trace_details_response = self.do_request("logs", item_id)

--- a/tests/snuba/api/endpoints/test_project_trace_item_details.py
+++ b/tests/snuba/api/endpoints/test_project_trace_item_details.py
@@ -67,7 +67,7 @@ class ProjectTraceItemDetailsEndpointTest(
             timestamp=self.one_min_ago,
         )
         self.store_eap_items([log])
-        item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
+        item_id = log.item_id.hex()
 
         trace_details_response = self.do_request("logs", item_id)
 
@@ -122,7 +122,7 @@ class ProjectTraceItemDetailsEndpointTest(
             timestamp=self.one_min_ago,
         )
         self.store_eap_items([log])
-        item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
+        item_id = log.item_id.hex()
 
         trace_details_response = self.do_request("logs", item_id)
 
@@ -322,7 +322,7 @@ class ProjectTraceItemDetailsEndpointTest(
             timestamp=self.one_min_ago,
         )
         self.store_eap_items([log])
-        item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
+        item_id = log.item_id.hex()
 
         trace_details_response = self.do_request("logs", item_id)
 
@@ -375,7 +375,7 @@ class ProjectTraceItemDetailsEndpointTest(
         )
 
         self.store_eap_items([log])
-        item_id = uuid.UUID(bytes=bytes(reversed(log.item_id))).hex
+        item_id = log.item_id.hex()
 
         trace_details_response = self.do_request("logs", item_id)
         assert trace_details_response.status_code == 200, trace_details_response.content


### PR DESCRIPTION
store_ourlogs is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "log_0" vs "eap_items_0"), which Snuba ignores.

Consolidating to a single helper reduces duplication in test utilities.
