### PR TITLE
feat(preprod): Add size_analysis webhook resource and broadcasting

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -254,6 +254,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:preprod-enforce-size-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable enforcement of preprod distribution quota checks (when disabled, distribution quota checks always return True)
     manager.add("organizations:preprod-enforce-distribution-quota", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable preprod size analysis webhooks
+    manager.add("organizations:preprod-size-analysis-webhooks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable preprod size monitors frontend
     manager.add("organizations:preprod-size-monitors-frontend", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable preprod snapshots product feature

--- a/src/sentry/preprod/size_analysis/tasks.py
+++ b/src/sentry/preprod/size_analysis/tasks.py
@@ -23,6 +23,7 @@ from sentry.preprod.size_analysis.grouptype import (
 )
 from sentry.preprod.size_analysis.models import ComparisonResults, SizeAnalysisResults
 from sentry.preprod.size_analysis.utils import build_size_metrics_map, can_compare_size_metrics
+from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -72,6 +73,7 @@ def compare_preprod_artifact_size_analysis(
             "preprod.size_analysis.compare.artifact_no_commit_comparison",
             extra={"artifact_id": artifact_id},
         )
+        send_size_analysis_webhook(artifact=artifact, organization_id=org_id)
         return
 
     comparisons: list[dict[str, PreprodArtifactSizeMetrics]] = []
@@ -92,6 +94,7 @@ def compare_preprod_artifact_size_analysis(
                     "caller": "compare_build_config_mismatch",
                 }
             )
+            send_size_analysis_webhook(artifact=artifact, organization_id=org_id)
             return
 
         base_size_metrics_qs = PreprodArtifactSizeMetrics.objects.filter(
@@ -248,6 +251,8 @@ def compare_preprod_artifact_size_analysis(
             "artifact_type": artifact_type_name,
         },
     )
+
+    send_size_analysis_webhook(artifact=artifact, organization_id=org_id)
 
 
 @instrumented_task(

--- a/src/sentry/preprod/size_analysis/webhooks.py
+++ b/src/sentry/preprod/size_analysis/webhooks.py
@@ -145,6 +145,7 @@ def _build_comparison_data(
             head_size_analysis=main_metric,
         )
         .select_related("base_size_analysis", "base_size_analysis__preprod_artifact")
+        .order_by("-date_added")
         .first()
     )
 

--- a/src/sentry/preprod/size_analysis/webhooks.py
+++ b/src/sentry/preprod/size_analysis/webhooks.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sentry import features
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.sentry_apps.metrics import SentryAppEventType
+from sentry.sentry_apps.tasks.sentry_apps import broadcast_webhooks_for_organization
+from sentry.sentry_apps.utils.webhooks import SizeAnalysisActionType
+
+logger = logging.getLogger(__name__)
+
+
+def build_webhook_payload(
+    artifact: PreprodArtifact,
+) -> dict[str, Any] | None:
+    """
+    Build the size_analysis.completed webhook payload for a given artifact.
+
+    Returns None if the webhook should not be fired (e.g. NOT_RAN state).
+    """
+    main_metric = (
+        PreprodArtifactSizeMetrics.objects.filter(
+            preprod_artifact=artifact,
+            metrics_artifact_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+        )
+        .select_related("preprod_artifact")
+        .first()
+    )
+
+    if main_metric is None:
+        logger.info(
+            "preprod.size_analysis.webhook.no_main_metric",
+            extra={"artifact_id": artifact.id},
+        )
+        return None
+
+    if main_metric.state == PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN:
+        return None
+
+    if main_metric.state in (
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING,
+    ):
+        logger.info(
+            "preprod.size_analysis.webhook.not_terminal",
+            extra={"artifact_id": artifact.id, "state": main_metric.state},
+        )
+        return None
+
+    analysis_failed = main_metric.state == PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED
+
+    error_code = _map_error_code(main_metric.error_code) if analysis_failed else None
+    error_message = main_metric.error_message if analysis_failed else None
+
+    comparison_data = _build_comparison_data(artifact, main_metric)
+    git_data = _build_git_data(artifact)
+
+    comparison_failed = comparison_data is not None and comparison_data["status"] == "error"
+    status = "error" if analysis_failed or comparison_failed else "success"
+
+    mobile_app_info = artifact.get_mobile_app_info()
+
+    return {
+        "buildId": str(artifact.id),
+        "status": status,
+        "errorCode": error_code,
+        "errorMessage": error_message,
+        "projectSlug": artifact.project.slug,
+        "platform": _get_platform(artifact),
+        "artifactType": _get_artifact_type(artifact),
+        "downloadSize": main_metric.max_download_size if not analysis_failed else None,
+        "installSize": main_metric.max_install_size if not analysis_failed else None,
+        "app": {
+            "name": mobile_app_info.app_name if mobile_app_info else None,
+            "version": mobile_app_info.build_version if mobile_app_info else None,
+            "buildNumber": mobile_app_info.build_number if mobile_app_info else None,
+        },
+        "comparison": comparison_data,
+        "git": git_data,
+    }
+
+
+def send_size_analysis_webhook(
+    artifact: PreprodArtifact,
+    organization_id: int,
+) -> None:
+    """
+    Send the size_analysis.completed webhook for a given artifact, if applicable.
+
+    Checks feature flag, builds the payload, and enqueues via the generic broadcaster.
+    """
+    organization = artifact.project.organization
+
+    if not features.has("organizations:preprod-size-analysis-webhooks", organization):
+        logger.info(
+            "preprod.size_analysis.webhook.feature_disabled",
+            extra={
+                "artifact_id": artifact.id,
+                "organization_id": organization_id,
+            },
+        )
+        return
+
+    payload = build_webhook_payload(artifact)
+    if payload is None:
+        logger.info(
+            "preprod.size_analysis.webhook.no_payload",
+            extra={"artifact_id": artifact.id},
+        )
+        return
+
+    event_name = SizeAnalysisActionType.COMPLETED.value
+
+    try:
+        broadcast_webhooks_for_organization.delay(
+            resource_name="size_analysis",
+            event_name=event_name,
+            organization_id=organization_id,
+            payload=payload,
+        )
+    except Exception:
+        logger.exception(
+            "preprod.size_analysis.webhook.broadcast_failed",
+            extra={
+                "artifact_id": artifact.id,
+                "organization_id": organization_id,
+                "event_type": SentryAppEventType.SIZE_ANALYSIS_COMPLETED.value,
+            },
+        )
+
+
+def _build_comparison_data(
+    artifact: PreprodArtifact,
+    main_metric: PreprodArtifactSizeMetrics,
+) -> dict[str, Any] | None:
+    """Build the comparison sub-object, or None if no comparison exists."""
+    comparison = (
+        PreprodArtifactSizeComparison.objects.filter(
+            head_size_analysis=main_metric,
+        )
+        .select_related("base_size_analysis", "base_size_analysis__preprod_artifact")
+        .first()
+    )
+
+    if comparison is None:
+        return None
+
+    comparison_succeeded = comparison.state == PreprodArtifactSizeComparison.State.SUCCESS
+    comparison_status = "success" if comparison_succeeded else "error"
+
+    base_artifact = comparison.base_size_analysis.preprod_artifact
+
+    download_size_change: int | None = None
+    install_size_change: int | None = None
+
+    if comparison_succeeded:
+        head_download = main_metric.max_download_size
+        head_install = main_metric.max_install_size
+        base_download = comparison.base_size_analysis.max_download_size
+        base_install = comparison.base_size_analysis.max_install_size
+
+        if (
+            head_download is not None
+            and base_download is not None
+            and head_install is not None
+            and base_install is not None
+        ):
+            download_size_change = head_download - base_download
+            install_size_change = head_install - base_install
+
+    return {
+        "status": comparison_status,
+        "baseBuildId": str(base_artifact.id),
+        "downloadSizeChange": download_size_change,
+        "installSizeChange": install_size_change,
+    }
+
+
+def _build_git_data(artifact: PreprodArtifact) -> dict[str, Any] | None:
+    """Build the git sub-object, or None if no git context exists."""
+    commit_comparison = artifact.commit_comparison
+    if commit_comparison is None:
+        return None
+
+    return {
+        "headSha": commit_comparison.head_sha,
+        "baseSha": commit_comparison.base_sha,
+        "headRef": commit_comparison.head_ref,
+        "baseRef": commit_comparison.base_ref,
+        "repoName": commit_comparison.head_repo_name,
+        "prNumber": commit_comparison.pr_number,
+    }
+
+
+def _get_platform(artifact: PreprodArtifact) -> str | None:
+    platform = artifact.platform
+    if platform is None:
+        return None
+    return platform.value
+
+
+def _get_artifact_type(artifact: PreprodArtifact) -> str | None:
+    if artifact.artifact_type is None:
+        return None
+    try:
+        return PreprodArtifact.ArtifactType(artifact.artifact_type).to_str()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _map_error_code(error_code: int | None) -> str | None:
+    """Map the integer error code to the string representation for the webhook."""
+    if error_code is None:
+        return None
+    try:
+        return PreprodArtifactSizeMetrics.ErrorCode(error_code).name
+    except (ValueError, AttributeError):
+        return None

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -30,6 +30,7 @@ from sentry.preprod.producer import PreprodFeature, produce_preprod_artifact_to_
 from sentry.preprod.quotas import has_installable_quota, has_size_quota
 from sentry.preprod.size_analysis.models import SizeAnalysisResults
 from sentry.preprod.size_analysis.tasks import compare_preprod_artifact_size_analysis
+from sentry.preprod.size_analysis.webhooks import send_size_analysis_webhook
 from sentry.preprod.vcs.pr_comments.tasks import create_preprod_pr_comment_task
 from sentry.preprod.vcs.status_checks.size.tasks import create_preprod_status_check_task
 from sentry.silo.base import SiloMode
@@ -605,6 +606,9 @@ def _assemble_preprod_artifact_size_analysis(
                             "organization_id": org_id,
                         },
                     )
+
+            # Fire webhook for analysis failure (comparison task won't be triggered)
+            send_size_analysis_webhook(artifact=preprod_artifact, organization_id=org_id)
 
         # Re-raise to trigger further error handling if needed
         raise

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -150,3 +150,6 @@ class SentryAppEventType(StrEnum):
     SEER_IMPACT_ASSESSMENT_STARTED = "seer.impact_assessment_started"
     SEER_IMPACT_ASSESSMENT_COMPLETED = "seer.impact_assessment_completed"
     SEER_PR_CREATED = "seer.pr_created"
+
+    # size analysis webhooks
+    SIZE_ANALYSIS_COMPLETED = "size_analysis.completed"

--- a/src/sentry/sentry_apps/models/sentry_app.py
+++ b/src/sentry/sentry_apps/models/sentry_app.py
@@ -44,6 +44,7 @@ REQUIRED_EVENT_PERMISSIONS = {
     "organization": "org:read",
     "team": "team:read",
     "comment": "event:read",
+    "size_analysis": "project:read",
 }
 
 # The only events valid for Sentry Apps are the ones listed in the values of

--- a/src/sentry/sentry_apps/utils/webhooks.py
+++ b/src/sentry/sentry_apps/utils/webhooks.py
@@ -54,6 +54,10 @@ class SeerActionType(SentryAppActionType):
     PR_CREATED = "pr_created"
 
 
+class SizeAnalysisActionType(SentryAppActionType):
+    COMPLETED = "completed"
+
+
 class SentryAppResourceType(StrEnum):
     @staticmethod
     def map_sentry_app_webhook_events(
@@ -71,6 +75,7 @@ class SentryAppResourceType(StrEnum):
     INSTALLATION = "installation"
     METRIC_ALERT = "metric_alert"
     SEER = "seer"
+    SIZE_ANALYSIS = "size_analysis"
 
     # Represents an issue alert resource
     EVENT_ALERT = "event_alert"
@@ -91,6 +96,9 @@ EVENT_EXPANSION: Final[dict[SentryAppResourceType, list[str]]] = {
     ),
     SentryAppResourceType.SEER: SentryAppResourceType.map_sentry_app_webhook_events(
         SentryAppResourceType.SEER.value, SeerActionType
+    ),
+    SentryAppResourceType.SIZE_ANALYSIS: SentryAppResourceType.map_sentry_app_webhook_events(
+        SentryAppResourceType.SIZE_ANALYSIS.value, SizeAnalysisActionType
     ),
 }
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not

--- a/tests/sentry/preprod/size_analysis/test_webhooks.py
+++ b/tests/sentry/preprod/size_analysis/test_webhooks.py
@@ -1,0 +1,411 @@
+from unittest.mock import patch
+
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeComparison,
+    PreprodArtifactSizeMetrics,
+)
+from sentry.preprod.size_analysis.webhooks import (
+    build_webhook_payload,
+    send_size_analysis_webhook,
+)
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class BuildWebhookPayloadTest(TestCase):
+    """Tests for the build_webhook_payload function."""
+
+    def _create_artifact_with_metrics(
+        self,
+        commit_comparison=None,
+        artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+        state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        max_download_size=28311552,
+        max_install_size=41943040,
+        error_code=None,
+        error_message=None,
+        app_name="My App",
+        build_version="2.4.1",
+        build_number=347,
+    ):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=artifact_type,
+            commit_comparison=commit_comparison,
+            app_name=app_name,
+            build_version=build_version,
+            build_number=build_number,
+        )
+        metric = self.create_preprod_artifact_size_metrics(
+            artifact,
+            metrics_type=PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
+            state=state,
+            max_download_size=max_download_size,
+            max_install_size=max_install_size,
+            error_code=error_code,
+            error_message=error_message,
+        )
+        return artifact, metric
+
+    def test_standalone_build_success(self):
+        """Standalone build with no comparison produces correct payload."""
+        artifact, _ = self._create_artifact_with_metrics()
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["buildId"] == str(artifact.id)
+        assert payload["status"] == "success"
+        assert payload["errorCode"] is None
+        assert payload["errorMessage"] is None
+        assert payload["projectSlug"] == self.project.slug
+        assert payload["platform"] == "apple"
+        assert payload["artifactType"] == "xcarchive"
+        assert payload["downloadSize"] == 28311552
+        assert payload["installSize"] == 41943040
+        assert payload["app"]["name"] == "My App"
+        assert payload["app"]["version"] == "2.4.1"
+        assert payload["app"]["buildNumber"] == 347
+        assert payload["comparison"] is None
+        assert payload["git"] is None
+
+    def test_standalone_build_with_git_context(self):
+        """Standalone build on main branch has git context but no comparison."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha="b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1",
+            head_ref="main",
+            base_ref="main",
+            head_repo_name="acme/my-android-app",
+            pr_number=None,
+        )
+        artifact, _ = self._create_artifact_with_metrics(
+            commit_comparison=commit_comparison,
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["status"] == "success"
+        assert payload["platform"] == "android"
+        assert payload["artifactType"] == "aab"
+        assert payload["comparison"] is None
+        assert payload["git"] is not None
+        assert payload["git"]["headSha"] == "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1"
+        assert payload["git"]["baseSha"] is not None
+        assert payload["git"]["headRef"] == "main"
+        assert payload["git"]["repoName"] == "acme/my-android-app"
+        assert payload["git"]["prNumber"] is None
+
+    def test_pr_build_comparison_succeeded(self):
+        """PR build with successful comparison includes comparison data."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_sha="a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            base_sha="f0e1d2c3b4a5f6e7d8c9b0a1f2e3d4c5b6a7f8e9",
+            head_ref="feature/new-onboarding",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1042,
+        )
+        head_artifact, head_metric = self._create_artifact_with_metrics(
+            commit_comparison=commit_comparison,
+            max_download_size=28311552,
+            max_install_size=41943040,
+        )
+
+        base_artifact, base_metric = self._create_artifact_with_metrics(
+            max_download_size=28259072,
+            max_install_size=41864920,
+        )
+
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_metric,
+            base_size_analysis=base_metric,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+        )
+
+        payload = build_webhook_payload(head_artifact)
+
+        assert payload is not None
+        assert payload["status"] == "success"
+        assert payload["comparison"] is not None
+        assert payload["comparison"]["status"] == "success"
+        assert payload["comparison"]["baseBuildId"] == str(base_artifact.id)
+        assert payload["comparison"]["downloadSizeChange"] == 28311552 - 28259072
+        assert payload["comparison"]["installSizeChange"] == 41943040 - 41864920
+        assert payload["git"] is not None
+        assert payload["git"]["prNumber"] == 1042
+
+    def test_pr_build_comparison_failed(self):
+        """PR build with failed comparison sets top-level status to error."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_ref="feature/new-onboarding",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1042,
+        )
+        head_artifact, head_metric = self._create_artifact_with_metrics(
+            commit_comparison=commit_comparison,
+        )
+        base_artifact, base_metric = self._create_artifact_with_metrics()
+
+        self.create_preprod_artifact_size_comparison(
+            organization=self.organization,
+            head_size_analysis=head_metric,
+            base_size_analysis=base_metric,
+            state=PreprodArtifactSizeComparison.State.FAILED,
+        )
+
+        payload = build_webhook_payload(head_artifact)
+
+        assert payload is not None
+        assert payload["status"] == "error"
+        assert payload["errorCode"] is None
+        assert payload["errorMessage"] is None
+        assert payload["downloadSize"] == 28311552
+        assert payload["installSize"] == 41943040
+        assert payload["comparison"] is not None
+        assert payload["comparison"]["status"] == "error"
+        assert payload["comparison"]["baseBuildId"] == str(base_artifact.id)
+        assert payload["comparison"]["downloadSizeChange"] is None
+        assert payload["comparison"]["installSizeChange"] is None
+
+    def test_analysis_failed(self):
+        """Analysis failure produces error payload with error details."""
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization,
+            head_ref="feature/broken-build",
+            base_ref="main",
+            head_repo_name="acme/my-ios-app",
+            pr_number=1050,
+        )
+        artifact, _ = self._create_artifact_with_metrics(
+            commit_comparison=commit_comparison,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.PROCESSING_ERROR,
+            error_message="Failed to extract size metrics from artifact",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["status"] == "error"
+        assert payload["errorCode"] == "PROCESSING_ERROR"
+        assert payload["errorMessage"] == "Failed to extract size metrics from artifact"
+        assert payload["downloadSize"] is None
+        assert payload["installSize"] is None
+        assert payload["comparison"] is None
+
+    def test_analysis_timeout_error_code(self):
+        """Timeout error code is mapped correctly."""
+        artifact, _ = self._create_artifact_with_metrics(
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.TIMEOUT,
+            error_message="Size analysis timed out",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["errorCode"] == "TIMEOUT"
+
+    def test_unsupported_artifact_error_code(self):
+        """Unsupported artifact error code is mapped correctly."""
+        artifact, _ = self._create_artifact_with_metrics(
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.FAILED,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.UNSUPPORTED_ARTIFACT,
+            error_message="Unsupported artifact type",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["errorCode"] == "UNSUPPORTED_ARTIFACT"
+
+    def test_not_ran_returns_none(self):
+        """NOT_RAN state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA,
+            error_message="No quota available",
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is None
+
+    def test_pending_returns_none(self):
+        """PENDING state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PENDING,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is None
+
+    def test_processing_returns_none(self):
+        """PROCESSING state should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.PROCESSING,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is None
+
+    def test_no_main_metric_returns_none(self):
+        """No main metric at all should not produce a webhook payload."""
+        artifact = self.create_preprod_artifact(project=self.project)
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is None
+
+    def test_no_mobile_app_info(self):
+        """Artifact without mobile app info has null app fields."""
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            create_mobile_app_info=False,
+        )
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["app"]["name"] is None
+        assert payload["app"]["version"] is None
+        assert payload["app"]["buildNumber"] is None
+
+    def test_build_id_is_string(self):
+        """buildId should always be a string, not an integer."""
+        artifact, _ = self._create_artifact_with_metrics()
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert isinstance(payload["buildId"], str)
+
+    def test_android_apk_platform_and_type(self):
+        """Android APK artifact has correct platform and type."""
+        artifact, _ = self._create_artifact_with_metrics(
+            artifact_type=PreprodArtifact.ArtifactType.APK,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["platform"] == "android"
+        assert payload["artifactType"] == "apk"
+
+    def test_android_aab_platform_and_type(self):
+        """Android AAB artifact has correct platform and type."""
+        artifact, _ = self._create_artifact_with_metrics(
+            artifact_type=PreprodArtifact.ArtifactType.AAB,
+        )
+
+        payload = build_webhook_payload(artifact)
+
+        assert payload is not None
+        assert payload["platform"] == "android"
+        assert payload["artifactType"] == "aab"
+
+
+@region_silo_test
+class SendSizeAnalysisWebhookTest(TestCase):
+    """Tests for the send_size_analysis_webhook function."""
+
+    def _create_artifact_with_metrics(self):
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_name="My App",
+            build_version="1.0.0",
+            build_number=1,
+        )
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.COMPLETED,
+        )
+        return artifact
+
+    @with_feature("organizations:preprod-size-analysis-webhooks")
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_sends_webhook_when_feature_enabled(self, mock_broadcast):
+        """Webhook is sent when feature flag is enabled."""
+        artifact = self._create_artifact_with_metrics()
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_called_once()
+        call_kwargs = mock_broadcast.delay.call_kwargs
+        # Use call_args since .delay is a mock
+        call_kwargs = mock_broadcast.delay.call_args
+        assert call_kwargs.kwargs["resource_name"] == "size_analysis"
+        assert call_kwargs.kwargs["event_name"] == "completed"
+        assert call_kwargs.kwargs["organization_id"] == self.organization.id
+        assert call_kwargs.kwargs["payload"]["buildId"] == str(artifact.id)
+        assert call_kwargs.kwargs["payload"]["status"] == "success"
+
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_does_not_send_when_feature_disabled(self, mock_broadcast):
+        """Webhook is NOT sent when feature flag is disabled."""
+        artifact = self._create_artifact_with_metrics()
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_not_called()
+
+    @with_feature("organizations:preprod-size-analysis-webhooks")
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_does_not_send_for_not_ran(self, mock_broadcast):
+        """Webhook is NOT sent for NOT_RAN state."""
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_artifact_size_metrics(
+            artifact,
+            state=PreprodArtifactSizeMetrics.SizeAnalysisState.NOT_RAN,
+            error_code=PreprodArtifactSizeMetrics.ErrorCode.NO_QUOTA,
+            error_message="No quota available",
+        )
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_not_called()
+
+    @with_feature("organizations:preprod-size-analysis-webhooks")
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_does_not_send_for_no_main_metric(self, mock_broadcast):
+        """Webhook is NOT sent when no main metric exists."""
+        artifact = self.create_preprod_artifact(project=self.project)
+
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_not_called()
+
+    @with_feature("organizations:preprod-size-analysis-webhooks")
+    @patch("sentry.preprod.size_analysis.webhooks.broadcast_webhooks_for_organization")
+    def test_broadcast_exception_is_caught(self, mock_broadcast):
+        """Exceptions from broadcast are caught and logged, not re-raised."""
+        artifact = self._create_artifact_with_metrics()
+        mock_broadcast.delay.side_effect = Exception("Celery task failed")
+
+        # Should not raise
+        send_size_analysis_webhook(artifact=artifact, organization_id=self.organization.id)
+
+        mock_broadcast.delay.assert_called_once()


### PR DESCRIPTION
## Summary

Adds webhook support for the size analysis product within Sentry's pre-production platform. When size analysis reaches a terminal state (success or error), subscribed Sentry Apps receive a `size_analysis.completed` webhook with a lean payload containing build ID, status, sizes, comparison data, git context, and app metadata. Consumers use the `buildId` to fetch full details via the public API.

Follows patterns established by the Seer webhook implementation (PR #96222) and reuses the existing `broadcast_webhooks_for_organization` infrastructure — no new webhook plumbing needed.

### Changes

- **Registration**: `SizeAnalysisActionType(COMPLETED)`, `SIZE_ANALYSIS` resource type, event expansion, `SIZE_ANALYSIS_COMPLETED` metrics enum, `size_analysis → project:read` permission
- **Feature flag**: `organizations:preprod-size-analysis-webhooks` (FLAGPOLE, not api_exposed)
- **Payload builder**: New `src/sentry/preprod/size_analysis/webhooks.py` with `build_webhook_payload()` and `send_size_analysis_webhook()`
- **Broadcast calls** at 4 terminal points:
  1. Standalone builds (no `commit_comparison`) — success with `comparison: null`
  2. After PR comparisons complete — success or error with comparison data
  3. Build config mismatch early return — success with `comparison: null`
  4. Analysis processing failure — error with `errorCode`/`errorMessage`
- **Tests**: 20 tests covering all payload scenarios, feature flag gating, exception handling

### Design doc

See `src/sentry/preprod/size_analysis/WEBHOOK_DESIGN.md` for full payload specification, examples, and rationale.

### Known limitation

When a PR build (head) is uploaded **before** its base branch build exists, the webhook fires with `comparison: null`. If the base build arrives later and a comparison is created retroactively, the head artifact does **not** receive an updated webhook. This is acceptable for v1 because:
- Most CI workflows upload the base (main branch) build before the PR build
- Fixing requires either dual webhooks per build or deferred emission, adding complexity
- Consumers can poll the API with the `buildId` if needed

### Companion PRs

- **Frontend**: Will follow in a separate PR (Sentry enforces non-atomic deploys for `static/` and `src/`)
- **Docs**: Will follow in `sentry-docs` repo

## Test plan

- [x] All 20 new webhook tests pass (`tests/sentry/preprod/size_analysis/test_webhooks.py`)
- [x] Existing size analysis task tests still pass
- [x] Existing sentry_apps webhook tests still pass
- [x] Pre-commit hooks pass on all modified files
- [ ] CI passes