### PR TITLE
ref: graduate session-replay-issue-emails and session-replay-slack-new-issue

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -330,14 +330,10 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-agent-pr-consolidation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables Seer Autopilot
     manager.add("organizations:seer-autopilot", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable linking from 'new issue' email notifs to the issue replay list
-    manager.add("organizations:session-replay-issue-emails", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Disable select orgs from ingesting mobile replay events.
     manager.add("organizations:session-replay-video-disabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable data scrubbing of replay recording payloads in Relay.
     manager.add("organizations:session-replay-recording-scrubbing", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
-    # Enable linking from 'new issue' slack notifs to the issue replay list
-    manager.add("organizations:session-replay-slack-new-issue", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable core Session Replay link in the sidebar
     manager.add("organizations:session-replay-ui", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable the rendering of @sentry/toolbar inside the sentry app. See `useInitSentryToolbar()`

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -257,10 +257,7 @@ def build_attachment_replay_link(
     group: Group, url_format: str, event: Event | GroupEvent | None = None
 ) -> str | None:
     has_replay = features.has("organizations:session-replay", group.organization)
-    has_slack_links = features.has(
-        "organizations:session-replay-slack-new-issue", group.organization
-    )
-    if has_replay and has_slack_links and group.has_replays():
+    if has_replay and group.has_replays():
         referrer = EXTERNAL_PROVIDERS[ExternalProviders.SLACK]
         replay_url = f"{group.get_absolute_url()}replays/?referrer={referrer}"
 

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -183,7 +183,6 @@ class DigestNotification(ProjectNotification):
         notification_uuid: str | None = None,
     ) -> MutableMapping[str, Any]:
         has_session_replay = features.has("organizations:session-replay", organization)
-        show_replay_link = features.has("organizations:session-replay-issue-emails", organization)
         return {
             **get_digest_as_context(digest.digest),
             "event_counts": digest.event_counts,
@@ -199,7 +198,7 @@ class DigestNotification(ProjectNotification):
                 alert_timestamp,
                 notification_uuid=notification_uuid,
             ),
-            "show_replay_links": has_session_replay and show_replay_link,
+            "show_replay_links": has_session_replay,
         }
 
     def get_extra_context(

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -226,10 +226,7 @@ class AlertRuleNotification(ProjectNotification):
             context.update({"tags": self.event.tags, "interfaces": get_interface_list(self.event)})
 
         has_session_replay = features.has("organizations:session-replay", self.organization)
-        show_replay_link = features.has(
-            "organizations:session-replay-issue-emails", self.organization
-        )
-        if has_session_replay and show_replay_link and get_replay_id(self.event):
+        if has_session_replay and get_replay_id(self.event):
             context.update(
                 {
                     "issue_replays_url": get_issue_replay_link(self.group, sentry_query_params),

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1318,9 +1318,7 @@ class BuildGroupAttachmentReplaysTest(TestCase):
         )
         assert event.group is not None
 
-        with self.feature(
-            ["organizations:session-replay", "organizations:session-replay-slack-new-issue"]
-        ):
+        with self.feature(["organizations:session-replay"]):
             blocks = SlackIssuesMessageBuilder(event.group, event.for_group(event.group)).build()
         assert isinstance(blocks, dict)
         assert (

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -912,7 +912,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
         event.group.substatus = GroupSubStatus.REGRESSED
         event.group.save()
 
-        features = ["organizations:session-replay", "organizations:session-replay-issue-emails"]
+        features = ["organizations:session-replay"]
         with self.feature(features):
             with self.tasks():
                 notification = Notification(event=event)
@@ -1526,7 +1526,7 @@ class MailAdapterNotifyDigestTest(BaseMailAdapterTest, ReplaysSnubaTestCase):
             project, (event_to_record(event, (rule,)), event_to_record(event2, (rule,)))
         )
 
-        features = ["organizations:session-replay", "organizations:session-replay-issue-emails"]
+        features = ["organizations:session-replay"]
         with self.feature(features), self.tasks():
             self.adapter.notify_digest(
                 project,


### PR DESCRIPTION
These rollout flags have been at ga=1.0 in all regions since Aug 2023. Remove the flag checks and simplify conditions.