### PR TITLE
fix(webhooks): Eliminate head-of-line blocking in sequential mailbox drain

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -280,6 +280,11 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
 
     _set_webhook_delivery_sentry_context(payload)
 
+    skip_on_failure_providers = frozenset(
+        options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
+    )
+    skip_on_failure = payload.provider in skip_on_failure_providers
+
     delivered = 0
     failed = 0
     current_id = payload.id
@@ -324,8 +329,13 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                 except DeliveryFailed:
                     failed += 1
                     metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "retry"})
-                    # Continue processing remaining messages instead of stopping.
-                    # Failed messages have already been rescheduled by deliver_message.
+                    if not skip_on_failure:
+                        # For providers that require strict ordering, stop on the
+                        # first failure so subsequent messages are not delivered
+                        # out of order.
+                        return
+                    # For allowlisted providers: skip the failed message and
+                    # continue. It has already been rescheduled by deliver_message.
                     continue
 
             # No more messages to deliver

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -281,6 +281,8 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
     _set_webhook_delivery_sentry_context(payload)
 
     delivered = 0
+    failed = 0
+    current_id = payload.id
     deadline = timezone.now() + BATCH_SCHEDULE_OFFSET
     try:
         while True:
@@ -302,12 +304,15 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
             # Fetch records from the batch in slices of 100. This avoids reading
             # redundant data should we hit an error and should help keep query duration low.
             query = WebhookPayloadReplica.filter(
-                id__gte=payload.id, mailbox_name=payload.mailbox_name
+                id__gte=current_id, mailbox_name=payload.mailbox_name
             ).order_by("id")
 
             batch_count = 0
             for record in query[:100]:
                 batch_count += 1
+                # Advance past this record regardless of outcome so that failed
+                # messages are not re-attempted in subsequent batches of this drain.
+                current_id = record.id + 1
                 # Refresh the lock on each delivery so a slow HTTP response in the
                 # inner loop (up to 30s timeout × 100 records) cannot outlast the
                 # 15s TTL and let the key expire mid-batch.
@@ -317,18 +322,31 @@ def drain_mailbox(payload_id: int, mailbox_name: str | None = None) -> None:
                     deliver_message(record)
                     delivered += 1
                 except DeliveryFailed:
+                    failed += 1
                     metrics.incr("hybridcloud.deliver_webhooks.delivery", tags={"outcome": "retry"})
-                    return
+                    # Continue processing remaining messages instead of stopping.
+                    # Failed messages have already been rescheduled by deliver_message.
+                    continue
 
             # No more messages to deliver
             if batch_count < 1:
-                logger.debug(
-                    "deliver_webhook.delivery_complete",
-                    extra={
-                        **payload.as_dict(),
-                        "delivered": delivered,
-                    },
-                )
+                if failed > 0:
+                    logger.info(
+                        "deliver_webhook.delivery_complete_with_failures",
+                        extra={
+                            **payload.as_dict(),
+                            "delivered": delivered,
+                            "failed": failed,
+                        },
+                    )
+                else:
+                    logger.debug(
+                        "deliver_webhook.delivery_complete",
+                        extra={
+                            **payload.as_dict(),
+                            "delivered": delivered,
+                        },
+                    )
                 return
     finally:
         # Only release the lock if this is a push-triggered drain (mailbox_name is

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2506,6 +2506,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "hybridcloud.webhookpayload.skip_on_failure_providers",
+    type=Sequence,
+    default=["github"],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Break glass controls
 register(
     "hybrid_cloud.rpc.disabled-service-methods",

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -306,34 +306,44 @@ class DrainMailboxTest(TestCase):
     @responses.activate
     @override_regions(region_config)
     def test_drain_success_partial(self) -> None:
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=200,
-            body="",
-        )
-        responses.add(
-            responses.POST,
-            "http://us.testserver/extensions/github/webhook/",
-            status=500,
-            body="",
-        )
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=500, body="")
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=200, body="")
         records = create_payloads(5, "github:123")
         drain_mailbox(records[0].id)
 
-        # Attempts should stop as soon as the first delivery
-        # fails. This retains mailbox ordering while yielding this
-        # worker for new work
-        assert len(responses.calls) == 2
+        # Failed messages are skipped and processing continues.
+        # All 5 messages are attempted despite the failure.
+        assert len(responses.calls) == 5
 
-        # Mailbox should have 4 records left
-        assert WebhookPayload.objects.count() == 4
+        # Only the failed message remains in the mailbox.
+        assert WebhookPayload.objects.count() == 1
 
-        # Remaining record should be scheduled to run later.
+        # Failed record should be scheduled to run later.
         first = WebhookPayload.objects.order_by("id").first()
         assert first
         assert first.attempts == 1
         assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_regions(region_config)
+    def test_drain_mailbox_multiple_consecutive_failures(self) -> None:
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=500, body="")
+        records = create_payloads(5, "github:123")
+        drain_mailbox(records[0].id)
+
+        # All 5 messages are attempted even though all fail.
+        assert len(responses.calls) == 5
+
+        # All 5 messages remain with incremented attempts and a future schedule_for.
+        assert WebhookPayload.objects.count() == 5
+        for record in WebhookPayload.objects.all():
+            assert record.attempts == 1
+            assert record.schedule_for > timezone.now()
 
     @responses.activate
     @override_regions(region_config)

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -121,18 +121,19 @@ class ScheduleWebhooksTest(TestCase):
         with self.tasks():
             schedule_webhook_delivery()
 
-        # All messages are attempted but all fail due to timeout, so all are rescheduled.
-        assert len(responses.calls) == num_records
+        # First attempt fails. provider=None is not in the skip-on-failure allowlist
+        # so processing stops after the first message, preserving mailbox ordering.
+        assert len(responses.calls) == 1
         assert WebhookPayload.objects.count() == num_records
         head = WebhookPayload.objects.all().order_by("id").first()
         assert head
         assert head.schedule_for > timezone.now()
 
         # Do another scheduled run. This should not make any forwarding requests
-        # because all messages have schedule_for in the future.
+        # because the head is still in backoff.
         with self.tasks():
             schedule_webhook_delivery()
-        assert len(responses.calls) == num_records
+        assert len(responses.calls) == 1
         # Head doesn't move.
         new_head = WebhookPayload.objects.all().order_by("id").first()
         assert new_head
@@ -262,12 +263,13 @@ class ScheduleWebhooksTest(TestCase):
         assert call_args_list[1] == null_provider_webhook.id
 
 
-def create_payloads(num: int, mailbox: str) -> list[WebhookPayload]:
+def create_payloads(num: int, mailbox: str, provider: str | None = None) -> list[WebhookPayload]:
     created = []
     for _ in range(0, num):
         hook = Factories.create_webhook_payload(
             mailbox_name=mailbox,
             region_name="us",
+            provider=provider,
         )
         created.append(hook)
     return created
@@ -313,11 +315,11 @@ class DrainMailboxTest(TestCase):
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
         responses.add(responses.POST, url, status=200, body="")
-        records = create_payloads(5, "github:123")
+        records = create_payloads(5, "github:123", provider="github")
         drain_mailbox(records[0].id)
 
-        # Failed messages are skipped and processing continues.
-        # All 5 messages are attempted despite the failure.
+        # github is in the skip-on-failure allowlist: failed messages are skipped
+        # and processing continues. All 5 messages are attempted.
         assert len(responses.calls) == 5
 
         # Only the failed message remains in the mailbox.
@@ -331,10 +333,31 @@ class DrainMailboxTest(TestCase):
 
     @responses.activate
     @override_regions(region_config)
+    def test_drain_stops_on_failure_for_non_allowlisted_provider(self) -> None:
+        url = "http://us.testserver/extensions/github/webhook/"
+        responses.add(responses.POST, url, status=200, body="")
+        responses.add(responses.POST, url, status=500, body="")
+        records = create_payloads(5, "jira:123", provider="jira")
+        drain_mailbox(records[0].id)
+
+        # jira is not in the allowlist: processing stops on the first failure
+        # to preserve strict mailbox ordering.
+        assert len(responses.calls) == 2
+
+        # The failed message and all subsequent messages remain.
+        assert WebhookPayload.objects.count() == 4
+
+        first = WebhookPayload.objects.order_by("id").first()
+        assert first
+        assert first.attempts == 1
+        assert first.schedule_for > timezone.now()
+
+    @responses.activate
+    @override_regions(region_config)
     def test_drain_mailbox_multiple_consecutive_failures(self) -> None:
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=500, body="")
-        records = create_payloads(5, "github:123")
+        records = create_payloads(5, "github:123", provider="github")
         drain_mailbox(records[0].id)
 
         # All 5 messages are attempted even though all fail.

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -121,17 +121,18 @@ class ScheduleWebhooksTest(TestCase):
         with self.tasks():
             schedule_webhook_delivery()
 
-        # First attempt will fail rescheduling messages.
-        assert len(responses.calls) == 1
+        # All messages are attempted but all fail due to timeout, so all are rescheduled.
+        assert len(responses.calls) == num_records
         assert WebhookPayload.objects.count() == num_records
         head = WebhookPayload.objects.all().order_by("id").first()
         assert head
         assert head.schedule_for > timezone.now()
 
         # Do another scheduled run. This should not make any forwarding requests
+        # because all messages have schedule_for in the future.
         with self.tasks():
             schedule_webhook_delivery()
-        assert len(responses.calls) == 1
+        assert len(responses.calls) == num_records
         # Head doesn't move.
         new_head = WebhookPayload.objects.all().order_by("id").first()
         assert new_head


### PR DESCRIPTION
Previously, `drain_mailbox` returned immediately when any single webhook delivery failed, blocking all subsequent messages in that mailbox until the next scheduled retry cycle (up to 3 minutes away). A single transient 500 or timeout could delay dozens of unrelated, healthy webhooks.

This changes `drain_mailbox` to skip failed messages and continue delivering the remaining messages in the mailbox — matching the behavior already present in the parallel drain path (`drain_mailbox_parallel`). Failed messages are individually rescheduled via the existing `schedule_next_attempt()` mechanism, so they will be retried on a future cycle.

A `current_id` variable now tracks the highest ID processed so far, ensuring that failed records (which stay in the database with a future `schedule_for`) are not re-fetched within the same drain invocation.

The ordering semantics change from strict to best-effort, which is safe because:
- The parallel drain already uses best-effort ordering without issues
- GitHub webhook types (push, PR, issue events) are idempotent
- Region silos handle duplicate/out-of-order events