### PR TITLE
feat(seer-explorer): Add copy-to-clipboard button to block action bar

### DIFF
--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -507,9 +507,7 @@ function BlockComponent({
               size="xs"
               tooltipProps={{title: t('Copy to clipboard')}}
               onClick={handleCopyClick}
-            >
-              {undefined}
-            </Button>
+            />
             <Button
               size="xs"
               priority="transparent"

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -376,6 +376,7 @@ function BlockComponent({
     !isAwaitingQuestion &&
     !readOnly;
   const showFeedbackButtons = block.message.role === 'assistant';
+  const showCopyButton = block.message.role !== 'tool_use';
 
   return (
     <Block
@@ -496,14 +497,16 @@ function BlockComponent({
           <ActionButtonBar gap="xs">
             {showFeedbackButtons && thumbsFeedbackButton('positive')}
             {showFeedbackButtons && thumbsFeedbackButton('negative')}
-            <Button
-              aria-label={t('Copy block content')}
-              icon={<IconCopy />}
-              priority="transparent"
-              size="xs"
-              tooltipProps={{title: t('Copy to clipboard')}}
-              onClick={handleCopyClick}
-            />
+            {showCopyButton && (
+              <Button
+                aria-label={t('Copy block content')}
+                icon={<IconCopy />}
+                priority="transparent"
+                size="xs"
+                tooltipProps={{title: t('Copy to clipboard')}}
+                onClick={handleCopyClick}
+              />
+            )}
             <Button
               size="xs"
               priority="transparent"

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -9,8 +9,9 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
-import {IconChevron, IconLink, IconThumb} from 'sentry/icons';
+import {IconChevron, IconCopy, IconLink, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -345,6 +346,16 @@ function BlockComponent({
     onDelete?.();
   };
 
+  const handleCopyClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(block.message.content);
+      addSuccessMessage(t('Copied to clipboard'));
+    } catch {
+      addErrorMessage(t('Failed to copy to clipboard'));
+    }
+  };
+
   const handleNavigateClick = (e: React.MouseEvent, linkIndex: number) => {
     e.stopPropagation();
     if (sortedToolLinks.length === 0) {
@@ -489,6 +500,16 @@ function BlockComponent({
           <ActionButtonBar gap="xs">
             {showFeedbackButtons && thumbsFeedbackButton('positive')}
             {showFeedbackButtons && thumbsFeedbackButton('negative')}
+            <Button
+              aria-label={t('Copy block content')}
+              icon={<IconCopy />}
+              priority="transparent"
+              size="xs"
+              tooltipProps={{title: t('Copy to clipboard')}}
+              onClick={handleCopyClick}
+            >
+              {undefined}
+            </Button>
             <Button
               size="xs"
               priority="transparent"

--- a/static/app/views/seerExplorer/blockComponents.tsx
+++ b/static/app/views/seerExplorer/blockComponents.tsx
@@ -9,12 +9,12 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
 import {IconChevron, IconCopy, IconLink, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
+import useCopyToClipboard from 'sentry/utils/useCopyToClipboard';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -158,6 +158,7 @@ function BlockComponent({
   readOnly = false,
   ref,
 }: BlockProps) {
+  const {copy} = useCopyToClipboard();
   const organization = useOrganization();
   const navigate = useNavigate();
   const {projects} = useProjects();
@@ -346,14 +347,9 @@ function BlockComponent({
     onDelete?.();
   };
 
-  const handleCopyClick = async (e: React.MouseEvent) => {
+  const handleCopyClick = (e: React.MouseEvent) => {
     e.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(block.message.content);
-      addSuccessMessage(t('Copied to clipboard'));
-    } catch {
-      addErrorMessage(t('Failed to copy to clipboard'));
-    }
+    copy(block.message.content);
   };
 
   const handleNavigateClick = (e: React.MouseEvent, linkIndex: number) => {


### PR DESCRIPTION
## Changes

Adds a copy-to-clipboard action button to `BlockComponent` in the Seer Explorer, positioned between the thumbs feedback buttons and the restart button.

- Copies `block.message.content` to the clipboard via the Clipboard API
- Shows a success toast on copy, error toast on failure
- Hidden when the block is loading (inherits the existing `showActions` guard which already checks `!block.loading`)