### PR TITLE
chore(tests): replace store_replays_eap with store_eap_items

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -4058,22 +4058,6 @@ class ReplayEAPTestCase(BaseTestCase):
             server_sample_rate=1.0,
         )
 
-    def store_replays_eap(self, replays):
-        import requests
-        from django.conf import settings
-
-        files = {f"replay_{i}": replay.SerializeToString() for i, replay in enumerate(replays)}
-        response = requests.post(
-            settings.SENTRY_SNUBA + EAP_ITEMS_INSERT_ENDPOINT,
-            files=files,
-        )
-        assert response.status_code == 200
-
-        for replay in replays:
-            # Reverse the ids here since these are stored in little endian in Clickhouse
-            # and end up reversed.
-            replay.item_id = replay.item_id[::-1]
-
 
 class UptimeResultEAPTestCase(BaseTestCase):
     """Test case for creating and storing EAP uptime results."""

--- a/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
+++ b/tests/sentry/replays/endpoints/test_query_replay_instance_eap.py
@@ -7,10 +7,10 @@ from sentry.replays.endpoints.organization_replay_details import (
     _query_replay_urls_eap,
     query_replay_instance_eap,
 )
-from sentry.testutils.cases import ReplayBreadcrumbType, ReplayEAPTestCase, TestCase
+from sentry.testutils.cases import ReplayBreadcrumbType, ReplayEAPTestCase, SnubaTestCase, TestCase
 
 
-class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
+class TestQueryReplayInstanceEAP(TestCase, SnubaTestCase, ReplayEAPTestCase):
     def test_eap_replay_query(self) -> None:
         replay_id1 = uuid4().hex
         replay_id2 = uuid4().hex
@@ -103,7 +103,7 @@ class TestQueryReplayInstanceEAP(TestCase, ReplayEAPTestCase):
             ),
         ]
 
-        self.store_replays_eap(replay1_breadcrumbs + replay2_breadcrumbs)
+        self.store_eap_items(replay1_breadcrumbs + replay2_breadcrumbs)
 
         start = now - datetime.timedelta(minutes=5)
         end = now + datetime.timedelta(minutes=5)


### PR DESCRIPTION
store_replays_eap is functionally identical to store_eap_items — both serialize protobuf TraceItems and POST them to the EAP items insert endpoint. The only difference was the multipart file key prefix (e.g. "replay_0" vs "eap_items_0"), which Snuba ignores.

The additional post-processing step (reversing item_id bytes for ClickHouse little-endian storage) is now handled by the new reverse_ids parameter on store_eap_items.
