### PR TITLE
feat(traces-explorer): pass through all chart visuals in Compare Queries

### DIFF
--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -640,7 +640,39 @@ describe('ExploreToolbar', () => {
     expect(aggregateSortBys).toEqual([{field: 'count(span.duration)', kind: 'asc'}]);
   });
 
-  it('opens compare queries', async () => {
+  it('disables compare queries when only one chart is available', async () => {
+    function Component() {
+      return <ExploreToolbar />;
+    }
+    act(() => {
+      render(
+        <Wrapper>
+          <Component />
+        </Wrapper>,
+        {
+          organization,
+          initialRouterConfig: {
+            location: {
+              pathname: '/traces/',
+              query: {
+                visualize: encodeURIComponent(
+                  '{"chartType":1,"yAxes":["p95(span.duration)"]}'
+                ),
+              },
+            },
+          },
+        }
+      );
+    });
+
+    const section = screen.getByTestId('section-save-as');
+    await userEvent.hover(within(section).getByText(/Compare Queries/));
+
+    const compareButton = within(section).getByRole('button', {name: 'Compare'});
+    expect(compareButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('opens compare queries when multiple charts are added and Compare Queries link is clicked', async () => {
     function Component() {
       return <ExploreToolbar />;
     }
@@ -663,9 +695,11 @@ describe('ExploreToolbar', () => {
       }
     );
 
+    await userEvent.click(screen.getByRole('button', {name: 'Add Chart'}));
+
     const section = screen.getByTestId('section-save-as');
 
-    await userEvent.click(within(section).getByText(/Compare/));
+    await userEvent.click(within(section).getByText(/Compare Queries/));
     expect(router.location.pathname).toBe(
       '/organizations/org-slug/explore/traces/compare/'
     );
@@ -673,7 +707,7 @@ describe('ExploreToolbar', () => {
       expect.objectContaining({
         queries: [
           '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
-          '{"fields":["id","span.duration","timestamp"],"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
+          '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":[null]}',
         ],
       })
     );

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -707,7 +707,7 @@ describe('ExploreToolbar', () => {
       expect.objectContaining({
         queries: [
           '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
-          '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":[null]}',
+          '{"chartType":0,"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["count(span.duration)"]}',
         ],
       })
     );

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -321,11 +321,11 @@ export function ToolbarSaveAs() {
             organization,
             mode,
             location,
-            queries: visualizeFunctions.map((visual, index) => ({
+            queries: visualizeFunctions.map(visual => ({
               query,
               groupBys,
               sortBys,
-              yAxes: [visualizeYAxes[index]!],
+              yAxes: [visual.yAxis],
               chartType: visual.chartType,
               caseInsensitive: caseInsensitive ? '1' : undefined,
             })),

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -344,7 +344,7 @@ export function ToolbarSaveAs() {
                 : {title: t('Add two or more charts to compare chart queries.')}
           }
         >
-          {`${t('Compare Queries')}`}
+          {t('Compare Queries')}
         </WideLinkButton>
       </Grid>
     </StyledToolbarSection>

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -68,7 +68,10 @@ export function ToolbarSaveAs() {
   const id = useQueryParamsId();
 
   const visualizeFunctions = visualizes.filter(isVisualizeFunction);
-  const visualizeYAxes = dedupeArray(visualizeFunctions.map(v => v.yAxis));
+  const visualizeYAxes = useMemo(
+    () => dedupeArray(visualizeFunctions.map(v => v.yAxis)),
+    [visualizeFunctions]
+  );
   const [caseInsensitive] = useCaseInsensitivity();
 
   const sortBys = mode === Mode.SAMPLES ? sampleSortBys : aggregateSortBys;

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -67,7 +67,10 @@ export function ToolbarSaveAs() {
   const mode = useQueryParamsMode();
   const id = useQueryParamsId();
 
-  const visualizeFunctions = visualizes.filter(isVisualizeFunction);
+  const visualizeFunctions = useMemo(
+    () => visualizes.filter(isVisualizeFunction),
+    [visualizes]
+  );
   const visualizeYAxes = useMemo(
     () => dedupeArray(visualizeFunctions.map(v => v.yAxis)),
     [visualizeFunctions]

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -66,10 +66,9 @@ export function ToolbarSaveAs() {
   const aggregateSortBys = useQueryParamsAggregateSortBys();
   const mode = useQueryParamsMode();
   const id = useQueryParamsId();
-  const visualizeYAxes = useMemo(
-    () => dedupeArray(visualizes.filter(isVisualizeFunction).map(v => v.yAxis)),
-    [visualizes]
-  );
+
+  const visualizeFunctions = visualizes.filter(isVisualizeFunction);
+  const visualizeYAxes = dedupeArray(visualizeFunctions.map(v => v.yAxis));
   const [caseInsensitive] = useCaseInsensitivity();
 
   const sortBys = mode === Mode.SAMPLES ? sampleSortBys : aggregateSortBys;
@@ -281,6 +280,8 @@ export function ToolbarSaveAs() {
     return null;
   }
 
+  const canCompareQueries = visualizeFunctions.length >= 2;
+
   return (
     <StyledToolbarSection data-test-id="section-save-as">
       <Grid flow="column" align="center" gap="md">
@@ -308,41 +309,45 @@ export function ToolbarSaveAs() {
             )}
           />
         </Tooltip>
-        <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Comparing cross event queries is not supported during early access.')}
-        >
-          <LinkButton
-            aria-label={t('Compare')}
-            disabled={hasCrossEvents}
-            onClick={() =>
-              trackAnalytics('trace_explorer.compare', {
-                organization,
-              })
-            }
-            to={generateExploreCompareRoute({
+        <WideLinkButton
+          aria-label={t('Compare')}
+          disabled={hasCrossEvents || !canCompareQueries}
+          onClick={() =>
+            trackAnalytics('trace_explorer.compare', {
               organization,
-              mode,
-              location,
-              queries: [
-                {
-                  query,
-                  groupBys,
-                  sortBys,
-                  yAxes: [visualizeYAxes[0]!],
-                  chartType: visualizes[0]!.chartType,
-                  caseInsensitive: caseInsensitive ? '1' : undefined,
-                },
-              ],
-            })}
-          >
-            {`${t('Compare Queries')}`}
-          </LinkButton>
-        </Tooltip>
+            })
+          }
+          to={generateExploreCompareRoute({
+            organization,
+            mode,
+            location,
+            queries: visualizeFunctions.map((visual, index) => ({
+              query,
+              groupBys,
+              sortBys,
+              yAxes: [visualizeYAxes[index]!],
+              chartType: visual.chartType,
+              caseInsensitive: caseInsensitive ? '1' : undefined,
+            })),
+          })}
+          tooltipProps={
+            hasCrossEvents
+              ? {title: t('Comparing queries is not supported during early access.')}
+              : canCompareQueries
+                ? undefined
+                : {title: t('Add two or more charts to compare chart queries.')}
+          }
+        >
+          {`${t('Compare Queries')}`}
+        </WideLinkButton>
       </Grid>
     </StyledToolbarSection>
   );
 }
+
+const WideLinkButton = styled(LinkButton)`
+  width: 100%;
+`;
 
 const DisabledText = styled('span')`
   color: ${p => p.theme.tokens.content.disabled};


### PR DESCRIPTION
Applies two changes:

* Disables the Compare Queries button/link if you don't have >=2 chart visuals available
    * This is partially split out from #110046
* Instead of passing just `visuals[0]`, maps all visuals to the route's queries param

The end result is that the Compare Queries button serves to map all charts to a comparisons review, when there are >=2 of them.

<img width="459" height="383" alt="Screenshot of the visualize toolbar with only one chart; the Compare Queries button is visually disabled with an 'Add two or more charts to compare chart queries' toolip" src="https://github.com/user-attachments/assets/a8465fb3-5604-43f4-998a-de1cec9203bd" />

Note that equations are still not supported in the compare view, so they're still not added to the route's queries param. That's a larger followup as noted in #105982. This PR doesn't make things different/worse in that context.

Example pages:

* `/explore/traces?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg%28span.duration%29%22%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp`: only one chart, so the button is disabled with the tooltip
* `/explore/traces?aggregateField=%7B"groupBy"%3A""%7D&aggregateField=%7B"yAxes"%3A%5B"avg%28span.duration%29"%5D%7D&aggregateField=%7B"yAxes"%3A%5B"equation%7Cavg%28tags%5Bbundle_load%2Cnumber%5D%29"%5D%7D&aggregateField=%7B"yAxes"%3A%5B"p75%28span.duration%29"%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp`: contains a chart, an equation, and a chart -> should link to a comparison that contains just the two charts

Fixes EXP-821