### PR TITLE
ref: graduate profiling-browser flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -278,8 +278,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:profiling-beta", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enables dropping of profiles that may come from buggy sdks
     manager.add("organizations:profiling-reject-sdks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables production profiling in sentry browser application
-    manager.add("organizations:profiling-browser", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enables separate differential flamegraph page
     manager.add("organizations:profiling-differential-flamegraph-page", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable global suspect functions in profiling

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from fnmatch import fnmatch
 
-import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
@@ -172,14 +171,7 @@ class ReactMixin:
 
         response = render_to_response("sentry/base-react.html", context=context, request=request)
 
-        try:
-            if "x-sentry-browser-profiling" in request.headers or (
-                organization is not None
-                and features.has("organizations:profiling-browser", organization)
-            ):
-                response["Document-Policy"] = "js-profiling"
-        except Exception as error:
-            sentry_sdk.capture_exception(error)
+        response["Document-Policy"] = "js-profiling"
 
         return response
 

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -401,21 +401,7 @@ class ReactPageViewTest(TestCase):
             ]
             assert "activeorg" in self.client.session
 
-    def test_document_policy_header_when_flag_is_enabled(self) -> None:
-        org = self.create_organization(owner=self.user)
-
-        self.login_as(self.user)
-
-        with self.feature({"organizations:profiling-browser": [org.slug]}):
-            response = self.client.get(
-                "/issues/",
-                HTTP_HOST=f"{org.slug}.testserver",
-                follow=True,
-            )
-            assert response.status_code == 200
-            assert response.headers["Document-Policy"] == "js-profiling"
-
-    def test_document_policy_header_when_flag_is_disabled(self) -> None:
+    def test_document_policy_header(self) -> None:
         org = self.create_organization(owner=self.user)
 
         self.login_as(self.user)
@@ -426,7 +412,7 @@ class ReactPageViewTest(TestCase):
             follow=True,
         )
         assert response.status_code == 200
-        assert "Document-Policy" not in response.headers
+        assert response.headers["Document-Policy"] == "js-profiling"
 
     def test_dns_prefetch(self) -> None:
         us_region = Cell("us", 1, "https://us.testserver", RegionCategory.MULTI_TENANT)


### PR DESCRIPTION
This flag has been at ga=0.5 in all regions since Nov 2023. Its only effect is setting the Document-Policy: js-profiling HTTP header. There's no reason it shouldn't be 100%.

Always set the header unconditionally.

Alternatively - should we just remove this feature?