### PR TITLE
feat(seer): Create an SCM config component to streamline seer setup

### DIFF
--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -113,7 +113,8 @@ export default function RepositoryRow({
                 }
                 onConfirm={deleteRepo}
                 message={t(
-                  'Are you sure you want to remove this repository? All associated commit data will be removed in addition to the repository.'
+                  'Are you sure you want to remove %s? All associated commit data will be removed in addition to the repository.',
+                  <code>{repository.name}</code>
                 )}
               >
                 <Button

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1184,6 +1184,11 @@ function buildRoutes(): RouteObject[] {
           component: make(() => import('getsentry/views/seerAutomation/seerAutomation')),
         },
         {
+          path: 'scm/',
+          // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
+          component: make(() => import('getsentry/views/seerAutomation/scm')),
+        },
+        {
           path: 'projects/',
           // eslint-disable-next-line boundaries/element-types -- TODO: move to getsentry routes
           component: make(() => import('getsentry/views/seerAutomation/projects')),

--- a/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTree.tsx
@@ -1,0 +1,308 @@
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import {useVirtualizer} from '@tanstack/react-virtual';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {addRepository, hideRepository} from 'sentry/actionCreators/integrations';
+import LoadingError from 'sentry/components/loadingError';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Panel from 'sentry/components/panels/panel';
+import {t} from 'sentry/locale';
+import type {
+  Integration,
+  IntegrationRepository,
+  Repository,
+} from 'sentry/types/integrations';
+import type {InfiniteData} from 'sentry/utils/queryClient';
+import {useQueryClient} from 'sentry/utils/queryClient';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import {buildIntegrationTreeNodes} from 'getsentry/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeNodes';
+import {ScmIntegrationTreeRow} from 'getsentry/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeRow';
+import {useScmIntegrationTreeData} from 'getsentry/views/seerAutomation/components/scmIntegrationTree/useScmIntegrationTreeData';
+import type {
+  ProviderFilter,
+  RepoFilter,
+  TreeNode,
+} from 'getsentry/views/seerAutomation/types';
+
+const ROW_HEIGHT = 56;
+const BOTTOM_PADDING = 24;
+
+type Props = {
+  providerFilter: ProviderFilter;
+  repoFilter: RepoFilter;
+  search: string;
+};
+
+export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) {
+  const api = useApi();
+  const organization = useOrganization();
+  const queryClient = useQueryClient();
+  const scrollBodyRef = useRef<HTMLDivElement>(null);
+
+  const {
+    scmProviders,
+    scmIntegrations,
+    connectedIdentifiers,
+    reposByIntegrationId,
+    reposPendingByIntegrationId,
+    reposQueryKey,
+    isPending,
+    isError,
+  } = useScmIntegrationTreeData();
+
+  // Expansion state
+  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
+  const [expandedIntegrations, setExpandedIntegrations] = useState<Set<string>>(
+    new Set()
+  );
+
+  // Expand all providers once data first loads
+  const providersInitialized = useRef(false);
+  useEffect(() => {
+    if (!providersInitialized.current && scmProviders.length > 0) {
+      providersInitialized.current = true;
+      setExpandedProviders(new Set(scmProviders.map(p => p.key)));
+    }
+  }, [scmProviders]);
+
+  // In-flight toggle state to disable checkboxes during mutation
+  const [togglingRepos, setTogglingRepos] = useState<Set<string>>(new Set());
+
+  const toggleProvider = useCallback((providerKey: string) => {
+    setExpandedProviders(prev => {
+      const next = new Set(prev);
+      if (next.has(providerKey)) {
+        next.delete(providerKey);
+      } else {
+        next.add(providerKey);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleIntegration = useCallback((integrationId: string) => {
+    setExpandedIntegrations(prev => {
+      const next = new Set(prev);
+      if (next.has(integrationId)) {
+        next.delete(integrationId);
+      } else {
+        next.add(integrationId);
+      }
+      return next;
+    });
+  }, []);
+
+  // Flatten the tree into a list based on current expansion state
+  const flatNodes = useMemo<TreeNode[]>(
+    () =>
+      buildIntegrationTreeNodes({
+        scmProviders,
+        scmIntegrations,
+        reposByIntegrationId,
+        reposPendingByIntegrationId,
+        connectedIdentifiers,
+        expandedProviders,
+        expandedIntegrations,
+        togglingRepos,
+        search,
+        repoFilter,
+        providerFilter,
+      }),
+    [
+      scmProviders,
+      scmIntegrations,
+      reposByIntegrationId,
+      reposPendingByIntegrationId,
+      connectedIdentifiers,
+      expandedProviders,
+      expandedIntegrations,
+      togglingRepos,
+      search,
+      repoFilter,
+      providerFilter,
+    ]
+  );
+
+  const virtualizer = useVirtualizer({
+    count: flatNodes.length,
+    getScrollElement: () => scrollBodyRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    getItemKey: i => {
+      const node = flatNodes[i]!;
+      if (node.type === 'provider') return `provider:${node.provider.key}`;
+      if (node.type === 'integration') return `integration:${node.integration.id}`;
+      if (node.type === 'add-config') return `add-config:${node.provider.key}`;
+      if (node.type === 'no-match') return `no-match:${node.integrationId}`;
+      return `repo:${node.repo.identifier}`;
+    },
+  });
+
+  const handleToggleRepo = useCallback(
+    async (
+      repo: IntegrationRepository,
+      integration: Integration,
+      isConnected: boolean
+    ) => {
+      setTogglingRepos(prev => new Set(prev).add(repo.identifier));
+
+      try {
+        if (isConnected) {
+          // Find the connected Repository to get its id for the API call
+          const connectedRepo = queryClient
+            .getQueryData<InfiniteData<{json: Repository[]}>>(reposQueryKey as any)
+            ?.pages.flatMap(p => p.json)
+            .find(r => r.name === repo.identifier);
+
+          if (!connectedRepo) {
+            return;
+          }
+
+          const updated = await hideRepository(api, organization.slug, connectedRepo.id);
+          queryClient.setQueryData(
+            reposQueryKey as any,
+            (old: InfiniteData<{json: Repository[]}> | undefined) => {
+              if (!old) return old;
+              return {
+                ...old,
+                pages: old.pages.map(page => ({
+                  ...page,
+                  json: page.json.map(r => (r.id === updated.id ? updated : r)),
+                })),
+              };
+            }
+          );
+          addSuccessMessage(t('Removed %s', repo.name));
+        } else {
+          const newRepo = await addRepository(
+            api,
+            organization.slug,
+            repo.identifier,
+            integration
+          );
+          queryClient.setQueryData(
+            reposQueryKey as any,
+            (old: InfiniteData<{json: Repository[]}> | undefined) => {
+              if (!old) return old;
+              return {
+                ...old,
+                pages: [
+                  {...old.pages[0]!, json: [newRepo, ...(old.pages[0]?.json ?? [])]},
+                  ...old.pages.slice(1),
+                ],
+              };
+            }
+          );
+          addSuccessMessage(t('Added %s', repo.name));
+        }
+      } finally {
+        setTogglingRepos(prev => {
+          const next = new Set(prev);
+          next.delete(repo.identifier);
+          return next;
+        });
+      }
+    },
+    [api, organization.slug, queryClient, reposQueryKey]
+  );
+
+  // Dynamic height: fill remaining viewport
+  const [scrollBodyHeight, setScrollBodyHeight] = useState<number | undefined>(undefined);
+  const setScrollBodyRef = useCallback((el: HTMLDivElement | null) => {
+    scrollBodyRef.current = el;
+    if (el) {
+      requestAnimationFrame(() => {
+        const top = el.getBoundingClientRect().top;
+        setScrollBodyHeight(Math.round(top + BOTTOM_PADDING));
+      });
+    }
+  }, []);
+
+  if (isPending) {
+    return (
+      <Flex justify="center" align="center" padding="xl" style={{minHeight: 200}}>
+        <LoadingIndicator />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Flex justify="center" align="center" padding="xl" style={{minHeight: 200}}>
+        <LoadingError />
+      </Flex>
+    );
+  }
+
+  if (scmProviders.length === 0) {
+    return (
+      <Flex direction="column" align="center" gap="md" padding="xl" minHeight={200}>
+        <Text size="md" variant="muted">
+          {t('No source code management integrations found.')}
+        </Text>
+        <LinkButton
+          priority="primary"
+          to={`/settings/${organization.slug}/integrations/?category=source+code+management`}
+        >
+          {t('Connect an Integration')}
+        </LinkButton>
+      </Flex>
+    );
+  }
+
+  return (
+    <TreePanel>
+      <ScrollableBody
+        ref={setScrollBodyRef}
+        style={{
+          maxHeight: scrollBodyHeight ? `calc(100vh - ${scrollBodyHeight}px)` : undefined,
+        }}
+      >
+        <VirtualInner style={{height: virtualizer.getTotalSize()}}>
+          {virtualizer.getVirtualItems().map(virtualItem => {
+            const node = flatNodes[virtualItem.index];
+            if (!node) return null;
+
+            return (
+              <ScmIntegrationTreeRow
+                key={virtualItem.key}
+                node={node}
+                style={{
+                  transform: `translateY(${virtualItem.start}px)`,
+                  height: virtualItem.size,
+                }}
+                orgSlug={organization.slug}
+                onToggleProvider={toggleProvider}
+                onToggleIntegration={toggleIntegration}
+                onToggleRepo={handleToggleRepo}
+              />
+            );
+          })}
+        </VirtualInner>
+      </ScrollableBody>
+    </TreePanel>
+  );
+}
+
+const TreePanel = styled(Panel)`
+  margin: 0;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const ScrollableBody = styled('div')`
+  position: relative;
+  overflow-y: auto;
+  min-height: 0;
+`;
+
+const VirtualInner = styled('div')`
+  position: relative;
+  width: 100%;
+`;

--- a/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeNodes.ts
+++ b/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeNodes.ts
@@ -1,0 +1,116 @@
+import {isSupportedAutofixProvider} from 'sentry/components/events/autofix/utils';
+import type {
+  Integration,
+  IntegrationProvider,
+  IntegrationRepository,
+} from 'sentry/types/integrations';
+
+import type {
+  ProviderFilter,
+  RepoFilter,
+  TreeNode,
+} from 'getsentry/views/seerAutomation/types';
+
+type Props = {
+  connectedIdentifiers: Set<string>;
+  expandedIntegrations: Set<string>;
+  expandedProviders: Set<string>;
+  providerFilter: ProviderFilter;
+  repoFilter: RepoFilter;
+  reposByIntegrationId: Record<string, IntegrationRepository[]>;
+  reposPendingByIntegrationId: Record<string, boolean>;
+  scmIntegrations: Integration[];
+  scmProviders: IntegrationProvider[];
+  search: string;
+  togglingRepos: Set<string>;
+};
+
+export function buildIntegrationTreeNodes({
+  scmProviders,
+  scmIntegrations,
+  reposByIntegrationId,
+  reposPendingByIntegrationId,
+  connectedIdentifiers,
+  expandedProviders,
+  expandedIntegrations,
+  togglingRepos,
+  search,
+  repoFilter,
+  providerFilter,
+}: Props): TreeNode[] {
+  const nodes: TreeNode[] = [];
+  const query = search.trim().toLowerCase();
+
+  const visibleProviders =
+    providerFilter === 'seer-supported'
+      ? scmProviders.filter(p => isSupportedAutofixProvider({id: p.key, name: p.name}))
+      : scmProviders;
+
+  for (const provider of visibleProviders) {
+    const providerIntegrations = scmIntegrations.filter(
+      i => i.provider.key === provider.key
+    );
+
+    nodes.push({
+      type: 'provider',
+      provider,
+      isExpanded: expandedProviders.has(provider.key),
+      integrationCount: providerIntegrations.length,
+    });
+
+    if (expandedProviders.has(provider.key)) {
+      for (const integration of providerIntegrations) {
+        const repos = reposByIntegrationId[integration.id] ?? [];
+
+        nodes.push({
+          type: 'integration',
+          integration,
+          isExpanded: expandedIntegrations.has(integration.id),
+          isReposPending: reposPendingByIntegrationId[integration.id] ?? false,
+          repoCount: repos.length,
+          connectedRepoCount: repos.filter(r => connectedIdentifiers.has(r.identifier))
+            .length,
+        });
+
+        if (expandedIntegrations.has(integration.id)) {
+          let visibleRepos = query
+            ? repos.filter(r => r.name.toLowerCase().includes(query))
+            : repos;
+
+          if (repoFilter === 'connected') {
+            visibleRepos = visibleRepos.filter(r =>
+              connectedIdentifiers.has(r.identifier)
+            );
+          } else if (repoFilter === 'not-connected') {
+            visibleRepos = visibleRepos.filter(
+              r => !connectedIdentifiers.has(r.identifier)
+            );
+          }
+
+          if (visibleRepos.length === 0 && (query || repoFilter !== 'all')) {
+            nodes.push({
+              type: 'no-match',
+              integrationId: integration.id,
+              search: query,
+              repoFilter,
+            });
+          } else {
+            for (const repo of visibleRepos) {
+              nodes.push({
+                type: 'repo',
+                repo,
+                integration,
+                isConnected: connectedIdentifiers.has(repo.identifier),
+                isToggling: togglingRepos.has(repo.identifier),
+              });
+            }
+          }
+        }
+      }
+
+      // nodes.push({type: 'add-config', provider});
+    }
+  }
+
+  return nodes;
+}

--- a/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -1,0 +1,360 @@
+import {useEffect, useState, type CSSProperties, type ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import {Badge} from '@sentry/scraps/badge';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {hasEveryAccess} from 'sentry/components/acl/access';
+import Confirm from 'sentry/components/confirm';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
+import {IconAdd, IconChevron, IconDelete, IconOpen} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {Integration, IntegrationRepository} from 'sentry/types/integrations';
+import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import useOrganization from 'sentry/utils/useOrganization';
+import useTimeout from 'sentry/utils/useTimeout';
+
+import RepoProviderIcon from 'getsentry/views/seerAutomation/components/repoProviderIcon';
+import type {TreeNode} from 'getsentry/views/seerAutomation/types';
+
+// ---------------------------------------------------------------------------
+// Row component
+// ---------------------------------------------------------------------------
+
+type Props = {
+  node: TreeNode;
+  onToggleIntegration: (integrationId: string) => void;
+  onToggleProvider: (providerKey: string) => void;
+  onToggleRepo: (
+    repo: IntegrationRepository,
+    integration: Integration,
+    isConnected: boolean
+  ) => void;
+  orgSlug: string;
+  style: CSSProperties;
+};
+
+export function ScmIntegrationTreeRow({
+  node,
+  onToggleProvider,
+  onToggleIntegration,
+  onToggleRepo,
+  orgSlug,
+  style,
+}: Props) {
+  const organization = useOrganization();
+  const canAccess =
+    hasEveryAccess(['org:integrations'], {organization}) || isActiveSuperuser();
+
+  if (node.type === 'provider') {
+    if (node.integrationCount === 0) {
+      return (
+        <RowContainer style={style} role="row" aria-level={1}>
+          <Flex
+            align="center"
+            gap="lg"
+            flex={1}
+            height="100%"
+            paddingLeft="3xl"
+            paddingRight="lg"
+          >
+            <Flex align="center" gap="sm" flex={1} justify="between">
+              <Flex align="center" gap="sm">
+                <RepoProviderIcon
+                  provider={`integrations:${node.provider.key}`}
+                  size="sm"
+                />
+                <Text bold size="md">
+                  {node.provider.name}
+                </Text>
+              </Flex>
+
+              <Tooltip
+                disabled={canAccess}
+                position="left"
+                title={t(
+                  'You must be an organization owner, manager or admin to configure'
+                )}
+              >
+                <LinkButton
+                  size="xs"
+                  icon={<IconAdd />}
+                  to={`/settings/${orgSlug}/integrations/${node.provider.slug}/`}
+                  disabled={!canAccess}
+                >
+                  {t('Install Config')}
+                </LinkButton>
+              </Tooltip>
+            </Flex>
+          </Flex>
+        </RowContainer>
+      );
+    }
+    return (
+      <RowContainer style={style} role="row" aria-level={1}>
+        <RowButton
+          onClick={() => onToggleProvider(node.provider.key)}
+          aria-expanded={node.isExpanded}
+          aria-label={node.provider.name}
+        >
+          <InteractionStateLayer hasSelectedBackground={false} />
+          <Flex align="center" gap="lg" flex={1}>
+            <IconChevron direction={node.isExpanded ? 'down' : 'right'} size="xs" />
+            <Flex align="center" gap="sm" flex={1} justify="between">
+              <Flex align="center" gap="sm">
+                <RepoProviderIcon
+                  provider={`integrations:${node.provider.key}`}
+                  size="sm"
+                />
+                <Text bold size="md">
+                  {node.provider.name}
+                </Text>
+              </Flex>
+
+              <Flex align="center" gap="lg">
+                <Badge variant="muted">{t('%s configs', node.integrationCount)}</Badge>
+                <Tooltip
+                  disabled={canAccess}
+                  position="left"
+                  title={t(
+                    'You must be an organization owner, manager or admin to configure'
+                  )}
+                >
+                  <LinkButton
+                    size="xs"
+                    icon={<IconAdd />}
+                    to={`/settings/${orgSlug}/integrations/${node.provider.slug}/`}
+                    disabled={!canAccess}
+                  >
+                    {t('Install Config')}
+                  </LinkButton>
+                </Tooltip>
+              </Flex>
+            </Flex>
+          </Flex>
+        </RowButton>
+      </RowContainer>
+    );
+  }
+
+  if (node.type === 'integration') {
+    return (
+      <RowContainer style={style} role="row" aria-level={2}>
+        <RowButton
+          onClick={() => onToggleIntegration(node.integration.id)}
+          aria-expanded={node.isExpanded}
+          aria-label={node.integration.name}
+        >
+          <InteractionStateLayer hasSelectedBackground={false} />
+          <Flex align="center" gap="lg" flex={1} height="100%" paddingLeft="2xl">
+            <IconChevron direction={node.isExpanded ? 'down' : 'right'} size="xs" />
+            <Flex align="center" gap="sm" flex={1} height="100%" justify="between">
+              <Flex align="center" gap="sm">
+                {node.integration.icon && (
+                  <img
+                    src={node.integration.icon}
+                    alt={node.integration.name}
+                    width={16}
+                    height={16}
+                  />
+                )}
+                <Text size="md">
+                  {node.integration.name}
+                  {node.integration.domainName && (
+                    <Text variant="muted"> &mdash; {node.integration.domainName}</Text>
+                  )}
+                </Text>
+              </Flex>
+              {node.isReposPending ? (
+                <LoadingReposMessage />
+              ) : (
+                <Badge variant="muted">
+                  {t('%s/%s repos connected', node.connectedRepoCount, node.repoCount)}
+                </Badge>
+              )}
+            </Flex>
+          </Flex>
+        </RowButton>
+      </RowContainer>
+    );
+  }
+
+  if (node.type === 'no-match') {
+    let noMatchMessage: ReactNode;
+    if (node.search && node.repoFilter !== 'all') {
+      noMatchMessage =
+        node.repoFilter === 'connected'
+          ? tct('No added repos matching "[search]"', {search: node.search})
+          : tct('No unconnected repos matching "[search]"', {search: node.search});
+    } else if (node.search) {
+      noMatchMessage = tct('No repos matching "[search]"', {search: node.search});
+    } else {
+      noMatchMessage =
+        node.repoFilter === 'connected'
+          ? t('No repos have been added yet')
+          : t('All repos have been added');
+    }
+    return (
+      <RowContainer style={style} role="row" aria-level={3}>
+        <Flex align="center" gap="sm" height="100%" padding="0 lg 0 3xl">
+          <Text size="md" variant="muted">
+            {noMatchMessage}
+          </Text>
+        </Flex>
+      </RowContainer>
+    );
+  }
+
+  if (node.type === 'add-config') {
+    return (
+      <RowContainer style={style} role="row" aria-level={3}>
+        <Flex align="center" gap="sm" height="100%" justify="end" padding="0 lg 0 3xl">
+          <Tooltip
+            disabled={canAccess}
+            position="left"
+            title={t('You must be an organization owner, manager or admin to configure')}
+          >
+            <LinkButton
+              size="xs"
+              icon={<IconAdd />}
+              to={`/settings/${orgSlug}/integrations/${node.provider.slug}/`}
+              disabled={!canAccess}
+            >
+              {t('Add %s Config', node.provider.name)}
+            </LinkButton>
+          </Tooltip>
+        </Flex>
+      </RowContainer>
+    );
+  }
+
+  // node.type === 'repo'
+  return (
+    <RowContainer style={style} role="row" aria-level={3}>
+      <Flex align="center" gap="sm" height="100%" paddingRight="lg">
+        <Flex
+          flex={1}
+          align="center"
+          gap="sm"
+          height="100%"
+          marginLeft="2xl"
+          paddingLeft="3xl"
+        >
+          {node.integration.domainName ? (
+            <ExternalLink
+              href={`https://${node.integration.domainName}/${node.repo.name}`}
+            >
+              <Flex align="center" gap="sm">
+                {node.integration.domainName}/{node.repo.name}
+                <IconOpen size="xs" />
+              </Flex>
+            </ExternalLink>
+          ) : (
+            <Text size="md">{node.repo.name}</Text>
+          )}
+          {node.repo.isInstalled && !node.isConnected && (
+            <Text size="sm" variant="muted">
+              {t('Already added elsewhere')}
+            </Text>
+          )}
+        </Flex>
+        {node.isConnected ? (
+          <Tooltip
+            disabled={canAccess}
+            title={t('You must be an organization owner, manager or admin to uninstall')}
+          >
+            <Confirm
+              onConfirm={() => onToggleRepo(node.repo, node.integration, true)}
+              disabled={!canAccess || node.isToggling}
+              message={t(
+                'Are you sure you want to remove %s? All associated commit data will be removed in addition to the repository.',
+                <code>{node.repo.name}</code>
+              )}
+            >
+              <Button
+                size="xs"
+                icon={<IconDelete />}
+                disabled={!canAccess || node.isToggling}
+                aria-label={t('Remove %s', node.repo.name)}
+              >
+                {t('Remove')}
+              </Button>
+            </Confirm>
+          </Tooltip>
+        ) : (
+          <Tooltip
+            disabled={canAccess}
+            title={t('You must be an organization owner, manager or admin to configure')}
+          >
+            <Button
+              size="xs"
+              icon={<IconAdd />}
+              disabled={!canAccess || node.isToggling}
+              onClick={() => onToggleRepo(node.repo, node.integration, false)}
+              aria-label={t('Add %s', <code>{node.repo.name}</code>)}
+            >
+              {t('Add')}
+            </Button>
+          </Tooltip>
+        )}
+      </Flex>
+    </RowContainer>
+  );
+}
+
+function LoadingReposMessage() {
+  const [messageIndex, setMessageIndex] = useState(0);
+  const {start} = useTimeout({
+    timeMs: 5000,
+    onTimeout: () => {
+      setMessageIndex(prev => prev + 1);
+      start();
+    },
+  });
+  useEffect(start, [start]);
+
+  const messages = [
+    t('Loading repos...'),
+    t('Loading a few repos...'),
+    t('Loading a lot more repos...'),
+    t('This is getting interesting...'),
+    t('Almost done...'),
+    t('Just kidding, still loading...'),
+  ];
+
+  return (
+    <Flex align="center" gap="sm">
+      <Text size="sm" variant="muted">
+        {messages[messageIndex]}
+      </Text>
+      <LoadingIndicator size={16} />
+    </Flex>
+  );
+}
+
+const RowContainer = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  border-bottom: 1px solid ${p => p.theme.tokens.border.neutral.muted};
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const RowButton = styled('button')`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background: none;
+  padding: 0 ${p => p.theme.space.lg} 0 ${p => p.theme.space.md};
+  border: none;
+  cursor: pointer;
+  position: relative;
+`;

--- a/static/gsApp/views/seerAutomation/components/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/gsApp/views/seerAutomation/components/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -1,0 +1,145 @@
+import {useEffect, useMemo} from 'react';
+
+import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import type {
+  Integration,
+  IntegrationProvider,
+  IntegrationRepository,
+  Repository,
+} from 'sentry/types/integrations';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useInfiniteQuery, useQueries, useQuery} from 'sentry/utils/queryClient';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type ScmIntegrationTreeData = {
+  connectedIdentifiers: Set<string>;
+  connectedRepos: Repository[];
+  isError: boolean;
+  isPending: boolean;
+  reposByIntegrationId: Record<string, IntegrationRepository[]>;
+  reposPendingByIntegrationId: Record<string, boolean>;
+  reposQueryKey: unknown;
+  scmIntegrations: Integration[];
+  scmProviders: IntegrationProvider[];
+};
+
+export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
+  const organization = useOrganization();
+
+  // 1. Fetch all integration providers and filter to SCM
+  const providersQuery = useQuery(
+    apiOptions.as<{providers: IntegrationProvider[]}>()(
+      '/organizations/$organizationIdOrSlug/config/integrations/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        staleTime: 60_000,
+      }
+    )
+  );
+
+  const scmProviders = useMemo(
+    () =>
+      (providersQuery.data?.providers ?? [])
+        .filter(p => p.metadata.features.some(f => f.featureGate.includes('commits')))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [providersQuery.data]
+  );
+
+  const scmProviderKeys = useMemo(
+    () => new Set(scmProviders.map(p => p.key)),
+    [scmProviders]
+  );
+
+  // 2. Fetch installed integrations and filter to SCM providers
+  const integrationsQuery = useQuery(
+    apiOptions.as<Integration[]>()('/organizations/$organizationIdOrSlug/integrations/', {
+      path: {organizationIdOrSlug: organization.slug},
+      staleTime: 0,
+    })
+  );
+
+  const scmIntegrations = useMemo(
+    () => (integrationsQuery.data ?? []).filter(i => scmProviderKeys.has(i.provider.key)),
+    [integrationsQuery.data, scmProviderKeys]
+  );
+
+  // 3. Fetch already-connected repos, auto-paginate to get all
+  const reposQueryOptions = organizationRepositoriesInfiniteOptions({organization});
+  const {
+    data: reposPages,
+    hasNextPage: reposHasNextPage,
+    isFetchingNextPage: reposIsFetchingNextPage,
+    fetchNextPage: reposFetchNextPage,
+    isError: reposIsError,
+  } = useInfiniteQuery(reposQueryOptions);
+
+  useEffect(() => {
+    if (!reposIsFetchingNextPage && reposHasNextPage) {
+      reposFetchNextPage();
+    }
+  }, [reposHasNextPage, reposIsFetchingNextPage, reposFetchNextPage]);
+
+  const connectedRepos = useMemo(
+    () => reposPages?.pages.flatMap(page => page.json) ?? [],
+    [reposPages]
+  );
+
+  // Use repo.name for matching, not externalSlug. For GitLab, externalSlug is a
+  // numeric project ID which never matches IntegrationRepository.identifier.
+  // repo.name is consistently "owner/repo" format across all SCM providers.
+  const connectedIdentifiers = useMemo(
+    () => new Set(connectedRepos.map(r => r.name)),
+    [connectedRepos]
+  );
+
+  // 4. Fetch available repos for each SCM integration in parallel.
+  // Use `combine` to derive a stable Record directly from useQueries,
+  // avoiding the unstable array reference in a useMemo dependency.
+  const {reposByIntegrationId, reposPendingByIntegrationId} = useQueries({
+    queries: scmIntegrations.map(integration =>
+      apiOptions.as<{repos: IntegrationRepository[]; searchable: boolean}>()(
+        '/organizations/$organizationIdOrSlug/integrations/$integrationId/repos/',
+        {
+          path: {
+            organizationIdOrSlug: organization.slug,
+            integrationId: integration.id,
+          },
+          staleTime: 0,
+        }
+      )
+    ),
+    combine: results => ({
+      reposByIntegrationId: Object.fromEntries(
+        scmIntegrations.map((integration, i) => [
+          integration.id,
+          results[i]?.data?.repos ?? [],
+        ])
+      ),
+      reposPendingByIntegrationId: Object.fromEntries(
+        scmIntegrations.map((integration, i) => [
+          integration.id,
+          results[i]?.isPending ?? false,
+        ])
+      ),
+    }),
+  });
+
+  const isPending =
+    providersQuery.isPending ||
+    integrationsQuery.isPending ||
+    (reposPages === undefined && !reposIsError);
+
+  const isError = providersQuery.isError || integrationsQuery.isError || reposIsError;
+
+  return {
+    scmProviders,
+    scmIntegrations,
+    connectedRepos,
+    connectedIdentifiers,
+    reposByIntegrationId,
+    reposPendingByIntegrationId,
+    reposQueryKey: reposQueryOptions.queryKey,
+    isPending,
+    isError,
+  };
+}

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -16,6 +16,7 @@ export default function SettingsPageTabs() {
 
   const tabs: Array<[string, Path]> = [
     [t('Settings'), `/settings/${organization.slug}/seer/`],
+    [t('SCM Config'), `/settings/${organization.slug}/seer/scm/`],
     [t('Issue Autofix'), `/settings/${organization.slug}/seer/projects/`],
     [t('Code Review'), `/settings/${organization.slug}/seer/repos/`],
   ];

--- a/static/gsApp/views/seerAutomation/scm.tsx
+++ b/static/gsApp/views/seerAutomation/scm.tsx
@@ -1,0 +1,91 @@
+import {parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
+
+import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
+import {Input} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+
+import AnalyticsArea from 'sentry/components/analyticsArea';
+import {t, tct} from 'sentry/locale';
+import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
+
+import {ScmIntegrationTree} from 'getsentry/views/seerAutomation/components/scmIntegrationTree/scmIntegrationTree';
+import SeerSettingsPageContent from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
+import SeerSettingsPageWrapper from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
+import type {ProviderFilter, RepoFilter} from 'getsentry/views/seerAutomation/types';
+
+const REPO_FILTER_OPTIONS: Array<SelectOption<RepoFilter>> = [
+  {value: 'all' as const, label: t('All repos')},
+  {value: 'connected' as const, label: t('Connected Repos')},
+  {value: 'not-connected' as const, label: t('Disconnected Repos')},
+];
+
+const PROVIDER_FILTER_OPTIONS: Array<SelectOption<ProviderFilter>> = [
+  {value: 'seer-supported' as const, label: t('Supported by Seer')},
+  {value: 'all' as const, label: t('All providers')},
+];
+
+const providerParser = parseAsStringLiteral(
+  PROVIDER_FILTER_OPTIONS.map(option => option.value)
+).withDefault('seer-supported');
+const repoParser = parseAsStringLiteral(
+  REPO_FILTER_OPTIONS.map(option => option.value)
+).withDefault('all');
+
+export default function SeerAutomationSCM() {
+  const [searchTerm, setSearchTerm] = useQueryState(
+    'search',
+    parseAsString.withDefault('')
+  );
+  const [providerFilter, setProviderFilter] = useQueryState('provider', providerParser);
+  const [repoFilter, setRepoFilter] = useQueryState('repo', repoParser);
+
+  return (
+    <AnalyticsArea name="scm">
+      <SeerSettingsPageWrapper>
+        <SettingsPageHeader
+          title={t('Seer SCM Config')}
+          subtitle={tct(
+            `Install an SCM Integration to connect your source code to Seer. Seer needs read access to your source code to perform code review, and analyze your issues. [read_the_docs:Read the docs] and our [privacy:AI Privacy Principles] to learn more.`,
+            {
+              privacy: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/ai-privacy-and-security/" />
+              ),
+              read_the_docs: (
+                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/#seer-capabilities" />
+              ),
+            }
+          )}
+        />
+        <SeerSettingsPageContent>
+          <Flex align="center" gap="md">
+            <CompactSelect
+              value={providerFilter}
+              onChange={(opt: SelectOption<ProviderFilter>) =>
+                setProviderFilter(opt.value)
+              }
+              options={PROVIDER_FILTER_OPTIONS}
+            />
+            <CompactSelect
+              value={repoFilter}
+              onChange={(opt: SelectOption<RepoFilter>) => setRepoFilter(opt.value)}
+              options={REPO_FILTER_OPTIONS}
+            />
+            <Input
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              placeholder={t('Search repos\u2026')}
+              style={{flex: 1}}
+            />
+          </Flex>
+
+          <ScmIntegrationTree
+            providerFilter={providerFilter}
+            repoFilter={repoFilter}
+            search={searchTerm}
+          />
+        </SeerSettingsPageContent>
+      </SeerSettingsPageWrapper>
+    </AnalyticsArea>
+  );
+}

--- a/static/gsApp/views/seerAutomation/types.ts
+++ b/static/gsApp/views/seerAutomation/types.ts
@@ -1,0 +1,55 @@
+import type {
+  Integration,
+  IntegrationProvider,
+  IntegrationRepository,
+} from 'sentry/types/integrations';
+
+export type ProviderNode = {
+  integrationCount: number;
+  isExpanded: boolean;
+  provider: IntegrationProvider;
+  type: 'provider';
+};
+
+export type IntegrationNode = {
+  connectedRepoCount: number;
+  integration: Integration;
+  isExpanded: boolean;
+  isReposPending: boolean;
+  repoCount: number;
+  type: 'integration';
+};
+
+export type RepoNode = {
+  integration: Integration;
+  isConnected: boolean;
+  isToggling: boolean;
+  repo: IntegrationRepository;
+  type: 'repo';
+};
+
+export type AddConfigNode = {
+  provider: IntegrationProvider;
+  type: 'add-config';
+};
+
+export type NoMatchNode = {
+  integrationId: string;
+  repoFilter: RepoFilter;
+  search: string;
+  type: 'no-match';
+};
+
+export type TreeNode =
+  | ProviderNode
+  | IntegrationNode
+  | RepoNode
+  | AddConfigNode
+  | NoMatchNode;
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export type RepoFilter = 'all' | 'connected' | 'not-connected';
+export type ProviderFilter = 'seer-supported' | 'all';


### PR DESCRIPTION
Add a new SCM Config tab under Seer settings that provides a unified
tree view for managing source code management integrations and repos.

The page displays a virtualized three-level tree (Provider → Integration
→ Repository) allowing users to browse all SCM providers and their
installed integrations, see which repos are connected, and add or remove
repos directly from the tree. Includes search filtering, provider
filtering (Seer-supported vs all), and repo status filtering (all,
connected, disconnected).

Key additions:
- `ScmIntegrationTree`: virtualized tree component with expand/collapse
- `useScmIntegrationTreeData`: data hook that fetches providers,
  integrations, connected repos (auto-paginated), and available repos
  per integration in parallel
- `ScmIntegrationTreeRow`: renders provider, integration, repo, and
  empty-state rows with permission checks and confirmation dialogs
- `buildIntegrationTreeNodes`: pure function to flatten the hierarchy
  into a filtered, virtualized list
- New route at /settings/:org/seer/scm/ with tab navigation
- Minor improvement to `repositoryRow` delete confirmation to include
  the repo name

---

# Seer SCM Config — Source Code Manager Integration Tree

*2026-03-09T18:57:23Z by Showboat 0.6.1*
<!-- showboat-id: 72b189dd-cb6e-4fcd-a96c-bb6a01c4d6c6 -->

## What this PR does

This branch adds a new **Seer SCM Config** settings page that lets organization admins connect their source code repositories to Seer (Sentry's AI engine).

Seer needs read access to source code to:
- Perform code review
- Analyze and fix issues with full context

Before this change, there was no dedicated UI to manage which repos are available to Seer. This PR introduces a filterable, virtualized tree that shows all SCM providers, their installed integrations, and the repos available under each — with one-click connect/disconnect toggles.

## Files changed

| File | Purpose |
|------|---------|
| `scm.tsx` | New settings page with search + filter controls |
| `scmIntegrationTree.tsx` | Virtualized tree component (react-virtual) |
| `scmIntegrationTreeRow.tsx` | Row renderer for provider / integration / repo / empty-state nodes |
| `scmIntegrationTreeNodes.ts` | Pure function that builds the flat node list from fetched data |
| `useScmIntegrationTreeData.ts` | Data hook — fetches providers, integrations, connected repos, available repos in parallel |
| `types.ts` | Discriminated union types for each node kind in the tree |
| `settingsPageTabs.tsx` | Adds the "SCM" tab to the Seer settings sidebar |
| `routes.tsx` | Registers the new `/settings/:orgId/seer/scm/` route |
| `repositoryRow.tsx` | Minor tweak (uses the shared `addRepository` action) |

## Architecture

### Data fetching (`useScmIntegrationTreeData`)

Four parallel queries, all resolved before the tree renders:

1. **Providers** — `/organizations/:org/config/integrations/` filtered to providers whose `featureGate` includes `commits` (i.e. SCM providers).
2. **Integrations** — `/organizations/:org/integrations/` filtered to the SCM providers above.
3. **Connected repos** — `/organizations/:org/repos/` fetched with auto-pagination (infinite query that chases `hasNextPage`).
4. **Available repos per integration** — `/organizations/:org/integrations/:id/repos/` fired in parallel for each installed integration via `useQueries`.

The hook returns a stable `connectedIdentifiers` Set (keyed on `repo.name`, not `externalSlug`, because GitLab uses a numeric project ID as the slug which never matches the `identifier` field on `IntegrationRepository`).

### Node model (`types.ts` + `scmIntegrationTreeNodes.ts`)

A flat array of `TreeNode` objects (a discriminated union) is built from the fetched data. The tree looks like:

```
ProviderNode  (GitHub)
  IntegrationNode  (my-org / GitHub)
    RepoNode  (my-org/frontend)
    RepoNode  (my-org/backend)
    NoMatchNode  (shown when filters leave 0 repos)
ProviderNode  (GitLab)
  ...
```

`buildIntegrationTreeNodes` applies three filters before emitting `RepoNode`s:
- **provider filter** — `seer-supported` (default) hides providers not in a supported allowlist; `all` shows everything
- **repo filter** — `connected` / `not-connected` / `all`
- **search** — case-insensitive substring match on `repo.identifier`

### Virtualisation

The flat node array is passed to `@tanstack/react-virtual`'s `useVirtualizer` so that only the visible rows are in the DOM. Each row is a fixed `56px` height.

### Row toggle logic

Connecting a repo calls `addRepository` (existing action creator), disconnecting calls `hideRepository`. Both optimistically update the `connectedIdentifiers` set in the react-query cache to give immediate feedback. The checkbox is disabled while the mutation is in-flight (`togglingRepos` state).

```bash
git diff master...HEAD --stat
```

```output
 static/app/components/repositoryRow.tsx            |   3 +-
 static/app/router/routes.tsx                       |   5 +
 .../scmIntegrationTree/scmIntegrationTree.tsx      | 308 ++++++++++++++++++
 .../scmIntegrationTree/scmIntegrationTreeNodes.ts  | 116 +++++++
 .../scmIntegrationTree/scmIntegrationTreeRow.tsx   | 360 +++++++++++++++++++++
 .../useScmIntegrationTreeData.ts                   | 145 +++++++++
 .../seerAutomation/components/settingsPageTabs.tsx |   1 +
 static/gsApp/views/seerAutomation/scm.tsx          |  91 ++++++
 static/gsApp/views/seerAutomation/types.ts         |  55 ++++
 9 files changed, 1083 insertions(+), 1 deletion(-)
```

```bash
git diff master...HEAD -- static/gsApp/views/seerAutomation/types.ts
```

```output
diff --git static/gsApp/views/seerAutomation/types.ts static/gsApp/views/seerAutomation/types.ts
new file mode 100644
index 00000000000..95a229168e4
--- /dev/null
+++ static/gsApp/views/seerAutomation/types.ts
@@ -0,0 +1,55 @@
+import type {
+  Integration,
+  IntegrationProvider,
+  IntegrationRepository,
+} from 'sentry/types/integrations';
+
+export type ProviderNode = {
+  integrationCount: number;
+  isExpanded: boolean;
+  provider: IntegrationProvider;
+  type: 'provider';
+};
+
+export type IntegrationNode = {
+  connectedRepoCount: number;
+  integration: Integration;
+  isExpanded: boolean;
+  isReposPending: boolean;
+  repoCount: number;
+  type: 'integration';
+};
+
+export type RepoNode = {
+  integration: Integration;
+  isConnected: boolean;
+  isToggling: boolean;
+  repo: IntegrationRepository;
+  type: 'repo';
+};
+
+export type NoMatchNode = {
+  integrationId: string;
+  repoFilter: RepoFilter;
+  search: string;
+  type: 'no-match';
+};
+
+export type TreeNode =
+  | ProviderNode
+  | IntegrationNode
+  | RepoNode
+  | NoMatchNode;
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export type RepoFilter = 'all' | 'connected' | 'not-connected';
+export type ProviderFilter = 'seer-supported' | 'all';
```

## Key design decisions

### 1. Flat list + virtual scroll over recursive tree

A nested tree renders every node in the DOM, which breaks down with hundreds of repos per integration. The flat `TreeNode[]` array lets `useVirtualizer` only mount visible rows. Expand/collapse just re-runs `buildIntegrationTreeNodes`, which is O(n) and synchronous.

### 2. `repo.name` (not `externalSlug`) for connection matching

GitLab's `externalSlug` is a numeric project ID (e.g. `12345`) while `IntegrationRepository.identifier` is always `owner/repo`. Using `repo.name` gives a consistent `owner/repo` key across GitHub, GitLab, and Bitbucket.

### 3. `seer-supported` provider filter as default

The default view hides obscure or legacy SCM providers that Seer doesn't actually use. Users can switch to `All providers` if they need to manage a non-standard integration.

### 4. URL-persisted filters via `nuqs`

Search term, provider filter, and repo filter are stored in the URL query string using `nuqs` (`parseAsString`, `parseAsStringLiteral`). This means filter state survives page refresh and can be linked.

### 5. Optimistic cache update on connect/disconnect

After calling `addRepository` / `hideRepository`, the tree immediately reflects the new connected state by mutating the react-query cache for the repos list. The toggle button is disabled while in-flight to prevent double-clicks.

## Reviewer checklist

- [ ] **Data fetching**: `useScmIntegrationTreeData` makes 4 parallel requests on mount — check network tab for any waterfall
- [ ] **Filter persistence**: navigate to the page, set filters, refresh — filters should be restored from URL params
- [ ] **Connect a repo**: click the toggle on an unconnected repo → success toast + row updates instantly
- [ ] **Disconnect a repo**: click the toggle on a connected repo → confirm dialog → row updates
- [ ] **Search**: type in the search box → repos filter in real time across all providers/integrations
- [ ] **No matches**: with a filter active that returns 0 repos, verify the `NoMatchNode` message renders per-integration
- [ ] **Add config**: for a provider with no installed integration, verify the "Install" CTA renders
- [ ] **Access control**: non-admin members should see repos but the connect toggle should be absent/disabled

## Known limitations

- Repo list per integration is not paginated from the Seer SCM page (the `/repos/` endpoint returns all repos for the integration, which could be large for orgs with many repos in a single integration)
- The `seer-supported` allowlist is maintained as a frontend constant — new providers require a code change

---

<img width="1106" height="612" alt="SCR-20260308-lpep" src="https://github.com/user-attachments/assets/b5d803dc-cb93-4d41-bb77-42c18509ef97" />


