### PR TITLE
feat(issues): Improve issue diff copy and loading experience

### DIFF
--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -47,6 +47,7 @@ describe('IssueDiff', () => {
 
   it('is loading when initially rendering', async () => {
     render(<IssueDiff baseIssueId="base" targetIssueId="target" />);
+    expect(screen.getByTestId('issue-diff-loading-skeleton')).toBeInTheDocument();
     expect(screen.queryByTestId('split-diff')).not.toBeInTheDocument();
     expect(await screen.findByTestId('split-diff')).toBeInTheDocument();
   });
@@ -62,6 +63,7 @@ describe('IssueDiff', () => {
     );
 
     expect(await screen.findByTestId('split-diff')).toBeInTheDocument();
+    expect(screen.getAllByTestId('split-diff')).toHaveLength(1);
     expect(trackAnalytics).toHaveBeenCalled();
   });
 

--- a/static/app/components/issueDiff/index.spec.tsx
+++ b/static/app/components/issueDiff/index.spec.tsx
@@ -45,13 +45,6 @@ describe('IssueDiff', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('is loading when initially rendering', async () => {
-    render(<IssueDiff baseIssueId="base" targetIssueId="target" />);
-    expect(screen.getByTestId('issue-diff-loading-skeleton')).toBeInTheDocument();
-    expect(screen.queryByTestId('split-diff')).not.toBeInTheDocument();
-    expect(await screen.findByTestId('split-diff')).toBeInTheDocument();
-  });
-
   it('can dynamically import SplitDiff', async () => {
     render(
       <IssueDiff
@@ -63,7 +56,6 @@ describe('IssueDiff', () => {
     );
 
     expect(await screen.findByTestId('split-diff')).toBeInTheDocument();
-    expect(screen.getAllByTestId('split-diff')).toHaveLength(1);
     expect(trackAnalytics).toHaveBeenCalled();
   });
 

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -1,12 +1,12 @@
 import {lazy, useEffect, useMemo, useRef} from 'react';
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
+
+import {Flex} from '@sentry/scraps/layout';
 
 import {isStacktraceNewestFirst} from 'sentry/components/events/interfaces/utils';
 import LazyLoad from 'sentry/components/lazyLoad';
 import LoadingError from 'sentry/components/loadingError';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
+import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -16,6 +16,8 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const SplitDiffLazy = lazy(() => import('../splitDiff'));
+const STACKTRACE_SECTION_SEPARATOR = '\n\n';
+const SKELETON_ROW_COUNT = 8;
 
 interface IssueDiffProps {
   baseIssueId: string;
@@ -24,6 +26,32 @@ interface IssueDiffProps {
   hasSimilarityEmbeddingsProjectFeature?: boolean;
   shouldBeGrouped?: string;
   targetEventId?: string;
+}
+
+function getCombinedStacktrace({
+  event,
+  hasSimilarityEmbeddingsFeature,
+  newestFirst,
+}: {
+  event: Event | undefined;
+  hasSimilarityEmbeddingsFeature: boolean;
+  newestFirst: boolean;
+}): string {
+  if (!event) {
+    return '';
+  }
+
+  const stacktrace = getStacktraceBody({
+    event,
+    hasSimilarityEmbeddingsFeature,
+    includeLocation: false,
+    rawTrace: false,
+    newestFirst,
+    includeJSContext: true,
+  });
+
+  const orderedStacktrace = newestFirst ? stacktrace.toReversed() : stacktrace;
+  return orderedStacktrace.join(STACKTRACE_SECTION_SEPARATOR);
 }
 
 export function IssueDiff({
@@ -108,34 +136,26 @@ export function IssueDiff({
     enabled: Boolean(resolvedTargetEventId),
   });
 
-  const baseStacktrace = useMemo(() => {
-    if (!baseEventQuery.data) {
-      return [];
-    }
-    return getStacktraceBody({
-      event: baseEventQuery.data,
+  const {combinedBase, combinedTarget} = useMemo(
+    () => ({
+      combinedBase: getCombinedStacktrace({
+        event: baseEventQuery.data,
+        hasSimilarityEmbeddingsFeature,
+        newestFirst,
+      }),
+      combinedTarget: getCombinedStacktrace({
+        event: targetEventQuery.data,
+        hasSimilarityEmbeddingsFeature,
+        newestFirst,
+      }),
+    }),
+    [
+      baseEventQuery.data,
+      targetEventQuery.data,
       hasSimilarityEmbeddingsFeature,
-      includeLocation: false,
-      rawTrace: false,
       newestFirst,
-      includeJSContext: true,
-    });
-  }, [baseEventQuery.data, hasSimilarityEmbeddingsFeature, newestFirst]);
-
-  const targetStacktrace = useMemo(() => {
-    if (!targetEventQuery.data) {
-      return [];
-    }
-
-    return getStacktraceBody({
-      event: targetEventQuery.data,
-      hasSimilarityEmbeddingsFeature,
-      includeLocation: false,
-      rawTrace: false,
-      newestFirst,
-      includeJSContext: true,
-    });
-  }, [targetEventQuery.data, hasSimilarityEmbeddingsFeature, newestFirst]);
+    ]
+  );
 
   useEffect(() => {
     if (
@@ -164,61 +184,63 @@ export function IssueDiff({
     targetEventQuery.data,
   ]);
 
-  const baseArray = useMemo(() => {
-    return newestFirst ? baseStacktrace.toReversed() : baseStacktrace;
-  }, [baseStacktrace, newestFirst]);
-
-  const targetArray = useMemo(() => {
-    return newestFirst ? targetStacktrace.toReversed() : targetStacktrace;
-  }, [newestFirst, targetStacktrace]);
-
   const hasError =
     baseLatestQuery.isError ||
     targetLatestQuery.isError ||
     baseEventQuery.isError ||
     targetEventQuery.isError;
 
-  const loading = baseEventQuery.isPending || targetEventQuery.isPending;
+  const isLoading = baseEventQuery.isPending || targetEventQuery.isPending;
 
   if (hasError) {
     return (
-      <StyledIssueDiff isLoading={false}>
+      <Flex background="secondary" overflow="auto" padding="md" direction="column">
         <LoadingError message={t('Error loading events')} />
-      </StyledIssueDiff>
+      </Flex>
     );
   }
 
+  if (isLoading) {
+    return <IssueDiffLoadingState />;
+  }
+
   return (
-    <StyledIssueDiff isLoading={loading}>
-      {loading ? (
-        <LoadingIndicator />
-      ) : (
-        baseArray.map((value: string, index: number) => (
-          <LazyLoad
-            key={index}
-            LazyComponent={SplitDiffLazy}
-            base={value}
-            target={targetArray[index] ?? ''}
-            type="lines"
-          />
-        ))
-      )}
-    </StyledIssueDiff>
+    <Flex background="secondary" overflow="auto" padding="md" direction="column">
+      <LazyLoad
+        LazyComponent={SplitDiffLazy}
+        base={combinedBase}
+        target={combinedTarget}
+        type="lines"
+        loadingFallback={<IssueDiffLoadingSkeletonRows />}
+      />
+    </Flex>
   );
 }
 
-const StyledIssueDiff = styled('div')<{isLoading: boolean}>`
-  background-color: ${p => p.theme.tokens.background.secondary};
-  overflow: auto;
-  padding: ${p => p.theme.space.md};
-  display: flex;
-  flex-direction: column;
+function IssueDiffLoadingState() {
+  return (
+    <Flex
+      background="primary"
+      overflow="auto"
+      padding="md"
+      direction="column"
+      data-test-id="issue-diff-loading-skeleton"
+    >
+      <IssueDiffLoadingSkeletonRows />
+    </Flex>
+  );
+}
 
-  ${p =>
-    p.isLoading &&
-    css`
-      background-color: ${p.theme.tokens.background.primary};
-      justify-content: center;
-      align-items: center;
-    `};
-`;
+function IssueDiffLoadingSkeletonRows() {
+  return (
+    <Flex direction="column" gap="sm">
+      {Array.from({length: SKELETON_ROW_COUNT}).map((_, index) => (
+        <Flex key={index} align="center">
+          <Placeholder height="18px" style={{flex: 1}} />
+          <Flex width="20px" flexShrink={0} />
+          <Placeholder height="18px" style={{flex: 1}} />
+        </Flex>
+      ))}
+    </Flex>
+  );
+}

--- a/static/app/components/splitDiff.spec.tsx
+++ b/static/app/components/splitDiff.spec.tsx
@@ -11,13 +11,13 @@ baz`;
 
     render(<SplitDiff base={base} target={target} />);
 
-    const rows = within(screen.getByTestId('split-diff')).getAllByRole('row');
-    const firstRowCells = within(rows[0]!).getAllByRole('cell');
-    const secondRowCells = within(rows[1]!).getAllByRole('cell');
+    const diff = screen.getByTestId('split-diff');
+    const leftCells = within(diff).getAllByTestId('split-diff-left-cell');
+    const rightCells = within(diff).getAllByTestId('split-diff-right-cell');
 
-    expect(firstRowCells[0]).toHaveTextContent('foo');
-    expect(firstRowCells[2]).toHaveTextContent('foo');
-    expect(secondRowCells[0]).toHaveTextContent('bar');
-    expect(secondRowCells[2]).toHaveTextContent('baz');
+    expect(leftCells[0]).toHaveTextContent('foo');
+    expect(rightCells[0]).toHaveTextContent('foo');
+    expect(leftCells[1]).toHaveTextContent('bar');
+    expect(rightCells[1]).toHaveTextContent('baz');
   });
 });

--- a/static/app/components/splitDiff.tsx
+++ b/static/app/components/splitDiff.tsx
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 import type {Change} from 'diff';
 import {diffChars, diffLines, diffWords} from 'diff';
 
-import {Flex} from '@sentry/scraps/layout';
-
 import {unreachable} from 'sentry/utils/unreachable';
 
 // @TODO(jonasbadalic): This used to be defined on the theme, but is component specific and lacks dark mode.
@@ -94,73 +92,103 @@ function SplitDiff({className, type = 'lines', base, target}: Props) {
     return processedLines;
   }, [base, target, type]);
 
+  const displayRows = useMemo(
+    () =>
+      groupedChanges.map(line => {
+        const highlightAdded = line.find(result => result.added);
+        const highlightRemoved = line.find(result => result.removed);
+        const displayData = getDisplayData(line, highlightAdded, highlightRemoved);
+
+        return {
+          highlightAdded,
+          highlightRemoved,
+          leftSegments: displayData.filter(result => !result.added),
+          rightSegments: displayData.filter(result => !result.removed),
+        };
+      }),
+    [groupedChanges]
+  );
+
   return (
-    <SplitTable className={className} data-test-id="split-diff">
+    <SplitDiffContainer className={className} data-test-id="split-diff">
       <SplitBody>
-        {groupedChanges.map((line, j) => {
-          const highlightAdded = line.find(result => result.added);
-          const highlightRemoved = line.find(result => result.removed);
-
+        {displayRows.map((row, j) => {
           return (
-            <tr key={j}>
-              <Cell isRemoved={highlightRemoved}>
-                <Flex wrap="wrap">
-                  {getDisplayData(line, highlightAdded, highlightRemoved)
-                    .filter(result => !result.added)
-                    .map((result, i) => (
-                      <Word key={i} isRemoved={result.removed}>
-                        {result.value}
-                      </Word>
-                    ))}
-                </Flex>
-              </Cell>
+            <Cell
+              key={`left-${j}`}
+              data-test-id="split-diff-left-cell"
+              row={j + 1}
+              side="left"
+              isRemoved={row.highlightRemoved}
+            >
+              <Line>
+                {row.leftSegments.map((result, i) => (
+                  <Word key={i} isRemoved={result.removed}>
+                    {result.value}
+                  </Word>
+                ))}
+              </Line>
+            </Cell>
+          );
+        })}
 
-              <Gap />
-
-              <Cell isAdded={highlightAdded}>
-                <Flex wrap="wrap">
-                  {getDisplayData(line, highlightAdded, highlightRemoved)
-                    .filter(result => !result.removed)
-                    .map((result, i) => (
-                      <Word key={i} isAdded={result.added}>
-                        {result.value}
-                      </Word>
-                    ))}
-                </Flex>
-              </Cell>
-            </tr>
+        {displayRows.map((row, j) => {
+          return (
+            <Cell
+              key={`right-${j}`}
+              data-test-id="split-diff-right-cell"
+              row={j + 1}
+              side="right"
+              isAdded={row.highlightAdded}
+            >
+              <Line>
+                {row.rightSegments.map((result, i) => (
+                  <Word key={i} isAdded={result.added}>
+                    {result.value}
+                  </Word>
+                ))}
+              </Line>
+            </Cell>
           );
         })}
       </SplitBody>
-    </SplitTable>
+    </SplitDiffContainer>
   );
 }
 
-const SplitTable = styled('table')`
-  table-layout: fixed;
-  border-collapse: collapse;
+const SplitDiffContainer = styled('div')`
   width: 100%;
 `;
 
-const SplitBody = styled('tbody')`
+const SplitBody = styled('div')`
   font-family: ${p => p.theme.font.family.mono};
   font-size: ${p => p.theme.font.size.sm};
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 20px minmax(0, 1fr);
 `;
 
-const Cell = styled('td')<{isAdded?: Change; isRemoved?: Change}>`
-  vertical-align: top;
+const Cell = styled('div')<{
+  row: number;
+  side: 'left' | 'right';
+  isAdded?: Change;
+  isRemoved?: Change;
+}>`
+  grid-row: ${p => p.row};
+  grid-column: ${p => (p.side === 'left' ? 1 : 3)};
+  min-width: 0;
+  min-height: 1.4em;
   overflow: hidden;
   ${p => p.isRemoved && `background-color: ${DIFF_COLORS.removedRow}`};
   ${p => p.isAdded && `background-color: ${DIFF_COLORS.addedRow}`};
 `;
 
-const Gap = styled('td')`
-  width: 20px;
+const Line = styled('div')`
+  white-space: pre-wrap;
 `;
 
 const Word = styled('span')<{isAdded?: boolean; isRemoved?: boolean}>`
   white-space: pre-wrap;
-  word-break: break-all;
+  overflow-wrap: anywhere;
   ${p => p.isRemoved && `background-color: ${DIFF_COLORS.removed}`};
   ${p => p.isAdded && `background-color: ${DIFF_COLORS.added}`};
 `;


### PR DESCRIPTION
- Render issue diff as a grid to allow text selecting a single side at a time.
- Add a issue diff loading skeleton and combine stacks into a single "diff" for the purpose of text selection.

[example issue](https://sentry.sentry.io/issues/7225230208/events/73d4fbe93ecc4a0f8072c04183d484af/merged/)