### PR TITLE
fix(seer): Add auth signing to grouping record delete-by-hash requests

### DIFF
--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -83,7 +83,7 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
             body=body,
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
-    except (ReadTimeoutError, TimeoutError, MaxRetryError) as e:
+    except (TimeoutError, MaxRetryError) as e:
         extra.update({"reason": type(e).__name__, "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT})
         logger.exception(
             "seer.delete_grouping_records.hashes.timeout",

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -83,8 +83,8 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
             body=body,
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
-    except (ReadTimeoutError, TimeoutError, MaxRetryError):
-        extra.update({"reason": "ReadTimeoutError", "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT})
+    except (ReadTimeoutError, TimeoutError, MaxRetryError) as e:
+        extra.update({"reason": type(e).__name__, "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT})
         logger.exception(
             "seer.delete_grouping_records.hashes.timeout",
             extra=extra,
@@ -92,7 +92,7 @@ def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> 
         metrics.incr(
             DELETE_HASH_METRIC,
             sample_rate=options.get("seer.similarity.metrics_sample_rate"),
-            tags={"success": False, "reason": "ReadTimeoutError"},
+            tags={"success": False, "reason": type(e).__name__},
         )
         return False
 

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from typing import TypedDict
 
 from django.conf import settings
-from urllib3.exceptions import ReadTimeoutError
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError, TimeoutError
 
 from sentry import options
 from sentry.conf.server import (
@@ -13,6 +13,7 @@ from sentry.conf.server import (
     SEER_PROJECT_GROUPING_RECORDS_DELETE_URL,
 )
 from sentry.net.http import connection_from_url
+from sentry.seer.signed_seer_api import make_signed_seer_api_request
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -75,15 +76,14 @@ def call_seer_to_delete_project_grouping_records(
 def call_seer_to_delete_these_hashes(project_id: int, hashes: Sequence[str]) -> bool:
     extra = {"project_id": project_id, "hashes": hashes}
     try:
-        body = {"project_id": project_id, "hash_list": hashes}
-        response = seer_grouping_connection_pool.urlopen(
-            "POST",
+        body = json.dumps({"project_id": project_id, "hash_list": hashes}).encode("utf-8")
+        response = make_signed_seer_api_request(
+            seer_grouping_connection_pool,
             SEER_HASH_GROUPING_RECORDS_DELETE_URL,
-            body=json.dumps(body),
-            headers={"Content-Type": "application/json;charset=utf-8"},
+            body=body,
             timeout=POST_BULK_GROUPING_RECORDS_TIMEOUT,
         )
-    except ReadTimeoutError:
+    except (ReadTimeoutError, TimeoutError, MaxRetryError):
         extra.update({"reason": "ReadTimeoutError", "timeout": POST_BULK_GROUPING_RECORDS_TIMEOUT})
         logger.exception(
             "seer.delete_grouping_records.hashes.timeout",

--- a/tests/sentry/seer/similarity/test_grouping_records.py
+++ b/tests/sentry/seer/similarity/test_grouping_records.py
@@ -18,7 +18,7 @@ DUMMY_POOL = ConnectionPool("dummy")
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_success(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -40,7 +40,7 @@ def test_delete_grouping_records_by_hash_success(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_timeout(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):
@@ -63,7 +63,7 @@ def test_delete_grouping_records_by_hash_timeout(
 
 @django_db_all
 @mock.patch("sentry.seer.similarity.grouping_records.logger")
-@mock.patch("sentry.seer.similarity.grouping_records.seer_grouping_connection_pool.urlopen")
+@mock.patch("sentry.seer.similarity.grouping_records.make_signed_seer_api_request")
 def test_delete_grouping_records_by_hash_failure(
     mock_seer_request: MagicMock, mock_logger: MagicMock
 ):


### PR DESCRIPTION
`call_seer_to_delete_these_hashes()` was making unsigned POST requests directly via `seer_grouping_connection_pool.urlopen()` to Seer's `/v0/issues/similar-issues/grouping-record/delete-by-hash` endpoint. This bypassed Seer's `auth_and_json_middleware`, which logged `"No auth header found for request to {url}"` and let the request through without authentication (see [HackerOne report](https://hackerone.com/reports/3552693)).

This switches to `make_signed_seer_api_request()` which adds the `Authorization: Rpcsignature rpc0:{signature}` header, matching how every other Seer call in the codebase works (e.g., `make_similar_issues_request()` in the sibling `similar_issues.py` module).

Also broadens exception handling to catch `TimeoutError` and `MaxRetryError` in addition to `ReadTimeoutError`, consistent with the patterns in `similar_issues.py`.

Note: `call_seer_to_delete_project_grouping_records()` (GET-based delete) still needs a coordinated fix with the Seer side to convert from GET to POST before it can be signed — tracked by the existing TODO in the code.