### PR TITLE
fix(detectors): Require data sources for Detector creation by default

### DIFF
--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -756,13 +756,6 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
     enforce_single_datasource = True
     data_sources = MonitorDataSourceListField(child=MonitorDataSourceValidator(), required=False)
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        if not self.instance and not attrs.get("data_sources"):
-            raise serializers.ValidationError(
-                {"data_sources": ["This field is required when creating a cron monitor."]}
-            )
-        return super().validate(attrs)
-
     def validate_enabled(self, value: bool) -> bool:
         """
         Validate that enabling a detector is allowed based on seat availability.

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -756,6 +756,13 @@ class MonitorIncidentDetectorValidator(BaseDetectorTypeValidator):
     enforce_single_datasource = True
     data_sources = MonitorDataSourceListField(child=MonitorDataSourceValidator(), required=False)
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if not self.instance and not attrs.get("data_sources"):
+            raise serializers.ValidationError(
+                {"data_sources": ["This field is required when creating a cron monitor."]}
+            )
+        return super().validate(attrs)
+
     def validate_enabled(self, value: bool) -> bool:
         """
         Validate that enabling a detector is allowed based on seat availability.

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -236,7 +236,7 @@ class PreprodSizeAnalysisDetectorHandler(
 
 
 class PreprodSizeAnalysisDetectorValidator(BaseDetectorTypeValidator):
-    pass
+    data_source_required = False
 
 
 @dataclass(frozen=True)

--- a/src/sentry/workflow_engine/endpoints/validators/base/detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/detector.py
@@ -53,6 +53,12 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
     This prevents invalid configurations for detector types that don't support multiple data sources.
     """
 
+    data_source_required = True
+    """
+    Set to False in subclasses if data sources are not required for this detector type.
+    By default, data sources are required when creating a new detector.
+    """
+
     name = serializers.CharField(
         required=True,
         max_length=200,
@@ -136,6 +142,17 @@ class BaseDetectorTypeValidator(CamelSnakeSerializer[Any]):
                 )
 
         return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        """
+        Validate detector data, enforcing data source requirements if configured.
+        """
+        # Check if data sources are missing when creating a new detector
+        if self.data_source_required and not self.instance and not attrs.get("data_sources"):
+            raise serializers.ValidationError(
+                {"data_sources": ["This field is required when creating a detector."]}
+            )
+        return attrs
 
     def get_quota(self) -> DetectorQuota:
         return DetectorQuota(has_exceeded=False, limit=-1, count=-1)

--- a/src/sentry/workflow_engine/endpoints/validators/error_detector.py
+++ b/src/sentry/workflow_engine/endpoints/validators/error_detector.py
@@ -14,6 +14,8 @@ from sentry.workflow_engine.models.detector import Detector
 
 
 class ErrorDetectorValidator(BaseDetectorTypeValidator):
+    data_source_required = False
+
     fingerprinting_rules = serializers.CharField(required=False, allow_blank=True, allow_null=True)
     resolve_age = EmptyIntegerField(
         required=False,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1027,6 +1027,19 @@ class OrganizationDetectorIndexPostTest(OrganizationDetectorIndexBaseTest):
         )
         assert response.data == {"name": ["This field is required."]}
 
+    def test_missing_data_sources(self) -> None:
+        data = {
+            "name": "Test Cron Monitor",
+            "type": MonitorIncidentType.slug,
+            "projectId": self.project.id,
+        }
+        response = self.get_error_response(
+            self.organization.slug,
+            **data,
+            status_code=400,
+        )
+        assert "dataSources" in response.data
+
     def test_empty_query_string(self) -> None:
         data = {**self.valid_data}
         data["dataSources"][0]["query"] = ""


### PR DESCRIPTION
This ensures that Detectors require data sources to be created by default, with an opt-out for DataSource-less cases.


Fixes SENTRY-5KZC.
