### PR TITLE
ref(seer): Remove context engine flag check from continue_run

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -363,13 +363,6 @@ class SeerExplorerClient:
             chat_body["artifact_key"] = artifact_key
             chat_body["artifact_schema"] = artifact_schema.schema()
 
-        if features.has(
-            "organizations:seer-explorer-context-engine",
-            self.organization,
-            actor=self.user,
-        ):
-            chat_body["is_context_engine_enabled"] = True
-
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
 
         if response.status >= 400:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -304,7 +304,7 @@ class SeerExplorerClient:
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-        ):
+        ):  # Set to True at the start of the run and persist in Seer explorer run state
             chat_body["is_context_engine_enabled"] = True
 
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)


### PR DESCRIPTION
+ Stop sending is_context_engine_enabled on continue_run requests. Seer already stores the value from the initial start_run and can determine it from the existing run state, so re-checking the feature flag is unnecessary.

