### PR TITLE
chore: enable @typescript-eslint/no-unnecessary-template-expression

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -590,6 +590,7 @@ export default typescript.config([
           '@typescript-eslint/no-base-to-string': 'error',
           '@typescript-eslint/no-duplicate-type-constituents': 'error',
           '@typescript-eslint/no-for-in-array': 'error',
+          '@typescript-eslint/no-unnecessary-template-expression': 'error',
           '@typescript-eslint/no-unnecessary-type-assertion': 'error',
           '@typescript-eslint/only-throw-error': 'error',
           '@typescript-eslint/prefer-optional-chain': 'error',

--- a/scripts/type-coverage-diff.ts
+++ b/scripts/type-coverage-diff.ts
@@ -528,7 +528,9 @@ async function main() {
     );
 
     console.log(
-      `${colors.dim(`\n📝 Note: Only showing type issues on lines that were literally added (+) or removed (-) in git diff`)}`
+      colors.dim(
+        `\n📝 Note: Only showing type issues on lines that were literally added (+) or removed (-) in git diff`
+      )
     );
 
     // Compare any-typed symbols (only in actually modified code)

--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -32,7 +32,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
 
   return {
     control: {
-      backgroundColor: `${theme.tokens.background.primary}`,
+      backgroundColor: theme.tokens.background.primary,
       fontSize: 15,
       fontWeight: 'normal',
     },
@@ -74,7 +74,7 @@ export function mentionStyle({theme, minHeight, streamlined}: Options) {
         maxHeight: 142,
         minWidth: 220,
         overflow: 'auto',
-        backgroundColor: `${theme.tokens.background.primary}`,
+        backgroundColor: theme.tokens.background.primary,
         border: '1px solid rgba(0,0,0,0.15)',
         borderRadius: theme.radius.md,
         fontSize: theme.font.size.sm,

--- a/static/app/components/assigneeSelectorDropdown.spec.tsx
+++ b/static/app/components/assigneeSelectorDropdown.spec.tsx
@@ -241,7 +241,7 @@ describe('AssigneeSelectorDropdown', () => {
     );
     expect(updateGroupSpy).toHaveBeenCalledWith(GROUP_1, {
       assignee: USER_1,
-      id: `${USER_1.id}`,
+      id: USER_1.id,
       type: 'user',
       suggestedAssignee: undefined,
     });
@@ -299,7 +299,7 @@ describe('AssigneeSelectorDropdown', () => {
         name: TEAM_1.slug,
         type: 'team',
       },
-      id: `${TEAM_1.id}`,
+      id: TEAM_1.id,
       type: 'team',
       suggestedAssignee: undefined,
     });
@@ -358,7 +358,7 @@ describe('AssigneeSelectorDropdown', () => {
 
     expect(updateGroupSpy).toHaveBeenCalledWith(GROUP_1, {
       assignee: USER_1,
-      id: `${USER_1.id}`,
+      id: USER_1.id,
       type: 'user',
       suggestedAssignee: undefined,
     });
@@ -389,7 +389,7 @@ describe('AssigneeSelectorDropdown', () => {
     );
     expect(updateGroupSpy).toHaveBeenCalledWith(GROUP_1, {
       assignee: USER_1,
-      id: `${USER_1.id}`,
+      id: USER_1.id,
       type: 'user',
       suggestedAssignee: undefined,
     });
@@ -495,9 +495,9 @@ describe('AssigneeSelectorDropdown', () => {
       expect(screen.getAllByRole('option')).toHaveLength(1);
     });
 
-    expect(await screen.findByText(`${USER_2.name}`)).toBeInTheDocument();
+    expect(await screen.findByText(USER_2.name)).toBeInTheDocument();
 
-    await userEvent.click(await screen.findByText(`${USER_2.name}`));
+    await userEvent.click(await screen.findByText(USER_2.name));
 
     await waitFor(() =>
       expect(assignMock).toHaveBeenLastCalledWith(
@@ -540,7 +540,7 @@ describe('AssigneeSelectorDropdown', () => {
       expect(screen.getAllByRole('option')).toHaveLength(1);
     });
 
-    expect(await screen.findByText(`${USER_4.name}`)).toBeInTheDocument();
+    expect(await screen.findByText(USER_4.name)).toBeInTheDocument();
   });
 
   it('successfully shows suggested assignees and suggestion reason', async () => {
@@ -609,7 +609,7 @@ describe('AssigneeSelectorDropdown', () => {
 
     expect(updateGroupSpy).toHaveBeenCalledWith(GROUP_2, {
       assignee: USER_1,
-      id: `${USER_1.id}`,
+      id: USER_1.id,
       type: 'user',
       suggestedAssignee: expect.objectContaining({id: USER_1.id}),
     });

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -371,7 +371,7 @@ export function computeChartTooltip(
   return {
     show: true,
     trigger: 'item',
-    backgroundColor: `${theme.tokens.background.primary}`,
+    backgroundColor: theme.tokens.background.primary,
     borderWidth: 0,
     extraCssText: `box-shadow: 0 0 0 1px ${theme.tokens.border.transparent.neutral.muted}, ${theme.dropShadowHeavy}`,
     transitionDuration: 0,

--- a/static/app/components/charts/groupStatusChart.tsx
+++ b/static/app/components/charts/groupStatusChart.tsx
@@ -77,7 +77,7 @@ function GroupStatusChart({
         color: theme.tokens.content.secondary,
         fontFamily: 'Rubik',
         fontSize: 10,
-        formatter: `${formattedMarkLine}`,
+        formatter: formattedMarkLine,
       },
     });
 

--- a/static/app/components/core/button/styles.tsx
+++ b/static/app/components/core/button/styles.tsx
@@ -99,7 +99,7 @@ export function DO_NOT_USE_getButtonStyles(
       position: 'absolute',
       inset: '0',
       height: `calc(100% - ${buttonElevation})`,
-      top: `${buttonElevation}`,
+      top: buttonElevation,
       transform: `translateY(-${buttonElevation})`,
       boxShadow: `0 ${buttonElevation} 0 0px ${buttonTheme.background}`,
       background: buttonTheme.background,

--- a/static/app/components/events/contexts/utils.spec.tsx
+++ b/static/app/components/events/contexts/utils.spec.tsx
@@ -135,7 +135,7 @@ describe('contexts utils', () => {
       expect(knownData[0]!.key).toEqual(knownStructuredData[0]!.key);
       expect(knownData[0]!.subject).toEqual(knownStructuredData[0]!.subject);
       render(<Fragment>{knownStructuredData[0]!.value as React.ReactNode}</Fragment>);
-      expect(screen.getByText(`${knownData[0]!.value as string}`)).toBeInTheDocument();
+      expect(screen.getByText(knownData[0]!.value as string)).toBeInTheDocument();
       expect(screen.getByTestId('annotated-text-error-icon')).toBeInTheDocument();
     });
   });

--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -77,7 +77,7 @@ export function EventTagsDataSection({
         onChange={handleTagFilterChange}
       >
         {[TagFilter.ALL, TagFilter.CUSTOM, ...availableFilters].map(v => (
-          <SegmentedControl.Item key={v}>{`${v}`}</SegmentedControl.Item>
+          <SegmentedControl.Item key={v}>{v}</SegmentedControl.Item>
         ))}
       </SegmentedControl>
     </Grid>

--- a/static/app/components/events/interfaces/frame/deprecatedLine.tsx
+++ b/static/app/components/events/interfaces/frame/deprecatedLine.tsx
@@ -416,9 +416,7 @@ const DefaultLine = styled('div')<{
   justify-content: space-between;
   align-items: center;
   background: ${p =>
-    p.isSubFrame
-      ? `${p.theme.colors.surface200}`
-      : `${p.theme.tokens.background.tertiary}`};
+    p.isSubFrame ? p.theme.colors.surface200 : p.theme.tokens.background.tertiary};
   min-height: 40px;
   word-break: break-word;
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.lg};

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -237,7 +237,7 @@ export function StacktraceLink({frame, event, line, disableSetup}: StacktraceLin
         ) : coverage &&
           shouldShowCodecovFeatures(organization, match, coverage.status) ? (
           <CodecovLink
-            coverageUrl={`${frame.sourceLink}`}
+            coverageUrl={frame.sourceLink}
             status={coverage.status}
             organization={organization}
             event={event}

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -363,7 +363,7 @@ function NativeFrame({
                 <AnnotatedText value={functionName.value} meta={functionName.meta} />
               </Tooltip>
             ) : isDartAsyncSuspensionFrame ? (
-              `${t('Dart')}`
+              t('Dart')
             ) : (
               `<${t('unknown')}>`
             )}{' '}
@@ -547,8 +547,8 @@ const RowHeader = styled('span')<{
   column-gap: ${p => p.theme.space.md};
   background-color: ${p =>
     !p.isInAppFrame && p.isSubFrame
-      ? `${p.theme.colors.surface200}`
-      : `${p.theme.tokens.background.secondary}`};
+      ? p.theme.colors.surface200
+      : p.theme.tokens.background.secondary};
   font-size: ${p => p.theme.font.size.sm};
   padding: ${p => p.theme.space.md};
   color: ${p => (p.isInAppFrame ? '' : p.theme.tokens.content.secondary)};

--- a/static/app/components/globalDrawer/useDrawerResizing.tsx
+++ b/static/app/components/globalDrawer/useDrawerResizing.tsx
@@ -77,9 +77,9 @@ export function useDrawerResizing({
       panelRef.current?.style.setProperty('--drawer-min-width', '100%');
       panelRef.current?.style.setProperty('--drawer-max-width', '100%');
     } else if (!enabled && drawerWidth) {
-      panelRef.current?.style.setProperty('--drawer-width', `${drawerWidth}`);
-      panelRef.current?.style.setProperty('--drawer-min-width', `${drawerWidth}`);
-      panelRef.current?.style.setProperty('--drawer-max-width', `${drawerWidth}`);
+      panelRef.current?.style.setProperty('--drawer-width', drawerWidth);
+      panelRef.current?.style.setProperty('--drawer-min-width', drawerWidth);
+      panelRef.current?.style.setProperty('--drawer-max-width', drawerWidth);
     } else {
       panelRef.current?.style.setProperty('--drawer-width', `${persistedWidthPercent}%`);
       panelRef.current?.style.setProperty('--drawer-min-width', `${MIN_WIDTH_PERCENT}%`);

--- a/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.spec.tsx
@@ -107,7 +107,7 @@ describe('SentryAppExternalIssueForm', () => {
           action="create"
         />
       );
-      expect(screen.getByRole('textbox', {name: 'Title'})).toHaveValue(`${group.title}`);
+      expect(screen.getByRole('textbox', {name: 'Title'})).toHaveValue(group.title);
 
       const url = addQueryParamsToExistingUrl(group.permalink, {
         referrer: sentryApp.name,

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -147,7 +147,7 @@ export const Body = styled('div')<{noRowGap?: boolean}>`
     display: grid;
     grid-template-columns: minmax(100px, auto) 325px;
     align-content: start;
-    gap: ${p => (p.noRowGap ? `0 ${p.theme.space['2xl']}` : `${p.theme.space['2xl']}`)};
+    gap: ${p => (p.noRowGap ? `0 ${p.theme.space['2xl']}` : p.theme.space['2xl'])};
   }
 `;
 

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -54,7 +54,7 @@ export default function ReplayTimeline() {
   return (
     <CenteredStack
       style={{
-        width: `${toPercent(timelineScale)}`,
+        width: toPercent(timelineScale),
         translate: `${toPercent(translate())} 0%`,
       }}
       ref={stackedRef}

--- a/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
+++ b/static/app/components/replays/preferences/replayPreferenceDropdown.tsx
@@ -95,7 +95,7 @@ export default function ReplayPreferenceDropdown({
         value={prefs.timestampType}
         onChange={opt => setPrefs({timestampType: opt.value})}
         options={REPLAY_TIMESTAMP_OPTIONS.map(option => ({
-          label: `${toTitleCase(option)}`,
+          label: toTitleCase(option),
           value: option,
         }))}
       />

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -238,8 +238,8 @@ async function createShortIdResult(
   const issue = shortIdLookup?.group;
   return [
     {
-      title: `${issue?.metadata?.type ?? shortIdLookup.shortId}`,
-      description: `${issue?.metadata?.value ?? t('Issue')}`,
+      title: issue?.metadata?.type ?? shortIdLookup.shortId,
+      description: issue?.metadata?.value ?? t('Issue'),
       model: shortIdLookup.group,
       sourceType: 'issue',
       resultType: 'issue',
@@ -262,7 +262,7 @@ async function createEventIdResult(
   const event = eventIdLookup?.event;
   return [
     {
-      title: `${event?.metadata?.type ?? t('Event')}`,
+      title: event?.metadata?.type ?? t('Event'),
       description: event?.metadata?.value,
       model: event,
       sourceType: 'event',

--- a/static/app/components/searchSyntax/mutableSearch.spec.tsx
+++ b/static/app/components/searchSyntax/mutableSearch.spec.tsx
@@ -557,7 +557,9 @@ describe('MutableSearch', () => {
     ];
 
     for (const {name, string, object} of cases) {
-      it(`${name}`, () => expect(object.formatString()).toEqual(string));
+      // https://github.com/jest-community/eslint-plugin-jest/issues/1940
+      // eslint-disable-next-line jest/valid-title
+      it(name, () => expect(object.formatString()).toEqual(string));
     }
   });
 });

--- a/static/app/components/searchSyntax/parser.spec.tsx
+++ b/static/app/components/searchSyntax/parser.spec.tsx
@@ -184,7 +184,9 @@ describe('searchSyntax/parser', () => {
     });
 
   Object.entries(testData).map(([name, cases]) =>
-    describe(`${name}`, () => {
+    // https://github.com/jest-community/eslint-plugin-jest/issues/1940
+    // eslint-disable-next-line jest/valid-title
+    describe(name, () => {
       cases.map(c => registerTestCase(c, {parse: true}));
     })
   );

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -82,10 +82,10 @@ function GroupChart({
                 label: {
                   show: true,
                   position: 'start',
-                  color: `${theme.tokens.content.secondary}`,
+                  color: theme.tokens.content.secondary,
                   fontFamily: 'Rubik',
                   fontSize: 10,
-                  formatter: `${formattedMarkLine}`,
+                  formatter: formattedMarkLine,
                 },
               })
             : undefined,

--- a/static/app/components/timeRangeSelector/utils.tsx
+++ b/static/app/components/timeRangeSelector/utils.tsx
@@ -202,7 +202,7 @@ function filterItems(items: TimeRangeItem[], inputValue: string): TimeRangeItem[
   return items.filter(item =>
     (typeof item.textValue === 'string' && item.textValue.length > 0
       ? item.textValue
-      : `${item.value}`
+      : item.value
     )
       .toLowerCase()
       .includes(inputValue.toLowerCase())

--- a/static/app/gettingStartedDocs/capacitor/utils.tsx
+++ b/static/app/gettingStartedDocs/capacitor/utils.tsx
@@ -58,13 +58,11 @@ const isVue = (siblingOption: string): boolean =>
   siblingOption === SiblingOption.VUE2 || siblingOption === SiblingOption.VUE3;
 
 function getPerformanceIntegration(siblingOption: string): string {
-  return `${
-    isVue(siblingOption)
-      ? `routingInstrumentation: SentryVue.vueRouterInstrumentation(router),`
-      : isAngular(siblingOption)
-        ? `routingInstrumentation: SentryAngular.routingInstrumentation,`
-        : ''
-  }`;
+  return isVue(siblingOption)
+    ? `routingInstrumentation: SentryVue.vueRouterInstrumentation(router),`
+    : isAngular(siblingOption)
+      ? `routingInstrumentation: SentryAngular.routingInstrumentation,`
+      : '';
 }
 
 const performanceAngularErrorHandler = `,

--- a/static/app/gettingStartedDocs/java/utils.tsx
+++ b/static/app/gettingStartedDocs/java/utils.tsx
@@ -89,7 +89,7 @@ sentry {
   projectName = "${params.project.slug}"
   authToken = System.getenv("SENTRY_AUTH_TOKEN")
 }
-${params.isProfilingSelected ? `${wrappedGradleSnippet(params)}` : ''}`;
+${params.isProfilingSelected ? wrappedGradleSnippet(params) : ''}`;
 
 const wrappedGradleSnippet = (params: Params) => `
 dependencies {

--- a/static/app/gettingStartedDocs/javascript-vue/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/utils.tsx
@@ -147,7 +147,7 @@ function getSentryInitLayout(params: Params, siblingOption: string): string {
   const config = buildSdkConfig({
     params,
     staticParts: [
-      `${siblingOption === VueVersion.VUE2 ? 'Vue' : 'app'}`,
+      siblingOption === VueVersion.VUE2 ? 'Vue' : 'app',
       `dsn: "${params.dsn.public}"`,
       `// Setting this option to true will send default PII data to Sentry.
       // For example, automatic IP address collection on events

--- a/static/app/gettingStartedDocs/javascript/profiling.tsx
+++ b/static/app/gettingStartedDocs/javascript/profiling.tsx
@@ -271,7 +271,7 @@ export const profilingFullStack = <
         {
           type: 'text',
           text: tct('For more information see the [link:node profiling documentation].', {
-            link: <ExternalLink href={`${nodeProfilingLink}`} />,
+            link: <ExternalLink href={nodeProfilingLink} />,
           }),
         },
       ],

--- a/static/app/gettingStartedDocs/python/featureFlag.tsx
+++ b/static/app/gettingStartedDocs/python/featureFlag.tsx
@@ -146,7 +146,7 @@ export const featureFlag: OnboardingConfig = {
               featureFlagOptions.integration === FeatureFlagProviderEnum.GENERIC
                 ? `You don't need an integration for a generic usecase. Simply use this API after initializing Sentry.`
                 : tct('Add [name] to your integrations list.', {
-                    name: <code>{`${integrationName}`}</code>,
+                    name: <code>{integrationName}</code>,
                   }),
           },
           {

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -44,7 +44,7 @@ export class StoryTreeNode {
           : '';
       this.slug = `${pathPrefix}${this.label.replaceAll(' ', '-').toLowerCase()}`;
     } else {
-      this.slug = `${this.label.replaceAll(' ', '-').toLowerCase()}`;
+      this.slug = this.label.replaceAll(' ', '-').toLowerCase();
     }
   }
 

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -135,7 +135,7 @@ export function formatRate(
 
   // 0 is special!
   if (value === 0) {
-    return `${0}${RATE_UNIT_LABELS[unit]}`;
+    return `0${RATE_UNIT_LABELS[unit]}`;
   }
 
   const minimumValue = options.minimumValue ?? 0;

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -141,7 +141,7 @@ export function MEPSettingProvider({
   const shouldQueryProvideMEPTransactionParams =
     canUseMEP && metricSettingState === MEPState.TRANSACTIONS_ONLY;
 
-  const memoizationKey = `${metricSettingState}`;
+  const memoizationKey = metricSettingState;
 
   return (
     <_MEPSettingProvider

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -260,7 +260,9 @@ describe('utils/tokenizeSearch', () => {
     ];
 
     for (const {name, string, object} of cases) {
-      it(`${name}`, () => expect(new MutableSearch(string)).toEqual(object));
+      // https://github.com/jest-community/eslint-plugin-jest/issues/1940
+      // eslint-disable-next-line jest/valid-title
+      it(name, () => expect(new MutableSearch(string)).toEqual(object));
     }
   });
 
@@ -695,7 +697,9 @@ describe('utils/tokenizeSearch', () => {
     ];
 
     for (const {name, string, object} of cases) {
-      it(`${name}`, () => expect(object.formatString()).toEqual(string));
+      // https://github.com/jest-community/eslint-plugin-jest/issues/1940
+      // eslint-disable-next-line jest/valid-title
+      it(name, () => expect(object.formatString()).toEqual(string));
     }
   });
 

--- a/static/app/views/alerts/rules/issue/index.spec.tsx
+++ b/static/app/views/alerts/rules/issue/index.spec.tsx
@@ -581,7 +581,7 @@ describe('IssueRuleEditor', () => {
           location: {
             query: {
               createFromDuplicate: 'true',
-              duplicateRuleId: `${rule.id}`,
+              duplicateRuleId: rule.id,
             },
           },
         },
@@ -606,7 +606,7 @@ describe('IssueRuleEditor', () => {
           location: {
             query: {
               createFromDuplicate: 'true',
-              duplicateRuleId: `${rule.id}`,
+              duplicateRuleId: rule.id,
             },
           },
         },

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1093,7 +1093,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
               styles={{
                 container: (provided: Record<string, string | number | boolean>) => ({
                   ...provided,
-                  marginBottom: `${space(1)}`,
+                  marginBottom: space(1),
                 }),
               }}
               options={projectOptions}

--- a/static/app/views/alerts/rules/metric/duplicate.spec.tsx
+++ b/static/app/views/alerts/rules/metric/duplicate.spec.tsx
@@ -83,7 +83,7 @@ describe('MetricRuleDuplicate', () => {
         location: {
           query: {
             createFromDuplicate: 'true',
-            duplicateRuleId: `${rule.id}`,
+            duplicateRuleId: rule.id,
           },
         },
       },
@@ -138,7 +138,7 @@ describe('MetricRuleDuplicate', () => {
         location: {
           query: {
             createFromDuplicate: 'true',
-            duplicateRuleId: `${rule.id}`,
+            duplicateRuleId: rule.id,
           },
         },
       },
@@ -182,7 +182,7 @@ describe('MetricRuleDuplicate', () => {
         location: {
           query: {
             createFromDuplicate: 'true',
-            duplicateRuleId: `${ruleWithExtrapolation.id}`,
+            duplicateRuleId: ruleWithExtrapolation.id,
           },
         },
       },

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -109,7 +109,7 @@ export default function EAPMetricsField({
     return [
       ...(shouldIncludeOptionFromTraceMetric ? [optionFromTraceMetric] : []),
       ...(metricOptionsData?.data?.map(option => ({
-        label: `${option[TraceMetricKnownFieldKey.METRIC_NAME]}`,
+        label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
           type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -213,7 +213,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
   };
 
   formElemBaseStyle = {
-    padding: `${space(0.5)}`,
+    padding: space(0.5),
     border: 'none',
   };
 
@@ -286,7 +286,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       }),
       container: (provided: Record<string, string | number | boolean>) => ({
         ...provided,
-        margin: `${space(0.5)}`,
+        margin: space(0.5),
       }),
     };
   }

--- a/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
@@ -91,5 +91,5 @@ const StyledFormField = styled(FormField)<{extraMargin?: boolean}>`
     width: 100%;
   }
 
-  margin-bottom: ${p => p.extraMargin ? '60px' : p.theme.space.md};
+  margin-bottom: ${p => (p.extraMargin ? '60px' : p.theme.space.md)};
 `;

--- a/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleNameOwnerForm.tsx
@@ -91,5 +91,5 @@ const StyledFormField = styled(FormField)<{extraMargin?: boolean}>`
     width: 100%;
   }
 
-  margin-bottom: ${p => `${p.extraMargin ? '60px' : p.theme.space.md}`};
+  margin-bottom: ${p => p.extraMargin ? '60px' : p.theme.space.md};
 `;

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -113,7 +113,7 @@ const getFullActionTitle = ({
     if (status && status !== 'published') {
       return `${sentryAppName} (${status})`;
     }
-    return `${sentryAppName}`;
+    return sentryAppName;
   }
 
   const label = ActionLabel[type];

--- a/static/app/views/alerts/rules/utils.tsx
+++ b/static/app/views/alerts/rules/utils.tsx
@@ -182,7 +182,7 @@ export function getAlertRuleLogsUrl({
     }
   }
 
-  return `${basePath}` + `?${qs.stringify(queryParams, {skipNull: true})}`;
+  return basePath + `?${qs.stringify(queryParams, {skipNull: true})}`;
 }
 
 export function getAlertRuleMetricsUrl({

--- a/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
+++ b/static/app/views/alerts/utils/getMetricRuleDiscoverUrl.tsx
@@ -73,7 +73,7 @@ export function getMetricRuleDiscoverQuery({
       : [
           'transaction',
           'project',
-          `${rule.aggregate}`,
+          rule.aggregate,
           'count_unique(user)',
           `user_misery(${DEFAULT_PROJECT_THRESHOLD})`,
         ];

--- a/static/app/views/automations/components/actionFilters/assignedTo.tsx
+++ b/static/app/views/automations/components/actionFilters/assignedTo.tsx
@@ -43,7 +43,7 @@ function AssignedToTeam({teamId}: {teamId: string}) {
 
 function AssignedToMember({memberId}: {memberId: number}) {
   const {data: user} = useUserFromId({id: memberId});
-  return t('Issue is assigned to member %s', `${user?.email ?? 'unknown'}`);
+  return t('Issue is assigned to member %s', user?.email ?? 'unknown');
 }
 
 export function AssignedToNode() {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/http/domainSummary.ts
@@ -108,7 +108,7 @@ const BIG_NUMBER_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('3XX'),
-          conditions: `${FILTER_STRING}`,
+          conditions: FILTER_STRING,
           fields: [PERCENTAGE_3XX],
           aggregates: [PERCENTAGE_3XX],
           columns: [],
@@ -126,7 +126,7 @@ const BIG_NUMBER_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('4XX'),
-          conditions: `${FILTER_STRING}`,
+          conditions: FILTER_STRING,
           fields: [PERCENTAGE_4XX],
           aggregates: [PERCENTAGE_4XX],
           columns: [],
@@ -144,7 +144,7 @@ const BIG_NUMBER_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: t('5XX'),
-          conditions: `${FILTER_STRING}`,
+          conditions: FILTER_STRING,
           fields: [PERCENTAGE_5XX],
           aggregates: [PERCENTAGE_5XX],
           columns: [],

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/appStarts.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/appStarts.ts
@@ -192,7 +192,7 @@ const COLD_START_DEVICE_DISTRIBUTION_WIDGET: Widget = {
       aggregates: [`avg(${SpanFields.APP_START_COLD})`],
       columns: [SpanFields.DEVICE_CLASS],
       conditions: TRANSACTION_OP_CONDITION,
-      orderby: `${SpanFields.DEVICE_CLASS}`,
+      orderby: SpanFields.DEVICE_CLASS,
     },
   ],
   layout: {
@@ -219,7 +219,7 @@ const WARM_START_DEVICE_DISTRIBUTION_WIDGET: Widget = {
       aggregates: [`avg(${SpanFields.APP_START_WARM})`],
       columns: [SpanFields.DEVICE_CLASS],
       conditions: TRANSACTION_OP_CONDITION,
-      orderby: `${SpanFields.DEVICE_CLASS}`,
+      orderby: SpanFields.DEVICE_CLASS,
     },
   ],
   layout: {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/mobileVitals/screenLoads.ts
@@ -192,7 +192,7 @@ const TTID_BAR_CHART_WIDGET: Widget = {
       columns: [SpanFields.DEVICE_CLASS],
       fieldAliases: ['Device Class', 'AVG TTID'],
       conditions: TRANSACTION_CONDITION,
-      orderby: `${SpanFields.DEVICE_CLASS}`,
+      orderby: SpanFields.DEVICE_CLASS,
     },
   ],
   layout: {
@@ -223,7 +223,7 @@ const TTFD_BAR_CHART_WIDGET: Widget = {
       columns: [SpanFields.DEVICE_CLASS],
       fieldAliases: ['Device Class', 'AVG TTFD'],
       conditions: TRANSACTION_CONDITION,
-      orderby: `${SpanFields.DEVICE_CLASS}`,
+      orderby: SpanFields.DEVICE_CLASS,
     },
   ],
   layout: {

--- a/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/webVitals/pageSummary.ts
@@ -15,7 +15,9 @@ export const WEB_VITALS_SUMMARY_PREBUILT_CONFIG: PrebuiltDashboard = {
     {
       id: 'score-breakdown-chart',
       title: t('Score Breakdown'),
-      description: `${t(`Each Web Vital score contributes a different amount to the total score. Refer to the Performance Score wheel for total contribution.`)}`,
+      description: t(
+        `Each Web Vital score contributes a different amount to the total score. Refer to the Performance Score wheel for total contribution.`
+      ),
       displayType: DisplayType.AREA,
       widgetType: WidgetType.SPANS,
       interval: '5m',

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
@@ -73,7 +73,7 @@ export function SortBySelectors({
   const columnSet = new Set(widgetQuery.columns);
   const [showCustomEquation, setShowCustomEquation] = useState(false);
   const [customEquation, setCustomEquation] = useState<Values>({
-    sortBy: `${EQUATION_PREFIX}`,
+    sortBy: EQUATION_PREFIX,
     sortDirection: values.sortDirection,
   });
   useEffect(() => {

--- a/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
+++ b/static/app/views/dashboards/widgetBuilder/releaseWidget/fields.tsx
@@ -334,7 +334,7 @@ export function generateReleaseWidgetFieldOptions(
     .sort((a, b) => a.localeCompare(b))
     .forEach(operation => {
       fieldOptions[`function:${operation}`] = {
-        label: `${operation}(${'\u2026'})`,
+        label: `${operation}(\u2026)`,
         value: {
           kind: FieldValueKind.FUNCTION,
           meta: {

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -306,7 +306,7 @@ export function getMenuOptions(
         const search = new MutableSearch(baseQuery);
         for (const group of timeSeries.groupBy ?? []) {
           if (group.value !== null && !Array.isArray(group.value)) {
-            search.addFilterValue(group.key, `${group.value}`);
+            search.addFilterValue(group.key, group.value);
           }
         }
 

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesLabel.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesLabel.tsx
@@ -19,7 +19,7 @@ export function formatCategoricalSeriesLabel(series: CategoricalSeries): string 
           return t('(no value)');
         }
 
-        return `${groupBy.value}`;
+        return groupBy.value;
       })
       .join(',');
   }

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/formatters/formatCategoricalSeriesName.tsx
@@ -5,7 +5,7 @@ import type {CategoricalSeries} from 'sentry/views/dashboards/widgets/common/typ
  * Combines valueAxis with groupBy information to create unique series names.
  */
 export function formatCategoricalSeriesName(series: CategoricalSeries): string {
-  let name = `${series.valueAxis}`;
+  let name = series.valueAxis;
 
   if (series.groupBy?.length) {
     name += ` : ${series.groupBy

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel.tsx
@@ -13,7 +13,7 @@ export function formatTimeSeriesLabel(timeSeries: TimeSeries): string {
   }
 
   if (timeSeries.groupBy?.length && timeSeries.groupBy.length > 0) {
-    return `${timeSeries.groupBy
+    return timeSeries.groupBy
       ?.map(groupBy => {
         if (Array.isArray(groupBy.value)) {
           return JSON.stringify(groupBy.value);
@@ -27,9 +27,9 @@ export function formatTimeSeriesLabel(timeSeries: TimeSeries): string {
           return t('(no value)');
         }
 
-        return `${groupBy.value}`;
+        return groupBy.value;
       })
-      .join(',')}`;
+      .join(',');
   }
 
   let {yAxis: seriesName} = timeSeries;

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName.tsx
@@ -1,7 +1,7 @@
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 
 export function formatTimeSeriesName(timeSeries: TimeSeries): string {
-  let name = `${timeSeries.yAxis}`;
+  let name = timeSeries.yAxis;
 
   if (timeSeries.groupBy?.length) {
     name += ` : ${timeSeries.groupBy

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -113,7 +113,7 @@ export function MetricsVisualize() {
     return [
       ...(shouldIncludeOptionFromTraceMetric ? [optionFromTraceMetric] : []),
       ...(metricOptionsData?.data?.map(option => ({
-        label: `${option[TraceMetricKnownFieldKey.METRIC_NAME]}`,
+        label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
           type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,

--- a/static/app/views/discover/utils.tsx
+++ b/static/app/views/discover/utils.tsx
@@ -170,7 +170,7 @@ export function getPrebuiltQueries(organization: Organization) {
 function disableMacros(value: string | null | boolean | number) {
   const unsafeCharacterRegex = /^[=+\-@]/;
 
-  if (typeof value === 'string' && `${value}`.match(unsafeCharacterRegex)) {
+  if (typeof value === 'string' && value.match(unsafeCharacterRegex)) {
     return `'${value}`;
   }
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -41,7 +41,7 @@ export function MetricSelector({
   );
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
-      label: `${traceMetric.name}`,
+      label: traceMetric.name,
       value: metricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricUnit: hasMetricUnitsUI ? (traceMetric.unit ?? '-') : undefined,
@@ -83,7 +83,7 @@ export function MetricSelector({
     return [
       ...(shouldIncludeOptionFromTraceMetric ? [optionFromTraceMetric] : []),
       ...(metricOptionsData?.data?.map(option => ({
-        label: `${option[TraceMetricKnownFieldKey.METRIC_NAME]}`,
+        label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
           name: option[TraceMetricKnownFieldKey.METRIC_NAME],
           type: option[TraceMetricKnownFieldKey.METRIC_TYPE] as TraceMetricTypeValue,

--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -177,7 +177,7 @@ function Content({datePageFilterProps}: ContentProps) {
                   triggerProps.onClick?.(e);
                 }}
               >
-                {shouldHighlightSaveButton ? `${t('Save')}` : `${t('Save as')}\u2026`}
+                {shouldHighlightSaveButton ? t('Save') : `${t('Save as')}\u2026`}
               </Button>
             )}
           />

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -310,7 +310,7 @@ export function ToolbarSaveAs() {
                   triggerProps.onClick?.(e);
                 }}
               >
-                {shouldHighlightSaveButton ? `${t('Save')}` : `${t('Save as')}\u2026`}
+                {shouldHighlightSaveButton ? t('Save') : `${t('Save as')}\u2026`}
               </SaveAsButton>
             )}
           />

--- a/static/app/views/insights/pages/agents/components/llmCallsWidget.tsx
+++ b/static/app/views/insights/pages/agents/components/llmCallsWidget.tsx
@@ -109,7 +109,7 @@ export default function LLMCallsWidget() {
   const footer = hasData && (
     <WidgetFooterTable>
       {models?.map((item, index) => {
-        const modelId = `${item['gen_ai.request.model']}`;
+        const modelId = item['gen_ai.request.model'];
         return (
           <Fragment key={modelId}>
             <div>

--- a/static/app/views/insights/pages/agents/components/modelsTable.tsx
+++ b/static/app/views/insights/pages/agents/components/modelsTable.tsx
@@ -126,7 +126,7 @@ export function ModelsTable() {
     }
 
     return modelsRequest.data.map(span => ({
-      model: `${span['gen_ai.request.model']}`,
+      model: span['gen_ai.request.model'],
       requests: span['count()'] ?? 0,
       avg: span['avg(span.duration)'] ?? 0,
       p95: span['p95(span.duration)'] ?? 0,

--- a/static/app/views/insights/pages/agents/components/toolsTable.tsx
+++ b/static/app/views/insights/pages/agents/components/toolsTable.tsx
@@ -95,7 +95,7 @@ export function ToolsTable() {
     }
 
     return toolsRequest.data.map(span => ({
-      tool: `${span['gen_ai.tool.name']}`,
+      tool: span['gen_ai.tool.name'],
       requests: Number(span['count()']),
       avg: Number(span['avg(span.duration)']),
       p95: Number(span['p95(span.duration)']),

--- a/static/app/views/insights/pages/platform/nextjs/serverTree.tsx
+++ b/static/app/views/insights/pages/platform/nextjs/serverTree.tsx
@@ -339,7 +339,7 @@ function TreeNodeRenderer({
                 showUnderline={!exploreLink}
                 body={
                   <OneLineCodeBlock>
-                    <code>{`${itemPath.join('/')}`}</code>
+                    <code>{itemPath.join('/')}</code>
                     <Button
                       size="zero"
                       priority="transparent"

--- a/static/app/views/integrationPipeline/githubInstallationSelect.tsx
+++ b/static/app/views/integrationPipeline/githubInstallationSelect.tsx
@@ -126,7 +126,7 @@ export function GithubInstallationSelect({
               name={installation.github_account}
             />
           )}
-          <span>{`${installation.github_account}`}</span>
+          <span>{installation.github_account}</span>
           {!doesntRequireUpgrade(installation.installation_id) && (
             <IconLightning size="xs" />
           )}

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -49,9 +49,7 @@ interface GroupEventAttachmentsQuery {
   screenshot?: '1';
   start?: DateString;
   statsPeriod?: string;
-  types?:
-    | `${GroupEventAttachmentsTypeFilter}`
-    | Array<`${GroupEventAttachmentsTypeFilter}`>;
+  types?: GroupEventAttachmentsTypeFilter | GroupEventAttachmentsTypeFilter[];
 }
 
 export const makeFetchGroupEventAttachmentsQueryKey = ({

--- a/static/app/views/issueDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/issueDetails/groupReplays/groupReplays.tsx
@@ -305,7 +305,7 @@ function ReplayOverlay({
 
   const nextReplay = replays?.[selectedReplayIndex + 1];
   const nextReplayText = nextReplay?.id
-    ? `${nextReplay.user.display_name || t('Anonymous User')}`
+    ? nextReplay.user.display_name || t('Anonymous User')
     : undefined;
 
   if (!nextReplayText || !replayCount) {

--- a/static/app/views/issueDetails/header.spec.tsx
+++ b/static/app/views/issueDetails/header.spec.tsx
@@ -67,7 +67,7 @@ describe('GroupHeader', () => {
         expect(router.location.query).toEqual({});
       };
 
-      expectLocation(`${baseUrl}`);
+      expectLocation(baseUrl);
 
       await userEvent.click(screen.getByRole('tab', {name: /activity/i}));
       expectLocation(`${baseUrl}activity/`);
@@ -91,7 +91,7 @@ describe('GroupHeader', () => {
       expectLocation(`${baseUrl}replays/`);
 
       await userEvent.click(screen.getByRole('tab', {name: /details/i}));
-      expectLocation(`${baseUrl}`);
+      expectLocation(baseUrl);
 
       expect(screen.getByRole('tab', {name: /replays/i})).toBeInTheDocument();
     });
@@ -190,7 +190,7 @@ describe('GroupHeader', () => {
         expect(router.location.query).toEqual({});
       };
 
-      expectLocation(`${baseUrl}`);
+      expectLocation(baseUrl);
 
       await userEvent.click(screen.getByRole('tab', {name: /tags/i}));
       expectLocation(`${baseUrl}distributions/`);

--- a/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
+++ b/static/app/views/nav/secondary/sections/prevent/preventSecondaryNav.tsx
@@ -45,7 +45,7 @@ export default function PreventSecondaryNav() {
         </SecondaryNav.Section>
         <Feature features={['prevent-test-analytics']}>
           <SecondaryNav.Section id="prevent-configure" title={t('Configure')}>
-            <SecondaryNav.Item to={`${tokensPathName}`} activeTo={tokensPathName}>
+            <SecondaryNav.Item to={tokensPathName} activeTo={tokensPathName}>
               {t('Tokens')}
             </SecondaryNav.Item>
           </SecondaryNav.Section>

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -81,7 +81,7 @@ export function TraceContextVitals({rootEventResults, tree, containerWidth}: Pro
         return (
           <div key={vitalKey}>
             <strong>
-              {`${vitalDetails.acronym ? vitalDetails.acronym : vitalDetails.name}`}:
+              {vitalDetails.acronym ? vitalDetails.acronym : vitalDetails.name}:
             </strong>{' '}
             <span>{formattedValue}</span>
             {vital?.score !== undefined &&
@@ -144,7 +144,7 @@ function VitalPill({vital, vitalDetails}: VitalPillProps) {
   return (
     <Flex>
       <VitalPillName status={status}>
-        <Tooltip title={toolTipTitle}>{`${acronym}`}</Tooltip>
+        <Tooltip title={toolTipTitle}>{acronym}</Tooltip>
       </VitalPillName>
       <VitalPillValue>{formattedMeterValueText}</VitalPillValue>
     </Flex>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -109,9 +109,7 @@ export function SpanDescription({
 
   const actions = exploreAttributeValue ? (
     <BodyContentWrapper
-      padding={
-        resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : `${space(1)}`
-      }
+      padding={resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : space(1)}
     >
       {node.value.is_transaction ? (
         <StyledLink

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/description.tsx
@@ -103,9 +103,7 @@ export function SpanDescription({
 
   const actions = showAction ? (
     <BodyContentWrapper
-      padding={
-        resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : `${space(1)}`
-      }
+      padding={resolvedModule === ModuleName.DB ? `${space(1)} ${space(2)}` : space(1)}
     >
       <SpanSummaryLink
         op={span.op}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -66,7 +66,7 @@ export function getSearchInExploreTarget(
   if (kind === TraceDrawerActionKind.INCLUDE) {
     search.setFilterValues(key, [value]);
   } else if (kind === TraceDrawerActionKind.EXCLUDE) {
-    search.setFilterValues(`!${key}`, [`${value}`]);
+    search.setFilterValues(`!${key}`, [value]);
   } else if (kind === TraceDrawerActionKind.GREATER_THAN) {
     search.setFilterValues(key, [`>${value}`]);
   } else {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/traceDrawer.tsx
@@ -291,11 +291,11 @@ export function TraceDrawer(props: TraceDrawerProps) {
         props.traceGridRef.style.gridTemplateRows = `1fr minmax(${minimizedBottomDrawerSize}px, 0%)`;
         size.current = minimizedBottomDrawerSize;
       } else if (traceStateRef.current.preferences.layout === 'drawer left') {
-        props.traceGridRef.style.gridTemplateColumns = `minmax(${0}px, 0%) 1fr`;
+        props.traceGridRef.style.gridTemplateColumns = `minmax(0px, 0%) 1fr`;
         props.traceGridRef.style.gridTemplateRows = '1fr auto';
         size.current = 0;
       } else {
-        props.traceGridRef.style.gridTemplateColumns = `1fr minmax(${0}px, 0%)`;
+        props.traceGridRef.style.gridTemplateColumns = `1fr minmax(0px, 0%)`;
         props.traceGridRef.style.gridTemplateRows = '1fr auto';
         size.current = 0;
       }

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchInput.tsx
@@ -237,16 +237,14 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
       />
       <InputGroup.TrailingItems>
         <StyledTrailingText data-test-id="trace-search-result-iterator">
-          {`${
-            traceState.search.query && !traceState.search.results?.length
-              ? t('no results')
-              : traceState.search.query
-                ? (traceState.search.resultIteratorIndex === null
-                    ? '-'
-                    : traceState.search.resultIteratorIndex + 1) +
-                  `/${traceState.search.results?.length ?? 0}`
-                : ''
-          }`}
+          {traceState.search.query && !traceState.search.results?.length
+            ? t('no results')
+            : traceState.search.query
+              ? (traceState.search.resultIteratorIndex === null
+                  ? '-'
+                  : traceState.search.resultIteratorIndex + 1) +
+                `/${traceState.search.results?.length ?? 0}`
+              : ''}
         </StyledTrailingText>
         {traceState.search.query ? (
           <Fragment>

--- a/static/app/views/projectDetail/projectIssues.tsx
+++ b/static/app/views/projectDetail/projectIssues.tsx
@@ -82,11 +82,11 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
       return `${issuesCountPath}?${qs.stringify(queryParameters)}`;
     };
     const params = [
-      `${IssuesQuery.NEW}`,
-      `${IssuesQuery.ALL}`,
-      `${IssuesQuery.RESOLVED}`,
-      `${IssuesQuery.UNHANDLED}`,
-      `${IssuesQuery.REGRESSED}`,
+      IssuesQuery.NEW,
+      IssuesQuery.ALL,
+      IssuesQuery.RESOLVED,
+      IssuesQuery.UNHANDLED,
+      IssuesQuery.REGRESSED,
     ];
     const queryParams = params.map(param => param);
     const queryParameters = {
@@ -106,11 +106,11 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
     try {
       const data = await api.requestPromise(issueCountEndpoint);
       setIssuesCount({
-        all: data[`${IssuesQuery.ALL}`] || 0,
-        new: data[`${IssuesQuery.NEW}`] || 0,
-        resolved: data[`${IssuesQuery.RESOLVED}`] || 0,
-        unhandled: data[`${IssuesQuery.UNHANDLED}`] || 0,
-        regressed: data[`${IssuesQuery.REGRESSED}`] || 0,
+        all: data[IssuesQuery.ALL] || 0,
+        new: data[IssuesQuery.NEW] || 0,
+        resolved: data[IssuesQuery.RESOLVED] || 0,
+        unhandled: data[IssuesQuery.UNHANDLED] || 0,
+        regressed: data[IssuesQuery.REGRESSED] || 0,
       });
     } catch {
       // do nothing
@@ -170,7 +170,7 @@ function ProjectIssues({organization, location, projectId, query, api}: Props) {
   const issueQuery = (Object.values(IssuesType) as string[]).includes(issuesType)
     ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       [`${IssuesQuery[issuesType.toUpperCase()]}`, query].join(' ').trim()
-    : [`${IssuesQuery.ALL}`, query].join(' ').trim();
+    : [IssuesQuery.ALL, query].join(' ').trim();
 
   const queryParams = {
     limit: 5,

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -311,12 +311,8 @@ export function CreateProject() {
 
         addSuccessMessage(
           team
-            ? t('Created project %s', `${project.slug}`)
-            : t(
-                'Created %s under new team %s',
-                `${project.slug}`,
-                `#${project.team.slug}`
-              )
+            ? t('Created project %s', project.slug)
+            : t('Created %s under new team %s', project.slug, `#${project.team.slug}`)
         );
 
         setCreatedProject({
@@ -338,7 +334,7 @@ export function CreateProject() {
           )
         );
       } catch (error: any) {
-        addErrorMessage(t('Failed to create project %s', `${projectName}`));
+        addErrorMessage(t('Failed to create project %s', projectName));
 
         if (error.status === 403) {
           Sentry.withScope(scope => {

--- a/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
+++ b/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
@@ -17,7 +17,7 @@ export default function ReplayIndexTimestampPrefPicker() {
           key: t('Timestamps'),
           label: t('Timestamps'),
           options: REPLAY_TIMESTAMP_OPTIONS.map(option => ({
-            label: `${toTitleCase(option)}`,
+            label: toTitleCase(option),
             value: option,
             key: option,
           })),

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -91,7 +91,7 @@ export default function AccountSecurity() {
           <TabsContainer>
             <Tabs value={activeTab}>
               <TabList>
-                <TabList.Item key="settings" to={`${routePrefix}`}>
+                <TabList.Item key="settings" to={routePrefix}>
                   {t('Settings')}
                 </TabList.Item>
                 <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>

--- a/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/sessionHistory/index.tsx
@@ -64,7 +64,7 @@ export default function SessionHistory() {
           <TabsContainer>
             <Tabs value={activeTab}>
               <TabList>
-                <TabList.Item key="settings" to={`${routePrefix}`}>
+                <TabList.Item key="settings" to={routePrefix}>
                   {t('Settings')}
                 </TabList.Item>
                 <TabList.Item key="sessionHistory" to={`${routePrefix}session-history/`}>

--- a/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByEntity.tsx
@@ -134,7 +134,7 @@ function NotificationSettingsByEntity({
       option => option.type === notificationType && option.scopeType === entityType
     );
     return matchedOptions.map(option => {
-      const entity = entityById[`${option.scopeIdentifier}`];
+      const entity = entityById[option.scopeIdentifier];
       if (!entity) {
         return null;
       }

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -225,15 +225,15 @@ function IntegrationStatus(
   const inner = (
     <div {...p}>
       <CircleIndicator size={6} color={color} />
-      <IntegrationStatusText data-test-id="integration-status">{`${
-        status === 'active'
+      <IntegrationStatusText data-test-id="integration-status">
+        {status === 'active'
           ? t('enabled')
           : status === 'pending_deletion'
             ? t('pending deletion')
             : status === 'disabled'
               ? t('disabled')
-              : t('unknown')
-      }`}</IntegrationStatusText>
+              : t('unknown')}
+      </IntegrationStatusText>
     </div>
   );
   return hideTooltip ? (

--- a/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -112,7 +112,7 @@ function IntegrationExternalUserMappings(props: Props) {
     return membersList
       .filter(member => member.user)
       .map(({user, email, name}) => {
-        const label = email === name ? `${email}` : `${name} - ${email}`;
+        const label = email === name ? email : `${name} - ${email}`;
         return {id: user?.id!, name: label};
       });
   };

--- a/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/sentryAppDetailedView.spec.tsx
@@ -97,7 +97,7 @@ describe('SentryAppDetailedView', () => {
         url: `/organizations/${organization.slug}/sentry-app-installations/`,
         body: {
           status: 'installed',
-          organization: {slug: `${organization.slug}`},
+          organization: {slug: organization.slug},
           app: {uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526', slug: 'clickup'},
           code: '1dc8b0a28b7f45959d01bbc99d9bd568',
           uuid: '687323fd-9fa4-4f8f-9bee-ca0089224b3e',

--- a/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipRulesTable.tsx
@@ -64,7 +64,7 @@ export function OwnershipRulesTable({
     const actors = combinedRules
       .flatMap(rule => rule.owners)
       .filter(actor => actor.name)
-      .map(owner => ({...owner, id: `${owner.id}`}));
+      .map(owner => ({...owner, id: owner.id}));
     return (
       uniqBy(actors, actor => `${actor.type}:${actor.id}`)
         // Sort by type, then by name
@@ -168,7 +168,7 @@ export function OwnershipRulesTable({
         {chunkedRules[page]?.map((rule, index) => {
           let name: string | undefined = 'unknown';
           // ID might not be a string, so we need to convert it
-          const owners = rule.owners.map(owner => ({...owner, id: `${owner.id}`}));
+          const owners = rule.owners.map(owner => ({...owner, id: owner.id}));
           if (owners[0]?.type === 'team') {
             const team = TeamStore.getById(owners[0].id);
             if (team?.slug) {

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -85,7 +85,7 @@ function SoftCapTypeDetail({
                 capitalize: true,
                 hadCustomDynamicSampling: shouldUseDsNames,
               })}: `}
-              {`${softCapName}`}
+              {softCapName}
             </small>
             <br />
           </Fragment>
@@ -130,7 +130,7 @@ function SubscriptionSummary({customer, onAction}: SubscriptionSummaryProps) {
                   onAction={onAction}
                 />
               )) ||
-              `${moment(customer.contractPeriodEnd).format('ll')}`}
+              moment(customer.contractPeriodEnd).format('ll')}
 
             <br />
             <small>{customer.contractInterval}</small>

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -398,12 +398,12 @@ function RelocationDetails() {
           </DetailLabel>
           <DetailLabel title="Autopause">
             {relocationData.scheduledPauseAtStep
-              ? `${titleCase(relocationData.scheduledPauseAtStep)}`
+              ? titleCase(relocationData.scheduledPauseAtStep)
               : '--'}
           </DetailLabel>
           <DetailLabel title="Owner Notified Of">
             {relocationData.latestNotified
-              ? `${titleCase(relocationData.latestNotified)}`
+              ? titleCase(relocationData.latestNotified)
               : '--'}
           </DetailLabel>
           <DetailLabel title="Unclaimed Users Last Notified">
@@ -438,7 +438,7 @@ function RelocationDetails() {
         }
 
         acc.push(
-          <span key={`${step}`}>
+          <span key={step}>
             {acc.length > 0 ? <span> | </span> : null}
             {text}
           </span>

--- a/static/gsAdmin/views/relocations.tsx
+++ b/static/gsAdmin/views/relocations.tsx
@@ -27,7 +27,7 @@ const getRow = (row: Relocation) => {
       {titleCase(row.step)}
     </td>,
     <td key="pause" style={{textAlign: 'center'}}>
-      {row.scheduledPauseAtStep ? `${titleCase(row.scheduledPauseAtStep)}` : '--'}
+      {row.scheduledPauseAtStep ? titleCase(row.scheduledPauseAtStep) : '--'}
     </td>,
     <td key="owner" style={{textAlign: 'right'}}>
       {row.owner ? (

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -75,7 +75,7 @@ function BillingDetailsPanel({
       ? tct('[credits] credit', {
           credits: formatCurrency(0 - subscription.accountBalance),
         })
-      : `${formatCurrency(subscription.accountBalance)}`;
+      : formatCurrency(subscription.accountBalance);
 
   return (
     <Flex

--- a/static/gsApp/utils/formatCurrency.tsx
+++ b/static/gsApp/utils/formatCurrency.tsx
@@ -12,7 +12,7 @@ import {displayPrice} from 'getsentry/views/amCheckout/utils';
  */
 const formatCurrency = (value: number | string) => {
   const cents = Number(value);
-  return `${displayPrice({cents})}`;
+  return displayPrice({cents});
 };
 
 export default formatCurrency;

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -103,7 +103,7 @@ function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
       ? tct('[credits] credit', {
           credits: formatCurrency(0 - subscription.accountBalance),
         })
-      : `${formatCurrency(subscription.accountBalance)}`;
+      : formatCurrency(subscription.accountBalance);
 
   return (
     <Flex


### PR DESCRIPTION
Follows up on https://github.com/getsentry/sentry/pull/110153#discussion_r2906645881 by fully enabling [`@typescript-eslint/no-unnecessary-template-expression`](https://typescript-eslint.io/rules/no-unnecessary-template-expression) on the codebase.

tl;dr: the rule reports on template expressions which take in an already-string value, but don't add anything to it. 

```ts
const original = 'apple';
const modified = `${apple}`; // 'apple'
```