### PR TITLE
Revert "ref(seer): Remove context engine flag check from continue_run"

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -310,7 +310,7 @@ class SeerExplorerClient:
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-        ):  # Set to True at the start of the run and persist in Seer explorer run state
+        ):
             chat_body["is_context_engine_enabled"] = True
 
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
@@ -368,6 +368,13 @@ class SeerExplorerClient:
         if artifact_key and artifact_schema:
             chat_body["artifact_key"] = artifact_key
             chat_body["artifact_schema"] = artifact_schema.schema()
+
+        if features.has(
+            "organizations:seer-explorer-context-engine",
+            self.organization,
+            actor=self.user,
+        ):
+            chat_body["is_context_engine_enabled"] = True
 
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -310,7 +310,7 @@ class SeerExplorerClient:
 
         if features.has(
             "organizations:seer-explorer-context-engine", self.organization, actor=self.user
-        ):
+        ):  # Set to True at the start of the run and persist in Seer explorer run state
             chat_body["is_context_engine_enabled"] = True
 
         response = make_explorer_chat_request(chat_body, viewer_context=self.viewer_context)


### PR DESCRIPTION
+ Reverts getsentry/sentry#110164
+ Passing this flag for continuing conversations. We will still store the value at the start of the conversation but this will this will be effectively used as a kill switch if we ever want to immediately shut off context engine. 