### PR TITLE
fix(dashboards): add datasource to text widget validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -384,6 +384,10 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
             if not data.get("title"):
                 raise serializers.ValidationError({"title": "Title is required during creation."})
 
+        dataset_source = data.get("dataset_source")
+        if dataset_source is not None:
+            data["dataset_source"] = DATASET_SOURCE_MAP[dataset_source]
+
         return data
 
     def validate(self, data):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1452,6 +1452,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 "title": "Text Widget Title",
                 "displayType": "text",
                 "description": "This is a text widget description",
+                "datasetSource": "user",
             }
             response = self.do_request(
                 "post",


### PR DESCRIPTION
missed the `dataset_source` validation in the text widget validation block so it wasn't getting converted properly for the backend. 