### PR TITLE
test(dashboards): Switch EventsSearchBar test to use paste

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -1,13 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
-import {
-  render,
-  screen,
-  userEvent,
-  waitFor,
-  within,
-} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -57,15 +51,19 @@ describe('EventsSearchBar', () => {
       }
     );
 
-    // Focus the input and type "has:p" to simulate a search for p50
     const input = await screen.findByRole('combobox', {name: 'Add a search term'});
     await userEvent.click(input, {delay: null});
     await userEvent.paste('has:p', {delay: null});
 
-    // Check that "p50" (a function tag) is NOT in the dropdown
-    await waitFor(() => {
-      expect(screen.queryByText(/p50/)).not.toBeInTheDocument();
-    });
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Edit value for filter: has'})
+    );
+
+    // Assert we actually have has: dropdown options before checking exclusions.
+    expect(await screen.findByRole('option', {name: 'environment'})).toBeInTheDocument();
+
+    // p50 is a function and should not be suggested as a has: tag.
+    expect(screen.queryByRole('option', {name: 'p50'})).not.toBeInTheDocument();
   });
 
   it('shows the selected aggregate in the dropdown', async () => {

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.spec.tsx
@@ -1,7 +1,13 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
-import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
@@ -53,12 +59,13 @@ describe('EventsSearchBar', () => {
 
     // Focus the input and type "has:p" to simulate a search for p50
     const input = await screen.findByRole('combobox', {name: 'Add a search term'});
-    await userEvent.type(input, 'has:p');
+    await userEvent.click(input, {delay: null});
+    await userEvent.paste('has:p', {delay: null});
 
     // Check that "p50" (a function tag) is NOT in the dropdown
-    expect(
-      within(screen.getByRole('listbox')).queryByText('p50')
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText(/p50/)).not.toBeInTheDocument();
+    });
   });
 
   it('shows the selected aggregate in the dropdown', async () => {
@@ -86,11 +93,11 @@ describe('EventsSearchBar', () => {
     );
 
     const input = await screen.findByRole('combobox', {name: 'Add a search term'});
-
-    await userEvent.type(input, 'count_uni');
+    await userEvent.click(input);
+    await userEvent.paste('count_uni', {delay: null});
 
     expect(
-      await within(screen.getByRole('listbox')).findByText('count_unique(...)')
+      await within(await screen.findByRole('listbox')).findByText('count_unique(...)')
     ).toBeInTheDocument();
   });
 
@@ -120,10 +127,11 @@ describe('EventsSearchBar', () => {
 
     const input = await screen.findByRole('combobox', {name: 'Add a search term'});
     await userEvent.clear(input);
-    await userEvent.type(input, 'transact');
+    await userEvent.click(input, {delay: null});
+    await userEvent.paste('transact', {delay: null});
 
     expect(
-      await within(screen.getByRole('listbox')).findByRole('option', {
+      await within(await screen.findByRole('listbox')).findByRole('option', {
         name: 'transaction',
       })
     ).toBeInTheDocument();


### PR DESCRIPTION
example flake https://github.com/getsentry/sentry/actions/runs/22865175272/job/66329929728 paste sometimes works a bit better because it doesn't have to rerender the complex component on every keyup/keydown that sort of thing. type literally types each character one by one.
