### PR TITLE
fix: Add dependency on column drop migration

### DIFF
--- a/src/sentry/migrations/1040_drop_fk_projecttemplate.py
+++ b/src/sentry/migrations/1040_drop_fk_projecttemplate.py
@@ -26,6 +26,7 @@ class Migration(CheckedMigration):
 
     dependencies = [
         ("sentry", "1039_widget_description_to_textfield"),
+        ("monitors", "0008_fix_processing_error_keys"),
     ]
 
     operations = [


### PR DESCRIPTION
The monitors/0008 migration includes a loop over all projects. Currently django occasionally, orders migrations in a way that results in this query failing. Having an additional dependency should prevent query failures.