### PR TITLE
fix(insights): handle nullable sentry.normalized_description

### DIFF
--- a/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
+++ b/static/app/views/insights/browser/resources/components/tables/resourceTable.tsx
@@ -142,7 +142,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
     const {key} = col;
 
     if (key === NORMALIZED_DESCRIPTION) {
-      const fileExtension = row[NORMALIZED_DESCRIPTION].split('.').pop() || '';
+      const fileExtension = (row[NORMALIZED_DESCRIPTION] ?? '').split('.').pop() || '';
       const extraLinkQueryParams = {};
       if (filters[SpanFields.USER_GEO_SUBREGION]) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
@@ -156,7 +156,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
             moduleName={ModuleName.RESOURCE}
             projectId={row[PROJECT_ID]}
             spanOp={row[SPAN_OP]}
-            description={row[NORMALIZED_DESCRIPTION]}
+            description={row[NORMALIZED_DESCRIPTION] ?? ''}
             group={row[SPAN_GROUP]}
             extraLinkQueryParams={extraLinkQueryParams}
           />
@@ -173,7 +173,7 @@ function ResourceTable({sort, defaultResourceTypes}: Props) {
       return <DurationCell milliseconds={row[key]} />;
     }
     if (key === SPAN_OP) {
-      const fileExtension = row[NORMALIZED_DESCRIPTION].split('.').pop() || '';
+      const fileExtension = (row[NORMALIZED_DESCRIPTION] ?? '').split('.').pop() || '';
       const spanOp = row[key];
       if (fileExtension === 'js' || spanOp === 'resource.script') {
         return <span>{t('JavaScript')}</span>;

--- a/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowAssetsWidget.tsx
@@ -144,7 +144,7 @@ export default function OverviewAssetsByTimeSpentWidget(props: LoadableChartWidg
           <SpanDescriptionCell
             projectId={Number(item[SpanFields.PROJECT_ID])}
             group={item[SpanFields.SPAN_GROUP]}
-            description={item[SpanFields.NORMALIZED_DESCRIPTION]}
+            description={item[SpanFields.NORMALIZED_DESCRIPTION] ?? ''}
             moduleName={ModuleName.RESOURCE}
           />
           <TimeSpentCell

--- a/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewSlowQueriesChartWidget.tsx
@@ -121,7 +121,7 @@ export default function OverviewSlowQueriesChartWidget(props: LoadableChartWidge
             <SpanDescriptionCell
               projectId={Number(item['project.id'])}
               group={item['span.group']}
-              description={item['sentry.normalized_description']}
+              description={item['sentry.normalized_description'] ?? ''}
               moduleName={ModuleName.DB}
             />
             <ControllerText>{item.transaction}</ControllerText>

--- a/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
+++ b/static/app/views/insights/common/components/widgets/overviewTimeConsumingQueriesWidget.tsx
@@ -148,7 +148,7 @@ export default function OverviewTimeConsumingQueriesWidget(
           <SpanDescriptionCell
             projectId={Number(item[SpanFields.PROJECT_ID])}
             group={item[SpanFields.SPAN_GROUP]}
-            description={item[SpanFields.NORMALIZED_DESCRIPTION]}
+            description={item[SpanFields.NORMALIZED_DESCRIPTION] ?? ''}
             moduleName={ModuleName.DB}
           />
           <TimeSpentCell

--- a/static/app/views/insights/database/components/tables/queriesTable.tsx
+++ b/static/app/views/insights/database/components/tables/queriesTable.tsx
@@ -162,7 +162,7 @@ function renderBodyCell(
     return (
       <SpanDescriptionCell
         moduleName={ModuleName.DB}
-        description={row['sentry.normalized_description']}
+        description={row['sentry.normalized_description'] ?? ''}
         group={row['span.group']}
         projectId={row['project.id']}
         system={system}

--- a/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
+++ b/static/app/views/insights/database/views/databaseSpanSummaryPage.tsx
@@ -199,7 +199,7 @@ export function DatabaseSpanSummaryPage() {
                   <DatabaseSpanDescription
                     groupId={groupId}
                     preliminaryDescription={
-                      spanMetrics?.[SpanFields.NORMALIZED_DESCRIPTION]
+                      spanMetrics?.[SpanFields.NORMALIZED_DESCRIPTION] ?? undefined
                     }
                   />
                 </DescriptionContainer>

--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -253,7 +253,11 @@ export type SpanNumberFields =
   | SpanFields.TTFD;
 
 // TODO: Enforce that these fields all come from SpanFields
-export type SpanStringFields =
+// These fields should never be `null` when coming from the backend. This list
+// is _not_ up-to-date! If you discover more nullable string fields, update this
+// list. In theory, maybe _all_ of these fields are actually nullable in
+// reality, which means we'll need to update a lot of code.
+export type NonNullableStringFields =
   | SpanFields.COMMAND
   | SpanFields.REQUEST_METHOD
   | SpanFields.HTTP_REQUEST_METHOD
@@ -300,7 +304,6 @@ export type SpanStringFields =
   | SpanFields.DEVICE_CLASS
   | SpanFields.SPAN_ACTION
   | SpanFields.SPAN_DOMAIN
-  | SpanFields.NORMALIZED_DESCRIPTION
   | SpanFields.MESSAGING_MESSAGE_BODY_SIZE
   | SpanFields.MESSAGING_MESSAGE_RECEIVE_LATENCY
   | SpanFields.MESSAGING_MESSAGE_RETRY_COUNT
@@ -326,6 +329,10 @@ export type SpanStringFields =
   | SpanFields.PROFILER_ID
   | SpanFields.USER_DISPLAY
   | SpanFields.SENTRY_ORIGIN;
+
+type NullableStringFields = SpanFields.NORMALIZED_DESCRIPTION;
+
+export type SpanStringFields = NullableStringFields | NonNullableStringFields;
 
 type WebVitalsMeasurements =
   | SpanFields.CLS_SCORE
@@ -491,7 +498,9 @@ type SpanResponseRaw = {
 } & {
   [Property in WebVitalsMeasurements as `${WebVitalsFunctions}(${Property})`]: number;
 } & {
-  [Property in SpanStringFields as `${Property}`]: string;
+  [Property in NonNullableStringFields as `${Property}`]: string;
+} & {
+  [Property in NullableStringFields as `${Property}`]: string | null;
 } & {
   [Property in SpanNumberFields as `${Property}`]: number;
 } & {


### PR DESCRIPTION
`sentry.normalized_description` can be `null` from the backend, but the `SpanResponseRaw` type previously typed it as `string`. This caused runtime errors when the value was null — most notably, the SQLish parser was being called with `null` input, causing a TypeError that was being captured as a Sentry error.

This PR updates the type to correctly reflect that `sentry.normalized_description` is nullable, and adds `?? ''` fallbacks at all call sites that pass it to components expecting a non-null `string`.

Fixes DAIN-1290