### PR TITLE
Fix(dashboards): Moves Open in External link to bottom of cell action

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -240,10 +240,6 @@ function makeCellActions({
     addMenuItem(Actions.OPEN_INTERNAL_LINK, getInternalLinkActionLabel(field));
   }
 
-  if (isUrl(value)) {
-    addMenuItem(Actions.OPEN_EXTERNAL_LINK, t('Open external link'));
-  }
-
   if (allowActions) {
     addMenuItem(Actions.OPEN_ROW_IN_EXPLORE, t('View span samples'));
   }
@@ -291,6 +287,10 @@ function makeCellActions({
       }),
       t('Edit threshold')
     );
+  }
+
+  if (isUrl(value)) {
+    addMenuItem(Actions.OPEN_EXTERNAL_LINK, t('Open external link'));
   }
 
   if (actions.length === 0) {


### PR DESCRIPTION
Moves `Open External Link` to lowest in the priority of cell actions
<img width="195" height="167" alt="image" src="https://github.com/user-attachments/assets/10f9779f-bff0-4ff6-b141-15fb76b7a535" />

