### PR TITLE
ref(dashboards): Add create alert option to span based timeseries widgets

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -288,7 +288,8 @@ function WidgetCard(props: Props) {
         location,
         props.onDelete,
         props.onDuplicate,
-        props.onEdit
+        props.onEdit,
+        data?.timeseriesResults
       )
     : [];
 

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -4,7 +4,7 @@ import {
   SERIES_NAME_PART_DELIMITER,
   transformLegacySeriesToTimeSeries,
 } from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
-import type {Widget} from 'sentry/views/dashboards/types';
+import type {Widget, WidgetQuery} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 
@@ -12,6 +12,7 @@ interface TransformedSeries {
   label: string;
   seriesName: string;
   timeSeries: TimeSeries;
+  widgetQuery: WidgetQuery;
 }
 
 /**
@@ -25,6 +26,9 @@ export function transformWidgetSeriesToTimeSeries(
   timeseriesResultsUnits?: Record<string, DataUnit>
 ): TransformedSeries | null {
   const firstQuery = widget.queries[0];
+  if (!firstQuery) {
+    return null;
+  }
   const aggregates = firstQuery?.aggregates ?? [];
   const columns = firstQuery?.columns ?? [];
   const fields = firstQuery?.fields ?? [...columns, ...aggregates];
@@ -38,9 +42,9 @@ export function transformWidgetSeriesToTimeSeries(
     aggregates[0] ??
     '';
 
-  const queryName =
-    widget.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ??
-    undefined;
+  const widgetQuery =
+    widget.queries.find(({name}) => name && splitSeriesName.includes(name)) ?? firstQuery;
+  const queryName = widgetQuery?.name || undefined;
 
   const timeSeries = transformLegacySeriesToTimeSeries(
     series,
@@ -72,5 +76,5 @@ export function transformWidgetSeriesToTimeSeries(
     .filter((part): part is string => part !== undefined)
     .join(SERIES_NAME_PART_DELIMITER);
 
-  return {timeSeries, label, seriesName};
+  return {timeSeries, label, seriesName, widgetQuery};
 }

--- a/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
+++ b/static/app/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries.tsx
@@ -1,0 +1,76 @@
+import type {Series} from 'sentry/types/echarts';
+import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
+import {
+  SERIES_NAME_PART_DELIMITER,
+  transformLegacySeriesToTimeSeries,
+} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
+import type {Widget} from 'sentry/views/dashboards/types';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
+
+interface TransformedSeries {
+  label: string;
+  seriesName: string;
+  timeSeries: TimeSeries;
+}
+
+/**
+ * Transforms a legacy echarts Series into a TimeSeries using the widget's
+ * query configuration, and computes a display label that matches the chart legend.
+ */
+export function transformWidgetSeriesToTimeSeries(
+  series: Series,
+  widget: Widget,
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>,
+  timeseriesResultsUnits?: Record<string, DataUnit>
+): TransformedSeries | null {
+  const firstQuery = widget.queries[0];
+  const aggregates = firstQuery?.aggregates ?? [];
+  const columns = firstQuery?.columns ?? [];
+  const fields = firstQuery?.fields ?? [...columns, ...aggregates];
+  const fieldAliases = firstQuery?.fieldAliases ?? [];
+
+  const seriesName = series.seriesName ?? aggregates[0] ?? '';
+  const splitSeriesName = seriesName.split(SERIES_NAME_PART_DELIMITER);
+
+  const yAxis =
+    aggregates.find(aggregate => splitSeriesName.includes(aggregate)) ??
+    aggregates[0] ??
+    '';
+
+  const queryName =
+    widget.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ??
+    undefined;
+
+  const timeSeries = transformLegacySeriesToTimeSeries(
+    series,
+    timeseriesResultsTypes,
+    timeseriesResultsUnits,
+    columns,
+    yAxis,
+    queryName
+  );
+
+  if (!timeSeries) {
+    return null;
+  }
+
+  const fieldIndex = fields.indexOf(yAxis);
+  // Only use field aliases for the yAxis if there are multiple yAxis and no group bys
+  const fieldAlias =
+    aggregates.length > 1 && columns.length === 0 && fieldIndex >= 0
+      ? fieldAliases[fieldIndex]
+      : undefined;
+
+  const labelParts = [queryName, fieldAlias ?? formatTimeSeriesLabel(timeSeries)];
+  // If there are multiple aggregates and columns, add the yAxis to the label for uniqueness
+  if (aggregates.length > 1 && columns.length > 1) {
+    labelParts.push(timeSeries.yAxis);
+  }
+
+  const label = labelParts
+    .filter((part): part is string => part !== undefined)
+    .join(SERIES_NAME_PART_DELIMITER);
+
+  return {timeSeries, label, seriesName};
+}

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -14,10 +14,6 @@ import type {Confidence} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import type {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import type {AggregationOutputType, DataUnit, Sort} from 'sentry/utils/discover/fields';
-import {
-  SERIES_NAME_PART_DELIMITER,
-  transformLegacySeriesToTimeSeries,
-} from 'sentry/utils/timeSeries/transformLegacySeriesToTimeSeries';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -33,13 +29,13 @@ import {
   getLinkedDashboardUrl,
 } from 'sentry/views/dashboards/utils/getLinkedDashboardUrl';
 import {getChartType} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
 import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   TabularColumn,
   TimeSeries,
   TimeSeriesGroupBy,
 } from 'sentry/views/dashboards/widgets/common/types';
-import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
 import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
 import type {Plottable} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/plottable';
@@ -194,52 +190,25 @@ function VisualizationWidgetContent({
   const firstWidgetQuery = widget.queries[0];
   const aggregates = firstWidgetQuery?.aggregates ?? []; // All widget queries have the same aggregates
   const columns = firstWidgetQuery?.columns ?? []; // All widget queries have the same columns
-  const fields = firstWidgetQuery?.fields ?? [...columns, ...aggregates];
-  const fieldAliases = firstWidgetQuery?.fieldAliases ?? [];
 
   const timeSeriesWithPlottable = timeseriesResults
     .map(series => {
-      const seriesName = series.seriesName ?? aggregates[0] ?? '';
-      const splitSeriesName = seriesName.split(SERIES_NAME_PART_DELIMITER);
-
-      const yAxis =
-        aggregates.find(aggregate => splitSeriesName.includes(aggregate)) ??
-        aggregates[0];
-
-      // This is the query name for the series, aka the legend alias from the UI
-      const queryName =
-        widget?.queries.find(({name}) => name && splitSeriesName.includes(name))?.name ||
-        undefined;
-
-      const timeSeries = transformLegacySeriesToTimeSeries(
+      const transformed = transformWidgetSeriesToTimeSeries(
         series,
+        widget,
         timeseriesResultsTypes,
-        timeseriesResultsUnits,
-        columns,
-        yAxis,
-        queryName
+        timeseriesResultsUnits
       );
 
-      if (!timeSeries) {
+      if (!transformed) {
         return null;
       }
 
-      const fieldIndex = yAxis === undefined ? -1 : fields.indexOf(yAxis);
-      // Only use field aliases for the yAxis if there are multiple yAxis and no group bys
-      const fieldAlias =
-        aggregates.length > 1 && columns.length === 0 && fieldIndex >= 0
-          ? fieldAliases[fieldIndex]
-          : undefined;
-
-      const labelParts = [queryName, fieldAlias ?? formatTimeSeriesLabel(timeSeries)];
-      // If there are multiple aggregates and columns, add the yAxis to the label for uniqueness
-      if (aggregates.length > 1 && columns.length > 1) {
-        labelParts.push(timeSeries.yAxis);
-      }
+      const {timeSeries, label, seriesName} = transformed;
       const plottable = createPlottableFromTimeSeries(
         timeSeries,
         widget,
-        labelParts.filter(defined).join(SERIES_NAME_PART_DELIMITER),
+        label,
         seriesName,
         timeSeries.meta.isOther ? theme.tokens.dataviz.semantic.neutral : undefined
       );

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -23,6 +23,7 @@ import {
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import useOrganization from 'sentry/utils/useOrganization';
+import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
 import {
@@ -32,12 +33,14 @@ import {
   isUsingPerformanceScore,
   isWidgetEditable,
   performanceScoreTooltip,
+  usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
 import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
+import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
 import {useDashboardsMEPContext} from './dashboardsMEPContext';
 
@@ -262,6 +265,40 @@ export function getMenuOptions(
         getReferrer(widget.displayType)
       ),
     });
+  }
+
+  if (widget.widgetType === WidgetType.SPANS && usesTimeSeriesData(widget.displayType)) {
+    const aggregates = widget.queries.flatMap(query => query.aggregates);
+    const uniqueAggregates = [...new Set(aggregates)];
+    const query = widget.queries[0]?.conditions ?? '';
+
+    if (uniqueAggregates.length > 0) {
+      const newAlertLabel = organization.features.includes('workflow-engine-ui')
+        ? t('Create a Monitor for')
+        : t('Create an Alert for');
+
+      const alertMenuOptions: MenuItemProps[] = uniqueAggregates.map(
+        (aggregate, index) => ({
+          key: `create-alert-${aggregate}-${index}`,
+          label: aggregate,
+          to: getAlertsUrl({
+            query,
+            aggregate,
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            pageFilters: selection,
+            organization,
+            referrer: getReferrer(widget.displayType),
+          }),
+        })
+      );
+
+      menuOptions.push({
+        key: 'create-alert',
+        label: newAlertLabel,
+        isSubmenu: true,
+        children: alertMenuOptions,
+      });
+    }
   }
 
   if (widget.widgetType === WidgetType.TRACEMETRICS) {

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -29,6 +29,7 @@ import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
 import {DashboardWidgetSource, WidgetType} from 'sentry/views/dashboards/types';
 import {
+  applyDashboardFilters,
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
   hasDatasetSelector,
@@ -276,49 +277,51 @@ export function getMenuOptions(
     usesTimeSeriesData(widget.displayType) &&
     timeseriesResults?.length
   ) {
-    const firstQuery = widget.queries[0];
-    const aggregates = widget.queries.flatMap(query => query.aggregates);
-    const uniqueAggregates = [...new Set(aggregates)];
-    const baseQuery = firstQuery?.conditions ?? '';
+    const newAlertLabel = organization.features.includes('workflow-engine-ui')
+      ? t('Create a Monitor for')
+      : t('Create an Alert for');
 
-    if (uniqueAggregates.length > 0) {
-      const newAlertLabel = organization.features.includes('workflow-engine-ui')
-        ? t('Create a Monitor for')
-        : t('Create an Alert for');
+    const alertMenuOptions = timeseriesResults
+      .map((series, index) => {
+        const transformed = transformWidgetSeriesToTimeSeries(series, widget);
 
-      const alertMenuOptions = timeseriesResults
-        .map((series, index) => {
-          const transformed = transformWidgetSeriesToTimeSeries(series, widget);
+        if (!transformed || transformed.timeSeries.meta.isOther) {
+          return null;
+        }
 
-          if (!transformed || transformed.timeSeries.meta.isOther) {
-            return null;
+        const {timeSeries, label, seriesName, widgetQuery} = transformed;
+
+        const baseQuery =
+          applyDashboardFilters(
+            widgetQuery?.conditions,
+            dashboardFilters,
+            widget.widgetType
+          ) ?? '';
+
+        // Add group-by values as filters to the alert query
+        const search = new MutableSearch(baseQuery);
+        for (const group of timeSeries.groupBy ?? []) {
+          if (group.value !== null && !Array.isArray(group.value)) {
+            search.addFilterValue(group.key, `${group.value}`);
           }
+        }
 
-          const {timeSeries, label, seriesName} = transformed;
+        return {
+          key: `create-alert-${seriesName}-${index}`,
+          label,
+          to: getAlertsUrl({
+            query: search.formatString(),
+            aggregate: timeSeries.yAxis,
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            pageFilters: selection,
+            organization,
+            referrer: getReferrer(widget.displayType),
+          }),
+        } satisfies MenuItemProps;
+      })
+      .filter(Boolean) as MenuItemProps[];
 
-          // Add group-by values as filters to the alert query
-          const search = new MutableSearch(baseQuery);
-          for (const group of timeSeries.groupBy ?? []) {
-            if (group.value !== null && !Array.isArray(group.value)) {
-              search.addFilterValue(group.key, `${group.value}`);
-            }
-          }
-
-          return {
-            key: `create-alert-${seriesName}-${index}`,
-            label,
-            to: getAlertsUrl({
-              query: search.formatString(),
-              aggregate: timeSeries.yAxis,
-              dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-              pageFilters: selection,
-              organization,
-              referrer: getReferrer(widget.displayType),
-            }),
-          } satisfies MenuItemProps;
-        })
-        .filter(Boolean) as MenuItemProps[];
-
+    if (alertMenuOptions.length > 0) {
       menuOptions.push({
         key: 'create-alert',
         label: newAlertLabel,

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -14,6 +14,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {t, tct} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
+import type {Series} from 'sentry/types/echarts';
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
@@ -21,6 +22,7 @@ import {
   MEPState,
   useMEPSettingContext,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import useOrganization from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
@@ -38,6 +40,7 @@ import {
 import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
+import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
@@ -188,7 +191,8 @@ export function getMenuOptions(
   location: Location,
   onDelete?: () => void,
   onDuplicate?: () => void,
-  onEdit?: () => void
+  onEdit?: () => void,
+  timeseriesResults?: Series[]
 ) {
   const menuOptions: MenuItemProps[] = [];
 
@@ -267,30 +271,53 @@ export function getMenuOptions(
     });
   }
 
-  if (widget.widgetType === WidgetType.SPANS && usesTimeSeriesData(widget.displayType)) {
+  if (
+    widget.widgetType === WidgetType.SPANS &&
+    usesTimeSeriesData(widget.displayType) &&
+    timeseriesResults?.length
+  ) {
+    const firstQuery = widget.queries[0];
     const aggregates = widget.queries.flatMap(query => query.aggregates);
     const uniqueAggregates = [...new Set(aggregates)];
-    const query = widget.queries[0]?.conditions ?? '';
+    const baseQuery = firstQuery?.conditions ?? '';
 
     if (uniqueAggregates.length > 0) {
       const newAlertLabel = organization.features.includes('workflow-engine-ui')
         ? t('Create a Monitor for')
         : t('Create an Alert for');
 
-      const alertMenuOptions: MenuItemProps[] = uniqueAggregates.map(
-        (aggregate, index) => ({
-          key: `create-alert-${aggregate}-${index}`,
-          label: aggregate,
-          to: getAlertsUrl({
-            query,
-            aggregate,
-            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-            pageFilters: selection,
-            organization,
-            referrer: getReferrer(widget.displayType),
-          }),
+      const alertMenuOptions = timeseriesResults
+        .map((series, index) => {
+          const transformed = transformWidgetSeriesToTimeSeries(series, widget);
+
+          if (!transformed || transformed.timeSeries.meta.isOther) {
+            return null;
+          }
+
+          const {timeSeries, label, seriesName} = transformed;
+
+          // Add group-by values as filters to the alert query
+          const search = new MutableSearch(baseQuery);
+          for (const group of timeSeries.groupBy ?? []) {
+            if (group.value !== null && !Array.isArray(group.value)) {
+              search.addFilterValue(group.key, `${group.value}`);
+            }
+          }
+
+          return {
+            key: `create-alert-${seriesName}-${index}`,
+            label,
+            to: getAlertsUrl({
+              query: search.formatString(),
+              aggregate: timeSeries.yAxis,
+              dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+              pageFilters: selection,
+              organization,
+              referrer: getReferrer(widget.displayType),
+            }),
+          } satisfies MenuItemProps;
         })
-      );
+        .filter(Boolean) as MenuItemProps[];
 
       menuOptions.push({
         key: 'create-alert',


### PR DESCRIPTION
Adds a create alert option for span based timeseries widgets
<img width="1260" height="331" alt="image" src="https://github.com/user-attachments/assets/32443ed0-9da6-421e-9f1a-677a304daf03" />


## Summary
- Extract shared `transformWidgetSeriesToTimeSeries` helper to deduplicate series transformation logic between `visualizationWidget` and `widgetCardContextMenu`, this also ensure the labels always match between the series and alert options.
- Alert submenu now shows one option per chart series (including group-by combinations) with labels matching the chart legend
- Group-by values are added as query filters when creating an alert from a grouped series
- Alert submenu only appears after data has loaded (no fallback with raw aggregates)