### PR TITLE
fix(github): Swallow error when getting back an error response for codeowners file

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -913,12 +913,12 @@ class GitHubBaseClient(
             headers=headers,
         )
 
-        result = (
-            contents.content.decode("utf-8")
-            if codeowners
-            else b64decode(contents["content"]).decode("utf-8")
-        )
-        return result
+        if codeowners:
+            if not contents.ok:
+                raise ApiError.from_response(contents)
+            return contents.content.decode("utf-8")
+
+        return b64decode(contents["content"]).decode("utf-8")
 
     def _graphql(
         self,

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -243,6 +243,51 @@ class GitHubApiClientTest(TestCase):
         assert mock_record.mock_calls[0].args[0] == EventLifecycleOutcome.STARTED
         assert mock_record.mock_calls[1].args[0] == EventLifecycleOutcome.SUCCESS
 
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_file_codeowners_raises_on_json_error_response(self, mock_jwt) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/contents/CODEOWNERS",
+            json={
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest",
+                "status": "404",
+            },
+            status=404,
+        )
+        with pytest.raises(ApiError):
+            self.github_client.get_file(self.repo, "CODEOWNERS", ref=None, codeowners=True)
+
+    @mock.patch(
+        "sentry.integrations.github.integration.GitHubIntegration.check_file",
+        return_value="https://github.com/Test-Organization/foo/blob/master/CODEOWNERS",
+    )
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_codeowner_file_returns_none_on_error_response(
+        self, mock_jwt, mock_check_file
+    ) -> None:
+        self.config = self.create_code_mapping(
+            repo=self.repo,
+            project=self.project,
+        )
+        for location in ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]:
+            responses.add(
+                method=responses.GET,
+                url=f"https://api.github.com/repos/{self.repo.name}/contents/{location}",
+                json={
+                    "message": "Not Found",
+                    "documentation_url": "https://docs.github.com/rest",
+                    "status": "404",
+                },
+                status=404,
+            )
+        result = self.install.get_codeowner_file(
+            self.config.repository, ref=self.config.default_branch
+        )
+        assert result is None
+
     @responses.activate
     def test_get_cached_repo_files_caching_functionality(self) -> None:
         """Fetch files for repo. Test caching logic."""


### PR DESCRIPTION
Currently we don't differentiate between a JSON response and the raw bytes response when getting back a codeowner file leading to[ bad state issues](https://sentry.slack.com/archives/CD4NYFD34/p1772658791476249). This PR will raise an error if we get an error response (status code >= 400) from github.

The callers of get_file will then swallow this exception so this error will not get propagated up but that's ok imo since we just want to prevent the bad state case.