### PR TITLE
chore(tests): replace store_uptime_results with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -4208,25 +4208,6 @@ class UptimeResultEAPTestCase(BaseTestCase):
             attributes=attributes_proto,
         )
 
-    def store_uptime_results(self, uptime_results):
-        """Store uptime results in the EAP dataset."""
-        import requests
-        from django.conf import settings
-
-        files = {
-            f"uptime_{i}": result.SerializeToString() for i, result in enumerate(uptime_results)
-        }
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
-        for result in uptime_results:
-            # Reverse the ids here since these are stored in little endian in Clickhouse
-            # and end up reversed.
-            result.item_id = result.item_id[::-1]
-
 
 class ProcessingErrorTestCase(BaseTestCase):
     """Test case for creating and storing EAP processing error items."""

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sentry.testutils.cases import APITestCase, UptimeResultEAPTestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase, UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.uptime.types import IncidentStatus
 from sentry.utils import json
@@ -149,7 +149,7 @@ class OrganizationUptimeStatsBaseTest(APITestCase):
 
 @freeze_time(MOCK_DATETIME)
 class OrganizationUptimeStatsEndpointWithEAPTests(
-    OrganizationUptimeStatsBaseTest, UptimeResultEAPTestCase
+    OrganizationUptimeStatsBaseTest, SnubaTestCase, UptimeResultEAPTestCase
 ):
     __test__ = True
 
@@ -168,7 +168,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             incident_status=incident_status,
             scheduled_check_time=scheduled_check_time,
         )
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
     def test_detector_ids_with_eap(self) -> None:
         """Test that the endpoint works with uptimeDetectorId parameters for EAP."""
@@ -191,7 +191,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
                 request_url="https://detector-eap-test.com",
                 **scenario,
             )
-            self.store_uptime_results([uptime_result])
+            self.store_eap_items([uptime_result], reverse_ids=True)
 
         with self.feature(self.features):
             response = self.get_success_response(
@@ -266,7 +266,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             )
             for scheduled_time, check_status, incident_status in test_scenarios
         ]
-        self.store_uptime_results(uptime_results)
+        self.store_eap_items(uptime_results, reverse_ids=True)
 
         start_time = base_time
         end_time = base_time + timedelta(minutes=8)

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_stats.py
@@ -168,7 +168,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             incident_status=incident_status,
             scheduled_check_time=scheduled_check_time,
         )
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
     def test_detector_ids_with_eap(self) -> None:
         """Test that the endpoint works with uptimeDetectorId parameters for EAP."""
@@ -191,7 +191,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
                 request_url="https://detector-eap-test.com",
                 **scenario,
             )
-            self.store_eap_items([uptime_result], reverse_ids=True)
+            self.store_eap_items([uptime_result])
 
         with self.feature(self.features):
             response = self.get_success_response(
@@ -266,7 +266,7 @@ class OrganizationUptimeStatsEndpointWithEAPTests(
             )
             for scheduled_time, check_status, incident_status in test_scenarios
         ]
-        self.store_eap_items(uptime_results, reverse_ids=True)
+        self.store_eap_items(uptime_results)
 
         start_time = base_time
         end_time = base_time + timedelta(minutes=8)

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
@@ -316,7 +316,7 @@ class OrganizationUptimeSummaryEAPTest(
             kwargs["check_duration_us"] = check_duration_us
 
         uptime_result = self.create_eap_uptime_result(**kwargs)
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
     def test_average_duration_available(self) -> None:
         """Test that average duration is available and correctly calculated for EAP uptime results."""

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_summary.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sentry.testutils.cases import APITestCase, UptimeResultEAPTestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase, UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.uptime.types import IncidentStatus
 
@@ -291,7 +291,9 @@ class OrganizationUptimeSummaryBaseTest(APITestCase):
 
 
 @freeze_time(MOCK_DATETIME)
-class OrganizationUptimeSummaryEAPTest(OrganizationUptimeSummaryBaseTest, UptimeResultEAPTestCase):
+class OrganizationUptimeSummaryEAPTest(
+    OrganizationUptimeSummaryBaseTest, SnubaTestCase, UptimeResultEAPTestCase
+):
     __test__ = True
 
     def store_uptime_data(
@@ -314,7 +316,7 @@ class OrganizationUptimeSummaryEAPTest(OrganizationUptimeSummaryBaseTest, Uptime
             kwargs["check_duration_us"] = check_duration_us
 
         uptime_result = self.create_eap_uptime_result(**kwargs)
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
     def test_average_duration_available(self) -> None:
         """Test that average duration is available and correctly calculated for EAP uptime results."""

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -211,4 +211,4 @@ class ProjectUptimeAlertCheckIndexEndpointWithEAPTests(
             ),
         }
         uptime_result = self.create_eap_uptime_result(**create_params)
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])

--- a/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
+++ b/tests/sentry/uptime/endpoints/test_project_uptime_alert_check_index.py
@@ -2,7 +2,7 @@ import uuid
 from abc import abstractmethod
 from datetime import datetime, timedelta, timezone
 
-from sentry.testutils.cases import UptimeResultEAPTestCase
+from sentry.testutils.cases import SnubaTestCase, UptimeResultEAPTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.uptime import MOCK_ASSERTION_FAILURE_DATA
 from sentry.testutils.silo import region_silo_test
@@ -184,7 +184,7 @@ class ProjectUptimeAlertCheckIndexBaseTest(UptimeAlertBaseEndpointTest):
 @region_silo_test
 @freeze_time(MOCK_DATETIME)
 class ProjectUptimeAlertCheckIndexEndpointWithEAPTests(
-    ProjectUptimeAlertCheckIndexBaseTest, UptimeResultEAPTestCase
+    ProjectUptimeAlertCheckIndexBaseTest, SnubaTestCase, UptimeResultEAPTestCase
 ):
     __test__ = True
 
@@ -211,4 +211,4 @@ class ProjectUptimeAlertCheckIndexEndpointWithEAPTests(
             ),
         }
         uptime_result = self.create_eap_uptime_result(**create_params)
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)

--- a/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
+++ b/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
@@ -31,7 +31,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -81,7 +81,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -125,7 +125,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -190,7 +190,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -249,7 +249,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -302,7 +302,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {
@@ -347,7 +347,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=base_time + timedelta(microseconds=2),
             ),
         ]
-        self.store_uptime_results(results)
+        self.store_eap_items(results, reverse_ids=True)
 
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
+++ b/tests/snuba/api/endpoints/test_organization_events_uptime_results.py
@@ -31,7 +31,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -81,7 +81,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -125,7 +125,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -190,7 +190,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -249,7 +249,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -302,7 +302,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=self.nine_mins_ago,
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {
@@ -347,7 +347,7 @@ class OrganizationEventsUptimeResultsEndpointTest(
                 scheduled_check_time=base_time + timedelta(microseconds=2),
             ),
         ]
-        self.store_eap_items(results, reverse_ids=True)
+        self.store_eap_items(results)
 
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -672,7 +672,7 @@ class OrganizationEventsTraceEndpointTest(
             check_duration_us=500000,
         )
 
-        self.store_eap_items([redirect_result, final_result], reverse_ids=True)
+        self.store_eap_items([redirect_result, final_result])
 
         with self.feature(features):
             response = self.client_get(
@@ -702,7 +702,7 @@ class OrganizationEventsTraceEndpointTest(
             scheduled_check_time=self.day_ago,
         )
 
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
         with self.feature(self.FEATURES):
             response = self.client_get(
@@ -756,7 +756,7 @@ class OrganizationEventsTraceEndpointTest(
 
         features = self.FEATURES
 
-        self.store_eap_items([redirect_result, final_result], reverse_ids=True)
+        self.store_eap_items([redirect_result, final_result])
 
         with self.feature(features):
             response = self.client_get(
@@ -791,7 +791,7 @@ class OrganizationEventsTraceEndpointTest(
 
         features = self.FEATURES
 
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
         with self.feature(features):
             response = self.client_get(
@@ -822,7 +822,7 @@ class OrganizationEventsTraceEndpointTest(
             scheduled_check_time=self.day_ago,
             check_duration_us=200000,
         )
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
         occurrence = IssueOccurrence(
             id=uuid4().hex,

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -672,7 +672,7 @@ class OrganizationEventsTraceEndpointTest(
             check_duration_us=500000,
         )
 
-        self.store_uptime_results([redirect_result, final_result])
+        self.store_eap_items([redirect_result, final_result], reverse_ids=True)
 
         with self.feature(features):
             response = self.client_get(
@@ -702,7 +702,7 @@ class OrganizationEventsTraceEndpointTest(
             scheduled_check_time=self.day_ago,
         )
 
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
         with self.feature(self.FEATURES):
             response = self.client_get(
@@ -756,7 +756,7 @@ class OrganizationEventsTraceEndpointTest(
 
         features = self.FEATURES
 
-        self.store_uptime_results([redirect_result, final_result])
+        self.store_eap_items([redirect_result, final_result], reverse_ids=True)
 
         with self.feature(features):
             response = self.client_get(
@@ -791,7 +791,7 @@ class OrganizationEventsTraceEndpointTest(
 
         features = self.FEATURES
 
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
         with self.feature(features):
             response = self.client_get(
@@ -822,7 +822,7 @@ class OrganizationEventsTraceEndpointTest(
             scheduled_check_time=self.day_ago,
             check_duration_us=200000,
         )
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
         occurrence = IssueOccurrence(
             id=uuid4().hex,

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -278,7 +278,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
         """Test that uptime_checks field is NOT present when include_uptime is not set"""
         self.load_trace()
         uptime_result = self.create_uptime_check()
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
@@ -302,7 +302,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
             self.create_uptime_check(check_status="failure"),
             self.create_uptime_check(check_status="success"),
         ]
-        self.store_eap_items(uptime_results, reverse_ids=True)
+        self.store_eap_items(uptime_results)
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -343,7 +343,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
         self.load_trace()
         other_trace_id = uuid4().hex
         uptime_result = self.create_uptime_check(trace_id=other_trace_id)
-        self.store_eap_items([uptime_result], reverse_ids=True)
+        self.store_eap_items([uptime_result])
 
         with self.feature(self.FEATURES):
             response = self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_trace_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_meta.py
@@ -278,7 +278,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
         """Test that uptime_checks field is NOT present when include_uptime is not set"""
         self.load_trace()
         uptime_result = self.create_uptime_check()
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
         with self.feature(self.FEATURES):
             response = self.client.get(
                 self.url,
@@ -302,7 +302,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
             self.create_uptime_check(check_status="failure"),
             self.create_uptime_check(check_status="success"),
         ]
-        self.store_uptime_results(uptime_results)
+        self.store_eap_items(uptime_results, reverse_ids=True)
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -343,7 +343,7 @@ class OrganizationTraceMetaUptimeTest(OrganizationEventsTraceEndpointBase, Uptim
         self.load_trace()
         other_trace_id = uuid4().hex
         uptime_result = self.create_uptime_check(trace_id=other_trace_id)
-        self.store_uptime_results([uptime_result])
+        self.store_eap_items([uptime_result], reverse_ids=True)
 
         with self.feature(self.FEATURES):
             response = self.client.get(


### PR DESCRIPTION
store_uptime_results is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "uptime_0" vs "eap_items_0"), which Snuba ignores.

The additional post-processing step (reversing item_id bytes for ClickHouse little-endian storage) is now handled by the new reverse_ids parameter on store_eap_items.

<!-- Describe your PR here. -->