### PR TITLE
fix(settings): remove double url normalization

### DIFF
--- a/static/app/utils/useNavigate.spec.tsx
+++ b/static/app/utils/useNavigate.spec.tsx
@@ -1,17 +1,8 @@
-import {useEffect} from 'react';
+import {render} from 'sentry-test/reactTestingLibrary';
 
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
-
-import ConfigStore from 'sentry/stores/configStore';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
 describe('useNavigate', () => {
-  const configState = ConfigStore.getState();
-
-  afterEach(() => {
-    ConfigStore.loadInitialData(configState);
-  });
-
   it('returns the navigate function', () => {
     let navigate: ReturnType<typeof useNavigate> | undefined = undefined;
 
@@ -23,32 +14,5 @@ describe('useNavigate', () => {
     render(<HomePage />);
 
     expect(typeof navigate).toBe('function');
-  });
-
-  it('applies url normalization for customer-domains', () => {
-    ConfigStore.set('customerDomain', {
-      subdomain: 'albertos-apples',
-      organizationUrl: 'https://albertos-apples.sentry.io',
-      sentryUrl: 'https://sentry.io',
-    });
-
-    function HomePage() {
-      const navigate = useNavigate();
-      useEffect(() => {
-        navigate('/organizations/acme/issues/');
-      }, [navigate]);
-
-      return null;
-    }
-
-    const {router} = render(<HomePage />, {
-      initialRouterConfig: {
-        location: {pathname: '/organizations/acme/issues/'},
-      },
-    });
-
-    return waitFor(() => {
-      expect(router.location.pathname).toBe('/issues/');
-    });
   });
 });

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -2,8 +2,6 @@ import {useCallback} from 'react';
 import {useNavigate as useReactRouter6Navigate} from 'react-router-dom';
 import type {LocationDescriptor} from 'history';
 
-import normalizeUrl from 'sentry/utils/url/normalizeUrl';
-
 import {locationDescriptorToTo} from './reactRouter6Compat/location';
 
 type NavigateOptions = {
@@ -32,8 +30,7 @@ export function useNavigate(): ReactRouter3Navigate {
         return router6Navigate(to);
       }
 
-      const normalizedTo = normalizeUrl(to);
-      return router6Navigate(locationDescriptorToTo(normalizedTo), options);
+      return router6Navigate(locationDescriptorToTo(to), options);
     },
     [router6Navigate]
   );

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -153,7 +153,6 @@ function OrganizationAuditLog() {
       eventType: value,
     }));
     navigate({
-      pathname: location.pathname,
       query: {...location.query, event: value},
     });
   };
@@ -198,7 +197,6 @@ function OrganizationAuditLog() {
     }
 
     navigate({
-      pathname: location.pathname,
       query: newQuery,
     });
   };

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -178,7 +178,6 @@ function ConfigureIntegration() {
     // XXX: Omit the cursor to prevent paginating the next tab's queries.
     const {cursor: _, ...query} = location.query;
     navigate({
-      pathname: location.pathname,
       query: {...query, tab: value},
     });
   };

--- a/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationListDirectory.tsx
@@ -268,7 +268,6 @@ export default function IntegrationListDirectory() {
     ({value: newCategory}: SelectOption<string>) => {
       navigate(
         {
-          ...location,
           query: {...location.query, category: newCategory ? newCategory : undefined},
         },
         {replace: true}
@@ -288,7 +287,6 @@ export default function IntegrationListDirectory() {
     (newSearch: string) => {
       navigate(
         {
-          ...location,
           query: {...location.query, search: newSearch ? newSearch : undefined},
         },
         {replace: true}

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -285,7 +285,6 @@ function OrganizationMembersList() {
 
   const handleQueryChange = (query: string) => {
     navigate({
-      pathname: location.pathname,
       query: {...location.query, query, cursor: undefined},
     });
   };

--- a/static/app/views/settings/organizationProjects/index.tsx
+++ b/static/app/views/settings/organizationProjects/index.tsx
@@ -92,14 +92,13 @@ function OrganizationProjects() {
         (searchQuery: string) =>
           navigate(
             {
-              pathname: location.pathname,
               query: {...location.query, query: searchQuery, cursor: undefined},
             },
             {replace: true}
           ),
         DEFAULT_DEBOUNCE_DURATION
       ),
-    [location.pathname, location.query, navigate]
+    [location.query, navigate]
   );
 
   return (

--- a/static/app/views/settings/project/preprod/statusCheckRules.tsx
+++ b/static/app/views/settings/project/preprod/statusCheckRules.tsx
@@ -60,7 +60,6 @@ export function StatusCheckRules() {
     (expandedIds: string[]) => {
       navigate(
         {
-          pathname: location.pathname,
           query: {
             ...location.query,
             expanded: expandedIds,
@@ -69,7 +68,7 @@ export function StatusCheckRules() {
         {replace: true}
       );
     },
-    [location.pathname, location.query, navigate]
+    [location.query, navigate]
   );
 
   const handleToggleExpanded = useCallback(

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -54,7 +54,6 @@ export default function ProjectTeams() {
 
   const handleCursor: CursorHandler = resultsCursor => {
     navigate({
-      pathname: location.pathname,
       query: {...location.query, cursor: resultsCursor},
     });
   };

--- a/static/app/views/settings/project/tempest/DevKitSettings.tsx
+++ b/static/app/views/settings/project/tempest/DevKitSettings.tsx
@@ -67,7 +67,6 @@ export default function DevKitSettings({organization, project}: Props) {
                   initialStep={decodeInteger(location.query.guidedStep)}
                   onStepChange={step => {
                     navigate({
-                      pathname: location.pathname,
                       query: {
                         ...location.query,
                         guidedStep: step,

--- a/static/app/views/settings/project/tempest/EmptyState.tsx
+++ b/static/app/views/settings/project/tempest/EmptyState.tsx
@@ -66,7 +66,6 @@ export default function EmptyState({
             initialStep={decodeInteger(location.query.guidedStep)}
             onStepChange={step => {
               navigate({
-                pathname: location.pathname,
                 query: {
                   ...location.query,
                   guidedStep: step,

--- a/static/app/views/settings/project/tempest/PlayStationSettings.tsx
+++ b/static/app/views/settings/project/tempest/PlayStationSettings.tsx
@@ -120,7 +120,6 @@ export default function PlayStationSettings({organization, project}: Props) {
                 size="sm"
                 onClick={() => {
                   navigate({
-                    pathname: location.pathname,
                     query: {
                       ...location.query,
                       setupInstructions: !isSetupInstructionsOpen,

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -60,7 +60,6 @@ export default function TempestSettings() {
     // setupInstructions is only available on the retail tab
     delete newQuery.setupInstructions;
     navigate({
-      pathname: location.pathname,
       query: newQuery,
     });
   };


### PR DESCRIPTION
Got reports that interacting with settings page filters on pages like `/settings/members` redirected users to `/settings/organization`.

28ffbf4d49e (#110000) deleted the RR3 `test-compat` branch from `useNavigate` but kept its `normalizeUrl()` call, unintentionally adding it to the RR6 code path. The original RR6 path (introduced in 57035b3773c / #70632) passed `to` directly to `locationDescriptorToTo()` without normalization.

I also removed the `applies url normalization for customer-domains` test in `useNavigate.spec.tsx` because the assertion added in 28ffbf4d49e validated the bugged behavior. The original version tested the RR3 path via `routeContext.router.push`, which is now deleted.

Keeping the original commits here that remove `pathname` from `useNavigate` calls since that is still correct, but not the root cause.