### PR TITLE
fix(seer): Set explicit 30s timeout on Seer connection pools

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from rest_framework import serializers
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 from urllib3.util.retry import Retry
+from urllib3.util.timeout import Timeout
 
 from sentry import features, options, ratelimits
 from sentry.constants import DataCategory
@@ -160,6 +161,7 @@ class CodingAgentStateUpdateRequest(BaseModel):
 
 autofix_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 

--- a/src/sentry/seer/code_review/utils.py
+++ b/src/sentry/seer/code_review/utils.py
@@ -10,6 +10,7 @@ from typing import Any
 import orjson
 from django.conf import settings
 from urllib3.exceptions import HTTPError
+from urllib3.util.timeout import Timeout
 
 from sentry import features
 from sentry.integrations.github.client import GitHubReaction
@@ -26,7 +27,9 @@ from .metrics import CodeReviewErrorType, record_webhook_handler_error
 
 logger = logging.getLogger(__name__)
 
-seer_code_review_connection_pool = connection_from_url(settings.SEER_PREVENT_AI_URL)
+seer_code_review_connection_pool = connection_from_url(
+    settings.SEER_PREVENT_AI_URL, timeout=Timeout(connect=30, read=30)
+)
 
 
 class Log(enum.StrEnum):

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+from urllib3.util.timeout import Timeout
 
 from sentry import features
 from sentry.constants import ObjectStatus
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 explorer_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -8,6 +8,7 @@ import orjson
 import sentry_sdk
 from django.conf import settings
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
+from urllib3.util.timeout import Timeout
 
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics
@@ -28,14 +29,17 @@ logger = logging.getLogger(__name__)
 
 seer_summarization_default_connection_pool = connection_from_url(
     settings.SEER_SUMMARIZATION_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 seer_autofix_default_connection_pool = connection_from_url(
     settings.SEER_AUTOFIX_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 seer_anomaly_detection_default_connection_pool = connection_from_url(
     settings.SEER_ANOMALY_DETECTION_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 

--- a/src/sentry/seer/similarity/grouping_records.py
+++ b/src/sentry/seer/similarity/grouping_records.py
@@ -6,6 +6,7 @@ from typing import TypedDict
 
 from django.conf import settings
 from urllib3.exceptions import MaxRetryError, ReadTimeoutError, TimeoutError
+from urllib3.util.timeout import Timeout
 
 from sentry import options
 from sentry.conf.server import (
@@ -29,7 +30,9 @@ class CreateGroupingRecordData(TypedDict):
     exception_type: str | None
 
 
-seer_grouping_connection_pool = connection_from_url(settings.SEER_GROUPING_URL)
+seer_grouping_connection_pool = connection_from_url(
+    settings.SEER_GROUPING_URL, timeout=Timeout(connect=30, read=30)
+)
 
 
 def call_seer_to_delete_project_grouping_records(

--- a/src/sentry/seer/similarity/similar_issues.py
+++ b/src/sentry/seer/similarity/similar_issues.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.utils import timezone
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 from urllib3.exceptions import MaxRetryError, TimeoutError
+from urllib3.util.timeout import Timeout
 
 from sentry import options
 from sentry.conf.server import (
@@ -33,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 seer_grouping_connection_pool = connection_from_url(
     settings.SEER_GROUPING_URL,
+    timeout=Timeout(connect=30, read=30),
 )
 
 


### PR DESCRIPTION
Sentry sets `socket.setdefaulttimeout(5)` globally in `conf/server.py`. When
Seer API calls were migrated from `requests.post()` to urllib3 connection pools,
pools created via `connection_from_url()` without an explicit timeout inherited
this 5-second global socket default through urllib3's `_DEFAULT_TIMEOUT` sentinel.

The old `requests.post()` calls were unaffected because the requests library
explicitly passes `timeout=None` to urllib3 internally, which overrides the
socket default. This meant calls that previously had no timeout suddenly got a
5s timeout after migration — causing spurious timeouts on AI-backed endpoints
that legitimately take longer to respond.

This sets `Timeout(connect=30, read=30)` on all Seer connection pools that
previously had no explicit timeout. 30s is a reasonable upper bound that
prevents hung connections while giving AI calls enough time to complete.

Pools with intentionally shorter timeouts (anomaly detection at 5s, breakpoint
detection at 5s, severity scoring at 300ms, fixability at 600ms, historical
anomaly detection at 10s) are unchanged — those had explicit timeout values
before the migration and were not affected.