### PR TITLE
feat(supergroups): lightweight RCA prototype

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -568,6 +568,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:relay-upload-endpoint", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable supergroup RCA embedding generation from autofix explorer runs
     manager.add("projects:supergroup-embeddings-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable lightweight Explorer RCA runs for supergroup quality evaluation
+    manager.add("projects:supergroup-lightweight-rca", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -43,6 +43,7 @@ from sentry.seer.signed_seer_api import (
     make_signed_seer_api_request,
     make_summarize_issue_request,
 )
+from sentry.seer.supergroups_lightweight_rca import trigger_lightweight_rca
 from sentry.services import eventstore
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.tasks.base import instrumented_task
@@ -192,6 +193,13 @@ def _trigger_autofix_task(
                 run_id=None,
                 stopping_point=stopping_point,
             )
+            try:
+                trigger_lightweight_rca(group)
+            except Exception:
+                logger.exception(
+                    "lightweight_rca.trigger_error_in_trigger_autofix_task",
+                    extra={"group_id": group_id},
+                )
         else:
             response = trigger_autofix(
                 group=group,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -178,6 +178,7 @@ class SeerExplorerClient:
             intelligence_level: Optionally set the intelligence level of the agent. Higher intelligence gives better result quality at the cost of significantly higher latency and cost.
             is_interactive: Enable full interactive, human-like features of the agent. Only enable if you support *all* available interactions in Seer. An example use of this is the explorer chat in Sentry UI.
             enable_coding: Include code editing tools. When False, the agent cannot make code changes. Default is False. If enable_coding is True and the organization does not have the enable_seer_coding option, a SeerPermissionError will be raised.
+            max_iterations: Optional maximum number of agent iterations. Useful for lightweight/fast runs that don't need full exploration depth.
     """
 
     def __init__(
@@ -192,6 +193,7 @@ class SeerExplorerClient:
         intelligence_level: Literal["low", "medium", "high"] = "medium",
         is_interactive: bool = False,
         enable_coding: bool = False,
+        max_iterations: int | None = None,
     ):
         self.organization = organization
         self.user = user
@@ -202,6 +204,7 @@ class SeerExplorerClient:
         self.category_key = category_key
         self.category_value = category_value
         self.is_interactive = is_interactive
+        self.max_iterations = max_iterations
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
             raise SeerPermissionError("Seer coding is not enabled for this organization")
@@ -271,6 +274,9 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
         )
+
+        if self.max_iterations is not None:
+            chat_body["max_iterations"] = self.max_iterations
 
         if self.project:
             chat_body["project_id"] = self.project.id

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -65,6 +65,7 @@ class ExplorerChatRequest(TypedDict):
     category_value: NotRequired[str]
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
+    max_iterations: NotRequired[int]
 
 
 class ExplorerRunsRequest(TypedDict):

--- a/src/sentry/seer/supergroups_lightweight_rca.py
+++ b/src/sentry/seer/supergroups_lightweight_rca.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+
+from sentry import features
+from sentry.models.group import Group
+from sentry.seer.autofix.artifact_schemas import RootCauseArtifact
+from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+from sentry.seer.explorer.client import SeerExplorerClient
+
+logger = logging.getLogger(__name__)
+
+
+def trigger_lightweight_rca(group: Group) -> int | None:
+    """
+    Trigger a lightweight Explorer RCA run for the given group.
+
+    Uses a low-intelligence agent with limited iterations to quickly generate
+    a root cause artifact. The result is stored as an Explorer run with
+    category_key="lightweight_rca" for later evaluation.
+
+    Args:
+        group: The Sentry group (issue) to analyze
+
+    Returns:
+        The run ID if successful, None if the feature flag is off or an error occurred
+    """
+    if not features.has("projects:supergroup-lightweight-rca", group.project):
+        return None
+
+    try:
+        client = SeerExplorerClient(
+            organization=group.organization,
+            project=group.project,
+            user=None,
+            intelligence_level="low",
+            max_iterations=3,
+            is_interactive=False,
+            category_key="lightweight_rca",
+            category_value=str(group.id),
+            on_completion_hook=AutofixOnCompletionHook,
+        )
+
+        short_id = group.qualified_short_id or str(group.id)
+        title = group.title or "Unknown error"
+        culprit = group.culprit or "unknown"
+
+        prompt = (
+            f'Analyze issue {short_id}: "{title}" (culprit: {culprit})\n\n'
+            "Find the root cause of this issue. Use your tools to fetch issue details "
+            "and examine the relevant code. Focus on identifying WHY the error happens, "
+            "not on proposing fixes.\n\n"
+            "Generate the root_cause artifact with:\n"
+            "- one_line_description: A concise summary under 30 words\n"
+            "- five_whys: Chain of brief 'why' statements leading to the root cause\n"
+            "- reproduction_steps: Steps that would reproduce this issue"
+        )
+
+        run_id = client.start_run(
+            prompt=prompt,
+            prompt_metadata={"step": "root_cause"},
+            artifact_key="root_cause",
+            artifact_schema=RootCauseArtifact,
+            metadata={"group_id": group.id},
+        )
+        return run_id
+    except Exception:
+        logger.exception(
+            "lightweight_rca.trigger_failed",
+            extra={
+                "group_id": group.id,
+                "organization_id": group.organization.id,
+            },
+        )
+        return None

--- a/src/sentry/seer/supergroups_lightweight_rca.py
+++ b/src/sentry/seer/supergroups_lightweight_rca.py
@@ -5,7 +5,6 @@ import logging
 from sentry import features
 from sentry.models.group import Group
 from sentry.seer.autofix.artifact_schemas import RootCauseArtifact
-from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.explorer.client import SeerExplorerClient
 
 logger = logging.getLogger(__name__)
@@ -38,7 +37,7 @@ def trigger_lightweight_rca(group: Group) -> int | None:
             is_interactive=False,
             category_key="lightweight_rca",
             category_value=str(group.id),
-            on_completion_hook=AutofixOnCompletionHook,
+            on_completion_hook=None,
         )
 
         short_id = group.qualified_short_id or str(group.id)

--- a/tests/sentry/seer/autofix/test_issue_summary.py
+++ b/tests/sentry/seer/autofix/test_issue_summary.py
@@ -17,6 +17,7 @@ from sentry.seer.autofix.issue_summary import (
     _fetch_user_preference,
     _get_event,
     _get_stopping_point_from_fixability,
+    _trigger_autofix_task,
     get_and_update_group_fixability_score,
     get_automation_stopping_point,
     get_issue_summary,
@@ -798,6 +799,85 @@ class TestRunAutomationStoppingPoint(APITestCase, SnubaTestCase):
         run_automation(self.group, self.user, self.event, SeerAutomationSource.ALERT)
 
         mock_trigger.assert_not_called()
+
+
+@with_feature(
+    {
+        "organizations:gen-ai-features": True,
+        "organizations:seer-explorer": True,
+        "organizations:autofix-on-explorer": True,
+    }
+)
+class TestTriggerAutofixTaskLightweightRca(APITestCase, SnubaTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.group = self.create_group()
+        event_data = load_data("python")
+        self.event = self.store_event(data=event_data, project_id=self.project.id)
+
+    @patch("sentry.seer.autofix.issue_summary.trigger_lightweight_rca")
+    @patch("sentry.seer.autofix.issue_summary.trigger_autofix_explorer", return_value=42)
+    def test_lightweight_rca_called_on_explorer_path(
+        self,
+        mock_explorer,
+        mock_lightweight_rca,
+    ):
+        """trigger_lightweight_rca is called when the explorer path is taken"""
+        _trigger_autofix_task(
+            group_id=self.group.id,
+            event_id=self.event.event_id,
+            user_id=None,
+            auto_run_source="post_process",
+        )
+
+        mock_explorer.assert_called_once()
+        mock_lightweight_rca.assert_called_once_with(self.group)
+
+    @patch("sentry.seer.autofix.issue_summary.trigger_lightweight_rca")
+    @patch(
+        "sentry.seer.autofix.issue_summary.trigger_autofix", return_value=Mock(data={"run_id": 42})
+    )
+    def test_lightweight_rca_not_called_on_legacy_path(
+        self,
+        mock_autofix,
+        mock_lightweight_rca,
+    ):
+        """trigger_lightweight_rca is NOT called on the legacy autofix path"""
+        with self.feature(
+            {
+                "organizations:seer-explorer": False,
+                "organizations:autofix-on-explorer": False,
+            }
+        ):
+            _trigger_autofix_task(
+                group_id=self.group.id,
+                event_id=self.event.event_id,
+                user_id=None,
+                auto_run_source="post_process",
+            )
+
+        mock_autofix.assert_called_once()
+        mock_lightweight_rca.assert_not_called()
+
+    @patch("sentry.seer.autofix.issue_summary.trigger_lightweight_rca")
+    @patch("sentry.seer.autofix.issue_summary.trigger_autofix_explorer", return_value=42)
+    def test_lightweight_rca_failure_does_not_block_explorer(
+        self,
+        mock_explorer,
+        mock_lightweight_rca,
+    ):
+        """Failure in trigger_lightweight_rca doesn't prevent the explorer autofix from completing"""
+        mock_lightweight_rca.side_effect = Exception("lightweight RCA failed")
+
+        _trigger_autofix_task(
+            group_id=self.group.id,
+            event_id=self.event.event_id,
+            user_id=None,
+            auto_run_source="post_process",
+        )
+
+        mock_explorer.assert_called_once()
+        mock_lightweight_rca.assert_called_once_with(self.group)
 
 
 class TestFetchUserPreference:

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -204,6 +204,62 @@ class TestSeerExplorerClient(TestCase):
         assert body["intelligence_level"] == "low"
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    def test_client_init_with_max_iterations(self, mock_access):
+        """Test that max_iterations is stored"""
+        mock_access.return_value = (True, None)
+
+        client = SeerExplorerClient(self.organization, self.user, max_iterations=3)
+        assert client.max_iterations == 3
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    def test_client_init_default_max_iterations(self, mock_access):
+        """Test that max_iterations defaults to None"""
+        mock_access.return_value = (True, None)
+
+        client = SeerExplorerClient(self.organization, self.user)
+        assert client.max_iterations is None
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_run_includes_max_iterations(self, mock_collect_context, mock_post, mock_access):
+        """Test that max_iterations is included in the payload when set"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 444}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerExplorerClient(self.organization, self.user, max_iterations=3)
+        run_id = client.start_run("Test query")
+
+        assert run_id == 444
+        body = mock_post.call_args[0][0]
+        assert body["max_iterations"] == 3
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_start_run_excludes_max_iterations_when_none(
+        self, mock_collect_context, mock_post, mock_access
+    ):
+        """Test that max_iterations is not included in the payload when None"""
+        mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"run_id": 445}
+        mock_response.status = 200
+        mock_post.return_value = mock_response
+
+        client = SeerExplorerClient(self.organization, self.user)
+        run_id = client.start_run("Test query")
+
+        assert run_id == 445
+        body = mock_post.call_args[0][0]
+        assert "max_iterations" not in body
+
+    @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
     def test_continue_run_basic(self, mock_post, mock_access):
         """Test continuing an existing run"""

--- a/tests/sentry/seer/test_supergroups_lightweight_rca.py
+++ b/tests/sentry/seer/test_supergroups_lightweight_rca.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.supergroups_lightweight_rca import trigger_lightweight_rca
+from sentry.testutils.cases import TestCase
+
+
+class TestTriggerLightweightRca(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+        self.group = self.create_group(project=self.project)
+
+    def test_returns_none_when_feature_flag_off(self):
+        run_id = trigger_lightweight_rca(self.group)
+
+        assert run_id is None
+
+    @patch("sentry.seer.supergroups_lightweight_rca.SeerExplorerClient")
+    def test_creates_client_with_correct_params(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 42
+        mock_client_cls.return_value = mock_client
+
+        with self.feature("projects:supergroup-lightweight-rca"):
+            run_id = trigger_lightweight_rca(self.group)
+
+        assert run_id == 42
+        mock_client_cls.assert_called_once()
+        kwargs = mock_client_cls.call_args[1]
+        assert kwargs["organization"] == self.organization
+        assert kwargs["project"] == self.project
+        assert kwargs["user"] is None
+        assert kwargs["intelligence_level"] == "low"
+        assert kwargs["max_iterations"] == 3
+        assert kwargs["is_interactive"] is False
+        assert kwargs["category_key"] == "lightweight_rca"
+        assert kwargs["category_value"] == str(self.group.id)
+
+    @patch("sentry.seer.supergroups_lightweight_rca.SeerExplorerClient")
+    def test_start_run_called_with_correct_params(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 42
+        mock_client_cls.return_value = mock_client
+
+        with self.feature("projects:supergroup-lightweight-rca"):
+            trigger_lightweight_rca(self.group)
+
+        mock_client.start_run.assert_called_once()
+        kwargs = mock_client.start_run.call_args[1]
+        assert kwargs["artifact_key"] == "root_cause"
+        assert kwargs["prompt_metadata"] == {"step": "root_cause"}
+        assert kwargs["metadata"] == {"group_id": self.group.id}
+        assert "root cause" in kwargs["prompt"].lower()
+
+    @patch("sentry.seer.supergroups_lightweight_rca.SeerExplorerClient")
+    def test_returns_none_on_error(self, mock_client_cls):
+        mock_client_cls.side_effect = Exception("connection failed")
+
+        with self.feature("projects:supergroup-lightweight-rca"):
+            run_id = trigger_lightweight_rca(self.group)
+
+        assert run_id is None


### PR DESCRIPTION
## Summary

Adds a lightweight Explorer RCA that runs in parallel alongside the main explorer-based autofix, for debugging and evaluation purposes.

- **`SeerExplorerClient` gains `max_iterations` support** — allows capping the number of agent iterations per run
- **`trigger_lightweight_rca()`** — fires a low-intelligence, limited-iteration (3 max) Explorer RCA on an issue, gated by its own feature flag (`projects:supergroup-lightweight-rca`)
- **Wired into `_trigger_autofix_task`** — lightweight RCA triggers only on the explorer code path (alongside `trigger_autofix_explorer`), so it only fires for Seer customers using explorer-based autofix. Failures are caught and logged without blocking the main flow.

### Why this is invisible to users

Lightweight runs use `category_key="lightweight_rca"`, while the frontend and API query `category_key="autofix"` — so these runs never appear in the UI or API responses.

### Feature flags

| Flag | Scope | Purpose |
|------|-------|---------|
| `projects:supergroup-lightweight-rca` | Project | Gates lightweight RCA triggering |
| `organizations:seer-explorer` + `organizations:autofix-on-explorer` | Organization | Required for the explorer path where lightweight RCA lives |

Relates to ID-1385