### PR TITLE
feat(preprod): Add size_analysis webhook to settings UI

### DIFF
--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -570,7 +570,7 @@ export type AppOrProviderOrPlugin =
 /**
  * Webhooks and servicehooks
  */
-export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer';
+export type WebhookEvent = 'issue' | 'error' | 'comment' | 'seer' | 'size_analysis';
 
 export type ServiceHook = {
   dateCreated: string;

--- a/static/app/views/settings/organizationDeveloperSettings/constants.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/constants.tsx
@@ -1,8 +1,15 @@
-export const EVENT_CHOICES = ['issue', 'error', 'comment', 'seer'] as const;
+export const EVENT_CHOICES = [
+  'issue',
+  'error',
+  'comment',
+  'seer',
+  'size_analysis',
+] as const;
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',
   error: 'Event',
   comment: 'Event',
   seer: 'Event',
+  size_analysis: 'Project',
 } as const;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -82,6 +82,7 @@ const getEventTypes = memoize((app: SentryApp) => {
         ]
       : []),
     ...issueLinkEvents,
+    ...(app.events.includes('size_analysis') ? ['size_analysis.completed'] : []),
   ];
 
   return events;

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -82,4 +82,26 @@ describe('SubscriptionBox', () => {
       )
     ).toBeInTheDocument();
   });
+
+  describe('size_analysis resource subscription', () => {
+    it('checkbox disabled without preprod-size-analysis-webhooks flag', async () => {
+      renderComponent({resource: 'size_analysis'});
+
+      expect(screen.getByRole('checkbox')).toBeDisabled();
+
+      await userEvent.hover(screen.getByRole('checkbox'));
+      expect(
+        await screen.findByText(
+          'Your organization does not have access to the size analysis subscription resource.'
+        )
+      ).toBeInTheDocument();
+    });
+
+    it('checkbox visible with preprod-size-analysis-webhooks flag', () => {
+      org = OrganizationFixture({features: ['preprod-size-analysis-webhooks']});
+      renderComponent({resource: 'size_analysis', organization: org});
+
+      expect(screen.getByRole('checkbox')).toBeEnabled();
+    });
+  });
 });

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -47,6 +47,16 @@ function SubscriptionBox({
     );
   }
 
+  if (
+    resource === 'size_analysis' &&
+    !features.includes('preprod-size-analysis-webhooks')
+  ) {
+    disabled = true;
+    message = t(
+      'Your organization does not have access to the size analysis subscription resource.'
+    );
+  }
+
   if (webhookDisabled) {
     message = t('Cannot enable webhook subscription without specifying a webhook url');
   }
@@ -56,6 +66,7 @@ function SubscriptionBox({
     error: 'created',
     comment: 'created, edited, deleted',
     seer: 'root_cause_started, root_cause_completed, solution_started, solution_completed, coding_started, coding_completed, pr_created',
+    size_analysis: 'completed',
   };
 
   return (


### PR DESCRIPTION
## Summary

Adds the `size_analysis` webhook resource to the Sentry App settings UI, allowing developers to subscribe to size analysis notifications when creating or editing custom integrations.

Companion to the backend PR #110196 — land that first.

### Changes

- **`integrations.tsx`**: Add `'size_analysis'` to `WebhookEvent` type union
- **`constants.tsx`**: Add to `EVENT_CHOICES` with `Project` permission mapping
- **`subscriptionBox.tsx`**: Add `'completed'` description, gate behind `preprod-size-analysis-webhooks` feature flag
- **`requestLog.tsx`**: Add `size_analysis.completed` to event filter dropdown
- **`subscriptionBox.spec.tsx`**: Tests for feature flag gating (disabled without flag, enabled with flag)

## Test plan

- [x] ESLint and Prettier pass
- [x] Frontend tests added for feature flag gating
- [x] Pre-commit hooks pass on all modified files
- [ ] CI passes