### PR TITLE
feat(eslint): add initial no-default-export-components rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -603,6 +603,7 @@ export default typescript.config([
           '@typescript-eslint/prefer-promise-reject-errors': 'error',
           '@typescript-eslint/require-await': 'error',
           '@typescript-eslint/no-meaningless-void-operator': 'error',
+          '@sentry/no-default-export-components': 'error',
           '@sentry/no-unnecessary-type-annotation': 'error',
         }
       : {},

--- a/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
+++ b/static/app/components/events/attachmentViewers/previewAttachmentTypes.tsx
@@ -1,7 +1,7 @@
 import {ImageViewer} from 'sentry/components/events/attachmentViewers/imageViewer';
 import {JsonViewer} from 'sentry/components/events/attachmentViewers/jsonViewer';
 import {LogFileViewer} from 'sentry/components/events/attachmentViewers/logFileViewer';
-import RRWebJsonViewer from 'sentry/components/events/attachmentViewers/rrwebJsonViewer';
+import {RRWebJsonViewer} from 'sentry/components/events/attachmentViewers/rrwebJsonViewer';
 import {VideoViewer} from 'sentry/components/events/attachmentViewers/videoViewer';
 import type {IssueAttachment} from 'sentry/types/group';
 

--- a/static/app/components/events/attachmentViewers/rrwebJsonViewer.tsx
+++ b/static/app/components/events/attachmentViewers/rrwebJsonViewer.tsx
@@ -10,7 +10,7 @@ type State = {
   showRawJson: boolean;
 };
 
-export default class RRWebJsonViewer extends Component<ViewerProps, State> {
+export class RRWebJsonViewer extends Component<ViewerProps, State> {
   state: State = {
     showRawJson: false,
   };

--- a/static/app/components/repositories/scmIntegrationTree/scmTreeFilters.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmTreeFilters.tsx
@@ -14,7 +14,7 @@ interface Props {
   setSearchTerm: (searchTerm: string) => void;
 }
 
-export default function ScmTreeFilters({
+export function ScmTreeFilters({
   repoFilter,
   setRepoFilter,
   searchTerm,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -81,7 +81,7 @@ import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {ConfidenceFooter} from 'sentry/views/explore/spans/charts/confidenceFooter';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
-import ThresholdsChart from './thresholdsChart';
+import {ThresholdsChart} from './thresholdsChart';
 
 type Props = {
   aggregate: MetricRule['aggregate'];

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -114,7 +114,7 @@ function getYAxisBounds(
  * This chart displays shaded regions that represent different Trigger thresholds in a
  * Metric Alert rule.
  */
-export default class ThresholdsChart extends PureComponent<Props> {
+export class ThresholdsChart extends PureComponent<Props> {
   static defaultProps: DefaultProps = {
     data: [],
     comparisonData: [],

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
@@ -28,7 +28,7 @@ import {
   sortDirections,
   type SortDirection,
 } from 'sentry/views/dashboards/widgetBuilder/utils';
-import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
+import {ArithmeticInput} from 'sentry/views/discover/table/arithmeticInput';
 import {QueryField} from 'sentry/views/discover/table/queryField';
 import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -61,7 +61,7 @@ import useIsEditingWidget from 'sentry/views/dashboards/widgetBuilder/hooks/useI
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
 import {SESSIONS_TAGS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
-import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
+import {ArithmeticInput} from 'sentry/views/discover/table/arithmeticInput';
 import {validateColumnTypes} from 'sentry/views/discover/table/queryField';
 import {FieldValueKind, type FieldValue} from 'sentry/views/discover/table/types';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';

--- a/static/app/views/discover/table/arithmeticInput.spec.tsx
+++ b/static/app/views/discover/table/arithmeticInput.spec.tsx
@@ -2,7 +2,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import type {Column} from 'sentry/utils/discover/fields';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
-import ArithmeticInput from 'sentry/views/discover/table/arithmeticInput';
+import {ArithmeticInput} from 'sentry/views/discover/table/arithmeticInput';
 
 describe('ArithmeticInput', () => {
   const operators = ['+', '-', '*', '/', '(', ')'];

--- a/static/app/views/discover/table/arithmeticInput.tsx
+++ b/static/app/views/discover/table/arithmeticInput.tsx
@@ -43,7 +43,7 @@ type State = {
   rawOptions: Column[];
 };
 
-export default class ArithmeticInput extends PureComponent<Props, State> {
+export class ArithmeticInput extends PureComponent<Props, State> {
   static defaultProps: DefaultProps = {
     options: [],
   };

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -28,7 +28,7 @@ import type {FieldValueType} from 'sentry/utils/fields';
 import {SESSIONS_OPERATIONS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 
-import ArithmeticInput from './arithmeticInput';
+import {ArithmeticInput} from './arithmeticInput';
 import type {FieldValue, FieldValueColumns} from './types';
 import {FieldValueKind} from './types';
 

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -31,7 +31,7 @@ import normalizeUrl from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import RouteError from 'sentry/views/routeError';
-import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {AddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import IntegrationLayout from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
 interface GitHubIntegrationInstallation {

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.spec.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import selectEvent from 'sentry-test/selectEvent';
 
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
-import AwsLambdaCloudformation from 'sentry/views/integrationPipeline/awsLambdaCloudformation';
+import {AwsLambdaCloudformation} from 'sentry/views/integrationPipeline/awsLambdaCloudformation';
 
 describe('AwsLambdaCloudformation', () => {
   beforeEach(() => {

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -56,7 +56,7 @@ type State = {
   submitting?: boolean;
 };
 
-export default class AwsLambdaCloudformation extends Component<Props, State> {
+export class AwsLambdaCloudformation extends Component<Props, State> {
   state: State = {
     accountNumber: this.props.accountNumber,
     region: this.props.region,

--- a/static/app/views/integrationPipeline/awsLambdaFunctionSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaFunctionSelect.spec.tsx
@@ -1,6 +1,6 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import AwsLambdaFunctionSelect from 'sentry/views/integrationPipeline/awsLambdaFunctionSelect';
+import {AwsLambdaFunctionSelect} from 'sentry/views/integrationPipeline/awsLambdaFunctionSelect';
 
 describe('AwsLambdaFunctionSelect', () => {
   it('choose lambdas', async () => {

--- a/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -37,7 +37,7 @@ type State = {
 
 const getLabel = (func: LambdaFunction) => func.FunctionName;
 
-export default class AwsLambdaFunctionSelect extends Component<Props, State> {
+export class AwsLambdaFunctionSelect extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     makeObservable(this, {allStatesToggled: computed});

--- a/static/app/views/integrationPipeline/awsLambdaProjectSelect.spec.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaProjectSelect.spec.tsx
@@ -5,7 +5,7 @@ import selectEvent from 'sentry-test/selectEvent';
 
 import type {Project} from 'sentry/types/project';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
-import AwsLambdaProjectSelect from 'sentry/views/integrationPipeline/awsLambdaProjectSelect';
+import {AwsLambdaProjectSelect} from 'sentry/views/integrationPipeline/awsLambdaProjectSelect';
 
 describe('AwsLambdaProjectSelect', () => {
   let projects: Project[];

--- a/static/app/views/integrationPipeline/awsLambdaProjectSelect.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaProjectSelect.tsx
@@ -20,7 +20,7 @@ import {HeaderWithHelp} from './components/headerWithHelp';
 
 type Props = {projects: Project[]};
 
-export default class AwsLambdaProjectSelect extends Component<Props> {
+export class AwsLambdaProjectSelect extends Component<Props> {
   model = new FormModel();
 
   handleSubmit = (e: React.MouseEvent) => {

--- a/static/app/views/integrationPipeline/pipelineView.spec.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.spec.tsx
@@ -13,10 +13,9 @@ function MockAwsLambdaProjectSelect() {
   return <div>mock_AwsLambdaProjectSelect</div>;
 }
 
-jest.mock(
-  'sentry/views/integrationPipeline/awsLambdaProjectSelect',
-  () => MockAwsLambdaProjectSelect
-);
+jest.mock('sentry/views/integrationPipeline/awsLambdaProjectSelect', () => ({
+  AwsLambdaProjectSelect: MockAwsLambdaProjectSelect,
+}));
 
 describe('PipelineView', () => {
   beforeEach(() => {

--- a/static/app/views/integrationPipeline/pipelineView.tsx
+++ b/static/app/views/integrationPipeline/pipelineView.tsx
@@ -22,10 +22,10 @@ import useApi from 'sentry/utils/useApi';
 import {GithubInstallationSelect} from 'sentry/views/integrationPipeline/githubInstallationSelect';
 import {OrganizationContextProvider} from 'sentry/views/organizationContext';
 
-import AwsLambdaCloudformation from './awsLambdaCloudformation';
+import {AwsLambdaCloudformation} from './awsLambdaCloudformation';
 import {AwsLambdaFailureDetails} from './awsLambdaFailureDetails';
-import AwsLambdaFunctionSelect from './awsLambdaFunctionSelect';
-import AwsLambdaProjectSelect from './awsLambdaProjectSelect';
+import {AwsLambdaFunctionSelect} from './awsLambdaFunctionSelect';
+import {AwsLambdaProjectSelect} from './awsLambdaProjectSelect';
 
 const pipelineMapper: Record<string, [React.ComponentType<any>, string]> = {
   awsLambdaProjectSelect: [AwsLambdaProjectSelect, 'AWS Lambda Select Project'],

--- a/static/app/views/navigation/secondary/sections/prevent/preventSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/prevent/preventSecondaryNavigation.tsx
@@ -19,7 +19,7 @@ function makePreventPathname({
   return normalizeUrl(`/organizations/${organization.slug}/prevent${path}`);
 }
 
-export default function PreventSecondaryNavigation() {
+export function PreventSecondaryNavigation() {
   const organization = useOrganization();
   const testsPathname = makePreventPathname({
     organization,

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -21,7 +21,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
-import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
+import {PermissionSelection} from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
 const API_INDEX_ROUTE = '/settings/account/api/auth-tokens/';
 

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 import {PRIMARY_NAVIGATION_GROUP_CONFIG} from 'sentry/views/navigation/primary/config';
 import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
 import type {PrimaryNavigationGroup} from 'sentry/views/navigation/types';
-import SettingsNavigationGroup from 'sentry/views/settings/components/settingsNavigationGroup';
+import {SettingsNavigationGroup} from 'sentry/views/settings/components/settingsNavigationGroup';
 import type {NavigationProps, NavigationSection} from 'sentry/views/settings/types';
 
 type DefaultProps = {

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -5,7 +5,7 @@ import {SecondaryNavigation} from 'sentry/views/navigation/secondary/secondary';
 import {SettingsNavItem} from 'sentry/views/settings/components/settingsNavItem';
 import type {NavigationGroupProps} from 'sentry/views/settings/types';
 
-function SettingsNavigationGroup(props: NavigationGroupProps) {
+export function SettingsNavigationGroup(props: NavigationGroupProps) {
   const {organization, project, name, items} = props;
   const params = useParams();
 
@@ -54,5 +54,3 @@ function SettingsNavigationGroup(props: NavigationGroupProps) {
     </SecondaryNavigation.Section>
   );
 }
-
-export default SettingsNavigationGroup;

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.spec.tsx
@@ -3,7 +3,7 @@ import selectEvent from 'sentry-test/selectEvent';
 
 import Form from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
-import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
+import {PermissionSelection} from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
 describe('PermissionSelection', () => {
   let onChange: jest.Mock;

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -113,7 +113,7 @@ function permissionStateToList(permissions: Permissions) {
   );
 }
 
-export default class PermissionSelection extends Component<Props, State> {
+export class PermissionSelection extends Component<Props, State> {
   state: State = {
     permissions: this.props.permissions,
   };

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.spec.tsx
@@ -2,7 +2,7 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import Form from 'sentry/components/forms/form';
 import FormModel from 'sentry/components/forms/model';
-import PermissionsObserver from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
+import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
 describe('PermissionsObserver', () => {
   let model: FormModel;

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -12,8 +12,8 @@ import {
   comparePermissionLevels,
   toResourcePermissions,
 } from 'sentry/utils/consolidatedScopes';
-import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
-import Subscriptions from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
+import {PermissionSelection} from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
+import {Subscriptions} from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 
 type DefaultProps = {
   appPublished: boolean;
@@ -32,7 +32,7 @@ type State = {
   permissions: Permissions;
 };
 
-export default class PermissionsObserver extends Component<Props, State> {
+export class PermissionsObserver extends Component<Props, State> {
   static defaultProps: DefaultProps = {
     webhookDisabled: false,
     appPublished: false,

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.tsx
@@ -1,7 +1,7 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import Form from 'sentry/components/forms/form';
-import Subscriptions from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
+import {Subscriptions} from 'sentry/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 
 describe('Resource Subscriptions', () => {
   describe('initial no-access permissions', () => {

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -21,7 +21,7 @@ type Props = DefaultProps & {
   permissions: Permissions;
 };
 
-export default class Subscriptions extends Component<Props> {
+export class Subscriptions extends Component<Props> {
   static defaultProps: DefaultProps = {
     webhookDisabled: false,
   };

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -56,7 +56,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {ApiTokenRow} from 'sentry/views/settings/account/apiTokenRow';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import PermissionsObserver from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
+import {PermissionsObserver} from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
 
 type Resource = 'Project' | 'Team' | 'Release' | 'Event' | 'Organization' | 'Member';
 

--- a/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
@@ -7,7 +7,7 @@ import {setWindowLocation} from 'sentry-test/utils';
 
 import ConfigStore from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import AddIntegration from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {AddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 
 describe('AddIntegration', () => {
   const provider = GitHubIntegrationProviderFixture();

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -31,7 +31,7 @@ type Props = {
   modalParams?: Record<string, string>;
 };
 
-export default class AddIntegration extends Component<Props> {
+export class AddIntegration extends Component<Props> {
   componentDidMount() {
     window.addEventListener('message', this.didReceiveMessage);
   }

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 
-import AddIntegration from './addIntegration';
+import {AddIntegration} from './addIntegration';
 
 interface AddIntegrationButtonProps
   extends

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -43,7 +43,7 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import AddIntegration from './addIntegration';
+import {AddIntegration} from './addIntegration';
 import {IntegrationAlertRules} from './integrationAlertRules';
 import {IntegrationCodeMappings} from './integrationCodeMappings';
 import {IntegrationExternalTeamMappings} from './integrationExternalTeamMappings';

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -40,7 +40,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
-import RepositoryProjectPathConfigModal from './repositoryProjectPathConfigForm';
+import {RepositoryProjectPathConfigModal} from './repositoryProjectPathConfigForm';
 import RepositoryProjectPathConfigRow, {
   ButtonWrapper,
   InputPathColumn,

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.spec.tsx
@@ -2,7 +2,7 @@ import {GitHubIntegrationFixture} from 'sentry-fixture/githubIntegration';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import IntegrationExternalMappingForm from './integrationExternalMappingForm';
+import {IntegrationExternalMappingForm} from './integrationExternalMappingForm';
 
 describe('IntegrationExternalMappingForm', () => {
   const dataEndpoint = '/test/dataEndpoint/';

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappingForm.tsx
@@ -34,7 +34,7 @@ type Props = Pick<FormProps, 'onCancel' | 'onSubmitSuccess' | 'onSubmitError'> &
     onResults?: (data: any, mappingKey?: string) => void;
   };
 
-export default class IntegrationExternalMappingForm extends Component<Props> {
+export class IntegrationExternalMappingForm extends Component<Props> {
   model = new FormModel();
 
   get initialData() {

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
@@ -25,7 +25,7 @@ import {capitalize} from 'sentry/utils/string/capitalize';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import IntegrationExternalMappingForm from './integrationExternalMappingForm';
+import {IntegrationExternalMappingForm} from './integrationExternalMappingForm';
 
 type CodeOwnersAssociationMappings = Record<
   string,

--- a/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -19,7 +19,7 @@ import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import IntegrationExternalMappingForm from './integrationExternalMappingForm';
+import {IntegrationExternalMappingForm} from './integrationExternalMappingForm';
 import {IntegrationExternalMappings} from './integrationExternalMappings';
 
 type Props = {

--- a/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -18,7 +18,7 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import IntegrationExternalMappingForm from './integrationExternalMappingForm';
+import {IntegrationExternalMappingForm} from './integrationExternalMappingForm';
 import {IntegrationExternalMappings} from './integrationExternalMappings';
 
 type Props = {

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.spec.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sentry/components/globalModal/components';
 import * as analytics from 'sentry/utils/analytics';
 
-import RepositoryProjectPathConfigModal from './repositoryProjectPathConfigForm';
+import {RepositoryProjectPathConfigModal} from './repositoryProjectPathConfigForm';
 
 describe('RepositoryProjectPathConfigModal', () => {
   const organization = OrganizationFixture();

--- a/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.tsx
+++ b/static/app/views/settings/organizationIntegrations/repositoryProjectPathConfigForm.tsx
@@ -45,7 +45,7 @@ const integrationReposOptions = (
     }
   );
 
-export default function RepositoryProjectPathConfigModal({
+export function RepositoryProjectPathConfigModal({
   Body,
   Footer,
   Header,

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.tsx
@@ -4,7 +4,7 @@ import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import OrganizationMemberRow from 'sentry/views/settings/organizationMembers/organizationMemberRow';
+import {OrganizationMemberRow} from 'sentry/views/settings/organizationMembers/organizationMemberRow';
 
 describe('OrganizationMemberRow', () => {
   const member = MemberFixture({

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -40,7 +40,7 @@ const DisabledMemberTooltip = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
-export default class OrganizationMemberRow extends PureComponent<Props, State> {
+export class OrganizationMemberRow extends PureComponent<Props, State> {
   state: State = {
     busy: false,
   };

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -42,7 +42,7 @@ import InviteBanner from 'sentry/views/settings/organizationMembers/inviteBanner
 
 import {MembersFilter} from './components/membersFilter';
 import {InviteRequestRow} from './inviteRequestRow';
-import OrganizationMemberRow from './organizationMemberRow';
+import {OrganizationMemberRow} from './organizationMemberRow';
 
 const MemberListHeader = HookOrDefault({
   hookName: 'component:member-list-header',

--- a/static/app/views/settings/organizationRepositories/index.tsx
+++ b/static/app/views/settings/organizationRepositories/index.tsx
@@ -3,7 +3,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import {ScmIntegrationTree} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTree';
-import ScmTreeFilters from 'sentry/components/repositories/scmIntegrationTree/scmTreeFilters';
+import {ScmTreeFilters} from 'sentry/components/repositories/scmIntegrationTree/scmTreeFilters';
 import useScmTreeFilters from 'sentry/components/repositories/scmIntegrationTree/useScmTreeFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';

--- a/static/app/views/settings/project/projectOwnership/editRulesModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/editRulesModal.tsx
@@ -6,7 +6,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import type {EditOwnershipRulesModalOptions} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 import {useUser} from 'sentry/utils/useUser';
-import OwnerInput from 'sentry/views/settings/project/projectOwnership/ownerInput';
+import {OwnerInput} from 'sentry/views/settings/project/projectOwnership/ownerInput';
 
 interface EditOwnershipRulesModalProps extends EditOwnershipRulesModalOptions {
   onCancel: () => void;

--- a/static/app/views/settings/project/projectOwnership/modal.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.tsx
@@ -15,7 +15,7 @@ import {uniq} from 'sentry/utils/array/uniq';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useUser} from 'sentry/utils/useUser';
-import OwnerInput from 'sentry/views/settings/project/projectOwnership/ownerInput';
+import {OwnerInput} from 'sentry/views/settings/project/projectOwnership/ownerInput';
 
 type IssueOwnershipResponse = {
   autoAssignment: boolean;

--- a/static/app/views/settings/project/projectOwnership/ownerInput.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.spec.tsx
@@ -5,7 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import MemberListStore from 'sentry/stores/memberListStore';
-import OwnerInput from 'sentry/views/settings/project/projectOwnership/ownerInput';
+import {OwnerInput} from 'sentry/views/settings/project/projectOwnership/ownerInput';
 
 describe('Project Ownership Input', () => {
   const {organization, project} = initializeOrg();

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -46,7 +46,7 @@ function parseError(error: InputError | null) {
   return <SyntaxOverlay line={parseInt(text.match(/line (\d*),/)?.[1] ?? '', 10) - 1} />;
 }
 
-function OwnerInput({
+export function OwnerInput({
   dateUpdated,
   disabled = false,
   initialText,
@@ -226,5 +226,3 @@ const SyncDate = styled('div')`
   font-weight: ${p => p.theme.font.weight.sans.regular};
   text-transform: none;
 `;
-
-export default OwnerInput;

--- a/static/eslint/eslintPluginSentry/index.ts
+++ b/static/eslint/eslintPluginSentry/index.ts
@@ -1,7 +1,9 @@
+import {noDefaultExportComponents} from './no-default-export-components';
 import {noStaticTranslations} from './no-static-translations';
 import {noUnnecessaryTypeAnnotation} from './no-unnecessary-type-annotation';
 
 export const rules = {
+  'no-default-export-components': noDefaultExportComponents,
   'no-static-translations': noStaticTranslations,
   'no-unnecessary-type-annotation': noUnnecessaryTypeAnnotation,
 };

--- a/static/eslint/eslintPluginSentry/no-default-export-components.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-default-export-components.spec.ts
@@ -1,0 +1,47 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noDefaultExportComponents} from './no-default-export-components';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ['*.ts', '*.tsx', 'static/app/*.ts', 'static/app/*.tsx'],
+      },
+      tsconfigRootDir: __dirname,
+    },
+  },
+});
+
+ruleTester.run('no-default-export-components', noDefaultExportComponents, {
+  valid: [
+    {
+      code: `export function MyComponent() { return <div />; }`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export const MyComponent = () => <div />;`,
+      filename: 'valid.tsx',
+    },
+    {
+      code: `export const util = () => null;`,
+      filename: 'valid.tsx',
+    },
+  ],
+  invalid: [
+    {
+      code: 'function MyComponent() { return <div />; }\nexport default MyComponent;',
+      output: 'export function MyComponent() { return <div />; }\n',
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+    {
+      code: `const Panel = styled('div')\`padding: 0;\`;
+export default Panel;`,
+      output: `export const Panel = styled('div')\`padding: 0;\`;
+`,
+      errors: [{messageId: 'forbidden'}],
+      filename: 'invalid.tsx',
+    },
+  ],
+});

--- a/static/eslint/eslintPluginSentry/no-default-export-components.ts
+++ b/static/eslint/eslintPluginSentry/no-default-export-components.ts
@@ -1,0 +1,189 @@
+import {AST_NODE_TYPES, ESLintUtils, type TSESTree} from '@typescript-eslint/utils';
+import {getParserServices} from '@typescript-eslint/utils/eslint-utils';
+import ts from 'typescript';
+
+import {isReactComponentLike} from './utils/isReactComponentLike';
+import {lazy} from './utils/lazy';
+
+function unwrapParenthesized(node: ts.Node): ts.Node {
+  return ts.isParenthesizedExpression(node) ? unwrapParenthesized(node.expression) : node;
+}
+
+function collectResolvedImportFiles(program: ts.Program) {
+  const allowedFiles = new Set<string>();
+  const compilerOptions = program.getCompilerOptions();
+
+  function addResolvedModuleFromImportCall(
+    callExpr: ts.CallExpression,
+    sourceFile: ts.SourceFile
+  ) {
+    if (
+      callExpr.expression.kind !== ts.SyntaxKind.ImportKeyword ||
+      callExpr.arguments.length !== 1
+    ) {
+      return;
+    }
+    const argument = callExpr.arguments[0]!;
+    if (ts.isStringLiteralLike(argument)) {
+      const resolved = ts.resolveModuleName(
+        argument.text,
+        sourceFile.fileName,
+        compilerOptions,
+        ts.sys
+      );
+      if (resolved.resolvedModule?.resolvedFileName) {
+        allowedFiles.add(resolved.resolvedModule.resolvedFileName);
+      }
+    }
+  }
+
+  function visit(node: ts.Node, sourceFile: ts.SourceFile): void {
+    if (ts.isArrowFunction(node)) {
+      const body = unwrapParenthesized(node.body);
+      if (ts.isCallExpression(body)) {
+        addResolvedModuleFromImportCall(body, sourceFile);
+      }
+    }
+
+    if (ts.isAwaitExpression(node)) {
+      const expr = unwrapParenthesized(node.expression);
+      if (ts.isCallExpression(expr)) {
+        addResolvedModuleFromImportCall(expr, sourceFile);
+      }
+    }
+
+    ts.forEachChild(node, child => visit(child, sourceFile));
+  }
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (!sourceFile.isDeclarationFile) {
+      ts.forEachChild(sourceFile, child => visit(child, sourceFile));
+    }
+  }
+
+  return allowedFiles;
+}
+
+function findTopLevelFunctionDeclaration(
+  body: TSESTree.ProgramStatement[],
+  name: string
+) {
+  return body.find(
+    statement =>
+      statement.type === AST_NODE_TYPES.FunctionDeclaration && statement.id?.name === name
+  );
+}
+
+function findTopLevelVariableDeclaration(
+  body: TSESTree.ProgramStatement[],
+  name: string
+): TSESTree.VariableDeclaration | undefined {
+  return body.find((statement): statement is TSESTree.VariableDeclaration => {
+    if (statement.type !== AST_NODE_TYPES.VariableDeclaration) {
+      return false;
+    }
+    return statement.declarations.some(
+      decl => decl.id.type === AST_NODE_TYPES.Identifier && decl.id.name === name
+    );
+  });
+}
+
+const allowedFilesLazy = lazy(collectResolvedImportFiles);
+
+export const noDefaultExportComponents = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow default exports of React components that are not lazy-imported',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      forbidden:
+        'We prefer named exports. Default exports are not allowed unless this file is lazy-imported.',
+    },
+  },
+
+  create(context) {
+    const parserServices = getParserServices(context);
+    const allowedFiles = allowedFilesLazy(parserServices.program);
+    const currentFileName = ts.sys.resolvePath(context.filename);
+
+    if (
+      allowedFiles.has(currentFileName) ||
+      // TODO: Eventually, it'd be nice to fully ban all default exports of components...
+      context.sourceCode.ast.body.some(
+        statement => statement.type === AST_NODE_TYPES.ExportNamedDeclaration
+      )
+    ) {
+      return {};
+    }
+
+    return {
+      ExportDefaultDeclaration(node) {
+        if (
+          node.declaration.type === AST_NODE_TYPES.ClassDeclaration ||
+          node.declaration.type === AST_NODE_TYPES.FunctionDeclaration
+        ) {
+          if (
+            !node.declaration.id ||
+            !isReactComponentLike(node.declaration, context.sourceCode)
+          ) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'forbidden',
+            fix: fixer => [
+              fixer.replaceTextRange(
+                [node.range[0], node.declaration.range[0]],
+                'export '
+              ),
+            ],
+          });
+          return;
+        }
+
+        if (node.declaration.type === AST_NODE_TYPES.Identifier) {
+          const exportedName = node.declaration.name;
+          const functionDeclaration = findTopLevelFunctionDeclaration(
+            node.parent.body,
+            exportedName
+          );
+          const variableDeclaration = findTopLevelVariableDeclaration(
+            node.parent.body,
+            exportedName
+          );
+
+          const declarator = variableDeclaration?.declarations.find(
+            decl =>
+              decl.id.type === AST_NODE_TYPES.Identifier && decl.id.name === exportedName
+          );
+
+          const isComponent = functionDeclaration
+            ? isReactComponentLike(functionDeclaration, context.sourceCode)
+            : declarator
+              ? isReactComponentLike(declarator, context.sourceCode)
+              : false;
+
+          const declarationToExport = functionDeclaration ?? variableDeclaration;
+          if (!declarationToExport || !isComponent) {
+            return;
+          }
+
+          context.report({
+            node,
+            messageId: 'forbidden',
+            fix: fixer => [
+              fixer.insertTextBefore(declarationToExport, 'export '),
+              fixer.remove(node),
+            ],
+          });
+          return;
+        }
+      },
+    };
+  },
+});

--- a/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
+++ b/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
@@ -74,45 +74,52 @@ function isStyledComponentInit(node: TSESTree.Node) {
 }
 
 export function isReactComponentLike(node: TSESTree.Node, sourceCode: SourceCode) {
-  if (node.type === AST_NODE_TYPES.Identifier) {
-    return isPascalCase(node.name);
-  }
+  switch (node.type) {
+    case AST_NODE_TYPES.ClassDeclaration:
+      return (
+        node.superClass !== null &&
+        node.superClass.type === AST_NODE_TYPES.Identifier &&
+        node.superClass.name.includes('Component')
+      );
 
-  if (
-    node.type === AST_NODE_TYPES.FunctionDeclaration ||
-    node.type === AST_NODE_TYPES.FunctionExpression ||
-    node.type === AST_NODE_TYPES.ArrowFunctionExpression
-  ) {
-    const name = getFunctionName(node);
-    if (name && isPascalCase(name)) {
-      return true;
+    case AST_NODE_TYPES.FunctionDeclaration:
+    case AST_NODE_TYPES.FunctionExpression:
+    case AST_NODE_TYPES.ArrowFunctionExpression: {
+      const name = getFunctionName(node);
+      if (name && isPascalCase(name)) {
+        return true;
+      }
+
+      return containsJsx(node.body, sourceCode);
     }
 
-    return containsJsx(node.body, sourceCode);
-  }
+    case AST_NODE_TYPES.Identifier:
+      return isPascalCase(node.name);
 
-  if (node.type === AST_NODE_TYPES.VariableDeclarator) {
-    if (
-      node.id.type !== AST_NODE_TYPES.Identifier ||
-      !node.init ||
-      !isPascalCase(node.id.name)
-    ) {
+    case AST_NODE_TYPES.VariableDeclarator: {
+      if (
+        node.id.type !== AST_NODE_TYPES.Identifier ||
+        !node.init ||
+        !isPascalCase(node.id.name)
+      ) {
+        return false;
+      }
+
+      if (
+        node.init.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+        node.init.type === AST_NODE_TYPES.FunctionExpression
+      ) {
+        return containsJsx(node.init, sourceCode);
+      }
+
+      if (isStyledComponentInit(node.init)) {
+        return true;
+      }
+
       return false;
     }
 
-    if (
-      node.init.type === AST_NODE_TYPES.FunctionExpression ||
-      node.init.type === AST_NODE_TYPES.ArrowFunctionExpression
-    ) {
-      return containsJsx(node.init, sourceCode);
-    }
-
-    if (isStyledComponentInit(node.init)) {
-      return true;
-    }
-
-    return false;
+    default:
+      return false;
   }
-
-  return false;
 }

--- a/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
+++ b/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
@@ -49,7 +49,11 @@ function getFunctionName(
 function isPascalCase(name: string) {
   return /^[A-Z][A-Za-z0-9]*$/u.test(name);
 }
+const PASCAL_CASE_RE = /^[A-Z][A-Za-z0-9]*$/u;
 
+function isPascalCase(name: string) {
+  return PASCAL_CASE_RE.test(name);
+}
 function isStyledCallExpression(node: TSESTree.Node) {
   if (node.type !== AST_NODE_TYPES.CallExpression) {
     return false;

--- a/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
+++ b/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
@@ -1,0 +1,118 @@
+import {AST_NODE_TYPES, type TSESTree} from '@typescript-eslint/utils';
+import type {SourceCode} from '@typescript-eslint/utils/ts-eslint';
+
+function containsJsx(node: TSESTree.Node, sourceCode: SourceCode): boolean {
+  const stack = [node];
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+
+    if (
+      current.type === AST_NODE_TYPES.JSXElement ||
+      current.type === AST_NODE_TYPES.JSXFragment
+    ) {
+      return true;
+    }
+
+    const keys = sourceCode.visitorKeys[current.type] ?? [];
+
+    for (const key of keys) {
+      const child = (current as any)[key];
+
+      if (Array.isArray(child)) {
+        stack.push(...child);
+      } else if (child) {
+        stack.push(child);
+      }
+    }
+  }
+
+  return false;
+}
+
+function getFunctionName(
+  node:
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression
+    | TSESTree.ArrowFunctionExpression
+) {
+  return (
+    (node.type === AST_NODE_TYPES.FunctionDeclaration ||
+      node.type === AST_NODE_TYPES.FunctionExpression) &&
+    node.id?.name
+  );
+}
+
+function isPascalCase(name: string) {
+  return /^[A-Z][A-Za-z0-9]*$/u.test(name);
+}
+
+function isStyledCallExpression(node: TSESTree.Node) {
+  if (node.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+  const callee = node.callee;
+  return (
+    (callee.type === AST_NODE_TYPES.Identifier && callee.name === 'styled') ||
+    (callee.type === AST_NODE_TYPES.MemberExpression &&
+      callee.property.type === AST_NODE_TYPES.Identifier &&
+      callee.property.name === 'styled')
+  );
+}
+
+function isStyledComponentInit(node: TSESTree.Node) {
+  if (isStyledCallExpression(node)) {
+    return true;
+  }
+  if (node.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+    return isStyledCallExpression(node.tag);
+  }
+  return false;
+}
+
+export function isReactComponentLike(node: TSESTree.Node, sourceCode: SourceCode) {
+  if (node.type === AST_NODE_TYPES.Identifier) {
+    return isPascalCase(node.name);
+  }
+
+  if (
+    node.type === AST_NODE_TYPES.FunctionDeclaration ||
+    node.type === AST_NODE_TYPES.FunctionExpression ||
+    node.type === AST_NODE_TYPES.ArrowFunctionExpression
+  ) {
+    const name = getFunctionName(node);
+    if (name && isPascalCase(name)) {
+      return true;
+    }
+
+    return containsJsx(node.body, sourceCode);
+  }
+
+  if (node.type === AST_NODE_TYPES.VariableDeclarator) {
+    if (
+      node.id.type !== AST_NODE_TYPES.Identifier ||
+      !node.init ||
+      !isPascalCase(node.id.name)
+    ) {
+      return false;
+    }
+
+    if (
+      node.init.type === AST_NODE_TYPES.FunctionExpression ||
+      node.init.type === AST_NODE_TYPES.ArrowFunctionExpression
+    ) {
+      return containsJsx(node.init, sourceCode);
+    }
+
+    if (isStyledComponentInit(node.init)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  return false;
+}

--- a/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
+++ b/static/eslint/eslintPluginSentry/utils/isReactComponentLike.ts
@@ -46,14 +46,12 @@ function getFunctionName(
   );
 }
 
-function isPascalCase(name: string) {
-  return /^[A-Z][A-Za-z0-9]*$/u.test(name);
-}
 const PASCAL_CASE_RE = /^[A-Z][A-Za-z0-9]*$/u;
 
 function isPascalCase(name: string) {
   return PASCAL_CASE_RE.test(name);
 }
+
 function isStyledCallExpression(node: TSESTree.Node) {
   if (node.type !== AST_NODE_TYPES.CallExpression) {
     return false;

--- a/static/eslint/eslintPluginSentry/utils/lazy.ts
+++ b/static/eslint/eslintPluginSentry/utils/lazy.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-restricted-types
+export function lazy<Value extends object, Args extends unknown[]>(
+  getValue: (...args: Args) => Value
+) {
+  let value: Value | undefined;
+
+  return (...args: Args) => {
+    return (value ??= getValue(...args));
+  };
+}

--- a/static/gsAdmin/components/users/userEmailLog.tsx
+++ b/static/gsAdmin/components/users/userEmailLog.tsx
@@ -29,7 +29,7 @@ type State = {
   results: any[];
 };
 
-export default class UserEmailLog extends Component<Props, State> {
+export class UserEmailLog extends Component<Props, State> {
   state: State = {
     loading: null,
     error: false,

--- a/static/gsAdmin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/components/newInstanceLevelOAuthClient.tsx
@@ -10,7 +10,7 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import ConfigStore from 'sentry/stores/configStore';
-import PermissionSelection from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
+import {PermissionSelection} from 'sentry/views/settings/organizationDeveloperSettings/permissionSelection';
 
 import {ClientSecretModal} from './clientSecretModal';
 

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -27,7 +27,7 @@ import DetailsPage from 'admin/components/detailsPage';
 import {MergeAccountsModal} from 'admin/components/mergeAccounts';
 import SelectableContainer from 'admin/components/selectableContainer';
 import {UserCustomers} from 'admin/components/users/userCustomers';
-import UserEmailLog from 'admin/components/users/userEmailLog';
+import {UserEmailLog} from 'admin/components/users/userEmailLog';
 import {UserEmails} from 'admin/components/users/userEmails';
 import {UserOverview} from 'admin/components/users/userOverview';
 import {UserPermissionsModal} from 'admin/components/users/userPermissionsModal';

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -25,8 +25,8 @@ import parseAsSort from 'sentry/utils/url/parseAsSort';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-import ProjectTableHeader from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableHeader';
-import SeerProjectTableRow from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableRow';
+import {ProjectTableHeader} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableHeader';
+import {SeerProjectTableRow} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableRow';
 
 export function SeerProjectTable() {
   const queryClient = useQueryClient();

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -64,7 +64,7 @@ function getMutationCallbacks(count: number) {
   };
 }
 
-export default function ProjectTableHeader({
+export function ProjectTableHeader({
   projects,
   onSortClick,
   sort,

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -32,7 +32,7 @@ interface Props {
   project: Project;
 }
 
-export default function SeerProjectTableRow({
+export function SeerProjectTableRow({
   autofixSettings,
   isPendingIntegrations,
   project,

--- a/static/gsApp/views/seerAutomation/scm.tsx
+++ b/static/gsApp/views/seerAutomation/scm.tsx
@@ -3,7 +3,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 
 import AnalyticsArea from 'sentry/components/analyticsArea';
 import {ScmIntegrationTree} from 'sentry/components/repositories/scmIntegrationTree/scmIntegrationTree';
-import ScmTreeFilters from 'sentry/components/repositories/scmIntegrationTree/scmTreeFilters';
+import {ScmTreeFilters} from 'sentry/components/repositories/scmIntegrationTree/scmTreeFilters';
 import useScmTreeFilters from 'sentry/components/repositories/scmIntegrationTree/useScmTreeFilters';
 import {t, tct} from 'sentry/locale';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';


### PR DESCRIPTION
Adds a `@sentry/no-default-export-components` rule that reports on `export default`s of things that seem to be React components. 

It intentionally ignores any file where:

* Another module `import('...')`s the file, which might indicate using a lazy import of a `.default`
* Existing named imports exist in the file, which I left out to not deal with naming mismatches/conflicts in fixing

Most of the corresponding fixes were in #110263, which this PR was stacked on. A few more violations were added to `master` since that PR was generated and are now fixed in this PR. This PR also adds detection for class components and fixes those new violations.

There are still ~1.2k `export default \w+`s in `static/app` excluding mocks. Collecting more of them will mean adding in more logic to the fixers / lint rule / prompts, which I'd like to propose as a followup.

Fixes ENG-7006.