### PR TITLE
fix(workflow_engine): Fix Workflow.DoesNotExist issue(s)

### DIFF
--- a/src/sentry/workflow_engine/receivers/detector_workflow.py
+++ b/src/sentry/workflow_engine/receivers/detector_workflow.py
@@ -1,12 +1,11 @@
 from typing import Any
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import router, transaction
 from django.db.models.signals import pre_delete, pre_save
 from django.dispatch import receiver
 
 from sentry.workflow_engine.caches.workflow import DEFAULT_VALUE, invalidate_processing_workflows
-from sentry.workflow_engine.models import DetectorWorkflow
+from sentry.workflow_engine.models import DetectorWorkflow, Workflow
 
 
 @receiver(pre_save, sender=DetectorWorkflow)
@@ -63,7 +62,7 @@ def invalidate_processing_workflows_cache_delete_relationship(
     # invalidate all environments related to the detector
     try:
         env_id = instance.workflow.environment_id
-    except ObjectDoesNotExist:
+    except Workflow.DoesNotExist:
         env_id = DEFAULT_VALUE
 
     transaction.on_commit(

--- a/src/sentry/workflow_engine/receivers/detector_workflow.py
+++ b/src/sentry/workflow_engine/receivers/detector_workflow.py
@@ -1,10 +1,11 @@
 from typing import Any
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import router, transaction
 from django.db.models.signals import pre_delete, pre_save
 from django.dispatch import receiver
 
-from sentry.workflow_engine.caches.workflow import invalidate_processing_workflows
+from sentry.workflow_engine.caches.workflow import DEFAULT_VALUE, invalidate_processing_workflows
 from sentry.workflow_engine.models import DetectorWorkflow
 
 
@@ -28,6 +29,7 @@ def invalidate_processing_workflows_cache_pre(
     # If updating an existing instance, also need to invalidate old relationship
     old_detector_id = None
     old_env_id = None
+
     if instance.pk is not None:
         try:
             # This lookup trade-off is okay, because we rarely update these relationships
@@ -56,7 +58,13 @@ def invalidate_processing_workflows_cache_delete_relationship(
     Uses transaction.on_commit to ensure invalidation happens after DB commit.
     """
     detector_id = instance.detector_id
-    env_id = instance.workflow.environment_id
+
+    # If we don't have a workflow (e.g., during cascade delete), we should
+    # invalidate all environments related to the detector
+    try:
+        env_id = instance.workflow.environment_id
+    except ObjectDoesNotExist:
+        env_id = DEFAULT_VALUE
 
     transaction.on_commit(
         lambda: invalidate_processing_workflows(detector_id, env_id),

--- a/tests/sentry/workflow_engine/receivers/test_detector_workflow.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector_workflow.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from sentry.testutils.cases import TestCase
+from sentry.workflow_engine.caches.workflow import DEFAULT_VALUE
 
 
 class DetectorWorkflowReceiverTests(TestCase):
@@ -54,3 +55,29 @@ class DetectorWorkflowReceiverTests(TestCase):
             self.dw.delete()
 
         mock_invalidate.assert_called_once_with(self.detector.id, self.environment.id)
+
+    def test_cache_invalidate__on_delete__missing_workflow(self) -> None:
+        detector = self.create_detector()
+        workflow = self.create_workflow()
+        dw = self.create_detector_workflow(detector=detector, workflow=workflow)
+        detector_id = detector.id
+
+        # Simulate cascade delete scenario where workflow is deleted before
+        # the pre_delete signal handler can access it
+        from django.core.exceptions import ObjectDoesNotExist
+
+        def raise_does_not_exist(self: object) -> None:
+            raise ObjectDoesNotExist()
+
+        with patch(
+            "sentry.workflow_engine.receivers.detector_workflow.invalidate_processing_workflows"
+        ) as mock_invalidate:
+            with self.capture_on_commit_callbacks(execute=True):
+                with patch.object(
+                    type(dw),
+                    "workflow",
+                    property(fget=raise_does_not_exist),
+                ):
+                    dw.delete()
+
+            mock_invalidate.assert_called_once_with(detector_id, DEFAULT_VALUE)

--- a/tests/sentry/workflow_engine/receivers/test_detector_workflow.py
+++ b/tests/sentry/workflow_engine/receivers/test_detector_workflow.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 from sentry.testutils.cases import TestCase
 from sentry.workflow_engine.caches.workflow import DEFAULT_VALUE
+from sentry.workflow_engine.models import Workflow
 
 
 class DetectorWorkflowReceiverTests(TestCase):
@@ -62,12 +63,8 @@ class DetectorWorkflowReceiverTests(TestCase):
         dw = self.create_detector_workflow(detector=detector, workflow=workflow)
         detector_id = detector.id
 
-        # Simulate cascade delete scenario where workflow is deleted before
-        # the pre_delete signal handler can access it
-        from django.core.exceptions import ObjectDoesNotExist
-
         def raise_does_not_exist(self: object) -> None:
-            raise ObjectDoesNotExist()
+            raise Workflow.DoesNotExist()
 
         with patch(
             "sentry.workflow_engine.receivers.detector_workflow.invalidate_processing_workflows"


### PR DESCRIPTION
# Description
Fixes: https://linear.app/getsentry/issue/ISWF-2182/workflowdoesnotexist-workflow-matching-query-does-not-exist

This use case would happen in async deletions. The workflow is already removed and then when we go to cleanup the relationships we cannot lookup the values.

Instead, we can simply invalidate the whole detector cache if it doesn't have a workflow associated with it.