### PR TITLE
fix: only disable SubmitButton while form is in submitting state

### DIFF
--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -69,14 +69,14 @@ const {useAppForm} = createFormHook({
 function SubmitButton(props: ButtonProps) {
   const form = useFormContext();
   return (
-    <form.Subscribe selector={state => state.isSubmitting || state.isDefaultValue}>
-      {isDisabled => (
+    <form.Subscribe selector={state => state.isSubmitting}>
+      {isSubmitting => (
         <Button
           {...props}
           priority="primary"
           type="submit"
           form={form.formId}
-          disabled={isDisabled || props.disabled}
+          disabled={isSubmitting || props.disabled}
         />
       )}
     </form.Subscribe>


### PR DESCRIPTION
the idea to also disable the SubmitButton if it's equal to the defaultValue falls apart for creation forms that have good default value set that you'd just want to submit. We want to keep the button enabled at all times, only disable it to avoid duplicate form submissions.