### PR TITLE
fix(preprod): Prevent diff mode buttons from being cut off on small viewports

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -90,7 +90,7 @@ export function DiffImageDisplay({
   const diffPercent = pair.diff === null ? null : `${(pair.diff * 100).toFixed(1)}%`;
 
   return (
-    <Flex direction="column" gap="lg" padding="xl" height="100%">
+    <Flex direction="column" gap="lg" padding="xl" flex="1" minHeight="0">
       {diffPercent && (
         <Text variant="muted" size="sm">
           {t('Diff: %s', diffPercent)}
@@ -120,7 +120,7 @@ export function DiffImageDisplay({
         />
       )}
 
-      <Flex justify="center">
+      <Flex justify="center" flexShrink={0}>
         <SegmentedControl value={diffMode} onChange={onDiffModeChange}>
           <SegmentedControl.Item key="split" icon={<IconPause />}>
             {t('Split')}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -197,7 +197,7 @@ export default function SnapshotsPage() {
           minHeight="0"
           width="100%"
           overflow="hidden"
-          style={{maxHeight: 'calc(100vh - 160px)'}}
+          style={{maxHeight: 'calc(100vh - 205px)'}}
         >
           <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
             <SnapshotSidebarContent


### PR DESCRIPTION
When the browser window height is reduced, the Split/Wipe/Onion segmented
control at the bottom of the diff image display gets clipped and becomes
inaccessible.

The root cause is `DiffImageDisplay`'s outer Flex using `height="100%"`
instead of flex properties. Since it sits inside a column flex parent
(`SnapshotMainContent`) that also contains a header row and separator,
`height="100%"` makes it compete for the full parent height, causing
content overflow.

Two changes:
- Replace `height="100%"` with `flex="1" minHeight="0"` so the container
  fills remaining space and can shrink below its content size
- Add `flexShrink={0}` to the SegmentedControl wrapper so the buttons
  are never compressed away