### PR TITLE
feat(seer): Add is_private field to repo definitions for code review

### DIFF
--- a/src/sentry/seer/code_review/models.py
+++ b/src/sentry/seer/code_review/models.py
@@ -86,6 +86,7 @@ class SeerCodeReviewRepoDefinition(BaseModel):
     # Optional in base, overridden in subclasses based on request type
     organization_id: int | None = None
     integration_id: str | None = None
+    is_private: bool | None = None
 
 
 class SeerCodeReviewRepoForPrReview(SeerCodeReviewRepoDefinition):

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -246,9 +246,10 @@ def _common_codegen_request_payload(
     repo: Repository,
     target_commit_sha: str,
     organization: Organization,
+    event_payload: Mapping[str, Any],
 ) -> dict[str, Any]:
     data: dict[str, Any] = {
-        "repo": _build_repo_definition(repo, target_commit_sha),
+        "repo": _build_repo_definition(repo, target_commit_sha, event_payload),
         "bug_prediction_specific_information": {
             "organization_id": organization.id,
             "organization_slug": organization.slug,
@@ -287,6 +288,7 @@ def transform_issue_comment_to_codegen_request(
         repo=repo,
         target_commit_sha=target_commit_sha,
         organization=organization,
+        event_payload=event_payload,
     )
     payload["data"]["pr_id"] = event_payload["issue"]["number"]
     config = payload["data"]["config"]
@@ -325,6 +327,7 @@ def transform_pull_request_to_codegen_request(
         repo=repo,
         target_commit_sha=target_commit_sha,
         organization=organization,
+        event_payload=event_payload,
     )
     pull_request = event_payload.get("pull_request", {})
     payload["data"]["pr_id"] = pull_request.get("number")
@@ -343,7 +346,11 @@ def transform_pull_request_to_codegen_request(
     return payload
 
 
-def _build_repo_definition(repo: Repository, target_commit_sha: str) -> dict[str, Any]:
+def _build_repo_definition(
+    repo: Repository,
+    target_commit_sha: str,
+    event_payload: Mapping[str, Any],
+) -> dict[str, Any]:
     """
     Build the repository definition for code review requests.
     """
@@ -359,6 +366,7 @@ def _build_repo_definition(repo: Repository, target_commit_sha: str) -> dict[str
         "external_id": repo.external_id,
         "base_commit_sha": target_commit_sha,
         "organization_id": repo.organization_id,
+        "is_private": event_payload.get("repository", {}).get("private"),
     }
 
     # add integration_id which is used in pr_closed_step for product metrics dashboarding only

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -433,6 +433,7 @@ def get_tags(
             - scm_owner: The repository owner/organization name
             - scm_provider: Always "github"
             - scm_repo_full_name: The repository full name (owner/repo)
+            - scm_repo_is_private: Whether the repo is private (if available)
             - scm_repo_name: The repository name
             - sentry_integration_id: The Sentry integration ID
             - sentry_organization_id: Sentry organization ID (if available)
@@ -456,6 +457,8 @@ def get_tags(
             result["scm_repo_name"] = repo_name
         if owner_repo_name := repository.get("full_name"):
             result["scm_repo_full_name"] = owner_repo_name
+        if (repo_private := repository.get("private")) is not None:
+            result["scm_repo_is_private"] = str(repo_private)
 
     github_event_action = event.get("action")
     if github_event_action:

--- a/src/sentry/seer/models/seer_api_models.py
+++ b/src/sentry/seer/models/seer_api_models.py
@@ -36,6 +36,7 @@ class SeerRepoDefinition(BaseModel):
     owner: str
     name: str
     external_id: str
+    is_private: bool | None = None
     branch_name: str | None = Field(
         default=None,
         description="The branch that will be used, otherwise the default branch will be used.",


### PR DESCRIPTION
Add `is_private: bool | None = None` to `SeerRepoDefinition` and `SeerCodeReviewRepoDefinition` models, and populate it from the GitHub webhook payload's `repository.private` field when building code review requests for Seer.

The field is extracted in `_build_repo_definition` which now receives the webhook `event_payload` through `_common_codegen_request_payload`. This avoids any extra GitHub API calls — the data is already present in every `pull_request` and `issue_comment` webhook.

For non-webhook flows (autofix, coding agents), the field defaults to `None` since the webhook payload isn't available in those contexts.

Seer PR https://github.com/getsentry/seer/pull/5165

Implements CW-986