### PR TITLE
chore: Update CODEOWNERS to use coding-workflows sub-teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -532,8 +532,8 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/views/seerExplorer/                             @getsentry/machine-learning-ai
 /src/sentry/seer/                                           @getsentry/machine-learning-ai
 /tests/sentry/seer/                                         @getsentry/machine-learning-ai
-/src/sentry/seer/fetch_issues/                              @getsentry/machine-learning-ai @getsentry/coding-workflows
-/tests/sentry/seer/fetch_issues/                            @getsentry/machine-learning-ai @getsentry/coding-workflows
+/src/sentry/seer/fetch_issues/                              @getsentry/machine-learning-ai @getsentry/coding-workflows-sentry-backend
+/tests/sentry/seer/fetch_issues/                            @getsentry/machine-learning-ai @getsentry/coding-workflows-sentry-backend
 ## End of ML & AI
 
 ## Issues
@@ -724,14 +724,14 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 ## End of Frontend Platform
 
 # Coding Workflows
-/static/app/components/prevent/                           @getsentry/coding-workflows
-/static/app/views/prevent/                                @getsentry/coding-workflows
-/static/app/views/nav/secondary/sections/prevent/         @getsentry/coding-workflows
-/static/gsApp/views/seerAutomation/                       @getsentry/coding-workflows
-/src/sentry/prevent/                                      @getsentry/coding-workflows
-/src/sentry/integrations/api/endpoints/organization_repository_settings.py   @getsentry/coding-workflows
-/src/sentry/seer/code_review/                                                @getsentry/coding-workflows
-/tests/sentry/seer/code_review/                                              @getsentry/coding-workflows
+/static/app/components/prevent/                           @getsentry/coding-workflows-sentry-frontend
+/static/app/views/prevent/                                @getsentry/coding-workflows-sentry-frontend
+/static/app/views/nav/secondary/sections/prevent/         @getsentry/coding-workflows-sentry-frontend
+/static/gsApp/views/seerAutomation/                       @getsentry/coding-workflows-sentry-frontend
+/src/sentry/prevent/                                      @getsentry/coding-workflows-sentry-backend
+/src/sentry/integrations/api/endpoints/organization_repository_settings.py   @getsentry/coding-workflows-sentry-backend
+/src/sentry/seer/code_review/                                                @getsentry/coding-workflows-sentry-backend
+/tests/sentry/seer/code_review/                                              @getsentry/coding-workflows-sentry-backend
 
 ## SCM
 /src/sentry/integrations/source_code_management/                        @getsentry/product-owners-settings-integrations @getsentry/ecosystem @getsentry/scm

--- a/src/sentry/api/api_owners.py
+++ b/src/sentry/api/api_owners.py
@@ -10,7 +10,7 @@ class ApiOwner(Enum):
     ALERTS_NOTIFICATIONS = "alerts-notifications"
     BILLING = "revenue"
     CODECOV = "codecov"
-    CODING_WORKFLOWS = "coding-workflows"
+    CODING_WORKFLOWS = "coding-workflows-sentry-backend"
     CRONS = "crons"
     DASHBOARDS = "dashboards"
     DATA_BROWSING = "data-browsing"


### PR DESCRIPTION
## Summary
- Replace `@getsentry/coding-workflows` with `@getsentry/coding-workflows-sentry-backend` and `@getsentry/coding-workflows-sentry-frontend` sub-teams in CODEOWNERS
- Backend paths (`/src/sentry/prevent/`, `/src/sentry/seer/code_review/`, etc.) → `coding-workflows-sentry-backend`
- Frontend paths (`/static/app/components/prevent/`, `/static/app/views/prevent/`, etc.) → `coding-workflows-sentry-frontend`

Follows getsentry/security-as-code#2538 which renames and nests these teams under the `coding-workflows` parent.

## Test plan
- [x] Verified no other CODEOWNERS references to the old parent team remain