### PR TITLE
feat(size): Ensure builds endpoint has parity with list-builds endpoint

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -1,3 +1,6 @@
+import logging
+from typing import Any
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,6 +18,8 @@ from sentry.preprod.api.models.project_preprod_build_details_models import (
 from sentry.preprod.artifact_search import queryset_for_query
 from sentry.preprod.models import PreprodArtifact
 from sentry.preprod.quotas import get_size_retention_cutoff
+
+logger = logging.getLogger(__name__)
 
 ERR_FEATURE_REQUIRED = "Feature {} is not enabled for the organization."
 
@@ -35,15 +40,25 @@ class BuildsEndpoint(OrganizationEndpoint):
                 status=403,
             )
 
-        on_results = lambda artifacts: [
-            transform_preprod_artifact_to_build_details(artifact).dict() for artifact in artifacts
-        ]
+        def on_results(artifacts: list[PreprodArtifact]) -> list[dict[str, Any]]:
+            results = []
+            for artifact in artifacts:
+                try:
+                    results.append(transform_preprod_artifact_to_build_details(artifact).dict())
+                except Exception:
+                    logger.warning(
+                        "preprod.builds.transform_failed", extra={"artifact_id": artifact.id}
+                    )
+            return results
+
         paginate = lambda queryset: self.paginate(
             order_by="-date_added",
             request=request,
             queryset=queryset,
             on_results=on_results,
             paginator_cls=OffsetPaginator,
+            default_per_page=25,
+            max_per_page=100,
         )
 
         try:
@@ -61,6 +76,9 @@ class BuildsEndpoint(OrganizationEndpoint):
 
         try:
             queryset = queryset_for_query(query, organization)
+            queryset = queryset.select_related(
+                "project", "build_configuration", "commit_comparison", "mobile_app_info"
+            ).prefetch_related("preprodartifactsizemetrics_set")
             queryset = queryset.filter(date_added__gte=cutoff)
             if start:
                 queryset = queryset.filter(date_added__gte=start)

--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -46,7 +46,7 @@ class BuildsEndpoint(OrganizationEndpoint):
                 try:
                     results.append(transform_preprod_artifact_to_build_details(artifact).dict())
                 except Exception:
-                    logger.warning(
+                    logger.exception(
                         "preprod.builds.transform_failed", extra={"artifact_id": artifact.id}
                     )
             return results

--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -40,6 +40,7 @@ search_config = SearchConfig.create_from(
         "download_size",
         "git_pr_number",
         "install_size",
+        "state",
     },
     # Keys that support date filtering
     # date_keys={"date_built", "date_added"},
@@ -69,6 +70,7 @@ search_config = SearchConfig.create_from(
         "is",
         "platform_name",
         "size_state",
+        "state",
     },
     # Enable boolean operators
     # allow_boolean=True,


### PR DESCRIPTION
in preparation for moving only remaining user of list-builds endpoint to the builds endpoint

artifact_search.py — Added state to the search config so the builds endpoint can filter
   by artifact state via query string (e.g. state:3), replacing the dedicated state param
   the old list-builds endpoint had.

  builds.py — Three changes for parity with the list-builds endpoint it replaces:
  1. Added select_related/prefetch_related to avoid N+1 queries during artifact
  transformation
  2. Set default_per_page=25, max_per_page=100 to match list-builds pagination
  3. Added per-artifact error handling in on_results so one bad artifact doesn't break
  the whole response