### PR TITLE
(span-repro): remove loggins empty segments

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -151,7 +151,6 @@ class SpansBuffer:
         self._buffer_logger = BufferLogger()
         self._flusher_logger = FlusherLogger()
         self._debug_trace_logger: DebugTraceLogger | None = None
-        self.empty_flush_segment_calls = 0
 
     @cached_property
     def client(self) -> RedisCluster[bytes] | StrictRedis[bytes]:
@@ -600,19 +599,6 @@ class SpansBuffer:
 
         metrics.timing("spans.buffer.flush_segments.num_segments", len(return_segments))
         metrics.timing("spans.buffer.flush_segments.has_root_span", num_has_root_spans)
-
-        if not return_segments:
-            self.empty_flush_segment_calls += 1
-        else:
-            if self.empty_flush_segment_calls > 0:
-                try:
-                    if self._debug_trace_logger is None:
-                        self._debug_trace_logger = DebugTraceLogger(self.client)
-                    self._debug_trace_logger.log_empty_segments(self.empty_flush_segment_calls)
-                except Exception:
-                    logger.exception("flush_segments: Failed to log empty flush count")
-                finally:
-                    self.empty_flush_segment_calls = 0
 
         self.any_shard_at_limit = any_shard_at_limit
         return return_segments

--- a/src/sentry/spans/debug_trace_logger.py
+++ b/src/sentry/spans/debug_trace_logger.py
@@ -173,16 +173,3 @@ class DebugTraceLogger:
                 "new_ttl_remaining_seconds": new_deadline - message_timestamp,
             },
         )
-
-    def log_empty_segments(self, empty_flush_count: int) -> None:
-        """
-        Log the number of consecutive empty flush_segments calls.
-
-        Args:
-            empty_flush_count: Number of consecutive calls to flush_segments
-                              that returned no segments
-        """
-        logger.info(
-            "spans.buffer.debug_empty_flushes",
-            extra={"empty_flush_count": empty_flush_count},
-        )


### PR DESCRIPTION
this is not used anymore. It was added to investigate premature flushing behaviours but it's not a new bug. See https://www.notion.so/sentry/Premature-Flushing-Investigation-31b8b10e4b5d805381aef99a70cb2107 for details