### PR TITLE
fix(cells): Fix ByCellName resolver

### DIFF
--- a/src/sentry/hybridcloud/rpc/resolvers.py
+++ b/src/sentry/hybridcloud/rpc/resolvers.py
@@ -47,11 +47,7 @@ class ByCellName(CellResolutionStrategy):
 
     def resolve(self, arguments: ArgumentDict) -> Cell:
         # TODO(cells): Temporary fall back to "region_name" while service methods are being migrated.
-        cell_name = (
-            arguments["region_name"]
-            if self.parameter_name not in arguments
-            else arguments[self.parameter_name]
-        )
+        cell_name = arguments.get("region_name") or arguments[self.parameter_name]
         return get_cell_by_name(cell_name)
 
 


### PR DESCRIPTION
Fixes a backward compatibility issue where `cell_name` will be temporarily None for old callers during the migration period.

This came up in https://github.com/getsentry/sentry/pull/110173, where resolvers need to support both `region_name` and `cell_name` temporarily.
