### PR TITLE
Adds integration tests for the new `occurrences` EAP dataset 

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -186,7 +186,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
                     "environment",
                     "timestamp",
                 ],
-                "statsPeriod": "1h",
+                "statsPeriod": "90d",
                 "project": [self.project.id],
                 "query": f"group_id:{group.group_id}",
             }
@@ -327,7 +327,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         timestamp_response = self.do_occurrences_request(
             {
                 "field": ["group_id", "title", "timestamp"],
-                "statsPeriod": "1h",
+                "statsPeriod": "90d",
                 "project": [self.project.id],
                 "sort": "-timestamp",
             }
@@ -349,7 +349,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         title_response = self.do_occurrences_request(
             {
                 "field": ["group_id", "title", "timestamp"],
-                "statsPeriod": "1h",
+                "statsPeriod": "90d",
                 "project": [self.project.id],
                 "sort": "title",
             }

--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -1,7 +1,9 @@
 import uuid
+from datetime import timedelta
 
 from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.testutils.cases import BaseOccurrenceTestCase
+from sentry.testutils.helpers.datetime import before_now
 from tests.snuba.api.endpoints.test_organization_events import (
     OrganizationEventsEndpointTestBase,
 )
@@ -14,6 +16,14 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
 
     def setUp(self) -> None:
         super().setUp()
+        self.reference_time = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
+
+    def do_occurrences_request(self, query, features=None):
+        query = {**query, "dataset": "occurrences"}
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            return self.do_request(query, features=features)
 
     def test_simple(self) -> None:
         event_id = uuid.uuid4().hex
@@ -28,16 +38,12 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         )
         self.store_eap_items([occ])
 
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["id", "group_id", "trace"],
-                    "project": [self.project.id],
-                    "dataset": "occurrences",
-                }
-            )
+        response = self.do_occurrences_request(
+            {
+                "field": ["id", "group_id", "trace"],
+                "project": [self.project.id],
+            }
+        )
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
         row = response.data["data"][0]
@@ -58,16 +64,306 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
         )
         self.store_eap_items([occ])
 
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self.do_request(
-                {
-                    "field": ["count()"],
-                    "statsPeriod": "1h",
-                    "query": f"project:{group.project.slug} group_id:{group.group_id}",
-                    "dataset": "occurrences",
-                }
-            )
+        response = self.do_occurrences_request(
+            {
+                "field": ["count()"],
+                "statsPeriod": "1h",
+                "query": f"project:{group.project.slug} group_id:{group.group_id}",
+            }
+        )
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
+
+    def test_generic_group_ids_filter(self) -> None:
+        timestamp = self.reference_time + timedelta(minutes=10)
+        trace_id_1 = uuid.uuid4().hex
+        trace_id_2 = uuid.uuid4().hex
+        event_id_1 = uuid.uuid4().hex
+        event_id_2 = uuid.uuid4().hex
+
+        occ_1, group_1 = self.create_occurrence(
+            data={
+                "event_id": event_id_1,
+                "fingerprint": ["group1"],
+                "title": "something bad happened",
+                "release": "1.2.3",
+                "environment": "prod",
+                "transaction": "/api/123",
+                "timestamp": timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": trace_id_1}},
+            },
+            project=self.project,
+        )
+        occ_2, group_2 = self.create_occurrence(
+            data={
+                "event_id": event_id_2,
+                "fingerprint": ["group2"],
+                "title": "another bad thing happened",
+                "release": "1.2.4",
+                "environment": "prod",
+                "transaction": "/api/456",
+                "timestamp": timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": trace_id_2}},
+            },
+            project=self.project,
+        )
+        self.store_eap_items([occ_1, occ_2])
+
+        response = self.do_occurrences_request(
+            {
+                "field": ["title", "release", "environment", "timestamp"],
+                "statsPeriod": "90d",
+                "query": f"group_id:{group_2.group_id}",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0] == {
+            "title": "another bad thing happened",
+            "release": "1.2.4",
+            "environment": "prod",
+            "timestamp": timestamp.replace(microsecond=0).isoformat(),
+        }
+
+    def test_multiple_group_ids_filter(self) -> None:
+        occ_1, group_1 = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group1"],
+                "title": "N+1 Query",
+                "transaction": "/books/",
+            },
+            project=self.project,
+        )
+        occ_2, group_2 = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group2"],
+                "title": "Slow DB Query",
+                "transaction": "/authors/",
+            },
+            project=self.project,
+        )
+        self.store_eap_items([occ_1, occ_2])
+
+        response = self.do_occurrences_request(
+            {
+                "field": ["count()"],
+                "statsPeriod": "1h",
+                "query": f"project:{group_1.project.slug} group_id:[{group_1.group_id},{group_2.group_id}]",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0]["count()"] == 2
+
+    def test_occurrence_descriptive_fields(self) -> None:
+        event_id = uuid.uuid4().hex
+        trace_id = uuid.uuid4().hex
+        timestamp = self.reference_time + timedelta(minutes=10)
+        occ, group = self.create_occurrence(
+            data={
+                "event_id": event_id,
+                "fingerprint": ["group1"],
+                "title": "A migrated occurrence",
+                "release": "frontend@1.0.0",
+                "environment": "production",
+                "transaction": "/issue-platform-demo/page/1",
+                "level": "warning",
+                "type": "generic",
+                "timestamp": timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": trace_id}},
+            },
+            project=self.project,
+        )
+        self.store_eap_items([occ])
+
+        response = self.do_occurrences_request(
+            {
+                "field": [
+                    "transaction",
+                    "title",
+                    "release",
+                    "environment",
+                    "timestamp",
+                ],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+                "query": f"group_id:{group.group_id}",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"][0] == {
+            "transaction": "/issue-platform-demo/page/1",
+            "title": "A migrated occurrence",
+            "release": "frontend@1.0.0",
+            "environment": "production",
+            "timestamp": timestamp.replace(microsecond=0).isoformat(),
+        }
+
+    def test_filters_on_release_and_environment(self) -> None:
+        matching_timestamp = self.reference_time + timedelta(minutes=10)
+        non_matching_timestamp = self.reference_time + timedelta(minutes=11)
+
+        matching_occ, _ = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group1"],
+                "title": "matching occurrence",
+                "release": "frontend@2.0.0",
+                "environment": "staging",
+                "transaction": "/release-match",
+                "timestamp": matching_timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        non_matching_occ, _ = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group2"],
+                "title": "non matching occurrence",
+                "release": "frontend@1.9.9",
+                "environment": "production",
+                "transaction": "/release-miss",
+                "timestamp": non_matching_timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        self.store_eap_items([matching_occ, non_matching_occ])
+
+        response = self.do_occurrences_request(
+            {
+                "field": ["title", "release", "environment", "transaction", "timestamp"],
+                "statsPeriod": "90d",
+                "project": [self.project.id],
+                "query": "release:frontend@2.0.0 environment:staging",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {
+                "title": "matching occurrence",
+                "release": "frontend@2.0.0",
+                "environment": "staging",
+                "transaction": "/release-match",
+                "timestamp": matching_timestamp.replace(microsecond=0).isoformat(),
+            }
+        ]
+
+    def test_groupby_group_id(self) -> None:
+        first_occ, first_group = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group1"],
+                "title": "Grouped occurrence A",
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        second_occ, _ = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group2"],
+                "title": "Grouped occurrence B",
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        second_occ.attributes["group_id"].int_value = first_group.group_id
+        third_occ, third_group = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group3"],
+                "title": "Grouped occurrence C",
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        self.store_eap_items([first_occ, second_occ, third_occ])
+
+        response = self.do_occurrences_request(
+            {
+                "field": ["group_id", "count()"],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+                "sort": "group_id",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["data"] == [
+            {"group_id": first_group.group_id, "count()": 2},
+            {"group_id": third_group.group_id, "count()": 1},
+        ]
+
+    def test_orderby_timestamp_and_title(self) -> None:
+        older_timestamp = self.reference_time + timedelta(minutes=10)
+        newer_timestamp = self.reference_time + timedelta(minutes=11)
+
+        older_occ, older_group = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group1"],
+                "title": "Zulu occurrence",
+                "transaction": "/older",
+                "timestamp": older_timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        newer_occ, newer_group = self.create_occurrence(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "fingerprint": ["group2"],
+                "title": "Alpha occurrence",
+                "transaction": "/newer",
+                "timestamp": newer_timestamp.timestamp(),
+                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+            },
+            project=self.project,
+        )
+        self.store_eap_items([older_occ, newer_occ])
+
+        timestamp_response = self.do_occurrences_request(
+            {
+                "field": ["group_id", "title", "timestamp"],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+                "sort": "-timestamp",
+            }
+        )
+        assert timestamp_response.status_code == 200, timestamp_response.content
+        assert timestamp_response.data["data"] == [
+            {
+                "group_id": newer_group.group_id,
+                "title": "Alpha occurrence",
+                "timestamp": newer_timestamp.replace(microsecond=0).isoformat(),
+            },
+            {
+                "group_id": older_group.group_id,
+                "title": "Zulu occurrence",
+                "timestamp": older_timestamp.replace(microsecond=0).isoformat(),
+            },
+        ]
+
+        title_response = self.do_occurrences_request(
+            {
+                "field": ["group_id", "title", "timestamp"],
+                "statsPeriod": "1h",
+                "project": [self.project.id],
+                "sort": "title",
+            }
+        )
+        assert title_response.status_code == 200, title_response.content
+        assert title_response.data["data"] == [
+            {
+                "group_id": newer_group.group_id,
+                "title": "Alpha occurrence",
+                "timestamp": newer_timestamp.replace(microsecond=0).isoformat(),
+            },
+            {
+                "group_id": older_group.group_id,
+                "title": "Zulu occurrence",
+                "timestamp": older_timestamp.replace(microsecond=0).isoformat(),
+            },
+        ]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 
 import pytest
@@ -28,11 +29,10 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
-        self.start = self.day_ago = before_now(days=1).replace(
-            hour=10, minute=0, second=0, microsecond=0
-        )
-        self.end = self.start + timedelta(hours=6)
-        self.two_days_ago = self.day_ago - timedelta(days=1)
+        self.reference_time = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
+        self.start = self.day_ago = self.reference_time
+        self.end = self.reference_time + timedelta(hours=6)
+        self.two_days_ago = self.reference_time - timedelta(days=1)
 
         self.url = reverse(
             self.endpoint,
@@ -45,6 +45,13 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
         features.update(self.features)
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")
+
+    def _do_occurrences_request(self, data, url=None, features=None):
+        data = {**data, "dataset": "occurrences"}
+        with self.options(
+            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
+        ):
+            return self._do_request(data=data, url=url, features=features)
 
     def test_count(self) -> None:
         event_counts = [6, 0, 6, 3, 0, 3]
@@ -66,19 +73,15 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             )
         self.store_eap_items([occurrence for occurrence, group in occurrence_and_groups])
 
-        with self.options(
-            {EAPOccurrencesComparator._callsite_allowlist_option_name(): self.callsite_name}
-        ):
-            response = self._do_request(
-                data={
-                    "start": self.start,
-                    "end": self.end,
-                    "interval": "1h",
-                    "yAxis": "count()",
-                    "project": self.project.id,
-                    "dataset": "occurrences",
-                },
-            )
+        response = self._do_occurrences_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+            },
+        )
         assert response.status_code == 200, response.content
         assert response.data["meta"] == {
             "dataset": "occurrences",
@@ -103,3 +106,242 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             "valueUnit": None,
             "interval": 3_600_000,
         }
+
+    def test_count_filtered_by_release_and_environment(self) -> None:
+        matching_counts = [2, 0, 3, 1, 0, 2]
+        non_matching_counts = [1, 1, 1, 1, 1, 1]
+        occurrences = []
+        for hour, count in enumerate(matching_counts):
+            occurrences.extend(
+                [
+                    self.create_occurrence(
+                        {
+                            "title": "matching occurrence",
+                            "release": "frontend@2.0.0",
+                            "environment": "staging",
+                            "timestamp": (
+                                self.start + timedelta(hours=hour, minutes=minute)
+                            ).timestamp(),
+                            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                        }
+                    )
+                    for minute in range(count)
+                ]
+            )
+        for hour, count in enumerate(non_matching_counts):
+            occurrences.extend(
+                [
+                    self.create_occurrence(
+                        {
+                            "title": "non matching occurrence",
+                            "release": "frontend@1.0.0",
+                            "environment": "production",
+                            "timestamp": (
+                                self.start + timedelta(hours=hour, minutes=30 + minute)
+                            ).timestamp(),
+                            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                        }
+                    )
+                    for minute in range(count)
+                ]
+            )
+        self.store_eap_items([occurrence for occurrence, _ in occurrences])
+
+        response = self._do_occurrences_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "query": "release:frontend@2.0.0 environment:staging",
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            matching_counts,
+            sample_count=matching_counts,
+            sample_rate=[1 if val else None for val in matching_counts],
+            confidence=[any_confidence if val else None for val in matching_counts],
+        )
+
+    def test_multiple_yaxis(self) -> None:
+        event_counts = [3, 1, 2, 0, 2, 1]
+        warning_counts = [2, 0, 1, 0, 1, 1]
+        occurrences = []
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                level = "warning" if minute < warning_counts[hour] else "info"
+                occurrences.append(
+                    self.create_occurrence(
+                        {
+                            "title": f"occurrence {hour}-{minute}",
+                            "level": level,
+                            "timestamp": (
+                                self.start + timedelta(hours=hour, minutes=minute)
+                            ).timestamp(),
+                            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                        }
+                    )
+                )
+        self.store_eap_items([occurrence for occurrence, _ in occurrences])
+
+        response = self._do_occurrences_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": ["count()", "count_if(level,equals,warning)"],
+                "project": self.project.id,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"] == {
+            "dataset": "occurrences",
+            "start": self.start.timestamp() * 1000,
+            "end": self.end.timestamp() * 1000,
+        }
+        assert len(response.data["timeSeries"]) == 2
+
+        count_series = response.data["timeSeries"][0]
+        assert count_series["yAxis"] == "count()"
+        assert count_series["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            event_counts,
+            sample_count=event_counts,
+            sample_rate=[1 if val else None for val in event_counts],
+            confidence=[any_confidence if val else None for val in event_counts],
+        )
+        assert count_series["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 3_600_000,
+        }
+
+        warning_series = response.data["timeSeries"][1]
+        assert warning_series["yAxis"] == "count_if(level,equals,warning)"
+        assert warning_series["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            warning_counts,
+            sample_count=warning_counts,
+            sample_rate=[1 if val else None for val in warning_counts],
+            confidence=[any_confidence if val else None for val in warning_counts],
+        )
+        assert warning_series["meta"] == {
+            "dataScanned": "full",
+            "valueType": "integer",
+            "valueUnit": None,
+            "interval": 3_600_000,
+        }
+
+    def test_comparison_delta(self) -> None:
+        event_counts = [4, 0, 2, 1, 0, 3]
+        comparison_counts = [2, 0, 1, 1, 0, 1]
+        occurrences = []
+        for hour, count in enumerate(event_counts):
+            occurrences.extend(
+                [
+                    self.create_occurrence(
+                        {
+                            "title": "current period",
+                            "timestamp": (
+                                self.start + timedelta(hours=hour, minutes=minute)
+                            ).timestamp(),
+                            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                        }
+                    )
+                    for minute in range(count)
+                ]
+            )
+        for hour, count in enumerate(comparison_counts):
+            occurrences.extend(
+                [
+                    self.create_occurrence(
+                        {
+                            "title": "comparison period",
+                            "timestamp": (
+                                self.two_days_ago + timedelta(hours=hour, minutes=minute)
+                            ).timestamp(),
+                            "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                        }
+                    )
+                    for minute in range(count)
+                ]
+            )
+        self.store_eap_items([occurrence for occurrence, _ in occurrences])
+
+        response = self._do_occurrences_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "project": self.project.id,
+                "comparisonDelta": 24 * 60 * 60,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert len(response.data["timeSeries"]) == 1
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["yAxis"] == "count()"
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start,
+            3_600_000,
+            event_counts,
+            comparison_counts,
+            ignore_accuracy=True,
+        )
+
+    def test_top_events_not_supported_yet(self) -> None:
+        alpha_counts = [3, 1, 2, 0, 0, 0]
+        beta_counts = [1, 1, 0, 1, 0, 0]
+        gamma_counts = [0, 0, 1, 0, 1, 0]
+        occurrences = []
+        for transaction, counts in [
+            ("/alpha", alpha_counts),
+            ("/beta", beta_counts),
+            ("/gamma", gamma_counts),
+        ]:
+            for hour, count in enumerate(counts):
+                occurrences.extend(
+                    [
+                        self.create_occurrence(
+                            {
+                                "transaction": transaction,
+                                "title": f"{transaction} occurrence",
+                                "timestamp": (
+                                    self.start + timedelta(hours=hour, minutes=minute)
+                                ).timestamp(),
+                                "contexts": {"trace": {"trace_id": uuid.uuid4().hex}},
+                            }
+                        )
+                        for minute in range(count)
+                    ]
+                )
+        self.store_eap_items([occurrence for occurrence, _ in occurrences])
+
+        response = self._do_occurrences_request(
+            data={
+                "start": self.start,
+                "end": self.end,
+                "interval": "1h",
+                "yAxis": "count()",
+                "groupBy": ["transaction"],
+                "orderby": ["-count()"],
+                "topEvents": 2,
+                "project": self.project.id,
+            }
+        )
+        assert response.status_code == 400, response.content
+        assert (
+            response.data["detail"]
+            == "<class 'sentry.snuba.occurrences_rpc.Occurrences'> doesn't support topEvents yet"
+        )


### PR DESCRIPTION
Adds integration tests for the new `occurrences` EAP dataset  on `/api/0/organizations/{org}/events/` and `/events-stats/` endpoints, introduced in #109727.

Tests are modelled after the existing test suiteS and verify behavioural parity between the new EAP-backed `occurrences` dataset and the legacy `Dataset.IssuePlatform` (`search_issues`) implementation.

Ref: EXP-818

