### PR TITLE
fix(preprod): Check code signature in is_installable_artifact

### DIFF
--- a/src/sentry/preprod/build_distribution_utils.py
+++ b/src/sentry/preprod/build_distribution_utils.py
@@ -48,12 +48,7 @@ def get_artifact_install_info(artifact: PreprodArtifact) -> ArtifactInstallInfo:
     install_url: str | None = None
 
     if installable:
-        if artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
-            if extras.get("is_code_signature_valid") is not True:
-                installable = False
-
-        if installable:
-            install_url = get_download_url_for_artifact(artifact)
+        install_url = get_download_url_for_artifact(artifact)
 
     download_count = get_download_count_for_artifact(artifact) if installable else 0
     release_notes = extras.get("release_notes")
@@ -81,10 +76,15 @@ def get_artifact_install_info(artifact: PreprodArtifact) -> ArtifactInstallInfo:
 
 
 def is_installable_artifact(artifact: PreprodArtifact) -> bool:
-    # TODO: Adjust this logic when we have a better way to determine if an artifact is installable
     mobile_app_info = artifact.get_mobile_app_info()
     build_number = mobile_app_info.build_number if mobile_app_info else None
-    return artifact.installable_app_file_id is not None and build_number is not None
+    if artifact.installable_app_file_id is None or build_number is None:
+        return False
+    if artifact.artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
+        extras = artifact.extras or {}
+        if extras.get("is_code_signature_valid") is not True:
+            return False
+    return True
 
 
 def get_download_count_for_artifact(artifact: PreprodArtifact) -> int:

--- a/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_tasks.py
@@ -17,6 +17,8 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import region_silo_test
 
+_sentinel = object()
+
 
 @region_silo_test
 class CreatePreprodPrCommentTaskTest(TestCase):
@@ -40,9 +42,14 @@ class CreatePreprodPrCommentTaskTest(TestCase):
         app_id="com.example.app",
         artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
         build_number=456,
-        extras=None,
+        extras=_sentinel,
         commit_comparison=None,
     ) -> PreprodArtifact:
+        if extras is _sentinel:
+            if artifact_type == PreprodArtifact.ArtifactType.XCARCHIVE:
+                extras = {"is_code_signature_valid": True}
+            else:
+                extras = None
         artifact = PreprodArtifact.objects.create(
             project=self.project,
             state=PreprodArtifact.ArtifactState.PROCESSED,
@@ -372,3 +379,11 @@ class CreatePreprodPrCommentTaskTest(TestCase):
             data={"body": "updated body"},
         )
         mock_client.create_comment.assert_not_called()
+
+    def test_skips_xcarchive_without_valid_code_signature(self):
+        artifact = self._create_artifact(extras={"is_code_signature_valid": False})
+
+        with self.feature("organizations:preprod-build-distribution-pr-comments"):
+            create_preprod_pr_comment_task(artifact.id)
+
+        # No comment posted — task returns early because artifact is not installable


### PR DESCRIPTION
XCARCHIVE artifacts without a valid code signature were incorrectly treated as installable because `is_installable_artifact()` only checked for `installable_app_file_id` and `build_number`. This caused PR comments to be posted on Cocoa SDK PRs even though the uploaded builds aren't actually installable.

The code signature check already existed in `get_artifact_install_info()` but not in `is_installable_artifact()`, which the PR comment task uses to filter sibling artifacts. This moves the check into `is_installable_artifact()` and removes the now-redundant check from `get_artifact_install_info()`.

Refs EME-917