### PR TITLE
Add solo snapshot status checks

### DIFF
--- a/bin/preprod/trigger_snapshot_status_check
+++ b/bin/preprod/trigger_snapshot_status_check
@@ -40,15 +40,29 @@ BUILD_1 = {
     "state": "compared_with_changes",
     "create_base": True,
     # Snapshot comparison results
-    "images_changed": 0,
-    "images_added": 0,
+    "images_changed": 3,
+    "images_added": 1,
     "images_removed": 0,
-    "images_unchanged": 24,
+    "images_unchanged": 20,
     "image_count": 24,
 }
 
 # Set to None to disable BUILD_2
-BUILD_2 = None
+BUILD_2 = {
+    "app_id": "com.emerge.hackernews.ios",
+    "artifact_type": PreprodArtifact.ArtifactType.XCARCHIVE,
+    "app_name": "HackerNews iOS",
+    "build_version": "1.0.3",
+    "build_number": 15,
+    "state": "compared_no_changes",
+    "create_base": True,
+    # Snapshot comparison results
+    "images_changed": 0,
+    "images_added": 0,
+    "images_removed": 0,
+    "images_unchanged": 15,
+    "image_count": 15,
+}
 
 # Available states:
 # - "no_metrics":              Artifact has no snapshot metrics yet (processing)

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -169,7 +169,8 @@ def create_preprod_snapshot_status_check_task(
                 snapshot_metrics_map,
             )
         else:
-            status = StatusCheckStatus.FAILURE
+            # TODO(EME-921) Add logic to fail if there's any base_sha set but no base artifact
+            status = StatusCheckStatus.SUCCESS
             title, subtitle, summary = format_missing_base_snapshot_status_check_messages(
                 all_artifacts,
                 snapshot_metrics_map,

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -20,6 +20,8 @@ from sentry.preprod.vcs.status_checks.size.tasks import (
     update_posted_status_check,
 )
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
+    format_first_snapshot_status_check_messages,
+    format_missing_base_snapshot_status_check_messages,
     format_snapshot_status_check_messages,
 )
 from sentry.shared_integrations.exceptions import ApiError
@@ -143,25 +145,52 @@ def create_preprod_snapshot_status_check_task(
 
     base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
 
-    status = _compute_snapshot_status(
-        all_artifacts, snapshot_metrics_map, comparisons_map, approvals_map
-    )
+    is_solo = not base_artifact_map
+    approve_action_identifier: str | None = None
+
+    if is_solo:
+        app_ids = {a.app_id for a in all_artifacts if a.app_id}
+        has_previous_snapshots = (
+            PreprodSnapshotMetrics.objects.filter(
+                preprod_artifact__project_id=preprod_artifact.project_id,
+                preprod_artifact__app_id__in=app_ids,
+            )
+            .exclude(preprod_artifact__commit_comparison_id=commit_comparison.id)
+            .exists()
+            if app_ids
+            else False
+        )
+        is_first_upload = not has_previous_snapshots
+
+        if is_first_upload:
+            status = StatusCheckStatus.SUCCESS
+            title, subtitle, summary = format_first_snapshot_status_check_messages(
+                all_artifacts,
+                snapshot_metrics_map,
+            )
+        else:
+            status = StatusCheckStatus.FAILURE
+            title, subtitle, summary = format_missing_base_snapshot_status_check_messages(
+                all_artifacts,
+                snapshot_metrics_map,
+            )
+    else:
+        status = _compute_snapshot_status(
+            all_artifacts, snapshot_metrics_map, comparisons_map, approvals_map
+        )
+        title, subtitle, summary = format_snapshot_status_check_messages(
+            all_artifacts,
+            snapshot_metrics_map,
+            comparisons_map,
+            status,
+            base_artifact_map,
+        )
+        if _has_snapshot_changes(all_artifacts, snapshot_metrics_map, comparisons_map):
+            approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     completed_at: datetime | None = None
     if GITHUB_STATUS_CHECK_STATUS_MAPPING[status] == GitHubCheckStatus.COMPLETED:
         completed_at = preprod_artifact.date_updated
-
-    title, subtitle, summary = format_snapshot_status_check_messages(
-        all_artifacts,
-        snapshot_metrics_map,
-        comparisons_map,
-        status,
-        base_artifact_map,
-    )
-
-    approve_action_identifier: str | None = None
-    if _has_snapshot_changes(all_artifacts, snapshot_metrics_map, comparisons_map):
-        approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     url_artifact = (
         preprod_artifact

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -9,6 +9,7 @@ from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSn
 from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_preprod_artifact_url
 
 _SNAPSHOT_TITLE_BASE = _("Snapshot Testing")
+_PROCESSING_STATUS = "⏳ Processing"
 
 
 def format_snapshot_status_check_messages(
@@ -112,6 +113,81 @@ def format_snapshot_status_check_messages(
     return str(title), str(subtitle), str(summary)
 
 
+def format_first_snapshot_status_check_messages(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+) -> tuple[str, str, str]:
+    if not artifacts:
+        raise ValueError("Cannot format messages for empty artifact list")
+
+    title = _SNAPSHOT_TITLE_BASE
+
+    total_images = 0
+    for artifact in artifacts:
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if metrics:
+            total_images += metrics.image_count
+
+    subtitle = ngettext(
+        "%(count)d snapshot uploaded",
+        "%(count)d snapshots uploaded",
+        total_images,
+    ) % {"count": total_images}
+
+    summary = _format_solo_snapshot_summary(artifacts, snapshot_metrics_map)
+    summary += "\n\nThis looks like your first snapshot upload. Snapshot diffs will appear when we have a base upload to compare against. Make sure to upload snapshots from your main branch."
+
+    return str(title), str(subtitle), str(summary)
+
+
+def format_missing_base_snapshot_status_check_messages(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+) -> tuple[str, str, str]:
+    if not artifacts:
+        raise ValueError("Cannot format messages for empty artifact list")
+
+    title = _SNAPSHOT_TITLE_BASE
+    subtitle = str(_("No base snapshots found"))
+
+    summary = _format_solo_snapshot_summary(artifacts, snapshot_metrics_map)
+    summary += "\n\nNo base snapshots found to compare against. Make sure snapshots are uploaded from your main branch."
+
+    return str(title), str(subtitle), str(summary)
+
+
+def _format_solo_snapshot_summary(
+    artifacts: list[PreprodArtifact],
+    snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
+) -> str:
+    table_rows = []
+
+    for artifact in artifacts:
+        mobile_app_info = getattr(artifact, "mobile_app_info", None)
+        app_name = mobile_app_info.app_name if mobile_app_info else None
+        app_display = app_name or artifact.app_id or str(_("Unknown App"))
+        app_id = artifact.app_id or ""
+
+        artifact_url = get_preprod_artifact_url(artifact, view_type="snapshots")
+
+        name_cell = (
+            f"[{app_display}]({artifact_url})<br>`{app_id}`"
+            if app_id
+            else f"[{app_display}]({artifact_url})"
+        )
+
+        metrics = snapshot_metrics_map.get(artifact.id)
+        if not metrics:
+            table_rows.append(f"| {name_cell} | - | {_PROCESSING_STATUS} |")
+            continue
+
+        table_rows.append(f"| {name_cell} | {metrics.image_count} | ✅ Uploaded |")
+
+    table_header = "| Name | Snapshots | Status |\n| :--- | :---: | :---: |\n"
+
+    return table_header + "\n".join(table_rows)
+
+
 def _format_snapshot_summary(
     artifacts: list[PreprodArtifact],
     snapshot_metrics_map: dict[int, PreprodSnapshotMetrics],
@@ -143,19 +219,19 @@ def _format_snapshot_summary(
         )
 
         if not metrics:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Processing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | {_PROCESSING_STATUS} |")
             continue
 
         comparison = comparisons_map.get(metrics.id)
         if not comparison:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Processing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | {_PROCESSING_STATUS} |")
             continue
 
         if comparison.state in (
             PreprodSnapshotComparison.State.PENDING,
             PreprodSnapshotComparison.State.PROCESSING,
         ):
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | ⏳ Comparing |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | {_PROCESSING_STATUS} |")
         else:
             added = comparison.images_added
             removed = comparison.images_removed

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -133,7 +133,7 @@ class SnapshotProcessingStateFormattingTest(SnapshotStatusCheckTestBase):
 
         assert title == "Snapshot Testing"
         assert subtitle == "Comparing snapshots..."
-        assert "Comparing" in summary
+        assert "Processing" in summary
 
     def test_comparison_in_processing_state_shows_comparing(self):
         head_artifact, head_metrics = self._create_artifact_with_metrics(app_id="com.example.head")
@@ -488,7 +488,7 @@ class SnapshotMixedStateFormattingTest(SnapshotStatusCheckTestBase):
 
         assert subtitle == "Comparing snapshots..."
         assert "✅ Unchanged" in summary
-        assert "Comparing" in summary
+        assert "Processing" in summary
 
 
 @region_silo_test
@@ -738,7 +738,7 @@ class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
             "| Name | Snapshots | Status |\n"
             "| :--- | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
-            "\n\n> This looks like your first snapshot upload. Snapshot diffs will appear when we have a base upload to compare against. Make sure to upload snapshots from your main branch."
+            "\n\nThis looks like your first snapshot upload. Snapshot diffs will appear when we have a base upload to compare against. Make sure to upload snapshots from your main branch."
         )
         assert summary == expected
 
@@ -805,6 +805,6 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
             "| Name | Snapshots | Status |\n"
             "| :--- | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
-            "\n\n> No base snapshots found to compare against. Make sure snapshots are uploaded from your main branch."
+            "\n\nNo base snapshots found to compare against. Make sure snapshots are uploaded from your main branch."
         )
         assert summary == expected

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -7,6 +7,8 @@ from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.status_checks.snapshots.templates import (
+    format_first_snapshot_status_check_messages,
+    format_missing_base_snapshot_status_check_messages,
     format_snapshot_status_check_messages,
 )
 from sentry.testutils.cases import TestCase
@@ -653,5 +655,156 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
             "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app` | 1 | 2 | 3 | 1 | 4 | ⏳ Needs approval |"
+        )
+        assert summary == expected
+
+
+@region_silo_test
+class SnapshotFirstUploadFormattingTest(SnapshotStatusCheckTestBase):
+    def test_first_upload_single_artifact(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=24
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        title, subtitle, summary = format_first_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "24 snapshots uploaded"
+        assert "My App" in summary
+        assert "24" in summary
+        assert "✅ Uploaded" in summary
+        assert "first snapshot upload" in summary
+
+    def test_first_upload_multiple_artifacts(self):
+        artifacts = []
+        snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
+
+        for i in range(3):
+            artifact, metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.app{i}",
+                build_number=i + 1,
+                image_count=10,
+            )
+            artifacts.append(artifact)
+            snapshot_metrics_map[artifact.id] = metrics
+
+        title, subtitle, summary = format_first_snapshot_status_check_messages(
+            artifacts, snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "30 snapshots uploaded"
+        for i in range(3):
+            assert f"com.example.app{i}" in summary
+        assert "first snapshot upload" in summary
+
+    def test_first_upload_artifact_without_metrics(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            app_id="com.example.app",
+            build_version="1.0.0",
+            build_number=1,
+        )
+
+        title, subtitle, summary = format_first_snapshot_status_check_messages([artifact], {})
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "0 snapshots uploaded"
+        assert "⏳ Processing" in summary
+        assert "com.example.app" in summary
+        assert "first snapshot upload" in summary
+
+    def test_first_upload_empty_artifacts_raises(self):
+        with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
+            format_first_snapshot_status_check_messages([], {})
+
+    def test_first_upload_summary_table_format(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=15
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        _, _, summary = format_first_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{artifact.id}"
+
+        expected = (
+            "| Name | Snapshots | Status |\n"
+            "| :--- | :---: | :---: |\n"
+            f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
+            "\n\n> This looks like your first snapshot upload. Snapshot diffs will appear when we have a base upload to compare against. Make sure to upload snapshots from your main branch."
+        )
+        assert summary == expected
+
+
+@region_silo_test
+class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
+    def test_missing_base_single_artifact(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=24
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        title, subtitle, summary = format_missing_base_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "No base snapshots found"
+        assert "My App" in summary
+        assert "24" in summary
+        assert "✅ Uploaded" in summary
+        assert "No base snapshots found to compare against" in summary
+
+    def test_missing_base_multiple_artifacts(self):
+        artifacts = []
+        snapshot_metrics_map: dict[int, PreprodSnapshotMetrics] = {}
+
+        for i in range(3):
+            artifact, metrics = self._create_artifact_with_metrics(
+                app_id=f"com.example.app{i}",
+                build_number=i + 1,
+                image_count=10,
+            )
+            artifacts.append(artifact)
+            snapshot_metrics_map[artifact.id] = metrics
+
+        title, subtitle, summary = format_missing_base_snapshot_status_check_messages(
+            artifacts, snapshot_metrics_map
+        )
+
+        assert title == "Snapshot Testing"
+        assert subtitle == "No base snapshots found"
+        for i in range(3):
+            assert f"com.example.app{i}" in summary
+        assert "No base snapshots found to compare against" in summary
+
+    def test_missing_base_empty_artifacts_raises(self):
+        with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
+            format_missing_base_snapshot_status_check_messages([], {})
+
+    def test_missing_base_summary_table_format(self):
+        artifact, metrics = self._create_artifact_with_metrics(
+            app_id="com.example.app", app_name="My App", image_count=15
+        )
+        snapshot_metrics_map = {artifact.id: metrics}
+
+        _, _, summary = format_missing_base_snapshot_status_check_messages(
+            [artifact], snapshot_metrics_map
+        )
+
+        artifact_url = f"http://testserver/organizations/{self.organization.slug}/preprod/snapshots/{artifact.id}"
+
+        expected = (
+            "| Name | Snapshots | Status |\n"
+            "| :--- | :---: | :---: |\n"
+            f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
+            "\n\n> No base snapshots found to compare against. Make sure snapshots are uploaded from your main branch."
         )
         assert summary == expected


### PR DESCRIPTION
Adds solo snapshot status checks. Three cases:

First upload (success - no base to be found)
<img width="1933" height="358" alt="Screenshot 2026-03-06 at 12 02 28 PM" src="https://github.com/user-attachments/assets/17cb4265-66ad-4bee-8310-352d03105039" />


Uploaded and no base provided (success - main branch is the use case here)
<img width="1275" height="323" alt="Screenshot 2026-03-06 at 10 49 16 AM" src="https://github.com/user-attachments/assets/2d29c9d7-2104-4a8f-be3e-22e41f256fa0" />



Uploaded and base provided but not found (error)
<img width="1301" height="362" alt="Screenshot 2026-03-06 at 2 23 39 PM" src="https://github.com/user-attachments/assets/47b395ee-cd6e-436f-adea-acb3ca524a12" />
