### PR TITLE
feat(integrations): Register platform detection feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -141,6 +141,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Project Management Integrations Feature Parity Flags
     manager.add("organizations:integrations-github_enterprise-project-management", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)


### PR DESCRIPTION
Register `organizations:integrations-github-platform-detection` flagpole
flag to gate the new platform detection endpoint behind a controlled
rollout.

This is the base of a 4-PR stack for GitHub platform detection:
- **PR 0 (this):** Feature flag registration
- [PR 1](https://github.com/getsentry/sentry/pull/109699): Core detection endpoint
- [PR 2](https://github.com/getsentry/sentry/pull/109700): Composable framework definitions
- [PR 3](https://github.com/getsentry/sentry/pull/109701): Expand to 97% picker coverage