### PR TITLE
ref(dashboards): Change save button text for prebuilt dashboard filters

### DIFF
--- a/static/app/views/dashboards/filtersBar.spec.tsx
+++ b/static/app/views/dashboards/filtersBar.spec.tsx
@@ -219,7 +219,7 @@ describe('FiltersBar', () => {
     expect(
       screen.getByRole('button', {name: /browser\.name.*Chrome/i})
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save for Everyone'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -344,7 +344,7 @@ export default function FiltersBar({
                 disabled={!hasEditAccess}
                 busy={shouldBusySaveButton}
               >
-                {t('Save')}
+                {isPrebuiltDashboard ? t('Save for Everyone') : t('Save')}
               </Button>
               <Button
                 data-test-id="filter-bar-cancel"


### PR DESCRIPTION
Change the save button label from "Save" to "Save for Everyone" on prebuilt dashboards to clarify that saving filter changes on a prebuilt dashboard affects all users.

Refs BROWSE-414