### PR TITLE
feat(nav): remove projects from insights sidebar, restore /projects/ path

### DIFF
--- a/static/app/components/idBadge/projectBadge.spec.tsx
+++ b/static/app/components/idBadge/projectBadge.spec.tsx
@@ -11,7 +11,7 @@ describe('ProjectBadge', () => {
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/projects/project-slug/?project=2'
+      '/organizations/org-slug/projects/project-slug/?project=2'
     );
     expect(screen.getByTestId('badge-display-name')).toHaveTextContent('project-slug');
   });

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -124,9 +124,7 @@ describe('ProjectPageFilter', () => {
     // Activating the link triggers a route change
     await userEvent.keyboard('{Enter}');
 
-    expect(router.location.pathname).toBe(
-      '/organizations/org-slug/insights/projects/project-1/'
-    );
+    expect(router.location.pathname).toBe('/organizations/org-slug/projects/project-1/');
     expect(router.location.query).toEqual({project: '1'});
 
     // Move focus to "Project Settings" link

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -193,7 +193,7 @@ describe('ApiSource', () => {
           model: expect.objectContaining({slug: 'foo-project'}),
           sourceType: 'project',
           resultType: 'route',
-          to: '/organizations/org-slug/insights/projects/foo-project/?project=2',
+          to: '/organizations/org-slug/projects/foo-project/?project=2',
         }),
         expect.objectContaining({
           model: expect.objectContaining({slug: 'foo-project'}),

--- a/static/app/components/waitingForEvents.spec.tsx
+++ b/static/app/components/waitingForEvents.spec.tsx
@@ -39,7 +39,7 @@ describe('WaitingForEvents', () => {
       await userEvent.click(screen.getByText('Installation Instructions'));
       await waitFor(() => {
         expect(router.location.pathname).toBe(
-          '/organizations/org-slug/insights/projects/project-slug/getting-started/'
+          '/organizations/org-slug/projects/project-slug/getting-started/'
         );
       });
     });

--- a/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
+++ b/static/app/views/insights/browser/webVitals/components/tables/pagePerformanceTable.spec.tsx
@@ -132,7 +132,7 @@ describe('PagePerformanceTable', () => {
     expect(screen.getByRole('cell', {name: 'View Project Details'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'View Project Details'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/projects/frontend/?project=11276'
+      '/organizations/org-slug/projects/frontend/?project=11276'
     );
     expect(screen.getByRole('cell', {name: '492'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '700ms'})).toBeInTheDocument();

--- a/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
+++ b/static/app/views/insights/cache/views/cacheLandingPage.spec.tsx
@@ -226,7 +226,7 @@ describe('CacheLandingPage', () => {
     expect(screen.getByRole('cell', {name: 'View Project Details'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'View Project Details'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/projects/backend/?project=1'
+      '/organizations/org-slug/projects/backend/?project=1'
     );
 
     expect(

--- a/static/app/views/insights/database/components/noDataMessage.spec.tsx
+++ b/static/app/views/insights/database/components/noDataMessage.spec.tsx
@@ -94,7 +94,7 @@ describe('NoDataMessage', () => {
 
     expect(screen.getAllByRole('link')[1]).toHaveAttribute(
       'href',
-      '/organizations/org-slug/insights/projects/awesome-api/'
+      '/organizations/org-slug/projects/awesome-api/'
     );
   });
 });

--- a/static/app/views/insights/http/views/httpLandingPage.spec.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.spec.tsx
@@ -393,10 +393,7 @@ describe('HTTPLandingPage', () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByRole('link', {name: 'View Project Details'})[0]
-    ).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/insights/projects/backend/?project=1'
-    );
+    ).toHaveAttribute('href', '/organizations/org-slug/projects/backend/?project=1');
     expect(screen.getByRole('cell', {name: '40.8K/s'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '0.04%'})).toBeInTheDocument();
     expect(screen.getByRole('cell', {name: '39.32%'})).toBeInTheDocument();

--- a/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/insights/insightsSecondaryNav.tsx
@@ -1,10 +1,8 @@
-import {Fragment, useMemo} from 'react';
-import partition from 'lodash/partition';
+import {Fragment} from 'react';
 
 import Feature from 'sentry/components/acl/feature';
 import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
-import useProjects from 'sentry/utils/useProjects';
 import {useUser} from 'sentry/utils/useUser';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import {
@@ -29,7 +27,6 @@ import {
 } from 'sentry/views/insights/pages/mobile/settings';
 import {DOMAIN_VIEW_BASE_URL} from 'sentry/views/insights/pages/settings';
 import {PRIMARY_NAV_GROUP_CONFIG} from 'sentry/views/nav/primary/config';
-import ProjectIcon from 'sentry/views/nav/projectIcon';
 import {SecondaryNav} from 'sentry/views/nav/secondary/secondary';
 import {PrimaryNavGroup} from 'sentry/views/nav/types';
 
@@ -37,17 +34,6 @@ export function InsightsSecondaryNav() {
   const user = useUser();
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
-
-  const {projects} = useProjects();
-
-  const [starredProjects, nonStarredProjects] = useMemo(() => {
-    return partition(projects, project => project.isBookmarked);
-  }, [projects]);
-
-  const displayStarredProjects = starredProjects.length > 0;
-  const projectsToDisplay = displayStarredProjects
-    ? starredProjects.slice(0, 8)
-    : nonStarredProjects.filter(project => project.isMember).slice(0, 8);
 
   const shouldRedirectToMonitors =
     organization.features.includes('workflow-engine-ui') && !user?.isStaff;
@@ -116,36 +102,6 @@ export function InsightsSecondaryNav() {
             </SecondaryNav.Item>
           </Feature>
         </SecondaryNav.Section>
-        <SecondaryNav.Section id="insights-projects-all">
-          <SecondaryNav.Item
-            to={`${baseUrl}/projects/`}
-            end
-            analyticsItemName="insights_projects_all"
-          >
-            {t('All Projects')}
-          </SecondaryNav.Item>
-        </SecondaryNav.Section>
-        {projectsToDisplay.length > 0 ? (
-          <SecondaryNav.Section
-            id="insights-starred-projects"
-            title={displayStarredProjects ? t('Starred Projects') : t('Projects')}
-          >
-            {projectsToDisplay.map(project => (
-              <SecondaryNav.Item
-                key={project.id}
-                to={`${baseUrl}/projects/${project.slug}/`}
-                leadingItems={
-                  <ProjectIcon
-                    projectPlatforms={project.platform ? [project.platform] : ['default']}
-                  />
-                }
-                analyticsItemName="insights_project_starred"
-              >
-                {project.slug}
-              </SecondaryNav.Item>
-            ))}
-          </SecondaryNav.Section>
-        ) : null}
       </SecondaryNav.Body>
     </Fragment>
   );

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -5,8 +5,8 @@ import {useRedirectNavV2Routes} from 'sentry/views/nav/useRedirectNavV2Routes';
 
 export default function Projects() {
   const redirectPath = useRedirectNavV2Routes({
-    oldPathPrefix: '/projects/',
-    newPathPrefix: '/insights/projects/',
+    oldPathPrefix: '/insights/projects/',
+    newPathPrefix: '/projects/',
   });
 
   if (redirectPath) {

--- a/static/app/views/projects/pathname.tsx
+++ b/static/app/views/projects/pathname.tsx
@@ -1,7 +1,7 @@
 import type {Organization} from 'sentry/types/organization';
 import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 
-const PROJECTS_BASE_PATHNAME = 'insights/projects';
+const PROJECTS_BASE_PATHNAME = 'projects';
 
 export function makeProjectsPathname({
   path,

--- a/static/app/views/replays/list/setupReplaysCTA.spec.tsx
+++ b/static/app/views/replays/list/setupReplaysCTA.spec.tsx
@@ -20,10 +20,7 @@ describe('SetupReplaysCTA', () => {
     render(<SetupReplaysCTA primaryAction="create" />);
     const createBtn = screen.getByTestId('create-project-btn');
     expect(createBtn).toBeInTheDocument();
-    expect(createBtn).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/insights/projects/new/`
-    );
+    expect(createBtn).toHaveAttribute('href', `/organizations/org-slug/projects/new/`);
   });
 
   it('create project w/ disabled state including tooltip', async () => {


### PR DESCRIPTION
We are making some UX changes in preparation for Insights --> Dashboard migration. This PR removes the "All Projects" link and starred/member projects list from the Insights second-level sidebar. Users are meant to reach the Projects page via the organization dropdown (logo menu) instead, which already has a "Projects" entry. This is somewhat of a stop-gap, because eventually we will move the Projects page completely, but for now it's becoming a strange little "orphan" page, in which it doesn't have a matching sidebar entry, which means that when people land on a project page, they get the default secondary sidebar.

Also restores the canonical projects URL from `/insights/projects/` back to `/projects/` — the path it occupied before the new nav was introduced. The `/insights/projects/` route now redirects to `/projects/` for backwards compatibility with bookmarks and external links.

Fixes DAIN-1208

**e.g.,**

No more "Projects" in Insights secondary:
<img width="281" height="505" alt="Screenshot 2026-03-09 at 11 50 28 AM" src="https://github.com/user-attachments/assets/9ed16ff1-b611-4c46-b9e6-35cafd4a19e3" />

"Projects" link in the logo nav:
<img width="282" height="287" alt="Screenshot 2026-03-09 at 11 50 32 AM" src="https://github.com/user-attachments/assets/e534ef78-e47b-4d82-a27d-6904f16c33ef" />

Projects already have a banner to let people know we're going to move that page:

<img width="815" height="127" alt="Screenshot 2026-03-09 at 11 51 36 AM" src="https://github.com/user-attachments/assets/572d5221-ae92-4390-bb1c-ac7271a9e23e" />
<img width="1171" height="76" alt="Screenshot 2026-03-09 at 11 51 45 AM" src="https://github.com/user-attachments/assets/8f200fbc-f9bb-4c4b-a83a-9c03f27e40c6" />
