### PR TITLE
feat(preprod): Filter snapshot artifacts from builds endpoint when display is set

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -67,6 +67,10 @@ class BuildsEndpoint(OrganizationEndpoint):
             if end:
                 queryset = queryset.filter(date_added__lte=end)
             queryset = queryset.filter(project_id__in=params["project_id"])
+
+            display = request.GET.get("display")
+            if display in ("size", "distribution"):
+                queryset = queryset.filter(preprodsnapshotmetrics__isnull=True)
         except InvalidSearchQuery as e:
             # CodeQL complains about str(e) below but ~all handlers
             # of InvalidSearchQuery do the same as this.


### PR DESCRIPTION
When the `display` query parameter is set to `size` or `distribution`, the builds endpoint now excludes artifacts that have associated snapshot metrics. These are snapshot artifacts that shouldn't appear in size/distribution build views — they're only relevant in the snapshots view.

The filtering uses a subquery on `PreprodSnapshotMetrics` to identify and exclude snapshot artifact IDs from the queryset.