### PR TITLE
fix(issues): Always allow archived issues to be unarchived

### DIFF
--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -428,7 +428,7 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
             </ResolvedWrapper>
 
             <Divider />
-            {resolveCap.enabled && (
+            {resolveCap.enabled && isResolved && (
               <Button
                 size="sm"
                 disabled={disabled || isAutoResolved}
@@ -440,7 +440,22 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
                   })
                 }
               >
-                {isResolved ? t('Unresolve') : t('Unarchive')}
+                {t('Unresolve')}
+              </Button>
+            )}
+            {isIgnored && (
+              <Button
+                size="sm"
+                disabled={disabled || isAutoResolved}
+                onClick={() =>
+                  onUpdate({
+                    status: GroupStatus.UNRESOLVED,
+                    statusDetails: {},
+                    substatus: GroupSubstatus.ONGOING,
+                  })
+                }
+              >
+                {t('Unarchive')}
               </Button>
             )}
           </Flex>


### PR DESCRIPTION
Closes ISWF-2200

Crons, uptime, and metric issues disallow resolving/unresolving which also hides the "unarchive" button. This is not intended.