### PR TITLE
ref: remove dead mobile perf score relay flag and code

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -195,8 +195,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:ownership-size-limit-large", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable xlarge ownership rule file size limit
     manager.add("organizations:ownership-size-limit-xlarge", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable mobile performance score calculation for transactions in relay
-    manager.add("organizations:performance-calculate-mobile-perf-score-relay", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables setting the fetch all custom measurements request time range to match the user selected time range instead of 90 days
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Temporary flag to test search performance that's running slow in S4S

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -987,73 +987,6 @@ def _get_default_browser_performance_profiles(
     ]
 
 
-def _get_mobile_performance_profiles(
-    organization: Organization,
-) -> list[dict[str, Any]]:
-    if not features.has(
-        "organizations:performance-calculate-mobile-perf-score-relay", organization
-    ):
-        return []
-
-    return [
-        {
-            "name": "Mobile",
-            "version": "mobile.alpha",
-            "scoreComponents": [
-                {
-                    "measurement": "time_to_initial_display",
-                    "weight": 0.25,
-                    "p10": 1800.0,
-                    "p50": 3000.0,
-                    "optional": True,
-                },
-                {
-                    "measurement": "time_to_full_display",
-                    "weight": 0.25,
-                    "p10": 2500.0,
-                    "p50": 4000.0,
-                    "optional": True,
-                },
-                {
-                    "measurement": "app_start_warm",
-                    "weight": 0.25,
-                    "p10": 200.0,
-                    "p50": 500.0,
-                    "optional": True,
-                },
-                {
-                    "measurement": "app_start_cold",
-                    "weight": 0.25,
-                    "p10": 200.0,
-                    "p50": 500.0,
-                    "optional": True,
-                },
-            ],
-            "condition": {
-                "op": "and",
-                "inner": [
-                    {
-                        "op": "or",
-                        "inner": [
-                            {
-                                "op": "eq",
-                                "name": "event.sdk.name",
-                                "value": "sentry.cocoa",
-                            },
-                            {
-                                "op": "eq",
-                                "name": "event.sdk.name",
-                                "value": "sentry.java.android",
-                            },
-                        ],
-                    },
-                    {"op": "eq", "name": "event.contexts.trace.op", "value": "ui.load"},
-                ],
-            },
-        }
-    ]
-
-
 def _get_project_config(
     project: Project, project_keys: Iterable[ProjectKey] | None = None
 ) -> ProjectConfig:
@@ -1150,7 +1083,6 @@ def _get_project_config(
     performance_score_profiles = [
         *_get_desktop_browser_performance_profiles(project.organization),
         *_get_mobile_browser_performance_profiles(project.organization),
-        *_get_mobile_performance_profiles(project.organization),
         *_get_default_browser_performance_profiles(project.organization),
     ]
     if performance_score_profiles:


### PR DESCRIPTION
The performance-calculate-mobile-perf-score-relay flag has been at 0% in all regions since creation.
