### PR TITLE
ref(dashboards): Use favorited column for favorite status instead of row existence

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -522,7 +522,7 @@ class DashboardListSerializer(Serializer, DashboardFiltersMixin):
 
         favorited_dashboard_ids = set(
             DashboardFavoriteUser.objects.filter(
-                user_id=user.id, dashboard_id__in=item_dict.keys()
+                user_id=user.id, dashboard_id__in=item_dict.keys(), favorited=True
             ).values_list("dashboard_id", flat=True)
         )
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -296,7 +296,7 @@ class OrganizationDashboardFavoriteEndpoint(OrganizationDashboardBase):
                     dashboard=dashboard,
                 )
             else:
-                DashboardFavoriteUser.objects.delete_favorite_dashboard(
+                DashboardFavoriteUser.objects.unfavorite_dashboard(
                     organization=organization,
                     user_id=request.user.id,
                     dashboard=dashboard,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -13,6 +13,7 @@ from django.db.models import (
     IntegerField,
     OrderBy,
     OuterRef,
+    Q,
     Subquery,
     Value,
     When,
@@ -374,9 +375,15 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         dashboards = Dashboard.objects.filter(organization_id=organization.id)
         for f in filters:
             if f == "onlyFavorites":
-                dashboards = dashboards.filter(dashboardfavoriteuser__user_id=request.user.id)
+                dashboards = dashboards.filter(
+                    dashboardfavoriteuser__user_id=request.user.id,
+                    dashboardfavoriteuser__favorited=True,
+                )
             elif f == "excludeFavorites":
-                dashboards = dashboards.exclude(dashboardfavoriteuser__user_id=request.user.id)
+                dashboards = dashboards.exclude(
+                    dashboardfavoriteuser__user_id=request.user.id,
+                    dashboardfavoriteuser__favorited=True,
+                )
             elif f == "owned":
                 dashboards = dashboards.filter(created_by_id=request.user.id)
             elif f == "shared":
@@ -493,7 +500,11 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             "organizations:dashboards-starred-reordering", organization, actor=request.user
         ):
             dashboards = dashboards.annotate(
-                favorites_count=Count("dashboardfavoriteuser", distinct=True)
+                favorites_count=Count(
+                    "dashboardfavoriteuser",
+                    filter=Q(dashboardfavoriteuser__favorited=True),
+                    distinct=True,
+                )
             )
             order_by = [
                 "favorites_count" if desc else "-favorites_count",
@@ -506,7 +517,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         pin_by = request.query_params.get("pin")
         if pin_by == "favorites":
             favorited_by_subquery = DashboardFavoriteUser.objects.filter(
-                dashboard=OuterRef("pk"), user_id=request.user.id
+                dashboard=OuterRef("pk"), user_id=request.user.id, favorited=True
             )
 
             order_by_favorites = [

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -159,7 +159,10 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
             if existing and existing.favorited:
                 return False
 
-            if self.count() == 0:
+            existing_favorites = self.filter(
+                organization=organization, user_id=user_id, favorited=True
+            )
+            if not existing_favorites.exists():
                 position = 0
             else:
                 position = self.get_last_position(organization, user_id) + 1

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -312,13 +312,23 @@ class Dashboard(Model):
         with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
             existing_favorites.filter(
                 user_id__in=existing_user_ids - new_user_ids, favorited=True
-            ).update(favorited=False)
+            ).update(favorited=False, position=None)
 
             users_to_add = new_user_ids - existing_user_ids
             users_to_refavorite = new_user_ids & existing_user_ids
-            existing_favorites.filter(user_id__in=users_to_refavorite, favorited=False).update(
-                favorited=True
-            )
+
+            for user_id in users_to_refavorite:
+                fav = existing_favorites.filter(user_id=user_id, favorited=False).first()
+                if fav:
+                    last_position = DashboardFavoriteUser.objects.get_last_position(
+                        self.organization, user_id
+                    )
+                    has_any = DashboardFavoriteUser.objects.filter(
+                        organization=self.organization, user_id=user_id, favorited=True
+                    ).exists()
+                    fav.favorited = True
+                    fav.position = 0 if not has_any else last_position + 1
+                    fav.save(update_fields=["favorited", "position"])
             DashboardFavoriteUser.objects.bulk_create(
                 [
                     DashboardFavoriteUser(

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -305,20 +305,28 @@ class Dashboard(Model):
         """
         from django.db import router, transaction
 
-        existing_user_ids = DashboardFavoriteUser.objects.filter(dashboard=self).values_list(
-            "user_id", flat=True
-        )
+        existing_favorites = DashboardFavoriteUser.objects.filter(dashboard=self)
+        existing_user_ids = set(existing_favorites.values_list("user_id", flat=True))
+        new_user_ids = set(user_ids)
+
         with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
-            newly_favourited = [
-                DashboardFavoriteUser(
-                    dashboard=self, user_id=user_id, organization=self.organization
-                )
-                for user_id in set(user_ids) - set(existing_user_ids)
-            ]
-            DashboardFavoriteUser.objects.filter(
-                dashboard=self, user_id__in=set(existing_user_ids) - set(user_ids)
-            ).delete()
-            DashboardFavoriteUser.objects.bulk_create(newly_favourited)
+            existing_favorites.filter(
+                user_id__in=existing_user_ids - new_user_ids, favorited=True
+            ).update(favorited=False)
+
+            users_to_add = new_user_ids - existing_user_ids
+            users_to_refavorite = new_user_ids & existing_user_ids
+            existing_favorites.filter(user_id__in=users_to_refavorite, favorited=False).update(
+                favorited=True
+            )
+            DashboardFavoriteUser.objects.bulk_create(
+                [
+                    DashboardFavoriteUser(
+                        dashboard=self, user_id=user_id, organization=self.organization
+                    )
+                    for user_id in users_to_add
+                ]
+            )
 
     @staticmethod
     def get_prebuilt_list(organization, user, title_query=None):

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -145,7 +145,18 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
             True if the dashboard was favorited, False if the dashboard was already favorited
         """
         with transaction.atomic(using=router.db_for_write(DashboardFavoriteUser)):
-            if self.get_favorite_dashboard(organization, user_id, dashboard):
+            # Lock any existing row to prevent concurrent insert races
+            existing = (
+                self.filter(
+                    organization=organization,
+                    user_id=user_id,
+                    dashboard=dashboard,
+                )
+                .select_for_update()
+                .first()
+            )
+
+            if existing and existing.favorited:
                 return False
 
             if self.count() == 0:
@@ -153,17 +164,10 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
             else:
                 position = self.get_last_position(organization, user_id) + 1
 
-            # Check if an unfavorited entry already exists and re-favorite it
-            existing_unfavorited = self.filter(
-                organization=organization,
-                user_id=user_id,
-                dashboard=dashboard,
-                favorited=False,
-            ).first()
-            if existing_unfavorited:
-                existing_unfavorited.favorited = True
-                existing_unfavorited.position = position
-                existing_unfavorited.save(update_fields=["favorited", "position"])
+            if existing:
+                existing.favorited = True
+                existing.position = position
+                existing.save(update_fields=["favorited", "position"])
             else:
                 self.create(
                     organization=organization,

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -45,6 +45,7 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
             self.filter(
                 organization=organization,
                 user_id=user_id,
+                favorited=True,
                 position__isnull=False,
             )
             .order_by("-position")
@@ -60,7 +61,7 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
         """
         Returns all favorited dashboards for a user in an organization.
         """
-        return self.filter(organization=organization, user_id=user_id).order_by(
+        return self.filter(organization=organization, user_id=user_id, favorited=True).order_by(
             "position", "dashboard__title"
         )
 
@@ -70,7 +71,9 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
         """
         Returns the favorite dashboard if it exists, otherwise None.
         """
-        return self.filter(organization=organization, user_id=user_id, dashboard=dashboard).first()
+        return self.filter(
+            organization=organization, user_id=user_id, dashboard=dashboard, favorited=True
+        ).first()
 
     def reorder_favorite_dashboards(
         self, organization: Organization, user_id: int, new_dashboard_positions: list[int]
@@ -90,6 +93,7 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
         existing_favorite_dashboards = self.filter(
             organization=organization,
             user_id=user_id,
+            favorited=True,
         )
 
         existing_dashboard_ids = {
@@ -149,25 +153,37 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
             else:
                 position = self.get_last_position(organization, user_id) + 1
 
-            self.create(
+            # Check if an unfavorited entry already exists and re-favorite it
+            existing_unfavorited = self.filter(
                 organization=organization,
                 user_id=user_id,
                 dashboard=dashboard,
-                position=position,
-            )
+                favorited=False,
+            ).first()
+            if existing_unfavorited:
+                existing_unfavorited.favorited = True
+                existing_unfavorited.position = position
+                existing_unfavorited.save(update_fields=["favorited", "position"])
+            else:
+                self.create(
+                    organization=organization,
+                    user_id=user_id,
+                    dashboard=dashboard,
+                    position=position,
+                )
             return True
 
-    def delete_favorite_dashboard(
+    def unfavorite_dashboard(
         self, organization: Organization, user_id: int, dashboard: Dashboard
     ) -> bool:
         """
-        Deletes a favorited dashboard from the list.
-        Decrements the position of all dashboards after the deletion point.
+        Unfavorites a dashboard by setting favorited=False and clearing its position.
+        Decrements the position of all remaining favorited dashboards after the removal point.
 
         Args:
             organization: The organization the dashboards belong to
             user_id: The ID of the user whose favorited dashboards are being updated
-            dashboard: The dashboard to delete
+            dashboard: The dashboard to unfavorite
 
         Returns:
             True if the dashboard was unfavorited, False if the dashboard was already unfavorited
@@ -177,10 +193,15 @@ class DashboardFavoriteUserManager(BaseManager["DashboardFavoriteUser"]):
                 return False
 
             deleted_position = favorite.position
-            favorite.delete()
+            favorite.favorited = False
+            favorite.position = None
+            favorite.save(update_fields=["favorited", "position"])
 
             self.filter(
-                organization=organization, user_id=user_id, position__gt=deleted_position
+                organization=organization,
+                user_id=user_id,
+                favorited=True,
+                position__gt=deleted_position,
             ).update(position=models.F("position") - 1)
             return True
 
@@ -265,7 +286,7 @@ class Dashboard(Model):
         """
         @deprecated Use the DashboardFavoriteUser object manager instead.
         """
-        user_ids = DashboardFavoriteUser.objects.filter(dashboard=self).values_list(
+        user_ids = DashboardFavoriteUser.objects.filter(dashboard=self, favorited=True).values_list(
             "user_id", flat=True
         )
         return user_ids

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -172,13 +172,18 @@ class DashboardFavoriteUserTest(TestCase):
 
         assert DashboardFavoriteUser.objects.count() == 2
 
-        DashboardFavoriteUser.objects.delete_favorite_dashboard(
+        DashboardFavoriteUser.objects.unfavorite_dashboard(
             self.organization, self.user.id, first_dashboard
         )
 
         dashboard = DashboardFavoriteUser.objects.get_favorite_dashboard(
             self.organization, self.user.id, second_dashboard
         )
-        assert DashboardFavoriteUser.objects.count() == 1
+        # Row still exists but with favorited=False
+        assert DashboardFavoriteUser.objects.count() == 2
+        assert DashboardFavoriteUser.objects.filter(favorited=True).count() == 1
+        unfavorited = DashboardFavoriteUser.objects.get(dashboard=first_dashboard)
+        assert unfavorited.favorited is False
+        assert unfavorited.position is None
         assert dashboard is not None
         assert dashboard.position == 0


### PR DESCRIPTION
Use the `favorited` boolean column on `DashboardFavoriteUser` to determine
favorite status, rather than checking for existence of a row in the table.

Previously, unfavoriting a dashboard deleted the `DashboardFavoriteUser`
row entirely. Now it sets `favorited=False` and clears the position, preserving
the row for potential re-favoriting. This avoids row churn and makes the
favorite state explicit.

Changes:
- All manager queries (`get_favorite_dashboards`, `get_favorite_dashboard`,
  `get_last_position`, `reorder_favorite_dashboards`) now filter by `favorited=True`
- `insert_favorite_dashboard` reactivates existing unfavorited entries instead
  of always creating new rows
- Renamed `delete_favorite_dashboard` → `unfavorite_dashboard` to reflect
  that the row is no longer deleted
- Updated serializer, list endpoint filters, sort, and pin-by-favorites
  queries to scope by `favorited=True`
- Fixed race condition in `insert_favorite_dashboard` using `select_for_update()`
  to prevent concurrent calls from causing `IntegrityError`
- Fixed position assignment bug where re-favoriting the first dashboard after
  unfavoriting all others assigned position 1 instead of 0 due to a global
  unscoped count check

Refs DAIN-1287