### PR TITLE
feat(snapshots): Fix sidebar rendering for uploads with lots of images

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -16,7 +16,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.api.paginator import OffsetPaginator
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -52,7 +51,7 @@ SNAPSHOT_POST_REQUEST_SCHEMA: dict[str, Any] = {
         "images": {
             "type": "object",
             "additionalProperties": ImageMetadata.schema(),
-            "maxProperties": 1000,
+            "maxProperties": 50000,
         },
         **VCS_SCHEMA_PROPERTIES,
     },
@@ -250,15 +249,15 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 duration_ms=int(duration.total_seconds() * 1000),
             )
 
-        def on_results(images: list[SnapshotImageResponse]) -> dict[str, Any]:
-            return SnapshotDetailsApiResponse(
+        return Response(
+            SnapshotDetailsApiResponse(
                 head_artifact_id=str(artifact.id),
                 base_artifact_id=base_artifact_id,
                 project_id=str(artifact.project_id),
                 comparison_type=comparison_type,
                 state=artifact.state,
                 vcs_info=vcs_info,
-                images=images,
+                images=image_list,
                 image_count=snapshot_metrics.image_count,
                 changed=categorized.changed,
                 changed_count=len(categorized.changed),
@@ -274,14 +273,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 errored_count=len(categorized.errored),
                 comparison_run_info=run_info,
             ).dict()
-
-        return self.paginate(
-            request=request,
-            queryset=image_list,
-            paginator_cls=OffsetPaginator,
-            on_results=on_results,
-            default_per_page=20,
-            max_per_page=100,
         )
 
 

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -6,7 +6,6 @@ import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {
   IconAdd,
   IconCheckmark,
@@ -36,51 +35,45 @@ const SECTION_ORDER: SectionConfig[] = [
     type: DiffStatus.ADDED,
     label: t('Added'),
     icon: <IconAdd size="xs" />,
-    defaultExpanded: false,
+    defaultExpanded: true,
   },
   {
     type: DiffStatus.REMOVED,
     label: t('Removed'),
     icon: <IconSubtract size="xs" />,
-    defaultExpanded: false,
+    defaultExpanded: true,
   },
   {
     type: DiffStatus.RENAMED,
     label: t('Renamed'),
     icon: <IconCopy size="xs" />,
-    defaultExpanded: false,
+    defaultExpanded: true,
   },
   {
     type: DiffStatus.UNCHANGED,
     label: t('Unchanged'),
     icon: <IconCheckmark size="xs" />,
-    defaultExpanded: false,
+    defaultExpanded: true,
   },
 ];
 
 interface SnapshotSidebarContentProps {
   currentItemName: string | null;
-  fetchNextPage: () => Promise<unknown>;
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
   items: SidebarItem[];
   onSearchChange: (query: string) => void;
   onSelectItem: (name: string) => void;
   searchQuery: string;
+  totalItemCount: number;
 }
 
 export function SnapshotSidebarContent({
   items,
+  totalItemCount,
   currentItemName,
   searchQuery,
   onSearchChange,
   onSelectItem,
-  hasNextPage,
-  isFetchingNextPage,
-  fetchNextPage,
 }: SnapshotSidebarContentProps) {
-  const loadMoreRef = useRef<HTMLDivElement>(null);
-
   const isDiffMode = items.length > 0 && items[0]!.type !== 'solo';
 
   const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>(
@@ -109,24 +102,6 @@ export function SnapshotSidebarContent({
     return groups;
   }, [items, isDiffMode]);
 
-  useEffect(() => {
-    const sentinel = loadMoreRef.current;
-    if (!sentinel || !hasNextPage) {
-      return undefined;
-    }
-
-    const observer = new IntersectionObserver(
-      entries => {
-        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
-          fetchNextPage();
-        }
-      },
-      {threshold: 0}
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
-
   const isSearching = searchQuery.length > 0;
 
   const handleExpandedChange = (type: string, expanded: boolean) => {
@@ -145,7 +120,7 @@ export function SnapshotSidebarContent({
           </InputGroup.LeadingItems>
           <InputGroup.Input
             size="sm"
-            placeholder={t('Search images...')}
+            placeholder={t('Search %s images...', totalItemCount)}
             value={searchQuery}
             onChange={e => onSearchChange(e.target.value)}
           />
@@ -238,17 +213,11 @@ export function SnapshotSidebarContent({
                 </SidebarItemRow>
               );
             })}
-        {items.length === 0 && !hasNextPage && !isFetchingNextPage && (
+        {items.length === 0 && (
           <Flex align="center" justify="center" padding="lg">
             <Text variant="muted" size="sm">
               {t('No images found.')}
             </Text>
-          </Flex>
-        )}
-        <div ref={loadMoreRef} />
-        {isFetchingNextPage && (
-          <Flex align="center" justify="center" padding="md">
-            <LoadingIndicator size={20} />
           </Flex>
         )}
       </Stack>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -12,7 +12,7 @@ import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {space} from 'sentry/styles/space';
 import getApiUrl from 'sentry/utils/api/getApiUrl';
-import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
+import {useApiQuery} from 'sentry/utils/queryClient';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
@@ -36,17 +36,8 @@ export default function SnapshotsPage() {
     snapshotId: string;
   }>();
 
-  const {
-    data,
-    isPending,
-    isError,
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-    refetch,
-  } = useInfiniteApiQuery<SnapshotDetailsApiResponse>({
-    queryKey: [
-      'infinite',
+  const {data, isPending, isError, refetch} = useApiQuery<SnapshotDetailsApiResponse>(
+    [
       getApiUrl(
         '/organizations/$organizationIdOrSlug/preprodartifacts/snapshots/$snapshotId/',
         {
@@ -56,11 +47,12 @@ export default function SnapshotsPage() {
           },
         }
       ),
-      {query: {per_page: 20}},
     ],
-    staleTime: 0,
-    enabled: !!snapshotId,
-  });
+    {
+      staleTime: 0,
+      enabled: !!snapshotId,
+    }
+  );
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItemName, setSelectedItemName] = useState<string | null>(null);
@@ -85,40 +77,38 @@ export default function SnapshotsPage() {
     sizeStorageKey: 'snapshot-sidebar-width',
   });
 
-  const firstPageData = data?.pages[0]?.[0];
-  const comparisonType = firstPageData?.comparison_type ?? 'solo';
-  const comparisonRunInfo = firstPageData?.comparison_run_info;
+  const comparisonType = data?.comparison_type ?? 'solo';
+  const comparisonRunInfo = data?.comparison_run_info;
 
   const sidebarItems = useMemo(() => {
-    if (!data?.pages) {
+    if (!data) {
       return [];
     }
 
-    if (comparisonType === 'diff' && firstPageData) {
+    if (comparisonType === 'diff') {
       const items: SidebarItem[] = [];
 
-      for (const pair of firstPageData.changed) {
+      for (const pair of data.changed) {
         items.push({type: 'changed', name: getImageName(pair.head_image), pair});
       }
-      for (const img of firstPageData.added) {
+      for (const img of data.added) {
         items.push({type: 'added', name: getImageName(img), image: img});
       }
-      for (const img of firstPageData.removed) {
+      for (const img of data.removed) {
         items.push({type: 'removed', name: getImageName(img), image: img});
       }
-      for (const img of firstPageData.renamed ?? []) {
+      for (const img of data.renamed ?? []) {
         items.push({type: 'renamed', name: getImageName(img), image: img});
       }
-      for (const img of firstPageData.unchanged) {
+      for (const img of data.unchanged) {
         items.push({type: 'unchanged', name: getImageName(img), image: img});
       }
 
       return items;
     }
 
-    const allImages = data.pages.flatMap(page => page[0].images);
     const groups = new Map<string, SnapshotImage[]>();
-    for (const image of allImages) {
+    for (const image of data.images) {
       const name = getImageName(image);
       const existing = groups.get(name);
       if (existing) {
@@ -131,7 +121,7 @@ export default function SnapshotsPage() {
     return [...groups.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([name, images]) => ({type: 'solo' as const, name, images}));
-  }, [data?.pages, comparisonType, firstPageData]);
+  }, [data, comparisonType]);
 
   const filteredItems = useMemo(() => {
     if (!searchQuery) {
@@ -156,9 +146,9 @@ export default function SnapshotsPage() {
     setVariantIndex(0);
   };
 
-  const imageBaseUrl = `/api/0/projects/${organization.slug}/${firstPageData?.project_id ?? ''}/files/images/`;
-  const diffImageBaseUrl = firstPageData
-    ? `/api/0/organizations/${organization.slug}/objectstore/v1/objects/preprod/org=${organization.id};project=${firstPageData.project_id}/${organization.id}/${firstPageData.project_id}/`
+  const imageBaseUrl = `/api/0/projects/${organization.slug}/${data?.project_id ?? ''}/files/images/`;
+  const diffImageBaseUrl = data
+    ? `/api/0/organizations/${organization.slug}/objectstore/v1/objects/preprod/org=${organization.id};project=${data.project_id}/${organization.id}/${data.project_id}/`
     : '';
 
   if (isPending) {
@@ -173,7 +163,7 @@ export default function SnapshotsPage() {
     );
   }
 
-  if (isError || !firstPageData) {
+  if (isError || !data) {
     return (
       <SentryDocumentTitle title={t('Snapshot')}>
         <Layout.Page>
@@ -189,16 +179,13 @@ export default function SnapshotsPage() {
     <SentryDocumentTitle title={t('Snapshot')}>
       <Layout.Page>
         <Layout.Header>
-          <SnapshotHeaderContent
-            projectId={firstPageData.project_id}
-            data={firstPageData}
-          />
+          <SnapshotHeaderContent projectId={data.project_id} data={data} />
           <Layout.HeaderActions>
             <SnapshotDevTools
               organizationSlug={organization.slug}
               snapshotId={snapshotId}
               comparisonRunInfo={comparisonRunInfo}
-              hasBaseArtifact={firstPageData.base_artifact_id !== null}
+              hasBaseArtifact={data.base_artifact_id !== null}
               refetch={refetch}
             />
           </Layout.HeaderActions>
@@ -215,13 +202,11 @@ export default function SnapshotsPage() {
           <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
             <SnapshotSidebarContent
               items={filteredItems}
+              totalItemCount={sidebarItems.length}
               currentItemName={currentItemName}
               searchQuery={searchQuery}
               onSearchChange={setSearchQuery}
               onSelectItem={handleSelectItem}
-              hasNextPage={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-              fetchNextPage={fetchNextPage}
             />
           </Flex>
           <DragHandle

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -357,7 +357,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert vcs_info["pr_number"] == 123
 
     @patch("sentry.preprod.api.endpoints.preprod_artifact_snapshot.get_preprod_session")
-    def test_get_snapshot_details_pagination(self, mock_get_session):
+    def test_get_snapshot_details_returns_all_images(self, mock_get_session):
         images = {
             f"img{i:03d}": {
                 "display_name": f"Image {i}",
@@ -372,22 +372,12 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         url = self._get_detail_url(artifact.id)
         with self.feature("organizations:preprod-snapshots"):
-            # First page: items 0-2
-            response = self.client.get(url, {"per_page": "3"})
+            response = self.client.get(url)
 
         assert response.status_code == 200
-        assert len(response.data["images"]) == 3
+        assert len(response.data["images"]) == 10
         assert response.data["images"][0]["key"] == "img000"
-        assert response.data["images"][2]["key"] == "img002"
-
-        with self.feature("organizations:preprod-snapshots"):
-            # Second page: cursor format is "{per_page}:{page}:0"
-            response = self.client.get(url, {"cursor": "3:1:0", "per_page": "3"})
-
-        assert response.status_code == 200
-        assert len(response.data["images"]) == 3
-        assert response.data["images"][0]["key"] == "img003"
-        assert response.data["images"][2]["key"] == "img005"
+        assert response.data["images"][9]["key"] == "img009"
 
     def test_get_snapshot_not_found(self):
         url = self._get_detail_url(99999)
@@ -421,28 +411,6 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 403
         assert response.data["detail"] == "Feature not enabled"
-
-    @patch("sentry.preprod.api.endpoints.preprod_artifact_snapshot.get_preprod_session")
-    def test_get_snapshot_invalid_pagination(self, mock_get_session):
-        artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
-        mock_get_session.return_value = self._create_mock_session(manifest_json)
-
-        url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url, {"per_page": "0"})
-
-        assert response.status_code == 400
-
-    @patch("sentry.preprod.api.endpoints.preprod_artifact_snapshot.get_preprod_session")
-    def test_get_snapshot_limit_too_large(self, mock_get_session):
-        artifact, _, _, manifest_json, _ = self._create_artifact_with_manifest()
-        mock_get_session.return_value = self._create_mock_session(manifest_json)
-
-        url = self._get_detail_url(artifact.id)
-        with self.feature("organizations:preprod-snapshots"):
-            response = self.client.get(url, {"per_page": "101"})
-
-        assert response.status_code == 400
 
     @patch("sentry.preprod.api.endpoints.preprod_artifact_snapshot.get_preprod_session")
     def test_get_snapshot_objectstore_error(self, mock_get_session):


### PR DESCRIPTION
Remove pagination from the snapshot details API endpoint and simplify the frontend to load all images in a single request.

The snapshot sidebar previously used `useInfiniteApiQuery` with an `IntersectionObserver`-based infinite scroll to paginate through images 20 at a time. This caused layout instability — the sidebar's scrollbar would jump as new pages loaded, making it difficult to browse uploads with many images. Since snapshot metadata (image keys, display names, dimensions) is lightweight and the endpoint already loads the full manifest from object storage in one call, paginating the response added complexity without meaningful performance benefit.

Changes:
- **Backend**: Replace `self.paginate()` with a direct `Response()`, removing the `OffsetPaginator` dependency. Increase `maxProperties` from 1,000 to 50,000 to support larger uploads.
- **Frontend**: Switch from `useInfiniteApiQuery` to `useApiQuery`, remove the `IntersectionObserver` sentinel and loading spinner, and pass the total image count to the search placeholder (`"Search 537 images..."`).
- **Tests**: Update pagination tests to verify all images are returned in a single response, remove invalid-pagination and limit-too-large test cases that no longer apply.