### PR TITLE
feat(dashboards): adds dashboards generate endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -154,6 +154,9 @@ from sentry.dashboards.endpoints.organization_dashboard_details import (
     OrganizationDashboardFavoriteEndpoint,
     OrganizationDashboardVisitEndpoint,
 )
+from sentry.dashboards.endpoints.organization_dashboard_generate import (
+    OrganizationDashboardGenerateEndpoint,
+)
 from sentry.dashboards.endpoints.organization_dashboard_widget_details import (
     OrganizationDashboardWidgetDetailsEndpoint,
 )
@@ -1569,6 +1572,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/dashboards/starred/order/$",
         OrganizationDashboardsStarredOrderEndpoint.as_view(),
         name="sentry-api-0-organization-dashboard-starred-order",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/dashboards/generate/$",
+        OrganizationDashboardGenerateEndpoint.as_view(),
+        name="sentry-api-0-organization-dashboards-generate",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/dashboards/(?P<dashboard_id>[^/]+)/$",

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
@@ -23,7 +24,7 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 logger = logging.getLogger(__name__)
 
 
-class DashboardGenerateSerializer(serializers.Serializer):
+class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
     prompt = serializers.CharField(
         required=True,
         allow_blank=False,

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -18,7 +18,7 @@ from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
 from sentry.seer.models import SeerApiError, SeerPermissionError
-from sentry.seer.seer_setup import has_seer_access_with_detail
+from sentry.seer.seer_setup import has_seer_explorer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
         ):
             return Response({"detail": "Feature not enabled"}, status=403)
 
-        has_access, error = has_seer_access_with_detail(organization, request.user)
+        has_access, error = has_seer_explorer_access_with_detail(organization, request.user)
         if not has_access:
             raise PermissionDenied(error)
 

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import logging
+
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashboard
+from sentry.models.organization import Organization
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.seer.explorer.client import SeerExplorerClient
+from sentry.seer.models import SeerPermissionError
+from sentry.seer.seer_setup import has_seer_access_with_detail
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+logger = logging.getLogger(__name__)
+
+
+class DashboardGenerateSerializer(serializers.Serializer):
+    prompt = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        help_text="Natural language description of the dashboard to generate.",
+    )
+
+
+class OrganizationDashboardGeneratePermission(OrganizationPermission):
+    scope_map = {
+        "POST": ["org:read"],
+    }
+
+
+@region_silo_endpoint
+class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ML_AI
+    enforce_rate_limit = True
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "POST": {
+                RateLimitCategory.IP: RateLimit(limit=10, window=60),
+                RateLimitCategory.USER: RateLimit(limit=10, window=60),
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=60, window=60 * 60),
+            },
+        }
+    )
+    permission_classes = (OrganizationDashboardGeneratePermission,)
+
+    def post(self, request: Request, organization: Organization) -> Response:
+        if not features.has(
+            "organizations:dashboards-ai-generate", organization, actor=request.user
+        ):
+            return Response({"detail": "Feature not enabled"}, status=403)
+
+        has_access, error = has_seer_access_with_detail(organization, request.user)
+        if not has_access:
+            raise PermissionDenied(error)
+
+        serializer = DashboardGenerateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        prompt = serializer.validated_data["prompt"]
+
+        try:
+            client = SeerExplorerClient(organization, request.user)
+            run_id = client.start_run(
+                prompt=prompt,
+                artifact_key="dashboard",
+                artifact_schema=GeneratedDashboard,
+                request=request,
+            )
+            return Response({"run_id": run_id})
+        except SeerPermissionError as e:
+            raise PermissionDenied(e.message) from e

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -17,7 +17,7 @@ from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashbo
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
-from sentry.seer.models import SeerPermissionError
+from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -83,3 +83,5 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
             return Response({"run_id": run_id})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
+        except SeerApiError:
+            return Response({"detail": "Seer request failed"}, status=502)

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -17,8 +17,8 @@ from sentry.dashboards.models.generate_dashboard_artifact import GeneratedDashbo
 from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.explorer.client import SeerExplorerClient
+from sentry.seer.explorer.client_utils import has_seer_explorer_access_with_detail
 from sentry.seer.models import SeerApiError, SeerPermissionError
-from sentry.seer.seer_setup import has_seer_explorer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -42,7 +42,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
-    owner = ApiOwner.ML_AI
+    owner = ApiOwner.DASHBOARDS
     enforce_rate_limit = True
     rate_limits = RateLimitConfig(
         limit_overrides={

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -28,9 +28,9 @@ WidgetType = Literal[
 class GeneratedWidgetQuery(BaseModel):
     name: str = ""
     conditions: str = ""
-    fields: list[str] = []
     aggregates: list[str] = []
     columns: list[str] = []
+    fields: list[str] = []
     orderby: str = ""
 
     @validator("fields", always=True)

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, validator
 
@@ -33,8 +33,9 @@ class GeneratedWidgetQuery(BaseModel):
     fields: list[str] = []
     orderby: str = ""
 
+    # Fields must include all columns and aggregates
     @validator("fields", always=True)
-    def populate_fields(cls, v: list[str], values: dict) -> list[str]:
+    def populate_fields(cls, v: list[str], values: dict[str, Any]) -> list[str]:
         return [*values.get("columns", []), *values.get("aggregates", [])]
 
 
@@ -70,7 +71,7 @@ class GeneratedWidgetLayout(BaseModel):
         return max(1, v)
 
     @validator("w", always=True)
-    def fit_within_grid(cls, w: int, values: dict) -> int:
+    def fit_within_grid(cls, w: int, values: dict[str, Any]) -> int:
         x = values.get("x", 0)
         if x + w > GRID_WIDTH:
             return GRID_WIDTH - x

--- a/src/sentry/dashboards/models/generate_dashboard_artifact.py
+++ b/src/sentry/dashboards/models/generate_dashboard_artifact.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, validator
+
+GRID_WIDTH = 6
+
+DisplayType = Literal[
+    "line",
+    "area",
+    "stacked_area",
+    "bar",
+    "table",
+    "big_number",
+    "top_n",
+]
+
+WidgetType = Literal[
+    "issue",
+    "error-events",
+    "spans",
+    "logs",
+    "tracemetrics",
+]
+
+
+class GeneratedWidgetQuery(BaseModel):
+    name: str = ""
+    conditions: str = ""
+    fields: list[str] = []
+    aggregates: list[str] = []
+    columns: list[str] = []
+    orderby: str = ""
+
+    @validator("fields", always=True)
+    def populate_fields(cls, v: list[str], values: dict) -> list[str]:
+        return [*values.get("columns", []), *values.get("aggregates", [])]
+
+
+class GeneratedWidgetLayout(BaseModel):
+    x: int = Field(
+        default=0,
+        description=f"Column position (0-{GRID_WIDTH - 1}). x + w must not exceed {GRID_WIDTH}.",
+    )
+    y: int = Field(default=0, description="Row position (0+).")
+    w: int = Field(
+        default=GRID_WIDTH,
+        description=f"Width in columns (1-{GRID_WIDTH}). x + w must not exceed {GRID_WIDTH}.",
+    )
+    h: int = Field(
+        default=2, description="Height in rows (1+). A height of 2 is approximately 256px."
+    )
+    min_h: int = Field(default=2, description="Minimum height in rows (1+).")
+
+    @validator("x", pre=True, always=True)
+    def clamp_x(cls, v: int) -> int:
+        return max(0, min(v, GRID_WIDTH - 1))
+
+    @validator("w", pre=True, always=True)
+    def clamp_w(cls, v: int) -> int:
+        return max(1, min(v, GRID_WIDTH))
+
+    @validator("h", pre=True, always=True)
+    def clamp_h(cls, v: int) -> int:
+        return max(1, v)
+
+    @validator("min_h", pre=True, always=True)
+    def clamp_min_h(cls, v: int) -> int:
+        return max(1, v)
+
+    @validator("w", always=True)
+    def fit_within_grid(cls, w: int, values: dict) -> int:
+        x = values.get("x", 0)
+        if x + w > GRID_WIDTH:
+            return GRID_WIDTH - x
+        return w
+
+
+class GeneratedWidget(BaseModel):
+    title: str
+    description: str | None = None
+    display_type: DisplayType
+    widget_type: WidgetType = "spans"
+    queries: list[GeneratedWidgetQuery]
+    layout: GeneratedWidgetLayout | None = None
+    limit: int | None = Field(default=None, le=10)
+
+
+class GeneratedDashboard(BaseModel):
+    title: str
+    widgets: list[GeneratedWidget]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -100,6 +100,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-issue-widget-series-display-type", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable text widgets for dashboards
     manager.add("organizations:dashboards-text-widgets", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable AI-powered dashboard generation via Seer
+    manager.add("organizations:dashboards-ai-generate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy
     manager.add("organizations:data-secrecy", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Data Secrecy v2 (with Break the Glass feature)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -217,6 +217,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/favorite/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/visit/'
+  | '/organizations/$organizationIdOrSlug/dashboards/generate/'
   | '/organizations/$organizationIdOrSlug/dashboards/starred/'
   | '/organizations/$organizationIdOrSlug/dashboards/starred/order/'
   | '/organizations/$organizationIdOrSlug/dashboards/widgets/'

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -10,6 +10,7 @@ from sentry.testutils.helpers.features import with_feature
 
 @with_feature("organizations:dashboards-ai-generate")
 @with_feature("organizations:gen-ai-features")
+@with_feature("organizations:seer-explorer")
 class OrganizationDashboardGenerateEndpointTest(APITestCase):
     endpoint = "sentry-api-0-organization-dashboards-generate"
 
@@ -55,7 +56,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
         assert response.status_code == 403
 
     @patch(
-        "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_access_with_detail"
+        "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_explorer_access_with_detail"
     )
     def test_post_without_seer_access_returns_403(self, mock_has_access: MagicMock) -> None:
         mock_has_access.return_value = (False, "AI features are disabled for this organization.")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import ANY, MagicMock, patch
+
+from sentry.seer.models import SeerPermissionError
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+@with_feature("organizations:dashboards-ai-generate")
+@with_feature("organizations:gen-ai-features")
+class OrganizationDashboardGenerateEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-dashboards-generate"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.url = f"/api/0/organizations/{self.organization.slug}/dashboards/generate/"
+
+    def test_post_without_prompt_returns_400(self) -> None:
+        data: dict[str, Any] = {}
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 400
+
+    def test_post_with_empty_prompt_returns_400(self) -> None:
+        data = {"prompt": ""}
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 400
+
+    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerExplorerClient")
+    def test_post_starts_run_and_returns_run_id(self, mock_client_class: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_run.return_value = 789
+        mock_client_class.return_value = mock_client
+
+        data = {"prompt": "Show me error rates by project"}
+        response = self.client.post(self.url, data, format="json")
+
+        assert response.status_code == 200
+        assert response.data == {"run_id": 789}
+
+        mock_client_class.assert_called_once_with(self.organization, ANY)
+        mock_client.start_run.assert_called_once_with(
+            prompt="Show me error rates by project",
+            artifact_key="dashboard",
+            artifact_schema=ANY,
+            request=ANY,
+        )
+
+    @with_feature({"organizations:dashboards-ai-generate": False})
+    def test_post_without_feature_flag_returns_403(self) -> None:
+        data = {"prompt": "Show me error rates"}
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 403
+
+    @patch(
+        "sentry.dashboards.endpoints.organization_dashboard_generate.has_seer_access_with_detail"
+    )
+    def test_post_without_seer_access_returns_403(self, mock_has_access: MagicMock) -> None:
+        mock_has_access.return_value = (False, "AI features are disabled for this organization.")
+        data = {"prompt": "Show me error rates"}
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 403
+
+    @patch("sentry.dashboards.endpoints.organization_dashboard_generate.SeerExplorerClient")
+    def test_post_seer_permission_error_returns_403(self, mock_client_class: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.start_run.side_effect = SeerPermissionError("Forbidden")
+        mock_client_class.return_value = mock_client
+
+        data = {"prompt": "Show me error rates"}
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 403
+
+    def test_get_not_allowed(self) -> None:
+        response = self.client.get(self.url)
+        assert response.status_code == 405


### PR DESCRIPTION
- Adds a new `GeneratedDashboard` artifact, for building dashboard and widget payloads via Seer
- Adds a new `dashboards/generate/` endpoint that start a new seer run using the new `GeneratedDashboard` artifact
- Only for internal testing at the moment