### PR TITLE
feat(issues): Improve regression breakpoint chart experience

### DIFF
--- a/static/app/chartcuterie/performance.tsx
+++ b/static/app/chartcuterie/performance.tsx
@@ -6,17 +6,12 @@ import {transformToLineSeries} from 'sentry/components/charts/lineChart';
 import getBreakpointChartOptionsFromData, {
   type EventBreakpointChartData,
 } from 'sentry/components/events/eventStatisticalDetector/breakpointChartOptions';
-import type {EventsStatsSeries} from 'sentry/types/organization';
 import {transformStatsResponse} from 'sentry/utils/profiling/hooks/utils';
 import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 
 import {DEFAULT_FONT_FAMILY, makeSlackChartDefaults, slackChartSize} from './slack';
 import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
-
-export type FunctionRegressionPercentileData = {
-  data: EventsStatsSeries<'p95()'>;
-};
 
 type FunctionRegressionChartData = {
   evidenceData: NormalizedTrendsTransaction;
@@ -85,12 +80,8 @@ export function makePerformanceCharts(theme: Theme): Array<RenderDescriptor<Char
         data.rawResponse
       );
 
-      const percentileData = {
-        data: transformed,
-      };
-
-      const param = {
-        percentileData: percentileData as FunctionRegressionPercentileData,
+      const param: EventBreakpointChartData = {
+        percentileData: transformed,
         evidenceData: data.evidenceData,
       };
 

--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.spec.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.spec.tsx
@@ -40,7 +40,7 @@ describe('EventBreakpointChart', () => {
     const link = await screen.findByRole('button', {name: 'Open in Explore'});
     expect(link).toHaveAttribute(
       'href',
-      '/organizations/org-slug/explore/traces/?end=2017-10-17T02%3A41%3A20.000&environment=prod&mode=aggregate&project=-1&query=transaction%3A%22%2Fapi%2Forders%22%20is_transaction%3ATrue&start=2024-01-18T00%3A00%3A00.000&utc=true&visualize=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%7D'
+      '/organizations/org-slug/explore/traces/?end=2017-10-17T02%3A41%3A20.000&environment=prod&mode=samples&project=-1&query=transaction%3A%22%2Fapi%2Forders%22%20is_transaction%3ATrue&start=2024-01-18T00%3A00%3A00.000&utc=true&visualize=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%7D'
     );
   });
 });

--- a/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChart.tsx
@@ -1,5 +1,3 @@
-import snakeCase from 'lodash/snakeCase';
-
 import {LinkButton} from '@sentry/scraps/button';
 
 import {ChartType} from 'sentry/chartcuterie/types';
@@ -21,8 +19,8 @@ import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
-import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 
+import type {BreakpointEvidenceData} from './breakpointChartOptions';
 import {RELATIVE_DAYS_WINDOW} from './consts';
 import Chart from './lineChart';
 
@@ -34,7 +32,8 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
   const organization = useOrganization();
   const location = useLocation();
 
-  const {transaction, breakpoint} = event?.occurrence?.evidenceData ?? {};
+  const occurrenceEvidenceData = event?.occurrence?.evidenceData;
+  const {transaction, breakpoint} = occurrenceEvidenceData ?? {};
 
   const eventView = EventView.fromLocation(location);
   eventView.query = `event.type:transaction transaction:"${transaction}"`;
@@ -60,7 +59,7 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
     typeof transaction === 'string' && typeof breakpoint === 'number'
       ? getExploreUrl({
           organization,
-          mode: Mode.AGGREGATE,
+          mode: Mode.SAMPLES,
           query: `transaction:"${transaction}" is_transaction:True`,
           visualize: [{yAxes: ['p95(span.duration)']}],
           selection: {
@@ -71,14 +70,11 @@ function EventBreakpointChart({event}: EventBreakpointChartProps) {
         })
       : undefined;
 
-  // The evidence data keys are returned to us in camelCase, but we need to
-  // convert them to snake_case to match the NormalizedTrendsTransaction type
-  const normalizedOccurrenceEvent = Object.entries(
-    event?.occurrence?.evidenceData ?? {}
-  ).reduce<Record<string, unknown>>((acc, [key, value]) => {
-    acc[snakeCase(key)] = value;
-    return acc;
-  }, {}) as NormalizedTrendsTransaction;
+  const normalizedOccurrenceEvent: BreakpointEvidenceData = {
+    aggregate_range_1: occurrenceEvidenceData?.aggregateRange1,
+    aggregate_range_2: occurrenceEvidenceData?.aggregateRange2,
+    breakpoint: occurrenceEvidenceData?.breakpoint,
+  };
 
   const {data, isPending} = useGenericDiscoverQuery<
     {

--- a/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
+++ b/static/app/components/events/eventStatisticalDetector/breakpointChartOptions.tsx
@@ -1,10 +1,9 @@
 import type {Theme} from '@emotion/react';
 
-import type {FunctionRegressionPercentileData} from 'sentry/chartcuterie/performance';
 import {ChartType} from 'sentry/chartcuterie/types';
+import type {BaseChartProps} from 'sentry/components/charts/baseChart';
 import VisualMap from 'sentry/components/charts/components/visualMap';
-import type {LineChart as EChartsLineChart} from 'sentry/components/charts/lineChart';
-import type {EventsStatsData} from 'sentry/types/organization';
+import type {EventsStatsData, EventsStatsSeries} from 'sentry/types/organization';
 import {
   axisLabelFormatter,
   getDurationUnit,
@@ -20,43 +19,60 @@ import transformEventStats from 'sentry/views/performance/trends/utils/transform
 import {getIntervalLine} from 'sentry/views/performance/utils/getIntervalLine';
 
 export type EventBreakpointChartData = {
-  evidenceData: NormalizedTrendsTransaction;
-  percentileData: EventsStatsData | FunctionRegressionPercentileData;
+  evidenceData: BreakpointEvidenceData;
+  percentileData: EventsStatsData | EventsStatsSeries<'p95()'>;
 };
+
+export type BreakpointEvidenceData = Pick<
+  NormalizedTrendsTransaction,
+  'aggregate_range_1' | 'aggregate_range_2' | 'breakpoint'
+>;
+
+function transformFunctionStatsToEventsStatsData(
+  stats?: EventsStatsSeries<'p95()'>
+): EventsStatsData {
+  const rawData = stats?.data.find(({axis}) => axis === 'p95()');
+  const timestamps = stats?.timestamps;
+  if (!timestamps || !rawData) {
+    return [];
+  }
+  return timestamps.map((timestamp, i) => [timestamp, [{count: rawData.values[i] ?? 0}]]);
+}
+
+function isEventsStatsData(
+  percentileData: EventBreakpointChartData['percentileData']
+): percentileData is EventsStatsData {
+  return Array.isArray(percentileData);
+}
+
+function toEventsStatsData(
+  chartType: ChartType,
+  percentileData: EventBreakpointChartData['percentileData']
+): EventsStatsData {
+  if (chartType === ChartType.SLACK_PERFORMANCE_FUNCTION_REGRESSION) {
+    return transformFunctionStatsToEventsStatsData(
+      isEventsStatsData(percentileData) ? undefined : percentileData
+    );
+  }
+
+  return isEventsStatsData(percentileData) ? percentileData : [];
+}
 
 function getBreakpointChartOptionsFromData(
   {percentileData, evidenceData}: EventBreakpointChartData,
   chartType: ChartType,
   theme: Theme
 ) {
-  const trendFunctionName: Partial<Record<ChartType, string>> = {
-    [ChartType.SLACK_PERFORMANCE_ENDPOINT_REGRESSION]: 'transaction.duration',
-    [ChartType.SLACK_PERFORMANCE_FUNCTION_REGRESSION]: 'function.duration',
-  };
-
-  const defaultTransform = (stats: any) => stats;
-
-  const transformFunctionStats = (stats: any) => {
-    const rawData = stats?.data?.data?.find(({axis}: any) => axis === 'p95()');
-    const timestamps = stats?.data?.timestamps;
-    if (!timestamps) {
-      return [];
-    }
-    return timestamps.map((timestamp: any, i: any) => [
-      timestamp,
-      [{count: rawData.values[i]}],
-    ]);
-  };
-
-  // Mapping from BreakpointType to transformation functions
-  const transformFunction: Partial<Record<ChartType, (arg: any) => EventsStatsData>> = {
-    [ChartType.SLACK_PERFORMANCE_ENDPOINT_REGRESSION]: defaultTransform,
-    [ChartType.SLACK_PERFORMANCE_FUNCTION_REGRESSION]: transformFunctionStats,
-  };
+  const transformedPercentileData = toEventsStatsData(chartType, percentileData);
+  const trendFunction =
+    chartType === ChartType.SLACK_PERFORMANCE_FUNCTION_REGRESSION
+      ? 'function.duration'
+      : 'transaction.duration';
+  const breakpointMs = evidenceData.breakpoint ? evidenceData.breakpoint * 1000 : 0;
 
   const transformedSeries = transformEventStats(
-    transformFunction[chartType]!(percentileData),
-    generateTrendFunctionAsString(TrendFunctionField.P95, trendFunctionName[chartType]!)
+    transformedPercentileData,
+    generateTrendFunctionAsString(TrendFunctionField.P95, trendFunction)
   );
 
   const intervalSeries = getIntervalLine(
@@ -74,11 +90,12 @@ function getBreakpointChartOptionsFromData(
     right: 16,
     top: 12,
     data: transformedSeries.map(s => s.seriesName),
-  };
+    selectedMode: false,
+  } satisfies BaseChartProps['legend'];
 
   const durationUnit = getDurationUnit(series);
 
-  const chartOptions: Omit<React.ComponentProps<typeof EChartsLineChart>, 'series'> = {
+  const chartOptions = {
     axisPointer: {
       link: [
         {
@@ -87,7 +104,7 @@ function getBreakpointChartOptionsFromData(
         },
       ],
     },
-    colors: [theme.colors.gray200, theme.colors.gray800],
+    colors: [theme.colors.gray800, theme.colors.gray800],
     grid: {
       top: '40px',
       bottom: '0px',
@@ -117,17 +134,17 @@ function getBreakpointChartOptionsFromData(
         pieces: [
           {
             gte: 0,
-            lt: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
+            lt: breakpointMs,
             color: theme.colors.gray800,
           },
           {
-            gte: evidenceData?.breakpoint ? evidenceData.breakpoint * 1000 : 0,
+            gte: breakpointMs,
             color: theme.colors.red400,
           },
         ],
       }),
     },
-  };
+  } satisfies BaseChartProps;
   return {
     series,
     chartOptions,

--- a/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/functionBreakpointChart.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {ChartType} from 'sentry/chartcuterie/types';
+import {type BreakpointEvidenceData} from 'sentry/components/events/eventStatisticalDetector/breakpointChartOptions';
 import Chart from 'sentry/components/events/eventStatisticalDetector/lineChart';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -10,7 +11,6 @@ import {useProfileEventsStats} from 'sentry/utils/profiling/hooks/useProfileEven
 import {useRelativeDateTime} from 'sentry/utils/profiling/hooks/useRelativeDateTime';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
-import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 
 import {RELATIVE_DAYS_WINDOW} from './consts';
 
@@ -69,7 +69,7 @@ function EventFunctionBreakpointChartInner({
     relativeDays: RELATIVE_DAYS_WINDOW,
   });
 
-  const functionStats = useProfileEventsStats({
+  const {data: functionPercentileData} = useProfileEventsStats({
     dataset: 'profileFunctions',
     datetime,
     query: `fingerprint:${fingerprint}`,
@@ -77,11 +77,11 @@ function EventFunctionBreakpointChartInner({
     yAxes: SERIES,
   });
 
-  const normalizedOccurrenceEvent = {
+  const normalizedOccurrenceEvent: BreakpointEvidenceData = {
     aggregate_range_1: evidenceData.aggregateRange1 / 1e6,
     aggregate_range_2: evidenceData.aggregateRange2 / 1e6,
     breakpoint: evidenceData.breakpoint,
-  } as NormalizedTrendsTransaction;
+  };
 
   return (
     <InterimSection
@@ -89,7 +89,7 @@ function EventFunctionBreakpointChartInner({
       title={t('Regression Breakpoint Chart')}
     >
       <Chart
-        percentileData={functionStats}
+        percentileData={functionPercentileData}
         evidenceData={normalizedOccurrenceEvent}
         datetime={datetime}
         chartType={ChartType.SLACK_PERFORMANCE_FUNCTION_REGRESSION}

--- a/static/app/components/events/eventStatisticalDetector/lineChart.tsx
+++ b/static/app/components/events/eventStatisticalDetector/lineChart.tsx
@@ -1,25 +1,30 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 
-import type {FunctionRegressionPercentileData} from 'sentry/chartcuterie/performance';
 import type {ChartType} from 'sentry/chartcuterie/types';
-import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart as EChartsLineChart} from 'sentry/components/charts/lineChart';
-import getBreakpointChartOptionsFromData from 'sentry/components/events/eventStatisticalDetector/breakpointChartOptions';
+import getBreakpointChartOptionsFromData, {
+  type BreakpointEvidenceData,
+  type EventBreakpointChartData,
+} from 'sentry/components/events/eventStatisticalDetector/breakpointChartOptions';
 import type {PageFilters} from 'sentry/types/core';
-import type {EventsStatsData} from 'sentry/types/organization';
-import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
+import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
 interface ChartProps {
   chartType: ChartType;
   datetime: PageFilters['datetime'];
-  evidenceData: NormalizedTrendsTransaction;
-  percentileData: EventsStatsData | FunctionRegressionPercentileData;
-  trendFunctionName?: string;
+  evidenceData: BreakpointEvidenceData;
+  percentileData: EventBreakpointChartData['percentileData'];
 }
 
 function LineChart({datetime, percentileData, evidenceData, chartType}: ChartProps) {
   const theme = useTheme();
+  const normalizedDateTime = {
+    period: datetime.period,
+    start: datetime.start ? getUtcToLocalDateObject(datetime.start) : undefined,
+    end: datetime.end ? getUtcToLocalDateObject(datetime.end) : undefined,
+    utc: datetime.utc ?? undefined,
+  };
 
   const {series, chartOptions} = useMemo(() => {
     return getBreakpointChartOptionsFromData(
@@ -30,11 +35,13 @@ function LineChart({datetime, percentileData, evidenceData, chartType}: ChartPro
   }, [percentileData, evidenceData, chartType, theme]);
 
   return (
-    <ChartZoom {...datetime}>
-      {zoomRenderProps => (
-        <EChartsLineChart {...zoomRenderProps} {...chartOptions} series={series} />
-      )}
-    </ChartZoom>
+    <EChartsLineChart
+      {...normalizedDateTime}
+      {...chartOptions}
+      isGroupedByDate
+      showTimeInTooltip
+      series={series}
+    />
   );
 }
 

--- a/static/app/views/performance/utils/getIntervalLine.tsx
+++ b/static/app/views/performance/utils/getIntervalLine.tsx
@@ -6,9 +6,10 @@ import type {LineChartSeries} from 'sentry/components/charts/lineChart';
 import {t} from 'sentry/locale';
 import type {Series} from 'sentry/types/echarts';
 import {tooltipFormatter} from 'sentry/utils/discover/charts';
-import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 import {getPerformanceDuration} from 'sentry/views/performance/utils/getPerformanceDuration';
-import transformTransaction from 'sentry/views/performance/utils/transformTransaction';
+import transformTransaction, {
+  type BreakpointTransaction,
+} from 'sentry/views/performance/utils/transformTransaction';
 
 const DEFAULT_CHART_HEIGHT = 200;
 const X_AXIS_MARGIN_OFFSET = 23;
@@ -18,7 +19,7 @@ export function getIntervalLine(
   series: Series[],
   intervalRatio: number,
   label: boolean,
-  transaction?: NormalizedTrendsTransaction,
+  transaction?: BreakpointTransaction,
   useRegressionFormat?: boolean
 ): LineChartSeries[] {
   if (!transaction || !series.length || !series[0]!.data?.length) {

--- a/static/app/views/performance/utils/transformTransaction.tsx
+++ b/static/app/views/performance/utils/transformTransaction.tsx
@@ -1,8 +1,13 @@
 import type {NormalizedTrendsTransaction} from 'sentry/views/performance/trends/types';
 
+export type BreakpointTransaction = Pick<
+  NormalizedTrendsTransaction,
+  'aggregate_range_1' | 'aggregate_range_2' | 'breakpoint'
+>;
+
 export default function transformTransaction(
-  transaction: NormalizedTrendsTransaction
-): NormalizedTrendsTransaction {
+  transaction: BreakpointTransaction
+): BreakpointTransaction {
   if (transaction?.breakpoint) {
     return {
       ...transaction,


### PR DESCRIPTION
- Route Open in Explore to span samples while preserving chart visualize context.
- Disable legend toggling and keep legend marker color aligned with displayed lines.
- Simplify breakpoint chart data typing and evidence normalization for endpoint and function regressions.

[example issue](https://scooper.sentry.io/issues/7250426731/)