### PR TITLE
feat(supergroups): add lightweight supergroups page and drawer

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -2554,6 +2554,10 @@ function buildRoutes(): RouteObject[] {
       ),
     },
     {
+      path: 'supergroups/',
+      component: make(() => import('sentry/views/issueList/pages/supergroups')),
+    },
+    {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
     },

--- a/static/app/views/issueList/pages/supergroups.tsx
+++ b/static/app/views/issueList/pages/supergroups.tsx
@@ -1,0 +1,201 @@
+import styled from '@emotion/styled';
+
+import {FeatureBadge} from '@sentry/scraps/badge';
+import {inlineCodeStyles} from '@sentry/scraps/code';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
+import {useDrawer} from 'sentry/components/globalDrawer';
+import * as Layout from 'sentry/components/layouts/thirds';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Redirect} from 'sentry/components/redirect';
+import {IconFocus} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import getApiUrl from 'sentry/utils/api/getApiUrl';
+import {MarkedText} from 'sentry/utils/marked/markedText';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {SupergroupDetailDrawer} from 'sentry/views/issueList/supergroups/supergroupDrawer';
+import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
+
+interface ListSupergroupsResponse {
+  data: SupergroupDetail[];
+}
+
+function SupergroupCard({
+  supergroup,
+  onClick,
+}: {
+  onClick: () => void;
+  supergroup: SupergroupDetail;
+}) {
+  return (
+    <CardContainer background="primary" border="primary" radius="md" onClick={onClick}>
+      <Stack padding="lg" gap="md">
+        <Text size="lg" bold wordBreak="break-word">
+          {supergroup.title}
+        </Text>
+
+        <Stack gap="xs">
+          <Text size="xs" variant="muted">
+            {tn('%s issue', '%s issues', supergroup.group_ids.length)}
+          </Text>
+          {supergroup.error_type && (
+            <Flex align="baseline" gap="xs">
+              <Text size="xs" variant="muted" bold>
+                {t('Error:')}
+              </Text>
+              <Text size="xs" variant="muted">
+                {supergroup.error_type}
+              </Text>
+            </Flex>
+          )}
+          {supergroup.code_area && (
+            <Flex align="baseline" gap="xs">
+              <Text size="xs" variant="muted" bold>
+                {t('Location:')}
+              </Text>
+              <Text size="xs" variant="muted">
+                {supergroup.code_area}
+              </Text>
+            </Flex>
+          )}
+        </Stack>
+
+        {supergroup.summary && (
+          <Container background="secondary" border="primary" radius="md">
+            <Flex direction="column" padding="md lg" gap="sm">
+              <Flex align="center" gap="xs">
+                <IconFocus size="xs" variant="promotion" />
+                <Text size="sm" bold>
+                  {t('Root Cause')}
+                </Text>
+              </Flex>
+              <Text size="sm">
+                <StyledMarkedText text={supergroup.summary} inline as="span" />
+              </Text>
+            </Flex>
+          </Container>
+        )}
+      </Stack>
+    </CardContainer>
+  );
+}
+
+function Supergroups() {
+  const organization = useOrganization();
+  const hasTopIssuesUI = organization.features.includes('top-issues-ui');
+  const {openDrawer} = useDrawer();
+
+  const {
+    data: response,
+    isPending,
+    isError,
+    refetch,
+  } = useApiQuery<ListSupergroupsResponse>(
+    [
+      getApiUrl('/organizations/$organizationIdOrSlug/seer/supergroups/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+    ],
+    {
+      staleTime: 60000,
+      enabled: hasTopIssuesUI,
+    }
+  );
+
+  const supergroups = response?.data ?? [];
+
+  const handleSupergroupClick = (supergroup: SupergroupDetail) => {
+    openDrawer(() => <SupergroupDetailDrawer supergroup={supergroup} />, {
+      ariaLabel: t('Supergroup details'),
+      drawerKey: 'supergroup-drawer',
+    });
+  };
+
+  if (!hasTopIssuesUI) {
+    return <Redirect to={`/organizations/${organization.slug}/issues/`} />;
+  }
+
+  return (
+    <Layout.Page>
+      <Layout.Header noActionWrap unified>
+        <Layout.HeaderContent>
+          <Flex align="center" gap="md">
+            <Heading as="h1">{t('Supergroups')}</Heading>
+            <FeatureBadge type="experimental" />
+          </Flex>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          <FeedbackButton
+            size="sm"
+            feedbackOptions={{
+              messagePlaceholder: t('What do you think about Supergroups?'),
+              tags: {
+                ['feedback.source']: 'supergroups',
+                ['feedback.owner']: 'issues',
+              },
+            }}
+          />
+        </Layout.HeaderActions>
+      </Layout.Header>
+
+      <Layout.Body>
+        <Layout.Main width="full">
+          {isPending ? (
+            <LoadingIndicator />
+          ) : isError ? (
+            <LoadingError onRetry={refetch} />
+          ) : supergroups.length === 0 ? (
+            <Container padding="lg" border="primary" radius="md" background="primary">
+              <Text variant="muted" align="center" as="div">
+                {t('No supergroups found')}
+              </Text>
+            </Container>
+          ) : (
+            <Stack gap="lg">
+              <Text size="sm" variant="muted">
+                {tn('%s supergroup', '%s supergroups', supergroups.length)}
+              </Text>
+              <Grid columns={{xs: '1fr', lg: '1fr 1fr'}} gap="lg">
+                {supergroups.map(sg => (
+                  <SupergroupCard
+                    key={sg.id}
+                    supergroup={sg}
+                    onClick={() => handleSupergroupClick(sg)}
+                  />
+                ))}
+              </Grid>
+            </Stack>
+          )}
+        </Layout.Main>
+      </Layout.Body>
+    </Layout.Page>
+  );
+}
+
+const CardContainer = styled(Container)`
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover {
+    background: ${p => p.theme.tokens.background.secondary};
+    border-color: ${p => p.theme.tokens.border.accent.moderate};
+    box-shadow: ${p => p.theme.dropShadowMedium};
+  }
+`;
+
+export const StyledMarkedText = styled(MarkedText)`
+  code:not(pre code) {
+    ${p => inlineCodeStyles(p.theme)};
+  }
+`;
+
+export default Supergroups;

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -1,0 +1,118 @@
+import {Fragment, useMemo} from 'react';
+import styled from '@emotion/styled';
+
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {
+  CrumbContainer,
+  NavigationCrumbs,
+  ShortId,
+} from 'sentry/components/events/eventDrawer';
+import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
+import GroupList from 'sentry/components/issues/groupList';
+import {IconFocus} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {StyledMarkedText} from 'sentry/views/issueList/pages/supergroups';
+import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
+
+export function SupergroupDetailDrawer({supergroup}: {supergroup: SupergroupDetail}) {
+  const organization = useOrganization();
+  const groupListQueryParams = useMemo(
+    () => ({
+      query: `issue.id:[${supergroup.group_ids.join(',')}]`,
+      limit: 25,
+    }),
+    [supergroup.group_ids]
+  );
+  const placeholderRows = Math.min(supergroup.group_ids.length, 10);
+
+  return (
+    <Fragment>
+      <DrawerHeader hideBar>
+        <Flex justify="between" align="center" gap="md" flexGrow={1}>
+          <NavigationCrumbs
+            crumbs={[
+              {label: t('Supergroups')},
+              {
+                label: (
+                  <CrumbContainer>
+                    <ShortId>{`SG-${supergroup.id}`}</ShortId>
+                  </CrumbContainer>
+                ),
+              },
+            ]}
+          />
+          <Link
+            to={`/organizations/${organization.slug}/issues/?query=issue.id:[${supergroup.group_ids.join(',')}]`}
+          >
+            {t('View All Issues')} ({supergroup.group_ids.length})
+          </Link>
+        </Flex>
+      </DrawerHeader>
+      <DrawerContentBody>
+        <Container padding="2xl" borderBottom="muted">
+          <Stack gap="lg">
+            <Heading as="h2" size="lg">
+              <StyledMarkedText text={supergroup.title} inline as="span" />
+            </Heading>
+
+            <Flex wrap="wrap" gap="lg">
+              {supergroup.error_type && (
+                <Flex gap="xs">
+                  <Text size="sm" variant="muted">
+                    {t('Error')}
+                  </Text>
+                  <Text size="sm">{supergroup.error_type}</Text>
+                </Flex>
+              )}
+              {supergroup.code_area && (
+                <Flex gap="xs">
+                  <Text size="sm" variant="muted">
+                    {t('Location')}
+                  </Text>
+                  <Text size="sm">{supergroup.code_area}</Text>
+                </Flex>
+              )}
+            </Flex>
+
+            {supergroup.summary && (
+              <Container background="secondary" border="primary" radius="md">
+                <Flex direction="column" padding="md lg" gap="sm">
+                  <Flex align="center" gap="xs">
+                    <IconFocus size="xs" variant="promotion" />
+                    <Text size="sm" bold>
+                      {t('Root Cause')}
+                    </Text>
+                  </Flex>
+                  <Text size="sm">
+                    <StyledMarkedText text={supergroup.summary} inline as="span" />
+                  </Text>
+                </Flex>
+              </Container>
+            )}
+          </Stack>
+        </Container>
+
+        {supergroup.group_ids.length > 0 && (
+          <Container padding="sm">
+            <GroupList
+              queryParams={groupListQueryParams}
+              canSelectGroups={false}
+              withChart={false}
+              withPagination={false}
+              source="supergroup-drawer"
+              numPlaceholderRows={placeholderRows}
+            />
+          </Container>
+        )}
+      </DrawerContentBody>
+    </Fragment>
+  );
+}
+
+const DrawerContentBody = styled(DrawerBody)`
+  padding: 0;
+`;

--- a/static/app/views/issueList/supergroups/types.ts
+++ b/static/app/views/issueList/supergroups/types.ts
@@ -1,0 +1,10 @@
+export interface SupergroupDetail {
+  code_area: string;
+  created_at: string;
+  error_type: string;
+  group_ids: number[];
+  id: number;
+  summary: string;
+  title: string;
+  updated_at: string;
+}

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -14,6 +14,8 @@ export function IssuesSecondaryNavigation() {
   const organization = useOrganization();
   const sectionRef = useRef<HTMLDivElement>(null);
   const baseUrl = `/organizations/${organization.slug}/issues`;
+  const hasTopIssuesUI = organization.features.includes('top-issues-ui');
+
   return (
     <Fragment>
       <SecondaryNavigation.Header>{t('Issues')}</SecondaryNavigation.Header>
@@ -26,6 +28,14 @@ export function IssuesSecondaryNavigation() {
           >
             {t('Feed')}
           </SecondaryNavigation.Item>
+          {hasTopIssuesUI && (
+            <SecondaryNavigation.Item
+              to={`${baseUrl}/supergroups/`}
+              analyticsItemName="issues_supergroups"
+            >
+              {t('Supergroups')}
+            </SecondaryNavigation.Item>
+          )}
         </SecondaryNavigation.Section>
         <SecondaryNavigation.Section id="issues-types">
           {Object.values(ISSUE_TAXONOMY_CONFIG).map(({key, label}) => (


### PR DESCRIPTION
Follow up of https://github.com/getsentry/sentry/pull/110262. Replacing the old top issues UI with our new supergroups work. Still temporary, since the long term vision is not having a separate page for this.

New (ui in progress):
<img width="1215" height="335" alt="Screenshot 2026-03-12 at 1 43 09 PM" src="https://github.com/user-attachments/assets/3db7b1e7-62ec-4d18-ada1-e7752b035468" />
