### PR TITLE
fix(dashboards): add missing `fields` key to non-table prebuilt widget queries

### DIFF
--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssets.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssets.ts
@@ -24,6 +24,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: ['epm()'],
           aggregates: ['epm()'],
           columns: [],
           conditions: FILTER_QUERY.formatString(),
@@ -40,6 +41,7 @@ const FIRST_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
           conditions: FILTER_QUERY.formatString(),

--- a/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsSummary.ts
+++ b/static/app/views/dashboards/utils/prebuiltConfigs/frontendAssets/frontendAssetsSummary.ts
@@ -60,6 +60,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: ['epm()'],
           aggregates: ['epm()'],
           columns: [],
           conditions: '',
@@ -76,6 +77,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.HTTP_RESPONSE_CONTENT_LENGTH})`],
           aggregates: [`avg(${SpanFields.HTTP_RESPONSE_CONTENT_LENGTH})`],
           columns: [],
           conditions: '',
@@ -92,6 +94,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`],
           aggregates: [`avg(${SpanFields.HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`],
           columns: [],
           conditions: '',
@@ -108,6 +111,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.HTTP_RESPONSE_TRANSFER_SIZE})`],
           aggregates: [`avg(${SpanFields.HTTP_RESPONSE_TRANSFER_SIZE})`],
           columns: [],
           conditions: '',
@@ -124,6 +128,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
           conditions: '',
@@ -140,6 +145,7 @@ const SECOND_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`sum(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`sum(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
           conditions: '',
@@ -163,6 +169,7 @@ const THIRD_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: ['epm()'],
           aggregates: ['epm()'],
           columns: [],
           conditions: '',
@@ -179,6 +186,7 @@ const THIRD_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           aggregates: [`avg(${SpanFields.SPAN_SELF_TIME})`],
           columns: [],
           conditions: '',
@@ -195,6 +203,11 @@ const THIRD_ROW_WIDGETS = spaceWidgetsEquallyOnRow(
       queries: [
         {
           name: '',
+          fields: [
+            `avg(${SpanFields.HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
+            `avg(${SpanFields.HTTP_RESPONSE_TRANSFER_SIZE})`,
+            `avg(${SpanFields.HTTP_RESPONSE_CONTENT_LENGTH})`,
+          ],
           aggregates: [
             `avg(${SpanFields.HTTP_DECODED_RESPONSE_CONTENT_LENGTH})`,
             `avg(${SpanFields.HTTP_RESPONSE_TRANSFER_SIZE})`,


### PR DESCRIPTION
Add the missing `fields` key to LINE and BIG_NUMBER widget query
definitions in the frontend assets prebuilt dashboard configs.

The backend `DashboardWidgetQuerySerializer.validate()` requires both
`fields` and `conditions` for new queries, but several non-table widget
definitions only defined `aggregates` and `columns`, omitting `fields`.
This caused validation errors when these prebuilt configs were saved.

For non-table widgets (no group-by), `fields` mirrors `aggregates`.
The fix adds this redundant-but-required key to all 11 affected queries
across `frontendAssets.ts` (2 widgets) and `frontendAssetsSummary.ts`
(9 widgets). All other prebuilt configs were audited and already had
`fields` defined.

Fixes DAIN-1298