### PR TITLE
fix(grouping): Handle grouphash cache invalidation errors gracefully

### DIFF
--- a/src/sentry/grouping/ingest/caching.py
+++ b/src/sentry/grouping/ingest/caching.py
@@ -35,7 +35,12 @@ def invalidate_grouphash_cache_on_save(instance: GroupHash, **kwargs: Any) -> No
         return
 
     cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
-    cache.delete(cache_key)
+    try:
+        cache.delete(cache_key)
+    except Exception:
+        # If we can't delete from the cache, likely we couldn't have put the grouphash there in the
+        # first place. Regardless, we don't want this to block the `save` call.
+        pass
 
 
 def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) -> None:
@@ -50,4 +55,9 @@ def invalidate_grouphash_caches_on_delete(instance: GroupHash, **kwargs: Any) ->
     object_cache_key = get_grouphash_object_cache_key(instance.hash, instance.project.id)
     existence_cache_key = get_grouphash_existence_cache_key(instance.hash, instance.project.id)
 
-    cache.delete_many([object_cache_key, existence_cache_key])
+    try:
+        cache.delete_many([object_cache_key, existence_cache_key])
+    except Exception:
+        # If we can't delete from the cache, likely we couldn't have put data there in the first
+        # place. Regardless, we don't want this to block the `delete` call.
+        pass

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -51,7 +51,12 @@ class GroupHashQuerySet(BaseQuerySet):
             )
         ]
 
-        cache.delete_many(cache_keys)
+        try:
+            cache.delete_many(cache_keys)
+        except Exception:
+            # If we can't delete from the cache, likely we couldn't have put the grouphashes there
+            # in the first place. Regardless, we don't want this to block the `update` call.
+            pass
 
         return len(cache_keys)
 

--- a/tests/sentry/event_manager/test_event_manager_grouping.py
+++ b/tests/sentry/event_manager/test_event_manager_grouping.py
@@ -584,6 +584,63 @@ class GroupHashCachingTest(TestCase):
             cache_use_expected=False,
         )
 
+    def test_cache_invalidation_error_handling(self):
+        # We don't want the cache invalidation triggered by saving, updating, or deleting a
+        # grouphash to ever make those processes crash
+
+        with (
+            # Called by the grouphash `save` hook
+            patch("sentry.grouping.ingest.caching.cache.delete", side_effect=Exception),
+            # Called by the grouphash `delete` hook
+            patch("sentry.grouping.ingest.caching.cache.delete_many", side_effect=Exception),
+            # The `cache` object is the same one used everywhere, so patching `delete_many` above
+            # also does the patching that the `patch` call below would do, so it's not necessary.
+            # (In fact, patching in both places causes an error when pytest tries to undo the
+            # mocking at the end of the test, because it tries to delete the mock method twice.)
+            #
+            # We can see that it's the same `cache` object everywhere because even when we import it
+            # here, the two mocked methods throw errors. (See the first assertions below.)
+            #
+            # Called by the overridden grouphash queryset `update` method
+            # patch("sentry.models.grouphash.cache.delete_many", side_effect=Exception),
+        ):
+            # Prove that mocking `cache.delete` and `cache.delete_many` in the `caching` module (to
+            # make them both throw errors) in fact causes that side effect everywhere. (See note
+            # above.)
+            with pytest.raises(Exception):
+                cache.delete("not_here")
+            with pytest.raises(Exception):
+                cache.delete_many(["not_here", "still_not_here"])
+
+            # `save` is called internally by `create`
+            GroupHash.objects.create(project=self.project, hash="dogs_are_great")
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash="dogs_are_great"
+            ).first()
+            # The record was successfully created
+            assert grouphash
+
+            # Test `save` directly
+            grouphash.hash = "maisey"
+            grouphash.save()
+            grouphash.refresh_from_db()
+            # The record was successfully updated
+            assert grouphash.hash == "maisey"
+
+            # Test `update`
+            grouphash.update(hash="adopt_dont_shop")
+            grouphash.refresh_from_db()
+            # The record was successfully updated
+            assert grouphash.hash == "adopt_dont_shop"
+
+            # Test `delete`
+            grouphash.delete()
+            grouphash = GroupHash.objects.filter(
+                project=self.project, hash="adopt_dont_shop"
+            ).first()
+            # The record was successfully deleted
+            assert not grouphash
+
 
 class PlaceholderTitleTest(TestCase):
     """


### PR DESCRIPTION
To reduce calls to the database during ingest, we cache both `GroupHash` objects and booleans tracking the existence of secondary grouphashes. They only stay in the cache for a minute (longer didn't seem to improve our hit rate), but even so, the data there can become stale if the corresponding database row is updated or deleted. We therefore hook into the `save`, `update`, and `delete` ORM methods, and have them invalidate the relevant cache entries when they run.

This system works just fine, but we've recently run into a problem where bad `hash` data in the `GroupHash` table is causing the cache invalidation to crash, thereby crashing the entire `delete` process, resulting in the records not getting successfully deleted. To fix this problem, this PR wraps the relevant `cache.delete_all` call in a `try-except`. (We obviously don't want the invalidation to fail, but data possibly being stale (for fewer than 60 seconds) is way better than a whole database call erroring out.) The same fix is also applied to our `cache.delete` and `cache.delete_all` calls in the `save` hook and the overridden `update` method, respectively.