### PR TITLE
fix(explorer): handle missing counts in get_filter_key_values and don't query both backends

### DIFF
--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -621,28 +621,30 @@ def get_filter_key_values(
     if issues_resp.status_code == 200 and issues_resp.data:
         all_results.extend(issues_resp.data)
 
-    # 3. Try events dataset with flags backend (feature flags)
-    flags_params = {**base_params, "dataset": Dataset.Events.value, "useFlagsBackend": "1"}
-    flags_resp = client.get(
-        auth=api_key,
-        user=None,
-        path=f"/organizations/{organization.slug}/tags/{attribute_key}/values/",
-        params=flags_params,
-    )
-    if flags_resp.status_code == 200 and flags_resp.data:
-        all_results.extend(flags_resp.data)
-
+    # 3. Try flags backend (feature flags) only if no results were found. This is only enabled for events dataset
     if not all_results:
-        return []
+        flags_params = {**base_params, "dataset": Dataset.Events.value, "useFlagsBackend": "1"}
+        flags_resp = client.get(
+            auth=api_key,
+            user=None,
+            path=f"/organizations/{organization.slug}/tags/{attribute_key}/values/",
+            params=flags_params,
+        )
+        if flags_resp.status_code == 200 and flags_resp.data:
+            all_results.extend(flags_resp.data)
 
     # Merge results by value, summing counts and keeping most recent timestamps
     merged: dict[str, dict[str, Any]] = {}
     for item in all_results:
+        if "count" not in item:
+            # filter malformed responses (should match TagValueSerializerResponse)
+            continue
+
         value = item["value"]
         if value not in merged:
             merged[value] = item.copy()
         else:
-            merged[value]["count"] = merged[value].get("count", 0) + item.get("count", 0)
+            merged[value]["count"] += item["count"]
             if "lastSeen" in item and "lastSeen" in merged[value]:
                 if item["lastSeen"] > merged[value]["lastSeen"]:
                     merged[value]["lastSeen"] = item["lastSeen"]
@@ -651,8 +653,7 @@ def get_filter_key_values(
                     merged[value]["firstSeen"] = item["firstSeen"]
 
     result = list(merged.values())
-    result.sort(key=lambda x: x.get("count", 0), reverse=True)
-
+    result.sort(key=lambda x: x["count"], reverse=True)
     return result
 
 

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -636,7 +636,9 @@ def get_filter_key_values(
     # Merge results by value, summing counts and keeping most recent timestamps
     merged: dict[str, dict[str, Any]] = {}
     for item in all_results:  # expected to be TagValueSerializerResponse
-        item["count"] = item.get("count") or 1
+        if not item.get("value") or not item.get("count"):
+            continue
+
         value = item["value"]
         if value not in merged:
             merged[value] = item.copy()

--- a/src/sentry/seer/assisted_query/issues_tools.py
+++ b/src/sentry/seer/assisted_query/issues_tools.py
@@ -635,11 +635,8 @@ def get_filter_key_values(
 
     # Merge results by value, summing counts and keeping most recent timestamps
     merged: dict[str, dict[str, Any]] = {}
-    for item in all_results:
-        if "count" not in item:
-            # filter malformed responses (should match TagValueSerializerResponse)
-            continue
-
+    for item in all_results:  # expected to be TagValueSerializerResponse
+        item["count"] = item.get("count") or 1
         value = item["value"]
         if value not in merged:
             merged[value] = item.copy()

--- a/src/sentry/tagstore/types.py
+++ b/src/sentry/tagstore/types.py
@@ -166,11 +166,10 @@ class TagValueSerializerResponseOptional(TypedDict, total=False):
 class TagValueSerializerResponse(TagValueSerializerResponseOptional):
     key: str
     name: str
-    value: str
-    count: int
-    # Empty values do not have last seen timestamps.
+    value: str | None
+    # Empty values do not have counts, last seen or first seen timestamps.
+    count: int | None
     lastSeen: str | None
-    # Empty values do not have first seen timestamps.
     firstSeen: str | None
 
 


### PR DESCRIPTION
Fixes [SENTRY-5KXR](https://sentry.sentry.io/issues/7316164948/events/d048e0931b4145518538677740efd446/)

The response type is TagValueSerializerResponse which appears to incorrectly have `int` count rather than `int | None`. Based on TagValue and TagValueSerializer, values and counts can be none. Updates the type and handle this edge case in our rpc by dropping them.

Also follows the pattern of skipping the feature flags query if we got results from tags, matching what we do for get_event_filter_key_values